### PR TITLE
Allows the input of non-checksum addresses when

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `836` Allows the use of non-checksum eth addresses in the frontend.
 * :bug:`1016` Rotki users can now delete their rotki premium API keys via API Keys -> Rotki Premium.
 * :feature:`1015` Rotki now lets the user manually refresh and take a snapshot of their balances, even if the balance save frequency has not lapsed. This functionality is accessible through the Save Indicator (floppy disk icon on the app bar).
 * :feature:`707` Rotki now supports makerdao vaults. The vaults of the user are autodetected and they can see all details of each

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug: `836` Allows the use of non-checksum eth addresses in the frontend.
+* :bug: `836` Allows the use of non-checksummed eth addresses in the frontend.
 * :bug:`1016` Rotki users can now delete their rotki premium API keys via API Keys -> Rotki Premium.
 * :feature:`1015` Rotki now lets the user manually refresh and take a snapshot of their balances, even if the balance save frequency has not lapsed. This functionality is accessible through the Save Indicator (floppy disk icon on the app bar).
 * :feature:`707` Rotki now supports makerdao vaults. The vaults of the user are autodetected and they can see all details of each

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -24514,14 +24514,136 @@
       }
     },
     "watchpack": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
-      "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
+      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.1.8",
+        "chokidar": "^3.4.0",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true,
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
       }
     },
     "wbuf": {
@@ -24714,16 +24836,16 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.42.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.1.tgz",
-      "integrity": "sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",
         "@webassemblyjs/wasm-edit": "1.9.0",
         "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.2.1",
+        "acorn": "^6.4.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
@@ -24740,7 +24862,7 @@
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
         "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.0",
+        "watchpack": "^1.6.1",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -94,7 +94,8 @@
     "vue-cli-plugin-vuetify": "2.0.5",
     "vue-jest": "^3.0.5",
     "vue-template-compiler": "2.6.11",
-    "vuetify-loader": "1.4.3"
+    "vuetify-loader": "1.4.3",
+    "webpack": "^4.43.0"
   },
   "homepage": "https://rotki.com",
   "license": "BSD-3-Clause",

--- a/frontend/app/src/components/accounts/AccountForm.vue
+++ b/frontend/app/src/components/accounts/AccountForm.vue
@@ -60,13 +60,8 @@ import TagInput from '@/components/inputs/TagInput.vue';
 import TagManager from '@/components/tags/TagManager.vue';
 import { TaskType } from '@/model/task-type';
 import { BlockchainAccountPayload } from '@/store/balances/actions';
-import { notify } from '@/store/notifications/utils';
-import {
-  Account,
-  Blockchain,
-  Severity,
-  SupportedBlockchains
-} from '@/typing/types';
+import { Message } from '@/store/store';
+import { Account, Blockchain, SupportedBlockchains } from '@/typing/types';
 
 const { mapGetters: mapTaskGetters } = createNamespacedHelpers('tasks');
 const { mapGetters } = createNamespacedHelpers('balances');
@@ -88,7 +83,6 @@ export default class AccountForm extends Vue {
 
   accountTags!: (blockchain: Blockchain, address: string) => string[];
   accountLabel!: (blockchain: Blockchain, address: string) => string;
-
   @Prop({ required: false, default: null })
   edit!: Account | null;
 
@@ -151,11 +145,11 @@ export default class AccountForm extends Vue {
       );
       this.editComplete();
     } catch (e) {
-      notify(
-        `Error while adding account: ${e}`,
-        'Adding Account',
-        Severity.ERROR
-      );
+      this.$store.commit('setMessage', {
+        description: `Error while adding account: ${e}`,
+        title: 'Adding Account',
+        success: false
+      } as Message);
     }
     this.pending = false;
   }

--- a/frontend/app/src/services/converters.ts
+++ b/frontend/app/src/services/converters.ts
@@ -3,9 +3,9 @@ import {
   ApiDSRBalances,
   ApiDSRHistory,
   ApiMakerDAOVault,
-  ApiManualBalances,
   ApiMakerDAOVaultDetails,
   ApiMakerDAOVaultEvent,
+  ApiManualBalances,
   SupportedAssets
 } from '@/services/types-api';
 import {
@@ -13,10 +13,10 @@ import {
   DSRHistory,
   DSRMovement,
   MakerDAOVault,
-  ManualBalance,
-  SupportedAsset,
   MakerDAOVaultDetails,
-  MakerDAOVaultEvent
+  MakerDAOVaultEvent,
+  ManualBalance,
+  SupportedAsset
 } from '@/services/types-model';
 import { bigNumberify } from '@/utils/bignumbers';
 
@@ -138,4 +138,14 @@ export function convertVaultDetails(
     totalLiquidatedUsd: bigNumberify(details.total_liquidated_usd),
     events: convertVaultEvents(details.events)
   }));
