### PR TITLE
Adds the VeChain Thor (VTHO) Token

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
   - `Aave Interest bearing DAI (aDAI) <https://www.coingecko.com/en/coins/aave-dai>`__
   - `Loki (LOKI) <https://coinmarketcap.com/currencies/loki/>`__
   - `HyperDAO (HDAO) <https://coinmarketcap.com/currencies/hyperdao/>`__
+  - `VeChain Thor (VTHO) <https://www.cryptocompare.com/coins/vtho/overview>`__
 
 * :release:`1.4.2 <2020-04-29>`
 * :bug:`927` Rotki should no longer fail to handle HTTP Rate limiting if your web3 providing node rate limits you.

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9474,6 +9474,12 @@
         "symbol": "VTC",
         "type": "own chain"
     },
+    "VTHO": {
+        "name": "VeChainThor",
+        "started": 1533254400,
+        "symbol": "VTHO",
+        "type": "vechain token"
+    },
     "VZT": {
         "ethereum_address": "0x9720b467a710382A232a32F540bDCed7d662a10B",
         "ethereum_token_decimals": 18,


### PR DESCRIPTION
VeChain Thor is the gas token for the VeChain blockchain. 

I assumed the same starting date as the VET (main token) on the VeChain chain.


https://www.cryptocompare.com/coins/vtho/overview