### PR TITLE
Remove shut down API and fix tests that were skipped in CI

### DIFF
--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -12,9 +12,6 @@ EV_LOAN_SETTLE = EventType('loan_settlement')
 EV_INTEREST_PAYMENT = EventType('interest_rate_payment')
 EV_MARGIN_CLOSE = EventType('margin_position_close')
 
-CURRENCYCONVERTER_API_KEY = '7ad371210f296db27c19'
-
-
 ZERO = FVal(0)
 
 

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -115,7 +115,7 @@ def test_cryptocompare_dao_query(cryptocompare):
     }, {
         'asset': Asset('cBAT'),
         'expected_price1': FVal('0.003522603'),
-        'expected_price2': FVal('0.002713524'),
+        'expected_price2': FVal('0.002723634'),
     }, {
         'asset': Asset('cETH'),
         'expected_price1': FVal('2.903'),


### PR DESCRIPTION
Removes currency converter API. The service seems to no longer operate. 
https://free.currencyconverterapi.com/api/v6/convert?q=USD_EUR says we need an API key and when giving it a 503 Error is returned.

Also adjusts the cryptocompare compound prices test.