### PR TITLE
Properly track SNX tokens by using the migrated address

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1285` Properly track SNX tokens by pointing to the `migrated <https://blog.synthetix.io/proxy-contract-cutover-on-may-10/`__ proxy contract
 * :feature: `1213` Taxable actions table in the tax report and in the CSV exports now include a location.
 * :bug: `1249` Fix some amounts not being converted to user's main currency correctly (two components were affected: Account Asset Balances in Accounts & Balances, and the AssetBalances component which was used in both Blockchain Balances as well as Exchange Balances sub-pages that showed totals across an asset).
 * :bug: `1247` Fix glitchy autocomplete component usage which caused select menus to not open properly if the "dropdown arrows" were clicked. This has fixed the following select menus throughout the app: Asset Select, Tag Input and Tag Filter, Owned Tokens.

--- a/rotkehlchen/chain/ethereum/aave.py
+++ b/rotkehlchen/chain/ethereum/aave.py
@@ -113,6 +113,13 @@ def _get_reserve_address_decimals(symbol: str) -> Tuple[ChecksumEthAddress, int]
     return reserve_address, decimals
 
 
+def _atoken_to_reserve_asset(atoken: EthereumToken) -> Asset:
+    reserve_symbol = atoken.identifier[1:]
+    if reserve_symbol == 'SUSD':
+        reserve_symbol = 'sUSD'
+    return Asset(reserve_symbol)
+
+
 class Aave(EthereumModule):
     """Aave integration module
 
@@ -366,7 +373,7 @@ class Aave(EthereumModule):
                 event['logIndex'], 'aave log index',
             )
 
-        reserve_asset = Asset(atoken.identifier[1:])
+        reserve_asset = _atoken_to_reserve_asset(atoken)
         reserve_address, decimals = _get_reserve_address_decimals(reserve_asset.identifier)
         aave_events = []
         for event in deposit_events:

--- a/rotkehlchen/constants/cryptocompare.py
+++ b/rotkehlchen/constants/cryptocompare.py
@@ -13,7 +13,7 @@ WORLD_TO_CRYPTOCOMPARE = {
     'aMKR': 'MKR',
     'aREP': 'REP',
     'aSNX': 'SNX',
-    'aSUSD': 'SUSD',
+    'aSUSD': 'sUSD',
     'aTUSD': 'TUSD',
     'aUSDC': 'USDC',
     'aUSDT': 'USDT',

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -8449,7 +8449,7 @@
         "type": "ethereum token"
     },
     "SNX": {
-        "ethereum_address": "0xC011A72400E58ecD99Ee497CF89E3775d4bd732F",
+        "ethereum_address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
         "ethereum_token_decimals": 18,
         "name": "Synthetix Network Token",
         "started": 1515283200,
@@ -8817,14 +8817,6 @@
         "name": "Suretly",
         "started": 1492646400,
         "symbol": "SUR",
-        "type": "ethereum token"
-    },
-    "SUSD": {
-        "ethereum_address": "0x57Ab1E02fEE23774580C119740129eAC7081e9D3",
-        "ethereum_token_decimals": 18,
-        "name": "sUSD",
-        "started": 1528426090,
-        "symbol": "SUSD",
         "type": "ethereum token"
     },
     "SUTER": {


### PR DESCRIPTION
Also remove the SUSD asset entry as it's pointing to the old contract
and we already got an sUSD entry pointing to the new one.

Fix #1285