### PR TITLE
Setting Premium API keys via the UI should now work properly again 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :bug:`602` A bug that lead to the coinbase exchange being unusable in last 2 releases was fixed.
+* :bug:`605` Adding a premium API key via the front-end now works properly again.
+* :bug:`602` Fixed a bug that lead to the coinbase exchange integration not working.
 
 * :release:`1.0.6 <2019-12-31>`
 * :bug:`589` If there is an error an unexpected error during sign-in properly catch it and add a log entry.

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -28,8 +28,6 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_trade_type,
 )
 from rotkehlchen.typing import (
-    ApiKey,
-    ApiSecret,
     B64EncodedBytes,
     B64EncodedString,
     BlockchainAddress,
@@ -258,13 +256,6 @@ class DataHandler():
             return False, f'{asset.identifier} is not in ignored assets'
         self.db.remove_from_ignored_assets(asset)
         return True, ''
-
-    def set_premium_credentials(
-            self,
-            api_key: ApiKey,
-            api_secret: ApiSecret,
-    ) -> None:
-        self.db.set_rotkehlchen_premium(api_key, api_secret)
 
     def set_main_currency(
             self,

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -7,7 +7,7 @@ import pytest
 
 from rotkehlchen.data.importer import DataImporter
 from rotkehlchen.history import TradesHistorian
-from rotkehlchen.premium.premium import Premium
+from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.premium.sync import PremiumSyncManager
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.server import RotkehlchenServer
@@ -25,13 +25,11 @@ def start_with_valid_premium():
 
 
 @pytest.fixture
-def rotkehlchen_api_key():
-    return base64.b64encode(make_random_b64bytes(128))
-
-
-@pytest.fixture
-def rotkehlchen_api_secret():
-    return base64.b64encode(make_random_b64bytes(128))
+def rotki_premium_credentials() -> PremiumCredentials:
+    return PremiumCredentials(
+        given_api_key=base64.b64encode(make_random_b64bytes(128)),
+        given_api_secret=base64.b64encode(make_random_b64bytes(128)),
+    )
 
 
 @pytest.fixture()
@@ -62,8 +60,7 @@ def initialize_mock_rotkehlchen_instance(
         accountant,
         blockchain,
         db_password,
-        rotkehlchen_api_key,
-        rotkehlchen_api_secret,
+        rotki_premium_credentials,
         data_dir,
 ):
     if start_with_logged_in_user:
@@ -97,10 +94,7 @@ def initialize_mock_rotkehlchen_instance(
             password=db_password,
         )
         if start_with_valid_premium:
-            rotki.premium = Premium(
-                api_key=rotkehlchen_api_key,
-                api_secret=rotkehlchen_api_secret,
-            )
+            rotki.premium = Premium(rotki_premium_credentials)
             rotki.premium_sync_manager.premium = rotki.premium
         else:
             rotki.premium = None
@@ -122,8 +116,7 @@ def rotkehlchen_server(
         start_with_valid_premium,
         function_scope_messages_aggregator,
         db_password,
-        rotkehlchen_api_key,
-        rotkehlchen_api_secret,
+        rotki_premium_credentials,
         accounting_data_dir,
 ):
     """A partially mocked rotkehlchen server instance"""
@@ -139,8 +132,7 @@ def rotkehlchen_server(
         accountant=accountant,
         blockchain=blockchain,
         db_password=db_password,
-        rotkehlchen_api_key=rotkehlchen_api_key,
-        rotkehlchen_api_secret=rotkehlchen_api_secret,
+        rotki_premium_credentials=rotki_premium_credentials,
         data_dir=accounting_data_dir,
     )
     return server
@@ -156,8 +148,7 @@ def rotkehlchen_instance(
         start_with_valid_premium,
         function_scope_messages_aggregator,
         db_password,
-        rotkehlchen_api_key,
-        rotkehlchen_api_secret,
+        rotki_premium_credentials,
         accounting_data_dir,
 ):
     """A partially mocked rotkehlchen instance"""
@@ -171,8 +162,7 @@ def rotkehlchen_instance(
         accountant=accountant,
         blockchain=blockchain,
         db_password=db_password,
-        rotkehlchen_api_key=rotkehlchen_api_key,
-        rotkehlchen_api_secret=rotkehlchen_api_secret,
+        rotki_premium_credentials=rotki_premium_credentials,
         data_dir=accounting_data_dir,
     )
     return uninitialized_rotkehlchen

--- a/tools/data_faker/data_faker/faker.py
+++ b/tools/data_faker/data_faker/faker.py
@@ -12,7 +12,6 @@ from data_faker.mock_apis.api import APIServer, RestAPI
 
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
-from rotkehlchen.typing import ApiKey, ApiSecret
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +73,5 @@ class DataFaker(object):
             password=given_password,
             create_new=True,
             sync_approval='no',
-            api_key=ApiKey(''),
-            api_secret=ApiSecret(b''),
+            premium_credentials=None,
         )


### PR DESCRIPTION
Fixes #605 by making a small refactor around premium credentials so
that all api key/secret pairs are encoded as soon as we get them and
passed around in a proper datastructure.