### PR TITLE
Force include all exchange modules in pyinstaller executable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`602` A bug that lead to the coinbase exchange being unusable in last 2 releases was fixed.
+
 * :release:`1.0.6 <2019-12-31>`
 * :bug:`589` If there is an error an unexpected error during sign-in properly catch it and add a log entry.
 * :bug:`588` The electron log is now written in the proper directory depending on the Operating system.

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -5,6 +5,7 @@ import platform
 import sys
 from distutils.spawn import find_executable
 
+from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES
 from rotkehlchen.utils.misc import get_system_spec
 
 """
@@ -70,12 +71,19 @@ executable_name = 'rotkehlchen-{}-{}'.format(
     get_system_spec()['rotkehlchen'],
     'macos' if platform.system() == 'Darwin' else platform.system().lower())
 
+hiddenimports = ['cytoolz.utils', 'cytoolz._signatures']
+# Since the exchanges are loaded dynamically and some of them may not be detected
+# by pyinstaller (https://github.com/rotki/rotki/issues/602) make sure they are
+# all included as imports in the created executable
+for exchange_name in SUPPORTED_EXCHANGES:
+    hiddenimports.append(f'rotkehlchen.exchanges.{exchange_name}')
+
 a = Entrypoint(
     'rotkehlchen',
     'console_scripts',
     'rotkehlchen',
     hookspath=['tools/pyinstaller_hooks'],
-    hiddenimports=['cytoolz.utils', 'cytoolz._signatures'],
+    hiddenimports=hiddenimports,
     datas=[
         ('rotkehlchen/data/token_abi.json', 'rotkehlchen/data'),
         ('rotkehlchen/data/all_assets.json', 'rotkehlchen/data'),


### PR DESCRIPTION
Fix #602 where essentially the coinbase module was not included in the
final executable due to the lack of static imports in the code. All
exchanges are loaded dynamically now.