### PR TITLE
Implements force save functionality

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1402,8 +1402,11 @@ Querying all balances
 
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
    :reqjson bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not.
+   :reqjson bool save_data: Boolean denoting whether to force save data even if the balance save frequency has not lapsed (see `Getting or modifying settings`_ ).
    :param bool async_query: Boolean denoting whether this is an asynchronous query or not
    :param bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not.
+   :param bool save_data: Boolean denoting whether to force save data even if the balance save frequency has not lapsed (see `Getting or modifying settings`_ ).
+
 
    **Example Response**:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -492,6 +492,8 @@ Getting or modifying settings
           "message": ""
       }
 
+   .. _balance_save_frequency:
+
    :resjson int version: The database version
    :resjson int last_write_ts: The unix timestamp at which an entry was last written in the database
    :resjson bool premium_should_sync: A boolean denoting whether premium users database should be synced from/to the server
@@ -1402,10 +1404,10 @@ Querying all balances
 
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
    :reqjson bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not.
-   :reqjson bool save_data: Boolean denoting whether to force save data even if the balance save frequency has not lapsed (see `Getting or modifying settings`_ ).
+   :reqjson bool save_data: Boolean denoting whether to force save data even if the balance save frequency has not lapsed (see `here <balance_save_frequency_>`_ ).
    :param bool async_query: Boolean denoting whether this is an asynchronous query or not
    :param bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not.
-   :param bool save_data: Boolean denoting whether to force save data even if the balance save frequency has not lapsed (see `Getting or modifying settings`_ ).
+   :param bool save_data: Boolean denoting whether to force save data even if the balance save frequency has not lapsed (see `here <balance_save_frequency_>`_ ).
 
 
    **Example Response**:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`1016` Rotki users can now delete their rotki premium API keys via API Keys -> Rotki Premium.
+* :feature:`1015` Rotki now lets the user manually refresh and save their balances, even if the balance save frequency has not lapsed. This functionality is accessible through the Save Indicator (floppy disk icon on the app bar).
 * :feature:`707` Rotki now supports makerdao vaults. The vaults of the user are autodetected and they can see all details of each
   vault in the DeFi borrowing section. Premium users can also see historical information and total interest owed or USD lost to liquidation.
 * :feature:`917` Rotki now has a new and improved Dashboard. Users can view their total net worth as well as totals per source of balances (exchanges, blockchains, and manual entries), as well as filter the full asset listing.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 * :bug:`1016` Rotki users can now delete their rotki premium API keys via API Keys -> Rotki Premium.
-* :feature:`1015` Rotki now lets the user manually refresh and save their balances, even if the balance save frequency has not lapsed. This functionality is accessible through the Save Indicator (floppy disk icon on the app bar).
+* :feature:`1015` Rotki now lets the user manually refresh and take a snapshot of their balances, even if the balance save frequency has not lapsed. This functionality is accessible through the Save Indicator (floppy disk icon on the app bar).
 * :feature:`707` Rotki now supports makerdao vaults. The vaults of the user are autodetected and they can see all details of each
   vault in the DeFi borrowing section. Premium users can also see historical information and total interest owed or USD lost to liquidation.
 * :feature:`917` Rotki now has a new and improved Dashboard. Users can view their total net worth as well as totals per source of balances (exchanges, blockchains, and manual entries), as well as filter the full asset listing.

--- a/electron-app/src/components/status/BalanceSavedIndicator.vue
+++ b/electron-app/src/components/status/BalanceSavedIndicator.vue
@@ -34,7 +34,8 @@
             <v-icon class="ml-3" v-on="on">fa fa-info-circle</v-icon>
           </template>
           <div>
-            This will force taking a snapshot of all your balances, ignoring any cache.<br />
+            This will force taking a snapshot of all your balances, ignoring any
+            cache.<br />
             Use this sparingly as it may lead to you being rate-limited.
           </div>
         </v-tooltip>

--- a/electron-app/src/components/status/BalanceSavedIndicator.vue
+++ b/electron-app/src/components/status/BalanceSavedIndicator.vue
@@ -24,12 +24,29 @@
           Never
         </span>
       </v-row>
+      <v-divider></v-divider>
+      <v-row>
+        <v-btn color="primary" outlined @click="refreshAllAndSave()">
+          <v-icon left>fa fa-save</v-icon>force save
+        </v-btn>
+        <v-tooltip bottom>
+          <template #activator="{ on }">
+            <v-icon class="ml-3" v-on="on">fa fa-info-circle</v-icon>
+          </template>
+          <div>
+            This will refresh all balances, ignore cache, and save your
+            balances.<br />
+            Use this very sparingly as it may lead to you being rate-limited.
+          </div>
+        </v-tooltip>
+      </v-row>
     </div>
   </v-menu>
 </template>
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import { AllBalancePayload } from '@/store/balances/actions';
 
 const { mapGetters } = createNamespacedHelpers('session');
 
