### PR TITLE
Cache autodetected tokens in the DB

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -547,6 +547,7 @@ class RestAPI():
         try:
             balances = self.rotkehlchen.chain_manager.query_balances(
                 blockchain=blockchain,
+                force_token_detection=ignore_cache,
                 ignore_cache=ignore_cache,
             )
         except EthSyncError as e:

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.constants.cryptocompare import WORLD_TO_CRYPTOCOMPARE
 from rotkehlchen.errors import DeserializationError, UnknownAsset, UnsupportedAsset
-from rotkehlchen.typing import AssetType, ChecksumEthAddress, Timestamp
+from rotkehlchen.typing import AssetType, ChecksumEthAddress, EthTokenInfo, Timestamp
 
 WORLD_TO_BITTREX = {
     # In Rotkehlchen Bitswift is BITS-2 but in Bittrex it's BITS
@@ -261,4 +261,12 @@ class HasEthereumToken(Asset):
 
 @dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=True)
 class EthereumToken(HasEthereumToken):
-    pass
+
+    def token_info(self) -> EthTokenInfo:
+        return EthTokenInfo(
+            identifier=self.identifier,
+            address=self.ethereum_address,
+            symbol=self.symbol,
+            name=self.name,
+            decimals=self.decimals,
+        )

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -14,7 +14,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, EthTokenInfo, Price
-from rotkehlchen.utils.misc import get_chunks
+from rotkehlchen.utils.misc import get_chunks, ts_now
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -33,36 +33,75 @@ class EthTokens():
         self.db = database
         self.ethereum = ethereum
 
-    def detect_tokens_for_addresses(self, addresses: List[ChecksumEthAddress]) -> TokensReturn:
-        token_usd_price = {}
+    def detect_tokens_for_address(
+            self,
+            address: ChecksumEthAddress,
+            token_usd_price: Dict[EthereumToken, Price],
+            chunks: List[List[EthTokenInfo]],
+    ) -> Dict[EthereumToken, FVal]:
+        balances: Dict[EthereumToken, FVal] = defaultdict(FVal)
+        for chunk in chunks:
+            self._get_tokens_balance_and_price(
+                address=address,
+                tokens=chunk,
+                balances=balances,
+                token_usd_price=token_usd_price,
+            )
+
+        # now that detection happened we also have to save it in the DB for the address
+        self.db.save_tokens_for_address(address, list(balances.keys()))
+
+        return balances
+
+    def query_tokens_for_addresses(self, addresses: List[ChecksumEthAddress]) -> TokensReturn:
         all_tokens = AssetResolver().get_all_eth_token_info()
         # With etherscan with chunks > 120, we get request uri too large
         # so the limitation is not in the gas, but in the request uri length
         chunks = list(get_chunks(all_tokens, n=ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH))
-
+        now = ts_now()
+        token_usd_price: Dict[EthereumToken, Price] = {}
         result = {}
+
         for address in addresses:
-            balances: Dict[EthereumToken, FVal] = defaultdict(FVal)
-            for chunk in chunks:
-                ret = self._get_multitoken_account_balance(tokens=chunk, account=address)
-                for token_identifier, value in ret.items():
-                    token = EthereumToken(token_identifier)
-                    balances[token] += value
-                    if token in token_usd_price:
-                        continue
-                    # else get the price
-                    try:
-                        usd_price = Inquirer().find_usd_price(token)
-                    except RemoteError:
-                        usd_price = Price(ZERO)
-                    token_usd_price[token] = usd_price
+            saved_list = self.db.get_tokens_for_address_if_time(address=address, current_time=now)
+            if saved_list is None:
+                balances = self.detect_tokens_for_address(
+                    address=address,
+                    token_usd_price=token_usd_price,
+                    chunks=chunks,
+                )
+            else:
+                balances = {}
+                self._get_tokens_balance_and_price(
+                    address=address,
+                    tokens=[x.token_info() for x in saved_list],
+                    balances=balances,
+                    token_usd_price=token_usd_price,
+                )
 
             result[address] = balances
 
         return result, token_usd_price
 
