### PR TITLE
Small UI tweaks to address display component and account balances

### DIFF
--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -101,7 +101,7 @@
                 </v-icon>
               </v-btn>
             </template>
-            <span>Edit account</span>
+            <span>{{ $t('account_balances.edit_tooltip') }}</span>
           </v-tooltip>
           <v-tooltip top>
             <template #activator="{ on, attrs }">
@@ -118,7 +118,7 @@
                 </v-icon>
               </v-btn>
             </template>
-            <span>Delete account</span>
+            <span>{{ $t('account_balances.delete_tooltip') }}</span>
           </v-tooltip>
         </span>
       </template>
@@ -150,7 +150,9 @@
             <v-icon v-if="expanded.includes(item)" small @click="expanded = []">
               mdi-arrow-up
             </v-icon>
-            <v-icon v-else small @click="expanded = [item]">mdi-arrow-down</v-icon>
+            <v-icon v-else small @click="expanded = [item]">
+              mdi-arrow-down
+            </v-icon>
           </v-btn>
         </span>
       </template>

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -19,7 +19,7 @@
               v-on="on"
               @click="refresh()"
             >
-              <v-icon>fa-refresh</v-icon>
+              <v-icon>mdi-refresh</v-icon>
             </v-btn>
           </template>
           <span>
@@ -86,22 +86,40 @@
       </template>
       <template #item.actions="{ item }">
         <span class="account-balances__actions">
-          <v-icon
-            small
-            class="mr-2"
-            :disabled="accountOperation"
-            @click="editAccount(item.account)"
-          >
-            mdi-pencil
-          </v-icon>
-          <v-icon
-            small
-            class="mr-2"
-            :disabled="accountOperation"
-            @click="toDeleteAccount = item.account"
-          >
-            mdi-delete
-          </v-icon>
+          <v-tooltip top>
+            <template #activator="{ on, attrs }">
+              <v-btn
+                small
+                v-bind="attrs"
+                icon
+                class="mx-1"
+                v-on="on"
+                @click="editAccount(item.account)"
+              >
+                <v-icon :disabled="accountOperation" small>
+                  mdi-pencil-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Edit account</span>
+          </v-tooltip>
+          <v-tooltip top>
+            <template #activator="{ on, attrs }">
+              <v-btn
+                small
+                v-bind="attrs"
+                icon
+                class="mx-1"
+                v-on="on"
+                @click="toDeleteAccount = item.account"
+              >
+                <v-icon :disabled="accountOperation" small>
+                  mdi-delete-outline
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Delete account</span>
+          </v-tooltip>
         </span>
       </template>
       <template v-if="balances.length > 0" #body.append>
@@ -128,11 +146,11 @@
       </template>
       <template #item.expand="{ item }">
         <span v-if="expandable && hasTokens(item.account)">
-          <v-btn icon>
-            <v-icon v-if="expanded.includes(item)" @click="expanded = []">
-              fa fa-angle-up
+          <v-btn icon small>
+            <v-icon v-if="expanded.includes(item)" small @click="expanded = []">
+              mdi-arrow-up
             </v-icon>
-            <v-icon v-else @click="expanded = [item]">fa fa-angle-down</v-icon>
+            <v-icon v-else small @click="expanded = [item]">mdi-arrow-down</v-icon>
           </v-btn>
         </span>
       </template>

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -3,29 +3,19 @@
     class="account-balances"
     :class="`${blockchain.toLocaleLowerCase()}-account-balances`"
   >
-    <v-row>
-      <v-col cols="11">
-        <h3 class="text-center account-balances__title">{{ title }}</h3>
+    <v-row align="center">
+      <v-col cols="auto" class="account-balances__column" />
+      <v-col>
+        <div class="text-h6 text-center account-balances__title">
+          {{ title }}
+        </div>
       </v-col>
