### PR TITLE
Add USD value fields to DSR and makerdao vault events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2844,11 +2844,13 @@ Getting MakerDAO vault details
               "events": [{
                   "event_type": "deposit",
                   "amount": "5.551",
+                  "amount_usd_value": "120.32",
                   "timestamp": 1589067899,
                   "tx_hash": "0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd"
               }, {
                   "event_type": "generate",
                   "amount": "325",
+                  "amount_usd_value": "12003.32",
                   "timestamp": 1589067900,
                   "tx_hash": "0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd"
               }]
@@ -2861,21 +2863,25 @@ Getting MakerDAO vault details
               "events": [{
                   "event_type": "deposit",
                   "amount": "1050.21",
+                  "amount_usd_value": "10500.21",
                   "timestamp": 1589067899,
                   "tx_hash": "0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd"
               }, {
                   "event_type": "generate",
                   "amount": "721.32",
+                  "amount_usd_value": "7213.2",
                   "timestamp": 1589067900,
                   "tx_hash": "0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd"
               }, {
                   "event_type": "liquidation",
                   "amount": "500",
+                  "amount_usd_value": "5000",
                   "timestamp": 1589068000,
                   "tx_hash": "0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd"
 	      }, {
                   "event_type": "liquidation",
                   "amount": "550.21",
+                  "amount_usd_value": "5502.1",
                   "timestamp": 1589068001,
                   "tx_hash": "0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd"
 	      }]
@@ -2891,6 +2897,7 @@ Getting MakerDAO vault details
    :resjson object events: A list of all events that occured for this vault
    :resjsonarr string event_type: The type of the event. Valid types are: ``["deposit", "withdraw", "generate", "payback", "liquidation"]``
    :resjsonarr string amount: The amount associated with the event. So collateral deposited/withdrawn, debt generated/paid back, amount of collateral lost in liquidation.
+   :resjsonarr string amount_usd_value: The usd value of the amount associated with the event at the time the event occured.
    :resjsonarr int timestamp: The unix timestamp of the event
    :resjsonarr string tx_hash: The transaction hash associated with the event.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2679,19 +2679,25 @@ Getting ethereum MakerDAO DSR historical report
                   "movements": [{
                       "movement_type": "deposit",
                       "gain_so_far": "0",
+                      "gain_so_far_usd_value": "0",
                       "amount": "350",
+                      "amount_usd_value": "351.21",
                       "block_number": 9128160,
                       "timestamp": 1582706553
                   }, {
                       "movement_type": "deposit",
                       "gain_so_far": "0.875232",
+                      "gain_so_far_usd_value": "0.885292",
                       "amount": "50",
+                      "amount_usd_value": "50.87",
                       "block_number": 9129165,
                       "timestamp": 1582806553
                   }, {
                       "movement_type": "withdrawal",
                       "gain_so_far": "1.12875932",
+                      "gain_so_far_usd_value": "1.34813",
                       "amount": "350",
+                      "amount_usd_value": "353.12",
                       "block_number": 9149160,
                       "timestamp": 1592706553
                   }, {
@@ -2702,11 +2708,14 @@ Getting ethereum MakerDAO DSR historical report
                   "movements": [{
                       "movement_type": "deposit",
                       "gain_so_far": "0",
+                      "gain_so_far_usd_value": "0",
                       "amount": "550",
+                      "amount_usd_value": "553.43",
                       "block_number": 9128174,
                       "timestamp": 1583706553
                   }],
                   "gain_so_far": "0.953423"
+                  "gain_so_far_usd_value": "0.998421"
               }
           },
           "message": ""
@@ -2714,10 +2723,13 @@ Getting ethereum MakerDAO DSR historical report
 
    :resjson object result: A mapping of accounts to the DSR history report of each account. If an account is not in the mapping Rotki does not see anything locked in DSR for it.
    :resjson object movements: A list of deposits/withdrawals to/from the DSR for each account.
