### PR TITLE
Fix flakiness in test_premium.py::test_upload_data_to_server

### DIFF
--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -65,10 +65,10 @@ def test_upload_data_to_server(rotkehlchen_instance, username, db_password):
         saved_data='foo',
     )
 
+    now = ts_now()
     with patched_get, patched_put:
         rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server()
 
-    now = ts_now()
     last_ts = rotkehlchen_instance.data.db.get_last_data_upload_ts()
     msg = 'The last data upload timestamp should have been saved in the db as now'
     assert last_ts >= now and last_ts - now < 50, msg


### PR DESCRIPTION
Fix #856

The test was taking the `now` timestamp after the action where the
time comparison should happen. So it was only passing if the action
took less than a second.

It failed for anything else. The intended usage of the test was to
take the `now` BEFORE the action occured.

Now it should no longer be flaky