### PR TITLE
Fixes big dialog integration with manual balances list

### DIFF
--- a/frontend/app/src/components/accounts/ManualBalances.vue
+++ b/frontend/app/src/components/accounts/ManualBalances.vue
@@ -21,13 +21,17 @@
           :display="openDialog"
           :title="dialogTitle"
           :subtitle="dialogSubtitle"
-          :action-disabled="dialogDisabled"
+          :action-disabled="dialogDisabled || !valid"
           :loading="dialogLoading"
           primary-action="Save"
           @confirm="save()"
           @cancel="cancel()"
         >
-          <manual-balances-form ref="dialogChild" :edit="balanceToEdit" />
+          <manual-balances-form
+            ref="dialogChild"
+            v-model="valid"
+            :edit="balanceToEdit"
+          />
         </big-dialog>
         <manual-balances-list @editBalance="edit($event)" />
       </v-card-text>
@@ -56,6 +60,7 @@ export default class ManualBalances extends Vue {
   openDialog: boolean = false;
   dialogDisabled: boolean = false;
   dialogLoading: boolean = false;
+  valid: boolean = false;
 
   newBalance() {
     this.dialogTitle = 'Add Manual Balance';

--- a/frontend/app/src/components/accounts/ManualBalances.vue
+++ b/frontend/app/src/components/accounts/ManualBalances.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-card class="manual-balances mt-8">
-      <v-card-title>Manually Tracked Balances</v-card-title>
+      <v-card-title>{{ $t('manual_balances.title') }}</v-card-title>
       <v-card-text>
         <v-btn
           absolute
@@ -21,6 +21,8 @@
           :display="openDialog"
           :title="dialogTitle"
           :subtitle="dialogSubtitle"
+          :action-disabled="dialogDisabled"
+          :loading="dialogLoading"
           primary-action="Save"
           @confirm="save()"
           @cancel="cancel()"
@@ -52,6 +54,8 @@ export default class ManualBalances extends Vue {
   dialogTitle: string = '';
   dialogSubtitle: string = '';
   openDialog: boolean = false;
+  dialogDisabled: boolean = false;
+  dialogLoading: boolean = false;
 
   newBalance() {
     this.dialogTitle = 'Add Manual Balance';
@@ -67,11 +71,17 @@ export default class ManualBalances extends Vue {
   }
 
   async save() {
+    this.dialogDisabled = true;
+    this.dialogLoading = true;
+
     interface dataForm extends Vue {
       save(): Promise<boolean>;
     }
     const form = this.$refs.dialogChild as dataForm;
     const success = await form.save();
+    this.dialogDisabled = false;
+    this.dialogLoading = false;
+
     if (!success) {
       return;
     }

--- a/frontend/app/src/components/accounts/ManualBalancesForm.vue
+++ b/frontend/app/src/components/accounts/ManualBalancesForm.vue
@@ -1,11 +1,5 @@
 <template>
   <v-form ref="form" v-model="valid" class="manual-balances-form">
-    <asset-select
-      v-model="asset"
-      class="manual-balances-form__asset"
-      :rules="assetRules"
-      :disabled="pending"
-    />
     <v-text-field
       v-model="label"
       class="manual-balances-form__label"
@@ -13,6 +7,12 @@
       :error-messages="errorMessages"
       :rules="labelRules"
       :disabled="pending || !!edit"
+    />
+    <asset-select
+      v-model="asset"
+      class="manual-balances-form__asset"
+      :rules="assetRules"
+      :disabled="pending"
     />
     <v-text-field
       v-model="amount"

--- a/frontend/app/src/components/accounts/ManualBalancesForm.vue
+++ b/frontend/app/src/components/accounts/ManualBalancesForm.vue
@@ -1,29 +1,32 @@
 <template>
-  <v-form ref="form" v-model="valid" class="manual-balances-form">
+  <v-form ref="form" :value="valid" class="manual-balances-form" @input="input">
     <v-text-field
       v-model="label"
       class="manual-balances-form__label"
-      label="Label"
+      :label="$t('manual_balances_form.fields.label')"
       :error-messages="errorMessages"
       :rules="labelRules"
       :disabled="pending || !!edit"
     />
     <asset-select
       v-model="asset"
+      :label="$t('manual_balances_form.fields.asset')"
       class="manual-balances-form__asset"
       :rules="assetRules"
       :disabled="pending"
     />
     <v-text-field
       v-model="amount"
+      :label="$t('manual_balances_form.fields.amount')"
       class="manual-balances-form__amount"
       type="number"
-      label="Amount"
+      autocomplete="off"
       :disabled="pending"
       :rules="amountRules"
     />
     <tag-input
       v-model="tags"
+      :label="$t('manual_balances_form.fields.tags')"
       :disabled="pending"
       class="manual-balances-form__tags"
     />
@@ -31,7 +34,7 @@
       v-model="location"
       class="manual-balances-form__location"
       :disabled="pending"
-      label="Location"
+      :label="$t('manual_balances_form.fields.location')"
       :items="locations"
     >
       <template #item="{ item, attrs, on }">
@@ -60,6 +63,8 @@ import { Location } from '@/services/types-common';
 export default class ManualBalancesForm extends Vue {
   @Prop({ required: false, default: null })
   edit!: ManualBalance | null;
+  @Prop({ required: true, type: Boolean })
+  value!: boolean;
 
   @Watch('edit', { immediate: true })
   onEdit(balance: ManualBalance | null) {
@@ -84,7 +89,9 @@ export default class ManualBalancesForm extends Vue {
       if (this.errorMessages.length > 0) {
         return;
       }
-      this.errorMessages.push(`Label ${label} already exists`);
+      this.errorMessages.push(
+        this.$tc('manual_balances_form.validation.label_exists', 0, { label })
+      );
     } else {
       this.errorMessages.pop();
     }
@@ -106,14 +113,23 @@ export default class ManualBalancesForm extends Vue {
     return Object.values(Location);
   }
 
-  readonly amountRules = [(v: string) => !!v || 'The amount cannot be empty'];
-  readonly assetRules = [(v: string) => !!v || 'The asset cannot be empty'];
-  readonly labelRules = [(v: string) => !!v || 'The label cannot be empty'];
+  readonly amountRules = [
+    (v: string) => !!v || this.$t('manual_balances_form.validation.amount')
+  ];
+  readonly assetRules = [
+    (v: string) => !!v || this.$t('manual_balances_form.validation.asset')
+  ];
+  readonly labelRules = [
+    (v: string) => !!v || this.$t('manual_balances_form.validation.label_empty')
+  ];
 
   @Emit()
   clear() {
     this.reset();
   }
+
+  @Emit()
+  input(_valid: boolean) {}
 
   private reset() {
     (this.$refs?.form as any)?.reset();

--- a/frontend/app/src/components/accounts/ManualBalancesList.vue
+++ b/frontend/app/src/components/accounts/ManualBalancesList.vue
@@ -26,6 +26,7 @@
               <v-col
                 cols="12"
                 class="font-weight-medium manual-balances-list__label"
+                :class="!item.tags ? 'pt-0' : ''"
               >
                 {{ item.label }}
               </v-col>
@@ -42,7 +43,11 @@
             </v-row>
           </template>
           <template #header.usdValue>
-            {{ currency.ticker_symbol }} Value
+            {{
+              $t('manual_balances_list.data_table.profit_currency_header', {
+                currencyTicker: currency.ticker_symbol
+              })
+            }}
           </template>
           <template #item.asset="{ item }">
             <asset-details :asset="item.asset" />
@@ -112,8 +117,8 @@
     <confirm-dialog
       v-if="labelToDelete !== null"
       display
-      title="Delete manually tracked balance"
-      message="Are you sure you want to delete this entry?"
+      :title="$t('manual_balances_list.delete_dialog.title')"
+      :message="$t('manual_balances_list.delete_dialog.message')"
       @cancel="labelToDelete = null"
       @confirm="deleteLabel()"
     />

--- a/frontend/app/src/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/components/dialogs/BigDialog.vue
@@ -21,6 +21,7 @@
           </v-col>
         </v-row>
         <v-card-actions class="px-6">
+          <v-progress-linear v-if="loading" indeterminate class="mx-4" />
           <v-spacer />
           <v-btn
             color="primary"
@@ -34,6 +35,7 @@
           </v-btn>
           <v-btn
             :color="confirmTypeProps[confirmType].color"
+            :disabled="actionDisabled"
             depressed
             class="big-dialog__buttons__confirm"
             @click="confirm()"
@@ -57,6 +59,10 @@ export default class BigDialog extends Vue {
   subtitle!: string;
   @Prop({ type: Boolean, required: true })
   display!: boolean;
+  @Prop({ type: Boolean, required: false, default: false })
+  loading!: boolean;
+  @Prop({ type: Boolean, required: false, default: false })
+  actionDisabled!: boolean;
   @Prop({ type: String, required: false, default: 'Confirm' })
   primaryAction!: string;
   @Prop({ type: String, required: false, default: 'Cancel' })

--- a/frontend/app/src/components/inputs/TagInput.vue
+++ b/frontend/app/src/components/inputs/TagInput.vue
@@ -6,7 +6,7 @@
       :items="tags"
       class="tag-input"
       small-chips
-      label="Tags"
+      :label="label"
       item-text="name"
       :menu-props="{ closeOnContentClick: true }"
       item-value="name"
@@ -84,6 +84,8 @@ export default class TagInput extends Vue {
   value!: string[];
   @Prop({ required: false, default: false, type: Boolean })
   disabled!: boolean;
+  @Prop({ required: false, type: String, default: 'Tags' })
+  label!: string;
   tags!: Tag[];
   manageTags: boolean = false;
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -384,9 +384,19 @@
     "copy": "Copy to clipboard",
     "open_link": "Open in external block explorer"
   },
+  "manual_balances": {
+    "title": "Manually Tracked Balances"
+  },
   "manual_balances_list": {
     "refresh": {
       "tooltip": "Refresh manual balances"
+    },
+    "data_table": {
+      "profit_currency_header": "{currencyTicker} Value"
+    },
+    "delete_dialog": {
+      "title": "Delete manually tracked balance",
+      "message": "Are you sure you want to delete this entry?"
     }
   },
   "labeled_address_display": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -473,5 +473,20 @@
       "amount": "Amount",
       "effective_interest_rate": "Effective Interest Rate"
     }
+  },
+  "manual_balances_form": {
+    "fields": {
+      "label": "Label",
+      "asset": "Asset",
+      "amount": "Amount",
+      "location": "Location",
+      "tags": "Tags"
+    },
+    "validation": {
+      "label_exists": "Label {label} already exists",
+      "amount": "The amount cannot be empty",
+      "asset": "The asset cannot be empty",
+      "label_empty": "The label cannot be empty"
+    }
   }
 }

--- a/frontend/app/tests/unit/components/accounts/manual-balance-list.spec.ts
+++ b/frontend/app/tests/unit/components/accounts/manual-balance-list.spec.ts
@@ -26,11 +26,11 @@ describe('ManualBalanceList.vue', () => {
   });
 
   test('currency header is properly updated', async () => {
-    expect(wrapper.find('th:nth-child(4)').text()).toMatch('USD Value');
+    expect(wrapper.find('th:nth-child(4)').text()).toContain('USD');
     store.commit('session/generalSettings', {
       selectedCurrency: findCurrency(currencies[1].ticker_symbol)
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('th:nth-child(4)').text()).toMatch('EUR Value');
+    expect(wrapper.find('th:nth-child(4)').text()).toContain('EUR');
   });
 });

--- a/frontend/app/tests/unit/i18n.ts
+++ b/frontend/app/tests/unit/i18n.ts
@@ -1,8 +1,16 @@
 import Vue from 'vue';
 
+function stringify(value: { [key: string]: any }): string {
+  return Object.values(value)
+    .map(value => value.toString())
+    .join(', ');
+}
+
 function I18n(vue: typeof Vue): void {
-  vue.prototype.$t = (key: string) => key;
-  vue.prototype.$tc = (key: string) => key;
+  vue.prototype.$t = (key: string, args?: object) =>
+    args ? `${key}::${stringify(args)}` : key;
+  vue.prototype.$tc = (key: string, choice?: number, args?: object) =>
+    args ? `${key}::${choice}::${stringify(args)}` : key;
 }
 
 Vue.use(I18n);


### PR DESCRIPTION
Part of #1435

* BigDialog can now take prop `loading` to display a loading indicator and prop `actionDisabled` to disable the primary action button.
* Add i18n support for ManualBalances & ManualBalancesList (see #999)
* Manual Balance bigDialog is disabled & shows progress indicator during Save
* Some CSS tweaks so that the Manual Balance label is centered in the Manual Balances List if it has no tags

[ui tests]