### PR TITLE
Fix cryptocompare price for Darwinia Network (RING) token

### DIFF
--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -65,6 +65,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('YAM'): Asset('USDT'),
     Asset('DEC-2'): Asset('USDT'),
     Asset('ORN'): Asset('USDT'),
+    Asset('RING'): Asset('USDT'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 


### PR DESCRIPTION
Cryptocompare is returning a wrong price for RING/USD.
https://min-api.cryptocompare.com/data/price?fsym=RING&tsyms=USD

This fix will request the price for RING/USDT instead:
https://min-api.cryptocompare.com/data/price?fsym=RING&tsyms=USDT