### PR TITLE
Adds a css-based scrollbar to the app and certain dialogs

### DIFF
--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -172,6 +172,8 @@ export default class App extends Vue {
     padding-top: 60px;
     z-index: 300 !important;
   }
+
+  @extend .themed-scrollbar;
 }
 
 .app {
@@ -247,10 +249,6 @@ export default class App extends Vue {
       content: '';
       border-bottom: var(--v-rotki-light-grey-darken1) solid thin;
     }
-  }
-
-  .v-navigation-drawer {
-    @extend .themed-scrollbar;
   }
 }
 </style>

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -161,6 +161,8 @@ export default class App extends Vue {
 </script>
 
 <style scoped lang="scss">
+@import '@/scss/scroll';
+
 .v-navigation-drawer {
   &--fixed {
     z-index: 100 !important;
@@ -246,27 +248,9 @@ export default class App extends Vue {
       border-bottom: var(--v-rotki-light-grey-darken1) solid thin;
     }
   }
-}
-::-webkit {
-  &-scrollbar {
-    width: 14px;
-    height: 18px;
 
-    &-thumb {
-      height: 6px;
-      border: 4px solid rgba(0, 0, 0, 0);
-      background-clip: padding-box;
-      border-radius: 7px;
-      background-color: rgba(0, 0, 0, 0.15);
-      box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05),
-        inset 1px 1px 0px rgba(0, 0, 0, 0.05);
-      &:hover {
-        background-color: rgba(0, 0, 0, 0.3);
-      }
-      &:active {
-        background-color: rgba(0, 0, 0, 0.5);
-      }
-    }
+  .v-navigation-drawer {
+    @extend .themed-scrollbar;
   }
 }
 </style>

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -247,4 +247,26 @@ export default class App extends Vue {
     }
   }
 }
+::-webkit {
+  &-scrollbar {
+    width: 14px;
+    height: 18px;
+
+    &-thumb {
+      height: 6px;
+      border: 4px solid rgba(0, 0, 0, 0);
+      background-clip: padding-box;
+      border-radius: 7px;
+      background-color: rgba(0, 0, 0, 0.15);
+      box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05),
+        inset 1px 1px 0px rgba(0, 0, 0, 0.05);
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.3);
+      }
+      &:active {
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+    }
+  }
+}
 </style>

--- a/frontend/app/src/components/inputs/TagInput.vue
+++ b/frontend/app/src/components/inputs/TagInput.vue
@@ -53,7 +53,12 @@
         </v-btn>
       </template>
     </v-autocomplete>
-    <v-dialog :value="!!manageTags" max-width="800" @input="manageTags = false">
+    <v-dialog
+      :value="!!manageTags"
+      max-width="800"
+      class="tag-input__tag-manager"
+      @input="manageTags = false"
+    >
       <tag-manager
         v-if="!!manageTags"
         dialog
@@ -107,6 +112,14 @@ export default class TagInput extends Vue {
 </script>
 
 <style scoped lang="scss">
+::v-deep {
+  .v-dialog {
+    &--active {
+      height: 100%;
+    }
+  }
+}
+
 .tag-input {
   &__tag {
     &__description {

--- a/frontend/app/src/components/tags/TagManager.vue
+++ b/frontend/app/src/components/tags/TagManager.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card light>
+  <v-card light class="tag-manager">
     <v-card-title>
       Tag Manager
       <v-spacer v-if="dialog"></v-spacer>
@@ -137,18 +137,23 @@ export default class TagManager extends Vue {
 }
 </script>
 
-<style scoped>
-::-webkit-scrollbar {
-    width: 12px;
+<style scoped lang="scss">
+@import '@/scss/scroll';
+
+::v-deep {
+  .v-dialog {
+    &__content {
+      .v-dialog {
+        &--active {
+          @extend .themed-scrollbar;
+        }
+      }
+    }
+  }
 }
- 
-::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3); 
-    border-radius: 10px;
-}
- 
-::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5); 
+
+.tag-manager {
+  overflow: auto;
+  height: 100%;
 }
 </style>

--- a/frontend/app/src/components/tags/TagManager.vue
+++ b/frontend/app/src/components/tags/TagManager.vue
@@ -137,4 +137,18 @@ export default class TagManager extends Vue {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+::-webkit-scrollbar {
+    width: 12px;
+}
+ 
+::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3); 
+    border-radius: 10px;
+}
+ 
+::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5); 
+}
+</style>

--- a/frontend/app/src/scss/scroll.scss
+++ b/frontend/app/src/scss/scroll.scss
@@ -1,0 +1,47 @@
+::-webkit-scrollbar {
+  width: 14px;
+  height: 18px;
+
+  &-thumb {
+    height: 6px;
+    border: 4px solid rgba(0, 0, 0, 0);
+    background-clip: padding-box;
+    border-radius: 7px;
+    background-color: rgba(0, 0, 0, 0.15);
+    box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05),
+      inset 1px 1px 0px rgba(0, 0, 0, 0.05);
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.3);
+    }
+
+    &:active {
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+  }
+}
+
+.themed-scrollbar {
+  ::-webkit-scrollbar {
+    width: 14px;
+    height: 18px;
+  
+    &-thumb {
+      height: 6px;
+      border: 4px solid rgba(0, 0, 0, 0);
+      background-clip: padding-box;
+      border-radius: 7px;
+      background-color: rgba(0, 0, 0, 0.15);
+      box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05),
+        inset 1px 1px 0px rgba(0, 0, 0, 0.05);
+  
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.3);
+      }
+  
+      &:active {
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Adds a css-based scrollbar to the app (main window) and the tagmanager dialog (which often scrolled
* This ensures consistency across OSes and also blends nicer with the rest of the app


@kelsos I'm having trouble getting this to apply to the navigation drawer scrollbar (which occurs if the window isn't tall enough for all of the nav links). Help woudl be appreciated!