### PR TITLE
Handle access permissions in given data dir or database file. Also flaky test fix

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,7 +146,7 @@ Handling user creation, sign-in, log-out and querying
    :resjson object result: For succesful requests, result contains the currently connected exchanges, and the user's settings. For details on the user settings refer to the `Getting or modifying settings`_ section.
    :statuscode 200: Adding the new user was succesful
    :statuscode 400: Provided JSON is in some way malformed
-   :statuscode 409: User already exists. Another user is already logged in. Given Premium API credentials are invalid.
+   :statuscode 409: User already exists. Another user is already logged in. Given Premium API credentials are invalid. Permission error while trying to access the directory where Rotki saves data.
    :statuscode 500: Internal Rotki error
 
 .. http:patch:: /api/(version)/users/(username)
@@ -207,7 +207,7 @@ Handling user creation, sign-in, log-out and querying
    :statuscode 300: Possibility of syncing exists and the login was sent with sync_approval set to ``"unknown"``. Consumer of api must resend with ``"yes"`` or ``"no"``.
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 401: Provided password is wrong for the user or some other authentication error.
-   :statuscode 409: Another user is already logged in. User does not exist. There was a fatal error during the upgrade of the DB.
+   :statuscode 409: Another user is already logged in. User does not exist. There was a fatal error during the upgrade of the DB. Permission error while trying to access the directory where Rotki saves data.
    :statuscode 500: Internal Rotki error
 
 .. http:patch:: /api/(version)/users/(username)

--- a/rotkehlchen/__main__.py
+++ b/rotkehlchen/__main__.py
@@ -1,7 +1,8 @@
 from gevent import monkey  # isort:skip # noqa
 monkey.patch_all()  # isort:skip # noqa
-
 import logging
+
+from rotkehlchen.errors import SystemPermissionError
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,9 @@ def main() -> None:
     from rotkehlchen.server import RotkehlchenServer
     try:
         rotkehlchen_server = RotkehlchenServer()
+    except SystemPermissionError as e:
+        print(f'ERROR at initialization: {str(e)}')
+        sys.exit(1)
     except SystemExit as e:
         # Mypy here thinks e.code is always None which is not correct according to the docs:
         # https://docs.python.org/3/library/exceptions.html#SystemExit

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -33,6 +33,7 @@ from rotkehlchen.errors import (
     PremiumAuthenticationError,
     RemoteError,
     RotkehlchenPermissionError,
+    SystemPermissionError,
     TagConstraintError,
 )
 from rotkehlchen.exchanges.data_structures import Trade
@@ -807,7 +808,7 @@ class RestAPI():
             )
         # not catching RotkehlchenPermissionError here as for new account with premium
         # syncing there is no way that permission needs to be asked by the user
-        except (AuthenticationError, PremiumAuthenticationError) as e:
+        except (AuthenticationError, PremiumAuthenticationError, SystemPermissionError) as e:
             self.rotkehlchen.reset_after_failed_account_creation_or_login()
             result_dict['message'] = str(e)
             return api_response(result_dict, status_code=HTTPStatus.CONFLICT)
@@ -853,7 +854,7 @@ class RestAPI():
             self.rotkehlchen.reset_after_failed_account_creation_or_login()
             result_dict['message'] = str(e)
             return api_response(result_dict, status_code=HTTPStatus.MULTIPLE_CHOICES)
-        except DBUpgradeError as e:
+        except (DBUpgradeError, SystemPermissionError) as e:
             self.rotkehlchen.reset_after_failed_account_creation_or_login()
             result_dict['message'] = str(e)
             return api_response(result_dict, status_code=HTTPStatus.CONFLICT)

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -164,8 +164,6 @@ class DataHandler():
                 if x.is_dir() and (x / 'rotkehlchen.db').exists():
                     users[x.stem] = 'loggedin' if x.stem == self.username else 'loggedout'
             except PermissionError:
-                # __import__("pdb").set_trace()
-
                 # ignore directories that can't be accessed
                 continue
 

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -41,6 +41,10 @@ class RotkehlchenPermissionError(Exception):
     pass
 
 
+class SystemPermissionError(Exception):
+    pass
+
+
 class RemoteError(Exception):
     """Thrown when a remote API can't be reached or throws unexpected error"""
     pass

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -113,7 +113,8 @@ class PremiumSyncManager():
 
         Returns true for success and False for error/failure
 