-    def query_tokens_for_addresses(self, addresses: List[ChecksumEthAddress]) -> TokensReturn:
-        return self.detect_tokens_for_addresses(addresses)
+    def _get_tokens_balance_and_price(
+            self,
+            address: ChecksumEthAddress,
+            tokens: List[EthTokenInfo],
+            balances: Dict[EthereumToken, FVal],
+            token_usd_price: Dict[EthereumToken, Price],
+    ) -> None:
+        ret = self._get_multitoken_account_balance(tokens=tokens, account=address)
+        for token_identifier, value in ret.items():
+            token = EthereumToken(token_identifier)
+            balances[token] += value
+            if token in token_usd_price:
+                continue
+            # else get the price
+            try:
+                usd_price = Inquirer().find_usd_price(token)
+            except RemoteError:
+                usd_price = Price(ZERO)
+            token_usd_price[token] = usd_price
 
     def _get_multitoken_multiaccount_balance(
             self,

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -272,10 +272,13 @@ class ChainManager(CacheableObject, LockableQueryObject):
     def query_balances(
             self,  # pylint: disable=unused-argument
             blockchain: Optional[SupportedBlockchain] = None,
+            force_token_detection: bool = False,
             # Kwargs here is so linters don't complain when the "magic" ignore_cache kwarg is given
             **kwargs: Any,
     ) -> BlockchainBalancesUpdate:
         """Queries either all, or specific blockchain balances
+
+        If force detection is true, then the ethereum token detection is forced.
 
         May raise:
         - RemoteError if an external service such as Etherscan or blockchain.info
@@ -287,7 +290,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
         should_query_btc = not blockchain or blockchain == SupportedBlockchain.BITCOIN
 
         if should_query_eth:
-            self.query_ethereum_balances()
+            self.query_ethereum_balances(force_token_detection=force_token_detection)
         if should_query_btc:
             self.query_btc_balances()
 
@@ -638,6 +641,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
             self,
             action: AccountAction,
             given_accounts: Optional[List[ChecksumEthAddress]] = None,
+            force_detection: bool = False,
     ) -> None:
         """Queries ethereum token balance via either etherscan or ethereum node
 
@@ -657,7 +661,10 @@ class ChainManager(CacheableObject, LockableQueryObject):
 
         ethtokens = EthTokens(database=self.database, ethereum=self.ethereum)
         try:
-            balance_result, token_usd_price = ethtokens.query_tokens_for_addresses(accounts)
+            balance_result, token_usd_price = ethtokens.query_tokens_for_addresses(
+                addresses=accounts,
+                force_detection=force_detection,
+            )
         except BadFunctionCallOutput as e:
             log.error(
                 'Assuming unsynced chain. Got web3 BadFunctionCallOutput '
@@ -720,7 +727,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
                         usd_value=new_usd_value,
                     )
 
-    def query_ethereum_tokens(self) -> None:
+    def query_ethereum_tokens(self, force_detection: bool) -> None:
         """Queries the ethereum token balances and populates the state
 
         May raise:
@@ -733,7 +740,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
         # tokens just zero out its balance
         for token in [x for x, _ in self.totals.items() if isinstance(x, EthereumToken)]:
             del self.totals[token]
-        self._query_ethereum_tokens(action=AccountAction.QUERY)
+        self._query_ethereum_tokens(action=AccountAction.QUERY, force_detection=force_detection)
 
         # If we have anything in DSR also count it towards total blockchain balances
         eth_balances = self.balances.eth
@@ -777,7 +784,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
         self.defi_balances_last_query_ts = ts_now()
         return self.defi_balances
 
-    def query_ethereum_balances(self) -> None:
+    def query_ethereum_balances(self, force_token_detection: bool) -> None:
         """Queries all the ethereum balances and populates the state
 
         May raise:
@@ -805,7 +812,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
         self.totals[A_ETH] = Balance(amount=eth_total, usd_value=eth_total * eth_usd_price)
 
         self.query_defi_balances()
-        self.query_ethereum_tokens()
+        self.query_ethereum_tokens(force_token_detection)
         vaults_module = self.makerdao_vaults
         if vaults_module is not None:
             normalized_balances = vaults_module.get_normalized_balances()

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -3,7 +3,7 @@ import operator
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import gevent
 import requests
@@ -379,44 +379,6 @@ class ChainManager(CacheableObject, LockableQueryObject):
                 usd_value=balance * btc_usd_price,
             )
         self.totals[A_BTC] = Balance(amount=total, usd_value=total * btc_usd_price)
