### PR TITLE
Fix long wait time for async aave balance query

### DIFF
--- a/rotkehlchen/chain/ethereum/aave.py
+++ b/rotkehlchen/chain/ethereum/aave.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from typing_extensions import Literal
 
@@ -141,10 +141,25 @@ class Aave(EthereumModule):
 
     def get_balances(
             self,
-            defi_balances: Dict[ChecksumEthAddress, List[DefiProtocolBalances]],
+            given_defi_balances: Union[
+                Dict[ChecksumEthAddress, List[DefiProtocolBalances]],
+                Callable[[], Dict[ChecksumEthAddress, List[DefiProtocolBalances]]],
+            ],
     ) -> Dict[ChecksumEthAddress, AaveBalances]:
+        """Retrieves the aave balances
+
+        Receives the defi balances from zerion as an argument. They can either be directly given
+        as the defi balances mapping or as a callable that will retrieve the
+        balances mapping when executed.
+        """
         aave_balances = {}
         reserve_cache: Dict[str, Tuple[Any, ...]] = {}
+
+        if isinstance(given_defi_balances, dict):
+            defi_balances = given_defi_balances
+        else:
+            defi_balances = given_defi_balances()
+
         for account, balance_entries in defi_balances.items():
             lending_map = {}
             borrowing_map = {}

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -956,7 +956,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
         if ts_now() - self.defi_balances_last_query_ts < DEFI_BALANCES_REQUERY_SECONDS:
             return self.defi_balances
 
-        # now also query defi balances
+        # query zerion for defi balances
         zerion = Zerion(ethereum_manager=self.ethereum, msg_aggregator=self.msg_aggregator)
         self.defi_balances = {}
         for account in self.accounts.eth:


### PR DESCRIPTION
The code before was making sure that the ETH balances were queried
before the Aave balance query.

This was not needed. Only the defi balances needed to have been
queried before. And the query was happening before the actual async
task was enqued. Which was a no no.

The code around those queries has been changed to prevent that from
happening.