### PR TITLE
Add better error message if api call with multiple msg check fails

### DIFF
--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -96,7 +96,8 @@ def assert_error_response(
         if isinstance(contained_in_msg, str):
             assert contained_in_msg in response_data['message']
         elif isinstance(contained_in_msg, list):
-            assert any(x in response_data['message'] for x in contained_in_msg)
+            msg = f'Response: {response_data["message"]} does not match what we expected'
+            assert any(x in response_data['message'] for x in contained_in_msg), msg
 
 
 def assert_ok_async_response(response: requests.Response) -> int:


### PR DESCRIPTION
Partly fix #935. Could not reproduce the flaky test. Now if the test
fails again we will at least have a proper error message.