### PR TITLE
Adds loading screen while waiting for the backend

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`770 major` Adds loading screen while waiting for the backend to start.
 * :bug:`772 major` Getting a rate limit error from Etherscan should be now handled properly.
 * :feature:`-` Support TRX in kraken, since it got listed.
 

--- a/electron-app/src/App.vue
+++ b/electron-app/src/App.vue
@@ -131,16 +131,14 @@ export default class App extends Vue {
 
   async created(): Promise<void> {
     this.$api.connect(4242);
+    await this.$store.dispatch('version');
+
     ipcRenderer.on('failed', () => {
       // get notified if the python subprocess dies
       this.startupError =
         'The Python backend crashed. Check rotkehlchen.log or open an issue in Github.';
       // send ack to main.
       ipcRenderer.send('ack', 1);
-    });
-    ipcRenderer.on('connected', async () => {
-      await this.$store.dispatch('version');
-      ipcRenderer.send('ack', 2);
     });
   }
 }

--- a/electron-app/src/components/AccountManagement.vue
+++ b/electron-app/src/components/AccountManagement.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <v-overlay v-if="!connected" class="account_management__loading">
+      <v-row align="center" justify="center">
+        <v-col cols="12" class="account_management__loading__content">
+          <v-progress-circular indeterminate size="72"></v-progress-circular>
+          <span class="account_management__loading__content__text">
+            Please wait...
+          </span>
+        </v-col>
+      </v-row>
+    </v-overlay>
     <div class="account_management__privacy_notice">
       <v-alert
         id="privacy_notice__message"
@@ -16,6 +26,7 @@
       </v-alert>
     </div>
     <login
+      v-if="connected"
       :displayed="!message && !logged && !accountCreation"
       :loading="loading"
       :sync-conflict="syncConflict"
@@ -69,7 +80,7 @@ const { mapState: mapSessionState } = createNamespacedHelpers('session');
   },
   computed: {
     ...mapSessionState(['syncConflict', 'premium']),
-    ...mapState(['version', 'message']),
+    ...mapState(['version', 'message', 'connected']),
     ...mapGetters(['updateNeeded', 'message'])
   }
 })
@@ -79,6 +90,7 @@ export default class AccountManagement extends Vue {
   loading: boolean = false;
   version!: Version;
   message!: boolean;
+  connected!: boolean;
   syncConflict!: boolean;
 
   private premiumVisible = false;
@@ -147,19 +159,34 @@ export default class AccountManagement extends Vue {
 </script>
 
 <style lang="scss">
-.account_management__privacy_notice {
-  width: 100%;
-  position: absolute;
-  bottom: 20px;
-  z-index: 9999;
-  align-items: center;
-  display: flex;
-  flex-direction: column;
+.account_management {
+  &__loading {
+    &__content {
+      align-items: center;
+      justify-content: center;
+      display: flex;
+      flex-direction: column;
+      &__text {
+        margin-top: 48px;
+        font-weight: 400;
+        font-size: 26px;
+      }
+    }
+  }
+  &__privacy_notice {
+    width: 100%;
+    position: absolute;
+    bottom: 20px;
+    z-index: 9999;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
 
-  &__message {
-    text-align: center;
-    max-width: 650px;
-    font-size: 14px !important;
+    &__message {
+      text-align: center;
+      max-width: 650px;
+      font-size: 14px !important;
+    }
   }
 }
 

--- a/electron-app/src/py-handler.ts
+++ b/electron-app/src/py-handler.ts
@@ -12,7 +12,6 @@ import { assert } from '@/utils/assertions';
 export default class PyHandler {
   private static PY_DIST_FOLDER = 'rotkehlchen_py_dist';
   private rpcFailureNotifier?: any;
-  private rpcConnectedNotifier?: any;
   private childProcess?: ChildProcess;
   private _port?: number;
   private executable?: string;
@@ -59,8 +58,6 @@ export default class PyHandler {
     ipcMain.on('ack', (event, ...args) => {
       if (args[0] == 1) {
         clearInterval(this.rpcFailureNotifier);
-      } else if (args[0] == 2) {
-        clearInterval(this.rpcConnectedNotifier);
       } else {
         this.logToFile(`Warning: unknown ack code ${args[0]}`);
       }
@@ -108,7 +105,6 @@ export default class PyHandler {
       this.logToFile(
         `The Python sub-process started on port: ${port} (PID: ${childProcess.pid})`
       );
-      handler.setConnectedNotification(window);
       return;
     }
     this.logToFile('The Python sub-process was not successfully started');
@@ -118,9 +114,6 @@ export default class PyHandler {
     this.logToFile('Exiting the application');
     if (this.rpcFailureNotifier) {
       clearInterval(this.rpcFailureNotifier);
-    }
-    if (this.rpcConnectedNotifier) {
-      clearInterval(this.rpcConnectedNotifier);
     }
     if (process.platform === 'win32') {
       await this.terminateWindowsProcesses();
@@ -155,12 +148,6 @@ export default class PyHandler {
   private setFailureNotification(window: Electron.BrowserWindow) {
     this.rpcFailureNotifier = setInterval(function() {
       window.webContents.send('failed', 'failed');
-    }, 2000);
-  }
-
-  private setConnectedNotification(window: Electron.BrowserWindow) {
-    this.rpcConnectedNotifier = setInterval(function() {
-      window.webContents.send('connected', 'connected');
     }, 2000);
   }
 

--- a/electron-app/src/store/store.ts
+++ b/electron-app/src/store/store.ts
@@ -31,7 +31,8 @@ const defaultVersion = () =>
 const store: StoreOptions<RotkehlchenState> = {
   state: {
     message: emptyMessage(),
-    version: defaultVersion()
+    version: defaultVersion(),
+    connected: false
   },
   mutations: {
     setMessage: (state: RotkehlchenState, message: Message) => {
@@ -46,6 +47,7 @@ const store: StoreOptions<RotkehlchenState> = {
         latestVersion: version.latest_version || '',
         url: version.url || ''
       };
+      state.connected = true;
     }
   },
   actions: {
@@ -96,6 +98,7 @@ export interface Version {
 export interface RotkehlchenState {
   message: Message;
   version: Version;
+  connected: boolean;
   session?: SessionState;
   tasks?: TaskState;
   notifications?: NotificationState;


### PR DESCRIPTION
Closes #770

Since we now poll the version API I removed the `connected` event since this is not necessary anymore.