### PR TITLE
Fix packaging for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,8 @@ jobs:
 
     - stage: deploy
       <<: *job-template-linux
+      install:
+        - echo "empty step to skip install.sh from the template"
       script:
         - source ./package.sh
       deploy:
@@ -122,6 +124,8 @@ jobs:
 
     - stage: deploy
       <<: *job-template-osx
+      install:
+        - echo "empty step to skip install.sh from the template"
       script:
         - source ./package.sh
       deploy:


### PR DESCRIPTION
install.sh from the tests template does pip install -r
requirements_dev.txt which is not needed when building the final
executable

[skip tests]