### PR TITLE
Fixes rendering of fiat balances amounts in certain cases

### DIFF
--- a/electron-app/src/components/accounts/FiatBalances.vue
+++ b/electron-app/src/components/accounts/FiatBalances.vue
@@ -46,7 +46,11 @@
                 <amount-display :value="item.amount"></amount-display>
               </template>
               <template #item.usdValue="{ item }">
-                <amount-display fiat :value="item.usdValue"></amount-display>
+                <amount-display
+                  :fiat-currency="item.currency"
+                  :amount="item.amount"
+                  :value="item.usdValue"
+                ></amount-display>
               </template>
               <template v-if="fiatBalances.length > 0" #body.append>
                 <tr class="fiat-balances__total">


### PR DESCRIPTION
Fix #980

Fixes incorrect rendering of fiat balances amounts in the Accounts & Balances -> Fiat Balances -> fiat balance line items.

[ui tests]