### PR TITLE
Add tooltips on app bar buttons

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-
+* :feature: `1186` Add tooltips to all app bar buttons (except drawer button)
 * :bug: `1226` Fix "Get Rotki Premium" menu button on macOS
 * :feature:`-` Added support for the following tokens
 

--- a/frontend/app/src/components/CurrencyDropDown.vue
+++ b/frontend/app/src/components/CurrencyDropDown.vue
@@ -2,13 +2,13 @@
   <div>
     <v-menu transition="slide-y-transition" bottom offset-y>
       <template #activator="{ on }">
-        <v-btn
-          class="currency-dropdown secondary--text text--lighten-2"
-          icon
-          v-on="on"
+        <menu-tooltip-button
+          tooltip="Profit Currency"
+          class-name="currency-dropdown secondary--text text--lighten-2"
+          :on-menu="on"
         >
           {{ currency.unicode_symbol }}
-        </v-btn>
+        </menu-tooltip-button>
       </template>
       <v-list>
         <v-list-item
@@ -37,11 +37,13 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { mapActions, mapGetters } from 'vuex';
+import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import { currencies } from '@/data/currencies';
 import { Currency } from '@/model/currency';
 import { SettingsUpdate } from '@/typing/types';
 
 @Component({
+  components: { MenuTooltipButton },
   computed: mapGetters('session', ['currency']),
   methods: {
     ...mapActions('session', ['updateSettings'])
@@ -66,9 +68,11 @@ export default class CurrencyDropDown extends Vue {
 </script>
 
 <style scoped lang="scss">
-.currency-dropdown {
-  font-size: 1.6em !important;
-  font-weight: bold !important;
+::v-deep {
+  .currency-dropdown {
+    font-size: 1.6em !important;
+    font-weight: bold !important;
+  }
 }
 
 .currency-list {

--- a/frontend/app/src/components/UserDropdown.vue
+++ b/frontend/app/src/components/UserDropdown.vue
@@ -7,13 +7,13 @@
       offset-y
     >
       <template #activator="{ on }">
-        <v-btn
-          class="user-dropdown secondary--text text--lighten-2"
-          icon
-          v-on="on"
+        <menu-tooltip-button
+          tooltip="Account"
+          class-name="user-dropdown secondary--text text--lighten-2"
+          :on-menu="on"
         >
           <v-icon>fa fa-user-circle</v-icon>
-        </v-btn>
+        </menu-tooltip-button>
       </template>
       <v-list>
         <v-list-item key="username" class="user-username">
@@ -70,13 +70,15 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
+import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 
 const { mapState } = createNamespacedHelpers('session');
 const { mapState: mapSessionState } = createNamespacedHelpers('session');
 
 @Component({
   components: {
-    ConfirmDialog
+    ConfirmDialog,
+    MenuTooltipButton
   },
   computed: {
     ...mapState(['privacyMode']),

--- a/frontend/app/src/components/helper/MenuTooltipButton.vue
+++ b/frontend/app/src/components/helper/MenuTooltipButton.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-tooltip bottom z-index="215" class="tooltip-menu-button" open-delay="250">
+    <template #activator="{ on: tooltip }">
+      <v-btn
+        icon
+        :class="className"
+        :retain-focus-on-click="retainFocusOnClick"
+        v-on="{ ...tooltip, ...onMenu }"
+      >
+        <slot></slot>
+      </v-btn>
+    </template>
+    <span>{{ tooltip }}</span>
+  </v-tooltip>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class MenuTooltipButton extends Vue {
+  @Prop({ required: true, default: '' })
+  tooltip!: string;
+  @Prop({ required: true, default: () => {} })
+  onMenu!: () => void;
+  @Prop({ required: false, default: false })
+  retainFocusOnClick!: boolean;
+  @Prop({ required: true, default: '' })
+  className!: string;
+}
+</script>
+
+<style scoped lang="scss">
+// v-tooltip will render a span with a height computed to 0
+// by v-menu, so we have to force a height here otherwise offset-y
+// on the v-menu won't work
+
+.tooltip-menu-button {
+  display: block;
+  height: 100%;
+}
+</style>

--- a/frontend/app/src/components/status/BalanceSavedIndicator.vue
+++ b/frontend/app/src/components/status/BalanceSavedIndicator.vue
@@ -7,11 +7,15 @@
     z-index="215"
   >
     <template #activator="{ on }">
-      <v-btn icon class="secondary--text text--lighten-2" v-on="on">
+      <menu-tooltip-button
+        tooltip="Balances Snasphot Save Status"
+        class-name="secondary--text text--lighten-2"
+        :on-menu="on"
+      >
         <v-icon>
           fa fa-save
         </v-icon>
-      </v-btn>
+      </menu-tooltip-button>
     </template>
     <div class="balance-saved-indicator__content">
       <v-row>
@@ -47,11 +51,13 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import { AllBalancePayload } from '@/store/balances/actions';
 
 const { mapGetters } = createNamespacedHelpers('session');
 
 @Component({
+  components: { MenuTooltipButton },
   computed: {
     ...mapGetters(['lastBalanceSave', 'dateDisplayFormat'])
   }

--- a/frontend/app/src/components/status/NodeStatusIndicator.vue
+++ b/frontend/app/src/components/status/NodeStatusIndicator.vue
@@ -7,7 +7,11 @@
     z-index="215"
   >
     <template #activator="{ on }">
-      <v-btn icon class="secondary--text text--lighten-2" v-on="on">
+      <menu-tooltip-button
+        tooltip="Ethereum Node Status"
+        class-name="secondary--text text--lighten-2"
+        :on-menu="on"
+      >
         <v-icon
           :class="`node-status-indicator__icon--${
             nodeConnection ? 'connected' : 'disconnected'
@@ -15,7 +19,7 @@
         >
           fa {{ nodeConnection ? 'fa-link' : 'fa-unlink' }}
         </v-icon>
-      </v-btn>
+      </menu-tooltip-button>
     </template>
     <v-row class="node-status-indicator__content">
       <v-col cols="2">
@@ -52,9 +56,11 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 const { mapState } = createNamespacedHelpers('session');
 
 @Component({
+  components: { MenuTooltipButton },
   computed: mapState(['nodeConnection'])
 })
 export default class NodeStatusIndicator extends Vue {

--- a/frontend/app/src/components/status/NotificationIndicator.vue
+++ b/frontend/app/src/components/status/NotificationIndicator.vue
@@ -13,16 +13,16 @@
           <template #badge>
             <span>{{ count }}</span>
           </template>
-          <v-btn
-            icon
+          <menu-tooltip-button
+            tooltip="Notifications"
+            class-name="secondary--text text--lighten-2"
+            :on-menu="on"
             retain-focus-on-click
-            class="secondary--text text--lighten-2"
-            v-on="on"
           >
             <v-icon>
               fa fa-bell
             </v-icon>
-          </v-btn>
+          </menu-tooltip-button>
         </v-badge>
       </template>
       <v-row class="notification-indicator__details">
@@ -126,6 +126,7 @@ import orderBy from 'lodash/orderBy';
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
+import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import { NotificationData, Severity } from '@/typing/types';
 
 const { mapState, mapGetters } = createNamespacedHelpers('notifications');
@@ -136,7 +137,8 @@ const { mapState, mapGetters } = createNamespacedHelpers('notifications');
     ...mapGetters(['count'])
   },
   components: {
-    ConfirmDialog
+    ConfirmDialog,
+    MenuTooltipButton
   }
 })
 export default class NotificationIndicator extends Vue {

--- a/frontend/app/src/components/status/ProgressIndicator.vue
+++ b/frontend/app/src/components/status/ProgressIndicator.vue
@@ -7,14 +7,18 @@
       offset-y
     >
       <template #activator="{ on }">
-        <v-btn icon class="secondary--text text--lighten-2" v-on="on">
+        <menu-tooltip-button
+          tooltip="Running Tasks"
+          class-name="secondary--text text--lighten-2"
+          :on-menu="on"
+        >
           <v-icon v-if="hasRunningTasks" class="top-loading-icon">
             fa fa-circle-o-notch fa-spin
           </v-icon>
           <v-icon v-else>
             fa fa-check-circle
           </v-icon>
-        </v-btn>
+        </menu-tooltip-button>
       </template>
       <v-row class="progress-indicator__details">
         <v-col v-if="tasks.length > 0">
@@ -53,12 +57,14 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { createNamespacedHelpers } from 'vuex';
+import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import { Task, TaskMeta } from '@/model/task';
 
 const { mapGetters } = createNamespacedHelpers('tasks');
 const { mapGetters: mapReportGetters } = createNamespacedHelpers('reports');
 
 @Component({
+  components: { MenuTooltipButton },
   computed: {
     ...mapGetters(['hasRunningTasks', 'tasks']),
     ...mapReportGetters(['progress'])


### PR DESCRIPTION
Fix #1186 

Add tooltips to all app bar buttons (except the hamburger menu which is AMHA enough explicit/known).