### PR TITLE
OSX vue fixes

### DIFF
--- a/electron-app/src/py-handler.ts
+++ b/electron-app/src/py-handler.ts
@@ -28,6 +28,7 @@ export default class PyHandler {
     if (process.platform === 'linux') {
       this.logsPath = app.getPath('appData');
     } else {
+      app.setAppLogsPath();
       this.logsPath = app.getPath('logs');
     }
     this.ELECTRON_LOG_PATH = path.join(this.logsPath, 'rotki_electron.log');

--- a/electron-app/vue.config.js
+++ b/electron-app/vue.config.js
@@ -24,6 +24,7 @@ module.exports = {
           }
         ],
         mac: {
+          identity: false,
           category: 'public.app-category.finance',
           icon: 'src/assets/images/rotki.icns'
         },


### PR DESCRIPTION
- Call app.setAppLogsPath() before app.getPath("logs")  (Fix #613)
- Disable code signing for electron builder in OSX