### PR TITLE
Properly save all historical balances to the DB when a user has input manually tracked balances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`942` Properly save all historical balances to the DB when a user has input manually tracked balances.
 * :bug:`946` Handle the malformed response by kraken that is sent if a Kraken user has no balances.
 * :bug:`943` If Kraken sends a malformed response Rotki no longer raises a 500 Internal server error. Also if such an error is thrown during setup of any exchange and a stale object is left in the Rotki state, trying to setup the exchange again should now work and no longer give an error that the exchange is already registered.
 * :bug:`930` Etherscan API keys are now properly included in all etherscan api queries. Also etherscan API key is no longer compulsory.

--- a/rotkehlchen/balances/manual.py
+++ b/rotkehlchen/balances/manual.py
@@ -100,20 +100,20 @@ def account_for_manually_tracked_balances(
         location_str = str(m_entry.location)
         if location_str not in balances:
             balances[location_str] = {}
-            balances[location_str][m_entry.asset.identifier] = {
+            balances[location_str][m_entry.asset] = {
                 'amount': m_entry.amount,
                 'usd_value': m_entry.usd_value,
             }
         else:
-            if m_entry.asset.identifier not in balances[location_str]:
-                balances[location_str][m_entry.asset.identifier] = {
+            if m_entry.asset not in balances[location_str]:
+                balances[location_str][m_entry.asset] = {
                     'amount': m_entry.amount,
                     'usd_value': m_entry.usd_value,
                 }
             else:
-                old_amount = balances[location_str][m_entry.asset.identifier]['amount']
-                old_usd_value = balances[location_str][m_entry.asset.identifier]['usd_value']
-                balances[location_str][m_entry.asset.identifier] = {
+                old_amount = balances[location_str][m_entry.asset]['amount']
+                old_usd_value = balances[location_str][m_entry.asset]['usd_value']
+                balances[location_str][m_entry.asset] = {
                     'amount': old_amount + m_entry.amount,
                     'usd_value': old_usd_value + m_entry.usd_value,
                 }

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1043,7 +1043,8 @@ class DBHandler:
             if key in ('location', 'net_usd'):
                 continue
 
-            assert isinstance(key, Asset), 'at this point the key should only be Asset type'
+            msg = f'at this point the key should be of Asset type and not {type(key)} {str(key)}'
+            assert isinstance(key, Asset), msg
             balances.append(AssetBalance(
                 time=timestamp,
                 asset=key,


### PR DESCRIPTION
Fix #942