### PR TITLE
If there is an unexpected failure at sign-in catch it and add a log entry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+
+* :bug:`589` If there is an error an unexpected error during sign-in properly catch it and add a log entry.
 * :bug:`588` The electron log is now written in the proper directory depending on the Operating system.
 * :bug:`587` If a user has a disabled taxfree period setting rotki no longer fails to sign the user in.
 * :bug:`561` Export unique asset symbols during CSV exporting and not long name descriptions.

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -529,6 +529,11 @@ class RotkehlchenServer():
             res['result'] = False
             res['permission_needed'] = True
             res['message'] = str(e)
+        except: # noqa
+            tb = traceback.format_exc()
+            logging.critical(tb)
+            res['result'] = False
+            res['message'] = 'Unexpected exception occured during unlock. Check log for details'
 
         return res
 


### PR DESCRIPTION
Fix #589 