### PR TITLE
Clear our all token balances before requerying

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1110` DSR Dai balance will now not be recounted with every force refresh querying of blockchain balances
 * :feature: `-` Support Australian Dollar (AUD) as fiat currency
 * :feature: `-` Count Kraken `off-chain staked assets <https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M->`__ as normal Kraken balance.
 

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -876,6 +876,11 @@ class ChainManager(CacheableObject, LockableQueryObject):
         - EthSyncError if querying the token balances through a provided ethereum
         client and the chain is not synced
         """
+        # Clear out all previous token balances
+        tokens = [x for x, _ in self.totals.items() if isinstance(x, EthereumToken)]
+        for token in tokens:
+            del self.totals[token]
+
         try:
             self._query_ethereum_tokens_alethio(action=AccountAction.QUERY)
         except RemoteError as e:

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -876,10 +876,13 @@ class ChainManager(CacheableObject, LockableQueryObject):
         - EthSyncError if querying the token balances through a provided ethereum
         client and the chain is not synced
         """
-        # Clear out all previous token balances
-        tokens = [x for x, _ in self.totals.items() if isinstance(x, EthereumToken)]
-        for token in tokens:
-            del self.totals[token]
+        # Clear out all previous token balances. If token is "tracked" via the owned
+        # tokens just zero out its balance
+        for token in [x for x, _ in self.totals.items() if isinstance(x, EthereumToken)]:
+            if token not in self.owned_eth_tokens:
+                del self.totals[token]
+            else:
+                self.totals[token] = Balance()
 
         try:
             self._query_ethereum_tokens_alethio(action=AccountAction.QUERY)

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -25,7 +25,11 @@ def test_query_owned_assets(
     # Disable caching of query results
     rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen
     rotki.chain_manager.cache_ttl_secs = 0
-    setup = setup_balances(rotki, ethereum_accounts, btc_accounts)
+    setup = setup_balances(
+        rotki=rotki,
+        ethereum_accounts=ethereum_accounts,
+        btc_accounts=btc_accounts,
+    )
 
     # Get all our mocked balances and save them in the DB
     with ExitStack() as stack:


### PR DESCRIPTION
Even though they were normally overwritten, if a user had a balance of something
and later he does not have it's not edited at requery. Same thing with
additional queries such as DSR.

Fix #1110 