### PR TITLE
Handle malformed kraken responses and 500 error on exchanges setup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`943` If Kraken sends a malformed response Rotki no longer raises a 500 Internal server error. Also if such an error is thrown during setup of any exchange and a stale object is left in the Rotki state, trying to setup the exchange again should now work and no longer give an error that the exchange is already registered.
 * :bug:`930` Etherscan API keys are now properly included in all etherscan api queries. Also etherscan API key is no longer compulsory.
 * :feature:`922` Speed up ethereum chain balance queries by utilizing the eth-scan contract to batch multiple ether and token balance queries into a single call.
 * :bug:`928` Action buttons in overlays ('Sign In', 'Create', etc.) are now never hidden by the privacy dialog regardless of resolution, app scaling, or zoom.

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -43,7 +43,7 @@ class ExchangeManager():
                 log.warning(
                     f'{name} exchange had no credentials in the DB but was in the '
                     f'connected exchanges mapping. Removing stale exchange from '
-                    f'mapping. This should not happen.'
+                    f'mapping. This should not happen.',
                 )
                 self.connected_exchanges.pop(name)
             return False

--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -88,10 +88,11 @@ def assert_error_response(
         response.headers["Content-Type"] == "application/json"
     )
     response_data = response.json()
-    if result_exists:
-        assert response_data['result'] is not None
-    else:
-        assert response_data['result'] is None
+    if status_code != HTTPStatus.INTERNAL_SERVER_ERROR:
+        if result_exists:
+            assert response_data['result'] is not None
+        else:
+            assert response_data['result'] is None
     if contained_in_msg:
         if isinstance(contained_in_msg, str):
             assert contained_in_msg in response_data['message']

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -327,6 +327,7 @@ class MockKraken(Kraken):
         self.random_balance_data = True
         self.random_ledgers_data = True
         self.remote_errors = False
+        self.use_original_kraken = False
 
         self.balance_data_return = {'XXBT': '5.0', 'XETH': '10.0', 'NOTAREALASSET': '15.0'}
         # Not required in the real Kraken instance but we use it in the tests
@@ -336,6 +337,9 @@ class MockKraken(Kraken):
         # Pretty ugly ... mock a kraken remote eror
         if self.remote_errors:
             raise RemoteError('Kraken remote error')
+
+        if self.use_original_kraken:
+            return super().api_query(method, req)
 
         if method == 'Balance':
             if self.random_balance_data:


### PR DESCRIPTION
Fix #943 

If Kraken sends a malformed response Rotki no longer raises a 500 Internal server error. Also if such an error is thrown during setup of any exchange and a stale object is left in the Rotki state, trying to setup the exchange again should now work and no longer give an error that the exchange is already registered.