### PR TITLE
Fixes active tab color not rendering properly in packaged version

### DIFF
--- a/frontend/app/src/components/helper/TabNavigation.vue
+++ b/frontend/app/src/components/helper/TabNavigation.vue
@@ -88,7 +88,7 @@ export default class TabNavigation extends Vue {
       }
 
       &--active {
-        color: white;
+        color: white !important;
         background-color: var(--v-primary-base) !important;
       }
 


### PR DESCRIPTION
Fix #1203

[ui tests]


Hopefully this fixes it. I compiled an .exe on my side and it works. I'm guessing for some reason the ordering of the CSS imports possibly changes in the packaged version thus an "!important" property was needed.