### PR TITLE
Make package installable via pip

### DIFF
--- a/rotkehlchen/exchanges/__init__.py
+++ b/rotkehlchen/exchanges/__init__.py
@@ -1,6 +1,9 @@
 from rotkehlchen.exchanges.binance import Binance  # noqa: F401
 from rotkehlchen.exchanges.bitmex import Bitmex  # noqa: F401
 from rotkehlchen.exchanges.bittrex import Bittrex  # noqa: F401
+from rotkehlchen.exchanges.coinbase import Coinbase  # noqa: F401
+from rotkehlchen.exchanges.coinbasepro import Coinbasepro  # noqa: F401
 from rotkehlchen.exchanges.exchange import ExchangeInterface  # noqa: F401
+from rotkehlchen.exchanges.gemini import Gemini  # noqa: F401
 from rotkehlchen.exchanges.kraken import Kraken  # noqa: F401
 from rotkehlchen.exchanges.poloniex import Poloniex  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 # Utility function to read the README file.
@@ -31,7 +31,10 @@ setup(
     license='BSD-3',
     keywords='accounting tax-report portfolio asset-management cryptocurrencies',
     url='https://github.com/rotki/rotki',
-    packages=['rotkehlchen'],
+    packages=find_packages('.'),
+    package_data={
+        "rotkehlchen": ["data/*.json"],
+    },
     install_requires=install_requirements,
     use_scm_version=True,
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
This will make sure that all you can install the python package via pip.

 * `find_packages` is required here because otherwise submodules of rotkehlchen will not be installed (like rotkehlchen.assets)
 * It will include data files like `all_assets.json`
 * I also fixed some imports in `exchanges/__init__.py`