### PR TITLE
Gracefully handle multiple location/balance entries for same timestamp and fix flaky test

### DIFF
--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -2,6 +2,7 @@ from contextlib import ExitStack
 from http import HTTPStatus
 from unittest.mock import patch
 
+import gevent
 import pytest
 import requests
 
@@ -173,6 +174,9 @@ def test_query_all_balances(
     new_save_timestamp = rotki.data.db.get_last_balance_save_time()
     assert last_save_timestamp == new_save_timestamp
 
+    # wait for at least 1 second to make sure that new balances can be saved.
+    # Can't save balances again if it's the same timestamp
+    gevent.sleep(1)
     # now do the same but test that balance are saved since the balance save frequency delay
     # is overriden via `save_data` = True
     with ExitStack() as stack:


### PR DESCRIPTION
Fix #1043 