### PR TITLE
Fixes app bar being visible for login

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1311` Fix app bar being visible for logged out users.
 * :feature: `1265` Removed fiat balance tracking as it was unnecessary. All fiat balances have now been migrated to manually tracked balances. Each fiat balance entry you had is now migrated to a corresponding manually tracked entry with location being "bank". As an example if you had 1500 EUR Fiat balance entry you will now have a manually tracked balance entry with 1500 EUR called "My EUR bank" and having a location bank.
 * :bug: `1298` Fix an issue where it was not possible to add a new manual balances after editing one.
 * :bug: `1243` Fix a problem where the "Get Premium" menu entry would not disappear without restarting the application.

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app id="rotki">
-    <div :show="logged" class="app__content rotki-light-grey">
+    <div v-show="logged" class="app__content rotki-light-grey">
       <v-navigation-drawer
         v-model="drawer"
         width="300"

--- a/frontend/app/src/background.ts
+++ b/frontend/app/src/background.ts
@@ -93,10 +93,15 @@ const defaultMenuTemplate: any[] = [
   {
     label: '&View',
     submenu: [
-      { role: 'reload' },
-      { role: 'forceReload' },
-      { role: 'toggleDevTools' },
-      { type: 'separator' },
+      ...(isDevelopment
+        ? [
+            { role: 'reload' },
+            { role: 'forceReload' },
+            { role: 'toggleDevTools' },
+            { type: 'separator' }
+          ]
+        : []),
+
       { role: 'resetZoom' },
       { role: 'zoomIn' },
       { role: 'zoomOut' },
@@ -170,7 +175,8 @@ function createWindow() {
       sandbox: true,
       enableRemoteModule: false,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(__dirname, 'preload.js'),
+      devTools: isDevelopment
     }
   });
 

--- a/frontend/app/src/components/AccountManagement.vue
+++ b/frontend/app/src/components/AccountManagement.vue
@@ -264,8 +264,8 @@ export default class AccountManagement extends Vue {
   &__loading {
     height: 800%;
     width: 800%;
-    top: -150% !important;
-    left: -40% !important;
+    top: -200% !important;
+    left: -100% !important;
     background: white url(~@/assets/images/rotkipattern2.svg);
     background-size: 450px 150px;
     filter: grayscale(0.5);

--- a/package.sh
+++ b/package.sh
@@ -97,7 +97,7 @@ if [[ "$PLATFORM" == "linux" ]]; then
     # travis can do the publishing
     # They don't do it automatically. Long discussion here:
     # https://github.com/electron-userland/electron-builder/issues/893
-    GENERATED_APPIMAGE=$(ls frontend/app/dist/*AppImage | head -n 1)
+    GENERATED_APPIMAGE=$(find "$(pwd)/frontend/app/dist/" -name "*AppImage"  | head -n 1)
     export GENERATED_APPIMAGE
     chmod +x "$GENERATED_APPIMAGE"
 fi


### PR DESCRIPTION
Closes #1311 

- Also disables `devTools` when not on development mode
- Hides some of the development options from the `View` menu when not on development mode.
- Fixes overlay not covering the whole window on 4K resolution fullscreen
- Fixes `GENERATED_APPIMAGE` not having the full path of the generated AppImage