### PR TITLE
Properly disable taxfree_after_period in vue when set in the UI

### DIFF
--- a/electron-app/src/views/settings/Accounting.vue
+++ b/electron-app/src/views/settings/Accounting.vue
@@ -171,6 +171,8 @@ export default class Accounting extends Vue {
     let period = this.taxFreeAfterPeriod;
     if (period !== null) {
       period *= 86400;
+    } else {
+      period = -1;
     }
 
     const { commit } = this.$store;


### PR DESCRIPTION
Can not set a setting to None by providing as `"setting_name": null`
from the API as that is interpreted as skipped setting. Each setting
that can be disabled has its own way and the `taxfree_after_period`
needs to be set to `-1` via the API in order to disable it.

@kelsos FYI ^