### PR TITLE
Frontend: Use the correct setSettings call for premium_should_sync …

### DIFF
--- a/frontend/app/public/index.html
+++ b/frontend/app/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="UI of the Rotkehlchen application">
+    <meta name="description" content="UI of the Rotki application">
     <meta name="author" content="Lefteris Karapetsas">
     <title>rotki</title>
 </head>

--- a/frontend/app/src/components/account-management/PremiumCredentials.vue
+++ b/frontend/app/src/components/account-management/PremiumCredentials.vue
@@ -28,7 +28,7 @@
         prepend-icon="fa-key"
         :type="showKey ? 'text' : 'password'"
         :rules="apiKeyRules"
-        label="Rotkehlchen API Key"
+        label="Rotki API Key"
         @input="apiKeyChanged"
         @click:append="showKey = !showKey"
       ></v-text-field>
@@ -39,7 +39,7 @@
         :append-icon="showSecret ? 'fa-eye' : 'fa-eye-slash'"
         prepend-icon="fa-user-secret"
         :type="showSecret ? 'text' : 'password'"
-        label="Rotkehlchen API Secret"
+        label="Rotki API Secret"
         :rules="apiSecretRules"
         @input="apiSecretChanged"
         @click:append="showSecret = !showSecret"

--- a/frontend/app/src/components/settings/PremiumSettings.vue
+++ b/frontend/app/src/components/settings/PremiumSettings.vue
@@ -206,7 +206,7 @@ export default class PremiumSettings extends Vue {
     const { commit } = this.$store;
     const shouldSync = this.sync;
     this.$api
-      .setPremiumSync(shouldSync)
+      .setSettings({ premium_should_sync: shouldSync })
       .then(() => {
         commit('session/premiumSync', shouldSync);
       })

--- a/frontend/app/src/components/settings/PremiumSettings.vue
+++ b/frontend/app/src/components/settings/PremiumSettings.vue
@@ -39,7 +39,7 @@
             ></v-text-field>
             <div v-if="premium" class="premium-settings__premium-active">
               <v-icon color="success">fa-check-circle</v-icon>
-              <div>Rotkehlchen Premium is active</div>
+              <div>Rotki Premium is active</div>
             </div>
           </v-card-text>
           <v-card-actions>
@@ -76,7 +76,7 @@
               v-if="premium && !edit"
               v-model="sync"
               class="premium-settings__sync"
-              label="Allow data sync with Rotkehlchen Server"
+              label="Allow data sync with Rotki Server"
               @change="onSyncChange()"
             ></v-switch>
           </v-card-actions>

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -644,28 +644,6 @@ export class RotkehlchenApi {
     });
   }
 
-  setPremiumSync(enabled: boolean): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
-      this.axios
-        .put<ActionResult<DBSettings>>(
-          '/settings',
-          {
-            premium_should_sync: enabled
-          },
-          { validateStatus: this.validate_status_put_settings }
-        )
-        .then(response => {
-          const { result, message } = response.data;
-          if (result) {
-            resolve(result.premium_should_sync);
-          } else {
-            reject(new Error(message));
-          }
-        })
-        .catch(error => reject(error));
-    });
-  }
-
   getFiatExchangeRates(currencies: string[]): Promise<FiatExchangeRates> {
     return new Promise<FiatExchangeRates>((resolve, reject) => {
       this.axios

--- a/frontend/app/src/typing/types.ts
+++ b/frontend/app/src/typing/types.ts
@@ -116,6 +116,7 @@ export interface SettingsPayload {
   include_crypto2crypto: boolean;
   taxfree_after_period: number;
   kraken_account_type: string;
+  premium_should_sync: boolean;
 }
 
 export type ExternalServiceName = 'etherscan' | 'cryptocompare';


### PR DESCRIPTION
Fix #1187

- Also remove unused frontend API function `setPremiumSync`
- Change some Rotkehlchen->Rotki remnants in the UI
