### PR TITLE
Handle the case where new account with premium uses wrong password

### DIFF
--- a/electron-app/src/components/PremiumCredentials.vue
+++ b/electron-app/src/components/PremiumCredentials.vue
@@ -1,11 +1,22 @@
 <template>
   <div>
-    <v-checkbox
-      :value="enabled"
-      label="Enable Premium"
-      off-icon="fa fa-square-o"
-      @change="enabledChanged"
-    ></v-checkbox>
+    <v-tooltip bottom>
+      <template #activator="{ on }">
+        <v-checkbox
+          :value="enabled"
+          label="Enable Premium"
+          off-icon="fa fa-square-o"
+          v-on="on"
+          @change="enabledChanged"
+        ></v-checkbox>
+      </template>
+      <div>
+        Enabling premium for a new account will restore the database associated
+        with these credentials from the server. Ensure that the account uses the
+        same password as the database originally backed up.
+      </div>
+    </v-tooltip>
+
     <div v-if="enabled">
       <v-text-field
         :value="apiKey"

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -129,7 +129,7 @@ class Rotkehlchen():
             if create_new:
                 raise
             # else let's just continue. User signed in succesfully, but he just
-            # has unauthenticable/invalide premium credentials remaining in his DB
+            # has unauthenticable/invalid premium credentials remaining in his DB
 
         settings = self.data.db.get_settings()
         maybe_submit_usage_analytics(settings.submit_usage_analytics)


### PR DESCRIPTION
When the user creates a new account and inputs valid premium keys,
then the database will be pulled from the server. In order for that to
work properly the new account should have the same password as the
original password given to the DB in the server.

This commit handles the case where the user gives a different password
more gracefully by providing an error message instead of a 500 server error