### PR TITLE
Updates settings to only send changed properties

### DIFF
--- a/electron-app/src/services/rotkehlchen-api.ts
+++ b/electron-app/src/services/rotkehlchen-api.ts
@@ -22,7 +22,8 @@ import {
   SyncConflictError,
   TaskResult,
   SyncApproval,
-  UnlockPayload
+  UnlockPayload,
+  SettingsUpdate
 } from '@/typing/types';
 import axios, { AxiosInstance } from 'axios';
 import { EthTokens } from '@/model/eth_token';
@@ -280,8 +281,8 @@ export class RotkehlchenApi {
     return status == 200 || status == 400 || status == 409;
   }
 
-  setSettings(settings: { [key: string]: any }): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
+  setSettings(settings: SettingsUpdate): Promise<DBSettings> {
+    return new Promise<DBSettings>((resolve, reject) => {
       this.axios
         .put<ActionResult<DBSettings>>(
           '/settings',
@@ -293,7 +294,7 @@ export class RotkehlchenApi {
         .then(response => {
           const { result, message } = response.data;
           if (result) {
-            resolve(true);
+            resolve(result);
           } else {
             reject(new Error(message));
           }

--- a/electron-app/src/typing/types.ts
+++ b/electron-app/src/typing/types.ts
@@ -29,7 +29,7 @@ export interface AccountingSettingsUpdate {
 export interface Credentials {
   readonly username: string;
   readonly password: string;
-  readonly syncApproval: SyncApproval;
+  readonly syncApproval?: SyncApproval;
   readonly apiKey?: string;
   readonly apiSecret?: string;
 }
@@ -93,4 +93,22 @@ export interface UnlockPayload {
   readonly syncApproval: SyncApproval;
   readonly apiKey?: string;
   readonly apiSecret?: string;
+}
+
+export type SettingsUpdate = {
+  +readonly [P in keyof SettingsPayload]+?: SettingsPayload[P];
+};
+
+export interface SettingsPayload {
+  balance_save_frequency: number;
+  main_currency: string;
+  anonymized_logs: boolean;
+  submit_usage_analytics: boolean;
+  historical_data_start: string;
+  eth_rpc_endpoint: string;
+  ui_floating_precision: number;
+  date_display_format: string;
+  include_gas_costs: boolean;
+  include_crypto2crypto: boolean;
+  taxfree_after_period: number;
 }

--- a/electron-app/src/views/settings/General.vue
+++ b/electron-app/src/views/settings/General.vue
@@ -2,7 +2,7 @@
   <v-container id="settings-general">
     <v-row>
       <v-col>
-        <h1 class="page-header">Settings</h1>
+        <h1>Settings</h1>
       </v-col>
     </v-row>
     <v-row>
@@ -11,22 +11,22 @@
           <v-card-title>General Settings</v-card-title>
           <v-card-text>
             <v-text-field
-              id="floating_precision"
               v-model="floatingPrecision"
+              class="settings-general__fields__floating-precision"
               label="Floating Precision"
               type="number"
             ></v-text-field>
 
             <v-checkbox
-              id="anonymized_logs_input"
               v-model="anonymizedLogs"
+              class="settings-general__fields__anonymized-logs"
               off-icon="fa fa-square-o"
               label="Should logs by anonymized?"
             ></v-checkbox>
 
             <v-checkbox
-              id="anonymous_usage_analytics"
               v-model="anonymousUsageAnalytics"
+              class="settings-general__fields__anonymous-usage-statistics"
               off-icon="fa fa-square-o"
               label="Should anonymous usage analytics be submitted?"
             ></v-checkbox>
@@ -43,8 +43,8 @@
             >
               <template #activator="{ on }">
                 <v-text-field
-                  id="historical_data_start"
                   v-model="historicDataStart"
+                  class="settings-general__fields__historic-data-start"
                   label="Date from when to count historical data"
                   hint="DD/MM/YYYY format"
                   prepend-icon="fa-calendar"
@@ -60,8 +60,8 @@
             </v-menu>
 
             <v-select
-              id="maincurrencyselector"
               v-model="selectedCurrency"
+              class="settings-general__fields__currency-selector"
               label="Select Main Currency"
               item-text="ticker_symbol"
               return-object
@@ -70,23 +70,23 @@
             </v-select>
 
             <v-text-field
-              id="eth_rpc_endpoint"
               v-model="rpcEndpoint"
+              class="settings-general__fields__rpc-endpoint"
               label="Eth RPC Endpoint"
               type="text"
               data-vv-name="eth_rpc_endpoint"
             ></v-text-field>
 
             <v-text-field
-              id="balance_save_frequency"
               v-model="balanceSaveFrequency"
+              class="settings-general__fields__balance-save-frequency"
               label="Balance data saving frequency in hours"
               type="number"
             ></v-text-field>
 
             <v-text-field
-              id="date_display_format"
               v-model="dateDisplayFormat"
+              class="settings-general__fields__date-display-format"
               label="Date display format"
               type="text"
             ></v-text-field>
@@ -94,8 +94,8 @@
 
           <v-card-actions>
             <v-btn
-              id="settingssubmit"
               depressed
+              class="settings-general__buttons__save"
               color="primary"
               type="submit"
               @click="save()"


### PR DESCRIPTION
- Updates settings so that only the actual changes are sent.
- Fixes a small validation bug with the historic date picker.
- Makes the API to return the settings object to update the local state after changing settings.
- Adds guarding to the settings API so that you cannot pass random properties.
- Fixes a bug that would send strings instead of numbers for floating precision.