-   :resjson string gain_so_far: The total gain so far from the DSR for this account.
+   :resjson string gain_so_far: The total gain so far in DAI from the DSR for this account.
+   :resjson string gain_so_far_usd_value: The total gain so far in USD from the DSR for this account. The USD value is approximate. It's essentially the known USD values at all movements and for whatever DAI remains the current DAI price is taken into account.
    :resjsonarr string movement_type: The type of movement involving the DSR. Can be either "deposit" or "withdrawal".
    :resjsonarr string gain_so_far: The amount of DAI gained for this account in the DSR up until the moment of the given deposit/withdrawal.
+   :resjsonarr string gain_so_far_usd_value: The usd value equivalnt of the DAI gained for this account in the DSR up until the moment of the given deposit/withdrawal. The rate is the DAI/USD rate at the movement's timestamp.
    :resjsonarr string amount: The amount of DAI deposited or withdrawn from the DSR.
+   :resjsonarr string amount_usd_value: The USD euivalent value of the amount of DAI deposited or withdrawn from the DSR. The rate is the DAI/USD rate at the movement's timestamp.
    :resjsonarr int block_number: The block number at which the deposit or withdrawal occured.
 
    :statuscode 200: DSR history succesfully queried.

--- a/frontend/app/src/components/defi/Lending.vue
+++ b/frontend/app/src/components/defi/Lending.vue
@@ -47,6 +47,9 @@
         <stat-card title="DAI earned" :locked="!premium">
           {{ accountGain(selection.address).dp(decimals) }}
         </stat-card>
+        <stat-card title="approximate $ earned" :locked="!premium">
+          {{ accountGainUsdValue(selection.address).dp(decimals) }}
+        </stat-card>
       </v-col>
     </v-row>
     <v-row class="loans__history">
@@ -99,6 +102,7 @@ const { mapGetters: mapTaskGetters } = createNamespacedHelpers('tasks');
       'dsrBalances',
       'totalGain',
       'accountGain',
+      'accountGainUsdValue',
       'dsrHistory'
     ])
   }
