### PR TITLE
cache_response_timewise now takes arguments into account

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`543` User will not get unexpected balance results in the same Rotki run due to same cache being used for different arguments.
 * :feature:`541` If the user allows anonymous usage analytics are submitted to a server for analysis of the application's active users.
 * :feature:`-` Rebranding Rotkehlchen to Rotki inside the application. All website and api links should now target rotki.com
 * :bug:`534` Old external trades can now be edited/deleted properly again.

--- a/rotkehlchen/tests/test_binance.py
+++ b/rotkehlchen/tests/test_binance.py
@@ -271,7 +271,6 @@ BINANCE_MYTRADES_RESPONSE = """
 def test_binance_query_trade_history(function_scope_binance):
     """Test that turning a binance trade as returned by the server to our format works"""
     binance = function_scope_binance
-    binance.cache_ttl_secs = 0
 
     def mock_my_trades(url):  # pylint: disable=unused-argument
         if 'symbol=BNBBTC' in url:
@@ -459,7 +458,6 @@ BINANCE_WITHDRAWALS_HISTORY_RESPONSE = """{
 def test_binance_query_deposits_withdrawals(function_scope_binance):
     """Test the happy case of binance deposit withdrawal query"""
     binance = function_scope_binance
-    binance.cache_ttl_secs = 0
 
     def mock_get_deposit_withdrawal(url):  # pylint: disable=unused-argument
         if 'deposit' in url:
@@ -515,7 +513,6 @@ def test_binance_query_deposits_withdrawals(function_scope_binance):
 def test_binance_query_deposits_withdrawals_unexpected_data(function_scope_binance):
     """Test that we handle unexpected deposit withdrawal query data gracefully"""
     binance = function_scope_binance
-    binance.cache_ttl_secs = 0
 
     def mock_binance_and_query(deposits, withdrawals, expected_warnings_num, expected_errors_num):
 

--- a/rotkehlchen/tests/test_bitmex.py
+++ b/rotkehlchen/tests/test_bitmex.py
@@ -107,7 +107,6 @@ def test_bitmex_api_withdrawals_deposit_and_query_after_subquery(test_bitmex):
 
 def test_bitmex_api_withdrawals_deposit_unexpected_data(test_bitmex):
     """Test getting unexpected data in bitmex withdrawals deposit query is handled gracefully"""
-    test_bitmex.cache_ttl_secs = 0
 
     original_input = """[{
 "transactID": "b6c6fd2c-4d0c-b101-a41c-fa5aa1ce7ef1", "account": 126541, "currency": "XBt",

--- a/rotkehlchen/tests/test_bittrex.py
+++ b/rotkehlchen/tests/test_bittrex.py
@@ -148,8 +148,6 @@ BITTREX_ORDER_HISTORY_RESPONSE = """
 
 def test_bittrex_query_trade_history(bittrex):
     """Test that turning a bittrex trade to our format works"""
-    # turn caching off
-    bittrex.cache_ttl_secs = 0
 
     def mock_order_history(url):  # pylint: disable=unused-argument
         response = MockResponse(200, BITTREX_ORDER_HISTORY_RESPONSE)
@@ -340,8 +338,6 @@ BITTREX_WITHDRAWAL_HISTORY_RESPONSE = """
 
 def test_bittrex_query_deposits_withdrawals(bittrex):
     """Test the happy case of bittrex deposit withdrawal query"""
-    # turn caching off
-    bittrex.cache_ttl_secs = 0
 
     def mock_get_deposit_withdrawal(url):  # pylint: disable=unused-argument
         if 'deposit' in url:
@@ -409,8 +405,6 @@ def test_bittrex_query_deposits_withdrawals(bittrex):
 
 def test_bittrex_query_deposits_withdrawals_unexpected_data(bittrex):
     """Test that we handle unexpected bittrex deposit withdrawal data gracefully"""
-    # turn caching off
-    bittrex.cache_ttl_secs = 0
 
     def mock_bittrex_and_query(deposits, withdrawals, expected_warnings_num, expected_errors_num):
 

--- a/rotkehlchen/tests/test_coinbase.py
+++ b/rotkehlchen/tests/test_coinbase.py
@@ -649,7 +649,6 @@ def test_coinbase_query_trade_history_unexpected_data(function_scope_coinbase):
 def test_coinbase_query_deposit_withdrawals(function_scope_coinbase):
     """Test that coinbase deposit/withdrawals history query works fine for the happy path"""
     coinbase = function_scope_coinbase
-    coinbase.cache_ttl_secs = 0
 
     with patch.object(coinbase.session, 'get', side_effect=mock_normal_coinbase_query):
         movements = coinbase.query_online_deposits_withdrawals(
@@ -713,7 +712,6 @@ def test_coinbase_query_deposit_withdrawals(function_scope_coinbase):
 def test_coinbase_query_deposit_withdrawals_unexpected_data(function_scope_coinbase):
     """Test that coinbase deposit/withdrawals query handles unexpected data properly"""
     coinbase = function_scope_coinbase
-    coinbase.cache_ttl_secs = 0
 
     # first query with proper data and expect no errors
     query_coinbase_and_test(

--- a/rotkehlchen/tests/test_kraken.py
+++ b/rotkehlchen/tests/test_kraken.py
@@ -132,7 +132,6 @@ def test_kraken_query_deposit_withdrawals_unexpected_data(function_scope_kraken)
     """Test if a kraken deposits_withdrawals query returns invalid data we handle it gracefully"""
     kraken = function_scope_kraken
     kraken.random_ledgers_data = False
-    kraken.cache_ttl_secs = 0
 
     test_deposits = """{
     "ledger": {

--- a/rotkehlchen/tests/test_poloniex.py
+++ b/rotkehlchen/tests/test_poloniex.py
@@ -213,7 +213,6 @@ def test_poloniex_trade_with_asset_needing_conversion():
 def test_query_trade_history(function_scope_poloniex):
     """Happy path test for poloniex trade history querying"""
     poloniex = function_scope_poloniex
-    poloniex.cache_ttl_secs = 0
 
     def mock_api_return(url, req):  # pylint: disable=unused-argument
         contents = """{ "BTC_BCH":


### PR DESCRIPTION
Fix #543

Calling a cached function with different arguments no longer return the cached result of the previous arguments.