### PR TITLE
Fix flakiness in blockchain tests that remove accounts

### DIFF
--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -685,12 +685,17 @@ class ChainManager(CacheableObject, LockableQueryObject):
                         usd_value=balance * token_usd_price[token],
                     )
                 else:
-                    self.totals[token] = Balance(
-                        amount=add_or_sub(self.totals[token].amount, balance),  # type: ignore
-                        usd_value=add_or_sub(  # type: ignore
+                    new_amount = add_or_sub(self.totals[token].amount, balance)  # type: ignore
+                    if new_amount == ZERO:
+                        new_usd_value = ZERO
+                    else:
+                        new_usd_value = add_or_sub(  # type: ignore
                             self.totals[token].usd_value,
                             balance * token_usd_price[token],
-                        ),
+                        )
+                    self.totals[token] = Balance(
+                        amount=new_amount,
+                        usd_value=new_usd_value,
                     )
 
     def _query_ethereum_tokens_normal(
@@ -781,12 +786,17 @@ class ChainManager(CacheableObject, LockableQueryObject):
                     # Removing the only account that holds this token
                     self.totals[token] = Balance(amount=ZERO, usd_value=ZERO)
                 else:
-                    self.totals[token] = Balance(
-                        amount=add_or_sub(self.totals[token].amount, token_total),  # type: ignore
-                        usd_value=add_or_sub(  # type: ignore
+                    new_amount = add_or_sub(self.totals[token].amount, token_total)  # type: ignore
+                    if new_amount == ZERO:
+                        new_usd_value = ZERO
+                    else:
+                        new_usd_value = add_or_sub(  # type: ignore
                             self.totals[token].usd_value,
                             token_total * token_usd_price[token],
-                        ),
+                        )
+                    self.totals[token] = Balance(
+                        amount=new_amount,
+                        usd_value=new_usd_value,
                     )
 
     def query_ethereum_tokens(


### PR DESCRIPTION
At account removals if an asset was expected to be zero the usd value
was also expected to be zero. But due to the way that usd value was
being decreased there could be minor floating point errors.

Right now we changed the implementation so that if asset value is
reduced to zero then usd value is also set to zero automatically.

Fix #879
Fix #871