### PR TITLE
Fix edge case in eth node initial connection

### DIFF
--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -207,20 +207,15 @@ class EthereumManager():
                     log.warning(message)
                     return False, message
 
-                if not isinstance(web3.eth.syncing, bool):  # pylint: disable=no-member
-                    current_block = web3.eth.syncing.currentBlock  # type: ignore # pylint: disable=no-member  # noqa: E501
-                    latest_block = web3.eth.syncing.highestBlock  # type: ignore # pylint: disable=no-member  # noqa: E501
-                    synchronized, msg = _is_synchronized(current_block, latest_block)
+                current_block = web3.eth.blockNumber  # pylint: disable=no-member
+                try:
+                    latest_block = self.query_eth_highest_block()
+                except RemoteError:
+                    msg = 'Could not query latest block'
+                    log.warning(msg)
+                    synchronized = False
                 else:
-                    current_block = web3.eth.blockNumber  # pylint: disable=no-member
-                    try:
-                        latest_block = self.query_eth_highest_block()
-                    except RemoteError:
-                        msg = 'Could not query latest block'
-                        log.warning(msg)
-                        synchronized = False
-                    else:
-                        synchronized, msg = _is_synchronized(current_block, latest_block)
+                    synchronized, msg = _is_synchronized(current_block, latest_block)
 
             if not synchronized:
                 self.msg_aggregator.add_warning(


### PR DESCRIPTION
In the very edge case where the ethereum node was syncing and suddenly
finished syncing between two of our function calls during the initial connection an exception
happened since `eth.syncing` was an object, and then suddenly it was
false.

This is how it manifested:

```
[11/08/2020 16:14:37 CEST] web3.providers.HTTPProvider: Getting response HTTP. URI: https://api.mycryptoapi.com/eth, Method: eth_syncing, Response: {'jsonrpc': '2.0', 'result': False, 'id': 4}
[11/08/2020 16:14:37 CEST] rotkehlchen.greenlets: Task for Attempt connection to mycrypto ethereum node died with exception: 'bool' object has no attribute 'highestBlock'.
Exception Name: <class 'AttributeError'>
Exception Info: 'bool' object has no attribute 'highestBlock'
Traceback:
   File "src/gevent/greenlet.py", line 818, in gevent._greenlet.Greenlet.run
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 240, in attempt_connect
    latest_block = web3.eth.syncing.highestBlock  # type: ignore # pylint: disable=no-member  # noqa: E501

[11/08/2020 16:14:37 CEST] rotkehlchen.user_messages: Task for Attempt
connection to mycrypto ethereum node died with exception: 'bool'
object has no attribute 'highestBlock'. Check the logs for more
details
```