### PR TITLE
Add ocean token

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :feature:`-` Added support for the following tokens
 
   - `UMA (UMA) <https://coinmarketcap.com/currencies/uma/>`__
+  - `Ocean Protocol (OCEAN) <https://coinmarketcap.com/currencies/ocean-protocol/>`__
 
 
 * :release:`1.6.1 <2020-07-25>`

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -6703,6 +6703,14 @@
         "symbol": "OCC",
         "type": "ethereum token"
     },
+    "OCEAN": {
+        "ethereum_address": "0x985dd3D42De1e256d09e1c10F112bCCB8015AD41",
+        "ethereum_token_decimals": 18,
+        "name": "OceanToken",
+        "started": 1556037118,
+        "symbol": "OCEAN",
+        "type": "ethereum token"
+    },
     "OCN": {
         "ethereum_address": "0x4092678e4E78230F46A1534C0fbc8fA39780892B",
         "ethereum_token_decimals": 18,


### PR DESCRIPTION
I took #1231 as an example to add OCEAN.
Contract creation timestamp is: https://etherscan.io/tx/0xaff2ecec180e5b52cec56af8c9c43f60c41681bbc0c3bad05c50e31e3ca5315b

```
1555993918
Is equivalent to:
04/23/2019 @ 4:31am (UTC)
2019-04-23T04:31:58+00:00 in ISO 8601
Tue, 23 Apr 2019 04:31:58 +0000 in RFC 822, 1036, 1123, 2822
Tuesday, 23-Apr-19 04:31:58 UTC in RFC 2822
2019-04-23T04:31:58+00:00 in RFC 3339
```