### PR TITLE
Fixes a minor overlay issue after logging in

### DIFF
--- a/electron-app/src/components/AccountManagement.vue
+++ b/electron-app/src/components/AccountManagement.vue
@@ -124,7 +124,7 @@ export default class AccountManagement extends Vue {
 
   upgrade() {
     shell.openExternal('https://rotki.com/products/');
-    this.dismiss();
+    this.loginComplete();
   }
 
   dismiss() {


### PR DESCRIPTION
Addresses #776 
* AccountManagement.vue - fixes an issue where clicking "Upgrade" on the Rotki Premium dialog did not dismiss the privacy notice on the bottom of the page (like "Close" does).