### PR TITLE
Deprecates currency.icon and replaces with currency.unicode_symbol

### DIFF
--- a/electron-app/src/components/CurrencyDropDown.vue
+++ b/electron-app/src/components/CurrencyDropDown.vue
@@ -2,7 +2,7 @@
   <v-menu transition="slide-y-transition" bottom>
     <template #activator="{ on }">
       <v-btn class="currency-dropdown" color="primary" dark icon text v-on="on">
-        <v-icon :class="currency.icon"> fa {{ currency.icon }} </v-icon>
+        {{ currency.unicode_symbol }}
       </v-btn>
     </template>
     <v-list>
@@ -12,8 +12,8 @@
         :key="currency.ticker_symbol"
         @click="onSelected(currency)"
       >
-        <v-list-item-avatar>
-          <v-icon color="primary">fa {{ currency.icon }}</v-icon>
+        <v-list-item-avatar class="currency-list primary--text">
+          {{ currency.unicode_symbol }}
         </v-list-item-avatar>
         <v-list-item-content>
           <v-list-item-title>
@@ -69,12 +69,12 @@ export default class CurrencyDropDown extends Vue {
 </script>
 
 <style scoped lang="scss">
-.fa-cad:before,
-.fa-aud:before,
-.fa-nzd:before,
-.fa-hkd:before,
-.fa-ars:before,
-.fa-mxn:before {
-  content: '\f155';
+.currency-dropdown {
+  font-size: 1.6em;
+  font-weight: bold;
+}
+.currency-list {
+  font-size: 2em;
+  font-weight: bold;
 }
 </style>

--- a/electron-app/src/components/dashboard/ExchangeBox.vue
+++ b/electron-app/src/components/dashboard/ExchangeBox.vue
@@ -25,9 +25,9 @@
               | formatPrice(floatingPrecision)
           }}
         </span>
-        <v-icon color="white" class="exchange-box__amount__currency">
-          fa {{ currency.icon }}
-        </v-icon>
+        <span class="exchange-box__currency__symbol">
+          {{ currency.unicode_symbol }}
+        </span>
       </v-col>
     </v-row>
     <v-row align="center" class="exchange-box__footer">
@@ -101,6 +101,10 @@ export default class ExchangeBox extends Vue {
 }
 </script>
 <style scoped lang="scss">
+.exchange-box__currency__symbol {
+  font-size: 2em;
+}
+
 .exchange-box__icon {
   margin-left: 8px;
   width: 45px;

--- a/electron-app/src/components/dashboard/InformationBox.vue
+++ b/electron-app/src/components/dashboard/InformationBox.vue
@@ -18,9 +18,9 @@
               | formatPrice(floatingPrecision)
           }}
         </span>
-        <v-icon color="white" class="information-box__amount__currency">
-          fa {{ currency.icon }}
-        </v-icon>
+        <span class="information-box__currency__symbol">
+          {{ currency.unicode_symbol }}
+        </span>
       </v-col>
     </v-row>
     <v-row
@@ -91,6 +91,10 @@ export default class InformationBox extends Vue {
 </script>
 
 <style scoped lang="scss">
+.information-box__currency__symbol {
+  font-size: 2em;
+}
+
 .information-box {
   min-height: 72px;
 }

--- a/electron-app/src/data/currencies.ts
+++ b/electron-app/src/data/currencies.ts
@@ -1,14 +1,14 @@
 import { Currency } from '@/model/currency';
 
 export const currencies: Currency[] = [
-  new Currency('United States Dollar', 'fa-usd', 'USD', '$'),
-  new Currency('Euro', 'fa-eur', 'EUR', '€'),
-  new Currency('British Pound', 'fa-gbp', 'GBP', '£'),
-  new Currency('Japanese Yen', 'fa-jpy', 'JPY', '¥'),
-  new Currency('Chinese Yuan', 'fa-jpy', 'CNY', '¥'),
-  new Currency('Korean Won', 'fa-krw', 'KRW', '₩'),
-  new Currency('Canadian Dollar', 'fa-cad', 'CAD', '$'),
-  new Currency('Russian Ruble', 'fa-rub', 'RUB', '₽'),
-  new Currency('South African Rand', 'fa-money', 'ZAR', 'R'),
-  new Currency('Turkish Lira', 'fa-try', 'TRY', '₺')
+  new Currency('United States Dollar', 'USD', '$'),
+  new Currency('Euro', 'EUR', '€'),
+  new Currency('British Pound', 'GBP', '£'),
+  new Currency('Japanese Yen', 'JPY', '¥'),
+  new Currency('Chinese Yuan', 'CNY', '¥'),
+  new Currency('Korean Won', 'KRW', '₩'),
+  new Currency('Canadian Dollar', 'CAD', '$'),
+  new Currency('Russian Ruble', 'RUB', '₽'),
+  new Currency('South African Rand', 'ZAR', 'R'),
+  new Currency('Turkish Lira', 'TRY', '₺')
 ];

--- a/electron-app/src/model/currency.ts
+++ b/electron-app/src/model/currency.ts
@@ -1,7 +1,6 @@
 export class Currency {
   constructor(
     readonly name: string,
-    readonly icon: string,
     readonly ticker_symbol: string,
     readonly unicode_symbol: string
   ) {}


### PR DESCRIPTION
This commit fixes Issue #818 

* Removed property Currency.icon & associated references (currency.ts, *.vue)
* Fixed related front-end elements previously referencing Currency.icon with to use Currency.unicode_symbol (*.vue)
* Modified currencies master data to remove initialization of deprecated property currency.icon (currencies.ts)
* Added some minor css classes/stylings to make the symbols look like the previous icons (*.vue)

--------------
Notes:
* ❗️ We seem to be using the npm module `cryptocurrency-icons` for (at least) the data tables in the All Balances section. _This functionality was not replaced in this commit_. We should see how many fiat currencies this module supports and determine whether we should replace this (in the case of fiat currencies) with something else.

--------------
**Before and After comparisons** (note: I used 1.2.1 to do the "before" screenshots, hence why currencies are not the same)
_Currency selector_
Before
![image](https://user-images.githubusercontent.com/27592/78503670-67ccca80-7768-11ea-8097-80282223bb86.png)

After
![image](https://user-images.githubusercontent.com/27592/78503672-68fdf780-7768-11ea-91d4-d2da2b3890b1.png)

_Currency List_
Before
![image](https://user-images.githubusercontent.com/27592/78503699-92b71e80-7768-11ea-9aa1-2b782f063c84.png)

After
![image](https://user-images.githubusercontent.com/27592/78503701-93e84b80-7768-11ea-91f8-c1218c2e3345.png)

_"Bank" Fiat Balances_ (the currency on the right of the big summarized amount with brown background)
Before
![image](https://user-images.githubusercontent.com/27592/78503727-bbd7af00-7768-11ea-8620-9022494d8f0a.png)

After
![image](https://user-images.githubusercontent.com/27592/78503731-bed29f80-7768-11ea-88cc-ce9c65481d9c.png)

_Exchange Fiat Balances_
:x:
I don't have any data to test this, can someone confirm it looks OK?