### PR TITLE
OSX Users can now exit by pressing [X]

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-
+* :feature:`779` OSX: User can now exit the application by simply pressing [X]
 * :bug:`794` If etherscan rate limits the user it should now be handled correctly after their new changes ... again
 * :feature:`643` Rotki will now autodetect the tokens owned by each of your ethereum accounts. Integration with alethio is possible, and you can add an Alethio API key.
 * :bug:`790 major` SegWit addresses (Bech32) can now be added to BTC balances.

--- a/electron-app/src/background.ts
+++ b/electron-app/src/background.ts
@@ -88,11 +88,7 @@ function createWindow() {
 }
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
     app.quit();
-  }
 });
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the


### PR DESCRIPTION
Fix #779 