@@ -41,6 +58,13 @@ const { mapGetters } = createNamespacedHelpers('session');
 export default class BalanceSavedIndicator extends Vue {
   lastBalanceSave!: number;
   dateDisplayFormat!: string;
+
+  refreshAllAndSave() {
+    this.$store.dispatch('balances/fetchBalances', {
+      ignoreCache: true,
+      saveData: true
+    } as AllBalancePayload);
+  }
 }
 </script>
 

--- a/electron-app/src/components/status/BalanceSavedIndicator.vue
+++ b/electron-app/src/components/status/BalanceSavedIndicator.vue
@@ -34,9 +34,8 @@
             <v-icon class="ml-3" v-on="on">fa fa-info-circle</v-icon>
           </template>
           <div>
-            This will refresh all balances, ignore cache, and save your
-            balances.<br />
-            Use this very sparingly as it may lead to you being rate-limited.
+            This will force taking a snapshot of all your balances, ignoring any cache.<br />
+            Use this sparingly as it may lead to you being rate-limited.
           </div>
         </v-tooltip>
       </v-row>

--- a/electron-app/src/services/rotkehlchen-api.ts
+++ b/electron-app/src/services/rotkehlchen-api.ts
@@ -433,12 +433,17 @@ export class RotkehlchenApi {
       .then(this.handleResponse);
   }
 
