### PR TITLE
Fix some problems with Vue.js account creation and login

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1027,7 +1027,7 @@ Querying FIAT balances
 Setting FIAT balances
 ======================
 
-.. http:get:: /api/(version)/balances/fiat/
+.. http:patch:: /api/(version)/balances/fiat/
 
    Doing a PATCH on the FIAT balances endpoint will edit the FIAT balances of the given currencies for the currently logged in user. If the balance for an asset is set to 0 then that asset is removed from the database.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -100,14 +100,12 @@ Handling user creation, sign-in, log-out and querying
       {
           "name": "john",
 	  "password": "supersecurepassword",
-	  "sync_approval": "unknown"
 	  "premium_api_key": "dasdsda",
 	  "premium_api_secret": "adsadasd",
       }
 
       :reqjson string name: The name to give to the new user
       :reqjson string password: The password with which to encrypt the database for the new user
-      :reqjson string sync_approval: A string denoting if the user approved an initial syncing of data from premium when premium keys are given. Valid values are ``"unknown"``, ``"yes"`` and ``"no"``.Should always be ``"unknown"`` at first and only if the user approves should creation with approval as ``"yes`` be sent. If he does not approve a creation with approval as ``"no"`` should be sent. If there is the possibility of data sync from the premium server and this is ``"unknown"`` the creation will fail with an appropriate error asking the consumer of the api to set it to ``"yes"`` or ``"no"``.
       :reqjson string premium_api_key: An optional api key if the user has a Rotki premium account.
       :reqjson string premium_api_secret: An optional api secret if the user has a Rotki premium account.
 
@@ -144,7 +142,6 @@ Handling user creation, sign-in, log-out and querying
       }
 
    :statuscode 200: Adding the new user was succesful
-   :statuscode 300: Possibility of syncing exists and the creation was sent with sync_approval set to ``"unknown"``. Consumer of api must resend with ``"yes"`` or ``"no"``.
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 409: User already exists. Another user is already logged in. Given Premium API credentials are invalid.
    :statuscode 500: Internal Rotki error

--- a/electron-app/src/components/CreateAccount.vue
+++ b/electron-app/src/components/CreateAccount.vue
@@ -32,6 +32,7 @@
             v-model="passwordConfirm"
             class="create-account__fields__password-repeat"
             prepend-icon="fa-repeat"
+            :error-messages="errorMessages"
             :rules="passwordConfirmRules"
             :disabled="loading"
             label="Repeat Password"
@@ -83,6 +84,7 @@ export default class CreateAccount extends Vue {
   passwordConfirm: string = '';
 
   valid: boolean = false;
+  errorMessages: string[] = [];
 
   readonly usernameRules = [
     (v: string) => !!v || 'Please provide a user name',
@@ -93,11 +95,35 @@ export default class CreateAccount extends Vue {
 
   readonly passwordRules = [(v: string) => !!v || 'Please provide a password'];
   readonly passwordConfirmRules = [
-    (v: string) => !!v || 'Please provide a password confirmation',
-    (v: string) =>
-      v == this.password ||
-      'The password confirmation does not match the provided password'
+    (v: string) => !!v || 'Please provide a password confirmation'
   ];
+
+  private updateConfirmationError() {
+    if (this.errorMessages.length > 0) {
+      return;
+    }
+    this.errorMessages.push(
+      'The password confirmation does not match the provided password'
+    );
+  }
+
+  @Watch('password')
+  onPasswordChange() {
+    if (this.password && this.password !== this.passwordConfirm) {
+      this.updateConfirmationError();
+    } else {
+      this.errorMessages.pop();
+    }
+  }
+
+  @Watch('passwordConfirm')
+  onPasswordConfirmationChange() {
+    if (this.passwordConfirm && this.passwordConfirm !== this.password) {
+      this.updateConfirmationError();
+    } else {
+      this.errorMessages.pop();
+    }
+  }
 
   @Watch('displayed')
   onDisplayChange() {

--- a/electron-app/src/components/CreateAccount.vue
+++ b/electron-app/src/components/CreateAccount.vue
@@ -93,7 +93,10 @@ export default class CreateAccount extends Vue {
 
   readonly passwordRules = [(v: string) => !!v || 'Please provide a password'];
   readonly passwordConfirmRules = [
-    (v: string) => !!v || 'Please provide a password confirmation'
+    (v: string) => !!v || 'Please provide a password confirmation',
+    (v: string) =>
+      v == this.password ||
+      'The password confirmation does not match the provided password'
   ];
 
   @Watch('displayed')

--- a/electron-app/src/services/rotkehlchen-api.ts
+++ b/electron-app/src/services/rotkehlchen-api.ts
@@ -592,7 +592,28 @@ export class RotkehlchenApi {
             reject(new Error(message));
           }
         })
-        .catch(error => reject(error));
+        .catch(error => {
+          if (error.response) {
+            const { result, message } = error.response.data;
+            if (result) {
+              resolve(result);
+            } else {
+              reject(new Error(message));
+            }
+          } else if (error.request) {
+            /*
+             * The request was made but no response was received, `error.request`
+             * is an instance of XMLHttpRequest in the browser and an instance
+             * of http.ClientRequest in Node.js
+             */
+            console.log(error.request);
+            reject(new Error(error));
+          } else {
+            // Something happened in setting up the request and triggered an Error
+            console.log('Error', error.message);
+            reject(new Error(error.message));
+          }
+        });
     });
   }
 

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -490,10 +490,6 @@ class ModifiableSettingsSchema(BaseSchema):
 class BaseUserSchema(BaseSchema):
     name = fields.String(required=True)
     password = fields.String(required=True)
