### PR TITLE
Conservative Kraken API query approach respecting call counter limit

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -137,7 +137,9 @@ Handling user creation, sign-in, log-out and querying
                   "eth_rpc_endpoint": "http://localhost:8545",
                   "main_currency": "USD",
                   "date_display_format": "%d/%m/%Y %H:%M:%S %Z",
-                  "last_balance_save": 1571552172
+                  "last_balance_save": 1571552172,
+                  "submit_usage_analytics": true,
+                  "kraken_account_type": "intermediate"
               }
           },
           "message": ""
@@ -196,7 +198,9 @@ Handling user creation, sign-in, log-out and querying
                   "eth_rpc_endpoint": "http://localhost:8545",
                   "main_currency": "USD",
                   "date_display_format": "%d/%m/%Y %H:%M:%S %Z",
-                  "last_balance_save": 1571552172
+                  "last_balance_save": 1571552172,
+                  "submit_usage_analytics": true,
+                  "kraken_account_type": "intermediate"
               }
           },
           "message": ""
@@ -453,7 +457,8 @@ Getting or modifying settings
               "main_currency": "USD",
               "date_display_format": "%d/%m/%Y %H:%M:%S %Z",
               "last_balance_save": 1571552172,
-              "submit_usage_analytics": true
+              "submit_usage_analytics": true,
+              "kraken_account_type": "intermediate"
           },
           "message": ""
       }
@@ -474,6 +479,7 @@ Getting or modifying settings
    :resjson string date_display_format: The format in which to display dates in the UI. Default is ``"%d/%m/%Y %H:%M:%S %Z"``.
    :resjson int last_balance_save: The timestamp at which the balances were last saved in the database.
    :resjson bool submit_usage_analytics: A boolean denoting wether or not to submit anonymous usage analytics to the Rotki server.
+   :resjson string kraken_account_type: The type of the user's kraken account if he has one. Valid values are "starter", "intermediate" and "pro".
 
    :statuscode 200: Querying of settings was succesful
    :statuscode 409: There is no logged in user
@@ -534,7 +540,8 @@ Getting or modifying settings
               "main_currency": "USD",
               "date_display_format": "%d/%m/%Y %H:%M:%S %Z",
               "last_balance_save": 1571552172,
-              "submit_usage_analytics": true
+              "submit_usage_analytics": true,
+              "kraken_account_type": "intermediate"
           },
           "message": ""
       }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`904` For Kraken users take into account the worst-case API call counter and make sure the maximum calls are not reached to avoid prolonged API bans.
 * :bug:`895` Fixes manually tracked balances value column header not updating properly.
 * :bug:`899` If a user's ethereum account held both old and new REP the new REP's account balance should now be properly automatically detected.
 * :bug:`895` If the current price of an asset of a manually tracked balance can not be found, a value of zero is returned instead of breaking all manually tracked balances.

--- a/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -69,10 +69,12 @@
             @click:append="showKey = !showKey"
           ></v-text-field>
           <v-select
+            v-if="selectedExchange === 'kraken'"
             v-model="selectedKrakenAccountType"
             class=""
             :items="krakenAccountTypes"
             label="Select the type of your Kraken account"
+            @change="onChangeKrakenAccountType"
           ></v-select>
         </v-card-text>
         <v-card-actions>
@@ -108,19 +110,19 @@ import ExchangeBadge from '@/components/ExchangeBadge.vue';
 import { convertToGeneralSettings } from '@/data/converters';
 import { exchanges } from '@/data/defaults';
 import { Message } from '@/store/store';
-import { GeneralSettings } from '@/typing/types';
 
