### PR TITLE
Taxfree_after_period 0 value is now not allowed in the API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -463,7 +463,7 @@ Getting or modifying settings
    :resjson bool anonymized_logs: A boolean denoting whether sensitive logs should be anonymized.
    :resjson int last_data_upload_ts: The unix timestamp at which the last data upload to the server happened.
    :resjson int ui_floating_precision: The number of decimals points to be shown for floating point numbers in the UI. Can be between 0 and 8.
-   :resjson int taxfree_after_period: The number of seconds after which holding a crypto in FIFO order is considered no longer taxable. The default is 1 year, as per current german tax rules. Can also be set to ``-1`` which will then set the taxfree_after_period to ``null`` which means there is no taxfree period.
+   :resjson int taxfree_after_period: The number of seconds after which holding a crypto in FIFO order is considered no longer taxable. Must be either a positive number, or -1. 0 is not a valid value. The default is 1 year, as per current german tax rules. Can also be set to ``-1`` which will then set the taxfree_after_period to ``null`` which means there is no taxfree period.
    :resjson int balance_save_frequency: The number of hours after which user balances should be saved in the DB again. This is useful for the statistics kept in the DB for each user. Default is 24 hours. Can't be less than 1 hour.
    :resjson bool include_gas_costs: A boolean denoting whether gas costs should be counted as loss in profit/loss calculation.
    :resjson string historical_data_start: A date in the DAY/MONTH/YEAR format at which we consider historical data to have started.
@@ -498,7 +498,7 @@ Getting or modifying settings
    :reqjson bool[optional] include_crypto2crypto: A boolean denoting whether crypto to crypto trades should be counted.
    :reqjson bool[optional] anonymized_logs: A boolean denoting whether sensitive logs should be anonymized.
    :reqjson int[optional] ui_floating_precision: The number of decimals points to be shown for floating point numbers in the UI. Can be between 0 and 8.
-   :reqjson int[optional] taxfree_after_period: The number of seconds after which holding a crypto in FIFO order is considered no longer taxable. The default is 1 year, as per current german tax rules. Can also be set to ``-1`` which will then set the taxfree_after_period to ``null`` which means there is no taxfree period.
+   :resjson int[optional] taxfree_after_period: The number of seconds after which holding a crypto in FIFO order is considered no longer taxable. Must be either a positive number, or -1. 0 is not a valid value. The default is 1 year, as per current german tax rules. Can also be set to ``-1`` which will then set the taxfree_after_period to ``null`` which means there is no taxfree period.
    :reqjson int[optional] balance_save_frequency: The number of hours after which user balances should be saved in the DB again. This is useful for the statistics kept in the DB for each user. Default is 24 hours. Can't be less than 1 hour.
    :reqjson bool[optional] include_gas_costs: A boolean denoting whether gas costs should be counted as loss in profit/loss calculation.
    :reqjson string[optional] historical_data_start: A date in the DAY/MONTH/YEAR format at which we consider historical data to have started.

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -48,6 +48,30 @@ class TimestampField(fields.Field):
         return timestamp
 
 
+class TaxFreeAfterPeriodField(fields.Field):
+
+    @staticmethod
+    def _serialize(value, attr, obj, **kwargs) -> str:  # pylint: disable=unused-argument
+        return str(value)
+
+    def _deserialize(  # pylint: disable=unused-argument
+            self,
+            value,
+            attr,
+            data,
+            **kwargs,
+    ) -> int:
+        if value < -1:
+            raise ValidationError(
+                'The taxfree_after_period value can not be negative, except for '
+                'the value of -1 to disable the setting',
+            )
+        if value == 0:
+            raise ValidationError('The taxfree_after_period value can not be set to zero')
+
+        return value
+
+
 class AmountField(fields.Field):
 
     @staticmethod
@@ -527,17 +551,7 @@ class ModifiableSettingsSchema(BaseSchema):
         ),
         missing=None,
     )
-    taxfree_after_period = fields.Integer(
-        strict=True,
-        validate=validate.Range(
-            min=-1,
-            error=(
-                'Number of seconds after which taxfree period starts should not '
-                'be negative. Apart from the value of -1 to disable the setting'
-            ),
-        ),
-        missing=None,
-    )
+    taxfree_after_period = TaxFreeAfterPeriodField(missing=None)
     balance_save_frequency = fields.Integer(
         strict=True,
         validate=validate.Range(

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -144,6 +144,27 @@ def test_disable_taxfree_after_period(rotkehlchen_api_server):
     json_data = response.json()
     assert json_data['result']['taxfree_after_period'] is None
 
+    # Test that any other negative value is refused
+    data = {
+        'taxfree_after_period': -5,
+    }
+    response = requests.put(api_url_for(rotkehlchen_api_server, "settingsresource"), json=data)
+    assert_error_response(
+        response=response,
+        contained_in_msg='The taxfree_after_period value can not be negative',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+    # Test that zero value is refused
+    data = {
+        'taxfree_after_period': 0,
+    }
+    response = requests.put(api_url_for(rotkehlchen_api_server, "settingsresource"), json=data)
+    assert_error_response(
+        response=response,
+        contained_in_msg='The taxfree_after_period value can not be set to zero',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+
 
 @pytest.mark.xfail(
     strict=True,


### PR DESCRIPTION
Noticed this was missing thanks to reviewing: https://github.com/rotki/rotki/pull/687