### PR TITLE
Partially implemented custom menu bar

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@ Changelog
 =========
 
 * :bug:`852` PUT or DELETE on ``/api/1/blockchains/eth`` without etherscan keys configured no longer results in 500 internal server error.
+* :feature:`869` Added some customized menu items to the applciation menu. Users can now access the `Usage Guide`, `FAQ`, `Issues & Feature Requests`, and `Logs Directory` from within the Help menu. Additionally, there is a `Get Premium` menu item for quick access to the rotki.com premium site. Finally, both backend and frontend logs (``rotkehlchen.log`` and ``rotki-electron.log`` respectively) are now found in these standard locations per OS:
+
+  * Linux: ``~/config/rotki/logs``
+  * OSX: ``~/Library/Application Support/rotki/logs``
+  * Windows: ``<WindowsDrive>:\Users\<User>\Roaming\rotki\logs\``
 * :feature:`862` Added a new API endpoint ``/api/1/ping`` as quick way to query API status for client/frontend initialization.
 * :feature:`860` Added a new API endpoint ``/api/1/assets/all`` to query information about all supported assets.
 * :bug:`848` Querying ``/api/1/balances/blockchains/btc`` with no BTC accounts tracked no longer results in a 500 Internal server error.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,9 +3,9 @@ Changelog
 =========
 
 * :bug:`852` PUT or DELETE on ``/api/1/blockchains/eth`` without etherscan keys configured no longer results in 500 internal server error.
-* :feature:`869` Added some customized menu items to the applciation menu. Users can now access the `Usage Guide`, `FAQ`, `Issues & Feature Requests`, and `Logs Directory` from within the Help menu. Additionally, there is a `Get Premium` menu item for quick access to the rotki.com premium site. Finally, both backend and frontend logs (``rotkehlchen.log`` and ``rotki-electron.log`` respectively) are now found in these standard locations per OS:
+* :feature:`869` The application menu now has some customized menu items. Users can now access the `Usage Guide`, `FAQ`, `Issues & Feature Requests`, and `Logs Directory` from within the Help menu. Additionally, there is a `Get Rotki Premium` menu item for easy access to the premium subscription purchase page. Finally, both backend and frontend logs (``rotkehlchen.log`` and ``rotki-electron.log`` respectively) are now found in these standard locations per OS:
 
-  * Linux: ``~/config/rotki/logs``
+  * Linux: ``~/.config/rotki/logs``
   * OSX: ``~/Library/Application Support/rotki/logs``
   * Windows: ``<WindowsDrive>:\Users\<User>\Roaming\rotki\logs\``
 * :feature:`862` Added a new API endpoint ``/api/1/ping`` as quick way to query API status for client/frontend initialization.

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -41,7 +41,7 @@ If your OSX version does not allow you to open the application you will have to 
 Troubleshooting
 ----------------
 
-If you get a problem when starting the application or during its usage please open an issue in Github and include all logs that can be found in ``~/Library/Logs/rotki``.
+If you get a problem when starting the application or during its usage please open an issue in Github and include all logs that can be found in ``~/Library/Application Support/rotki/logs``.
 
 
 Windows
@@ -56,7 +56,7 @@ Troubleshooting
 
 If you get "The python backend crashed" or any other error please run the executable via the Command Prompt. Then provide us with the output that is visible in the prompt and this will help us debug your issue.
 
-You should also include all logs that can be found in ``%APPDATA%/rotki/``.
+You should also include all logs that can be found in ``<WindowsDrive>:\Users\<User>\Roaming\rotki\logs\`` (``%APPDATA%\rotki\logs``).
 
 
 Build from Source

--- a/electron-app/src/components/AccountManagement.vue
+++ b/electron-app/src/components/AccountManagement.vue
@@ -113,6 +113,7 @@ export default class AccountManagement extends Vue {
     this.loading = false;
     if (this.logged) {
       this.showPremiumDialog();
+      this.showGetPremiumButton();
     }
   }
 
@@ -148,6 +149,10 @@ export default class AccountManagement extends Vue {
       return;
     }
     this.premiumVisible = true;
