### PR TITLE
Add a package-lock.json rule that only bumps version for rotki

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,6 +9,12 @@ serialize = {major}.{minor}.{patch}
 [bumpversion:file:electron-app/package.json]
 serialize = {major}.{minor}.{patch}
 
+[bumpversion:file:electron-app/package-lock.json]
+search = "name": "rotki",
+  "version": "{current_version}"
+replace = "name": "rotki",
+  "version": "{new_version}"
+
 [bumpversion:file:docs/conf.py]
 serialize = {major}.{minor}.{patch}
 


### PR DESCRIPTION
Depends on https://github.com/c4urself/bump2version/issues/127 being
merged and included in a release.

Fix #447