-const { mapState } = createNamespacedHelpers('session');
+const { mapState } = createNamespacedHelpers('balances');
+const { mapGetters } = createNamespacedHelpers('session');
 
 @Component({
   components: { ConfirmDialog, MessageDialog, ExchangeBadge, BaseExternalLink },
   computed: {
     ...mapState(['connectedExchanges']),
-    ...mapState(['settings'])
+    ...mapGetters(['krakenAccountType'])
   }
 })
 export default class ExchangeSettings extends Vue {
-  settings!: GeneralSettings;
+  krakenAccountType!: string;
   apiKey: string = '';
   apiSecret: string = '';
   passphrase: string | null = null;
@@ -136,7 +138,7 @@ export default class ExchangeSettings extends Vue {
   selectedKrakenAccountType = '';
 
   mounted() {
-    this.selectedKrakenAccountType = this.settings.krakenAccountType;
+    this.selectedKrakenAccountType = this.krakenAccountType;
   }
 
   @Watch('selectedExchange')
@@ -144,7 +146,6 @@ export default class ExchangeSettings extends Vue {
     this.resetFields();
   }
 
-  @Watch('selectedKrakenAccountType')
   onChangeKrakenAccountType() {
     const { commit } = this.$store;
     this.$api

--- a/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/electron-app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -71,7 +71,7 @@
           <v-select
             v-if="selectedExchange === 'kraken'"
             v-model="selectedKrakenAccountType"
-            class=""
+            class="exchange-settings__fields__kraken-account-type"
             :items="krakenAccountTypes"
             label="Select the type of your Kraken account"
             @change="onChangeKrakenAccountType"
@@ -107,7 +107,6 @@ import BaseExternalLink from '@/components/base/BaseExternalLink.vue';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 import MessageDialog from '@/components/dialogs/MessageDialog.vue';
 import ExchangeBadge from '@/components/ExchangeBadge.vue';
-import { convertToGeneralSettings } from '@/data/converters';
 import { exchanges } from '@/data/defaults';
 import { Message } from '@/store/store';
 
@@ -146,24 +145,11 @@ export default class ExchangeSettings extends Vue {
     this.resetFields();
   }
 
-  onChangeKrakenAccountType() {
-    const { commit } = this.$store;
-    this.$api
-      .setSettings({ kraken_account_type: this.selectedKrakenAccountType })
-      .then(settings => {
-        commit('setMessage', {
-          title: 'Success',
-          description: 'Successfully set kraken account type',
-          success: true
-        } as Message);
-        commit('session/settings', convertToGeneralSettings(settings));
-      })
-      .catch(reason => {
-        commit('setMessage', {
-          title: 'Error',
-          description: `Error setting kraken account type ${reason.message}`
-        } as Message);
-      });
+  async onChangeKrakenAccountType() {
+    await this.$store.dispatch(
+      'session/setKrakenAccountType',
+      this.selectedKrakenAccountType
+    );
   }
 
   private resetFields(includeExchange: boolean = false) {

--- a/electron-app/src/data/converters.ts
+++ b/electron-app/src/data/converters.ts
@@ -23,7 +23,8 @@ export const convertToGeneralSettings = (
   balanceSaveFrequency: settings.balance_save_frequency,
   ethRpcEndpoint: settings.eth_rpc_endpoint,
   anonymizedLogs: settings.anonymized_logs,
-  anonymousUsageAnalytics: settings.submit_usage_analytics
+  anonymousUsageAnalytics: settings.submit_usage_analytics,
+  krakenAccountType: settings.kraken_account_type
 });
 
 export const convertToAccountingSettings = (

--- a/electron-app/src/data/defaults.ts
+++ b/electron-app/src/data/defaults.ts
@@ -10,8 +10,8 @@ export class Defaults {
 }
 
 export const exchanges = [
-  'kraken',
   'poloniex',
+  'kraken',
   'bittrex',
   'bitmex',
   'binance',

--- a/electron-app/src/data/defaults.ts
+++ b/electron-app/src/data/defaults.ts
@@ -6,6 +6,7 @@ export class Defaults {
   static ANONYMIZED_LOGS = false;
   static HISTORICAL_DATA_START = '01/08/2015';
   static ANONYMOUS_USAGE_ANALYTICS = true;
+  static KRAKEN_DEFAULT_ACCOUNT_TYPE = 'starter';
 }
 
 export const exchanges = [

--- a/electron-app/src/data/factories.ts
+++ b/electron-app/src/data/factories.ts
@@ -10,7 +10,8 @@ export const defaultSettings = (): GeneralSettings => ({
   dateDisplayFormat: Defaults.DEFAULT_DISPLAY_FORMAT,
   historicDataStart: Defaults.HISTORICAL_DATA_START,
   anonymousUsageAnalytics: Defaults.ANONYMOUS_USAGE_ANALYTICS,
-  selectedCurrency: currencies[0]
+  selectedCurrency: currencies[0],
+  krakenAccountType: Defaults.KRAKEN_DEFAULT_ACCOUNT_TYPE
 });
 
 export const defaultAccountingSettings = (): AccountingSettings => ({

--- a/electron-app/src/model/action-result.ts
+++ b/electron-app/src/model/action-result.ts
@@ -27,6 +27,7 @@ export interface DBSettings {
   readonly last_balance_save: number;
   readonly anonymized_logs: boolean;
   readonly date_display_format: string;
+  readonly kraken_account_type: string;
 }
 
 export interface AsyncQuery {

--- a/electron-app/src/store/session/actions.ts
+++ b/electron-app/src/store/session/actions.ts
@@ -172,5 +172,32 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
       );
     }
     dispatch('balances/removeTag', tagName, { root: true });
+  },
+
+  async setKrakenAccountType({ commit }, account_type: string) {
+    try {
+      const settings = await api.setSettings({
+        kraken_account_type: account_type
+      });
+      commit('settings', convertToGeneralSettings(settings));
+      commit(
+        'setMessage',
+        {
+          title: 'Success',
+          description: 'Succesfully set kraken account type',
+          success: true
+        } as Message,
+        { root: true }
+      );
+    } catch (e) {
+      commit(
+        'setMessage',
+        {
+          title: 'Error setting kraken account type',
+          description: e.message || ''
+        } as Message,
+        { root: true }
+      );
+    }
   }
 };

--- a/electron-app/src/store/session/getters.ts
+++ b/electron-app/src/store/session/getters.ts
@@ -21,5 +21,9 @@ export const getters: GetterTree<SessionState, RotkehlchenState> = {
 
   tags: (state: SessionState) => {
     return Object.values(state.tags);
+  },
+
+  krakenAccountType: (state: SessionState) => {
+    return state.settings.krakenAccountType;
   }
 };

--- a/electron-app/src/typing/types.ts
+++ b/electron-app/src/typing/types.ts
@@ -12,6 +12,7 @@ export interface GeneralSettings {
   readonly balanceSaveFrequency: number;
   readonly dateDisplayFormat: string;
   readonly selectedCurrency: Currency;
+  readonly krakenAccountType: string;
 }
 
 export interface AccountingSettings {
@@ -113,6 +114,7 @@ export interface SettingsPayload {
   include_gas_costs: boolean;
   include_crypto2crypto: boolean;
   taxfree_after_period: number;
+  kraken_account_type: string;
 }
 
 export type ExternalServiceName = 'etherscan' | 'cryptocompare';

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -13,6 +13,7 @@ from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.bitcoin import is_valid_btc_address
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import DeserializationError, UnknownAsset
+from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import (
@@ -146,6 +147,23 @@ class TaxFreeAfterPeriodField(fields.Field):
             raise ValidationError('The taxfree_after_period value can not be set to zero')
 
         return value
+
+
+class KrakenAccountTypeField(fields.Field):
+
+    def _deserialize(
+            self,
+            value: str,
+            attr: Optional[str],  # pylint: disable=unused-argument
+            data: Optional[Mapping[str, Any]],  # pylint: disable=unused-argument
+            **_kwargs: Any,
+    ) -> KrakenAccountType:
+        try:
+            acc_type = KrakenAccountType.deserialize(value)
+        except DeserializationError:
+            raise ValidationError(f'{value} is not a valid kraken account type')
+
+        return acc_type
 
 
 class AmountField(fields.Field):
@@ -643,6 +661,7 @@ class ModifiableSettingsSchema(Schema):
     main_currency = FiatAssetField(missing=None)
     # TODO: Add some validation to this field
     date_display_format = fields.String(missing=None)
+    kraken_account_type = KrakenAccountTypeField(missing=None)
 
 
 class BaseUserSchema(Schema):

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -50,6 +50,7 @@ from rotkehlchen.api.v1.encoding import (
 from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.db.settings import ModifiableDBSettings
+from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.typing import (
     ApiKey,
     ApiSecret,
@@ -154,6 +155,7 @@ class SettingsResource(BaseResource):
             eth_rpc_endpoint: Optional[str],
             main_currency: Optional[Asset],
             date_display_format: Optional[str],
+            kraken_account_type: Optional[KrakenAccountType],
     ) -> Response:
         settings = ModifiableDBSettings(
             premium_should_sync=premium_should_sync,
@@ -168,6 +170,7 @@ class SettingsResource(BaseResource):
             main_currency=main_currency,
             date_display_format=date_display_format,
             submit_usage_analytics=submit_usage_analytics,
+            kraken_account_type=kraken_account_type,
         )
         return self.rest_api.set_settings(settings)
 

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -4,15 +4,6 @@ if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
 
 
-class RecoverableRequestError(Exception):
-    def __init__(self, exchange: str, err: str) -> None:
-        self.exchange = exchange
-        self.err = err
-
-    def __str__(self) -> str:
-        return 'While querying {} got error: "{}"'.format(self.exchange, self.err)
-
-
 class InputError(Exception):
     pass
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -602,6 +602,11 @@ class Rotkehlchen():
                 if not result:
                     return False, msg
 
+            if settings.kraken_account_type is not None:
+                kraken = self.exchange_manager.get('kraken')
+                if kraken:
+                    kraken.set_account_type(settings.kraken_account_type)  # type: ignore
+
             self.data.db.set_settings(settings)
             return True, ''
 
@@ -618,7 +623,7 @@ class Rotkehlchen():
             passphrase: Optional[str] = None,
     ) -> Tuple[bool, str]:
         """
-        Setup a new exchange with an api key and an api secret
+        Setup a new exchange with an api key and an api secret and optionally a passphrase
 
         By default the api keys are always validated unless validate is False.
         """

--- a/rotkehlchen/serialization/serialize.py
+++ b/rotkehlchen/serialization/serialize.py
@@ -6,6 +6,7 @@ from rotkehlchen.chain.ethereum.makerdao import DSRCurrentBalances
 from rotkehlchen.db.settings import DBSettings
 from rotkehlchen.db.utils import AssetBalance, LocationData, SingleAssetBalance
 from rotkehlchen.exchanges.data_structures import Trade
+from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import deserialize_location_from_db
 from rotkehlchen.typing import EthTokenInfo, Location, TradeType
@@ -62,7 +63,7 @@ def _process_entry(entry: Any) -> Union[str, List[Any], Dict[str, Any], Any]:
         raise ValueError('Query results should not contain plain tuples')
     elif isinstance(entry, Asset):
         return entry.identifier
-    elif isinstance(entry, (TradeType, Location)):
+    elif isinstance(entry, (TradeType, Location, KrakenAccountType)):
         return str(entry)
     else:
         return entry

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -1,10 +1,12 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 import requests
 
 from rotkehlchen.constants.assets import A_JPY
-from rotkehlchen.db.settings import ROTKEHLCHEN_DB_VERSION, DBSettings
+from rotkehlchen.db.settings import DEFAULT_KRAKEN_ACCOUNT_TYPE, ROTKEHLCHEN_DB_VERSION, DBSettings
+from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
@@ -75,6 +77,10 @@ def test_set_settings(rotkehlchen_api_server):
             value = not value
         elif type(value) == int:
             value += 1
+        elif setting == 'kraken_account_type':
+            # Change the account type to anything other than default
+            assert value != str(KrakenAccountType.PRO)
+            value = str(KrakenAccountType.PRO)
         else:
             raise AssertionError(f'Unexpected settting {setting} encountered')
 
@@ -135,6 +141,27 @@ def test_set_rpc_endpoint_fail_not_set_others(rotkehlchen_api_server):
     assert json_data['message'] == ''
     assert result['main_currency'] != 'JPY'
     assert result['eth_rpc_endpoint'] != 'http://working.nodes.com:8545'
+
+
+@pytest.mark.parametrize('added_exchanges', [('kraken',)])
+def test_set_kraken_account_type(rotkehlchen_api_server_with_exchanges):
+    server = rotkehlchen_api_server_with_exchanges
+    rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen
+    kraken = rotki.exchange_manager.get('kraken')
+    assert kraken.account_type == DEFAULT_KRAKEN_ACCOUNT_TYPE
+    assert kraken.call_limit == 15
+    assert kraken.reduction_every_secs == 3
+
+    data = {'kraken_account_type': 'intermediate'}
+    response = requests.put(api_url_for(server, "settingsresource"), json=data)
+    assert_proper_response(response)
+    json_data = response.json()
+    result = json_data['result']
+    assert json_data['message'] == ''
+    assert result['kraken_account_type'] == 'intermediate'
+    assert kraken.account_type == KrakenAccountType.INTERMEDIATE
+    assert kraken.call_limit == 20
+    assert kraken.reduction_every_secs == 2
 
 
 def test_disable_taxfree_after_period(rotkehlchen_api_server):
@@ -385,5 +412,27 @@ def test_set_settings_errors(rotkehlchen_api_server):
     assert_error_response(
         response=response,
         contained_in_msg='Not a valid string',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+
+    # invalid type kraken_account_type
+    data = {
+        'kraken_account_type': 124.1,
+    }
+    response = requests.put(api_url_for(rotkehlchen_api_server, "settingsresource"), json=data)
+    assert_error_response(
+        response=response,
+        contained_in_msg='is not a valid kraken account type',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+
+    # invalid value kraken_account_type
+    data = {
+        'kraken_account_type': 'super hyper pro',
+    }
+    response = requests.put(api_url_for(rotkehlchen_api_server, "settingsresource"), json=data)
+    assert_error_response(
+        response=response,
+        contained_in_msg='is not a valid kraken account type',
         status_code=HTTPStatus.BAD_REQUEST,
     )

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -19,6 +19,7 @@ from rotkehlchen.db.settings import (
     DEFAULT_DATE_DISPLAY_FORMAT,
     DEFAULT_INCLUDE_CRYPTO2CRYPTO,
     DEFAULT_INCLUDE_GAS_COSTS,
+    DEFAULT_KRAKEN_ACCOUNT_TYPE,
     DEFAULT_MAIN_CURRENCY,
     DEFAULT_START_DATE,
     DEFAULT_UI_FLOATING_PRECISION,
@@ -265,6 +266,7 @@ def test_writting_fetching_data(data_dir, username):
         'premium_should_sync': False,
         'submit_usage_analytics': True,
         'last_write_ts': 0,
+        'kraken_account_type': DEFAULT_KRAKEN_ACCOUNT_TYPE,
     }
     assert len(expected_dict) == len(DBSettings()), 'One or more settings are missing'
 

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -23,7 +23,7 @@ def test_name():
 def test_coverage_of_kraken_balances(kraken):
     # Since 05/08/2019 Kraken removed all delisted assets from their public API
     # query except for BSV. No idea why or why this incosistency.
-    got_assets = set(kraken.query_public('Assets').keys())
+    got_assets = set(kraken.api_query('Assets').keys())
     expected_assets = (set(KRAKEN_TO_WORLD.keys()) - set(KRAKEN_DELISTED)).union({'BSV'})
     # Ignore the staking assets from the got assets
     got_assets.remove('XTZ.S')
@@ -100,7 +100,7 @@ def test_kraken_to_world_pair(kraken):
 
     # now try to test all pairs that kraken returns and if one does not work note
     # down a test warning so that it can be fixed by us later
-    pairs = kraken.query_public('AssetPairs').keys()
+    pairs = kraken.api_query('AssetPairs').keys()
     for pair in pairs:
         try:
             kraken_to_world_pair(pair)

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -332,7 +332,7 @@ class MockKraken(Kraken):
         # Not required in the real Kraken instance but we use it in the tests
         self.tradeable_pairs = self.api_query('AssetPairs')
 
-    def query_private(self, method: str, req: Optional[dict] = None) -> dict:
+    def api_query(self, method: str, req: Optional[dict] = None) -> dict:
         # Pretty ugly ... mock a kraken remote eror
         if self.remote_errors:
             raise RemoteError('Kraken remote error')

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -330,7 +330,7 @@ class MockKraken(Kraken):
 
         self.balance_data_return = {'XXBT': '5.0', 'XETH': '10.0', 'NOTAREALASSET': '15.0'}
         # Not required in the real Kraken instance but we use it in the tests
-        self.tradeable_pairs = self.query_public('AssetPairs')
+        self.tradeable_pairs = self.api_query('AssetPairs')
 
     def query_private(self, method: str, req: Optional[dict] = None) -> dict:
         # Pretty ugly ... mock a kraken remote eror
@@ -372,4 +372,4 @@ class MockKraken(Kraken):
 
             return rlk_jsonloads_dict(response)
 
-        return super().query_private(method, req)
+        return super().api_query(method, req)


### PR DESCRIPTION
This is an attempt to a solution for
#904

Rotki now assumes that all users have starter kraken account type and
keeps the call counter below the maximum limits set in
https://www.kraken.com/features/api#api-call-rate-limit

If this approach is kept, we should also either somehow detect the
user's kraken account type (does not seem possible:
https://twitter.com/krakensupport/status/1251835040817975298) or allow
the user to customize it.

---

May not merge this yet as I am still trying to gather information if it's required. The user who reported 904 seems to have been blocked from the Kraken API for a long amount of time (current develop would be about 5 retries all failing within 35 seconds).

Having never seen this happen before and seeing that the API docs specify a 15 min ban if the call counter is exceeded (https://www.kraken.com/features/api#api-call-rate-limit) then this approach seems to be the proper solution to avoid a 15 min ban.

But having used Kraken heaviliy myself I have never been banned for 15 mins and so far the incremental backoff Rotki was doing was working fine. Incrementally backing off if an API Rate limit exceeded error was returned always worked.

Also Kraken support in Twitter seems to think the API rate limit won't ban you for 15 mins -- contradicting their docs: https://twitter.com/krakensupport/status/1251841977303302144

So more information is needed.