### PR TITLE
API Keys page redesign & descriptions for API connections

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`895` Fixes manually tracked balances value column header not updating properly.
 * :bug:`899` If a user's ethereum account held both old and new REP the new REP's account balance should now be properly automatically detected.
 * :bug:`895` If the current price of an asset of a manually tracked balance can not be found, a value of zero is returned instead of breaking all manually tracked balances.
+* :feature:`838` Added additional information about API Keys that can be set up by the user and grouped the API connections page into 3 categories: Rotki Premium / Exchanges / External Services.
 * :feature:`-` Added support for the following tokens
 
   - `Rupiah token (IDRT) <https://coinmarketcap.com/currencies/rupiah-token/>`__

--- a/electron-app/src/background.ts
+++ b/electron-app/src/background.ts
@@ -251,6 +251,7 @@ app.on('ready', async () => {
     if (
       !(
         args.indexOf('https://rotki.com') > -1 ||
+        args.indexOf('https://rotki.readthedocs.io/') > -1 ||
         args.indexOf('https://github.com/rotki/rotki/') > -1
       )
     ) {

--- a/electron-app/src/components/base/BaseExternalLink.vue
+++ b/electron-app/src/components/base/BaseExternalLink.vue
@@ -1,0 +1,25 @@
+<template>
+  <a
+    :href="$interop ? undefined : href"
+    target="_blank"
+    @click="$interop ? openLink() : undefined"
+  >
+    <slot></slot>
+  </a>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+@Component({})
+export default class BaseExternalLink extends Vue {
+  @Prop({ required: true })
+  href!: string;
+
+  openLink() {
+    this.$interop.openUrl(this.href);
+  }
+}
+</script>
+
+<style scoped></style>

--- a/electron-app/src/components/base/BaseExternalLink.vue
+++ b/electron-app/src/components/base/BaseExternalLink.vue
@@ -1,8 +1,8 @@
 <template>
   <a
-    :href="$interop ? undefined : href"
+    :href="$interop.isPackaged ? undefined : href"
     target="_blank"
-    @click="$interop ? openLink() : undefined"
+    @click="$interop.isPackaged ? openLink() : undefined"
   >
     <slot></slot>
   </a>

--- a/electron-app/src/components/settings/PremiumSettings.vue
+++ b/electron-app/src/components/settings/PremiumSettings.vue
@@ -8,7 +8,7 @@
             Rotki Premium is an optional subscription service to gain access to
             analytics, graphs, and unlock many additional features. For more
             information on what is available visit the
-            <base-external-link href="https://rotki.com/products/">
+            <base-external-link :href="$interop.premiumURL">
               Rotki Premium
             </base-external-link>
             website.

--- a/electron-app/src/components/settings/PremiumSettings.vue
+++ b/electron-app/src/components/settings/PremiumSettings.vue
@@ -6,12 +6,12 @@
         <v-card-text>
           <p>
             Rotki Premium is an optional subscription service to gain access to
-            analytics and reporting features in Rotki. More information is
-            available on the
+            analytics, graphs, and unlock many additional features. For more
+            information on what is available visit the
             <base-external-link href="https://rotki.com/products/">
               Rotki Premium
             </base-external-link>
-            site.
+            website.
           </p>
           <v-text-field
             v-model="apiKey"

--- a/electron-app/src/components/settings/PremiumSettings.vue
+++ b/electron-app/src/components/settings/PremiumSettings.vue
@@ -2,8 +2,17 @@
   <v-row class="premium-settings">
     <v-col>
       <v-card>
-        <v-card-title>Premium Settings</v-card-title>
+        <v-card-title>Rotki Premium</v-card-title>
         <v-card-text>
+          <p>
+            Rotki Premium is an optional subscription service to gain access to
+            analytics and reporting features in Rotki. More information is
+            available on the
+            <base-external-link href="https://rotki.com/products/">
+              Rotki Premium
+            </base-external-link>
+            site.
+          </p>
           <v-text-field
             v-model="apiKey"
             class="premium-settings__fields__api-key"
@@ -11,7 +20,7 @@
             prepend-icon="fa-key"
             :disabled="premium && !edit"
             :type="showKey ? 'text' : 'password'"
-            label="Rotkehlchen API Key"
+            label="Rotki API Key"
             @click:append="showKey = !showKey"
           ></v-text-field>
           <v-text-field
@@ -21,7 +30,7 @@
             :disabled="premium && !edit"
             prepend-icon="fa-user-secret"
             :type="showSecret ? 'text' : 'password'"
-            label="Rotkehlchen API Secret"
+            label="Rotki API Secret"
             @click:append="showSecret = !showSecret"
           ></v-text-field>
           <div v-if="premium" class="premium-settings__premium-active">
@@ -64,6 +73,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import BaseExternalLink from '@/components/base/BaseExternalLink.vue';
 import MessageDialog from '@/components/dialogs/MessageDialog.vue';
 import { Message } from '@/store/store';
 
@@ -71,7 +81,8 @@ const { mapState } = createNamespacedHelpers('session');
 
 @Component({
   components: {
-    MessageDialog
+    MessageDialog,
+    BaseExternalLink
   },
   computed: mapState(['premium', 'premiumSync', 'username'])
 })

--- a/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -5,10 +5,8 @@
         <v-card-title>Exchanges</v-card-title>
         <v-card-text>
           <p>
-            Rotki can connect to supported exchanges and automatically obtain
-            your trades and balances in that exchange. Each exchange may require
-            a different set of credentials for the connection, so make sure that
-            everything is provided. See the
+            Rotki can connect to supported exchanges and automatically pull your
+            your trades and balances from that exchange. See the
             <base-external-link
               href="https://rotki.readthedocs.io/en/latest/usage_guide.html#adding-an-exchange"
             >

--- a/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -8,7 +8,7 @@
             Rotki can connect to supported exchanges and automatically pull your
             your trades and balances from that exchange. See the
             <base-external-link
-              href="https://rotki.readthedocs.io/en/latest/usage_guide.html#adding-an-exchange"
+              :href="$interop.usageGuideURL + '#adding-an-exchange'"
             >
               Usage Guide
             </base-external-link>

--- a/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -2,8 +2,20 @@
   <v-row class="exchange-settings">
     <v-col>
       <v-card>
-        <v-card-title>Exchange Settings</v-card-title>
+        <v-card-title>Exchanges</v-card-title>
         <v-card-text>
+          <p>
+            Rotki can connect to supported exchanges and automatically obtain
+            your trades and balances in that exchange. Each exchange may require
+            a different set of credentials for the connection, so make sure that
+            everything is provided. See the
+            <base-external-link
+              href="https://rotki.readthedocs.io/en/latest/usage_guide.html#adding-an-exchange"
+            >
+              Usage Guide
+            </base-external-link>
+            for more information.
+          </p>
           <v-row class="exchange-settings__connected-exchanges">
             <exchange-badge
               v-for="exchange in connectedExchanges"
@@ -85,6 +97,7 @@
 <script lang="ts">
 import { Component, Vue, Watch } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import BaseExternalLink from '@/components/base/BaseExternalLink.vue';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 import MessageDialog from '@/components/dialogs/MessageDialog.vue';
 import ExchangeBadge from '@/components/ExchangeBadge.vue';
@@ -94,7 +107,7 @@ import { Message } from '@/store/store';
 const { mapState } = createNamespacedHelpers('balances');
 
 @Component({
-  components: { ConfirmDialog, MessageDialog, ExchangeBadge },
+  components: { ConfirmDialog, MessageDialog, ExchangeBadge, BaseExternalLink },
   computed: mapState(['connectedExchanges'])
 })
 export default class ExchangeSettings extends Vue {

--- a/electron-app/src/components/settings/api-keys/ExternalServices.vue
+++ b/electron-app/src/components/settings/api-keys/ExternalServices.vue
@@ -6,8 +6,8 @@
           <v-card-title>External Services</v-card-title>
           <v-card-text>
             <p>
-              Rotki can connect to service providers in order to obtain more
-              details about your transactions, usually of an optional nature. In
+              Rotki connects to various service providers in order to obtain
+              information such as historical prices or blockchain data. In
               certain cases Rotki depends on these APIs for basic information,
               in which case you will need to provide an API key.
             </p>
@@ -21,7 +21,7 @@
           v-model="etherscanKey"
           class="external-services__etherscan-key"
           title="Etherscan"
-          description="Required for any Ethereum blockchain balances or transactions. Rotki uses etherscan to obtain basic information about ethereum blockchain addresses and transactions."
+          description="Required for any Ethereum blockchain balances or transactions. Rotki uses Etherscan to query Ethereum blockchain data if you are not using your own Ethereum node. If you are, it's still needed but only for historical data."
           label="API key"
           hint="Enter your Etherscan API key"
           :loading="loading"
@@ -53,7 +53,7 @@
           v-model="alethioKey"
           class="external-services__alethio-key"
           title="Alethio"
-          description="Rotki uses Alethio for supplementary Ethereum blockchain information. An API key is only needed if you have a lot of assets and are being rate-limited."
+          description="Rotki uses Alethio to query Ethereum blockchain information. An API key is only needed if you have a lot of assets and are being rate-limited."
           label="API key"
           hint="Enter your Alethio API key"
           :loading="loading"

--- a/electron-app/src/components/settings/api-keys/ExternalServices.vue
+++ b/electron-app/src/components/settings/api-keys/ExternalServices.vue
@@ -1,8 +1,18 @@
 <template>
-  <div>
+  <v-container>
     <v-row>
       <v-col cols="12">
-        <h2>External Services</h2>
+        <v-card>
+          <v-card-title>External Services</v-card-title>
+          <v-card-text>
+            <p>
+              Rotki can connect to service providers in order to obtain more
+              details about your transactions, usually of an optional nature. In
+              certain cases Rotki depends on these APIs for basic information,
+              in which case you will need to provide an API key.
+            </p>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
     <v-row>
@@ -11,6 +21,7 @@
           v-model="etherscanKey"
           class="external-services__etherscan-key"
           title="Etherscan"
+          description="Required for any Ethereum blockchain balances or transactions. Rotki uses etherscan to obtain basic information about ethereum blockchain addresses and transactions."
           label="API key"
           hint="Enter your Etherscan API key"
           :loading="loading"
@@ -26,6 +37,7 @@
           v-model="cryptocompareKey"
           class="external-services__cryptocompare-key"
           title="CryptoCompare"
+          description="Rotki uses cryptocompare to obtain price information about assets in your portfolio. An API key is only needed if you have a lot of assets and are being rate-limited."
           label="API key"
           hint="Enter your CryptoCompare API key"
           :loading="loading"
@@ -41,6 +53,7 @@
           v-model="alethioKey"
           class="external-services__alethio-key"
           title="Alethio"
+          description="Rotki uses Alethio for supplementary Ethereum blockchain information. An API key is only needed if you have a lot of assets and are being rate-limited."
           label="API key"
           hint="Enter your Alethio API key"
           :loading="loading"
@@ -58,7 +71,7 @@
       @cancel="serviceToDelete = ''"
     >
     </confirm-dialog>
-  </div>
+  </v-container>
 </template>
 
 <script lang="ts">

--- a/electron-app/src/components/settings/api-keys/ServiceKey.vue
+++ b/electron-app/src/components/settings/api-keys/ServiceKey.vue
@@ -3,33 +3,38 @@
     <v-card-title>
       {{ title }}
     </v-card-title>
-    <v-card-text class="service-key__content">
-      <revealable-input
-        :value="editMode ? currentValue : ''"
-        class="service-key__api-key"
-        :hint="currentValue ? '' : hint"
-        :disabled="!editMode"
-        :label="label"
-        @input="currentValue = $event"
-      ></revealable-input>
-      <v-tooltip top>
-        <template #activator="{ on }">
-          <v-btn
-            icon
-            text
-            class="service-key__content__delete"
-            :disabled="loading || !currentValue"
-            color="primary"
-            v-on="on"
-            @click="deleteKey()"
-          >
-            <v-icon>fa-trash</v-icon>
-          </v-btn>
-        </template>
-        <span>
-          {{ tooltip }}
-        </span>
-      </v-tooltip>
+    <v-card-text class="service-key__content" style="display: block;">
+      <div>
+        {{ description }}
+      </div>
+      <div style="display: flex; align-items: center;">
+        <revealable-input
+          :value="editMode ? currentValue : ''"
+          class="service-key__api-key"
+          :hint="currentValue ? '' : hint"
+          :disabled="!editMode"
+          :label="label"
+          @input="currentValue = $event"
+        ></revealable-input>
+        <v-tooltip top>
+          <template #activator="{ on }">
+            <v-btn
+              icon
+              text
+              class="service-key__content__delete"
+              :disabled="loading || !currentValue"
+              color="primary"
+              v-on="on"
+              @click="deleteKey()"
+            >
+              <v-icon>fa-trash</v-icon>
+            </v-btn>
+          </template>
+          <span>
+            {{ tooltip }}
+          </span>
+        </v-tooltip>
+      </div>
     </v-card-text>
     <v-card-actions>
       <v-btn
@@ -68,6 +73,8 @@ export default class ServiceKey extends Vue {
   value!: string;
   @Prop({ required: true })
   title!: string;
+  @Prop({ required: false, default: '' })
+  description!: string;
   @Prop({ required: false, default: false })
   loading!: boolean;
   @Prop({ required: false, default: '' })

--- a/electron-app/src/electron-interop.ts
+++ b/electron-app/src/electron-interop.ts
@@ -1,7 +1,9 @@
 export class ElectronInterop {
   private packagedApp: boolean = !!window.interop;
   readonly baseUrl = 'https://rotki.com';
+  readonly baseDocsUrl = 'https://rotki.readthedocs.io';
   readonly premiumURL: string = `${this.baseUrl}/products/`;
+  readonly usageGuideURL: string = `${this.baseDocsUrl}/en/stable/usage_guide.html`;
 
   get isPackaged(): boolean {
     return this.packagedApp;

--- a/electron-app/src/views/Statistics.vue
+++ b/electron-app/src/views/Statistics.vue
@@ -10,7 +10,9 @@
         No premium subscription detected. Statistics are only available to
         premium users. <br />
         To get a premium subscription please visit our
-        <a :href="$interop.premiumURL" target="_blank">website</a>.
+        <base-external-link href="https://rotki.com/products/">
+          website.
+        </base-external-link>
       </div>
       <div v-else>
         <premium-statistics
@@ -25,13 +27,14 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import BaseExternalLink from '@/components/base/BaseExternalLink.vue';
 import MessageDialog from '@/components/dialogs/MessageDialog.vue';
 import { PremiumStatistics } from '@/utils/premium';
 
 const { mapState, mapGetters } = createNamespacedHelpers('session');
 
 @Component({
-  components: { MessageDialog, PremiumStatistics },
+  components: { MessageDialog, PremiumStatistics, BaseExternalLink },
   computed: {
     ...mapState(['premium']),
     ...mapGetters(['floatingPrecision'])

--- a/electron-app/src/views/Statistics.vue
+++ b/electron-app/src/views/Statistics.vue
@@ -10,7 +10,7 @@
         No premium subscription detected. Statistics are only available to
         premium users. <br />
         To get a premium subscription please visit our
-        <base-external-link href="https://rotki.com/products/">
+        <base-external-link :href="$interop.premiumURL">
           website.
         </base-external-link>
       </div>

--- a/electron-app/src/views/settings/ApiKeys.vue
+++ b/electron-app/src/views/settings/ApiKeys.vue
@@ -12,9 +12,9 @@
       </v-col>
     </v-row>
     <v-tabs grow>
-      <v-tab>Rotki Premium</v-tab>
-      <v-tab>Exchanges</v-tab>
-      <v-tab>External Services</v-tab>
+      <v-tab class="api-keys__tab__rotki-premium">Rotki Premium</v-tab>
+      <v-tab class="api-keys__tab__exchanges">Exchanges</v-tab>
+      <v-tab class="api-keys__tab__external-services">External Services</v-tab>
       <v-tab-item><premium-settings></premium-settings></v-tab-item>
       <v-tab-item><exchange-settings></exchange-settings></v-tab-item>
       <v-tab-item><external-services></external-services></v-tab-item>

--- a/electron-app/src/views/settings/ApiKeys.vue
+++ b/electron-app/src/views/settings/ApiKeys.vue
@@ -7,7 +7,7 @@
     </v-row>
     <v-row>
       <v-col>
-        Rotki can communciate with various APIs to provide additional
+        Rotki can communicate with various APIs to provide additional
         functionality. Click each tab below to explore what is offered.
       </v-col>
     </v-row>

--- a/electron-app/src/views/settings/ApiKeys.vue
+++ b/electron-app/src/views/settings/ApiKeys.vue
@@ -5,9 +5,20 @@
         <h1>API Keys</h1>
       </v-col>
     </v-row>
-    <premium-settings></premium-settings>
-    <exchange-settings></exchange-settings>
-    <external-services></external-services>
+    <v-row>
+      <v-col>
+        Rotki can communciate with various APIs to provide additional
+        functionality. Click each tab below to explore what is offered.
+      </v-col>
+    </v-row>
+    <v-tabs grow>
+      <v-tab>Rotki Premium</v-tab>
+      <v-tab>Exchanges</v-tab>
+      <v-tab>External Services</v-tab>
+      <v-tab-item><premium-settings></premium-settings></v-tab-item>
+      <v-tab-item><exchange-settings></exchange-settings></v-tab-item>
+      <v-tab-item><external-services></external-services></v-tab-item>
+    </v-tabs>
   </v-container>
 </template>
 

--- a/electron-app/tests/e2e/pages/api-keys-page.ts
+++ b/electron-app/tests/e2e/pages/api-keys-page.ts
@@ -5,6 +5,7 @@ export class ApiKeysPage {
   }
 
   addExchange(apiKey: string, apiSecret: string, exchange: string) {
+    cy.get('.api-keys__tab__exchanges').click();
     cy.get('.exchange-settings__fields__exchange').click();
     cy.get(`.exchange__${exchange}`).click();
     cy.get('.exchange-settings__fields__api-key').type(apiKey);

--- a/electron-app/tests/e2e/pages/rotki-app.ts
+++ b/electron-app/tests/e2e/pages/rotki-app.ts
@@ -15,10 +15,9 @@ export class RotkiApp {
   }
 
   closePremiumOverlay() {
-    cy.contains(
-      '.account_management__premium .message-overlay__title',
-      'Upgrade to Premium'
-    );
+    cy.get('.account_management__premium .message-overlay__title', {
+      timeout: 10000
+    }).should('include.text', 'Upgrade to Premium');
     cy.get('.message-overlay__buttons__cancel').click();
   }
 


### PR DESCRIPTION
Fixes #838

* Added rotki.readthedocs.io to the URL whitelist (background.ts)
* Created BaseExternalLink component that can be used in both electron and web-version to create links outside the rotki "app" (BaseExteranLink.vue)
* Added tabs to the "API Keys" page (Rotki Premium / Exchanges / External Services), with descriptions and external links, where appropriate, for each tab (ApiKeys.vue, ExchangeSettings.vue, ExternalServices.vue, PremiumSettings.vue)
* Added the ability to provide a description for the cards info on each external service (ServiceKey.vue)
* Changed the external link in Statistics to use the BaseExternalLink component (Statistics.vue)
* Changelog entry for above

[ui tests]
