### PR TITLE
Fixes validation for AccountForm disallowing empty or existing addresses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Users can now easily copy the address from the blockchain account view.
 * :bug:`1453` Users will now see an validation error message when attempting to add an existing account.
 * :feature:`804` Users can now track borrowing from Compound in the DeFi borrowing page.
 * :feature:`597` Users can now track the interest earned by Compound loans in the DeFi lending page.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1453` Users will now see an validation error message when attempting to add an existing account.
 * :feature:`804` Users can now track borrowing from Compound in the DeFi borrowing page.
 * :feature:`597` Users can now track the interest earned by Compound loans in the DeFi lending page.
 * :bug:`1462` ycrvRenWSBTC vault token should now properly appear in the dashboard and have its price calculated correctly.

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -203,8 +203,6 @@ export default class App extends Vue {
 
 .app {
   &__app-bar {
-    z-index: 2015;
-
     &__button {
       i {
         &:focus {

--- a/frontend/app/src/DevApp.vue
+++ b/frontend/app/src/DevApp.vue
@@ -1,5 +1,10 @@
 <template>
   <v-app id="rotki">
+    <v-app-bar app fixed>
+      <v-btn icon @click="refresh()">
+        <v-icon>mdi-reload</v-icon>
+      </v-btn>
+    </v-app-bar>
     <v-main>
       <router-view />
     </v-main>
@@ -9,5 +14,10 @@
 import { Vue, Component } from 'vue-property-decorator';
 
 @Component({})
-export default class DevApp extends Vue {}
+export default class DevApp extends Vue {
+  refresh() {
+    sessionStorage.removeItem('vuex');
+    window.location.reload();
+  }
+}
 </script>

--- a/frontend/app/src/components/AccountManagement.vue
+++ b/frontend/app/src/components/AccountManagement.vue
@@ -193,6 +193,7 @@ export default class AccountManagement extends Vue {
       apiSecret,
       submitUsageAnalytics
     } as UnlockPayload);
+    this.accountCreation = false;
     this.loading = false;
     if (this.logged) {
       this.showGetPremiumButton();

--- a/frontend/app/src/components/account-management/CreateAccount.vue
+++ b/frontend/app/src/components/account-management/CreateAccount.vue
@@ -113,6 +113,7 @@
                 <v-col>
                   <v-checkbox
                     v-model="submitUsageAnalytics"
+                    :disabled="loading"
                     :label="$t('create_account.usage_analytics.label_confirm')"
                   />
                 </v-col>
@@ -124,6 +125,7 @@
                 color="primary"
                 class="create-account__analytics__buttons__back"
                 depressed
+                :disabled="loading"
                 outlined
                 @click="step = 1"
               >
@@ -132,6 +134,8 @@
               <v-btn
                 color="primary"
                 depressed
+                :disabled="loading"
+                :loading="loading"
                 class="create-account__analytics__buttons__confirm"
                 @click="confirm()"
               >

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -63,7 +63,7 @@
         <v-row>
           <v-col cols="12" class="account-balances__account">
             <labeled-address-display :account="item" />
-            <span v-if="item.tags">
+            <span v-if="item.tags.length > 0" class="mt-2">
               <tag-icon
                 v-for="tag in item.tags"
                 :key="tag"

--- a/frontend/app/src/components/accounts/AccountForm.vue
+++ b/frontend/app/src/components/accounts/AccountForm.vue
@@ -1,50 +1,66 @@
 <template>
-  <v-row>
-    <v-col cols="12">
-      <v-select
-        v-model="selected"
-        class="blockchain-balances__chain"
-        :items="items"
-        label="Choose blockchain"
-        :disabled="accountOperation || loading || !!edit"
-      />
-      <v-text-field
-        v-model="address"
-        class="blockchain-balances__address"
-        label="Account"
-        :error-messages="errorMessages"
-        :disabled="accountOperation || loading || !!edit"
-      />
-      <v-text-field
-        v-model="label"
-        class="blockchain-balances__label"
-        label="Label"
-        :disabled="accountOperation || loading"
-      />
-      <tag-input v-model="tags" :disabled="accountOperation || loading" />
-      <div class="blockchain-balances--progress">
-        <v-progress-linear v-if="accountOperation" indeterminate />
-      </div>
-    </v-col>
-  </v-row>
+  <v-form ref="form" :value="value" @input="input">
+    <v-row>
+      <v-col cols="12">
+        <v-select
+          v-model="selected"
+          class="blockchain-balances__chain"
+          :items="items"
+          :label="$t('account_form.labels.blockchain')"
+          :disabled="accountOperation || loading || !!edit"
+        >
+          <template #selection="{ item }">
+            <asset-details class="pt-2 pb-2" :asset="item" />
+          </template>
+          <template #item="{ item }">
+            <asset-details class="pt-2 pb-2" :asset="item" />
+          </template>
+        </v-select>
+        <v-text-field
+          v-model="address"
+          class="blockchain-balances__address"
+          :label="$t('account_form.labels.account')"
+          :rules="rules"
+          :error-messages="errorMessages"
+          autocomplete="off"
+          :disabled="accountOperation || loading || !!edit"
+        />
+        <v-text-field
+          v-model="label"
+          class="blockchain-balances__label"
+          :label="$t('account_form.labels.label')"
+          :disabled="accountOperation || loading"
+        />
+        <tag-input v-model="tags" :disabled="accountOperation || loading" />
+        <div class="blockchain-balances--progress">
+          <v-progress-linear v-if="accountOperation" indeterminate />
+        </div>
+      </v-col>
+    </v-row>
+  </v-form>
 </template>
 <script lang="ts">
 import { Component, Emit, Prop, Vue, Watch } from 'vue-property-decorator';
-import { createNamespacedHelpers } from 'vuex';
+import { mapGetters } from 'vuex';
 import TagInput from '@/components/inputs/TagInput.vue';
 import { TaskType } from '@/model/task-type';
 import { deserializeApiErrorMessage } from '@/services/converters';
 import { BlockchainAccountPayload } from '@/store/balances/actions';
 import { Message } from '@/store/types';
-import { Account, Blockchain, SupportedBlockchains } from '@/typing/types';
+import {
+  Account,
+  Blockchain,
+  GeneralAccount,
+  SupportedBlockchains
+} from '@/typing/types';
+import { assert } from '@/utils/assertions';
 
-const { mapGetters: mapTaskGetters } = createNamespacedHelpers('tasks');
-const { mapGetters } = createNamespacedHelpers('balances');
+type ValidationRule = (value: string) => boolean | string;
 @Component({
   components: { TagInput },
   computed: {
-    ...mapTaskGetters(['isTaskRunning']),
-    ...mapGetters(['accountTags', 'accountLabel'])
+    ...mapGetters('tasks', ['isTaskRunning']),
+    ...mapGetters('balances', ['account'])
   }
 })
 export default class AccountForm extends Vue {
@@ -56,11 +72,30 @@ export default class AccountForm extends Vue {
   label: string = '';
   tags: string[] = [];
   errorMessages: string[] = [];
+  account!: (address: string) => GeneralAccount | undefined;
 
-  accountTags!: (blockchain: Blockchain, address: string) => string[];
-  accountLabel!: (blockchain: Blockchain, address: string) => string;
+  get rules(): ValidationRule[] {
+    const rules: ValidationRule[] = [
+      (v: string) =>
+        !!v || this.$tc('account_form.validation.address_non_empty')
+    ];
+    if (!this.edit) {
+      rules.push(this.checkIfExists);
+    }
+    return rules;
+  }
+
+  private checkIfExists(value: string): boolean | string {
+    return (
+      (!!value && !this.account(value)) ||
+      this.$tc('account_form.validation.address_exists')
+    );
+  }
+
   @Prop({ required: false, default: null })
   edit!: Account | null;
+  @Prop({ required: true, type: Boolean, default: false })
+  value!: boolean;
 
   private setEditMode() {
     if (!this.edit) {
@@ -70,8 +105,11 @@ export default class AccountForm extends Vue {
     const { address, chain } = this.edit;
     this.address = address;
     this.selected = chain;
-    this.label = this.accountLabel(this.selected, address);
-    this.tags = this.accountTags(this.selected, address);
+
+    const account = this.account(address);
+    assert(account);
+    this.label = account.label;
+    this.tags = account.tags;
   }
 
   mounted() {
@@ -92,12 +130,15 @@ export default class AccountForm extends Vue {
     this.setEditMode();
   }
 
-  @Emit()
-  editComplete() {
+  reset() {
     this.address = '';
     this.label = '';
     this.tags = [];
+    (this.$refs.form as any).resetValidation();
   }
+
+  @Emit()
+  input(_valid: boolean) {}
 
   get accountOperation(): boolean {
     return (
@@ -128,18 +169,20 @@ export default class AccountForm extends Vue {
         this.edit ? 'balances/editAccount' : 'balances/addAccount',
         payload
       );
-      this.editComplete();
+      this.reset();
     } catch (e) {
       const apiErrorMessage = deserializeApiErrorMessage(e.message);
       if (apiErrorMessage && 'address' in apiErrorMessage) {
         this.clearErrors();
-        this.errorMessages.push(...apiErrorMessage['address']);
+        this.setErrors(apiErrorMessage['address']);
         this.pending = false;
         return false;
       }
       this.$store.commit('setMessage', {
-        description: `Error while adding account: ${e}`,
-        title: 'Adding Account',
+        description: this.$tc('account_form.error.description', 0, {
+          error: e.message
+        }),
+        title: this.$tc('account_form.error.title'),
         success: false
       } as Message);
       return false;
@@ -148,10 +191,16 @@ export default class AccountForm extends Vue {
     return true;
   }
 
+  private setErrors(errors: string[]) {
+    this.errorMessages.push(...errors);
+    this.input(false);
+  }
+
   private clearErrors() {
     for (let i = 0; i < this.errorMessages.length; i++) {
       this.errorMessages.pop();
     }
+    this.input(true);
   }
 }
 </script>

--- a/frontend/app/src/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/components/dialogs/BigDialog.vue
@@ -1,11 +1,12 @@
 <template>
   <v-bottom-sheet
-    v-model="display"
+    :value="display"
     over
     class="big-dialog"
     width="98%"
     @click:outside="cancel()"
     @keydown.esc.stop="cancel()"
+    @input="cancel"
   >
     <v-card class="big-dialog">
       <v-card-title class="text-h5 big-dialog__title pt-6">
@@ -85,7 +86,7 @@ export default class BigDialog extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '@/scss/scroll';
+@import '~@/scss/scroll';
 
 .big-dialog {
   height: calc(100vh - 80px);

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -1,23 +1,40 @@
 <template>
-  <v-tooltip top>
-    <template #activator="{ on }">
-      <span class="labeled-address-display__address" v-on="on">
-        <v-chip label outlined>
-          <span v-if="account.identifier !== account.account" class="pr-1">
-            {{
-              $t('labeled_address_display.identifier', {
-                identifier: account.identifier
-              })
-            }}
-          </span>
-          <span :class="privacyMode ? 'blur-content' : null">
-            {{ address | truncateAddress }}
-          </span>
-        </v-chip>
-      </span>
-    </template>
-    <span> {{ address }} </span>
-  </v-tooltip>
+  <div>
+    <v-tooltip top>
+      <template #activator="{ on }">
+        <span class="labeled-address-display__address" v-on="on">
+          <v-chip label outlined>
+            <span v-if="account.identifier !== account.account" class="pr-1">
+              {{
+                $t('labeled_address_display.identifier', {
+                  identifier: account.identifier
+                })
+              }}
+            </span>
+            <span :class="privacyMode ? 'blur-content' : null">
+              {{ address | truncateAddress }}
+            </span>
+          </v-chip>
+        </span>
+      </template>
+      <span> {{ address }} </span>
+    </v-tooltip>
+    <v-tooltip top>
+      <template #activator="{ on, attrs }">
+        <v-btn
+          x-small
+          v-bind="attrs"
+          icon
+          class="ml-2"
+          v-on="on"
+          @click="copy(address)"
+        >
+          <v-icon>mdi-content-copy</v-icon>
+        </v-btn>
+      </template>
+      <span>{{ $t('labeled_address_display.copy') }}</span>
+    </v-tooltip>
+  </div>
 </template>
 
 <script lang="ts">
@@ -39,6 +56,10 @@ export default class LabeledAddressDisplay extends Mixins(ScrambleMixin) {
 
   get address(): string {
     return this.scrambleData ? randomHex() : this.account.account;
+  }
+
+  copy(address: string) {
+    navigator.clipboard.writeText(address);
   }
 }
 </script>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -498,7 +498,7 @@
     },
     "validation": {
       "address_non_empty": "The address cannot be empty",
-      "address_exists": "The address already exists"
+      "address_exists": "The address is already tracked"
     },
     "error": {
       "title": "Adding Account",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -400,7 +400,8 @@
     }
   },
   "labeled_address_display": {
-    "identifier": "{identifier} |"
+    "identifier": "{identifier} |",
+    "copy": "Copy the address to the clipboard"
   },
   "defi_selector_item": {
     "vault": "Maker Vault"
@@ -487,6 +488,38 @@
       "amount": "The amount cannot be empty",
       "asset": "The asset cannot be empty",
       "label_empty": "The label cannot be empty"
+    }
+  },
+  "account_form": {
+    "labels": {
+      "blockchain": "Choose blockchain",
+      "account": "Account",
+      "label": "Label"
+    },
+    "validation": {
+      "address_non_empty": "The address cannot be empty",
+      "address_exists": "The address already exists"
+    },
+    "error": {
+      "title": "Adding Account",
+      "description": "Error while adding account: {error}"
+    }
+  },
+  "blockchain_balances": {
+    "title": "Blockchain Balances",
+    "form_dialog": {
+      "save": "Save",
+      "cancel": "Cancel",
+      "add_title": "Add Blockchain Account",
+      "edit_title": "Edit Blockchain Account",
+      "edit_subtitle": "Modify account details"
+    },
+    "per_asset": {
+      "title": "Blockchain Balances per Asset"
+    },
+    "balances": {
+      "eth": "ETH per account balances",
+      "btc": "BTC per account balances"
     }
   }
 }

--- a/frontend/app/src/store/balances/getters.ts
+++ b/frontend/app/src/store/balances/getters.ts
@@ -226,6 +226,11 @@ export const getters: GetterTree<BalanceState, RotkehlchenState> = {
     return accounts;
   },
 
+  account: (_, getters) => (address: string) => {
+    const accounts = getters.accounts as GeneralAccount[];
+    return accounts.find(acc => acc.address === address);
+  },
+
   isEthereumToken: ({ supportedAssets }) => (asset: string) => {
     const match = supportedAssets.find(
       supportedAsset => supportedAsset.symbol === asset

--- a/frontend/app/src/store/session/actions.ts
+++ b/frontend/app/src/store/session/actions.ts
@@ -58,22 +58,21 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
         loadFrontendSettings(commit, settings.frontend_settings);
       }
 
-      await dispatch('balances/fetchSupportedAssets', null, {
-        root: true
-      });
-
       await dispatch('start', {
         settings
-      });
-
-      await dispatch('session/fetchWatchers', null, {
-        root: true
       });
 
       monitor.start();
       commit('tags', await api.getTags());
       commit('login', { username, newAccount: create });
-      const fetchBalances = [
+
+      const async = [
+        dispatch('balances/fetchSupportedAssets', null, {
+          root: true
+        }),
+        dispatch('session/fetchWatchers', null, {
+          root: true
+        }),
         dispatch('balances/fetchManualBalances', null, {
           root: true
         }),
@@ -88,7 +87,8 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
           }
         )
       ];
-      await Promise.all(fetchBalances);
+
+      Promise.all(async).then();
     } catch (e) {
       if (e instanceof SyncConflictError) {
         commit('syncConflict', e.message);


### PR DESCRIPTION
Closes #1453 

Plus:
- Chain selector now uses the AssetDetails component.
- Login should be slightly faster now.
- Addresses displayed in the account list should include a copy button

![image](https://user-images.githubusercontent.com/2269732/93268463-828e7b00-f7ad-11ea-97fe-7495028e5eb2.png)
