### PR TITLE
Adds extra step in installation_guide.rst

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -91,12 +91,11 @@ then do::
 
     pip install -r requirements_dev.txt
 
-Now to start the application you need to type ``npm run electron:serve``.
+Since the electron application is located in a different directory you also need to do::
 
-If you get runtime errors about a Node version mismatch, you can try to rebuild the electron
-modules like this::
+    pip install -e .
 
-    ./node_modules/.bin/electron-rebuild
+Now to start the application you need to change to the ``electron-app`` directory and type ``npm run electron:serve``.
 
 OSX
 =====
@@ -154,6 +153,10 @@ then do::
    Make sure that pysqlcipher3 is properly installed. If ``$ pip freeze | grep pysqlcipher3`` returns nothing for you then it was not installed. Try to manually install only that dependency with the verbose option to see where it fails. ``$ pip install pysqlcipher3 -v``. If it fails at the stage of finding the library for ``-lsqlcipher`` then ``brew install sqlciper`` did not place the installed lib directory to the ``LIBRARY_PATH`` and you will have to do it manually. For example if ``sqlcipher`` was installed at ``/usr/local/Cellar/sqlcipher/3.4.2/`` then use pip install this way:
      ``$ LIBRARY_PATH=/usr/local/Cellar/sqlcipher/3.4.2/lib pip install pysqlcipher3``.
 
+Since the electron application is located in a different directory you also need to do::
+
+    pip install -e .
+
 Rotki uses electron, we need to install it. To do so you need ``node.js`` and ``npm``. If you don't have it use homebrew to install it::
 
     $ brew install node
@@ -162,7 +165,7 @@ Almost there, we can now install all the NodeJS dependencies. Using a recent Nod
 
     $ npm ci
 
-You can now start Rotki::
+You can now go to the ``electron-app`` directory and start Rotki::
 
     $ npm run electron:serve
 
@@ -205,17 +208,17 @@ Sqlcipher and pysqlcipher3
 
 In order to build rotki on Windows, you will need to have installed and built pysqlcipher3 (instructions on this further down) which needs sqlcipher.
 
-1. As no pre-compiled Windows binaries and dlls are readily available for sqlcipher, you will need to build it from source. `Here <https://github.com/sqlitebrowser/sqlitebrowser/wiki/Win64-setup-%E2%80%94-Compiling-SQLCipher>`__ is a good guide on how to compile SQLCipher for Windows. 
+1. As no pre-compiled Windows binaries and dlls are readily available for sqlcipher, you will need to build it from source. `Here <https://github.com/sqlitebrowser/sqlitebrowser/wiki/Win64-setup-%E2%80%94-Compiling-SQLCipher>`__ is a good guide on how to compile SQLCipher for Windows.
 2. The guide also requires you to get ``OpenSSL``. You can do that from `here <https://slproweb.com/products/Win32OpenSSL.html>`__.
 
     .. NOTE::
-        a) Because of some pysqlcipher3 dependencies, and because it most closely matches the version used in the sqlcipher build guide, you should get OpenSSL 1.0.2 and not 1.1.1 (the naming of libs and dlls has changed between versions and the building of some dependencies will fail). 
+        a) Because of some pysqlcipher3 dependencies, and because it most closely matches the version used in the sqlcipher build guide, you should get OpenSSL 1.0.2 and not 1.1.1 (the naming of libs and dlls has changed between versions and the building of some dependencies will fail).
 
         b) Get the version of OpenSSL that matches the architecture of your Windows and python installs (i.e. 32- or 64-bit)
 
-        c) When prompted for an install directory for OpenSSL, choose one that does not have spaces in it (i.e. avoid \Program Files\) as installing it in a directory with spaces will cause you numerous headaches when trying to edit the Makefile mentioned in the sqlcipher build instructions. 
+        c) When prompted for an install directory for OpenSSL, choose one that does not have spaces in it (i.e. avoid \Program Files\) as installing it in a directory with spaces will cause you numerous headaches when trying to edit the Makefile mentioned in the sqlcipher build instructions.
 
-        d) Follow the instructions in the sqlcipher build guide regarding changes to ``Makefile.msc`` very closely, ensuring that variables that point to the directory where you have actually installed OpenSSL. 
+        d) Follow the instructions in the sqlcipher build guide regarding changes to ``Makefile.msc`` very closely, ensuring that variables that point to the directory where you have actually installed OpenSSL.
 
 3. Once you have completed up to and including Step 6 in the sqlcipher build guide (you can ignore Step 7), you will have compiled sqlcipher and built the necessary headers and libraries that pysqlcipher3 depends on. In the directory you should now see ``sqlcipher.dll``, copy and paste this file to your ``<Windows>\System32`` directory. These files will be used later; you can now move on to setting up your rotki dev environment.
 
@@ -253,9 +256,13 @@ If at any time you want to dissasociate with the virtual env, you can use the co
 
     pip install -r requirements_dev.txt
 
-Pay close attention to the results of the command. Sometimes modules are reported as successfully installed but in reality the build has failed. You should carefully scroll through the buffer to ensure everything has been built & installed correct. 
+Pay close attention to the results of the command. Sometimes modules are reported as successfully installed but in reality the build has failed. You should carefully scroll through the buffer to ensure everything has been built & installed correct.
 
 At this point, it's likely that pysqlcipher3 has not been built and installed correctly, and you will need to install it manually. If pysqlcipher3 installed successfully, you can skip Steps 7 - 9 and move on to the next section.
+
+Since the electron application is located in a different directory you also need to do::
+
+    pip install -e .
 
 7. Go back to your development directory and download / clone (if you want to use git but don't want to clone the whole project, check out `degit <https://www.npmjs.com/package/degit>`_) the source for `pysqlcipher3 <https://github.com/rigglemania/pysqlcipher3>`_.
 
@@ -322,8 +329,8 @@ Microsoft Visual C++ 14.0 is required
 
 If you get::
 
-    building 'gevent.libev.corecext' extension                                                                                                                                                                                                                            
-    error: Microsoft Visual C++ 14.0 is required. Get it with "Microsoft Visual C++ Build Tools": https://visualstudio.microsoft.com/downloads/                 
+    building 'gevent.libev.corecext' extension
+    error: Microsoft Visual C++ 14.0 is required. Get it with "Microsoft Visual C++ Build Tools": https://visualstudio.microsoft.com/downloads/
 
 
 Then go `here <https://visualstudio.microsoft.com/downloads/>`__ and get the microsoft visual studio build tools and install them. The specific parts of the tools that need to be installed can be seen in `this SO answer <https://stackoverflow.com/questions/29846087/microsoft-visual-c-14-0-is-required-unable-to-find-vcvarsall-bat/49986365#49986365>`__.


### PR DESCRIPTION
- Adds info about `pip install -e .`
- Fixes whitespace issues
- Removes `electron-rebuild` step (we have no native modules since we removed the `zerorpc` and the `electron-rebuild` dependency has been removed since the rewrite)