### PR TITLE
Support compound tokens and especially cryptocompare query of said tokens

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Changelog
   - `Exchange Union (XUC) <https://coinmarketcap.com/currencies/exchange-union/>`__
   - `Compound DAI (cDAI) <https://coinmarketcap.com/currencies/compound-dai/>`__
   - `Compound BAT (cBAT) <https://etherscan.io/address/0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e>`__
+  - `Compound ETH (cETH) <https://etherscan.io/address/0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Changelog
   - `Compound Augur (cREP) <https://www.coingecko.com/en/coins/compound-augur>`__
   - `Compound USD coin (cUSDC) <https://www.coingecko.com/en/coins/compound-usd-coin>`__
   - `Compound Wrapped BTC (cWBTC) <https://www.coingecko.com/en/coins/compound-wrapped-btc>`__
+  - `Compound 0x (cZRX) <https://www.coingecko.com/en/coins/compound-0x>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
   - `Compound BAT (cBAT) <https://etherscan.io/address/0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e>`__
   - `Compound ETH (cETH) <https://etherscan.io/address/0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5>`__
   - `Compound Augur (cREP) <https://www.coingecko.com/en/coins/compound-augur>`__
+  - `Compound USD coin (cUSDC) <https://www.coingecko.com/en/coins/compound-usd-coin>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changelog
   - `Compound DAI (cDAI) <https://coinmarketcap.com/currencies/compound-dai/>`__
   - `Compound BAT (cBAT) <https://etherscan.io/address/0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e>`__
   - `Compound ETH (cETH) <https://etherscan.io/address/0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5>`__
+  - `Compound Augur (cREP) <https://www.coingecko.com/en/coins/compound-augur>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 
   - `Rupiah token (IDRT) <https://coinmarketcap.com/currencies/rupiah-token/>`__
   - `Exchange Union (XUC) <https://coinmarketcap.com/currencies/exchange-union/>`__
+  - `Compound DAI (cDAI) <https://coinmarketcap.com/currencies/compound-dai/>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
   - `Rupiah token (IDRT) <https://coinmarketcap.com/currencies/rupiah-token/>`__
   - `Exchange Union (XUC) <https://coinmarketcap.com/currencies/exchange-union/>`__
   - `Compound DAI (cDAI) <https://coinmarketcap.com/currencies/compound-dai/>`__
+  - `Compound BAT (cBAT) <https://etherscan.io/address/0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Changelog
   - `Compound ETH (cETH) <https://etherscan.io/address/0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5>`__
   - `Compound Augur (cREP) <https://www.coingecko.com/en/coins/compound-augur>`__
   - `Compound USD coin (cUSDC) <https://www.coingecko.com/en/coins/compound-usd-coin>`__
+  - `Compound Wrapped BTC (cWBTC) <https://www.coingecko.com/en/coins/compound-wrapped-btc>`__
 
 * :release:`1.4.0 <2020-04-16>`
 * :feature:`807` Enables the addition and querying of manually tracked balances.

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -202,7 +202,8 @@ class Asset():
                     f'documented as returning None and is not handled',
                 )
 
-        return cryptocompare_str
+        # Seems cryptocompare capitalizes everything. So cDAI -> CDAI
+        return cryptocompare_str.upper()
 
     def __hash__(self) -> int:
         return hash(self.identifier)

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1597,6 +1597,14 @@
         "symbol": "C8",
         "type": "ethereum token"
     },
+    "cBAT": {
+        "ethereum_address": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
+        "ethereum_token_decimals": 8,
+        "name": "Compound BAT",
+        "started": 1557192085,
+        "symbol": "cBAT",
+        "type": "ethereum token"
+    },
     "cDAI": {
         "ethereum_address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
         "ethereum_token_decimals": 8,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1629,6 +1629,14 @@
         "symbol": "cREP",
         "type": "ethereum token"
     },
+    "cUSDC": {
+        "ethereum_address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+        "ethereum_token_decimals": 8,
+        "name": "Compound USD Coin",
+        "started": 1557192331,
+        "symbol": "cUSDC",
+        "type": "ethereum token"
+    },
     "CACH": {
         "active": false,
         "ended": 1541548800,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1637,6 +1637,14 @@
         "symbol": "cUSDC",
         "type": "ethereum token"
     },
+    "cWBTC": {
+        "ethereum_address": "0xC11b1268C1A384e55C48c2391d8d480264A3A7F4",
+        "ethereum_token_decimals": 8,
+        "name": "Compound Wrapped BTC",
+        "started": 1563263257,
+        "symbol": "cWBTC",
+        "type": "ethereum token"
+    },
     "CACH": {
         "active": false,
         "ended": 1541548800,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1605,6 +1605,14 @@
         "symbol": "cBAT",
         "type": "ethereum token"
     },
+    "cETH": {
+        "ethereum_address": "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+        "ethereum_token_decimals": 8,
+        "name": "Compound ETH",
+        "started": 1557192318,
+        "symbol": "cETH",
+        "type": "ethereum token"
+    },
     "cDAI": {
         "ethereum_address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
         "ethereum_token_decimals": 8,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1621,6 +1621,14 @@
         "symbol": "cDAI",
         "type": "ethereum token"
     },
+    "cREP": {
+        "ethereum_address": "0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1",
+        "ethereum_token_decimals": 8,
+        "name": "Compound Augur",
+        "started": 1557192288,
+        "symbol": "cREP",
+        "type": "ethereum token"
+    },
     "CACH": {
         "active": false,
         "ended": 1541548800,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1597,6 +1597,14 @@
         "symbol": "C8",
         "type": "ethereum token"
     },
+    "cDAI": {
+        "ethereum_address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+        "ethereum_token_decimals": 8,
+        "name": "Compound DAI",
+        "started": 1574471013,
+        "symbol": "cDAI",
+        "type": "ethereum token"
+    },
     "CACH": {
         "active": false,
         "ended": 1541548800,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1645,6 +1645,14 @@
         "symbol": "cWBTC",
         "type": "ethereum token"
     },
+    "cZRX": {
+        "ethereum_address": "0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407",
+        "ethereum_token_decimals": 8,
+        "name": "Compound 0x",
+        "started": 1557192054,
+        "symbol": "cZRX",
+        "type": "ethereum token"
+    },
     "CACH": {
         "active": false,
         "ended": 1541548800,


### PR DESCRIPTION
At the moment cryptocompare can't query arbitrary pairs for the
compound tokens. But it can query a price between each compound token
and its normal equivalent.

So even though cDAI -> XXX does not work, you can query cryptocompare
for cDAI -> DAI and then DAI -> XXX and figure out the final price
through this.

Same applies for all other compound tokens and cryptocompare queries