### PR TITLE
Support new atokens added on 16/07/2020

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 
   - `Aave Interest bearing BAT (aBAT) <https://www.coingecko.com/en/coins/aave-bat>`__
   - `Aave Interest bearing Binance USD (aBUSD) <https://www.coingecko.com/en/coins/aave-busd>`__
+  - `Aave Interest bearing ENJ (aENJ) <https://www.coingecko.com/en/coins/aave-enj>`__
   - `Aave Interest bearing ETH (aETH) <https://www.coingecko.com/en/coins/aave-eth>`__
   - `Aave Interest bearing KNC (aKNC) <https://www.coingecko.com/en/coins/aave-knc>`__
   - `Aave Interest bearing LEND (aLEND) <https://www.coingecko.com/en/coins/aave-lend>`__

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Changelog
   - `Aave Interest bearing LINK (aLINK) <https://www.coingecko.com/en/coins/aave-link>`__
   - `Aave Interest bearing MANA (aMANA) <https://www.coingecko.com/en/coins/aave-mana>`__
   - `Aave Interest bearing MKR (aMKR) <https://www.coingecko.com/en/coins/aave-mkr>`__
+  - `Aave Interest bearing REN (aREN) <https://www.coingecko.com/en/coins/aave-ren>`__
   - `Aave Interest bearing REP (aREP) <https://www.coingecko.com/en/coins/aave-rep>`__
   - `Aave Interest bearing SNX (aSNX) <https://www.coingecko.com/en/coins/aave-snx>`__
   - `Aave Interest bearing SUSD (aSUSD) <https://www.coingecko.com/en/coins/aave-susd>`__

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -10470,6 +10470,14 @@
         "symbol": "aMKR",
         "type": "ethereum token"
     },
+    "aREN": {
+        "ethereum_address": "0x69948cC03f478B95283F7dbf1CE764d0fc7EC54C",
+        "ethereum_token_decimals": 18,
+        "name": "Aave Interest bearing REN",
+        "started": 1594923128,
+        "symbol": "aREN",
+        "type": "ethereum token"
+    },
     "aREP": {
         "ethereum_address": "0x71010A9D003445aC60C4e6A7017c1E89A477B438",
         "ethereum_token_decimals": 18,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -10414,6 +10414,14 @@
         "symbol": "aDAI",
         "type": "ethereum token"
     },
+    "aENJ": {
+        "ethereum_address": "0x712DB54daA836B53Ef1EcBb9c6ba3b9Efb073F40",
+        "ethereum_token_decimals": 18,
+        "name": "Aave Interest bearing ENJ",
+        "started": 1594921488,
+        "symbol": "aENJ",
+        "type": "ethereum token"
+    },
     "aETH": {
         "ethereum_address": "0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04",
         "ethereum_token_decimals": 18,


### PR DESCRIPTION
Support new aREN and aENJ tokens added in Aaave protocol yesterday: https://medium.com/aave/aave-launches-new-features-and-listings-3f5596fb80a7