### PR TITLE
Fixes message display on new account creation

### DIFF
--- a/electron-app/src/App.vue
+++ b/electron-app/src/App.vue
@@ -49,14 +49,15 @@
       :message="startupError"
     ></error-screen>
     <account-management
-      v-if="startupError.length === 0 && !logged"
+      v-if="startupError.length === 0 && !loginIn"
       :logged="logged"
+      @login-complete="loginComplete = true"
     ></account-management>
   </v-app>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Watch } from 'vue-property-decorator';
 import UserDropdown from '@/components/UserDropdown.vue';
 import NavigationMenu from '@/components/NavigationMenu.vue';
 import CurrencyDropDown from '@/components/CurrencyDropDown.vue';
@@ -101,6 +102,19 @@ export default class App extends Vue {
   logged!: boolean;
   message!: Message;
   version!: string;
+
+  loginComplete: boolean = false;
+
+  get loginIn(): boolean {
+    return this.logged && this.loginComplete;
+  }
+
+  @Watch('logged')
+  onLoggedChange() {
+    if (!this.logged) {
+      this.loginComplete = false;
+    }
+  }
 
   drawer = true;
 

--- a/electron-app/src/components/AccountManagement.vue
+++ b/electron-app/src/components/AccountManagement.vue
@@ -44,7 +44,7 @@
       action="Upgrade"
       :visible="!message && premiumVisible"
       @primary="upgrade()"
-      @close="dismiss()"
+      @close="loginComplete"
     >
       <template #title>
         Upgrade to Premium
@@ -59,7 +59,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers, mapGetters, mapState } from 'vuex';
 import Login from './Login.vue';
 import CreateAccount from './CreateAccount.vue';
@@ -95,6 +95,11 @@ export default class AccountManagement extends Vue {
 
   @Prop({ required: true, type: Boolean })
   logged!: boolean;
+
+  @Emit()
+  loginComplete() {
+    this.dismiss();
+  }
 
   async login(credentials: Credentials) {
     const { username, password } = credentials;


### PR DESCRIPTION
This PR fixes the display of the Welcome and Upgrade Messages during account creation. It was accidentally broken when I modified the AccountManagement.vue to only render if the user is not logged and there are no errors to avoid multiple messages showing. 