### PR TITLE
Increase wait task timeout to decrease OSX tests failure rate

### DIFF
--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -492,7 +492,7 @@ def _add_blockchain_accounts_test_start(
 
         if async_query:
             task_id = assert_ok_async_response(response)
-            json_data = wait_for_async_task(api_server, task_id, timeout=40)
+            json_data = wait_for_async_task(api_server, task_id, timeout=60)
         else:
             assert_proper_response(response)
             json_data = response.json()

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -217,7 +217,7 @@ def test_query_vaults_async(rotkehlchen_api_server, ethereum_accounts):
         "makerdaovaultsresource",
     ), json={'async_query': True})
     task_id = assert_ok_async_response(response)
-    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=50)
+    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=70)
     assert outcome['message'] == ''
     vaults = outcome['result']
     _check_vaults_values(vaults, ethereum_accounts[0])
@@ -227,7 +227,7 @@ def test_query_vaults_async(rotkehlchen_api_server, ethereum_accounts):
         "makerdaovaultdetailsresource",
     ), json={'async_query': True})
     task_id = assert_ok_async_response(response)
-    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=50)
+    outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=70)
     assert outcome['message'] == ''
     details = outcome['result']
     _check_vault_details_values(


### PR DESCRIPTION
Last failed test in OSX failed due to timeout here: https://travis-ci.org/github/rotki/rotki/jobs/711271751