### PR TITLE
Minor tweaks to build docs and package.bat

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -313,16 +313,8 @@ After the app is built, if everything went well you should see the below text in
 
 If you get any errors about missing dependencies, try to install them via npm and run again; consult the troubleshooting section for other errors.
 
-3. Alternatively, you can also choose to build the application. In order to do so, navigate to your rotki development directory and execute the ``package.bat`` file. NOTE: You will need to edit the directories in the batch file to point to where you built pysqlcipher3 and your rotki development directory. The relevant section of the script (`example <https://github.com/isidorosp/rotki/blob/47c92cdb0b48115fb668efe59219783efeb075ce/package.bat#L27-L30>`_) is::
-
-    Rem also for Windows we expect a pysqlcipher3 project to exist to properly
-    Rem build and install that into the venv since pip install pysqlcipher3 without
-    Rem having manually compiled sqlcipher will not work.
-    Rem Reference: https://rotki.readthedocs.io/en/latest/installation_guide.html#sqlcipher-and-pysqlcipher3
-    cd ../pysqlcipher3
-    python setup.py build
-    python setup.py install
-    cd ../rotkehlchen
+3. Alternatively, you can also choose to build the application. In order to do so, navigate to your rotki development directory and execute the ``package.bat`` file. 
+NOTE: You will need to edit the directories in the batch file to point to where you built pysqlcipher3 and your rotki development directory (`see here <https://github.com/rotki/rotki/blob/5f55522efc8faa1992b64e8b27c96ce8c844d70c/package.bat#L27-L30>`_).
 
 Troubleshooting
 ---------------

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -313,7 +313,16 @@ After the app is built, if everything went well you should see the below text in
 
 If you get any errors about missing dependencies, try to install them via npm and run again; consult the troubleshooting section for other errors.
 
-3. Alternatively, you can also choose to build the application. In order to do so, navigate to your rotki development directory and execute the ``package.bat`` file. NOTE: You will need to edit the directory in Line 30 to the name of your rotki development directory.
+3. Alternatively, you can also choose to build the application. In order to do so, navigate to your rotki development directory and execute the ``package.bat`` file. NOTE: You will need to edit the directories in the batch file to point to where you built pysqlcipher3 and your rotki development directory. The relevant section of the script (`example <https://github.com/isidorosp/rotki/blob/47c92cdb0b48115fb668efe59219783efeb075ce/package.bat#L27-L30>`_) is::
+
+    Rem also for Windows we expect a pysqlcipher3 project to exist to properly
+    Rem build and install that into the venv since pip install pysqlcipher3 without
+    Rem having manually compiled sqlcipher will not work.
+    Rem Reference: https://rotki.readthedocs.io/en/latest/installation_guide.html#sqlcipher-and-pysqlcipher3
+    cd ../pysqlcipher3
+    python setup.py build
+    python setup.py install
+    cd ../rotkehlchen
 
 Troubleshooting
 ---------------

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -184,7 +184,7 @@ Install `node (includes npm) <https://nodejs.org/en/download/>`_.
 Python
 ^^^^^^^^^^^^^^^^^^^^
 
-1. Get `python 3.7 <https://www.python.org/downloads/release/python-374/>`_ (3.7 is recommended due to some rotki dependencies). Make sure to download the 64-bit version of python if your version of Windows is 64-bit! If you're unsure of what Windows version you have, you can check in Control Panel -> System and Security -> System.
+1. Get `python 3.7 <https://www.python.org/downloads/release/python-374/>`_ (3.7 is required due to some rotki dependencies). Make sure to download the 64-bit version of python if your version of Windows is 64-bit! If you're unsure of what Windows version you have, you can check in Control Panel -> System and Security -> System.
 2. For some reason python does not always install to the Path variable in Windows. To ensure you have the necessary python directories referenced, go to Control Panel -> System -> Advanced system settings -> Advanced (tab) -> Environment Variables... In the Environment Variables... dialog under "System Varaiables" open the "Path" variable and ensure that both the root python directory as well as the ``\Scripts\`` subdirectory are included. If they are not, add them one by one by clicking "New" and then "Browse" and locating the correct directories. NOTE: By default the Windows MSI installer place python in the ``C:\Users\<username>\AppData\Local\Programs\`` directory.
 3. To test if you have entered python correctly into the Path variable, open a command prompt and type in ``python`` then hit Enter. The python cli should run and you should see the python version you installed depicted above the prompt. Press CTRL+Z, then Enter to exit.
 
@@ -260,7 +260,7 @@ Pay close attention to the results of the command. Sometimes modules are reporte
 
 At this point, it's likely that pysqlcipher3 has not been built and installed correctly, and you will need to install it manually. If pysqlcipher3 installed successfully, you can skip Steps 7 - 9 and move on to the next section.
 
-Since the electron application is located in a different directory you also need to do::
+Since the electron application is located in a different directory you also need to do (NOTE: execute this only after pysqlcipher3 has successfully installed)::
 
     pip install -e .
 
@@ -313,6 +313,7 @@ After the app is built, if everything went well you should see the below text in
 
 If you get any errors about missing dependencies, try to install them via npm and run again; consult the troubleshooting section for other errors.
 