-    sync_approval = fields.String(
-        missing='unknown',
-        validate=validate.OneOf(choices=('unknown', 'yes', 'no')),
-    )
 
     class Meta:
         strict = True

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -311,14 +311,12 @@ class UsersResource(BaseResource):
             self,
             name: str,
             password: str,
-            sync_approval: str,
             premium_api_key: str,
             premium_api_secret: str,
     ) -> Response:
         return self.rest_api.create_new_user(
             name=name,
             password=password,
-            sync_approval=sync_approval,
             premium_api_key=premium_api_key,
             premium_api_secret=premium_api_secret,
         )

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -57,7 +57,6 @@ class DataHandler():
             password: str,
             create_new: bool,
     ) -> FilePath:
-        self.username = username
         user_data_dir = FilePath(os.path.join(self.data_directory, username))
         if create_new:
             if os.path.exists(user_data_dir):
@@ -89,6 +88,7 @@ class DataHandler():
         self.db: DBHandler = DBHandler(user_data_dir, password, self.msg_aggregator)
         self.user_data_dir = user_data_dir
         self.logged_in = True
+        self.username = username
         return user_data_dir
 
     def main_currency(self) -> Asset:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -167,10 +167,11 @@ class DBHandler:
                 migrated, errstr = self.upgrade_db_sqlcipher_3_to_4(password)
 
             if self.sqlcipher_version != 4 or not migrated:
+                # Note this can also happen if trying to use an sqlcipher 4 version
+                # DB with sqlcipher version 3
                 log.error(
-                    f'SQLCipher version: {self.sqlcipher_version} - Error: {errstr}'
-                    f'Wrong password while decrypting the database or not a database. Perhaps '
-                    f'trying to use an sqlcipher 4 version DB with sqlciper 3?',
+                    f'SQLCipher version: {self.sqlcipher_version} - Error: {errstr}. '
+                    f'Wrong password while decrypting the database or not a database.',
                 )
                 raise AuthenticationError('Wrong password or invalid/corrupt database for user')
 

--- a/rotkehlchen/tests/api/test_users.py
+++ b/rotkehlchen/tests/api/test_users.py
@@ -78,7 +78,6 @@ def test_user_creation(rotkehlchen_api_server, data_dir):
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     assert_proper_response(response)
@@ -103,7 +102,6 @@ def test_user_creation_with_premium_credentials(rotkehlchen_api_server, data_dir
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_key': VALID_PREMIUM_KEY,
         'premium_api_secret': VALID_PREMIUM_SECRET,
     }
