### PR TITLE
Add support for aDAI and LOKI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :feature:`-` Added support for the following tokens
+
+  - `Aave Interest bearing DAI (aDAI) <https://www.coingecko.com/en/coins/aave-dai>`__
+
 * :release:`1.4.2 <2020-04-29>`
 * :bug:`927` Rotki should no longer fail to handle HTTP Rate limiting if your web3 providing node rate limits you.
 * :bug:`950` If too many BTC accounts are used Rotki will no longer delay for a long time due to balance query rate limiting. Proper batching of queries to both bitcoin.info and blockcypher is now happening.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :feature:`-` Added support for the following tokens
 
   - `Aave Interest bearing DAI (aDAI) <https://www.coingecko.com/en/coins/aave-dai>`__
+  - `Loki (LOKI) <https://coinmarketcap.com/currencies/loki/>`__
 
 * :release:`1.4.2 <2020-04-29>`
 * :bug:`927` Rotki should no longer fail to handle HTTP Rate limiting if your web3 providing node rate limits you.

--- a/rotkehlchen/constants/cryptocompare.py
+++ b/rotkehlchen/constants/cryptocompare.py
@@ -1,5 +1,7 @@
 WORLD_TO_CRYPTOCOMPARE = {
+    # Botch CHAI and aDAI should be switched to proper queries with coingecko support
     'CHAI': 'DAI',
+    'aDAI': 'DAI',
     'LBRY': 'LBC',
     'DATAcoin': 'DATA',
     'IOTA': 'MIOTA',

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -10250,6 +10250,14 @@
         "symbol": "ZXC",
         "type": "ethereum token"
     },
+    "aDAI": {
+        "ethereum_address": "0xfC1E690f61EFd961294b3e1Ce3313fBD8aa4f85d",
+        "ethereum_token_decimals": 18,
+        "name": "Aave Interest bearing DAI",
+        "started": 1578501167,
+        "symbol": "aDAI",
+        "type": "ethereum token"
+    },
     "cBAT": {
         "ethereum_address": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
         "ethereum_token_decimals": 8,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -5335,6 +5335,12 @@
         "symbol": "LOCUS",
         "type": "ethereum token"
     },
+    "LOKI": {
+        "name": "Loki",
+        "started": 1519516800,
+        "symbol": "LOKI",
+        "type": "own chain"
+    },
     "LOOM": {
         "ethereum_address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0",
         "ethereum_token_decimals": 18,


### PR DESCRIPTION
aDAI support is still not perfect. Price query is naively equated to DAI since it's not supported by cryptocompare.

Real solution is to switch it when cryptocompare supports it and/or use coingecko as a source too. https://github.com/rotki/rotki/issues/722