### PR TITLE
Fix reference before assignment if blockchain balance query fails

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`726 major` Fail gracefully and don't throw a 500 server error if blockchain balance query fails.
 * :bug:`724 major` If latest block remote query fails do not revert to etherscan but persist with using the provided ethereum node after warning the user.
 * :feature:`99987` Added support for the following tokens
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -409,13 +409,12 @@ class Rotkehlchen():
                 blockchain=None,
                 ignore_cache=ignore_cache,
             )
+            balances['blockchain'] = {
+                asset: balance.to_dict() for asset, balance in blockchain_result.totals.items()
+            }
         except (RemoteError, EthSyncError) as e:
             problem_free = False
             log.error(f'Querying blockchain balances failed due to: {str(e)}')
-
-        balances['blockchain'] = {
-            asset: balance.to_dict() for asset, balance in blockchain_result.totals.items()
-        }
 
         result = self.query_fiat_balances()
         if result != {}:


### PR DESCRIPTION
Fix the reference before assignment in the case of blockchain query failure that is seen #726