@@ -149,7 +147,6 @@ def test_user_creation_with_invalid_premium_credentials(rotkehlchen_api_server, 
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_key': 'foo',
         'premium_api_secret': 'boo',
     }
@@ -167,7 +164,6 @@ def test_user_creation_with_invalid_premium_credentials(rotkehlchen_api_server, 
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_key': VALID_PREMIUM_KEY,
         'premium_api_secret': VALID_PREMIUM_SECRET,
     }
@@ -197,7 +193,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     username = 'hania'
     data = {
         'password': '1234',
-        'sync_approval': 'unknown',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     assert_error_response(
@@ -208,7 +203,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     username = 'hania'
     data = {
         'name': username,
-        'sync_approval': 'unknown',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     assert_error_response(
@@ -220,7 +214,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': 5435345.31,
         'password': '1234',
-        'sync_approval': 'unknown',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     assert_error_response(
@@ -232,19 +225,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': username,
         'password': 4535,
-        'sync_approval': 'unknown',
-    }
-    response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
-    assert_error_response(
-        response=response,
-        contained_in_msg='Not a valid string',
-    )
-
-    # Invalid type for sync_approval
-    data = {
-        'name': username,
-        'password': '1234',
-        'sync_approval': False,
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     assert_error_response(
@@ -256,7 +236,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_key': 'asdsada',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
@@ -268,7 +247,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_secret': 'asdsada',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
@@ -280,7 +258,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_key': True,
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
@@ -292,7 +269,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
         'premium_api_secret': 45.2,
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
@@ -310,7 +286,6 @@ def test_user_creation_errors(rotkehlchen_api_server, data_dir):
     data = {
         'name': 'another_user',
         'password': '1234',
-        'sync_approval': 'unknown',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     assert_error_response(
@@ -326,7 +301,6 @@ def test_user_creation_with_already_loggedin_user(rotkehlchen_api_server, userna
     data = {
         'name': username,
         'password': '1234',
-        'sync_approval': 'unknown',
     }
     response = requests.put(api_url_for(rotkehlchen_api_server, "usersresource"), json=data)
     msg = (

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -78,6 +78,7 @@ def initialize_mock_rotkehlchen_instance(
         # messages caused by DB initialization
         rotki.data.db = database
         rotki.data.username = username
+        rotki.data.logged_in = True
         rotki.data_importer = DataImporter(db=rotki.data.db)
         rotki.password = db_password
         # Remember accountant fixture has a mocked accounting data dir


### PR DESCRIPTION
## What does the PR do

Fix #616 

- New Account: Check password confirmation matches provided password
- Catch non-2XX responses for account login and show error to user 

## Feedback needed

@kelsos I need help here.

I discovered that Axios, at least with the current settings you have treats any non `2XX` response as an error. So catching errors from the API needs to be in the `        .catch(error => {` part of the code.

Saw a gist explaining how to do that [here](https://gist.github.com/fgilio/230ccd514e9381fafa51608fcf137253).

But that seems like a lot of work to put such logic in each endpoint of Rotki in `rotkehlchen-api.ts`.

Especially since almost all of the endpoints do return non 2XX codes which should be process-able by the front-end. Can't we generalize this somehow? To check the status code if it matches the ones expected by the endpoint from the docs. If it does, process it and if there is no result get the message and show it to the user as an error. Else it's  probably a `500` error and then the user should check the backend logs.

Anyway as you can see from commit https://github.com/rotki/rotki/commit/a47a54107c0e4625d2a23e94b106a9a33dea42fb I actually did something close to this logic only for the login endpoint but something is wrong. The first time I tried to login I did get the `'message'` text shown to me as I wanted: (Check also the console)

![2020-01-07-000504_1330x610_scrot](https://user-images.githubusercontent.com/1658405/71855854-82989000-30e2-11ea-97bc-20abe8a704dd.png)


The second time I tried I got a 409 error and checking the console I see different endpoints being queried. Why?

![2020-01-07-000517_1552x624_scrot](https://user-images.githubusercontent.com/1658405/71855902-9d6b0480-30e2-11ea-93a0-d22fc52f56b0.png)
