### PR TITLE
If blockcypher does not work for latest block, query etherscan

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`724 major` If latest block remote query fails do not revert to etherscan but persist with using the provided ethereum node after warning the user.
 * :feature:`99987` Added support for the following tokens
 
   - `LTO Network (LTO) <https://coinmarketcap.com/currencies/lto-network/>`__

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -187,6 +187,7 @@ class Rotkehlchen():
         ethchain = Ethchain(
             ethrpc_endpoint=eth_rpc_endpoint,
             etherscan=self.etherscan,
+            msg_aggregator=self.msg_aggregator,
         )
         self.blockchain = Blockchain(
             blockchain_accounts=self.data.db.get_blockchain_accounts(),

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -84,9 +84,14 @@ def etherscan(database, messages_aggregator):
 
 
 @pytest.fixture
-def ethchain_client(ethrpc_port, etherscan):
+def ethchain_client(ethrpc_port, etherscan, messages_aggregator):
     ethrpc_endpoint = f'http://localhost:{ethrpc_port}'
-    return Ethchain(ethrpc_endpoint, etherscan=etherscan, attempt_connect=False)
+    return Ethchain(
+        ethrpc_endpoint=ethrpc_endpoint,
+        etherscan=etherscan,
+        msg_aggregator=messages_aggregator,
+        attempt_connect=False,
+    )
 
 
 def _geth_blockchain(

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -186,6 +186,11 @@ def request_get(
         handle_429: bool = False,
         backoff_in_seconds: Union[int, float] = 0,
 ) -> Union[Dict, List]:
+    """
+    May raise:
+    - UnableToDecryptRemoteData from request_get
+    - Remote error if the get request fails
+    """
     # TODO make this a bit more smart. Perhaps conditional on the type of request.
     # Not all requests would need repeated attempts
     response = retry_calls(
@@ -220,7 +225,12 @@ def request_get_direct(
         handle_429: bool = False,
         backoff_in_seconds: Union[int, float] = 0,
 ) -> str:
-    """Like request_get, but the endpoint only returns a direct value"""
+    """Like request_get, but the endpoint only returns a direct value
+
+    May raise:
+    - UnableToDecryptRemoteData from request_get
+    - Remote error if the get request fails
+    """
     return str(request_get(url, timeout, handle_429, backoff_in_seconds))
 
 
@@ -230,7 +240,12 @@ def request_get_dict(
         handle_429: bool = False,
         backoff_in_seconds: Union[int, float] = 0,
 ) -> Dict:
-    """Like request_get, but the endpoint only returns a dict"""
+    """Like request_get, but the endpoint only returns a dict
+
+    May raise:
+    - UnableToDecryptRemoteData from request_get
+    - Remote error if the get request fails
+    """
     response = request_get(url, timeout, handle_429, backoff_in_seconds)
     assert isinstance(response, Dict)
     return response


### PR DESCRIPTION
- If latest block remote query fails do not revert to etherscan but persist with using the provided ethereum node after warning the user
- Also use etherscan as a fallback after blockcypher query

Fix #724