### PR TITLE
Disables dev server progress

### DIFF
--- a/frontend/app/vue.config.js
+++ b/frontend/app/vue.config.js
@@ -2,6 +2,9 @@
 const { ContextReplacementPlugin } = require('webpack');
 
 module.exports = {
+  devServer: {
+    progress: false
+  },
   productionSourceMap: false,
   css: {
     loaderOptions: {


### PR DESCRIPTION
We discussed with @isidorosp about the progress of the webpack dev server when loading that was spamming the tests. 

@isidorosp in linux it works properly, can you verify that it also works on windows? I will also check the CI logs to verify that it has the required result