### PR TITLE
Querying aave balances or historical data is now protected by a lock

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1329` If aave historical data is queried in quick succession a UNIQUE constraint error will no longer be generated.
 * :feature: `840` Add a new notification UI. Backend errors should now display a notification on the upper right corner.
 * :feature: `1235` Numerical displays can now be customized. Users can choose the thousands, the decimals separator. and the position of the currency symbol.
 * :feature: `1186` Add tooltips to all app bar buttons (except drawer button)


### PR DESCRIPTION
Querying aave balances or historical data is now protected by a lock.

This way we fix #1239 by not allowing two different greenlets get into
the same code and try to write the same things in the DB.

The second greenlet will just return what the first writes in the DB.