### PR TITLE
Fix glitchy autocomplete components

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1247` Fix glitchy autocomplete components which were not opening properly if the "dropdown arrows" were cliked.
 * :bug: `1234` Bittrex history can now be properly queried again. Rotki uses bittrex v3 API from now and on.
 * :feature: `1187` There is now a setting per protocol with which users can specify which addresses should be queried for each protocol. If none are specified, then all addresses are queried. This should allow users to save a lot of time when querying historical and current balances for some protocols.
 * :feature:`-` Added support for the following tokens

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug: `1247` Fix glitchy autocomplete components which were not opening properly if the "dropdown arrows" were cliked.
+* :bug: `1247` Fix glitchy autocomplete component usage which caused select menus to not open properly if the "dropdown arrows" were clicked. This has fixed the following select menus throughout the app: Asset Select, Tag Input and Tag Filter, Owned Tokens.
 * :bug: `1234` Bittrex history can now be properly queried again. Rotki uses bittrex v3 API from now and on.
 * :feature: `1187` There is now a setting per protocol with which users can specify which addresses should be queried for each protocol. If none are specified, then all addresses are queried. This should allow users to save a lot of time when querying historical and current balances for some protocols.
 * :feature:`-` Added support for the following tokens

--- a/frontend/app/src/components/inputs/AssetSelect.vue
+++ b/frontend/app/src/components/inputs/AssetSelect.vue
@@ -12,7 +12,7 @@
     :error-messages="errorMessages"
     item-value="key"
     :item-text="assetText"
-    :menu-props="{ closeOnClick: true, closeOnContentClick: true }"
+    :menu-props="{ closeOnContentClick: true }"
     @input="input"
   >
     <template #selection="{ item }">

--- a/frontend/app/src/components/inputs/TagFilter.vue
+++ b/frontend/app/src/components/inputs/TagFilter.vue
@@ -8,7 +8,7 @@
     label="Filter by tag(s)"
     prepend-inner-icon="fa-search"
     item-text="name"
-    :menu-props="{ closeOnClick: true, closeOnContentClick: true }"
+    :menu-props="{ closeOnContentClick: true }"
     item-value="name"
     multiple
     @input="input"

--- a/frontend/app/src/components/inputs/TagInput.vue
+++ b/frontend/app/src/components/inputs/TagInput.vue
@@ -8,7 +8,7 @@
       small-chips
       label="Tags"
       item-text="name"
-      :menu-props="{ closeOnClick: true, closeOnContentClick: true }"
+      :menu-props="{ closeOnContentClick: true }"
       item-value="name"
       multiple
       @input="input"

--- a/frontend/app/src/components/settings/TokenTrack.vue
+++ b/frontend/app/src/components/settings/TokenTrack.vue
@@ -12,7 +12,7 @@
         label="Owned Tokens"
         item-text="symbol"
         :filter="filter"
-        :menu-props="{ closeOnClick: true, closeOnContentClick: true }"
+        :menu-props="{ closeOnContentClick: true }"
         item-value="symbol"
         multiple
         @input="add($event)"


### PR DESCRIPTION
Fix #1198

* Adjusts the `menuProps` in autocomplete component to not cause the automatic opening/closing of components if the "drop down arrow" was clicked.

[ui tests]

@kelsos do you recall if for any reason we needed both`closeOnClick: true` and `closeOnContentClick: true`? It seems that `closeOnClick` was the culprit for this behavior where clicking the "down" arrow lead to the autocomplete opening and closing super fast.