### PR TITLE
Updates the Login Dialog to use the new scrollbar

### DIFF
--- a/frontend/app/src/components/AccountManagement.vue
+++ b/frontend/app/src/components/AccountManagement.vue
@@ -235,6 +235,7 @@ export default class AccountManagement extends Vue {
 </script>
 
 <style scoped lang="scss">
+@import '@/scss/scroll';
 @keyframes scrollLarge {
   0% {
     transform: rotate(-13deg) translateY(0);
@@ -257,9 +258,14 @@ export default class AccountManagement extends Vue {
 
 .account-management {
   &__card {
+    max-height: 90vh;
+    overflow: auto;
+
     &__title {
       background-color: var(--v-primary-base);
     }
+
+    @extend .themed-scrollbar;
   }
 
   &__loading {
@@ -313,6 +319,12 @@ export default class AccountManagement extends Vue {
       font-size: 14px !important;
       background: #e0e0e0 !important;
     }
+  }
+}
+
+::v-deep {
+  .v-dialog {
+    overflow-y: hidden;
   }
 }
 </style>


### PR DESCRIPTION
Login dialog was using native scrollbar instead of the new one (should only appear if the login dialog is > the vertical viewport)

[ui tests]

![image](https://user-images.githubusercontent.com/27592/88641726-e22aad00-d0bf-11ea-9e4e-2ed61959e33f.png)
