### PR TITLE
Move psutil to dev requirements and bump to v5.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ requests==2.20.0
 pycryptodome==3.6.6
 pycryptodomex==3.6.6
 coincurve==13.0.0
-psutil==5.4.3
 typing-extensions==3.7.4
 base58check==1.0.2
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,5 +4,6 @@
 pytest==5.2.4
 bump2version==0.5.8
 pytest-cov==2.7.1
+psutil==5.7.0
 
 -r requirements_docs.txt


### PR DESCRIPTION
Move it to dev-requirements since it's only used in tests.
Bump due to https://github.com/advisories/GHSA-qfc5-mcwq-26q8