### PR TITLE
Long running greenlet fixes

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -246,10 +246,10 @@ class Rotkehlchen():
 
     def main_loop(self) -> None:
         while self.shutdown_event.wait(MAIN_LOOP_SECS_DELAY) is not True:
-            log.debug('Main loop start')
-            self.premium_sync_manager.maybe_upload_data_to_server()
-
-            log.debug('Main loop end')
+            if self.user_is_logged_in:
+                log.debug('Main loop start')
+                self.premium_sync_manager.maybe_upload_data_to_server()
+                log.debug('Main loop end')
 
     def add_blockchain_account(
             self,

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -113,21 +113,29 @@ class RotkehlchenServer():
             log.warning('handle_killed_greenlets without an exception')
             return
 
+        try:
+            task_id = greenlet.task_id
+            task_str = f'Greenlet for task {task_id}'
+        except AttributeError:
+            task_id = None
+            task_str = f'Main greenlet'
+
         log.error(
-            'Greenlet for task {} dies with exception: {}.\n'
+            '{} dies with exception: {}.\n'
             'Exception Name: {}\nException Info: {}\nTraceback:\n {}'
             .format(
-                greenlet.task_id,
+                task_str,
                 greenlet.exception,
                 greenlet.exc_info[0],
                 greenlet.exc_info[1],
                 ''.join(traceback.format_tb(greenlet.exc_info[2])),
             ))
-        # also write an error for the task result
-        result = {
-            'error': str(greenlet.exception),
-        }
-        self.write_task_result(greenlet.task_id, result)
+        # also write an error for the task result if it's not the main greenlet
+        if task_id is not None:
+            result = {
+                'error': str(greenlet.exception),
+            }
+            self.write_task_result(greenlet.task_id, result)
 
     def _query_async(self, command, task_id, **kwargs):
         result = getattr(self, command)(**kwargs)

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -90,19 +90,18 @@ def initialize_mock_rotkehlchen_instance(
             exchange_manager=rotki.exchange_manager,
         )
         rotki.user_is_logged_in = True
+        rotki.premium_sync_manager = PremiumSyncManager(
+            data=rotki.data,
+            password=db_password,
+        )
         if start_with_valid_premium:
             rotki.premium = Premium(
                 api_key=rotkehlchen_api_key,
                 api_secret=rotkehlchen_api_secret,
             )
-            rotki.premium_sync_manager = PremiumSyncManager(
-                data=rotki.data,
-                password=db_password,
-            )
             rotki.premium_sync_manager.premium = rotki.premium
         else:
             rotki.premium = None
-            rotki.premium_sync_manager = None
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Main loop premium sync should only go if logged in
- handle_killed_greenlet should differentiate between task greenlets
  and the main loop greenlet.
- Rotkehlhen instance test fixture should always instantiate PremiumSyncManager