### PR TITLE
Fix makerdao vault API tests

### DIFF
--- a/rotkehlchen/tests/utils/checks.py
+++ b/rotkehlchen/tests/utils/checks.py
@@ -1,21 +1,44 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from rotkehlchen.fval import FVal
 
 
-def assert_serialized_lists_equal(a: List, b: List) -> None:
+def assert_serialized_lists_equal(
+        a: List,
+        b: List,
+        max_length_to_check: Optional[int] = None,
+        ignore_keys: Optional[List] = None,
+        length_list_keymap: Optional[Dict] = None,
+) -> None:
     """Compares lists of serialized dicts"""
     assert isinstance(a, list), "Expected 2 lists. Comparing {type(a)} to {type(b)}"
     assert isinstance(b, list), "Expected 2 lists. Comparing {type(a)} to {type(b)}"
-    assert len(a) == len(b), f"Lists don't have the same key length {len(a)} != {len(b)}"
+    if not max_length_to_check:
+        assert len(a) == len(b), f"Lists don't have the same key length {len(a)} != {len(b)}"
     for idx, a_entry in enumerate(a):
-        assert_serialized_dicts_equal(a_entry, b[idx])
+        if max_length_to_check and idx + 1 > max_length_to_check:
+            break
+        assert_serialized_dicts_equal(
+            a=a_entry,
+            b=b[idx],
+            ignore_keys=ignore_keys,
+            length_list_keymap=length_list_keymap,
+        )
 
 
-def assert_serialized_dicts_equal(a: Dict, b: Dict) -> None:
+def assert_serialized_dicts_equal(
+        a: Dict,
+        b: Dict,
+        ignore_keys: Optional[List] = None,
+        length_list_keymap: Optional[Dict] = None,
+) -> None:
     """Compares serialized dicts so that serialized numbers can be compared for equality"""
     assert len(a) == len(b), f"Dicts don't have the same key length {len(a)} != {len(b)}"
     for a_key, a_val in a.items():
+
+        if ignore_keys and a_key in ignore_keys:
+            continue
+
         if isinstance(a_val, FVal):
             try:
                 compare_val = FVal(b[a_key])
@@ -30,6 +53,15 @@ def assert_serialized_dicts_equal(a: Dict, b: Dict) -> None:
             msg = f"{a_key} doesn't match. {compare_val} != {b[a_key]}"
             assert compare_val.is_close(b[a_key]), msg
         elif isinstance(a_val, list):
-            assert_serialized_lists_equal(a_val, b[a_key])
+            max_length_to_check = None
+            if length_list_keymap and a_key in length_list_keymap:
+                max_length_to_check = length_list_keymap[a_key]
+            assert_serialized_lists_equal(
+                a=a_val,
+                b=b[a_key],
+                max_length_to_check=max_length_to_check,
+                ignore_keys=ignore_keys,
+                length_list_keymap=length_list_keymap,
+            )
         else:
             assert a_val == b[a_key], f"{a_key} doesn't match. {a_val} != {b[a_key]}"


### PR DESCRIPTION
Should fix the develop tests.

Essentially introduced ignored keys and specific list length to check
for the list/dict checks in the test