### PR TITLE
Use submenu for `Get Rotki Premium` button on macOS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug: `1226` Fix "Get Rotki Premium" menu button on macOS
+
 * :release:`1.6.2 <2020-08-11>`
 * :bug: `1311` When user logs out the app bar is no longer visible.
 * :feature: `1303` User can now purge cached ethereum transactions and exchange data (deposits/withdrawals/trades). The next time data is fetched, the respective source will be queried to repopulate the local database cache. This might take some time depending on the amount of entries that will be queried.

--- a/frontend/app/src/background.ts
+++ b/frontend/app/src/background.ts
@@ -230,10 +230,25 @@ app.on('ready', async () => {
   ipcMain.on('PREMIUM_USER_LOGGED_IN', (event, args) => {
     const getRotkiPremiumButton = {
       label: '&Get Rotki Premium',
-      id: 'premium-button',
-      click: () => {
-        shell.openExternal('https://rotki.com/products/');
-      }
+      ...(isMac
+        ? {
+            // submenu is mandatory to be displayed on macOS
+            submenu: [
+              {
+                label: 'Get Rotki Premium',
+                id: 'premium-button',
+                click: () => {
+                  shell.openExternal('https://rotki.com/products/');
+                }
+              }
+            ]
+          }
+        : {
+            id: 'premium-button',
+            click: () => {
+              shell.openExternal('https://rotki.com/products/');
+            }
+          })
     };
 
     // Re-render the menu with the 'Get Rotki Premium' button if the user who just logged in


### PR DESCRIPTION
Fix #1226 

On macOS we have to provide `submenu` array to show the item in the app bar. I don't find anything about that in the documentation but I guess this is a limitation from the macOS system.

<img width="285" alt="Screenshot 2020-08-11 at 22 59 16" src="https://user-images.githubusercontent.com/10224453/89949371-1659ae00-dc28-11ea-87d0-b9b4ad0f386f.png">

Feel free to comment if I should label them differently.