### PR TITLE
Introduces Github Actions CI

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -1,0 +1,99 @@
+name: Rotki CI
+
+on: [push, pull_request]
+
+jobs:
+  lint-frontend:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [12.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        working-directory: ./electron-app
+        run: npm ci
+      - name: Lint
+        working-directory: ./electron-app
+        run: npm run lint:check
+      - name: Build
+        working-directory: ./electron-app
+        run: npm run build
+      - name: Run unit tests
+        working-directory: ./electron-app
+        run: npm run test:unit
+  lint-backend:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_lint.txt
+          pip install -e .
+          git rev-parse HEAD
+      - name: Lint
+        run: make lint
+
+  test-backend:
+    env:
+      CI: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7]
+        node-version: [12.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Geth
+        run: |
+          .travis/download_geth.sh ${{ matrix.os }}
+          echo "::add-path::$HOME/.bin"
+        env:
+          GETH_URL_LINUX: https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.13-225171a4.tar.gz
+          GETH_URL_MACOS: https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.8.13-225171a4.tar.gz
+          GETH_VERSION: 1.8.13
+      - name: Setup SQLCipher
+        run: |
+          if [ ${{ matrix.os }} == 'ubuntu-latest' ];
+          then
+            sudo apt-get install libxml2-utils
+            ./install_deps.sh
+            sudo ldconfig
+          fi
+          if [ ${{ matrix.os }} == 'macos-latest' ];
+          then
+            brew install sqlcipher
+          fi
+      - name: Set up python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade "pip<19.0.0" wheel
+          pip install pytest-travis-fold codecov pytest-cov
+          pip install -r requirements_dev.txt
+          pip install -e .
+      - name: Run Test
+        run: |
+          COVERAGE_ARGS='--cov=./ --travis-fold=always'
+          if [ ${{ matrix.os }} == 'macos-latest' ];
+          then
+            COVERAGE_ARGS=''
+          fi
+          python pytestgeventwrapper.py $COVERAGE_ARGS rotkehlchen/tests
+

--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: make lint
 
   test-backend:
+    needs: lint-backend
     env:
       CI: true
     strategy:
@@ -126,11 +127,12 @@ jobs:
           python pytestgeventwrapper.py $COVERAGE_ARGS rotkehlchen/tests
   test-integration:
     if: "contains(github.event.head_commit.message, '[ui tests]')"
+    needs: [lint-frontend, test-backend]
     env:
       CI: true
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.7]
         node-version: [12.x]
     runs-on: ${{ matrix.os }}
@@ -138,6 +140,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up python
         uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
       - uses: actions/cache@v1
         if: startsWith(runner.os, 'Linux')
         with:
@@ -187,6 +191,7 @@ jobs:
       - name: Setup backend
         run: |
           pip install -r requirements.txt
+          pip install -e .
       - name: Run integration tests
         working-directory: ./electron-app
         run: |
@@ -202,3 +207,59 @@ jobs:
         with:
           name: videos-${{ runner.os }}
           path: ./electron-app/tests/e2e/videos
