### PR TITLE
Various improvements to AmountDisplay and Data Tables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Rotki users now have two options to further enhance their privacy. If a user wants to temporarily obscure values in the application, they can do so by turning `Privacy Mode` on and off in the User Menu. Additionally, if a user wants to scramble their data (e.g. before sharing screenshots or videos), they can do so via the `Scramble Data` setting in the application's General Settings.
 * :bug:`966` Rotki now supports the new Kraken LTC and XRP trade pairs
 * :feature:`-` Added support for the following tokens
 

--- a/electron-app/src/components/UserDropdown.vue
+++ b/electron-app/src/components/UserDropdown.vue
@@ -71,10 +71,10 @@ import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 
-const { mapGetters } = createNamespacedHelpers('session');
+const { mapState } = createNamespacedHelpers('session');
 
 @Component({
-  computed: mapGetters(['privacyMode']),
+  computed: mapState(['privacyMode']),
   components: {
     ConfirmDialog
   }

--- a/electron-app/src/components/UserDropdown.vue
+++ b/electron-app/src/components/UserDropdown.vue
@@ -30,6 +30,18 @@
           <v-list-item-title>Settings</v-list-item-title>
         </v-list-item>
 
+        <v-list-item
+          key="privacy-mode"
+          class="user-dropdown__privacy-mode"
+          @click="togglePrivacyMode()"
+        >
+          <v-list-item-avatar>
+            <v-icon v-if="privacyMode" color="primary">fa-eye-slash</v-icon>
+            <v-icon v-else color="primary">fa-eye</v-icon>
+          </v-list-item-avatar>
+          <v-list-item-title>Toggle Privacy Mode</v-list-item-title>
+        </v-list-item>
+
         <v-divider></v-divider>
 
         <v-list-item
@@ -56,15 +68,24 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
+import { createNamespacedHelpers } from 'vuex';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 
+const { mapGetters } = createNamespacedHelpers('session');
+
 @Component({
+  computed: mapGetters(['privacyMode']),
   components: {
     ConfirmDialog
   }
 })
 export default class UserDropdown extends Vue {
+  privacyMode!: boolean;
   confirmLogout: boolean = false;
+
+  togglePrivacyMode() {
+    this.$store.commit('session/privacyMode', !this.privacyMode);
+  }
 
   async logout() {
     this.confirmLogout = false;

--- a/electron-app/src/components/accounts/AccountBalances.vue
+++ b/electron-app/src/components/accounts/AccountBalances.vue
@@ -82,7 +82,10 @@
         <amount-display :value="item.amount"></amount-display>
       </template>
       <template #item.usdValue="{ item }">
-        <amount-display fiat :value="item.usdValue"></amount-display>
+        <amount-display
+          fiat-currency="USD"
+          :value="item.usdValue"
+        ></amount-display>
       </template>
       <template #item.actions="{ item }">
         <span class="account-balances__actions">
@@ -115,7 +118,7 @@
           </td>
           <td class="text-end">
             <amount-display
-              fiat
+              fiat-currency="USD"
               :value="visibleBalances.map(val => val.usdValue) | balanceSum"
             >
             </amount-display>

--- a/electron-app/src/components/accounts/AccountBalances.vue
+++ b/electron-app/src/components/accounts/AccountBalances.vue
@@ -108,19 +108,17 @@
         <tr class="account-balances__total">
           <td>Total</td>
           <td>
-            {{
-              visibleBalances.map(val => val.amount)
-                | balanceSum
-                | formatPrice(floatingPrecision)
-            }}
+            <amount-display
+              :value="visibleBalances.map(val => val.amount) | balanceSum"
+            >
+            </amount-display>
           </td>
           <td>
-            {{
-              visibleBalances.map(val => val.usdValue)
-                | balanceSum
-                | calculatePrice(exchangeRate(currency.ticker_symbol))
-                | formatPrice(floatingPrecision)
-            }}
+            <amount-display
+              usd-value
+              :value="visibleBalances.map(val => val.usdValue) | balanceSum"
+            >
+            </amount-display>
           </td>
         </tr>
       </template>

--- a/electron-app/src/components/accounts/AccountBalances.vue
+++ b/electron-app/src/components/accounts/AccountBalances.vue
@@ -115,7 +115,7 @@
           </td>
           <td class="text-end">
             <amount-display
-              usd-value
+              fiat
               :value="visibleBalances.map(val => val.usdValue) | balanceSum"
             >
             </amount-display>

--- a/electron-app/src/components/accounts/AccountBalances.vue
+++ b/electron-app/src/components/accounts/AccountBalances.vue
@@ -107,13 +107,13 @@
       <template v-if="balances.length > 0" #body.append>
         <tr class="account-balances__total">
           <td>Total</td>
-          <td>
+          <td class="text-end">
             <amount-display
               :value="visibleBalances.map(val => val.amount) | balanceSum"
             >
             </amount-display>
           </td>
-          <td>
+          <td class="text-end">
             <amount-display
               usd-value
               :value="visibleBalances.map(val => val.usdValue) | balanceSum"
@@ -252,8 +252,8 @@ export default class AccountBalances extends Vue {
 
   headers = [
     { text: 'Account', value: 'account' },
-    { text: this.blockchain, value: 'amount' },
-    { text: 'USD Value', value: 'usdValue' },
+    { text: this.blockchain, value: 'amount', align: 'end' },
+    { text: 'USD Value', value: 'usdValue', align: 'end' },
     { text: 'Actions', value: 'actions', sortable: false, width: '50' },
     { text: '', value: 'expand', align: 'end' }
   ];

--- a/electron-app/src/components/accounts/FiatBalances.vue
+++ b/electron-app/src/components/accounts/FiatBalances.vue
@@ -54,7 +54,7 @@
                   <td></td>
                   <td class="text-end">
                     <amount-display
-                      fiat
+                      fiat-currency="USD"
                       :value="
                         fiatBalances.map(val => val.usdValue) | balanceSum
                       "

--- a/electron-app/src/components/accounts/FiatBalances.vue
+++ b/electron-app/src/components/accounts/FiatBalances.vue
@@ -52,13 +52,13 @@
                 <tr class="fiat-balances__total">
                   <td>Total</td>
                   <td></td>
-                  <td>
-                    {{
-                      fiatBalances.map(val => val.usdValue)
-                        | balanceSum
-                        | calculatePrice(exchangeRate(currency.ticker_symbol))
-                        | formatPrice(floatingPrecision)
-                    }}
+                  <td class="text-end">
+                    <amount-display
+                      fiat
+                      :value="
+                        fiatBalances.map(val => val.usdValue) | balanceSum
+                      "
+                    ></amount-display>
                   </td>
                 </tr>
               </template>
@@ -128,8 +128,8 @@ export default class FiatBalances extends Vue {
 
   headers = [
     { text: 'Currency', value: 'currency' },
-    { text: 'Amount', value: 'amount' },
-    { text: 'value', value: 'usdValue' }
+    { text: 'Amount', value: 'amount', align: 'end' },
+    { text: 'value', value: 'usdValue', align: 'end' }
   ];
 
   get availableCurrencies(): Currency[] {

--- a/electron-app/src/components/accounts/ManualBalancesList.vue
+++ b/electron-app/src/components/accounts/ManualBalancesList.vue
@@ -77,9 +77,9 @@
               <td>Total</td>
               <td></td>
               <td></td>
-              <td>
+              <td class="text-end">
                 <amount-display
-                  usd-value
+                  fiat
                   class="manual-balances-list__amount"
                   :value="visibleBalances.map(val => val.usdValue) | balanceSum"
                 ></amount-display>
@@ -169,8 +169,8 @@ export default class ManualBalancesList extends Vue {
   headers = [
     { text: 'Label', value: 'label' },
     { text: 'Asset', value: 'asset', width: '200' },
-    { text: 'Amount', value: 'amount' },
-    { text: 'USD Value', value: 'usdValue' },
+    { text: 'Amount', value: 'amount', align: 'end' },
+    { text: 'USD Value', value: 'usdValue', align: 'end' },
     { text: 'Location', value: 'location' },
     { text: 'Actions', value: 'actions', sortable: false, width: '50' }
   ];

--- a/electron-app/src/components/accounts/ManualBalancesList.vue
+++ b/electron-app/src/components/accounts/ManualBalancesList.vue
@@ -47,7 +47,13 @@
             ></amount-display>
           </template>
           <template #item.usdValue="{ item }">
-            <amount-display fiat :value="item.usdValue"></amount-display>
+            <amount-display
+              fiat
+              :amount="item.amount"
+              :fiat-currency="item.asset"
+              :value="item.usdValue"
+            >
+            </amount-display>
           </template>
           <template #item.location="{ item }">
             <span class="manual-balances-list__location">

--- a/electron-app/src/components/accounts/ManualBalancesList.vue
+++ b/electron-app/src/components/accounts/ManualBalancesList.vue
@@ -48,7 +48,6 @@
           </template>
           <template #item.usdValue="{ item }">
             <amount-display
-              fiat
               :amount="item.amount"
               :fiat-currency="item.asset"
               :value="item.usdValue"
@@ -85,7 +84,7 @@
               <td></td>
               <td class="text-end">
                 <amount-display
-                  fiat
+                  fiat-currency="USD"
                   class="manual-balances-list__amount"
                   :value="visibleBalances.map(val => val.usdValue) | balanceSum"
                 ></amount-display>

--- a/electron-app/src/components/accounts/ManualBalancesList.vue
+++ b/electron-app/src/components/accounts/ManualBalancesList.vue
@@ -78,12 +78,11 @@
               <td></td>
               <td></td>
               <td>
-                {{
-                  visibleBalances.map(val => val.usdValue)
-                    | balanceSum
-                    | calculatePrice(exchangeRate(currency.ticker_symbol))
-                    | formatPrice(floatingPrecision)
-                }}
+                <amount-display
+                  usd-value
+                  class="manual-balances-list__amount"
+                  :value="visibleBalances.map(val => val.usdValue) | balanceSum"
+                ></amount-display>
               </td>
             </tr>
           </template>

--- a/electron-app/src/components/dashboard/ExchangeBox.vue
+++ b/electron-app/src/components/dashboard/ExchangeBox.vue
@@ -19,14 +19,11 @@
       </v-col>
       <v-col cols="10" class="exchange-box__amount text-right">
         <span class="exchange-box__amount__number">
-          {{
-            amount
-              | calculatePrice(exchangeRate(currency.ticker_symbol))
-              | formatPrice(floatingPrecision)
-          }}
-        </span>
-        <span class="exchange-box__currency__symbol">
-          {{ currency.unicode_symbol }}
+          <amount-display
+            show-currency="symbol"
+            fiat
+            :value="amount"
+          ></amount-display>
         </span>
       </v-col>
     </v-row>
@@ -66,6 +63,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import AmountDisplay from '@/components/display/AmountDisplay.vue';
 import { Currency } from '@/model/currency';
 import { ExchangeBalancePayload } from '@/store/balances/actions';
 
@@ -73,6 +71,7 @@ const { mapGetters } = createNamespacedHelpers('session');
 const { mapGetters: mapBalanceGetters } = createNamespacedHelpers('balances');
 
 @Component({
+  components: { AmountDisplay },
   computed: {
     ...mapGetters(['floatingPrecision', 'currency']),
     ...mapBalanceGetters(['exchangeRate'])

--- a/electron-app/src/components/dashboard/ExchangeBox.vue
+++ b/electron-app/src/components/dashboard/ExchangeBox.vue
@@ -21,7 +21,7 @@
         <span class="exchange-box__amount__number">
           <amount-display
             show-currency="symbol"
-            fiat
+            fiat-currency="USD"
             :value="amount"
           ></amount-display>
         </span>

--- a/electron-app/src/components/dashboard/InformationBox.vue
+++ b/electron-app/src/components/dashboard/InformationBox.vue
@@ -14,7 +14,7 @@
         <span class="information-box__amount__number">
           <amount-display
             show-currency="symbol"
-            fiat
+            fiat-currency="USD"
             :value="amount"
           ></amount-display>
         </span>

--- a/electron-app/src/components/dashboard/InformationBox.vue
+++ b/electron-app/src/components/dashboard/InformationBox.vue
@@ -14,7 +14,7 @@
         <span class="information-box__amount__number">
           <amount-display
             show-currency="symbol"
-            usd-value
+            fiat
             :value="amount"
           ></amount-display>
         </span>

--- a/electron-app/src/components/dashboard/InformationBox.vue
+++ b/electron-app/src/components/dashboard/InformationBox.vue
@@ -12,14 +12,11 @@
       </v-col>
       <v-col cols="10" class="information-box__amount text-right">
         <span class="information-box__amount__number">
-          {{
-            amount
-              | calculatePrice(exchangeRate(currency.ticker_symbol))
-              | formatPrice(floatingPrecision)
-          }}
-        </span>
-        <span class="information-box__currency__symbol">
-          {{ currency.unicode_symbol }}
+          <amount-display
+            show-currency="symbol"
+            usd-value
+            :value="amount"
+          ></amount-display>
         </span>
       </v-col>
     </v-row>
@@ -53,6 +50,7 @@
 import { default as BigNumber } from 'bignumber.js';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import AmountDisplay from '@/components/display/AmountDisplay.vue';
 import { Currency } from '@/model/currency';
 import { BlockchainBalancePayload } from '@/store/balances/actions';
 
@@ -60,6 +58,9 @@ const { mapGetters } = createNamespacedHelpers('session');
 const { mapGetters: mapBalanceGetters } = createNamespacedHelpers('balances');
 
 @Component({
+  components: {
+    AmountDisplay
+  },
   computed: {
     ...mapGetters(['floatingPrecision', 'currency']),
     ...mapBalanceGetters(['exchangeRate'])

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -51,16 +51,14 @@ import { Currency } from '@/model/currency';
 import { bigNumberify } from '@/utils/bignumbers';
 
 const { mapGetters } = createNamespacedHelpers('session');
+const { mapState } = createNamespacedHelpers('session');
+
 const { mapGetters: mapBalancesGetters } = createNamespacedHelpers('balances');
 
 @Component({
   computed: {
-    ...mapGetters([
-      'floatingPrecision',
-      'currency',
-      'privacyMode',
-      'scrambleData'
-    ]),
+    ...mapGetters(['floatingPrecision', 'currency']),
+    ...mapState(['privacyMode', 'scrambleData']),
     ...mapBalancesGetters(['exchangeRate']),
     renderValue: function () {
       const multiplier = [10, 100, 1000];

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -1,8 +1,6 @@
 <template>
-  <span>
-    <span v-if="fiat" class="amount-display__value"
-      :class="privacyMode ? 'blur-content' : ''"
-    >
+  <span :class="privacyMode ? 'blur-content' : ''">
+    <span v-if="fiat" class="amount-display__value">
       {{
         renderValue
           | calculatePrice(exchangeRate(currency.ticker_symbol))
@@ -16,7 +14,7 @@
     <v-tooltip v-if="!fiat" top>
       <template #activator="{ on }">
         <span
-          v-if="value.decimalPlaces() > floatingPrecision"
+          v-if="renderValue.decimalPlaces() > floatingPrecision"
           class="amount-display__asterisk"
           v-on="on"
         >
@@ -28,6 +26,7 @@
       </span>
       <span v-else class="amount-display__full-value">
         {{ renderValue }}
+      </span>
     </v-tooltip>
     <span v-if="showCurrency === 'ticker'" class="amount-display__currency">
       {{ currency.ticker_symbol }}
@@ -49,6 +48,7 @@ import { default as BigNumber } from 'bignumber.js';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
 import { Currency } from '@/model/currency';
+import { bigNumberify } from '@/utils/bignumbers';
 
 const { mapGetters } = createNamespacedHelpers('session');
 const { mapGetters: mapBalancesGetters } = createNamespacedHelpers('balances');
@@ -71,6 +71,9 @@ const { mapGetters: mapBalancesGetters } = createNamespacedHelpers('balances');
             multiplier[Math.floor(Math.random() * multiplier.length)]
           )
           .plus(BigNumber.random(2));
+      }
+      if (typeof this.$props.value === 'string') {
+        return bigNumberify(this.$props.value);
       }
       return this.$props.value;
     }

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -50,8 +50,7 @@ import { createNamespacedHelpers } from 'vuex';
 import { Currency } from '@/model/currency';
 import { bigNumberify } from '@/utils/bignumbers';
 
-const { mapGetters } = createNamespacedHelpers('session');
-const { mapState } = createNamespacedHelpers('session');
+const { mapGetters, mapState } = createNamespacedHelpers('session');
 
 const { mapGetters: mapBalancesGetters } = createNamespacedHelpers('balances');
 
@@ -117,7 +116,6 @@ td.text-end .amount-display {
   }
 }
 .blur-content {
-  color: transparent;
-  text-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  filter: blur(0.3em);
 }
 </style>

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :class="privacyMode ? 'blur-content' : ''">
+  <span class="amount-display" :class="privacyMode ? 'blur-content' : ''">
     <span
       v-if="fiatCurrency && fiatCurrency != currency.ticker_symbol"
       class="amount-display__value"
@@ -131,6 +131,7 @@ td.text-end .amount-display {
     }
   }
 }
+
 .blur-content {
   filter: blur(0.3em);
 }

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -1,7 +1,7 @@
 <template>
   <span :class="privacyMode ? 'blur-content' : ''">
     <span
-      v-if="fiat && fiatCurrency != currency.ticker_symbol"
+      v-if="fiatCurrency && fiatCurrency != currency.ticker_symbol"
       class="amount-display__value"
     >
       {{
@@ -14,7 +14,7 @@
       {{ renderValue | formatPrice(floatingPrecision) }}
     </span>
 
-    <v-tooltip v-if="!fiat" top>
+    <v-tooltip v-if="!fiatCurrency" top>
       <template #activator="{ on }">
         <span
           v-if="renderValue.decimalPlaces() > floatingPrecision"
@@ -24,7 +24,7 @@
           *
         </span>
       </template>
-      <span v-if="fiat" class="amount-display__full-value">
+      <span v-if="fiatCurrency" class="amount-display__full-value">
         {{ renderValue | calculatePrice(exchangeRate(currency.ticker_symbol)) }}
       </span>
       <span v-else class="amount-display__full-value">
@@ -69,10 +69,8 @@ export default class AmountDisplay extends Vue {
   value!: BigNumber;
   @Prop({ required: false })
   amount!: BigNumber;
-  @Prop({ required: false, default: false, type: Boolean })
-  fiat!: boolean;
-  @Prop({ required: false, default: '', type: String })
-  fiatCurrency!: string;
+  @Prop({ required: false, default: null, type: String })
+  fiatCurrency!: string | null;
   @Prop({
     required: false,
     default: 'none',

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -89,7 +89,7 @@ export default class AmountDisplay extends Vue {
     let valueToRender;
 
     // return a random number if scrambeData is on
-    if (this.$store.state.session.scrambleData) {
+    if (this.scrambleData) {
       return BigNumber.random()
         .multipliedBy(multiplier[Math.floor(Math.random() * multiplier.length)])
         .plus(BigNumber.random(2));

--- a/electron-app/src/components/display/AmountDisplay.vue
+++ b/electron-app/src/components/display/AmountDisplay.vue
@@ -98,10 +98,18 @@ export default class AmountDisplay extends Vue {
 </script>
 
 <style scoped lang="scss">
+td.text-end .amount-display {
+  &__asterisk {
+    float: right;
+    margin-right: -0.6em;
+    top: -0.1em;
+  }
+}
+
 .amount-display {
   &__asterisk {
     font-weight: 500;
-    padding: 2px;
+    font-size: 0.8em;
     &:hover {
       cursor: pointer;
     }

--- a/electron-app/src/components/settings/AssetBalances.vue
+++ b/electron-app/src/components/settings/AssetBalances.vue
@@ -35,12 +35,11 @@
           <td>Total</td>
           <td></td>
           <td>
-            {{
-              balances.map(val => val.usdValue)
-                | balanceSum
-                | calculatePrice(exchangeRate(currency.ticker_symbol))
-                | formatPrice(floatingPrecision)
-            }}
+            <amount-display
+              usd-value
+              :value="balances.map(val => val.usdValue) | balanceSum"
+            >
+            </amount-display>
           </td>
         </tr>
       </template>

--- a/electron-app/src/components/settings/AssetBalances.vue
+++ b/electron-app/src/components/settings/AssetBalances.vue
@@ -36,7 +36,7 @@
           <td></td>
           <td class="text-end">
             <amount-display
-              fiat
+              fiat-currency="USD"
               :value="balances.map(val => val.usdValue) | balanceSum"
             >
             </amount-display>

--- a/electron-app/src/components/settings/AssetBalances.vue
+++ b/electron-app/src/components/settings/AssetBalances.vue
@@ -34,7 +34,7 @@
         <tr class="asset-balances__total">
           <td>Total</td>
           <td></td>
-          <td>
+          <td class="text-end">
             <amount-display
               usd-value
               :value="balances.map(val => val.usdValue) | balanceSum"
@@ -85,8 +85,8 @@ export default class AssetBalances extends Vue {
 
   headers = [
     { text: 'Asset', value: 'asset' },
-    { text: 'Amount', value: 'amount' },
-    { text: 'USD Value', value: 'usdValue' }
+    { text: 'Amount', value: 'amount', align: 'end' },
+    { text: 'USD Value', value: 'usdValue', align: 'end' }
   ];
 }
 </script>

--- a/electron-app/src/components/settings/AssetBalances.vue
+++ b/electron-app/src/components/settings/AssetBalances.vue
@@ -36,7 +36,7 @@
           <td></td>
           <td class="text-end">
             <amount-display
-              usd-value
+              fiat
               :value="balances.map(val => val.usdValue) | balanceSum"
             >
             </amount-display>

--- a/electron-app/src/store/session/getters.ts
+++ b/electron-app/src/store/session/getters.ts
@@ -15,14 +15,6 @@ export const getters: GetterTree<SessionState, RotkehlchenState> = {
     return state.accountingSettings.lastBalanceSave;
   },
 
-  privacyMode: (state: SessionState) => {
-    return state.privacyMode;
-  },
-
-  scrambleData: (state: SessionState) => {
-    return state.scrambleData;
-  },
-
   currency: (state: SessionState) => {
     return state.settings.selectedCurrency;
   },

--- a/electron-app/src/store/session/getters.ts
+++ b/electron-app/src/store/session/getters.ts
@@ -15,6 +15,14 @@ export const getters: GetterTree<SessionState, RotkehlchenState> = {
     return state.accountingSettings.lastBalanceSave;
   },
 
+  privacyMode: (state: SessionState) => {
+    return state.privacyMode;
+  },
+
+  scrambleData: (state: SessionState) => {
+    return state.scrambleData;
+  },
+
   currency: (state: SessionState) => {
     return state.settings.selectedCurrency;
   },

--- a/electron-app/src/store/session/mutations.ts
+++ b/electron-app/src/store/session/mutations.ts
@@ -26,6 +26,12 @@ export const mutations: MutationTree<SessionState> = {
   settings(state: SessionState, settings: GeneralSettings) {
     state.settings = Object.assign(state.settings, settings);
   },
+  privacyMode(state: SessionState, privacyMode: boolean) {
+    state.privacyMode = privacyMode;
+  },
+  scrambleData(state: SessionState, scrambleData: boolean) {
+    state.scrambleData = scrambleData;
+  },
   premium(state: SessionState, premium: boolean) {
     state.premium = premium;
   },

--- a/electron-app/src/store/session/state.ts
+++ b/electron-app/src/store/session/state.ts
@@ -9,6 +9,8 @@ export interface SessionState {
   accountingSettings: AccountingSettings;
   premium: boolean;
   premiumSync: boolean;
+  privacyMode: boolean;
+  scrambleData: boolean;
   nodeConnection: boolean;
   syncConflict: string;
   tags: Tags;
@@ -20,6 +22,8 @@ export const defaultState: () => SessionState = () => ({
   username: '',
   settings: defaultSettings(),
   accountingSettings: defaultAccountingSettings(),
+  privacyMode: false,
+  scrambleData: false,
   premium: false,
   premiumSync: false,
   nodeConnection: false,

--- a/electron-app/src/views/Dashboard.vue
+++ b/electron-app/src/views/Dashboard.vue
@@ -68,13 +68,13 @@
               <tr class="dashboard__balances__total">
                 <td>Total</td>
                 <td></td>
-                <td>
-                  {{
-                    aggregatedBalances.map(val => val.usdValue)
-                      | balanceSum
-                      | calculatePrice(exchangeRate(currency.ticker_symbol))
-                      | formatPrice(floatingPrecision)
-                  }}
+                <td class="text-end">
+                  <amount-display
+                    fiat
+                    :value="
+                      aggregatedBalances.map(val => val.usdValue) | balanceSum
+                    "
+                  ></amount-display>
                 </td>
               </tr>
             </template>

--- a/electron-app/src/views/Dashboard.vue
+++ b/electron-app/src/views/Dashboard.vue
@@ -54,7 +54,11 @@
               <amount-display :value="item.amount"></amount-display>
             </template>
             <template #item.usdValue="{ item }">
-              <amount-display fiat :value="item.usdValue"></amount-display>
+              <amount-display
+                :fiat-currency="item.asset"
+                :amount="item.amount"
+                :value="item.usdValue"
+              ></amount-display>
             </template>
             <template #item.percentage="{ item }">
               <amount-display
@@ -72,7 +76,7 @@
                 <td></td>
                 <td class="text-end">
                   <amount-display
-                    fiat
+                    fiat-currency="USD"
                     :value="
                       aggregatedBalances.map(val => val.usdValue) | balanceSum
                     "

--- a/electron-app/src/views/Dashboard.vue
+++ b/electron-app/src/views/Dashboard.vue
@@ -141,9 +141,14 @@ export default class Dashboard extends Vue {
 
   headers = [
     { text: 'Asset', value: 'asset' },
-    { text: 'Amount', value: 'amount' },
-    { text: 'Value', value: 'usdValue' },
-    { text: '% of net Value', value: 'percentage', sortable: false }
+    { text: 'Amount', value: 'amount', align: 'end' },
+    { text: 'Value', value: 'usdValue', align: 'end' },
+    {
+      text: '% of net Value',
+      value: 'percentage',
+      align: 'end',
+      sortable: false
+    }
   ];
 }
 </script>

--- a/electron-app/src/views/Dashboard.vue
+++ b/electron-app/src/views/Dashboard.vue
@@ -57,7 +57,9 @@
               <amount-display fiat :value="item.usdValue"></amount-display>
             </template>
             <template #item.percentage="{ item }">
-              {{ item.usdValue | percentage(total, floatingPrecision) }}
+              <amount-display
+                :value="item.usdValue | percentage(total, floatingPrecision)"
+              ></amount-display>
             </template>
             <template #no-results>
               <v-alert :value="true" color="error" icon="warning">

--- a/electron-app/src/views/OtcTrades.vue
+++ b/electron-app/src/views/OtcTrades.vue
@@ -24,16 +24,24 @@
             item-key="trade_id"
           >
             <template #item.pair="{ item }" class="trade">
-              <span class="otc-trades__trade__pair">{{ item.pair }}</span>
+              <span class="otc-trades__trade__pair">
+                {{ item.pair }}
+              </span>
             </template>
             <template #item.trade_type="{ item }">
               <span class="otc-trades__trade__type">{{ item.trade_type }}</span>
             </template>
             <template #item.amount="{ item }">
-              <span class="otc-trades__trade__amount">{{ item.amount }}</span>
+              <amount-display
+                class="otc-trades__trade__amount"
+                :value="item.amount"
+              ></amount-display>
             </template>
             <template #item.rate="{ item }">
-              <span class="otc-trades__trade__rate">{{ item.rate }}</span>
+              <amount-display
+                class="otc-trades__trade__rate"
+                :value="item.rate"
+              ></amount-display>
             </template>
             <template #item.timestamp="{ item }">
               <span class="otc-trades__trade__time">
@@ -99,6 +107,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 import MessageDialog from '@/components/dialogs/MessageDialog.vue';
+import AmountDisplay from '@/components/display/AmountDisplay.vue';
 import OtcForm from '@/components/OtcForm.vue';
 import { StoredTrade, TradePayload } from '@/model/stored-trade';
 import { Message } from '@/store/store';
@@ -106,7 +115,7 @@ import { assert } from '@/utils/assertions';
 
 const { mapGetters } = createNamespacedHelpers('session');
 @Component({
-  components: { ConfirmDialog, MessageDialog, OtcForm },
+  components: { ConfirmDialog, MessageDialog, OtcForm, AmountDisplay },
   computed: mapGetters(['dateDisplayFormat'])
 })
 export default class OtcTrades extends Vue {
@@ -123,8 +132,8 @@ export default class OtcTrades extends Vue {
   readonly headers = [
     { text: 'Pair', value: 'pair' },
     { text: 'Type', value: 'trade_type' },
-    { text: 'Amount', value: 'amount' },
-    { text: 'Rate', value: 'rate' },
+    { text: 'Amount', value: 'amount', align: 'end' },
+    { text: 'Rate', value: 'rate', align: 'end' },
     { text: 'Time', value: 'timestamp' },
     { text: 'Actions', value: 'actions', width: '50' },
     { text: '', value: 'data-table-expand' }

--- a/electron-app/src/views/settings/General.vue
+++ b/electron-app/src/views/settings/General.vue
@@ -119,6 +119,7 @@
           <v-card-text>
             <v-switch
               v-model="scrambleData"
+              class="settings-general__fields__scramble-data"
               :label="`Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions.`"
             >
             </v-switch>

--- a/electron-app/src/views/settings/General.vue
+++ b/electron-app/src/views/settings/General.vue
@@ -21,7 +21,7 @@
               v-model="anonymizedLogs"
               class="settings-general__fields__anonymized-logs"
               off-icon="fa fa-square-o"
-              label="Should logs by anonymized?"
+              label="Should logs be anonymized?"
             ></v-checkbox>
 
             <v-checkbox
@@ -113,6 +113,17 @@
             </v-btn>
           </v-card-actions>
         </v-card>
+        <br />
+        <v-card>
+          <v-card-title>Frontend-only Settings</v-card-title>
+          <v-card-text>
+            <v-switch
+              v-model="scrambleData"
+              :label="`Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions.`"
+            >
+            </v-switch>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
   </v-container>
@@ -134,12 +145,21 @@ const { mapState, mapGetters } = createNamespacedHelpers('session');
   components: { MessageDialog },
   computed: {
     ...mapState(['settings']),
-    ...mapGetters(['currency'])
+    ...mapGetters(['currency']),
+    scrambleData: {
+      get: function () {
+        return this.$store.getters['session/scrambleData'];
+      },
+      set: function (value) {
+        this.$store.commit('session/scrambleData', value);
+      }
+    }
   }
 })
 export default class General extends Vue {
   settings!: GeneralSettings;
   currency!: Currency;
+  scrambleData!: boolean;
 
   floatingPrecision: string = '0';
   anonymizedLogs: boolean = false;

--- a/electron-app/src/views/settings/General.vue
+++ b/electron-app/src/views/settings/General.vue
@@ -145,21 +145,12 @@ const { mapState, mapGetters } = createNamespacedHelpers('session');
   components: { MessageDialog },
   computed: {
     ...mapState(['settings']),
-    ...mapGetters(['currency']),
-    scrambleData: {
-      get: function () {
-        return this.$store.getters['session/scrambleData'];
-      },
-      set: function (value) {
-        this.$store.commit('session/scrambleData', value);
-      }
-    }
+    ...mapGetters(['currency'])
   }
 })
 export default class General extends Vue {
   settings!: GeneralSettings;
   currency!: Currency;
-  scrambleData!: boolean;
 
   floatingPrecision: string = '0';
   anonymizedLogs: boolean = false;
@@ -176,6 +167,14 @@ export default class General extends Vue {
   @Watch('date')
   dateWatch() {
     this.historicDataStart = this.formatDate(this.date);
+  }
+
+  get scrambleData() {
+    return this.$store.state.session.scrambleData;
+  }
+
+  set scrambleData(value: boolean) {
+    this.$store.commit('session/scrambleData', value);
   }
 
   formatDate(date: string) {

--- a/electron-app/tests/e2e/pages/account-balances-page.ts
+++ b/electron-app/tests/e2e/pages/account-balances-page.ts
@@ -38,12 +38,6 @@ export class AccountBalancesPage {
 
       i += 1;
     }
-
-    // cy.get('.manual-balances-list tbody').find('tr').eq(position).as('row');
-
-    // cy.get('@row')
-    //   .find('.manual-balances-list__amount')
-    //   .should('contain', bigNumberify(balance.amount).toFormat(2));
   }
 
   balanceShouldNotMatch(balances: ApiManualBalance[]) {
@@ -57,11 +51,6 @@ export class AccountBalancesPage {
 
       i += 1;
     }
-    // cy.get('.manual-balances-list tbody').find('tr').eq(position).as('row');
-
-    // cy.get('@row')
-    //   .find('.manual-balances-list__amount')
-    //   .should('not.contain', bigNumberify(balance.amount).toFormat(2));
   }
 
   isVisible(position: number, balance: ApiManualBalance) {

--- a/electron-app/tests/e2e/pages/account-balances-page.ts
+++ b/electron-app/tests/e2e/pages/account-balances-page.ts
@@ -27,6 +27,43 @@ export class AccountBalancesPage {
       .should('have.length', visible + 1);
   }
 
+  balanceShouldMatch(balances: ApiManualBalance[]) {
+    let i = 0;
+    for (const balance of balances) {
+      cy.get('.manual-balances-list tbody').find('tr').eq(i).as('row');
+
+      cy.get('@row')
+        .find('.manual-balances-list__amount')
+        .should('contain', bigNumberify(balance.amount).toFormat(2));
+
+      i += 1;
+    }
+
+    // cy.get('.manual-balances-list tbody').find('tr').eq(position).as('row');
+
+    // cy.get('@row')
+    //   .find('.manual-balances-list__amount')
+    //   .should('contain', bigNumberify(balance.amount).toFormat(2));
+  }
+
+  balanceShouldNotMatch(balances: ApiManualBalance[]) {
+    let i = 0;
+    for (const balance of balances) {
+      cy.get('.manual-balances-list tbody').find('tr').eq(i).as('row');
+
+      cy.get('@row')
+        .find('.manual-balances-list__amount')
+        .should('not.contain', bigNumberify(balance.amount).toFormat(2));
+
+      i += 1;
+    }
+    // cy.get('.manual-balances-list tbody').find('tr').eq(position).as('row');
+
+    // cy.get('@row')
+    //   .find('.manual-balances-list__amount')
+    //   .should('not.contain', bigNumberify(balance.amount).toFormat(2));
+  }
+
   isVisible(position: number, balance: ApiManualBalance) {
     cy.get('.manual-balances-list tbody').find('tr').eq(position).as('row');
 
@@ -63,6 +100,14 @@ export class AccountBalancesPage {
     for (const tag of balance.tags) {
       cy.get('@row').find('.tag').contains(tag).should('be.visible');
     }
+  }
+
+  amountDisplayIsBlurred() {
+    cy.get('.amount-display').should('have.class', 'blur-content');
+  }
+
+  amountDisplayIsNotBlurred() {
+    cy.get('.amount-display').should('not.have.class', 'blur-content');
   }
 
   editBalance(position: number, amount: string) {

--- a/electron-app/tests/e2e/pages/general-settings-page.ts
+++ b/electron-app/tests/e2e/pages/general-settings-page.ts
@@ -39,6 +39,10 @@ export class GeneralSettingsPage {
     cy.get('.settings-general__fields__date-display-format').type(value);
   }
 
+  toggleScrambleData() {
+    cy.get('.settings-general__fields__scramble-data').click();
+  }
+
   saveSettings() {
     cy.get('.settings-general__buttons__save').click();
   }

--- a/electron-app/tests/e2e/pages/rotki-app.ts
+++ b/electron-app/tests/e2e/pages/rotki-app.ts
@@ -41,6 +41,11 @@ export class RotkiApp {
     cy.get(`#change-to-${currency.toLocaleLowerCase()}`).click();
   }
 
+  togglePrivacyMode() {
+    cy.get('.user-dropdown').click();
+    cy.get('.user-dropdown__privacy-mode').click();
+  }
+
   logoutApi(username: string, cb: () => void) {
     axios
       .create({

--- a/electron-app/tests/e2e/specs/accounts-balances.spec.ts
+++ b/electron-app/tests/e2e/specs/accounts-balances.spec.ts
@@ -1,6 +1,7 @@
 import { ApiManualBalance } from '../../../src/services/types-api';
 import { Guid } from '../../common/guid';
 import { AccountBalancesPage } from '../pages/account-balances-page';
+import { GeneralSettingsPage } from '../pages/general-settings-page';
 import { RotkiApp } from '../pages/rotki-app';
 import { TagManager } from '../pages/tag-manager';
 
@@ -9,12 +10,14 @@ describe('Accounts', () => {
   let app: RotkiApp;
   let page: AccountBalancesPage;
   let tagManager: TagManager;
+  let settings: GeneralSettingsPage;
 
   before(() => {
     username = Guid.newGuid().toString();
     app = new RotkiApp();
     page = new AccountBalancesPage();
     tagManager = new TagManager();
+    settings = new GeneralSettingsPage();
     app.visit();
     app.createAccount(username);
     app.closePremiumOverlay();
@@ -55,6 +58,29 @@ describe('Accounts', () => {
       page.addBalance(manualBalances[1]);
       page.visibleEntries(2);
       page.isVisible(1, manualBalances[1]);
+    });
+
+    it('test privacy mode is off', () => {
+      page.amountDisplayIsNotBlurred();
+    });
+
+    it('test privacy mode is on', () => {
+      app.togglePrivacyMode();
+      page.amountDisplayIsBlurred();
+      app.togglePrivacyMode();
+    });
+
+    it('test scramble mode', () => {
+      page.balanceShouldMatch(manualBalances);
+
+      settings.visit();
+      settings.toggleScrambleData();
+      page.visit();
+      page.balanceShouldNotMatch(manualBalances);
+
+      settings.visit();
+      settings.toggleScrambleData();
+      page.visit();
     });
 
     it('edit', () => {

--- a/electron-app/tests/unit/components/display/amount-display.spec.ts
+++ b/electron-app/tests/unit/components/display/amount-display.spec.ts
@@ -10,7 +10,11 @@ import '@/filters';
 
 Vue.use(Vuetify);
 
-function createWrapper(value: BigNumber, amount: BigNumber, fiatCurrency: string | null) {
+function createWrapper(
+  value: BigNumber,
+  amount: BigNumber,
+  fiatCurrency: string | null
+) {
   let vuetify: typeof Vuetify = new Vuetify();
   return mount(AmountDisplay, {
     store,
@@ -45,7 +49,11 @@ describe('AmountDisplay.vue', () => {
     });
 
     test('displays amount converted to selected fiat currency (does not double-convert)', async () => {
-      wrapper = createWrapper(bigNumberify(1.20440001), bigNumberify(1.20440001), 'EUR');
+      wrapper = createWrapper(
+        bigNumberify(1.20440001),
+        bigNumberify(1.20440001),
+        'EUR'
+      );
       expect(wrapper.find('.amount-display__value').text()).toMatch('1.20');
       expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
     });
@@ -78,7 +86,11 @@ describe('AmountDisplay.vue', () => {
     });
 
     test('displays amount converted to selected fiat currency (does not double-convert) as scrambled', async () => {
-      wrapper = createWrapper(bigNumberify(1.20440001), bigNumberify(1.20440001), 'EUR');
+      wrapper = createWrapper(
+        bigNumberify(1.20440001),
+        bigNumberify(1.20440001),
+        'EUR'
+      );
       expect(wrapper.find('.amount-display__value').text()).not.toMatch('1.20');
       expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
     });

--- a/electron-app/tests/unit/components/display/amount-display.spec.ts
+++ b/electron-app/tests/unit/components/display/amount-display.spec.ts
@@ -5,12 +5,12 @@ import Vuetify from 'vuetify';
 import AmountDisplay from '@/components/display/AmountDisplay.vue';
 import { currencies } from '@/data/currencies';
 import store from '@/store/store';
-import { bigNumberify } from '@/utils/bignumbers';
+import { Zero, bigNumberify } from '@/utils/bignumbers';
 import '@/filters';
 
 Vue.use(Vuetify);
 
-function createWrapper(value: BigNumber, fiat: boolean = false) {
+function createWrapper(value: BigNumber, amount: BigNumber, fiatCurrency: string | null) {
   let vuetify: typeof Vuetify = new Vuetify();
   return mount(AmountDisplay, {
     store,
@@ -18,7 +18,8 @@ function createWrapper(value: BigNumber, fiat: boolean = false) {
     stubs: ['v-tooltip'],
     propsData: {
       value,
-      fiat
+      fiatCurrency,
+      amount
     }
   });
 }
@@ -26,27 +27,68 @@ function createWrapper(value: BigNumber, fiat: boolean = false) {
 describe('AmountDisplay.vue', () => {
   let wrapper: Wrapper<AmountDisplay>;
 
-  beforeEach(() => {
-    store.commit('session/defaultCurrency', currencies[1]);
-    store.commit('balances/usdToFiatExchangeRates', { EUR: 1.2 });
-    store.commit('session/settings', { floatingPrecision: 2 });
+  describe('Common case', () => {
+    beforeEach(() => {
+      store.commit('session/defaultCurrency', currencies[1]);
+      store.commit('balances/usdToFiatExchangeRates', { EUR: 1.2 });
+      store.commit('session/settings', { floatingPrecision: 2 });
+    });
+
+    afterEach(() => {
+      store.commit('session/reset');
+    });
+
+    test('displays amount converted to selected fiat currency', async () => {
+      wrapper = createWrapper(bigNumberify(1.20440001), Zero, 'USD');
+      expect(wrapper.find('.amount-display__value').text()).toMatch('1.45');
+      expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
+    });
+
+    test('displays amount converted to selected fiat currency (does not double-convert)', async () => {
+      wrapper = createWrapper(bigNumberify(1.20440001), bigNumberify(1.20440001), 'EUR');
+      expect(wrapper.find('.amount-display__value').text()).toMatch('1.20');
+      expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
+    });
+
+    test('displays amount as it is without fiat conversion', async () => {
+      wrapper = createWrapper(bigNumberify(1.20540001), Zero, null);
+      expect(wrapper.find('.amount-display__value').text()).toMatch('1.21');
+      expect(wrapper.find('.amount-display__full-value').text()).toMatch(
+        '1.20540001'
+      );
+    });
   });
 
-  afterEach(() => {
-    store.commit('session/reset');
-  });
+  describe('Scramble data', () => {
+    beforeEach(() => {
+      store.commit('session/defaultCurrency', currencies[1]);
+      store.commit('balances/usdToFiatExchangeRates', { EUR: 1.2 });
+      store.commit('session/settings', { floatingPrecision: 2 });
+      store.commit('session/scrambleData', true);
+    });
 
-  test('displays amount converted to selected currency on fiat flag', async () => {
-    wrapper = createWrapper(bigNumberify(1.20440001), true);
-    expect(wrapper.find('.amount-display__value').text()).toMatch('1.45');
-    expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
-  });
+    afterEach(() => {
+      store.commit('session/reset');
+    });
 
-  test('displays amount as it is without the fiat flag', async () => {
-    wrapper = createWrapper(bigNumberify(1.20540001));
-    expect(wrapper.find('.amount-display__value').text()).toMatch('1.21');
-    expect(wrapper.find('.amount-display__full-value').text()).toMatch(
-      '1.20540001'
-    );
+    test('displays amount converted to selected fiat currency as scrambled', async () => {
+      wrapper = createWrapper(bigNumberify(1.20440001), Zero, 'USD');
+      expect(wrapper.find('.amount-display__value').text()).not.toMatch('1.45');
+      expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
+    });
+
+    test('displays amount converted to selected fiat currency (does not double-convert) as scrambled', async () => {
+      wrapper = createWrapper(bigNumberify(1.20440001), bigNumberify(1.20440001), 'EUR');
+      expect(wrapper.find('.amount-display__value').text()).not.toMatch('1.20');
+      expect(wrapper.find('.amount-display__full-value').exists()).toBe(false);
+    });
+
+    test('displays amount as it is without fiat conversion as scrambled', async () => {
+      wrapper = createWrapper(bigNumberify(1.20540001), Zero, null);
+      expect(wrapper.find('.amount-display__value').text()).not.toMatch('1.21');
+      expect(wrapper.find('.amount-display__full-value').text()).not.toMatch(
+        '1.20540001'
+      );
+    });
   });
 });

--- a/electron-app/tests/unit/components/display/amount-display.spec.ts
+++ b/electron-app/tests/unit/components/display/amount-display.spec.ts
@@ -31,17 +31,17 @@ function createWrapper(
 describe('AmountDisplay.vue', () => {
   let wrapper: Wrapper<AmountDisplay>;
 
+  beforeEach(() => {
+    store.commit('session/defaultCurrency', currencies[1]);
+    store.commit('balances/usdToFiatExchangeRates', { EUR: 1.2 });
+    store.commit('session/settings', { floatingPrecision: 2 });
+  });
+
+  afterEach(() => {
+    store.commit('session/reset');
+  });
+
   describe('Common case', () => {
-    beforeEach(() => {
-      store.commit('session/defaultCurrency', currencies[1]);
-      store.commit('balances/usdToFiatExchangeRates', { EUR: 1.2 });
-      store.commit('session/settings', { floatingPrecision: 2 });
-    });
-
-    afterEach(() => {
-      store.commit('session/reset');
-    });
-
     test('displays amount converted to selected fiat currency', async () => {
       wrapper = createWrapper(bigNumberify(1.20440001), Zero, 'USD');
       expect(wrapper.find('.amount-display__value').text()).toMatch('1.45');
@@ -69,14 +69,7 @@ describe('AmountDisplay.vue', () => {
 
   describe('Scramble data', () => {
     beforeEach(() => {
-      store.commit('session/defaultCurrency', currencies[1]);
-      store.commit('balances/usdToFiatExchangeRates', { EUR: 1.2 });
-      store.commit('session/settings', { floatingPrecision: 2 });
       store.commit('session/scrambleData', true);
-    });
-
-    afterEach(() => {
-      store.commit('session/reset');
     });
 
     test('displays amount converted to selected fiat currency as scrambled', async () => {


### PR DESCRIPTION
This is a PR built on top of kelsos' #920 and latest develop. It extends the component AmountDisplay introduced in 920 so that it can also scramble and/or blur the rendered values. Additionally AmountDisplay can also display an inline currency representation (symbol / ticker / name). I've replaced some more calls to values/amounts with calls to the AmountDisplay component, but not "% of net value" and anything that's in Loans, OTC Trades, or in Premium features.

- Adds a privacy mode (accessibly from the User Menu) to blur any amounts/values displayed using the AmountDisplay component _(does not persist across sessions)_
![image](https://user-images.githubusercontent.com/27592/80281243-1df15780-870a-11ea-9652-7c05caf9a38c.png) 
- Adds a scramble data front-end only setting accessibly via the Settings page to scramble data displayed using the AmountDisplay component _(does not persist across sessions)_
![image](https://user-images.githubusercontent.com/27592/80281251-26e22900-870a-11ea-83b3-7bcb8a9f89d8.png)
- Adds the ability to render currency symbol/ticket/name for amounts displayed using the AmountDisplay component
![image](https://user-images.githubusercontent.com/27592/80281360-cf908880-870a-11ea-8dc2-e2ca55267162.png)
- Fixed bug with wrong property being called in ManualBalanceList
- Replaced rendering of amounts in ManualBalancesList, AssetBalances, AccountBalances with AmountDisplay component

I haven't touched the asterisk things yet.