### PR TITLE
Give warning not error when aave event is about to be duplicated in the DB

### DIFF
--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -293,7 +293,7 @@ class EthereumManager():
 
             try:
                 result = method(web3, **kwargs)
-            except (RemoteError, BlockchainQueryError):
+            except (RemoteError, BlockchainQueryError, requests.exceptions.HTTPError):
                 # Catch all possible errors here and just try next node call
                 continue
 


### PR DESCRIPTION
Some work on #1329. It's a fix, but not the proper fix as I can't yet reproduce.