### PR TITLE
Fix two bugs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -676,7 +676,7 @@ Query the current fiat currencies exchange rate
 
       {"currencies": ["EUR", "CNY", "GBP"]}
 
-   :query strings-list currencies: A comma separated list of fiat currencies to query.
+   :query strings-list currencies: A comma separated list of fiat currencies to query. e.g.: /api/1/fiat_exchange_rates?currencies=EUR,CNY,GBP
    :reqjson list currencies: A list of fiat currencies to query
 
    **Example Response**:

--- a/electron-app/src/services/rotkehlchen-api.ts
+++ b/electron-app/src/services/rotkehlchen-api.ts
@@ -649,7 +649,7 @@ export class RotkehlchenApi {
       this.axios
         .get<ActionResult<FiatExchangeRates>>('/fiat_exchange_rates', {
           params: {
-            currencies
+            currencies: currencies.join(',')
           },
           validateStatus: function(status) {
             return status == 200 || status == 400;

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -64,6 +64,18 @@ from rotkehlchen.typing import (
 )
 
 
+def _combine_data_and_view_args(data, view_args, schema) -> MultiDictProxy:
+    if view_args is not missing:
+        if data == {}:
+            data = MultiDictProxy(view_args, schema)
+        else:
+            all_data = data.to_dict() if isinstance(data, MultiDictProxy) else data
+            for key, value in view_args.items():
+                all_data[key] = value
+            data = MultiDictProxy(all_data, schema)
+    return data
+
+
 @parser.location_loader('json_and_view_args')
 def load_json_viewargs_data(request, schema):
     """Load data from a request accepting either json or view_args encoded data"""
@@ -72,14 +84,7 @@ def load_json_viewargs_data(request, schema):
     if data is missing:
         return data
 
-    # If we had any viewargs append them to the data
-    if view_args is not missing:
-        if data == {}:
-            data = MultiDictProxy(view_args, schema)
-        else:
-            for key, value in view_args.items():
-                data[key] = value
-
+    data = _combine_data_and_view_args(data, view_args, schema)
     return data
 
 
@@ -101,18 +106,10 @@ def load_json_query_viewargs_data(request, schema):
     if data is missing:
         data = parser.load_querystring(request, schema)
 
-    # if not data exists return missing
     if data is missing:
         return data
 
-    # If we had any viewargs append them to the data
-    if view_args is not missing:
-        if data == {}:
-            data = MultiDictProxy(view_args, schema)
-        else:
-            for key, value in view_args.items():
-                data[key] = value
-
+    data = _combine_data_and_view_args(data, view_args, schema)
     return data
 
 

--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -635,7 +635,12 @@ def test_blockchain_accounts_endpoint_errors(rotkehlchen_api_server, api_port, m
         api_url_for(rotkehlchen_api_server, "blockchainsaccountsresource", blockchain='ETH'),
         json=data,
     )
-    message = "'accounts': ['Not a valid list.'"
+    if method == 'GET':
+        message = "'accounts': ['Not a valid list.'"
+    elif method == 'DELETE':
+        message = 'Given value foo is not a checksummed ethereum address'
+    else:
+        message = "'accounts': {0: {'_schema': ['Invalid input type.'"
     assert_error_response(
         response=response,
         contained_in_msg=message,
@@ -1025,7 +1030,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="'accounts': ['Not a valid list",
+        contained_in_msg='Invalid input type',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -327,10 +327,21 @@ def test_exchange_query_balances_async(rotkehlchen_api_server_with_exchanges):
         outcome = wait_for_async_task(server, task_id)
     assert_binance_balances_result(outcome['result'])
 
-    # async query balances of all setup exchanges
+    # async query of one exchange with querystring parameters
     poloniex = server.rest_api.rotkehlchen.exchange_manager.connected_exchanges['poloniex']
 
     poloniex_patch = patch_poloniex_balances_query(poloniex)
+    with binance_patch:
+        response = requests.get(api_url_for(
+            server,
+            "named_exchanges_balances_resource",
+            name='binance',
+        ) + '?async_query=true')
+        task_id = assert_ok_async_response(response)
+        outcome = wait_for_async_task(server, task_id)
+    assert_poloniex_balances_result(outcome['result'])
+
+    # async query balances of all setup exchanges
     with binance_patch, poloniex_patch:
         response = requests.get(
             api_url_for(server, "exchangebalancesresource"),

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -331,11 +331,11 @@ def test_exchange_query_balances_async(rotkehlchen_api_server_with_exchanges):
     poloniex = server.rest_api.rotkehlchen.exchange_manager.connected_exchanges['poloniex']
 
     poloniex_patch = patch_poloniex_balances_query(poloniex)
-    with binance_patch:
+    with poloniex_patch:
         response = requests.get(api_url_for(
             server,
             "named_exchanges_balances_resource",
-            name='binance',
+            name='poloniex',
         ) + '?async_query=true')
         task_id = assert_ok_async_response(response)
         outcome = wait_for_async_task(server, task_id)


### PR DESCRIPTION
Bug1: All GET endpoint calls with viewargs via the front-end that used querystring parameters (and not json encoded data) would fail due to a problem in the way we used `MultiDictProxy`.

Bug2: Upgrading to webargs 6 uncovered that the way the frontend was calling the `fiat_exchange_rates` API was very wrong.