+  package:
+    needs: test-backend
+    if: startsWith(github.event.ref, 'refs/tags')
+    env:
+      CI: true
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7]
+        node-version: [12.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Setup SQLCipher
+        run: |
+          if [ ${{ matrix.os }} == 'ubuntu-latest' ];
+          then
+            sudo apt-get install libxml2-utils
+            ./install_deps.sh
+            sudo ldconfig
+          fi
+          if [ ${{ matrix.os }} == 'macos-latest' ];
+          then
+            brew install sqlcipher
+          fi
+      - name: Package
+        run: ./package.sh

--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -15,6 +15,19 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
       - name: Install dependencies
         working-directory: ./electron-app
         run: npm ci
@@ -82,6 +95,21 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.7'
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           pip install --upgrade "pip<19.0.0" wheel
@@ -96,4 +124,11 @@ jobs:
             COVERAGE_ARGS=''
           fi
           python pytestgeventwrapper.py $COVERAGE_ARGS rotkehlchen/tests
-
+      - id: log
+        run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
+      - name: integration tests
+        if: "!contains(steps.log.outputs.message, '[ui tests]')"
+        working-directory: ./electron-app
+        run: |
+          npm ci
+          npm run test:integration-ci

--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -124,11 +124,81 @@ jobs:
             COVERAGE_ARGS=''
           fi
           python pytestgeventwrapper.py $COVERAGE_ARGS rotkehlchen/tests
-      - id: log
-        run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
-      - name: integration tests
-        if: "!contains(steps.log.outputs.message, '[ui tests]')"
+  test-integration:
+    if: "contains(github.event.head_commit.message, '[ui tests]')"
+    env:
+      CI: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7]
+        node-version: [12.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python
+        uses: actions/setup-python@v1
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Setup SQLCipher
+        run: |
+          if [ ${{ matrix.os }} == 'ubuntu-latest' ];
+          then
+            sudo apt-get install libxml2-utils
+            ./install_deps.sh
+            sudo ldconfig
+          fi
+          if [ ${{ matrix.os }} == 'macos-latest' ];
+          then
+            brew install sqlcipher
+          fi
+      - name: Setup backend
+        run: |
+          pip install -r requirements.txt
+      - name: Run integration tests
         working-directory: ./electron-app
         run: |
           npm ci
           npm run test:integration-ci
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: screenshots-${{ runner.os }}
+          path: ./electron-app/tests/e2e/screenshots
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: videos-${{ runner.os }}
+          path: ./electron-app/tests/e2e/videos

--- a/.travis/download_geth.sh
+++ b/.travis/download_geth.sh
@@ -40,7 +40,17 @@ warn() {
     fi
 }
 
-if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+    if [[ "$1" == "macos-latest" ]]; then
+        OS_NAME="osx"
+    else
+        OS_NAME=""
+    fi
+else
+    OS_NAME=${TRAVIS_OS_NAME}
+fi
+
+if [[ "${OS_NAME}" == "osx" ]]; then
     GETH_URL=${GETH_URL_MACOS}
 else
     GETH_URL=${GETH_URL_LINUX}
@@ -49,7 +59,7 @@ fi
 [ -z "${GETH_URL}" ] && fail 'missing GETH_URL'
 [ -z "${GETH_VERSION}" ] && fail 'missing GETH_VERSION'
 
-if [ ! -x $HOME/.bin/geth-${GETH_VERSION}-${TRAVIS_OS_NAME} ]; then
+if [ ! -x $HOME/.bin/geth-${GETH_VERSION}-${OS_NAME} ]; then
     mkdir -p $HOME/.bin
 
     TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'gethtmp')
@@ -58,7 +68,7 @@ if [ ! -x $HOME/.bin/geth-${GETH_VERSION}-${TRAVIS_OS_NAME} ]; then
     tar xzf geth.tar.gz
 
     cd geth*/
-    install -m 755 geth $HOME/.bin/geth-${GETH_VERSION}-${TRAVIS_OS_NAME}
+    install -m 755 geth $HOME/.bin/geth-${GETH_VERSION}-${OS_NAME}
 
     success "geth ${GETH_VERSION} installed"
 else
@@ -68,4 +78,4 @@ fi
 # always recreate the symlink since we dont know if it's pointing to a different
 # version
 [ -h $HOME/.bin/geth ] && unlink $HOME/.bin/geth
-ln -s $HOME/.bin/geth-${GETH_VERSION}-${TRAVIS_OS_NAME} $HOME/.bin/geth
+ln -s $HOME/.bin/geth-${GETH_VERSION}-${OS_NAME} $HOME/.bin/geth

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -45,7 +45,7 @@ def _handle_killed_greenlets(greenlet: gevent.Greenlet) -> None:
 
 
 @pytest.mark.skipif(
-    'TRAVIS' in os.environ,
+    'CI' in os.environ,
     reason='no real etherscan tests in Travis yet due to API key',
 )
 def test_maximum_rate_limit_reached(temp_etherscan):

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -25,7 +25,7 @@ def data_dir(use_clean_caching_directory, tmpdir_factory) -> Path:
         return Path(tmpdir_factory.mktemp('test_data_dir'))
 
     home = os.path.expanduser("~")
-    if 'TRAVIS' in os.environ:
+    if 'CI' in os.environ:
         data_directory = os.path.join(home, '.cache', '.rotkehlchen-test-dir')
     else:
         data_directory = os.path.join(home, '.rotkehlchen', 'tests_data_directory')

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -12,7 +12,7 @@ from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
 
 @pytest.mark.skipif(
-    'TRAVIS' in os.environ,
+    'CI' in os.environ,
     reason='some of these APIs frequently become unavailable',
 )
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -26,7 +26,7 @@ def test_query_realtime_price_apis(inquirer):
 
 
 @pytest.mark.skipif(
-    'TRAVIS' in os.environ,
+    'CI' in os.environ,
     reason='some of these APIs frequently become unavailable',
 )
 @pytest.mark.parametrize('use_clean_caching_directory', [True])


### PR DESCRIPTION
Testing out #809

It should include all the functionality that is currently in the Travis configuration
- Lint backend
- Lint/test/build frontend
- Test backend on Linux/OSX
- Test integration on Linux only (same issues here as with travis on OSX)
- Packaging on tag (tested that the build happens)

A successful run here: https://github.com/kelsos/rotki/actions/runs/72906412
The time is because some tests kept failing and I was restarting.

We can enable it as an experiment, but not require it and see if it makes sense to move to it or not.