-  queryBalancesAsync(): Promise<AsyncQuery> {
+  queryBalancesAsync(
+    ignoreCache: boolean = false,
+    saveData: boolean = false
+  ): Promise<AsyncQuery> {
     return new Promise<AsyncQuery>((resolve, reject) => {
       this.axios
         .get<ActionResult<AsyncQuery>>('/balances/', {
           params: {
-            async_query: true
+            async_query: true,
+            ignore_cache: ignoreCache ? true : undefined,
+            save_data: saveData ? true : undefined
           },
           validateStatus: function (status) {
             return status == 200 || status == 400 || status == 409;

--- a/electron-app/src/store/balances/actions.ts
+++ b/electron-app/src/store/balances/actions.ts
@@ -29,13 +29,20 @@ import { bigNumberify } from '@/utils/bignumbers';
 import { toMap } from '@/utils/conversion';
 
 export const actions: ActionTree<BalanceState, RotkehlchenState> = {
-  async fetchBalances({ commit, rootGetters, dispatch }) {
+  async fetchBalances(
+    { commit, rootGetters, dispatch },
+    payload: AllBalancePayload = {
+      ignoreCache: false,
+      saveData: false
+    }
+  ) {
+    const { ignoreCache, saveData } = payload;
     const isTaskRunning = rootGetters['tasks/isTaskRunning'];
     if (isTaskRunning(TaskType.QUERY_BALANCES)) {
       return;
     }
     try {
-      const result = await api.queryBalancesAsync();
+      const result = await api.queryBalancesAsync(ignoreCache, saveData);
       const task = createTask(result.task_id, TaskType.QUERY_BALANCES, {
         description: `Query All Balances`,
         ignoreResult: true
@@ -432,4 +439,9 @@ export interface ExchangeBalancePayload {
 export interface BlockchainBalancePayload {
   readonly blockchain?: Blockchain;
   readonly ignoreCache: boolean;
+}
+
+export interface AllBalancePayload {
+  readonly ignoreCache: boolean;
+  readonly saveData: boolean;
 }

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -717,7 +717,7 @@ class NewUserSchema(BaseUserSchema):
 
 class AllBalancesQuerySchema(Schema):
     async_query = fields.Boolean(missing=False)
-    save_data = fields.Boolean(missing=True)
+    save_data = fields.Boolean(missing=None)
     ignore_cache = fields.Boolean(missing=False)
 
 

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -717,7 +717,7 @@ class NewUserSchema(BaseUserSchema):
 
 class AllBalancesQuerySchema(Schema):
     async_query = fields.Boolean(missing=False)
-    save_data = fields.Boolean(missing=None)
+    save_data = fields.Boolean(missing=False)
     ignore_cache = fields.Boolean(missing=False)
 
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -506,13 +506,15 @@ class Rotkehlchen():
 
     def query_balances(
             self,
-            requested_save_data: bool = None,
+            requested_save_data: bool = False,
             timestamp: Timestamp = None,
             ignore_cache: bool = False,
     ) -> Dict[str, Any]:
         """Query all balances rotkehlchen can see.
 
-        If requested_save_data is True then the data are saved in the DB.
+        If requested_save_data is True then the data are always saved in the DB,
+        if it is False then data are saved if self.data.should_save_balances()
+        is True.
         If timestamp is None then the current timestamp is used.
         If a timestamp is given then that is the time that the balances are going
         to be saved in the DB
@@ -583,15 +585,7 @@ class Rotkehlchen():
 
         result_dict = merge_dicts(combined, stats)
 
-        """
-        If requested_save_data is false, we never save.
-        We save user balances when should_save_balances() is true (i.e. if we haven't saved within
-        the last user-defined save period), or if save has been explicitly requested.
-        """
-        if requested_save_data is not False:
-            allowed_to_save = requested_save_data or self.data.should_save_balances()
-        else:
-            allowed_to_save = requested_save_data
+        allowed_to_save = requested_save_data or self.data.should_save_balances()
 
         if problem_free and allowed_to_save:
             if not timestamp:

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -506,7 +506,7 @@ class Rotkehlchen():
 
     def query_balances(
             self,
-            requested_save_data: bool = True,
+            requested_save_data: bool = None,
             timestamp: Timestamp = None,
             ignore_cache: bool = False,
     ) -> Dict[str, Any]:
@@ -583,7 +583,16 @@ class Rotkehlchen():
 
         result_dict = merge_dicts(combined, stats)
 
-        allowed_to_save = requested_save_data and self.data.should_save_balances()
+        """
+        If requested_save_data is false, we never save.
+        We save user balances when should_save_balances() is true (i.e. if we haven't saved within
+        the last user-defined save period), or if save has been explicitly requested.
+        """
+        if requested_save_data is not False:
+            allowed_to_save = requested_save_data or self.data.should_save_balances()
+        else:
+            allowed_to_save = requested_save_data
+
         if problem_free and allowed_to_save:
             if not timestamp:
                 timestamp = Timestamp(int(time.time()))

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -157,6 +157,9 @@ def test_query_all_balances(
         setup=setup,
     )
 
+    # rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    last_save_timestamp = rotki.data.db.get_last_balance_save_time()
+
     # now do the same but check to see if the balance save frequency delay works
     # and thus data will not be saved
     with ExitStack() as stack:
@@ -168,13 +171,8 @@ def test_query_all_balances(
             ),
         )
     assert_proper_response(response)
-    json_data = response.json()
-    assert_all_balances(
-        data=json_data,
-        db=rotki.data.db,
-        expected_data_in_db=False,
-        setup=setup,
-    )
+    new_save_timestamp = rotki.data.db.get_last_balance_save_time()
+    assert last_save_timestamp == new_save_timestamp
 
     # now do the same but test that balance are saved since the balance save frequency delay
     #  is overriden via `save_data` = True
@@ -187,13 +185,8 @@ def test_query_all_balances(
             ), json={'save_data': True},
         )
     assert_proper_response(response)
-    json_data = response.json()
-    assert_all_balances(
-        data=json_data,
-        db=rotki.data.db,
-        expected_data_in_db=True,
-        setup=setup,
-    )
+    new_save_timestamp = rotki.data.db.get_last_balance_save_time()
+    assert last_save_timestamp != new_save_timestamp
 
 
 @pytest.mark.parametrize('number_of_eth_accounts', [2])

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -157,7 +157,6 @@ def test_query_all_balances(
         setup=setup,
     )
 
-    # rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     last_save_timestamp = rotki.data.db.get_last_balance_save_time()
 
     # now do the same but check to see if the balance save frequency delay works
@@ -175,7 +174,7 @@ def test_query_all_balances(
     assert last_save_timestamp == new_save_timestamp
 
     # now do the same but test that balance are saved since the balance save frequency delay
-    #  is overriden via `save_data` = True
+    # is overriden via `save_data` = True
     with ExitStack() as stack:
         setup.enter_all_patches(stack)
         response = requests.get(


### PR DESCRIPTION
Fix #1015

Users can now "force save" their balances even within the Balance Save Frequency period.
![image](https://user-images.githubusercontent.com/27592/82735945-fb148c00-9d25-11ea-8637-c79acf024239.png)


In general, specifying `save_data=False` on the GET call to `api/v1/balances/` will _never_ save. The query that is called during app startup will only save if the Balance Save Frequency period has lapsed, and the Force Save button will force a refresh, ignore cache, and save of all balances.


---------

* Updates `/balances/` endpoint API docs to explain usage of save_data
* Adds "Force Save" button and tooltip description in the BalanceSavedIndicator in the frontend
* Modifies the frontend queryBalancesAsync method to allow for the saveData parameter for the `/balances/` API call
* Modifies the backend query_balances function so that balances are either saved if the balance save frequency has lapsed or if a save has been explicitly requested.