-
-    @overload
-    @staticmethod
-    def _query_token_balances(
-            token_asset: EthereumToken,
-            query_callback: Callable[[EthereumToken, ChecksumEthAddress], FVal],
-            argument: ChecksumEthAddress,
-    ) -> FVal:
-        ...
-
-    @overload  # noqa: F811
-    @staticmethod
-    def _query_token_balances(
-            token_asset: EthereumToken,
-            query_callback: Callable[
-                [EthereumToken, List[ChecksumEthAddress]],
-                Dict[ChecksumEthAddress, FVal],
-            ],
-            argument: List[ChecksumEthAddress],
-    ) -> Dict[ChecksumEthAddress, FVal]:
-        ...
-
-    @staticmethod  # noqa: F811
-    def _query_token_balances(
-            token_asset: EthereumToken,
-            query_callback: Callable,
-            argument: Union[List[ChecksumEthAddress], ChecksumEthAddress],
-    ) -> Union[FVal, Dict[ChecksumEthAddress, FVal]]:
-        """Query tokens by checking the eth_tokens mapping and using the respective query callback.
-
-        The callback is either self.ethereum.get_multiaccount_token_balance or
-        self.ethereum.get_token_balance"""
-        result = query_callback(
-            token_asset,
-            argument,
-        )
-
-        return result
 
     def modify_btc_account(
             self,

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -892,9 +892,10 @@ class DBHandler:
             (address,),
         )
         result = query.fetchall()
+        if len(result) == 0:
+            return None  # no saved entry
         if current_time - result[0][1] > 86400:
-            # The saved entry is outdated
-            return None
+            return None  # saved entry is outdated
 
         try:
             json_ret = json.loads(result[0][0])
@@ -913,7 +914,7 @@ class DBHandler:
             )
             return None
 