-      <v-col cols="1">
-        <v-tooltip bottom>
-          <template #activator="{ on }">
-            <v-btn
-              class="account-balances__refresh"
-              color="primary"
-              text
-              icon
-              :disabled="isLoading"
-              v-on="on"
-              @click="refresh()"
-            >
-              <v-icon>mdi-refresh</v-icon>
-            </v-btn>
-          </template>
-          <span>
-            {{ $t('account_balances.refresh_tooltip', { blockchain }) }}
-          </span>
-        </v-tooltip>
+      <v-col cols="auto">
+        <refresh-button
+          class="account-balances__refresh"
+          :loading="isLoading"
+          :tooltip="$t('account_balances.refresh_tooltip', { blockchain })"
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -85,42 +75,14 @@
         />
       </template>
       <template #item.actions="{ item }">
-        <span class="account-balances__actions">
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-btn
-                small
-                v-bind="attrs"
-                icon
-                class="mx-1"
-                v-on="on"
-                @click="editAccount(item.account)"
-              >
-                <v-icon :disabled="accountOperation" small>
-                  mdi-pencil-outline
-                </v-icon>
-              </v-btn>
-            </template>
-            <span>{{ $t('account_balances.edit_tooltip') }}</span>
-          </v-tooltip>
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-btn
-                small
-                v-bind="attrs"
-                icon
-                class="mx-1"
-                v-on="on"
-                @click="toDeleteAccount = item.account"
-              >
-                <v-icon :disabled="accountOperation" small>
-                  mdi-delete-outline
-                </v-icon>
-              </v-btn>
-            </template>
-            <span>{{ $t('account_balances.delete_tooltip') }}</span>
-          </v-tooltip>
-        </span>
+        <row-actions
+          class="account-balances__actions"
+          :edit-tooltip="$t('account_balances.edit_tooltip')"
+          :delete-tooltip="$t('account_balances.delete_tooltip')"
+          :disabled="accountOperation"
+          @delete-click="toDeleteAccount = item.account"
+          @edit-click="editAccount(item.account)"
+        />
       </template>
       <template v-if="balances.length > 0" #body.append>
         <tr class="account-balances__total">
@@ -145,16 +107,11 @@
         </td>
       </template>
       <template #item.expand="{ item }">
-        <span v-if="expandable && hasTokens(item.account)">
-          <v-btn icon small>
-            <v-icon v-if="expanded.includes(item)" small @click="expanded = []">
-              mdi-arrow-up
-            </v-icon>
-            <v-icon v-else small @click="expanded = [item]">
-              mdi-arrow-down
-            </v-icon>
-          </v-btn>
-        </span>
+        <row-expander
+          v-if="expandable && hasTokens(item.account)"
+          :expanded="expanded.includes(item)"
+          @click="expanded = expanded.includes(item) ? [] : [item]"
+        />
       </template>
     </v-data-table>
     <confirm-dialog
@@ -175,6 +132,9 @@ import { mapGetters, mapState } from 'vuex';
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 import AmountDisplay from '@/components/display/AmountDisplay.vue';
 import LabeledAddressDisplay from '@/components/display/LabeledAddressDisplay.vue';
+import RefreshButton from '@/components/helper/RefreshButton.vue';
+import RowActions from '@/components/helper/RowActions.vue';
+import RowExpander from '@/components/helper/RowExpander.vue';
 import TagFilter from '@/components/inputs/TagFilter.vue';
 import AccountAssetBalances from '@/components/settings/AccountAssetBalances.vue';
 import TagIcon from '@/components/tags/TagIcon.vue';
