### PR TITLE
Re-order nav menu and update nav icons

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`1415` The navigation drawer has been re-ordered for better usability (the most-used pages have been floated up, and least-used moved to the bottom), and its icons have been updated to use Material Design Icons.
+  
 * :feature:`-` Added support for the following tokens:
 
   - `SushiToken (SUSHI) <https://www.coingecko.com/en/coins/sushi>`__

--- a/frontend/app/src/components/NavigationMenu.vue
+++ b/frontend/app/src/components/NavigationMenu.vue
@@ -39,6 +39,11 @@
               />
             </v-list-item>
           </v-list-group>
+          <v-divider
+            v-else-if="navItem.type === 'divider'"
+            :key="i"
+            class="mb-2"
+          />
         </template>
       </v-list-item-group>
     </v-list>
@@ -50,11 +55,11 @@ import { Component, Vue, Prop } from 'vue-property-decorator';
 import NavigationMenuItem from '@/components/NavigationMenuItem.vue';
 
 type NavItem = {
-  readonly type: 'item' | 'group';
-  readonly text: string;
-  readonly route: string;
+  readonly type: 'item' | 'group' | 'divider';
+  readonly text?: string;
+  readonly route?: string;
   readonly class?: string;
-  readonly icon: string;
+  readonly icon?: string;
 };
 
 type GroupNavItem = NavItem & { items?: NavItem[] };
@@ -72,27 +77,14 @@ export default class NavigationMenu extends Vue {
       text: this.$tc('navigation_menu.dashboard'),
       route: '/dashboard',
       class: 'dashboard',
-      icon: 'fa-dashboard'
+      icon: 'mdi-monitor-dashboard'
     },
     {
       type: 'item',
       text: this.$tc('navigation_menu.accounts_balances'),
       route: '/accounts-balances',
       class: 'accounts-balances',
-      icon: 'fa-briefcase'
-    },
-    {
-      type: 'item',
-      text: this.$tc('navigation_menu.api_keys'),
-      route: '/settings/api-keys/rotki-premium',
-      class: 'settings__api-keys',
-      icon: 'fa-key'
-    },
-    {
-      type: 'item',
-      text: this.$tc('navigation_menu.import_data'),
-      route: '/import',
-      icon: 'fa-upload'
+      icon: 'mdi-briefcase-variant'
     },
     {
       type: 'group',
@@ -119,7 +111,7 @@ export default class NavigationMenu extends Vue {
           type: 'item',
           text: this.$tc('navigation_menu.history_sub.ethereum_transactions'),
           route: '/history/transactions',
-          icon: 'mdi-swap-horizontal',
+          icon: 'mdi-swap-horizontal-bold',
           class: 'eth-transactions'
         }
       ]
@@ -128,7 +120,7 @@ export default class NavigationMenu extends Vue {
       type: 'item',
       text: this.$tc('navigation_menu.defi'),
       route: '/defi/overview',
-      icon: 'fa-line-chart',
+      icon: 'mdi-finance',
       class: 'defi'
     },
     {
@@ -136,14 +128,30 @@ export default class NavigationMenu extends Vue {
       text: this.$tc('navigation_menu.statistics'),
       route: '/statistics',
       class: 'statistics',
-      icon: 'fa-bar-chart'
+      icon: 'mdi-chart-bar'
     },
     {
       type: 'item',
       text: this.$tc('navigation_menu.tax_report'),
       route: '/tax-report',
       class: 'tax-report',
-      icon: 'fa-calculator'
+      icon: 'mdi-calculator'
+    },
+    {
+      type: 'divider'
+    },
+    {
+      type: 'item',
+      text: this.$tc('navigation_menu.api_keys'),
+      route: '/settings/api-keys/rotki-premium',
+      class: 'settings__api-keys',
+      icon: 'mdi-key-chain-variant'
+    },
+    {
+      type: 'item',
+      text: this.$tc('navigation_menu.import_data'),
+      route: '/import',
+      icon: 'mdi-database-import'
     }
   ];
 }

--- a/frontend/app/src/components/NavigationMenu.vue
+++ b/frontend/app/src/components/NavigationMenu.vue
@@ -54,15 +54,19 @@
 import { Component, Vue, Prop } from 'vue-property-decorator';
 import NavigationMenuItem from '@/components/NavigationMenuItem.vue';
 
-type NavItem = {
-  readonly type: 'item' | 'group' | 'divider';
-  readonly text?: string;
-  readonly route?: string;
+type NavItemDetails = {
+  readonly text: string;
+  readonly route: string;
   readonly class?: string;
-  readonly icon?: string;
+  readonly icon: string;
 };
 
-type GroupNavItem = NavItem & { items?: NavItem[] };
+type NavItem = { readonly type: 'item' } & NavItemDetails;
+type NavGroupItem = {
+  readonly type: 'group';
+} & NavItemDetails & { items: NavItem[] };
+type DividerItem = { readonly type: 'divider' };
+type MenuItem = NavItem | NavGroupItem | DividerItem;
 
 @Component({
   components: { NavigationMenuItem }
@@ -71,7 +75,7 @@ export default class NavigationMenu extends Vue {
   @Prop({ required: false, default: false })
   showTooltips!: boolean;
 
-  readonly navItems: GroupNavItem[] = [
+  readonly navItems: MenuItem[] = [
     {
       type: 'item',
       text: this.$tc('navigation_menu.dashboard'),


### PR DESCRIPTION
Changes
------------------

* Re-ordered navigation menu as per #1415 
* Swapped icons from fontawesome to material design icons. I found icons closely matching the current ones for all except the dashboard. I purposefully picked something that looks more like a computer dashboard as opposed to a speedometer. If we want to go back to the speedometer we can (there is icon available here https://iconify.design/icon-sets/mdi/speedometer.html).

Before
![image](https://user-images.githubusercontent.com/27592/91968900-a4035780-ed15-11ea-8d71-061eb0a809fe.png)

After
![image](https://user-images.githubusercontent.com/27592/91968909-a5cd1b00-ed15-11ea-9883-5c8bc30a8732.png)

-----------

Changelog
----------
Fix #1415
* Re-order navigation menu
* Swap remainder of navigation icons to use `mdi` instead of `fa` (like the History group)

[ui tests]


