### PR TITLE
Fix update indicator

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`783 major` Fixes the update indicator to indicate to users if their client is out of date.
+
 * :release:`1.2.1 <2020-03-10>` 770, 772, 99986
 * :bug:`770 major` Adds loading screen while waiting for the backend to start.
 * :bug:`772 major` Getting a rate limit error from Etherscan should be now handled properly.

--- a/electron-app/src/components/status/UpdateIndicator.vue
+++ b/electron-app/src/components/status/UpdateIndicator.vue
@@ -30,7 +30,7 @@ export default class UpdateIndicator extends Vue {
   version!: Version;
 
   openLink() {
-    shell.openExternal(this.version.url);
+    shell.openExternal(this.version.downloadUrl);
   }
 }
 </script>

--- a/electron-app/src/model/version-check.ts
+++ b/electron-app/src/model/version-check.ts
@@ -1,5 +1,5 @@
 export interface VersionCheck {
   readonly our_version?: string;
   readonly latest_version?: string;
-  readonly url?: string;
+  readonly download_url?: string;
 }

--- a/electron-app/src/store/store.ts
+++ b/electron-app/src/store/store.ts
@@ -25,7 +25,7 @@ const defaultVersion = () =>
   ({
     version: '',
     latestVersion: '',
-    url: ''
+    downloadUrl: ''
   } as Version);
 
 const store: StoreOptions<RotkehlchenState> = {
@@ -45,7 +45,7 @@ const store: StoreOptions<RotkehlchenState> = {
       state.version = {
         version: version.our_version || '',
         latestVersion: version.latest_version || '',
-        url: version.url || ''
+        downloadUrl: version.download_url || ''
       };
       state.connected = true;
     }
@@ -67,8 +67,8 @@ const store: StoreOptions<RotkehlchenState> = {
   },
   getters: {
     updateNeeded: (state: RotkehlchenState) => {
-      const { version, url } = state.version;
-      return version.indexOf('dev') >= 0 ? false : !!url;
+      const { version, downloadUrl } = state.version;
+      return version.indexOf('dev') >= 0 ? false : !!downloadUrl;
     },
     version: (state: RotkehlchenState) => {
       const { version } = state.version;
@@ -92,7 +92,7 @@ export default new Vuex.Store(store);
 export interface Version {
   readonly version: string;
   readonly latestVersion: string;
-  readonly url: string;
+  readonly downloadUrl: string;
 }
 
 export interface RotkehlchenState {


### PR DESCRIPTION
Addresses #781 

Fixed `version` model in vue to match API response so that update indicator shows properly.

