### PR TITLE
Provide details to the user when there is a problem with the backend

### DIFF
--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -154,9 +154,8 @@ export default class App extends Vue {
   async created(): Promise<void> {
     await this.$store.dispatch('connect');
     await this.$store.dispatch('version');
-    this.$interop.onError(() => {
-      this.startupError =
-        'The Python backend crashed. Check rotkehlchen.log or open an issue in Github.';
+    this.$interop.onError((backendOutput: string) => {
+      this.startupError = `The Python backend crashed. Open an issue in Github and include rotki_electron.log and rotkehlchen.log. The backend's output follows below:\n\n ${backendOutput}`;
     });
   }
 }

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -155,7 +155,7 @@ export default class App extends Vue {
     await this.$store.dispatch('connect');
     await this.$store.dispatch('version');
     this.$interop.onError((backendOutput: string) => {
-      this.startupError = `The Python backend crashed. Open an issue in Github and include rotki_electron.log and rotkehlchen.log. The backend's output follows below:\n\n ${backendOutput}`;
+      this.startupError = `There is a problem with the backend. Open an issue in Github and include rotki_electron.log and rotkehlchen.log. The backend's output follows below:\n\n ${backendOutput}`;
     });
   }
 }

--- a/frontend/app/src/electron-interop.ts
+++ b/frontend/app/src/electron-interop.ts
@@ -17,7 +17,7 @@ export class ElectronInterop {
     window.interop?.openUrl(this.baseUrl);
   }
 
-  onError(callback: () => void) {
+  onError(callback: (backendOutput: string) => void) {
     window.interop?.listenForErrors(callback);
   }
 

--- a/frontend/app/src/preload.ts
+++ b/frontend/app/src/preload.ts
@@ -16,9 +16,9 @@ contextBridge.exposeInMainWorld('interop', {
   openDirectory: (title: string) => ipcAction('OPEN_DIRECTORY', title),
   premiumUserLoggedIn: (premiumUser: boolean) =>
     ipcRenderer.send('PREMIUM_USER_LOGGED_IN', premiumUser),
-  listenForErrors: (callback: () => void) => {
-    ipcRenderer.on('failed', () => {
-      callback();
+  listenForErrors: (callback: (backendOutput: string) => void) => {
+    ipcRenderer.on('failed', (event, args) => {
+      callback(args);
       ipcRenderer.send('ack', 1);
     });
   }

--- a/frontend/app/src/py-handler.ts
+++ b/frontend/app/src/py-handler.ts
@@ -108,13 +108,16 @@ export default class PyHandler {
         this.logBackendOutput(value)
       );
     }
+
+    const handler = this;
     childProcess.on('error', (err: Error) => {
       this.logToFile(
         `Encountered an error while trying to start the python sub-process\n\n${err}`
       );
+      // Notify the main window every 2 seconds until it acks the notification
+      handler.setFailureNotification(window, err);
     });
 
-    const handler = this;
     childProcess.on('exit', (code: number, signal: any) => {
       this.logToFile(
         `The Python sub-process exited with signal: ${signal} (Code: ${code})`
@@ -175,7 +178,7 @@ export default class PyHandler {
 
   private setFailureNotification(
     window: Electron.BrowserWindow | null,
-    backendOutuput: string
+    backendOutuput: string | Error
   ) {
     this.rpcFailureNotifier = setInterval(function () {
       window?.webContents.send('failed', backendOutuput);

--- a/frontend/app/src/py-handler.ts
+++ b/frontend/app/src/py-handler.ts
@@ -26,7 +26,7 @@ export default class PyHandler {
   private readonly logsPath: string;
   private readonly ELECTRON_LOG_PATH: string;
   private _corsURL?: string;
-  private backend_output: string = '';
+  private backendOutput: string = '';
 
   get port(): number {
     assert(this._port != null);
@@ -51,7 +51,7 @@ export default class PyHandler {
 
   private logBackendOutput(msg: string | Error) {
     this.logToFile(msg);
-    this.backend_output += msg;
+    this.backendOutput += msg;
   }
 
   setCorsURL(url: string) {
@@ -121,7 +121,7 @@ export default class PyHandler {
       );
       if (code !== 0) {
         // Notify the main window every 2 seconds until it acks the notification
-        handler.setFailureNotification(window);
+        handler.setFailureNotification(window, this.backendOutput);
       }
     });
 
@@ -173,9 +173,12 @@ export default class PyHandler {
     return this._port;
   }
 
-  private setFailureNotification(window: Electron.BrowserWindow | null) {
+  private setFailureNotification(
+    window: Electron.BrowserWindow | null,
+    backendOutuput: string
+  ) {
     this.rpcFailureNotifier = setInterval(function () {
-      window?.webContents.send('failed', 'failed');
+      window?.webContents.send('failed', backendOutuput);
     }, 2000);
   }
 

--- a/frontend/app/src/types.d.ts
+++ b/frontend/app/src/types.d.ts
@@ -1,7 +1,7 @@
 export interface Interop {
   openUrl(url: string): Promise<void>;
   closeApp(): void;
-  listenForErrors(callback: () => void): void;
+  listenForErrors(callback: (backendOutuput: string) => void): void;
   openFile(title: string): Promise<undefined | string>;
   openDirectory(title: string): Promise<undefined | string>;
   premiumUserLoggedIn(premiumUser: boolean): Promise<undefined | boolean>;


### PR DESCRIPTION
Fix #1211

- Logs the stdout/stderr of the backend to the rotki_electron log
- If the backend terminated with an error code then the backend output is also shown to the user at the "Backend problem error page"
- If the backend can not be started for some reason (e.g. permission problems) then the user is also notified via the "Backend problem error page"
- The backend problem error page got a new text to be more generic and ask the user to open and issue and provide specific information