@@ -111,6 +115,7 @@ export default class Lending extends Vue {
   selection: DSRBalance | null = null;
   totalGain!: BigNumber;
   accountGain!: (address: string) => BigNumber;
+  accountGainUsdValue!: (address: string) => BigNumber;
   dsrHistory!: AccountDSRMovement[];
   isTaskRunning!: (type: TaskType) => boolean;
 

--- a/frontend/app/src/services/converters.ts
+++ b/frontend/app/src/services/converters.ts
@@ -111,6 +111,7 @@ function convertVaultEvents(
   return apiVaultEvents.map(event => ({
     eventType: event.event_type,
     amount: bigNumberify(event.amount),
+    amountUsdValue: bigNumberify(event.amount_usd_value),
     timestamp: event.timestamp,
     txHash: event.tx_hash
   }));

--- a/frontend/app/src/services/converters.ts
+++ b/frontend/app/src/services/converters.ts
@@ -39,23 +39,33 @@ export function convertDSRHistory(history: ApiDSRHistory): DSRHistory {
     [address: string]: {
       movements: DSRMovement[];
       gainSoFar: BigNumber;
+      gainSoFarUsdValue: BigNumber;
     };
   } = {};
   for (const account of Object.keys(history)) {
-    const { gain_so_far: accountGain, movements } = history[account];
+    const {
+      gain_so_far: accountGain,
+      gain_so_far_usd_value: accountGainUsdValue,
+      movements
+    } = history[account];
     data[account] = {
       gainSoFar: bigNumberify(accountGain),
+      gainSoFarUsdValue: bigNumberify(accountGainUsdValue),
       movements: movements.map(
         ({
           amount,
+          amount_usd_value,
           block_number,
           gain_so_far: gain_so_far,
+          gain_so_far_usd_value: gain_so_far_usd_value,
           movement_type,
           timestamp
         }) => ({
           movementType: movement_type,
           gainSoFar: bigNumberify(gain_so_far),
+          gainSoFarUsdValue: bigNumberify(gain_so_far_usd_value),
           amount: bigNumberify(amount),
+          amountUsdValue: bigNumberify(amount_usd_value),
           blockNumber: block_number,
           timestamp
         })

--- a/frontend/app/src/services/types-api.ts
+++ b/frontend/app/src/services/types-api.ts
@@ -80,6 +80,7 @@ export interface ApiMakerDAOVaultDetails {
 export interface ApiMakerDAOVaultEvent {
   readonly event_type: MakerDAOVaultEventType;
   readonly amount: string;
+  readonly amount_usd_value: string;
   readonly timestamp: number;
   readonly tx_hash: string;
 }

--- a/frontend/app/src/services/types-api.ts
+++ b/frontend/app/src/services/types-api.ts
@@ -13,7 +13,9 @@ export interface ApiDSRBalances {
 export interface ApiDSRMovement {
   readonly movement_type: DSRMovementType;
   readonly gain_so_far: string;
+  readonly gain_so_far_usd_value: string;
   readonly amount: string;
+  readonly amount_usd_value: string;
   readonly block_number: number;
   readonly timestamp: number;
 }
@@ -21,6 +23,7 @@ export interface ApiDSRMovement {
 export interface ApiDSRHistory {
   readonly [address: string]: {
     gain_so_far: string;
+    gain_so_far_usd_value: string;
     movements: ApiDSRMovement[];
   };
 }

--- a/frontend/app/src/services/types-model.ts
+++ b/frontend/app/src/services/types-model.ts
@@ -69,6 +69,7 @@ export interface MakerDAOVaultDetails {
 export interface MakerDAOVaultEvent {
   readonly eventType: MakerDAOVaultEventType;
   readonly amount: BigNumber;
+  readonly amountUsdValue: BigNumber;
   readonly timestamp: number;
   readonly txHash: string;
 }

--- a/frontend/app/src/services/types-model.ts
+++ b/frontend/app/src/services/types-model.ts
@@ -14,6 +14,7 @@ export interface DSRBalances {
 export interface DSRHistory {
   readonly [address: string]: {
     gainSoFar: BigNumber;
+    gainSoFarUsdValue: BigNumber;
     movements: DSRMovement[];
   };
 }
@@ -21,7 +22,9 @@ export interface DSRHistory {
 export interface DSRMovement {
   readonly movementType: DSRMovementType;
   readonly gainSoFar: BigNumber;
+  readonly gainSoFarUsdValue: BigNumber;
   readonly amount: BigNumber;
+  readonly amountUsdValue: BigNumber;
   readonly blockNumber: number;
   readonly timestamp: number;
 }

--- a/frontend/app/src/store/balances/getters.ts
+++ b/frontend/app/src/store/balances/getters.ts
@@ -258,6 +258,12 @@ export const getters: GetterTree<BalanceState, RotkehlchenState> = {
     return dsrHistory[account]?.gainSoFar ?? Zero;
   },
 
+  accountGainUsdValue: ({ dsrHistory }: BalanceState) => (
+    account: string
+  ): BigNumber => {
+    return dsrHistory[account]?.gainSoFarUsdValue ?? Zero;
+  },
+
   dsrHistory: ({ dsrHistory }: BalanceState): AccountDSRMovement[] => {
     return Object.keys(dsrHistory).reduce((acc, address) => {
       const { movements } = dsrHistory[address];

--- a/frontend/app/src/typing/types.ts
+++ b/frontend/app/src/typing/types.ts
@@ -157,7 +157,9 @@ export interface AccountDSRMovement {
   readonly address: string;
   readonly movementType: DSRMovementType;
   readonly gainSoFar: BigNumber;
+  readonly gainSoFarUsdValue: BigNumber;
   readonly amount: BigNumber;
+  readonly amountUsdValue: BigNumber;
   readonly blockNumber: number;
   readonly timestamp: number;
 }

--- a/rotkehlchen/chain/ethereum/makerdao.py
+++ b/rotkehlchen/chain/ethereum/makerdao.py
@@ -799,6 +799,9 @@ class MakerDAO(EthereumModule):
                     method_name='pie',
                     arguments=[proxy],
                 )
+                if guy_slice == 0:
+                    # no current DSR balance for this proxy
+                    continue
                 chi = self.ethereum.call_contract(
                     contract_address=MAKERDAO_POT.address,
                     abi=MAKERDAO_POT.abi,
@@ -813,7 +816,6 @@ class MakerDAO(EthereumModule):
                 abi=MAKERDAO_POT.abi,
                 method_name='dsr',
             )
-
             # Calculation is from here:
             # https://docs.makerdao.com/smart-contract-modules/rates-module#a-note-on-setting-rates
             current_dsr_percentage = ((FVal(current_dsr / RAY) ** 31622400) % 1) * 100
@@ -1026,6 +1028,10 @@ class MakerDAO(EthereumModule):
             reports = {}
             for account, proxy in proxy_mappings.items():
                 report = self._historical_dsr_for_account(account, proxy)
+                if len(report.movements) == 0:
+                    # This proxy has never had any DSR events
+                    continue
+
                 reports[account] = report
 
         return reports

--- a/rotkehlchen/chain/ethereum/makerdao.py
+++ b/rotkehlchen/chain/ethereum/makerdao.py
@@ -1118,11 +1118,13 @@ class MakerDAO(EthereumModule):
             current_dai_price = Price(FVal(1))
 
         # Calculate the total gain so far in USD
-        unaccounted_gain = gain
+        unaccounted_gain = _dsrdai_to_dai(gain)
         last_usd_value = ZERO
+        last_dai_gain = 0
         if len(movements) != 0:
-            unaccounted_gain = gain - movements[-1].gain_so_far
             last_usd_value = movements[-1].gain_so_far_usd_value
+            last_dai_gain = movements[-1].gain_so_far
+        unaccounted_gain = _dsrdai_to_dai(gain - last_dai_gain)
         gain_so_far_usd_value = unaccounted_gain * current_dai_price + last_usd_value
 
         return DSRAccountReport(

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -599,3 +599,27 @@ def test_query_historical_dsr_with_a_zero_withdrawal(
     assert_serialized_lists_equal(movements, expected_movements)
     errors = rotki.msg_aggregator.consume_errors()
     assert len(errors) == 0
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662']])
+@pytest.mark.parametrize('ethereum_modules', [['makerdao']])
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_dsr_for_account_with_proxy_but_no_dsr(
+        rotkehlchen_api_server,
+):
+    """Assure that an account with a DSR proxy but no DSR balance isn't returned in the balances"""
+    response = requests.get(api_url_for(
+        rotkehlchen_api_server,
+        "makerdaodsrbalanceresource",
+    ))
+    assert_proper_response(response)
+    json_data = response.json()
+    assert json_data['message'] == ''
+    assert len(json_data['result']['balances']) == 0
+    response = requests.get(api_url_for(
+        rotkehlchen_api_server,
+        "makerdaodsrhistoryresource",
+    ))
+    json_data = response.json()
+    assert json_data['message'] == ''
+    assert len(json_data['result']) == 0

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -20,6 +20,60 @@ from rotkehlchen.tests.utils.checks import (
 from rotkehlchen.tests.utils.constants import A_USDC, A_WBTC
 from rotkehlchen.tests.utils.makerdao import mock_proxies
 
+mocked_prices = {
+    'ETH': {
+        'USD': {
+            1582699808: FVal('223.73'),
+            1583958747: FVal('194.86'),
+            1584061534: FVal('135.44'),
+            1584061897: FVal('135.44'),
+            1584061977: FVal('135.44'),
+            1586785858: FVal('156.82'),
+            1587910979: FVal('197.78'),
+            1588174425: FVal('215.55'),
+            1588964667: FVal('211.54'),
+            1589993538: FVal('209.85'),
+            1590043499: FVal('198.56'),
+            1590043699: FVal('198.56'),
+        },
+    },
+    'DAI': {
+        'USD': {
+            1582699808: FVal('1.002'),
+            1584024065: FVal('1.002'),
+            1585286480: FVal('1.023'),
+            1585286769: FVal('1.023'),
+            1585290263: FVal('1.023'),
+            1586785858: FVal('1.024'),
+            1586788927: FVal('1.024'),
+            1586805054: FVal('1.024'),
+            1587539880: FVal('1.016'),
+            1587539889: FVal('1.016'),
+            1587910979: FVal('1.015'),
+            1588174425: FVal('1.014'),
+            1588664698: FVal('1.006'),
+            1588696496: FVal('1.006'),
+            1588964616: FVal('1.006'),
+            1589989097: FVal('1.003'),
+            1590042891: FVal('1.001'),
+            1590044118: FVal('1.001'),
+            1590521879: FVal('1.003'),
+        },
+    },
+    'WBTC': {
+        'USD': {
+            1588664698: FVal('7915.09'),
+            1588720248: FVal('7915.09'),
+        },
+    },
+    'USDC': {
+        'USD': {
+            1585286480: FVal(1),
+            1585290300: FVal(1),
+        },
+    },
+}
+
 VAULT_8015 = {
     'identifier': 8015,  # owner is missing and is filled in by the test function
     'collateral_type': 'ETH-A',
@@ -42,36 +96,43 @@ VAULT_8015_DETAILS = {
     'events': [{
         'event_type': 'deposit',
         'amount': FVal('41.1641807'),
+        'amount_usd_value': FVal('6455.366829'),
         'timestamp': 1586785858,
         'tx_hash': '0xd382ea1efa843c68914b2377057d384aca2a41710b23be89f165bb0a21986512',
     }, {
         'event_type': 'generate',
         'amount': FVal('1800'),
+        'amount_usd_value': FVal('1843.2'),
         'timestamp': 1586785858,
         'tx_hash': '0xd382ea1efa843c68914b2377057d384aca2a41710b23be89f165bb0a21986512',
     }, {
         'event_type': 'payback',
         'amount': FVal('51'),
+        'amount_usd_value': FVal('52.224'),
         'timestamp': 1586788927,
         'tx_hash': '0xc4ddd0e1b0a6cb4e55ac0be34201a5176372734db3bada58a73bccf98e47b3e7',
     }, {
         'event_type': 'generate',
         'amount': FVal('1000'),
+        'amount_usd_value': FVal('1024'),
         'timestamp': 1586805054,
         'tx_hash': '0x135a1ce0059ea8ca161cff4dba0b579538aa4550c96a895f5cebcc0c56e598d8',
     }, {
         'event_type': 'payback',
         'amount': FVal('1076'),
+        'amount_usd_value': FVal('1093.216'),
         'timestamp': 1587539880,
         'tx_hash': '0x3dd24fc5c64f151bc4a8c1d1a0de39ba23aa760ed27a591a462d822eb5c8fb80',
     }, {
         'event_type': 'payback',
         'amount': FVal('1673.2743084'),
+        'amount_usd_value': FVal('1683.31395425'),
         'timestamp': 1588964616,
         'tx_hash': '0x317f829a351ad9a8fb1a1e5f2f1ee786c0081087dc3a9ece8489e4092f258956',
     }, {
         'event_type': 'withdraw',
         'amount': FVal('41.1641807'),
+        'amount_usd_value': FVal('8707.87080185'),
         'timestamp': 1588964667,
         'tx_hash': '0xa67149325d5e2e20fab2befc3553332866c27ed32a4d04a3975e6eb4b130263b',
     }],
@@ -107,6 +168,8 @@ def _check_vault_details_values(details):
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
     """Check querying the vaults endpoint works. Uses real vault data"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -130,6 +193,8 @@ def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_query_vaults_async(rotkehlchen_api_server, ethereum_accounts):
     """Check querying the vaults endpoint asynchronously works. Uses real vault data"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -159,6 +224,8 @@ def test_query_vaults_async(rotkehlchen_api_server, ethereum_accounts):
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_query_only_details_and_not_vaults(rotkehlchen_api_server, ethereum_accounts):
     """Check querying the vaults details endpoint works before even querying vaults"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -198,15 +265,8 @@ def test_query_vaults_details_non_premium(rotkehlchen_api_server):
 @pytest.mark.parametrize('number_of_eth_accounts', [3])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-@pytest.mark.parametrize('mocked_price_queries', [{
-    'ETH': {
-        'USD': {
-            1584061534: FVal(135.44),
-            1584061897: FVal(135.44),
-            1584061977: FVal(135.44),
-        },
-    },
-}])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_query_vaults_details_liquidation(rotkehlchen_api_server, ethereum_accounts):
     """Check vault details of a vault with liquidations
 
@@ -260,36 +320,43 @@ def test_query_vaults_details_liquidation(rotkehlchen_api_server, ethereum_accou
         'events': [{
             'event_type': 'deposit',
             'amount': FVal('140'),
+            'amount_usd_value': FVal('31322.2'),
             'timestamp': 1582699808,
             'tx_hash': '0x3246ef91fd3d6e1f7c5766de4fa1f0991ba67d92e518447ba8207fe98569c309',
         }, {
             'event_type': 'generate',
             'amount': FVal('14000'),
+            'amount_usd_value': FVal('14028'),
             'timestamp': 1582699808,
             'tx_hash': '0x3246ef91fd3d6e1f7c5766de4fa1f0991ba67d92e518447ba8207fe98569c309',
         }, {
             'event_type': 'deposit',
             'amount': FVal('1.7'),
+            'amount_usd_value': FVal('331.262'),
             'timestamp': 1583958747,
             'tx_hash': '0x65ac798cb9f22068e43fd9ef8303a31e436989062ae87e25650cc44c7788ab62',
         }, {
             'event_type': 'payback',
             'amount': FVal('2921.344902'),
+            'amount_usd_value': FVal('2927.187591'),
             'timestamp': 1584024065,
             'tx_hash': '0x6e44d22d6898ee012369787cd75ea6fb9ace6f995cd157675f370e8ba4a7b9ad',
         }, {
             'event_type': 'liquidation',
             'amount': FVal('50'),
+            'amount_usd_value': FVal('6772'),
             'timestamp': 1584061534,
             'tx_hash': '0xb02050d914ab40f59a9e07eb4f8161ce36eb97cea9c189b027eb1ceeac83a516',
         }, {
             'event_type': 'liquidation',
             'amount': FVal('50'),
+            'amount_usd_value': FVal('6772'),
             'timestamp': 1584061897,
             'tx_hash': '0x678f31d49dd70d76c0ce441343c0060dc600f4c8dbb4cee2b08c6b451b6097cd',
         }, {
             'event_type': 'liquidation',
             'amount': FVal('41.7'),
+            'amount_usd_value': FVal('5647.848'),
             'timestamp': 1584061977,
             'tx_hash': '0xded0f9de641087692555d92a7fa94fa9fa7abf22744b2d16c20a66c5e48a8edf',
         }],
@@ -303,6 +370,8 @@ def test_query_vaults_details_liquidation(rotkehlchen_api_server, ethereum_accou
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
     """Check vault info and details for a vault with WBTC as collateral"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -349,21 +418,25 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
         'events': [{
             'event_type': 'deposit',
             'amount': FVal('0.011'),
+            'amount_usd_value': FVal('87.06599'),
             'timestamp': 1588664698,
             'tx_hash': '0x9ba4a6187fa2c49ba327e7c923846a08a1e972017ec41d3f9f66ef524f7dde59',
         }, {
             'event_type': 'generate',
             'amount': FVal('25'),
+            'amount_usd_value': FVal('25.15'),
             'timestamp': 1588664698,
             'tx_hash': '0x9ba4a6187fa2c49ba327e7c923846a08a1e972017ec41d3f9f66ef524f7dde59',
         }, {
             'event_type': 'payback',
             'amount': FVal('25.000248996'),
+            'amount_usd_value': FVal('25.15025'),
             'timestamp': 1588696496,
             'tx_hash': '0x8bd960e7eb8b9e2b81d2446d1844dd63f94636c7800ea5e3b4d926ea0244c66c',
         }, {
             'event_type': 'deposit',
             'amount': FVal('0.0113'),
+            'amount_usd_value': FVal('89.440517'),
             'timestamp': 1588720248,
             'tx_hash': '0x678c4da562173c102473f1904ff293a767ebac9ec6c7d728ef2fd41acf00a13a',
         }],  # way too many events in the vault, so no need to check them all
@@ -381,6 +454,8 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_query_vaults_usdc(rotkehlchen_api_server, ethereum_accounts):
     """Check vault info and details for a vault with USDC as collateral"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -423,26 +498,31 @@ def test_query_vaults_usdc(rotkehlchen_api_server, ethereum_accounts):
         'events': [{
             'event_type': 'deposit',
             'amount': FVal('45'),
+            'amount_usd_value': FVal('45'),
             'timestamp': 1585286480,
             'tx_hash': '0x8b553dd0e8ee5385ec91105bf911143666d9df0ecd84c04f288278f7658aa7d6',
         }, {
             'event_type': 'generate',
             'amount': FVal('20'),
+            'amount_usd_value': FVal('20.46'),
             'timestamp': 1585286480,
             'tx_hash': '0x8b553dd0e8ee5385ec91105bf911143666d9df0ecd84c04f288278f7658aa7d6',
         }, {
             'event_type': 'generate',
             'amount': FVal('15.99'),
+            'amount_usd_value': FVal('16.35777'),
             'timestamp': 1585286769,
             'tx_hash': '0xdb861c893a51e4649ff3740cd3658cd4c9b1d048d3b8b4d117f4319bd60aee01',
         }, {
             'event_type': 'payback',
             'amount': FVal('35.990506367'),
+            'amount_usd_value': FVal('36.818288'),
             'timestamp': 1585290263,
             'tx_hash': '0xdd7825fe4a93c6f1ffa25a91b6da2396c229fe16b17242ad5c0bf7962928b2ec',
         }, {
             'event_type': 'withdraw',
             'amount': FVal('45'),
+            'amount_usd_value': FVal('45'),
             'timestamp': 1585290300,
             'tx_hash': '0x97462ebba7ce2467787bf6de25a25c24e538cf8a647919112c5f048b6a293408',
         }],
@@ -455,6 +535,8 @@ def test_query_vaults_usdc(rotkehlchen_api_server, ethereum_accounts):
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
 def test_two_vaults_same_account_same_collateral(rotkehlchen_api_server, ethereum_accounts):
     """Check that no events are duplicated between vaults for same collateral by same account
 
@@ -514,26 +596,31 @@ def test_two_vaults_same_account_same_collateral(rotkehlchen_api_server, ethereu
         'events': [{
             'event_type': 'deposit',
             'amount': FVal('1'),
+            'amount_usd_value': FVal('197.78'),
             'timestamp': 1587910979,
             'tx_hash': '0xf59858df4e42cdc2aecfebdcf38e1df841866c6a9eb3adb6bde9a844564a3bb6',
         }, {
             'event_type': 'generate',
             'amount': FVal('80'),
+            'amount_usd_value': FVal('81.2'),
             'timestamp': 1587910979,
             'tx_hash': '0xf59858df4e42cdc2aecfebdcf38e1df841866c6a9eb3adb6bde9a844564a3bb6',
         }, {
             'event_type': 'payback',
             'amount': FVal('80'),
+            'amount_usd_value': FVal('80.24'),
             'timestamp': 1589989097,
             'tx_hash': '0x52396f7d20db54e2e9e716698b643a39815ff149a6cccbe9c7597dc9e06bb9d3',
         }, {
             'event_type': 'deposit',
             'amount': FVal('3.5'),
+            'amount_usd_value': FVal('734.475'),
             'timestamp': 1589993538,
             'tx_hash': '0x3c3942dc40fe68303098d91e765ceecaed4664bba0ef8f8e684b6f0e61968c6c',
         }, {
             'event_type': 'withdraw',
             'amount': FVal('4.5'),
+            'amount_usd_value': FVal('893.52'),
             'timestamp': 1590043499,
             'tx_hash': '0xbcd4158f0089404f6ab5378517762cddc13d21c9d2fcf3fd45cf1cf4b656242c',
         }],
@@ -547,26 +634,31 @@ def test_two_vaults_same_account_same_collateral(rotkehlchen_api_server, ethereu
         'events': [{
             'event_type': 'deposit',
             'amount': FVal('2.4'),
+            'amount_usd_value': FVal('517.32'),
             'timestamp': 1588174425,
             'tx_hash': '0xdb677a4257b5bdb305c278102d7b2460408bb7a3981414b994f4dd80a737ac2a',
         }, {
             'event_type': 'generate',
             'amount': FVal('192'),
+            'amount_usd_value': FVal('194.688'),
             'timestamp': 1588174425,
             'tx_hash': '0xdb677a4257b5bdb305c278102d7b2460408bb7a3981414b994f4dd80a737ac2a',
         }, {
             'event_type': 'payback',
             'amount': FVal('192'),
+            'amount_usd_value': FVal('192.192'),
             'timestamp': 1590042891,
             'tx_hash': '0x488a937677030cc810d0062001c08c944ecf6329b24a45ae9480bada8147bf75',
         }, {
             'event_type': 'deposit',
             'amount': FVal('4.4'),
+            'amount_usd_value': FVal('873.664'),
             'timestamp': 1590043699,
             'tx_hash': '0x712ddb654b878bcb30c5344d7c18f7f796fe94abd6e5b8a22b2da0a6c99bb425',
         }, {
             'event_type': 'generate',
             'amount': FVal('429.79'),
+            'amount_usd_value': FVal('430.21979'),
             'timestamp': 1590044118,
             'tx_hash': '0x36bfa27e157c03393a8816f6c1e3e990474f8f7473413810d87e2f4981d58044',
         }],

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -54,6 +54,18 @@ def should_mock_price_queries():
 
 
 @pytest.fixture
+def default_mock_price_value() -> Optional[FVal]:
+    """Determines test behavior If a mock price is not found
+
+    If it's None, then test fails with an error. If it is any other
+    value then this is returned by the price mocking function. It's used
+    for tests where other price queries may happen apart from the ones we check
+    but we never check them so we don't care about the price.
+    """
+    return None
+
+
+@pytest.fixture
 def mocked_price_queries():
     return defaultdict(defaultdict)
 

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -80,6 +80,7 @@ def initialize_mock_rotkehlchen_instance(
         ignored_assets,
         tags,
         manually_tracked_balances,
+        default_mock_price_value,
 ):
     if start_with_logged_in_user:
         rotki.unlock_user(
@@ -108,6 +109,7 @@ def initialize_mock_rotkehlchen_instance(
             historian=PriceHistorian(),
             should_mock_price_queries=should_mock_price_queries,
             mocked_price_queries=mocked_price_queries,
+            default_mock_value=default_mock_price_value,
         )
 
 
@@ -144,6 +146,7 @@ def rotkehlchen_api_server(
         ignored_assets,
         tags,
         manually_tracked_balances,
+        default_mock_price_value,
 ):
     """A partially mocked rotkehlchen server instance"""
 
@@ -167,6 +170,7 @@ def rotkehlchen_api_server(
         ignored_assets=ignored_assets,
         tags=tags,
         manually_tracked_balances=manually_tracked_balances,
+        default_mock_price_value=default_mock_price_value,
     )
     return api_server
 
@@ -190,6 +194,7 @@ def rotkehlchen_instance(
         ignored_assets,
         tags,
         manually_tracked_balances,
+        default_mock_price_value,
 ):
     """A partially mocked rotkehlchen instance"""
 
@@ -211,6 +216,7 @@ def rotkehlchen_instance(
         ignored_assets=ignored_assets,
         tags=tags,
         manually_tracked_balances=manually_tracked_balances,
+        default_mock_price_value=default_mock_price_value,
     )
     return uninitialized_rotkehlchen
 

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -921,6 +921,7 @@ def maybe_mock_historical_price_queries(
         historian,
         should_mock_price_queries: bool,
         mocked_price_queries,
+        default_mock_value: Optional[FVal] = None,
 ) -> None:
     """If needed will make sure the historian's price queries are mocked"""
     if not should_mock_price_queries:
@@ -933,10 +934,13 @@ def maybe_mock_historical_price_queries(
         try:
             price = mocked_price_queries[from_asset.identifier][to_asset.identifier][timestamp]
         except KeyError:
-            raise AssertionError(
-                f'No mocked price found from {from_asset.identifier} to '
-                f'{to_asset.identifier} at {timestamp}',
-            )
+            if default_mock_value is None:
+                raise AssertionError(
+                    f'No mocked price found from {from_asset.identifier} to '
+                    f'{to_asset.identifier} at {timestamp}',
+                )
+            # else just use the default
+            return default_mock_value
 
         return price
 


### PR DESCRIPTION
Fix #1047 and add usd_value fields to DSR and vault events. Also for the `gain_so_far` fields of DSR.

The frontend part is not really done. Just pulling the data from the API but not sure how to convert/show them.

@kelsos @isidorosp would be nice to get a review and help with the frontend part

