### PR TITLE
Adding/removing blockchain accounts without an etherscan key is now handled properly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`852` PUT or DELETE on ``/api/1/blockchains/eth`` without etherscan keys configured no longer results in 500 internal server error.
 * :feature:`862` Added a new API endpoint ``/api/1/ping`` as quick way to query API status for client/frontend initialization.
 * :feature:`860` Added a new API endpoint ``/api/1/assets/all`` to query information about all supported assets.
 * :bug:`848` Querying ``/api/1/balances/blockchains/btc`` with no BTC accounts tracked no longer results in a 500 Internal server error.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1141,7 +1141,7 @@ class RestAPI():
         except TagConstraintError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.CONFLICT}
         except RemoteError as e:
-            return {'result': None, 'message': str(e), 'status_code:': HTTPStatus.BAD_GATEWAY}
+            return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_GATEWAY}
 
         # success
         return {'result': result.serialize(), 'message': ''}
@@ -1211,7 +1211,7 @@ class RestAPI():
         except InputError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_REQUEST}
         except RemoteError as e:
-            return {'result': None, 'message': str(e), 'status_code:': HTTPStatus.BAD_GATEWAY}
+            return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_GATEWAY}
 
         return {'result': result.serialize(), 'message': ''}
 

--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -540,6 +540,46 @@ def test_add_blockchain_accounts(
     )
 
 
+@pytest.mark.parametrize('include_etherscan_key', [False])
+def test_add_blockchain_accounts_synchronously_no_etherscan(rotkehlchen_api_server):
+    """Make sure that adding an ethereum blockchain account without etherscan key returns error
+
+    Regression test for https://github.com/rotki/rotki/issues/852
+    """
+    response = requests.put(api_url_for(
+        rotkehlchen_api_server,
+        "blockchainsaccountsresource",
+        blockchain='ETH',
+    ), json={'accounts': [{'address': make_ethereum_address()}]})
+    assert_error_response(
+        response=response,
+        contained_in_msg='Etherscan has introduced compulsory API keys.',
+        status_code=HTTPStatus.BAD_GATEWAY,
+    )
+
+
+@pytest.mark.parametrize('include_etherscan_key', [False])
+@pytest.mark.parametrize('number_of_eth_accounts', [2])
+def test_remove_blockchain_accounts_synchronously_no_etherscan(
+        rotkehlchen_api_server,
+        ethereum_accounts,
+):
+    """Make sure that removing an ethereum blockchain account without etherscan key returns error
+
+    Regression test for https://github.com/rotki/rotki/issues/852
+    """
+    response = requests.delete(api_url_for(
+        rotkehlchen_api_server,
+        "blockchainsaccountsresource",
+        blockchain='ETH',
+    ), json={'accounts': [ethereum_accounts[0]]})
+    assert_error_response(
+        response=response,
+        contained_in_msg='Etherscan has introduced compulsory API keys.',
+        status_code=HTTPStatus.BAD_GATEWAY,
+    )
+
+
 @pytest.mark.parametrize('number_of_eth_accounts', [2])
 @pytest.mark.parametrize('btc_accounts', [[UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2]])
 @pytest.mark.parametrize('owned_eth_tokens', [[A_RDN]])


### PR DESCRIPTION
Fix #852