### PR TITLE
Also kill python process when terminating electron in Windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`698 major` Rotki should now also display the version in the UI for Windows and OSX.
+* :bug:`709 major` Rotki no longer crashes after second time of opening the application in Windows.
 * :bug:`716 major` The rotki logs for linux now go into a proper directory: ``~/.config/rotki/logs``
 * :feature:`461` You can now label your blockchain accounts and tag them with any numer of custom tags to group them into categories. Tags can be customized.
 * :bug:`739 major` If there is an error during DBUpgrade or if the user uses old software to run a new DB we don't crash and burn with a 500 error but instead show a proper message.

--- a/electron-app/src/background.ts
+++ b/electron-app/src/background.ts
@@ -105,7 +105,9 @@ app.on('ready', async () => {
 app.on('will-quit', async e => {
   e.preventDefault();
   await pyHandler.exitPyProc();
-  app.exit();
+  if (process.platform !== 'win32') {
+    app.exit();
+  }
 });
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {

--- a/electron-app/src/py-handler.ts
+++ b/electron-app/src/py-handler.ts
@@ -178,6 +178,17 @@ export default class PyHandler {
       }
       defaultArgs.push('--data-dir', tempPath);
     }
+    // in some systems the virtualenv's python is not detected from inside electron and the
+    // system python is used. Electron/node seemed to add /usr/bin to the path before the
+    // virtualenv directory and as such system's python is used. Not sure why this happens only
+    // in some systems. Check again in the future if this happens in Lefteris laptop Archlinux.
+    // To mitigate this if a virtualenv is detected we add its bin directory to the start
+    // start of the path
+    if (process.env.VIRTUAL_ENV) {
+      this.logToFile('Setting path');
+      process.env.PATH = process.env.VIRTUAL_ENV + '/bin:' + process.env.PATH;
+      this.logToFile('Path is now:' + process.env.PATH);
+    }
 
     this.childProcess = spawn('python', defaultArgs.concat(args));
   }

--- a/electron-app/src/py-handler.ts
+++ b/electron-app/src/py-handler.ts
@@ -116,7 +116,12 @@ export default class PyHandler {
 
   async exitPyProc() {
     this.logToFile('Exiting the application');
-
+    if (this.rpcFailureNotifier) {
+      clearInterval(this.rpcFailureNotifier);
+    }
+    if (this.rpcConnectedNotifier) {
+      clearInterval(this.rpcConnectedNotifier);
+    }
     if (process.platform === 'win32') {
       await this.terminateWindowsProcesses();
     } else {

--- a/electron-app/src/py-handler.ts
+++ b/electron-app/src/py-handler.ts
@@ -190,9 +190,8 @@ export default class PyHandler {
     // To mitigate this if a virtualenv is detected we add its bin directory to the start
     // start of the path
     if (process.env.VIRTUAL_ENV) {
-      this.logToFile('Setting path');
-      process.env.PATH = process.env.VIRTUAL_ENV + '/bin:' + process.env.PATH;
-      this.logToFile('Path is now:' + process.env.PATH);
+      process.env.PATH =
+        process.env.VIRTUAL_ENV + path.sep + 'bin:' + process.env.PATH;
     } else {
       this.logAndQuit(
         'ERROR: Running in development mode and not inside a python virtual environment'
@@ -200,7 +199,7 @@ export default class PyHandler {
     }
 
     this.logToFile(
-      'Starting non-packaged python subprocess: python ' + defaultArgs.join(' ')
+      `Starting non-packaged python subprocess: python ${defaultArgs.join(' ')}`
     );
     this.childProcess = spawn('python', defaultArgs.concat(args));
   }
@@ -227,15 +226,9 @@ export default class PyHandler {
     args.push('--logfile', path.join(this.logsPath, 'rotkehlchen.log'));
     args = ['--api-port', port.toString()].concat(args);
     this.logToFile(
-      'Starting packaged python subprocess: ' +
-        executable +
-        ' ' +
-        args.join(' ')
+      `Starting packaged python subprocess: ${executable} ${args.join(' ')}`
     );
-    this.childProcess = execFile(
-      executable,
-      ['--api-port', port.toString()].concat(args)
-    );
+    this.childProcess = execFile(executable, args);
   }
 
   private async terminateWindowsProcesses() {

--- a/electron-app/src/store/store.ts
+++ b/electron-app/src/store/store.ts
@@ -50,14 +50,17 @@ const store: StoreOptions<RotkehlchenState> = {
   },
   actions: {
     async version({ commit }): Promise<void> {
-      try {
-        const version = await api.checkVersion();
-        if (version) {
-          commit('versions', version);
+      const timerId = setInterval(async function() {
+        try {
+          const version = await api.checkVersion();
+          if (version) {
+            commit('versions', version);
+            clearInterval(timerId);
+          }
+        } catch (e) {
+          console.error(e);
         }
-      } catch (e) {
-        console.error(e);
-      }
+      }, 1000);
     }
   },
   getters: {

--- a/rotkehlchen/externalapis/github.py
+++ b/rotkehlchen/externalapis/github.py
@@ -13,7 +13,14 @@ class Github():
         self.prefix = 'https://api.github.com/'
 
     def _query(self, path: str) -> Dict:
-        response = requests.get(f'{self.prefix}{path}')
+        """
+        May raise:
+        - RemoteError if there is a problem querying Github
+        """
+        try:
+            response = requests.get(f'{self.prefix}{path}')
+        except requests.exceptions.ConnectionError as e:
+            raise RemoteError(f'Failed to query Github: {str(e)}')
 
         if response.status_code != 200:
             raise RemoteError(


### PR DESCRIPTION
Fix #709


@kelsos Before merging this I need you or someone else to confirm this "should work". I tried v1.1.1 in my Windows 7 desktop and I could not see the problem described in #709.

Can you try and see if this is reproducible? But looking at the code the part of killing the pyproc client was indeed missing in Windows and this PR should add it and in theory fix the problem, right?

Only setback is I have not reproduced it.