### PR TITLE
Fix flakiness on test_log_anonymization

### DIFF
--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -83,7 +83,7 @@ def accountant(
         database,
         data_dir,
         accounting_create_csv,
-        messages_aggregator,
+        function_scope_messages_aggregator,
         start_with_logged_in_user,
         accounting_initialize_parameters,
 ) -> Optional[Accountant]:
@@ -93,7 +93,7 @@ def accountant(
     accountant = Accountant(
         db=database,
         user_directory=data_dir,
-        msg_aggregator=messages_aggregator,
+        msg_aggregator=function_scope_messages_aggregator,
         create_csv=accounting_create_csv,
     )
 

--- a/rotkehlchen/tests/unit/test_logging.py
+++ b/rotkehlchen/tests/unit/test_logging.py
@@ -39,6 +39,8 @@ def test_log_anonymization(anonymized_logs, caplog):
         entry = f'{key}={str(value)}'
         if anonymized_logs:
             assert key + '=' in caplog.text
-            assert entry not in caplog.text, f'{key} entry should have been modified'
+            msg = f'{key} entry should have been modified'
+            assert entry not in caplog.text or entry + ',' not in caplog.text, msg
         else:
-            assert entry in caplog.text, f'{key} entry should not have been modified'
+            msg = f'{key} entry should not have been modified'
+            assert entry in caplog.text or entry + ',' in caplog.text


### PR DESCRIPTION
Anonymizing logs creates random values for them. And the check was
just checking that the original value is in or not in. But it was
failing with something like amount=55 still being in the logs. But it
was actually a random value starting with 55 like 5564.1 .. or 55.15 e.t.c.

Fix #945