### PR TITLE
Adds script to start python backend using temp directory

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -5,7 +5,7 @@
   "author": "Lefteris Karapetsas",
   "scripts": {
     "serve": "vue-cli-service serve",
-    "serve:backend": "python -m rotkehlchen --api-port 4242 --api-cors http://localhost:8080",
+    "serve:backend": "node start-backend.js",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",

--- a/electron-app/start-backend.js
+++ b/electron-app/start-backend.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+const tmpDir = os.tmpdir();
+let tempPath = path.join(tmpDir, 'rotki');
+
+process.stdout.write(`Using ${tempPath} to start tests`);
+
+if (!fs.existsSync(tempPath)) {
+  fs.mkdirSync(tempPath);
+} else {
+  const contents = fs.readdirSync(tempPath);
+  contents.forEach(name => {
+    const currentPath = path.join(tempPath, name);
+    if (fs.statSync(currentPath).isDirectory()) {
+      fs.rmdirSync(currentPath, { recursive: true });
+    }
+  });
+}
+
+const args = [
+  '-m',
+  'rotkehlchen',
+  '--api-port',
+  '4242',
+  '--api-cors',
+  'http://localhost:8080',
+  '--data-dir',
+  tempPath
+];
+
+spawn('python', args);


### PR DESCRIPTION
The reason behind doing it in a script is that I wanted to not limit the code only to unix.

The script will create a `rotki` folder under `tmp` and then it will pass it to the python process as a data dir argument.

On each start it will delete all previous folders.