### PR TITLE
Handle the bittrex API v3 pair format

### DIFF
--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -117,7 +117,7 @@ def trade_from_bittrex(bittrex_trade: Dict[str, Any]) -> Trade:
     order_type = deserialize_trade_type(bittrex_trade['direction'])
     fee = deserialize_fee(bittrex_trade['commission'])
     pair = bittrex_pair_to_world(bittrex_trade['marketSymbol'])
-    base_currency = get_pair_position_asset(pair, 'first')
+    quote_currency = get_pair_position_asset(pair, 'second')
 
     log.debug(
         'Processing bittrex Trade',
@@ -138,7 +138,7 @@ def trade_from_bittrex(bittrex_trade: Dict[str, Any]) -> Trade:
         amount=amount,
         rate=rate,
         fee=fee,
-        fee_currency=base_currency,
+        fee_currency=quote_currency,
         link=str(bittrex_trade['id']),
     )
 

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -21,12 +21,7 @@ from rotkehlchen.errors import (
     UnprocessableTradePair,
     UnsupportedAsset,
 )
-from rotkehlchen.exchanges.data_structures import (
-    AssetMovement,
-    Trade,
-    get_pair_position_asset,
-    trade_pair_from_assets,
-)
+from rotkehlchen.exchanges.data_structures import AssetMovement, Trade, get_pair_position_asset
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
@@ -79,13 +74,9 @@ def bittrex_pair_to_world(given_pair: str) -> TradePair:
             f'but found {type(given_pair)}',
         )
     pair = TradePair(given_pair.replace('-', '_'))
-    base_currency = asset_from_bittrex(get_pair_position_str(pair, 'first'))
-    quote_currency = asset_from_bittrex(get_pair_position_str(pair, 'second'))
-
-    # Since in Bittrex the base currency is the cost currency, iow in Bittrex
-    # for BTC_ETH we buy ETH with BTC and sell ETH for BTC, we need to turn it
-    # into the Rotkehlchen way which is following the base/quote approach.
-    pair = trade_pair_from_assets(quote_currency, base_currency)
+    # Check that there is no unsupported asset in the trade
+    _ = asset_from_bittrex(get_pair_position_str(pair, 'first'))
+    _ = asset_from_bittrex(get_pair_position_str(pair, 'second'))
     return pair
 
 

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -117,7 +117,7 @@ def trade_from_bittrex(bittrex_trade: Dict[str, Any]) -> Trade:
     order_type = deserialize_trade_type(bittrex_trade['direction'])
     fee = deserialize_fee(bittrex_trade['commission'])
     pair = bittrex_pair_to_world(bittrex_trade['marketSymbol'])
-    quote_currency = get_pair_position_asset(pair, 'second')
+    base_currency = get_pair_position_asset(pair, 'first')
 
     log.debug(
         'Processing bittrex Trade',
@@ -138,7 +138,7 @@ def trade_from_bittrex(bittrex_trade: Dict[str, Any]) -> Trade:
         amount=amount,
         rate=rate,
         fee=fee,
-        fee_currency=quote_currency,
+        fee_currency=base_currency,
         link=str(bittrex_trade['id']),
     )
 

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -95,7 +95,7 @@ def test_bittrex_query_balances_unknown_asset(bittrex):
 BITTREX_LIMIT_TRADE = """
     {
       "id": "fd97d393-e9b9-4dd1-9dbf-f288fc72a185",
-      "marketSymbol": "BTC-LTC",
+      "marketSymbol": "LTC-BTC",
       "direction": "BUY",
       "type": "LIMIT",
       "fillQuantity": 667.03644955,
@@ -108,7 +108,7 @@ BITTREX_LIMIT_TRADE = """
 BITTREX_MARKET_TRADE = """
     {
       "id": "ad97d393-19b9-6dd1-9dbf-f288fc72a185",
-      "marketSymbol": "BTC-ETH",
+      "marketSymbol": "ETH-BTC",
       "direction": "SELL",
       "type": "MARKET",
       "fillQuantity": 2,
@@ -221,14 +221,14 @@ def test_bittrex_query_trade_history_unexpected_data(bittrex):
 
     # Check that for non-string pairs we give a graceful error
     input_str = history.replace(
-        '"marketSymbol": "BTC-LTC"',
+        '"marketSymbol": "LTC-BTC"',
         '"marketSymbol": 4324234',
     )
     query_bittrex_and_test(input_str, expected_warnings_num=0, expected_errors_num=1)
 
     # Check that for unsupported assets in the pair are caught
     input_str = history.replace(
-        '"marketSymbol": "BTC-LTC"',
+        '"marketSymbol": "LTC-BTC"',
         '"marketSymbol": "BTC-PTON"',
     )
     query_bittrex_and_test(
@@ -240,7 +240,7 @@ def test_bittrex_query_trade_history_unexpected_data(bittrex):
 
     # Check that unprocessable pair is caught
     input_str = history.replace(
-        '"marketSymbol": "BTC-LTC"',
+        '"marketSymbol": "LTC-BTC"',
         '"marketSymbol": "SSSS"',
     )
     query_bittrex_and_test(

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -315,7 +315,7 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
             payload = """
 [{
       "id": "fd97d393-e9b9-4dd1-9dbf-f288fc72a185",
-      "marketSymbol": "BTC-LTC",
+      "marketSymbol": "LTC-BTC",
       "closedAt": "2017-05-01T15:00:00.00Z",
       "direction": "BUY",
       "type": "LIMIT",
@@ -324,7 +324,7 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
       "commission": 0.00004921
     }, {
       "id": "ad97d393-e9b9-4dd1-9dbf-f288fc72a185",
-      "marketSymbol": "ETH-LTC",
+      "marketSymbol": "LTC-ETH",
       "closedAt": "2017-05-02T15:00:00.00Z",
       "direction": "SELL",
       "type": "LIMIT",
@@ -342,7 +342,7 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
       "limit": 0.0000295
     }, {
       "id": "1d97d393-e9b9-4dd1-9dbf-f288fc72a185",
-      "marketSymbol": "ETH-IDONTEXIST",
+      "marketSymbol": "IDONTEXIST-ETH",
       "closedAt": "2017-05-02T15:00:00.00Z",
       "direction": "SELL",
       "type": "LIMIT",


### PR DESCRIPTION
In the previous version of the bittrex API the base currency was the
cost currency and vice versa. So we had to switch the pairs to make
them agree with our trade format.

Since v3 of their API they switched the pairs to the same format we
use so this switch is unnecessary.

Fix #1302