### PR TITLE
Take into account bittrex dates that have no milliseconds

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1151` Fix for bittrex users so that if bittrex returns dates without a millisecond component Rotki can still parse them properly.
 * :feature: `1105` Rotki now uses a standard compliant directory per OS to store user data. If the directory does not exist it is created and at the same time the old directory is migrated by copying it to the new one. The new directories per OS are:
   - Linux: ``~/.local/share/rotki/data``
   - OSX: ``~/Library/Application Support/rotki/data``

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -85,7 +85,11 @@ def deserialize_timestamp(timestamp: Union[int, str, FVal]) -> Timestamp:
     return processed_timestamp
 
 
-def deserialize_timestamp_from_date(date: str, formatstr: str, location: str) -> Timestamp:
+def deserialize_timestamp_from_date(
+        date: Optional[str],
+        formatstr: str,
+        location: str,
+) -> Timestamp:
     """Deserializes a timestamp from a date entry depending on the format str
 
     formatstr can also have a special value of 'iso8601' in which case the iso8601
@@ -124,7 +128,7 @@ def deserialize_timestamp_from_poloniex_date(date: str) -> Timestamp:
     return deserialize_timestamp_from_date(date, '%Y-%m-%d %H:%M:%S', 'poloniex')
 
 
-def deserialize_timestamp_from_bittrex_date(date: str) -> Timestamp:
+def deserialize_timestamp_from_bittrex_date(date: Optional[str]) -> Timestamp:
     """Deserializes a timestamp from a bittrex api query result date entry
 
     Bittrex trades follow the given format and unfortunately
@@ -134,7 +138,7 @@ def deserialize_timestamp_from_bittrex_date(date: str) -> Timestamp:
     Can throw DeserializationError if the data is not as expected
     """
     # Some dates have milliseconds, some not. Add 0 milliseconds for this to work
-    if '.' not in date:
+    if date is not None and '.' not in date:
         date += '.0'
     return deserialize_timestamp_from_date(date, '%Y-%m-%dT%H:%M:%S.%f', 'bittrex')
 

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -133,6 +133,9 @@ def deserialize_timestamp_from_bittrex_date(date: str) -> Timestamp:
 
     Can throw DeserializationError if the data is not as expected
     """
+    # Some dates have milliseconds, some not. Add 0 milliseconds for this to work
+    if '.' not in date:
+        date += '.0'
     return deserialize_timestamp_from_date(date, '%Y-%m-%dT%H:%M:%S.%f', 'bittrex')
 
 

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -9,9 +9,22 @@ from rotkehlchen.errors import UnknownAsset, UnsupportedAsset
 from rotkehlchen.exchanges.bittrex import Bittrex
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
+from rotkehlchen.serialization.deserialize import deserialize_timestamp_from_bittrex_date
 from rotkehlchen.tests.utils.history import TEST_END_TS
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import AssetMovementCategory, Location, TradeType
+
+
+def test_deserialize_timestamp_from_bittrex_date():
+    """Test for deserialize_timestamp_from_bittrex_date() and regression for #1151
+
+    In https://github.com/rotki/rotki/issues/1151 a user encountered an error with
+    the following date: 2017-07-08T07:57:12
+    """
+    assert deserialize_timestamp_from_bittrex_date('2014-02-13T00:00:00.00') == 1392249600
+    assert deserialize_timestamp_from_bittrex_date('2015-06-15T07:38:53.883') == 1434353933
+    assert deserialize_timestamp_from_bittrex_date('2015-08-19T04:24:47.217') == 1439958287
+    assert deserialize_timestamp_from_bittrex_date('2017-07-08T07:57:12') == 1499500632
 
 
 def test_name():


### PR DESCRIPTION
Fix #1151

It seems that Bittrex started also returning dates without a
millisecond component from their API. This patch fixes rotki so that
it takes them also into account