+}
+
+export function deserializeApiErrorMessage(
+  message: string
+): { [key: string]: string[] } | undefined {
+  try {
+    return JSON.parse(message.replace(/'/gi, '"'));
+  } catch (e) {
+    return undefined;
+  }
 }

--- a/frontend/app/src/services/converters.ts
+++ b/frontend/app/src/services/converters.ts
@@ -144,7 +144,7 @@ export function deserializeApiErrorMessage(
   message: string
 ): { [key: string]: string[] } | undefined {
   try {
-    return JSON.parse(message.replace(/'/gi, '"'));
+    return JSON.parse(message);
   } catch (e) {
     return undefined;
   }

--- a/frontend/app/vue.config.js
+++ b/frontend/app/vue.config.js
@@ -1,4 +1,6 @@
 // vue.config.js
+const { ContextReplacementPlugin } = require('webpack');
+
 module.exports = {
   productionSourceMap: false,
   configureWebpack: config => {
@@ -32,6 +34,9 @@ module.exports = {
         return `webpack-vue:///${info.resourcePath}`;
       };
     }
+    config.plugins.push(
+      new ContextReplacementPlugin(/moment[/\\]locale$/, /en/)
+    );
   },
   pluginOptions: {
     electronBuilder: {

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -159,7 +160,15 @@ def handle_request_parsing_error(
 ) -> None:
     """ This handles request parsing errors generated for example by schema
     field validation failing."""
-    abort(HTTPStatus.BAD_REQUEST, result=None, message=str(err))
+    msg = str(err)
+    if isinstance(err.messages, dict):
+        # first key is just the location. Ignore
+        key = list(err.messages.keys())[0]
+        msg = json.dumps(err.messages[key])
+    elif isinstance(err.messages, list):
+        msg = ','.join(err.messages)
+
+    abort(HTTPStatus.BAD_REQUEST, result=None, message=msg)
 
 
 class APIServer():

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -136,7 +136,7 @@ def test_ignored_assets_endpoint_errors(rotkehlchen_api_server_with_exchanges, m
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'assets': ['Missing data for required field",
+        contained_in_msg='"assets": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -149,7 +149,7 @@ def test_ignored_assets_endpoint_errors(rotkehlchen_api_server_with_exchanges, m
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'assets': ['Not a valid list.'",
+        contained_in_msg='"assets": ["Not a valid list."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -795,7 +795,7 @@ def test_blockchain_accounts_endpoint_errors(rotkehlchen_api_server, api_port, m
     elif method == 'DELETE':
         message = 'Given value foo is not an ethereum address'
     else:
-        message = "'accounts': {0: {'_schema': ['Invalid input type.'"
+        message = '"accounts": {"0": {"_schema": ["Invalid input type.'
     assert_error_response(
         response=response,
         contained_in_msg=message,
@@ -1167,7 +1167,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="accounts': ['Missing data for required field",
+        contained_in_msg='"accounts": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -1196,7 +1196,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="address': ['Missing data for required field",
+        contained_in_msg='address": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -1213,7 +1213,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="address': ['Not a valid string",
+        contained_in_msg='address": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -1247,7 +1247,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="label': ['Not a valid string",
+        contained_in_msg='label": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -1264,7 +1264,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="tags': ['Not a valid list",
+        contained_in_msg='tags": ["Not a valid list',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -1281,7 +1281,7 @@ def test_edit_blockchain_account_errors(
     ), json=request_data)
     assert_error_response(
         response=response,
-        contained_in_msg="tags': {0: ['Not a valid string",
+        contained_in_msg='tags": {"0": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_data_import.py
+++ b/rotkehlchen/tests/api/test_data_import.py
@@ -43,7 +43,7 @@ def test_data_import_errors(rotkehlchen_api_server, tmpdir_factory):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="filepath': ['Missing data for required field",
+        contained_in_msg='filepath": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -57,7 +57,7 @@ def test_data_import_errors(rotkehlchen_api_server, tmpdir_factory):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="source': ['Missing data for required field",
+        contained_in_msg='source": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -71,7 +71,7 @@ def test_data_import_errors(rotkehlchen_api_server, tmpdir_factory):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="source': ['Not a valid string.'",
+        contained_in_msg='source": ["Not a valid string."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -85,7 +85,7 @@ def test_data_import_errors(rotkehlchen_api_server, tmpdir_factory):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="source': ['Must be one of: cointracking.info",
+        contained_in_msg='source": ["Must be one of: cointracking.info',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_eth_tokens.py
+++ b/rotkehlchen/tests/api/test_eth_tokens.py
@@ -151,7 +151,7 @@ def check_modifying_eth_tokens_error_responses(
     ), json={})
     assert_error_response(
         response=response,
-        contained_in_msg="eth_tokens': ['Missing data for required field",
+        contained_in_msg='eth_tokens": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
     # See that providing invalid type for eth_tokens is an error
@@ -161,7 +161,7 @@ def check_modifying_eth_tokens_error_responses(
     ), json={'eth_tokens': {}})
     assert_error_response(
         response=response,
-        contained_in_msg="'eth_tokens': ['Not a valid list.'",
+        contained_in_msg='"eth_tokens": ["Not a valid list."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
     # See that providing invalid type for eth_tokens is an error
@@ -171,7 +171,7 @@ def check_modifying_eth_tokens_error_responses(
     ), json={'eth_tokens': {}})
     assert_error_response(
         response=response,
-        contained_in_msg="'eth_tokens': ['Not a valid list.'",
+        contained_in_msg='"eth_tokens": ["Not a valid list."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
     # See that providing invalid type for a single eth token is an error

--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -140,7 +140,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="services': ['Missing data for required field.",
+        contained_in_msg='services": ["Missing data for required field.',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -152,7 +152,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'services': ['Not a valid list.'",
+        contained_in_msg='"services": ["Not a valid list."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -164,7 +164,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="services': {0: {'_schema': ['Invalid input type",
+        contained_in_msg='services": {"0": {"_schema": ["Invalid input type',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -176,7 +176,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'api_key': ['Missing data for required field.'",
+        contained_in_msg='"api_key": ["Missing data for required field."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -188,7 +188,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'name': ['Missing data for required field.'",
+        contained_in_msg='"name": ["Missing data for required field."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -200,7 +200,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'name': ['External service unknown is not known'",
+        contained_in_msg='"name": ["External service unknown is not known"',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -224,7 +224,7 @@ def test_add_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'api_key': ['Not a valid string.'",
+        contained_in_msg='"api_key": ["Not a valid string."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -237,7 +237,7 @@ def test_remove_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="services': ['Missing data for required field.",
+        contained_in_msg='services": ["Missing data for required field.',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -249,7 +249,7 @@ def test_remove_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'services': ['Not a valid list.'",
+        contained_in_msg='"services": ["Not a valid list.',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -261,7 +261,7 @@ def test_remove_external_services_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'services': {0: ['External service name should be a string']",
+        contained_in_msg='"services": {"0": ["External service name should be a string"]',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -296,7 +296,7 @@ def test_query_history_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="async_query': ['Not a valid boolean",
+        contained_in_msg='async_query": ["Not a valid boolean',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -536,7 +536,7 @@ def test_history_export_csv_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'directory_path': ['Given path /idont/exist/for/sure/ does not exist",
+        contained_in_msg='"directory_path": ["Given path /idont/exist/for/sure/ does not exist',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_manually_tracked_balances.py
+++ b/rotkehlchen/tests/api/test_manually_tracked_balances.py
@@ -287,7 +287,7 @@ def test_add_edit_manually_tracked_balances_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="balances': ['Missing data for required field",
+        contained_in_msg='balances": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -301,7 +301,7 @@ def test_add_edit_manually_tracked_balances_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="balances': ['Not a valid list",
+        contained_in_msg='balances": ["Not a valid list',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -381,7 +381,7 @@ def test_add_edit_manually_tracked_balances_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="label': ['Not a valid string",
+        contained_in_msg='label": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -474,7 +474,7 @@ def test_add_edit_manually_tracked_balances_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="tags': ['Not a valid list",
+        contained_in_msg='tags": ["Not a valid list',
         status_code=HTTPStatus.BAD_REQUEST,
     )
     # wrong type in list of tags
@@ -489,7 +489,7 @@ def test_add_edit_manually_tracked_balances_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'tags': {1: ['Not a valid string.'",
+        contained_in_msg='"tags": {"1": ["Not a valid string."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -597,7 +597,7 @@ def test_delete_manually_tracked_balances_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="labels': ['Missing data for required field",
+        contained_in_msg='labels": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -610,7 +610,7 @@ def test_delete_manually_tracked_balances_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="labels': ['Not a valid list",
+        contained_in_msg='"labels": ["Not a valid list',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -623,7 +623,7 @@ def test_delete_manually_tracked_balances_errors(rotkehlchen_api_server):
     )
     assert_error_response(
         response=response,
-        contained_in_msg="'labels': {1: ['Not a valid string.'",
+        contained_in_msg='"labels": {"1": ["Not a valid string."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -208,7 +208,7 @@ def test_set_unknown_settings(rotkehlchen_api_server):
     response = requests.put(api_url_for(rotkehlchen_api_server, "settingsresource"), json=data)
     assert_error_response(
         response=response,
-        contained_in_msg="{'invalid_setting': ['Unknown field.'",
+        contained_in_msg='{"invalid_setting": ["Unknown field."',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_tags.py
+++ b/rotkehlchen/tests/api/test_tags.py
@@ -161,7 +161,7 @@ def test_add_edit_tag_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="name': ['Missing data for required field",
+        contained_in_msg='name": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -181,7 +181,7 @@ def test_add_edit_tag_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="name': ['Not a valid string",
+        contained_in_msg='name": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
     # Invalid type for description
@@ -200,7 +200,7 @@ def test_add_edit_tag_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="description': ['Not a valid string",
+        contained_in_msg='description": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
@@ -225,7 +225,7 @@ def test_add_edit_tag_errors(
             )
             assert_error_response(
                 response=response,
-                contained_in_msg=f"{field}': ['Missing data for required field",
+                contained_in_msg=f'"{field}": ["Missing data for required field',
                 status_code=HTTPStatus.BAD_REQUEST,
             )
         # Invalid color type
@@ -240,7 +240,7 @@ def test_add_edit_tag_errors(
         )
         assert_error_response(
             response=response,
-            contained_in_msg=f"{field}': ['Failed to deserialize color code from int",
+            contained_in_msg=f'"{field}": ["Failed to deserialize color code from int',
             status_code=HTTPStatus.BAD_REQUEST,
         )
         # Wrong kind of string
@@ -256,8 +256,8 @@ def test_add_edit_tag_errors(
         assert_error_response(
             response=response,
             contained_in_msg=(
-                f"{field}': ['The given color code value \"went\" could "
-                f"not be processed as a hex color value"
+                f'"{field}": ["The given color code value \\"went\\" could '
+                f'not be processed as a hex color value'
             ),
             status_code=HTTPStatus.BAD_REQUEST,
         )
@@ -274,8 +274,8 @@ def test_add_edit_tag_errors(
         assert_error_response(
             response=response,
             contained_in_msg=(
-                f"{field}': ['The given color code value \"ffef01ff\" is out "
-                f"of range for a normal color field"
+                f'"{field}": ["The given color code value \\"ffef01ff\\" is out '
+                f'of range for a normal color field'
             ),
             status_code=HTTPStatus.BAD_REQUEST,
         )
@@ -292,8 +292,8 @@ def test_add_edit_tag_errors(
         assert_error_response(
             response=response,
             contained_in_msg=(
-                f"{field}': ['The given color code value \"ff\" does not "
-                f"have 6 hexadecimal digits"
+                f'"{field}": ["The given color code value \\"ff\\" does not '
+                f'have 6 hexadecimal digits'
             ),
             status_code=HTTPStatus.BAD_REQUEST,
         )
@@ -572,7 +572,7 @@ def test_delete_tag_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="name': ['Missing data for required field",
+        contained_in_msg='name": ["Missing data for required field',
         status_code=HTTPStatus.BAD_REQUEST,
     )
     # Invalid type for name
@@ -585,7 +585,7 @@ def test_delete_tag_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg="name': ['Not a valid string",
+        contained_in_msg='name": ["Not a valid string',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_trades.py
+++ b/rotkehlchen/tests/api/test_trades.py
@@ -212,7 +212,7 @@ def assert_all_missing_fields_are_handled(correct_trade, server):
         )
         assert_error_response(
             response=response,
-            contained_in_msg=f"{field}': ['Missing data for required field",
+            contained_in_msg=f'"{field}": ["Missing data for required field',
             status_code=HTTPStatus.BAD_REQUEST,
         )
 


### PR DESCRIPTION
Fixes #836 

Initially, I thought about adding the conversion to the backend API but I could not figure a good place to put it so I ended up adding this to the frontend.

Eth addresses will be converted to checksum format before being send to the backend.

Also, I realized that despite being an async action, the validation happens immediately so any error from the API call will show a modal dialog instead of a notification now.

To further improve the experience, I was thinking though if we could improve the response for the data validation. Currently, the message when validation fails is `"{'_schema' :[ 'messages',...]}`.

I could either fix the quotes and parse and show directly the message/es, or if possible, we could make it the validation message has some mapping between the invalid field and the message. E.g. in the case of the address the message would contain something like `"{'address' :[ 'messages',...]}` with extra messages for the different data failing the validation.

This, with some effort in the frontend, would help us map the validated fields to the input fields displaying specific errors directly under the input with the invalid value.