### PR TITLE
Properly handle the disabled taxfree_after_period setting from DB 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`587` If a user has a disabled taxfree period setting rotki no longer fails to sign the user in.
 * :bug:`561` Export unique asset symbols during CSV exporting and not long name descriptions.
 * :feature:`-` Add support for the Turkish Lyra  (TRY - ₺) as a fiat currency
 * :feature:`-` Add support for the Russian ruble (RUB - ‎₽) as a fiat currency

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -68,7 +68,23 @@ def db_settings_from_dict(
         elif key == 'include_crypto2crypto':
             specified_args[key] = read_boolean(value)
         elif key == 'taxfree_after_period':
-            specified_args[key] = int(value)
+            # taxfree_after_period can also be None, to signify disabled setting
+            if value is None:
+                specified_args[key] = value
+            else:
+                int_value = int(value)
+                if int_value <= 0:
+                    value = None
+                    msg_aggregator.add_warning(
+                        f'A negative or zero value ({int_value}) for taxfree_after_period '
+                        f'ended up in the DB. Setting it to None. Please open an issue in '
+                        f'Github: https://github.com/rotki/rotki/issues/new/choose',
+                    )
+
+                else:
+                    value = int_value
+
+                specified_args[key] = value
         elif key == 'balance_save_frequency':
             specified_args[key] = int(value)
         elif key == 'main_currency':

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1038,3 +1038,21 @@ def test_add_ethereum_transactions(data_dir, username):
     assert len(warnings) == 0
     returned_transactions = data.db.get_ethereum_transactions()
     assert returned_transactions == [tx1, tx2, tx3]
+
+
+def test_can_unlock_db_with_disabled_taxfree_after_period(data_dir, username):
+    """Test that with taxfree_after_period being empty the DB can be opened
+
+    Regression test for https://github.com/rotki/rotki/issues/587
+    """
+    msg_aggregator = MessagesAggregator()
+    data = DataHandler(data_dir, msg_aggregator)
+    data.unlock(username, '123', create_new=True)
+    data.db.set_settings({'taxfree_after_period': None})
+
+    # now relogin and check that no exception is thrown
+    del data
+    data = DataHandler(data_dir, msg_aggregator)
+    data.unlock(username, '123', create_new=False)
+    settings = data.db.get_settings()
+    assert settings.taxfree_after_period is None


### PR DESCRIPTION
If a user has a disabled taxfree period setting rotki no longer fails to sign the user in.

Fix #587 