@@ -187,6 +147,9 @@ import { Account, Blockchain, Tags } from '@/typing/types';
 
 @Component({
   components: {
+    RefreshButton,
+    RowActions,
+    RowExpander,
     LabeledAddressDisplay,
     AmountDisplay,
     TagFilter,
@@ -324,6 +287,10 @@ export default class AccountBalances extends Vue {
 .account-balances {
   margin-top: 16px;
   margin-bottom: 16px;
+
+  &__column {
+    width: 80px;
+  }
 
   &__account {
     display: flex;

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -19,21 +19,23 @@
       </template>
       <span> {{ address }} </span>
     </v-tooltip>
-    <v-tooltip top>
-      <template #activator="{ on, attrs }">
-        <v-btn
-          x-small
-          v-bind="attrs"
-          icon
-          class="ml-2"
-          v-on="on"
-          @click="copy(address)"
-        >
-          <v-icon>mdi-content-copy</v-icon>
-        </v-btn>
-      </template>
-      <span>{{ $t('labeled_address_display.copy') }}</span>
-    </v-tooltip>
+    <div class="labeled-address-display__copy">
+      <v-tooltip top>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            small
+            v-bind="attrs"
+            tile
+            icon
+            v-on="on"
+            @click="copy(address)"
+          >
+            <v-icon small>mdi-content-copy</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ $t('labeled_address_display.copy') }}</span>
+      </v-tooltip>
+    </div>
   </div>
 </template>
 
@@ -70,6 +72,29 @@ export default class LabeledAddressDisplay extends Mixins(ScrambleMixin) {
     font-weight: 500;
     padding-top: 6px;
     padding-bottom: 6px;
+    background-color: white;
+
+    ::v-deep {
+      .v-chip {
+        &--label {
+          border-top-right-radius: 0 !important;
+          border-bottom-right-radius: 0 !important;
+        }
+      }
+    }
+  }
+
+  &__copy {
+    display: inline-block;
+    background-color: var(--v-rotki-light-grey-base);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-left-width: 0;
+    border-radius: 0 4px 4px 0;
+
+    button {
+      height: 30px;
+      width: 30px;
+    }
   }
 }
 

--- a/frontend/app/src/components/helper/RefreshButton.vue
+++ b/frontend/app/src/components/helper/RefreshButton.vue
@@ -10,7 +10,7 @@
         @click="refresh"
         v-on="on"
       >
-        <v-icon color="primary">fa-refresh</v-icon>
+        <v-icon color="primary">mdi-refresh</v-icon>
       </v-btn>
     </template>
     <span>{{ tooltip }}</span>

--- a/frontend/app/src/components/helper/RowActions.vue
+++ b/frontend/app/src/components/helper/RowActions.vue
@@ -1,0 +1,58 @@
+<template>
+  <span>
+    <v-tooltip top>
+      <template #activator="{ on, attrs }">
+        <v-btn
+          small
+          v-bind="attrs"
+          icon
+          class="mx-1"
+          v-on="on"
+          @click="editClick"
+        >
+          <v-icon :disabled="disabled" small>
+            mdi-pencil-outline
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>{{ editTooltip }}</span>
+    </v-tooltip>
+    <v-tooltip top>
+      <template #activator="{ on, attrs }">
+        <v-btn
+          small
+          v-bind="attrs"
+          icon
+          class="mx-1"
+          v-on="on"
+          @click="deleteClick"
+        >
+          <v-icon :disabled="disabled" small>
+            mdi-delete-outline
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>{{ deleteTooltip }}</span>
+    </v-tooltip>
+  </span>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator';
+
+@Component({})
+export default class RowActions extends Vue {
+  @Prop({ required: false, type: Boolean })
+  disabled!: boolean;
+  @Prop({ required: true, type: String })
+  editTooltip!: string;
+  @Prop({ required: true, type: String })
+  deleteTooltip!: string;
+
+  @Emit()
+  editClick() {}
+
+  @Emit()
+  deleteClick() {}
+}
+</script>

--- a/frontend/app/src/components/helper/RowExpander.vue
+++ b/frontend/app/src/components/helper/RowExpander.vue
@@ -1,0 +1,25 @@
+<template>
+  <span>
+    <v-btn icon small @click="click">
+      <v-icon v-if="expanded" small>
+        mdi-chevron-up
+      </v-icon>
+      <v-icon v-else small>
+        mdi-chevron-down
+      </v-icon>
+    </v-btn>
+  </span>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator';
+
+@Component({})
+export default class RowExpander extends Vue {
+  @Prop({ required: true, type: Boolean })
+  expanded!: boolean;
+
+  @Emit()
+  click() {}
+}
+</script>

--- a/frontend/app/src/components/settings/AssetBalances.vue
+++ b/frontend/app/src/components/settings/AssetBalances.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="asset-balances">
     <v-row v-if="title">
-      <v-col>
-        <h3 class="text-center">{{ title }}</h3>
+      <v-col class="text-center text-h6">
+        {{ title }}
       </v-col>
     </v-row>
     <v-data-table
       :headers="headers"
       :items="balances"
       :loading="isLoading"
-      loading-text="Please wait while Rotki queries the blockchain..."
+      loading-text="Please wait while rotki queries the blockchain..."
       sort-by="usdValue"
       sort-desc
       :footer-props="footerProps"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -401,7 +401,7 @@
   },
   "labeled_address_display": {
     "identifier": "{identifier} |",
-    "copy": "Copy the address to the clipboard"
+    "copy": "Copy address to clipboard"
   },
   "defi_selector_item": {
     "vault": "Maker Vault"
@@ -421,7 +421,7 @@
     "select_loan_hint": "Please select a loan to see information"
   },
   "account_balances": {
-    "refresh_tooltip": "Refreshes the {blockchain} balances ignoring any cached entries",
+    "refresh_tooltip": "Refresh {blockchain} balances ignoring any cached entries",
     "data_table": {
       "loading": "Please wait while rotki queries the blockchain..."
     },

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -422,6 +422,8 @@
   },
   "account_balances": {
     "refresh_tooltip": "Refresh {blockchain} balances ignoring any cached entries",
+    "edit_tooltip": "Edit account",
+    "delete_tooltip": "Delete account",
     "data_table": {
       "loading": "Please wait while rotki queries the blockchain..."
     },

--- a/frontend/app/tests/unit/components/settings/account-balances.spec.ts
+++ b/frontend/app/tests/unit/components/settings/account-balances.spec.ts
@@ -43,7 +43,10 @@ describe('AccountBalances.vue', () => {
     await wrapper.vm.$nextTick();
 
     expect(
-      wrapper.find('.account-balances__refresh').attributes('disabled')
+      wrapper
+        .find('.account-balances__refresh')
+        .find('button')
+        .attributes('disabled')
     ).toBe('disabled');
 
     expect(wrapper.find('.v-data-table__progress').exists()).toBeTruthy();
@@ -55,7 +58,10 @@ describe('AccountBalances.vue', () => {
     await wrapper.vm.$nextTick();
 
     expect(
-      wrapper.find('.account-balances__refresh').attributes('disabled')
+      wrapper
+        .find('.account-balances__refresh')
+        .find('button')
+        .attributes('disabled')
     ).toBeUndefined();
     expect(wrapper.find('.v-data-table__progress').exists()).toBeFalsy();
     expect(wrapper.find('.v-data-table__empty-wrapper td').text()).toMatch(

--- a/frontend/app/tests/unit/components/settings/asset-balances.spec.ts
+++ b/frontend/app/tests/unit/components/settings/asset-balances.spec.ts
@@ -43,7 +43,7 @@ describe('AssetBalances.vue', () => {
 
     expect(wrapper.find('.v-data-table__progress').exists()).toBeTruthy();
     expect(wrapper.find('.v-data-table__empty-wrapper td').text()).toMatch(
-      'Please wait while Rotki queries the blockchain...'
+      'Please wait while rotki queries the blockchain...'
     );
 
     store.commit('tasks/remove', 1);


### PR DESCRIPTION
* Attach the "copy" button to the address label
* Convert icons in AccountBlanaces from font awesome to mdi and change to outlined versions so they are consistent with the copy and expand-arrow icons
* Homogenize wording in some strings

[ui tests]