-        return json_ret
+        return [EthereumToken(x) for x in json_ret]
 
     def save_tokens_for_address(
             self,
@@ -926,7 +927,7 @@ class DBHandler:
         cursor.execute(
             'INSERT OR REPLACE INTO ethereum_accounts_details '
             '(account, tokens_list, time) VALUES (?, ?, ?)',
-            (address, json.dumps(x.identifier for x in tokens), now),
+            (address, json.dumps([x.identifier for x in tokens]), now),
         )
         self.conn.commit()
         self.update_last_write()

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import os
 import re
@@ -71,7 +72,7 @@ from rotkehlchen.typing import (
     ApiKey,
     ApiSecret,
     BlockchainAccountData,
-    ChecksumAddress,
+    ChecksumEthAddress,
     EthereumTransaction,
     ExternalService,
     ExternalServiceApiCredentials,
@@ -645,7 +646,7 @@ class DBHandler:
         self.conn.commit()
         self.update_last_write()
 
-    def add_aave_events(self, address: ChecksumAddress, events: List[AaveEvent]) -> None:
+    def add_aave_events(self, address: ChecksumEthAddress, events: List[AaveEvent]) -> None:
         cursor = self.conn.cursor()
         cursor.executemany(
             'INSERT INTO '
@@ -666,7 +667,11 @@ class DBHandler:
         self.conn.commit()
         self.update_last_write()
 
-    def get_aave_events(self, address: ChecksumAddress, atoken: EthereumToken) -> List[AaveEvent]:
+    def get_aave_events(
+            self,
+            address: ChecksumEthAddress,
+            atoken: EthereumToken,
+    ) -> List[AaveEvent]:
         cursor = self.conn.cursor()
         query = cursor.execute(
             'SELECT event_type, amount, usd_value, block_number, timestamp, tx_hash, log_index '
@@ -843,11 +848,12 @@ class DBHandler:
         - InputError if any of the given accounts to delete did not exist
         """
         tuples = [(blockchain.value, x) for x in accounts]
+        account_tuples = [(x,) for x in accounts]
 
         cursor = self.conn.cursor()
         cursor.executemany(
             'DELETE FROM tag_mappings WHERE '
-            'object_reference = ?;', [(x,) for x in accounts],
+            'object_reference = ?;', account_tuples,
         )
         cursor.executemany(
             'DELETE FROM blockchain_accounts WHERE '
@@ -860,6 +866,68 @@ class DBHandler:
                 f'f{blockchain.value} accounts that do not exist',
             )
 
+        # Also remove saved details (tokens detected) if it's ethereum and if any exist
+        if blockchain == SupportedBlockchain.ETHEREUM:
+            cursor.executemany(
+                'DELETE FROM ethereum_accounts_details WHERE '
+                'account = ?;', account_tuples,
+            )
+
+        self.conn.commit()
+        self.update_last_write()
+
+    def get_tokens_for_address_if_time(
+            self,
+            address: ChecksumEthAddress,
+            current_time: Timestamp,
+    ) -> Optional[List[EthereumToken]]:
+        """Gets the detected tokens for the given address if the given current time
+        is recent enough.
+
+        If not, or if there is no saved entry, return None
+        """
+        cursor = self.conn.cursor()
+        query = cursor.execute(
+            'SELECT tokens_list, time FROM ethereum_accounts_details WHERE account = ?',
+            (address,),
+        )
+        result = query.fetchall()
+        if current_time - result[0][1] > 86400:
+            # The saved entry is outdated
+            return None
+
+        try:
+            json_ret = json.loads(result[0][0])
+        except json.decoder.JSONDecodeError as e:
+            # This should never happen
+            self.msg_aggregator.add_error(
+                f'Found undecodeable tokens_list {result[0][0]} in the DB for {address}.'
+                f'Error: {str(e)}',
+            )
+            return None
+
+        if not isinstance(json_ret, list):
+            # This should never happen
+            self.msg_aggregator.add_error(
+                f'Found non-list tokens_list {json_ret} in the DB for {address}.',
+            )
+            return None
+
+        return json_ret
+
+    def save_tokens_for_address(
+            self,
+            address: ChecksumEthAddress,
+            tokens: List[EthereumToken],
+    ) -> None:
+        """Saves detected tokens for an address"""
+        now = ts_now()
+        cursor = self.conn.cursor()
+        cursor.execute(
+            'INSERT OR REPLACE INTO ethereum_accounts_details '
+            '(account, tokens_list, time) VALUES (?, ?, ?)',
+            (address, json.dumps(x.identifier for x in tokens), now),
+        )
         self.conn.commit()
         self.update_last_write()
 
@@ -1492,7 +1560,7 @@ class DBHandler:
             self,
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
-            address: Optional[ChecksumAddress] = None,
+            address: Optional[ChecksumEthAddress] = None,
     ) -> List[EthereumTransaction]:
         """Returns a list of ethereum transactions optionally filtered by time and/or from address
 

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -131,6 +131,14 @@ CREATE TABLE IF NOT EXISTS blockchain_accounts (
 );
 """
 
+DB_CREATE_ETHEREUM_ACCOUNTS_DETAILS = """
+CREATE TABLE IF NOT EXISTS ethereum_accounts_details (
+    account VARCHAR[42] NOT NULL PRIMARY KEY,
+    tokens_list NOT NULL TEXT,
+    time NOT NULL INTEGER,
+);
+"""
+
 DB_CREATE_MANUALLY_TRACKED_BALANCES = """
 CREATE TABLE IF NOT EXISTS manually_tracked_balances (
     asset VARCHAR[24] NOT NULL,
@@ -248,7 +256,7 @@ CREATE TABLE IF NOT EXISTS settings (
 DB_SCRIPT_CREATE_TABLES = """
 PRAGMA foreign_keys=off;
 BEGIN TRANSACTION;
-{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}
+{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}
 COMMIT;
 PRAGMA foreign_keys=on;
 """.format(
@@ -260,6 +268,7 @@ PRAGMA foreign_keys=on;
     DB_CREATE_USER_CREDENTIALS,
     DB_CREATE_EXTERNAL_SERVICE_CREDENTIALS,
     DB_CREATE_BLOCKCHAIN_ACCOUNTS,
+    DB_CREATE_ETHEREUM_ACCOUNTS_DETAILS,
     DB_CREATE_MULTISETTINGS,
     DB_CREATE_MANUALLY_TRACKED_BALANCES,
     DB_CREATE_CURRENT_BALANCES,

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -134,8 +134,8 @@ CREATE TABLE IF NOT EXISTS blockchain_accounts (
 DB_CREATE_ETHEREUM_ACCOUNTS_DETAILS = """
 CREATE TABLE IF NOT EXISTS ethereum_accounts_details (
     account VARCHAR[42] NOT NULL PRIMARY KEY,
-    tokens_list NOT NULL TEXT,
-    time NOT NULL INTEGER,
+    tokens_list TEXT NOT NULL,
+    time INTEGER NOT NULL
 );
 """
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -476,6 +476,7 @@ class Rotkehlchen():
         try:
             blockchain_result = self.chain_manager.query_balances(
                 blockchain=None,
+                force_token_detection=ignore_cache,
                 ignore_cache=ignore_cache,
             )
             balances['blockchain'] = {

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -72,7 +72,7 @@ TABLES_AT_INIT = [
     'external_service_credentials',
     'user_credentials',
     'blockchain_accounts',
-    'ethereum_accounts_details'
+    'ethereum_accounts_details',
     'multisettings',
     'current_balances',
     'trades',

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -72,6 +72,7 @@ TABLES_AT_INIT = [
     'external_service_credentials',
     'user_credentials',
     'blockchain_accounts',
+    'ethereum_accounts_details'
     'multisettings',
     'current_balances',
     'trades',

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -1,8 +1,14 @@
+from unittest.mock import patch
+
 import pytest
+import requests
 
 from rotkehlchen.chain.ethereum.tokens import EthTokens
+from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.blockchain import mock_etherscan_query
+from rotkehlchen.tests.utils.factories import make_ethereum_address
 
 
 @pytest.fixture
@@ -23,7 +29,7 @@ def test_detect_tokens_for_addresses(ethtokens, inquirer):  # pylint: disable=un
     """
     addr1 = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
     addr2 = '0xD3A962916a19146D658de0ab62ee237ed3115873'
-    result, token_usd_prices = ethtokens.query_tokens_for_addresses([addr1, addr2])
+    result, token_usd_prices = ethtokens.query_tokens_for_addresses([addr1, addr2], False)
 
     assert len(result[addr1]) >= 2
     balance = result[addr1]['aDAI']
@@ -32,3 +38,46 @@ def test_detect_tokens_for_addresses(ethtokens, inquirer):  # pylint: disable=un
     assert len(result[addr2]) >= 20
 
     assert len(token_usd_prices) == len(set(result[addr1].keys()).union(set(result[addr2].keys())))
+
+
+def test_detected_tokens_cache(ethtokens, inquirer):  # pylint: disable=unused-argument
+    """Test that a cache of the detected tokens is created and used at subsequent queries.
+
+    Also test that the cache can be ignored and recreated with a forced redetection
+    """
+    addr1 = make_ethereum_address()
+    addr2 = make_ethereum_address()
+    eth_map = {addr1: {'GNO': 5000, 'MKR': 4000}, addr2: {'MKR': 6000}}
+    etherscan_patch = mock_etherscan_query(
+        eth_map=eth_map,
+        etherscan=ethtokens.ethereum.etherscan,
+        original_queries=None,
+        original_requests_get=requests.get,
+    )
+    ethtokens_max_chunks_patch = patch(
+        'rotkehlchen.chain.ethereum.tokens.ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH',
+        new=800,
+    )
+
+    with etherscan_patch as etherscan_mock, ethtokens_max_chunks_patch:
+        # Initially autodetect the tokens at the first call
+        result1, _ = ethtokens.query_tokens_for_addresses([addr1, addr2], False)
+        initial_call_count = etherscan_mock.call_count
+
+        # Then in second call autodetect queries should not have been made, and DB cache used
+        result2, _ = ethtokens.query_tokens_for_addresses([addr1, addr2], False)
+        call_count = etherscan_mock.call_count
+        assert call_count == initial_call_count + 2
+
+        # In the third call force re-detection
+        result3, _ = ethtokens.query_tokens_for_addresses([addr1, addr2], True)
+        call_count = etherscan_mock.call_count
+        assert call_count == initial_call_count + 2 + initial_call_count
+
+        assert result1 == result2 == result3
+        assert len(result1) == len(eth_map)
+        for key, entry in result1.items():
+            eth_map_entry = eth_map[key]
+            assert len(entry) == len(eth_map_entry)
+            for token, val in entry.items():
+                assert token_normalized_value(eth_map_entry[token], token.decimals) == val

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -23,7 +23,7 @@ def test_detect_tokens_for_addresses(ethtokens, inquirer):  # pylint: disable=un
     """
     addr1 = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
     addr2 = '0xD3A962916a19146D658de0ab62ee237ed3115873'
-    result, token_usd_prices = ethtokens.detect_tokens_for_addresses([addr1, addr2])
+    result, token_usd_prices = ethtokens.query_tokens_for_addresses([addr1, addr2])
 
     assert len(result[addr1]) >= 2
     balance = result[addr1]['aDAI']


### PR DESCRIPTION
Fix #1273 

- Save autodetected tokens for an address in the DB. If the saved tokens
are recent (24 hours), next time this address is queried, only query the detected
tokens and do not do another autodetection

- Introduce argument to enforce token autodetection. At the moment it's bundled with the `ignore_cache` argument of the API calls. So if `ignore_cache` is given, `force_detection` is also True.