### PR TITLE
Fix flakiness for tests that use a real geth blockchain

### DIFF
--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -22,9 +22,8 @@ def random_marker():
     value.
     """
     random_hex = hex(random.getrandbits(100))
-
-    # strip the leading 0x and trailing L
-    return random_hex[2:-1]
+    # strip the leading 0x
+    return random_hex[2:]
 
 
 @pytest.fixture(scope='session')

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -140,7 +140,7 @@ def geth_wait_and_check(ethereum_manager, rpc_endpoint, random_marker):
             ethereum_manager.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
             jsonrpc_running = True
             block = ethereum_manager.get_block_by_number(0)
-            running_marker = hexlify(block['proofOfAuthorityData'])[:24].decode()
+            running_marker = hexlify(block['proofOfAuthorityData'])[:len(random_marker)].decode()
             if running_marker != random_marker:
                 raise RuntimeError(
                     'the test marker does not match, maybe two tests are running in '


### PR DESCRIPTION
The length of the generated test random marker(100 bits) is not guaranteed in
hex. Most of the times it was indeed 24 characters but some times it
was 23. This lead to a failure when comparing with the running marker.

Now we take the random marker's length into account and no longer
compare to a hard coded 24.

Fix #29