### PR TITLE
Temporary fixes to Win integration test scripts

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -8,6 +8,7 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "CODE_COVERAGE=true vue-cli-service test:e2e",
+    "test:e2e-win": "set CODE_COVERAGE=true && vue-cli-service test:e2e",
     "lint": "vue-cli-service lint",
     "electron:build": "vue-cli-service electron:build",
     "electron:serve": "vue-cli-service electron:serve",
@@ -17,6 +18,7 @@
     "serve:backend": "node start-backend.js",
     "test:e2e-ci": "CODE_COVERAGE=true nyc vue-cli-service test:e2e --headless",
     "test:integration": "start-server-and-test serve:backend http://localhost:4242/api/1/version test:e2e",
+    "test:integration-win": "start-server-and-test serve:backend http://localhost:4242/api/1/version test:e2e-win",
     "test:integration-ci": "start-server-and-test serve:backend http://localhost:4242/api/1/version test:e2e-ci",
     "test:spectron": "jest --config tests/spectron/jest.config.js --runInBand"
   },


### PR DESCRIPTION
Fix #932

Just opening this PR so anyone who is building on windows can use it for Windows integration test scripts. Let's decide if we just want to have separate scripts or set it up so we have cross-platform scripts.