### PR TITLE
Fixes login screen so that privacy notice never covers action buttons

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`928` Action buttons in overlays ('Sign In', 'Create', etc.) are now never hidden by the privacy dialog regardless of resolution, app scaling, or zoom.
 * :feature:`908` Adds the ability to view the full amount on tables when hovering over a hint (asterisk) indicating that the display number has been rounded.
 * :bug:`924` LINK is now properly supported for Gemini balance and trade queries.
 * :feature:`912` Adds total net value to the dashboard, fiat, and manual balances table. Makes account balance totals to reflect the filtered results.

--- a/electron-app/src/App.vue
+++ b/electron-app/src/App.vue
@@ -141,6 +141,10 @@ export default class App extends Vue {
 </script>
 
 <style scoped lang="scss">
+.v-navigation-drawer--fixed {
+  z-index: 8000 !important;
+}
+
 .rotki__logo {
   max-height: 150px;
 }

--- a/electron-app/src/components/AccountManagement.vue
+++ b/electron-app/src/components/AccountManagement.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <v-overlay v-if="!connected" class="account_management__loading">
+    <v-overlay
+      v-if="!connected"
+      class="account_management__loading"
+      z-index="8000"
+    >
       <v-row align="center" justify="center">
         <v-col cols="12" class="account_management__loading__content">
           <v-progress-circular indeterminate size="72"></v-progress-circular>
@@ -25,6 +29,7 @@
         </div>
       </v-alert>
     </div>
+
     <login
       v-if="connected"
       :displayed="!message && !logged && !accountCreation"
@@ -163,6 +168,14 @@ export default class AccountManagement extends Vue {
 </script>
 
 <style lang="scss">
+.v-overlay {
+  z-index: 8000 !important;
+}
+
+.v-dialog__content {
+  z-index: 9999 !important;
+}
+
 .account_management {
   &__loading {
     &__content {
@@ -181,7 +194,7 @@ export default class AccountManagement extends Vue {
     width: 100%;
     position: absolute;
     bottom: 20px;
-    z-index: 9999;
+    z-index: 8100;
     align-items: center;
     display: flex;
     flex-direction: column;

--- a/electron-app/src/components/AccountManagement.vue
+++ b/electron-app/src/components/AccountManagement.vue
@@ -1,10 +1,6 @@
 <template>
   <div>
-    <v-overlay
-      v-if="!connected"
-      class="account_management__loading"
-      z-index="8000"
-    >
+    <v-overlay v-if="!connected" class="account_management__loading">
       <v-row align="center" justify="center">
         <v-col cols="12" class="account_management__loading__content">
           <v-progress-circular indeterminate size="72"></v-progress-circular>
@@ -169,7 +165,7 @@ export default class AccountManagement extends Vue {
 
 <style lang="scss">
 .v-overlay {
-  z-index: 8000 !important;
+  z-index: 200 !important;
 }
 
 .v-dialog__content {

--- a/electron-app/tests/e2e/pages/rotki-app.ts
+++ b/electron-app/tests/e2e/pages/rotki-app.ts
@@ -7,6 +7,7 @@ export class RotkiApp {
   }
 
   createAccount(username: string) {
+    // simulate high scaling / low res by making a very small viewpoirt
     cy.get('.login__button__new-account').click();
     cy.get('.create-account__fields__username').type(username);
     cy.get('.create-account__fields__password').type('1234');

--- a/electron-app/tests/e2e/specs/account-creation.spec.ts
+++ b/electron-app/tests/e2e/specs/account-creation.spec.ts
@@ -5,21 +5,35 @@ describe('Accounts', () => {
   let username: string;
   let app: RotkiApp;
 
+  const viewPortSizes = [
+    [1000, 660, 'Cypress default viewport'],
+    [800, 600, 'Rotki minimum supported resolution'],
+    [640, 480, 'Small res to simulate high app scaling or zoom']
+  ];
+
   before(() => {
-    username = Guid.newGuid().toString();
     app = new RotkiApp();
   });
 
-  it('create account', () => {
-    app.visit();
-    app.createAccount(username);
-    app.closePremiumOverlay();
-    app.logout();
-  });
+  viewPortSizes.forEach(size => {
+    context(`Viewport: ${size[2]} (${size[0]}x${size[1]})`, () => {
+      before(() => {
+        cy.viewport(Number(size[0]), Number(size[1]));
+        username = Guid.newGuid().toString();
+      });
 
-  it('login', () => {
-    app.login(username);
-    app.closePremiumOverlay();
-    app.logout();
+      it('create account', () => {
+        app.visit();
+        app.createAccount(username);
+        app.closePremiumOverlay();
+        app.logout();
+      });
+
+      it('login', () => {
+        app.login(username);
+        app.closePremiumOverlay();
+        app.logout();
+      });
+    });
   });
 });


### PR DESCRIPTION
Fix #928

* Adjusted ordering of z-index in overlay & model elements so that content and action buttons on modal dialogs in the login screen are always on top.
![rotkiCreateModal](https://user-images.githubusercontent.com/27592/80302777-6c573280-87ac-11ea-9fc1-63a16410f6ca.gif)

@kelsos can you confirm it's OK on your end as well? Will update changelog and try to come up with a cypress test for this, I have to tinker if the zoom/viewport can be adjusted. But if we're in a rush to get this out today maybe we can add that later.