### PR TITLE
Implements the AssetSelect for the Ignore Assets setting

### DIFF
--- a/electron-app/src/components/inputs/AssetSelect.vue
+++ b/electron-app/src/components/inputs/AssetSelect.vue
@@ -2,10 +2,11 @@
   <v-autocomplete
     :value="value"
     :disabled="disabled"
-    :items="supportedAssets"
+    :items="assets"
     class="asset-select"
+    :hint="hint"
     single-line
-    label="Asset"
+    :label="label"
     :rules="rules"
     item-value="key"
     :item-text="assetText"
@@ -48,6 +49,15 @@ const { mapState } = createNamespacedHelpers('balances');
 export default class AssetSelect extends Vue {
   supportedAssets!: SupportedAsset[];
 
+  @Prop({ required: false, default: null })
+  items?: string[];
+
+  @Prop({ required: false, default: '' })
+  hint?: string;
+
+  @Prop({ required: false, default: 'Asset' })
+  label?: string;
+
   @Prop({ required: true, default: '' })
   value!: string;
 
@@ -59,6 +69,19 @@ export default class AssetSelect extends Vue {
 
   @Emit()
   input(_value: string) {}
+
+  get assets(): SupportedAsset[] {
+    if (this.items) {
+      const filteredAssets = this.supportedAssets.filter(asset => {
+        if (this.items!.find(item => item === asset.key)) {
+          return asset;
+        }
+      });
+      return filteredAssets;
+    }
+
+    return this.supportedAssets;
+  }
 
   assetText(asset: SupportedAsset): string {
     return `${asset.symbol} ${asset.name}`;

--- a/electron-app/src/components/inputs/AssetSelect.vue
+++ b/electron-app/src/components/inputs/AssetSelect.vue
@@ -50,13 +50,13 @@ export default class AssetSelect extends Vue {
   supportedAssets!: SupportedAsset[];
 
   @Prop({ required: false, default: null })
-  items?: string[];
+  items!: string[] | null;
 
   @Prop({ required: false, default: '' })
-  hint?: string;
+  hint!: string;
 
   @Prop({ required: false, default: 'Asset' })
-  label?: string;
+  label!: string;
 
   @Prop({ required: true, default: '' })
   value!: string;
@@ -72,12 +72,9 @@ export default class AssetSelect extends Vue {
 
   get assets(): SupportedAsset[] {
     if (this.items) {
-      const filteredAssets = this.supportedAssets.filter(asset => {
-        if (this.items!.find(item => item === asset.key)) {
-          return asset;
-        }
-      });
-      return filteredAssets;
+      return this.supportedAssets.filter(asset =>
+        this.items!.includes(asset.key)
+      );
     }
 
     return this.supportedAssets;

--- a/electron-app/src/views/settings/Accounting.vue
+++ b/electron-app/src/views/settings/Accounting.vue
@@ -62,12 +62,12 @@
           <v-card-text>
             <v-row>
               <v-col cols="10">
-                <v-text-field
+                <asset-select
                   v-model="assetToIgnore"
-                  class="settings-accounting__asset"
-                  label="Asset To Ignore"
-                  @keyup.enter="addAsset()"
-                ></v-text-field>
+                  label="Select asset to ignore"
+                  hint="Click to see all assets and select one to ignore"
+                  class="manual-balances-form__asset"
+                ></asset-select>
               </v-col>
               <v-col cols="2">
                 <v-btn
@@ -82,8 +82,25 @@
               </v-col>
             </v-row>
             <v-row>
-              <v-col cols="10">
-                <v-select
+              <v-col cols="10" style="display: flex;">
+                <asset-select
+                  v-model="assetToRemove"
+                  label="Select asset to remove from ignored assets"
+                  value="test"
+                  :items="ignoredAssets"
+                  hint="Click to see all ignored assets and select one for removal"
+                  class="manual-balances-form__asset"
+                ></asset-select>
+                <div slot="append-outer">
+                  <v-badge>
+                    <template #badge>
+                      <span class="settings-accounting__ignored-assets__badge">
+                        {{ ignoredAssets.length }}
+                      </span>
+                    </template>
+                  </v-badge>
+                </div>
+                <!-- <v-select
                   v-model="assetToRemove"
                   class="settings-accounting__ignored-assets"
                   :items="ignoredAssets"
@@ -101,7 +118,7 @@
                       </template>
                     </v-badge>
                   </div>
-                </v-select>
+                </v-select> -->
               </v-col>
               <v-col cols="2">
                 <v-btn
@@ -126,14 +143,17 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
 import MessageDialog from '@/components/dialogs/MessageDialog.vue';
+import AssetSelect from '@/components/inputs/AssetSelect.vue';
 import { Message } from '@/store/store';
+
 import { AccountingSettings } from '@/typing/types';
 
 const { mapState } = createNamespacedHelpers('session');
 
 @Component({
   components: {
-    MessageDialog
+    MessageDialog,
+    AssetSelect
   },
   computed: mapState(['accountingSettings'])
 })
@@ -148,6 +168,8 @@ export default class Accounting extends Vue {
   ignoredAssets: string[] = [];
   assetToIgnore: string = '';
   assetToRemove: string = '';
+
+  asset: string = '';
 
   taxFreeRules = [
     (v: string) => !!v || 'Please enter the number of days',

--- a/electron-app/src/views/settings/Accounting.vue
+++ b/electron-app/src/views/settings/Accounting.vue
@@ -66,7 +66,7 @@
                   v-model="assetToIgnore"
                   label="Select asset to ignore"
                   hint="Click to see all assets and select one to ignore"
-                  class="manual-balances-form__asset"
+                  class="settings-accounting__asset-to-ignore"
                 ></asset-select>
               </v-col>
               <v-col cols="2">
@@ -89,7 +89,7 @@
                   value="test"
                   :items="ignoredAssets"
                   hint="Click to see all ignored assets and select one for removal"
-                  class="manual-balances-form__asset"
+                  class="settings-accounting__ignored-assets"
                 ></asset-select>
                 <div slot="append-outer">
                   <v-badge>
@@ -100,25 +100,6 @@
                     </template>
                   </v-badge>
                 </div>
-                <!-- <v-select
-                  v-model="assetToRemove"
-                  class="settings-accounting__ignored-assets"
-                  :items="ignoredAssets"
-                  hint="Click to see all ignored assets and select one for removal"
-                  label="Ignored Assets"
-                >
-                  <div slot="append-outer">
-                    <v-badge>
-                      <template #badge>
-                        <span
-                          class="settings-accounting__ignored-assets__badge"
-                        >
-                          {{ ignoredAssets.length }}
-                        </span>
-                      </template>
-                    </v-badge>
-                  </div>
-                </v-select> -->
               </v-col>
               <v-col cols="2">
                 <v-btn


### PR DESCRIPTION
Fixes #878

* Enhances AssetSelect to accept a list of assets (`items`) for which to pull the associated full asset info and present in the select.
* Replaces the basic asset selections in the in the "Ignore Assets" section in Accounting.vue with full AssetSelects (both add to ignore and remove to ignore).

This PR should be enough to validate/test the new functionality, but we discussed with Kelsos to do some things differently so that we have an appropriately placed getter for any cases where we would need to get "full" asset info in the frontend. @kelsos Can you provide some guidance on moving the assets getter to Balances and how the computed properties in AssetSelect would need to be refactored? I can work on it and then update the PR.