+3. Alternatively, you can also choose to build the application. In order to do so, navigate to your rotki development directory and execute the ``package.bat`` file. NOTE: You will need to edit the directory in Line 30 to the name of your rotki development directory.
 
 Troubleshooting
 ---------------

--- a/package.bat
+++ b/package.bat
@@ -1,21 +1,25 @@
+@echo on
 Rem Perform sanity checks before pip install
 pip install packaging
 Rem We use npm ci. That needs npm >= 5.7.0
 npm --version | python -c "import sys;npm_version=sys.stdin.readlines()[0].rstrip('\n');from packaging import version;supported=version.parse(npm_version) >= version.parse('5.7.0');sys.exit(1) if not supported else sys.exit(0);"
+@echo off
 if %errorlevel% neq 0 (
    echo "package.bat - ERROR: The system's npm version is not >= 5.7.0 which is required for npm ci"
    exit /b %errorlevel%
 )
-Rem uninstall packaging package since it's no longer required
-pip uninstall -y packaging
 
+@echo on
 Rem Install the rotkehlchen package and pyinstaller. Needed by the pyinstaller
 pip install -e .
 pip install pyinstaller==3.5
+@echo off
 if %errorlevel% neq 0 (
    echo "package.bat - ERROR - Pip install step failed"
    exit /b %errorlevel%
 )
+
+@echo on
 Rem also for Windows we expect a pysqlcipher3 project to exist to properly
 Rem build and install that into the venv since pip install pysqlcipher3 without
 Rem having manually compiled sqlcipher will not work.
@@ -27,6 +31,7 @@ cd ../rotkehlchen
 
 Rem Perform sanity checks that need pip install
 python -c "import sys;from rotkehlchen.db.dbhandler import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)"
+@echo off
 if %errorlevel% neq 0 (
    echo "package.bat - ERROR: The packaging system's sqlcipher version is not >= v4"
    exit /b %errorlevel%
@@ -34,15 +39,18 @@ if %errorlevel% neq 0 (
 
 for /f %%i in ('python setup.py --version') do set ROTKEHLCHEN_VERSION=%%i
 
+@echo on
 Rem Use pyinstaller to package the python app
 IF EXIST build rmdir build /s /Q
 IF EXIST rotkehlchen_py_dist rmdir rotkehlchen_py_dist /s /Q
 pyinstaller --noconfirm --clean --distpath rotkehlchen_py_dist rotkehlchen.spec
+@echo off
 if %errorlevel% neq 0 (
    echo "package.bat - ERROR - pyinstaller step failed"
    exit /b %errorlevel%
 )
 
+@echo on
 Rem Sanity check that the generated python executable works
 FOR %%F IN (rotkehlchen_py_dist/*.exe) DO (
  set PYINSTALLER_GENERATED_EXECUTABLE=%%F
@@ -52,24 +60,30 @@ FOR %%F IN (rotkehlchen_py_dist/*.exe) DO (
 echo "%PYINSTALLER_GENERATED_EXECUTABLE%"
 
 call rotkehlchen_py_dist\%PYINSTALLER_GENERATED_EXECUTABLE% version
+@echo off
 if %errorlevel% neq 0 (
    echo "package.bat - ERROR - The generated python executable does not work properly"
    exit /b %errorlevel%
 )
 
+@echo on
 CD electron-app/
 
 Rem npm stuff
 call npm ci
+@echo off
 if %errorlevel% neq 0 (
    echo "package.bat - ERROR - npm ci step failed"
    exit /b %errorlevel%
 )
-
+@echo on
 call npm run electron:build
+
+@echo off
 if %errorlevel% neq 0 (
    echo "ERROR - npm build step failed"
    exit /b %errorlevel%
 )
+@echo on
 
 echo "SUCCESS - rotkehlchen is now packaged for windows!"

--- a/package.sh
+++ b/package.sh
@@ -11,8 +11,6 @@ if [[ $? -ne 0 ]]; then
     echo "package.sh - ERROR: The system's npm version is not >= 5.7.0 which is required for npm ci"
     exit 1
 fi
-# uninstall packaging package since it's no longer required
-pip uninstall -y packaging
 
 # Install the rotki package and pyinstaller. Needed by the pyinstaller
 pip install -e .

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -88,7 +88,7 @@ a = Entrypoint(
         ('rotkehlchen/data/token_abi.json', 'rotkehlchen/data'),
         ('rotkehlchen/data/all_assets.json', 'rotkehlchen/data'),
     ],
-    excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'],
+    excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter', 'packaging'],
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)


### PR DESCRIPTION
* Tweaks to windows build instructions
* Updates to package.bat to not uninstall ``packaging`` package (I was getting errors after running package.bat and then trying to build docs in windows+python+sphinx environment).
* Updates to package.bat so the internal batch logic is not displayed in the terminal if the .bat file is executed from the CLI (this is preferred as executing the .bat from the GUI will exit the window if it fails / errors). Internal batch logic displaying can be confusing as "error traps" are printed.