-        Can raise PremiumAuthenticationError due to an UnableToDecryptRemoteData
+        May raise:
+        - PremiumAuthenticationError due to an UnableToDecryptRemoteData
         coming from  decompress_and_decrypt_db. This happens when the given password
         does not match the one on the saved DB.
         """

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -129,6 +129,7 @@ class Rotkehlchen():
         or can't authenticate with the server
         - DBUpgradeError if the rotki DB version is newer than the software or
         there is a DB upgrade and there is an error.
+        - SystemPermissionError if the directory or DB file can not be accessed
         """
         log.info(
             'Unlocking user',

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -15,6 +15,11 @@ log = RotkehlchenLogsAdapter(logger)
 
 class RotkehlchenServer():
     def __init__(self) -> None:
+        """Initializes the backend server
+        May raise:
+        - SystemPermissionError due to the given args containing a datadir
+        that does not have the correct permissions
+        """
         arg_parser = app_args(
             prog='rotki',
             description=(

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -16,18 +16,10 @@ from rotkehlchen.tests.utils.premium import (
     VALID_PREMIUM_SECRET,
     assert_db_got_replaced,
     create_patched_requests_get_for_premium,
+    get_different_hash,
     setup_starting_environment,
 )
 from rotkehlchen.utils.misc import ts_now
-
-
-def get_different_hash(given_hash: str) -> str:
-    """Given the string hash get one that's different but has same length"""
-    new_hash = ''
-    for x in given_hash:
-        new_hash = new_hash + chr(ord(x) + 1)
-
-    return new_hash
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/test_users.py
+++ b/rotkehlchen/tests/test_users.py
@@ -1,6 +1,11 @@
+import os
 import string
+from pathlib import Path
+
+import pytest
 
 from rotkehlchen.data_handler import DataHandler
+from rotkehlchen.errors import SystemPermissionError
 
 
 def _user_creation_and_login(username, password, data_dir, msg_aggregator):
@@ -52,3 +57,35 @@ def test_user_password_with_all_ascii(data_dir, function_scope_messages_aggregat
         data_dir=data_dir,
         msg_aggregator=function_scope_messages_aggregator,
     )
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_users_query_permission_error(data_dir, function_scope_messages_aggregator):
+    not_allowed_dir = os.path.join(data_dir, 'notallowed')
+    allowed_user_dir = os.path.join(data_dir, 'allowed_user')
+    os.mkdir(not_allowed_dir)
+    os.chmod(not_allowed_dir, 0o200)
+    os.mkdir(allowed_user_dir)
+    Path(Path(allowed_user_dir) / 'rotkehlchen.db').touch()
+    handler = DataHandler(
+        data_directory=data_dir,
+        msg_aggregator=function_scope_messages_aggregator,
+    )
+    assert handler.get_users() == {'allowed_user': 'loggedout'}
+    # Change permissions back to that pytest cleanup can clean it
+    os.chmod(not_allowed_dir, 0o777)
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_new_user_permission_error(data_dir, function_scope_messages_aggregator):
+    not_allowed_dir = os.path.join(data_dir, 'notallowed')
+    os.mkdir(not_allowed_dir)
+    os.chmod(not_allowed_dir, 0o200)
+    handler = DataHandler(
+        data_directory=not_allowed_dir,
+        msg_aggregator=function_scope_messages_aggregator,
+    )
+    with pytest.raises(SystemPermissionError):
+        handler.unlock(username='someuser', password='123', create_new=True)
+    # Change permissions back to that pytest cleanup can clean it
+    os.chmod(not_allowed_dir, 0o777)

--- a/rotkehlchen/tests/unit/test_app.py
+++ b/rotkehlchen/tests/unit/test_app.py
@@ -1,4 +1,10 @@
+import os
+
+import pytest
+
+from rotkehlchen.errors import SystemPermissionError
 from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES
+from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
 
 
@@ -38,3 +44,10 @@ def test_initializing_exchanges(uninitialized_rotkehlchen):
     )
 
     assert all(name in rotki.exchange_manager.connected_exchanges for name in SUPPORTED_EXCHANGES)
+
+
+def test_initializing_rotki_with_datadir_with_wrong_permissions(cli_args, data_dir):
+    os.chmod(data_dir, 0o200)
+    with pytest.raises(SystemPermissionError):
+        Rotkehlchen(args=cli_args)
+    os.chmod(data_dir, 0o777)

--- a/rotkehlchen/tests/unit/test_usage_analytics.py
+++ b/rotkehlchen/tests/unit/test_usage_analytics.py
@@ -1,3 +1,5 @@
+import sys
+
 from rotkehlchen.usage_analytics import create_usage_analytics
 from rotkehlchen.utils.misc import get_system_spec
 
@@ -9,5 +11,9 @@ def test_create_usage_analytics():
     assert 'system_release' in analytics
     assert 'system_version' in analytics
     assert analytics['rotki_version'] == get_system_spec()['rotkehlchen']
-    assert analytics['country'] != 'unknown'
-    assert analytics['city'] != 'unknown'
+    if sys.platform != 'darwin':
+        assert analytics['country'] != 'unknown'
+        assert analytics['city'] != 'unknown'
+    else:
+        assert analytics['country'] is not None
+        assert analytics['city'] is not None

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -122,6 +122,15 @@ def create_patched_premium(
     return patched_premium_at_start, patched_premium_at_set, patched_get
 
 
+def get_different_hash(given_hash: str) -> str:
+    """Given the string hash get one that's different but has same length"""
+    new_hash = ''
+    for x in given_hash:
+        new_hash = new_hash + chr(ord(x) + 1)
+
+    return new_hash
+
+
 def setup_starting_environment(
         rotkehlchen_instance: Rotkehlchen,
         username: str,
@@ -150,7 +159,7 @@ def setup_starting_environment(
     if same_hash_with_remote:
         remote_hash = our_hash
     else:
-        remote_hash = 'a' + our_hash[1:]
+        remote_hash = get_different_hash(our_hash)
 
     if newer_remote_db:
         metadata_last_modify_ts = our_last_write_ts + 10


### PR DESCRIPTION
Fix #882
Fix #819
Fix #881 

- Handle access permissions in given data dir or database file
- Fix flakiness in the OSX version of the test usage analytics
- Fix flakines in try_premium_at_start_old_account_can_pull_old_data