### PR TITLE
Increase test wait_for_async_task() default timeout

### DIFF
--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -492,7 +492,7 @@ def _add_blockchain_accounts_test_start(
 
         if async_query:
             task_id = assert_ok_async_response(response)
-            json_data = wait_for_async_task(api_server, task_id, timeout=20)
+            json_data = wait_for_async_task(api_server, task_id, timeout=40)
         else:
             assert_proper_response(response)
             json_data = response.json()

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -217,7 +217,7 @@ def test_query_vaults_async(rotkehlchen_api_server, ethereum_accounts):
         "makerdaovaultsresource",
     ), json={'async_query': True})
     task_id = assert_ok_async_response(response)
-    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=30)
+    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=50)
     assert outcome['message'] == ''
     vaults = outcome['result']
     _check_vaults_values(vaults, ethereum_accounts[0])
@@ -227,7 +227,7 @@ def test_query_vaults_async(rotkehlchen_api_server, ethereum_accounts):
         "makerdaovaultdetailsresource",
     ), json={'async_query': True})
     task_id = assert_ok_async_response(response)
-    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=30)
+    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=50)
     assert outcome['message'] == ''
     details = outcome['result']
     _check_vault_details_values(

--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -110,7 +110,7 @@ def assert_ok_async_response(response: requests.Response) -> int:
     return int(data['result']['task_id'])
 
 
-def wait_for_async_task(server: APIServer, task_id: int, timeout=10) -> Dict[str, Any]:
+def wait_for_async_task(server: APIServer, task_id: int, timeout=30) -> Dict[str, Any]:
     """Waits until an async task is ready and when it is returns the response's outcome
 
     If the task's outcome is not ready within timeout seconds then the test fails"""


### PR DESCRIPTION
Most times the Travis OSX VM seems to fail due to timeout hitting on
wait_for_async_task().
To address this we just double the default timeout.