+  }
+
+  private showGetPremiumButton() {
+    this.$interop.premiumUserLoggedIn(this.premium);
   }
 
   closeUpdateDialog() {

--- a/electron-app/src/electron-interop.ts
+++ b/electron-app/src/electron-interop.ts
@@ -31,6 +31,10 @@ export class ElectronInterop {
     window.interop?.openUrl(url);
   }
 
+  premiumUserLoggedIn(premiumUser: boolean) {
+    window.interop?.premiumUserLoggedIn(premiumUser);
+  }
+
   closeApp() {
     window.interop?.closeApp();
   }

--- a/electron-app/src/preload.ts
+++ b/electron-app/src/preload.ts
@@ -14,6 +14,7 @@ contextBridge.exposeInMainWorld('interop', {
   closeApp: () => ipcRenderer.send('CLOSE_APP'),
   openFile: (title: string) => ipcAction('OPEN_FILE', title),
   openDirectory: (title: string) => ipcAction('OPEN_DIRECTORY', title),
+  premiumUserLoggedIn: (premiumUser: boolean) => ipcRenderer.send('PREMIUM_USER_LOGGED_IN', premiumUser),
   listenForErrors: (callback: () => void) => {
     ipcRenderer.on('failed', () => {
       callback();

--- a/electron-app/src/preload.ts
+++ b/electron-app/src/preload.ts
@@ -14,7 +14,8 @@ contextBridge.exposeInMainWorld('interop', {
   closeApp: () => ipcRenderer.send('CLOSE_APP'),
   openFile: (title: string) => ipcAction('OPEN_FILE', title),
   openDirectory: (title: string) => ipcAction('OPEN_DIRECTORY', title),
-  premiumUserLoggedIn: (premiumUser: boolean) => ipcRenderer.send('PREMIUM_USER_LOGGED_IN', premiumUser),
+  premiumUserLoggedIn: (premiumUser: boolean) =>
+    ipcRenderer.send('PREMIUM_USER_LOGGED_IN', premiumUser),
   listenForErrors: (callback: () => void) => {
     ipcRenderer.on('failed', () => {
       callback();

--- a/electron-app/src/py-handler.ts
+++ b/electron-app/src/py-handler.ts
@@ -21,13 +21,8 @@ export default class PyHandler {
   }
 
   constructor(private app: App) {
-    if (process.platform === 'linux') {
-      app.setAppLogsPath(path.join(app.getPath('appData'), 'rotki', 'logs'));
-      this.logsPath = app.getPath('logs');
-    } else {
-      app.setAppLogsPath();
-      this.logsPath = app.getPath('logs');
-    }
+    app.setAppLogsPath(path.join(app.getPath('appData'), 'rotki', 'logs'));
+    this.logsPath = app.getPath('logs');
     this.ELECTRON_LOG_PATH = path.join(this.logsPath, 'rotki_electron.log');
     fs.writeFileSync(
       this.ELECTRON_LOG_PATH,
@@ -163,6 +158,8 @@ export default class PyHandler {
     if (this._corsURL) {
       defaultArgs.push('--api-cors', this._corsURL);
     }
+
+    defaultArgs.push('--logfile', path.join(this.logsPath, 'rotkehlchen.log'));
 
     if (process.env.ROTKEHLCHEN_ENVIRONMENT === 'test') {
       let tempPath = path.join(this.app.getPath('temp'), 'rotkehlchen');

--- a/electron-app/src/types.d.ts
+++ b/electron-app/src/types.d.ts
@@ -4,6 +4,7 @@ export interface Interop {
   listenForErrors(callback: () => void): void;
   openFile(title: string): Promise<undefined | string>;
   openDirectory(title: string): Promise<undefined | string>;
+  premiumUserLoggedIn(premiumUser: boolean): Promise<undefined | boolean>;
 }
 
 declare global {


### PR DESCRIPTION
* Partially addresses issue #864
* Should provide a basic menu (File, Edit, View, Help) that works for all OSes, with necessary cut/copy/paste functionality retained for macs.
* Got rid of "Window" menu item which didn't offer much.
* Replaced all electron-related items in Help with Rotki-related items

❔ We probably want a "Upgrade to premium" menu item somewhere, where should it go?

🆘 **_Non-windows functionality tests:_**
**Mac**
- Do cut/copy/paste still work?
- Do all the relevant menus show up? (File | Edit | View | Help)
- Do the Hide / Hide Others menu options work properly? I recall we had an issue where sometimes closing/hiding the app on mac didn't have the desired effect.

**Linux & Mac**
Does Help -> Logs directory work?

📝 **_Notes:_**
Why do we do this weird thing? 
https://github.com/rotki/rotki/compare/develop...isidorosp:workon_864?expand=1#diff-5520b8846598fb030a7d825b5c58c7b4R189
```
const menuTemplate: MenuItemConstructorOptions[] = defaultMenuTemplate as MenuItemConstructorOptions[];
```
If you try to cast `defaultMenuTemplate` to `MenuItemConstructorOptions[]` when defining it, typescript gives you an error that it doesn't match the interface (this is because of the `...(isMac)` spreading). If we assign it once it's computed, there's no issue.

Comments/suggestions for other items welcome!