### PR TITLE
Do not even include crypto2crypto trades in report if setting is off

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `1393` When users set the "crypto to crypto trades" setting off, they will no longer see the USD equivalent part of crypto to crypto buys in the tax report history.
 * :feature: `1085` Users can now view their exchange trades, along with there deposit and withdraw actions on the connected exchanges.
 * :bug: `1321` CSV export formulas have now been fixed and should properly calculate profit/loss per different action type.
 * :feature:`-` Add support for New Zealand Dollar (NZD) as a fiat currency

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -311,6 +311,14 @@ class TaxableEvents():
         - RemoteError if there is a problem reaching the price oracle server
         or with reading the response returned by the server
         """
+        skip_trade = (
+            not self.include_crypto2crypto and
+            not bought_asset.is_fiat() and
+            not paid_with_asset.is_fiat()
+        )
+        if skip_trade:
+            return
+
         paid_with_asset_rate = self.get_rate_in_profit_currency(paid_with_asset, timestamp)
         buy_rate = paid_with_asset_rate * trade_rate
 
@@ -461,6 +469,13 @@ class TaxableEvents():
         - RemoteError if there is a problem reaching the price oracle server
         or with reading the response returned by the server
         """
+        skip_trade = (
+            not self.include_crypto2crypto and
+            not selling_asset.is_fiat() and
+            not receiving_asset.is_fiat()
+        )
+        if skip_trade:
+            return
 
         if selling_asset not in self.events:
             self.events[selling_asset] = Events([], [])

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -472,7 +472,7 @@ class TaxableEvents():
         skip_trade = (
             not self.include_crypto2crypto and
             not selling_asset.is_fiat() and
-            not receiving_asset.is_fiat()
+            receiving_asset and not receiving_asset.is_fiat()
         )
         if skip_trade:
             return

--- a/rotkehlchen/tests/unit/test_accounting.py
+++ b/rotkehlchen/tests/unit/test_accounting.py
@@ -226,6 +226,10 @@ history5 = history1 + [{
 }])
 def test_nocrypto2crypto(accountant):
     accounting_history_process(accountant, 1436979735, 1519693374, history5)
+    # Expected = 3 trades + the creation of ETC and BCH after fork times
+    msg = 'The crypto to crypto trades should not appear in the list at all'
+    assert len(accountant.csvexporter.all_events) == 5, msg
+
     assert accountant.general_trade_pl.is_close("264693.43364282")
     assert accountant.taxable_trade_pl.is_close("0")
 


### PR DESCRIPTION
When users set the "crypto to crypto trades" setting off, they will no longer see the USD equivalent part of crypto to crypto buys in the tax report history.

Fix #1393