### PR TITLE
Add password backup warning on account creation

### DIFF
--- a/frontend/app/src/components/account-management/CreateAccount.vue
+++ b/frontend/app/src/components/account-management/CreateAccount.vue
@@ -47,6 +47,11 @@
                 required
               >
               </v-text-field>
+              <v-checkbox
+                v-model="userPrompted"
+                class="create-account__boxes__user-prompted"
+                label="Rotki saves all user data locally. I understand that if I lose my password, I lose access to my data. I have created a backup of the password."
+              ></v-checkbox>
               <premium-credentials
                 :enabled="premiumEnabled"
                 :api-secret="apiSecret"
@@ -74,7 +79,7 @@
               class="create-account__buttons__continue"
               depressed
               color="primary"
-              :disabled="!valid || loading"
+              :disabled="!valid || loading || !userPrompted"
               :loading="loading"
               @click="step = 2"
             >
@@ -157,6 +162,7 @@ export default class CreateAccount extends Vue {
   passwordConfirm: string = '';
 
   premiumEnabled: boolean = false;
+  userPrompted: boolean = false;
 
   submitUsageAnalytics: boolean = true;
   apiKey: string = '';

--- a/frontend/app/tests/e2e/pages/rotki-app.ts
+++ b/frontend/app/tests/e2e/pages/rotki-app.ts
@@ -12,6 +12,7 @@ export class RotkiApp {
     cy.get('.create-account__fields__username').type(username);
     cy.get('.create-account__fields__password').type(password);
     cy.get('.create-account__fields__password-repeat').type(password);
+    cy.get('.create-account__boxes__user-prompted').click();
     cy.get('.create-account__buttons__continue').click();
     cy.get('.create-account__analytics__buttons__confirm').click();
   }


### PR DESCRIPTION
Fix #1056 

The user must check the checkbox to be able to continue the account creation:

<img width="495" alt="Screenshot 2020-08-11 at 12 26 05" src="https://user-images.githubusercontent.com/10224453/89887006-dd8ceb00-dbcd-11ea-80dd-5d43d0b7e27e.png">
<img width="493" alt="Screenshot 2020-08-11 at 12 26 11" src="https://user-images.githubusercontent.com/10224453/89887013-df56ae80-dbcd-11ea-92ce-bec512d27379.png">

