### PR TITLE
Only run builds for pull requests and pushes into master or develop

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -1,6 +1,14 @@
 name: Rotki CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
   lint-frontend:


### PR DESCRIPTION
this should improve the situation a bit buy reducing duplicate builds