### PR TITLE
Fake almost all current price queries in tests

### DIFF
--- a/rotkehlchen/tests/api/test_async.py
+++ b/rotkehlchen/tests/api/test_async.py
@@ -16,8 +16,15 @@ from rotkehlchen.tests.utils.mock import MockResponse
 
 
 @pytest.mark.parametrize('added_exchanges', [('binance', 'poloniex')])
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_query_async_tasks(rotkehlchen_api_server_with_exchanges):
-    """Test that querying the outcomes of async tasks works as expected"""
+    """Test that querying the outcomes of async tasks works as expected
+
+    We don't mock price queries in this test only because that cause the tasks
+    list test below to fail since due to the mocking the tasks returns immediately and
+    does not wait on a gevent context switching. So if we mock we don't get to
+    test the task is still pending functionality.
+    """
 
     # async query balances of one specific exchange
     server = rotkehlchen_api_server_with_exchanges

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -118,6 +118,9 @@ def assert_all_balances(
         assert locations == expected_locations
 
 
+# Use real current price querying in this test since it's very extensive
+# and we can make sure that we can query current prices properly in the real app
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('number_of_eth_accounts', [2])
 @pytest.mark.parametrize('btc_accounts', [[UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2]])
 @pytest.mark.parametrize('owned_eth_tokens', [[A_RDN]])

--- a/rotkehlchen/tests/api/test_manually_tracked_balances.py
+++ b/rotkehlchen/tests/api/test_manually_tracked_balances.py
@@ -162,6 +162,7 @@ def test_add_and_query_manually_tracked_balances(
     assert set(rotki.data.db.query_owned_assets()) == {'BTC', 'XMR', 'BNB', 'ETH'}
 
 
+@pytest.mark.parametrize('mocked_current_prices', [{'CYFM': FVal(0)}])
 def test_add_manually_tracked_balances_no_price(rotkehlchen_api_server):
     """Test that adding a manually tracked balance of an asset for which we cant
     query a price is handled properly both in the adding and querying part
@@ -170,7 +171,7 @@ def test_add_manually_tracked_balances_no_price(rotkehlchen_api_server):
     _populate_tags(rotkehlchen_api_server)
     balances: List[Dict[str, Any]] = [{
         "asset": "CYFM",
-        "label": "CUFM account",
+        "label": "CYFM account",
         "amount": "50.315",
         "tags": ["public"],
         "location": "blockchain",

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -86,6 +86,7 @@ def test_gemini_wrong_key_permissions(sandbox_gemini):
     assert not result
 
 
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_gemini_query_balances(sandbox_gemini):
     """Test that querying the balances endpoint works correctly
 

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import traceback
+import warnings as test_warnings
 
 import gevent
 import pytest
@@ -14,7 +15,10 @@ from rotkehlchen.typing import ExternalService, ExternalServiceApiCredentials
 def temp_etherscan(function_scope_messages_aggregator, tmpdir_factory):
     api_key = os.environ.get('ETHERSCAN_API_KEY', None)
     if not api_key:
-        pytest.fail('No ETHERSCAN_API_KEY environment variable found.')
+        msg = 'No ETHERSCAN_API_KEY environment variable found. Skipping test'
+        test_warnings.warn(UserWarning(msg))
+        pytest.skip(msg)
+
     directory = tmpdir_factory.mktemp('data')
     db = DBHandler(
         user_data_dir=directory,

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -8,6 +8,7 @@ from typing import Optional
 import pytest
 
 from rotkehlchen.accounting.accountant import Accountant
+from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 
@@ -113,10 +114,13 @@ def session_should_mock_current_price_queries():
     return True
 
 
-def create_inquirer(data_dir, cryptocompare, should_mock_current_price_queries) -> Inquirer:
+def create_inquirer(data_dir, should_mock_current_price_queries) -> Inquirer:
     # Since this is a singleton and we want it initialized everytime the fixture
     # is called make sure its instance is always starting from scratch
     Inquirer._Inquirer__instance = None  # type: ignore
+    # Get a cryptocompare without a DB since invoking DB fixture here causes problems
+    # of existing user for some tests
+    cryptocompare = Cryptocompare(data_directory=data_dir, database=None)
     inquirer = Inquirer(data_dir=data_dir, cryptocompare=cryptocompare)
     if not should_mock_current_price_queries:
         return inquirer
@@ -135,18 +139,16 @@ def create_inquirer(data_dir, cryptocompare, should_mock_current_price_queries) 
 
 
 @pytest.fixture
-def inquirer(data_dir, cryptocompare, should_mock_current_price_queries):
-    return create_inquirer(data_dir, cryptocompare, should_mock_current_price_queries)
+def inquirer(data_dir, should_mock_current_price_queries):
+    return create_inquirer(data_dir, should_mock_current_price_queries)
 
 
 @pytest.fixture(scope='session')
 def session_inquirer(
         session_data_dir,
-        session_cryptocompare,
         session_should_mock_current_price_queries,
 ):
     return create_inquirer(
         session_data_dir,
-        session_cryptocompare,
         session_should_mock_current_price_queries,
     )

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -114,7 +114,17 @@ def session_should_mock_current_price_queries():
     return True
 
 
-def create_inquirer(data_dir, should_mock_current_price_queries) -> Inquirer:
+@pytest.fixture
+def mocked_current_prices():
+    return {}
+
+
+@pytest.fixture(scope='session')
+def session_mocked_current_prices():
+    return {}
+
+
+def create_inquirer(data_dir, should_mock_current_price_queries, mocked_prices) -> Inquirer:
     # Since this is a singleton and we want it initialized everytime the fixture
     # is called make sure its instance is always starting from scratch
     Inquirer._Inquirer__instance = None  # type: ignore
@@ -126,7 +136,7 @@ def create_inquirer(data_dir, should_mock_current_price_queries) -> Inquirer:
         return inquirer
 
     def mock_find_usd_price(asset):  # pylint: disable=unused-argument
-        return FVal(1)
+        return mocked_prices.get(asset, FVal('1.5'))
 
     inquirer.find_usd_price = mock_find_usd_price  # type: ignore
 
@@ -139,16 +149,18 @@ def create_inquirer(data_dir, should_mock_current_price_queries) -> Inquirer:
 
 
 @pytest.fixture
-def inquirer(data_dir, should_mock_current_price_queries):
-    return create_inquirer(data_dir, should_mock_current_price_queries)
+def inquirer(data_dir, should_mock_current_price_queries, mocked_current_prices):
+    return create_inquirer(data_dir, should_mock_current_price_queries, mocked_current_prices)
 
 
 @pytest.fixture(scope='session')
 def session_inquirer(
         session_data_dir,
         session_should_mock_current_price_queries,
+        session_mocked_current_prices,
 ):
     return create_inquirer(
         session_data_dir,
         session_should_mock_current_price_queries,
+        session_mocked_current_prices,
     )

--- a/rotkehlchen/tests/fixtures/history.py
+++ b/rotkehlchen/tests/fixtures/history.py
@@ -4,7 +4,7 @@ from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.exchanges.manager import ExchangeManager
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 from rotkehlchen.history import PriceHistorian, TradesHistorian
-from rotkehlchen.tests.utils.history import maybe_mock_price_queries
+from rotkehlchen.tests.utils.history import maybe_mock_historical_price_queries
 
 TEST_HISTORY_DATA_START = "01/01/2015"
 
@@ -35,7 +35,7 @@ def price_historian(
         history_date_start=TEST_HISTORY_DATA_START,
         cryptocompare=cryptocompare,
     )
-    maybe_mock_price_queries(
+    maybe_mock_historical_price_queries(
         historian=historian,
         should_mock_price_queries=should_mock_price_queries,
         mocked_price_queries=mocked_price_queries,

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -112,8 +112,15 @@ def initialize_mock_rotkehlchen_instance(
 
 
 @pytest.fixture()
-def uninitialized_rotkehlchen(cli_args):
-    """A rotkehlchen instance that has only had __init__ run but is not unlocked"""
+def uninitialized_rotkehlchen(cli_args, inquirer):  # pylint: disable=unused-argument
+    """A rotkehlchen instance that has only had __init__ run but is not unlocked
+
+    Adding the inquirer fixture as a requirement to make sure that any mocking that
+    happens at the inquirer level is reflected in the tests.
+
+    For this to happen inquirer fixture must be initialized before Rotkehlchen so
+    that the inquirer initialization in Rotkehlchen's __init__ uses the fixture's instance
+    """
     return Rotkehlchen(cli_args)
 
 

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -17,7 +17,7 @@ from rotkehlchen.tests.utils.database import (
     maybe_include_etherscan_key,
 )
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
-from rotkehlchen.tests.utils.history import maybe_mock_price_queries
+from rotkehlchen.tests.utils.history import maybe_mock_historical_price_queries
 
 
 @pytest.fixture
@@ -104,7 +104,7 @@ def initialize_mock_rotkehlchen_instance(
         add_blockchain_accounts_to_db(rotki.data.db, blockchain_accounts)
         add_tags_to_test_db(rotki.data.db, tags)
         add_manually_tracked_balances_to_test_db(rotki.data.db, manually_tracked_balances)
-        maybe_mock_price_queries(
+        maybe_mock_historical_price_queries(
             historian=PriceHistorian(),
             should_mock_price_queries=should_mock_price_queries,
             mocked_price_queries=mocked_price_queries,

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -30,6 +30,7 @@ def test_query_realtime_price_apis(inquirer):
     reason='some of these APIs frequently become unavailable',
 )
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_switching_to_backup_api(inquirer):
     count = 0
     original_get = requests.get
@@ -47,6 +48,7 @@ def test_switching_to_backup_api(inquirer):
         assert count > 1, 'requests.get should have been called more than once'
 
 
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_caching(inquirer):
     def mock_currency_converter_api(url, timeout):  # pylint: disable=unused-argument
@@ -61,6 +63,7 @@ def test_caching(inquirer):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_fallback_to_cached_values_within_a_month(inquirer):  # pylint: disable=unused-argument
     def mock_api_remote_fail(url, timeout):  # pylint: disable=unused-argument
         return MockResponse(500, '{"msg": "shit hit the fan"')

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -908,7 +908,11 @@ def assert_poloniex_trades_result(
             raise AssertionError('index out of range')
 
 
-def maybe_mock_price_queries(historian, should_mock_price_queries: bool, mocked_price_queries):
+def maybe_mock_historical_price_queries(
+        historian,
+        should_mock_price_queries: bool,
+        mocked_price_queries,
+) -> None:
     """If needed will make sure the historian's price queries are mocked"""
     if not should_mock_price_queries:
         return

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -203,7 +203,8 @@ def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
     # Also check a copy of our old DB is kept around.
     directory = os.path.join(rotkehlchen_instance.data.data_directory, username)
     files = [os.path.join(directory, f) for f in os.listdir(directory)]
-    assert len(files) == 2
+    msg = f'Expected 2 files in the directory but got {files}'
+    assert len(files) == 2, msg
     # The order of the files is not guaranteed
     assert 'rotkehlchen.db' in files[0] or 'rotkehlchen.db' in files[1]
     assert 'backup' in files[0] or 'backup' in files[1]


### PR DESCRIPTION
This should fix #937 by reducing calls to cryptocompare or any other current price Oracle we are using.