### PR TITLE
Submit usage analytics asynchronously

### DIFF
--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -54,6 +54,7 @@ class Accountant():
             msg_aggregator: MessagesAggregator,
             create_csv: bool,
     ) -> None:
+        log.debug('Initializing Accountant')
         self.db = db
         profit_currency = db.get_main_currency()
         self.msg_aggregator = msg_aggregator

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -70,6 +70,7 @@ class EthereumManager():
             attempt_connect: bool = True,
             eth_rpc_timeout: int = DEFAULT_ETH_RPC_TIMEOUT,
     ) -> None:
+        log.debug(f'Initializing Ethereum Manager with {ethrpc_endpoint}')
         self.web3: Optional[Web3] = None
         self.rpc_endpoint = ethrpc_endpoint
         self.etherscan = etherscan

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -146,6 +146,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
             premium: Optional[Premium],
             eth_modules: Optional[List[str]] = None,
     ):
+        log.debug('Initializing ChainManager')
         super().__init__()
         self.ethereum = ethereum_manager
         self.alethio = alethio

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -108,6 +108,7 @@ class ExchangeManager():
             exchange_credentials: Dict[str, ApiCredentials],
             database: 'DBHandler',
     ) -> None:
+        log.debug('Initializing exchanges')
         # initialize exchanges for which we have keys and are not already initialized
         for name, credentials in exchange_credentials.items():
             if name not in self.connected_exchanges:

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -166,7 +166,11 @@ class Rotkehlchen():
             # has unauthenticable/invalid premium credentials remaining in his DB
 
         settings = self.get_settings()
-        maybe_submit_usage_analytics(settings.submit_usage_analytics)
+        self.greenlet_manager.spawn_and_track(
+            task_name='submit_usage_analytics',
+            method=maybe_submit_usage_analytics,
+            should_submit=settings.submit_usage_analytics,
+        )
         self.etherscan = Etherscan(database=self.data.db, msg_aggregator=self.msg_aggregator)
         alethio = Alethio(
             database=self.data.db,

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -224,6 +224,7 @@ class Rotkehlchen():
             chain_manager=self.chain_manager,
         )
         self.user_is_logged_in = True
+        log.debug('User unlocking complete')
 
     def logout(self) -> None:
         if not self.user_is_logged_in:


### PR DESCRIPTION
The creation/unlock of a new user is a process that is done synchronously. That is why it should be as fast as possible.

@MysticRyuujin reported a case where a new user creation was taking ~20 seconds to complete. And in the UI no reaction is given to the clicking of the "create" button ... for 20 seconds.

That's bad. We should also see how we can tell the user that his account is being created (cc @kelsos @isidorosp )

But from looking at the code and screen sharing with @MysticRyuujin we discovered that analytics are submitted syncrhonously as part of the unlock.

This PR adds some more logging and also turns the analytics submission into an asynchronous task.

It's worth noting that the same thing does not take that long on my computer, but networking issues could be a factor. And they should not be for new user creation.