### PR TITLE
Replaces hard-coded port with backend env variable

### DIFF
--- a/electron-app/.env
+++ b/electron-app/.env
@@ -1,0 +1,1 @@
+VUE_APP_BACKEND_URL=http://localhost:4242

--- a/electron-app/src/App.vue
+++ b/electron-app/src/App.vue
@@ -133,7 +133,7 @@ export default class App extends Vue {
   }
 
   async created(): Promise<void> {
-    this.$api.connect(4242);
+    this.$api.connect();
     await this.$store.dispatch('connect');
     await this.$store.dispatch('version');
     this.$interop.onError(() => {

--- a/electron-app/src/services/rotkehlchen-api.ts
+++ b/electron-app/src/services/rotkehlchen-api.ts
@@ -61,9 +61,9 @@ export class RotkehlchenApi {
     throw new Error(message);
   }
 
-  connect(port: number): void {
+  connect(): void {
     this._axios = axios.create({
-      baseURL: `http://localhost:${port}/api/1/`,
+      baseURL: `${process.env.VUE_APP_BACKEND_URL}/api/1/`,
       timeout: 30000
     });
   }

--- a/electron-app/vue.config.js
+++ b/electron-app/vue.config.js
@@ -1,5 +1,6 @@
 // vue.config.js
 module.exports = {
+  productionSourceMap: false,
   configureWebpack: config => {
     if (
       process.env.NODE_ENV === 'development' ||


### PR DESCRIPTION
With this we can also create a `.env.development.local` that is not committed in the repo with a different backend url for usage with the proxy or we can have configurations for different build modes, e.g. Docker

I tested it both locally with and without the mentioned `env.development.local` and also packaged