### PR TITLE
Fix Aave historical event query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,8 @@
 =========
 Changelog
 =========
+
+* :bug:`1491` All aave historical events should now be properly returned. Not only interest events.
 * :bug:`1482` Use binance api server time to avoid clock skew error with the signatures
 * :feature:`-` Users can now easily copy the address from the blockchain account view.
 * :bug:`1453` Users will now see an validation error message when attempting to add an existing account.

--- a/rotkehlchen/chain/ethereum/aave.py
+++ b/rotkehlchen/chain/ethereum/aave.py
@@ -225,7 +225,6 @@ class Aave(EthereumModule):
         result = {}
         latest_block = self.ethereum.get_latest_block_number()
         with self.history_lock:
-
             if reset_db_data is True:
                 self.database.delete_aave_data()
 
@@ -455,7 +454,7 @@ class Aave(EthereumModule):
             ))
 
         for event in withdraw_events:
-            if hex_or_bytes_to_address(event['topics'][0]) == reserve_address:
+            if hex_or_bytes_to_address(event['topics'][1]) == reserve_address:
                 # first 32 bytes of the data are the amount
                 withdrawal = hex_or_bytes_to_int(event['data'][:66])
                 block_number = deserialize_blocknumber(event['blockNumber'])

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -670,11 +670,12 @@ class DBHandler:
             address: ChecksumEthAddress,
             atoken: EthereumToken,
     ) -> List[AaveEvent]:
+        """Get aave for a single address and a single aToken"""
         cursor = self.conn.cursor()
         query = cursor.execute(
             'SELECT event_type, amount, usd_value, block_number, timestamp, tx_hash, log_index '
-            'from aave_events WHERE address=? AND asset=?',
-            (address, atoken.identifier),
+            'from aave_events WHERE address=? AND asset=? OR asset=?',
+            (address, atoken.identifier, atoken.identifier[1:]),
         )
         events = []
         for result in query:

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -10,7 +10,7 @@ from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.typing import AVAILABLE_MODULES, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 
-ROTKEHLCHEN_DB_VERSION = 17
+ROTKEHLCHEN_DB_VERSION = 18
 DEFAULT_TAXFREE_AFTER_PERIOD = YEAR_IN_SECONDS
 DEFAULT_INCLUDE_CRYPTO2CRYPTO = True
 DEFAULT_INCLUDE_GAS_COSTS = True

--- a/rotkehlchen/db/upgrade_manager.py
+++ b/rotkehlchen/db/upgrade_manager.py
@@ -19,6 +19,7 @@ from rotkehlchen.db.upgrades.v13_v14 import upgrade_v13_to_v14
 from rotkehlchen.db.upgrades.v14_v15 import upgrade_v14_to_v15
 from rotkehlchen.db.upgrades.v15_v16 import upgrade_v15_to_v16
 from rotkehlchen.db.upgrades.v16_v17 import upgrade_v16_to_v17
+from rotkehlchen.db.upgrades.v17_v18 import upgrade_v17_to_v18
 from rotkehlchen.errors import DBUpgradeError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
@@ -137,6 +138,10 @@ UPGRADES_LIST = [
     UpgradeRecord(
         from_version=16,
         function=upgrade_v16_to_v17,
+    ),
+    UpgradeRecord(
+        from_version=17,
+        function=upgrade_v17_to_v18,
     ),
 ]
 

--- a/rotkehlchen/db/upgrades/v17_v18.py
+++ b/rotkehlchen/db/upgrades/v17_v18.py
@@ -1,0 +1,16 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+
+
+def upgrade_v17_to_v18(db: 'DBHandler') -> None:
+    """Upgrades the DB from v17 to v18
+
+    - Deletes all aave historical data and cache to allow for fixes after
+    https://github.com/rotki/rotki/issues/1491 to happen immediately
+    """
+    cursor = db.conn.cursor()
+    cursor.execute('DELETE FROM aave_events;')
+    cursor.execute('DELETE FROM used_query_ranges WHERE name LIKE "aave_events%";')
+    db.conn.commit()

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -150,8 +150,8 @@ def test_query_aave_history(rotkehlchen_api_server, ethereum_accounts):  # pylin
         ), json={'async_query': async_query})
         if async_query:
             task_id = assert_ok_async_response(response)
-            # Timeout of 120 since this test can take a long time
-            outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=120)
+            # Big timeout since this test can take a long time
+            outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=600)
             assert outcome['message'] == ''
             result = outcome['result']
         else:
@@ -165,9 +165,10 @@ def test_query_aave_history(rotkehlchen_api_server, ethereum_accounts):  # pylin
     assert len(total_earned['aDAI']) == 2
     assert FVal(total_earned['aDAI']['amount']) >= FVal('24.207179802347627414')
     assert FVal(total_earned['aDAI']['usd_value']) >= FVal('24.580592532348742989192')
+
     expected_events = process_result_list(expected_aave_test_events)
-    assert len(events) >= 12
-    assert events[:12] == expected_events
+    assert len(events) >= 16
+    assert events[:16] == expected_events
 
 
 @pytest.mark.parametrize('ethereum_modules', [['aave']])

--- a/rotkehlchen/tests/utils/aave.py
+++ b/rotkehlchen/tests/utils/aave.py
@@ -167,5 +167,49 @@ expected_aave_test_events = [
         timestamp=Timestamp(1594502373),
         tx_hash='0xc3a8978418afa1a4f139e9314ac787cacfbed79b1daa28e146bb0bf6fdf79a41',
         log_index=100,
+    ), AaveEvent(
+        event_type='deposit',
+        asset=A_DAI,
+        value=Balance(
+            amount=FVal('2507.675873220870275072'),
+            usd_value=FVal('2507.675873220870275072'),
+        ),
+        block_number=10505913,
+        timestamp=Timestamp(1595376667),
+        tx_hash='0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410',
+        log_index=96,
+    ), AaveEvent(
+        event_type='interest',
+        asset=A_ADAI,
+        value=Balance(
+            amount=FVal('17.91499070977557364'),
+            usd_value=FVal('17.91499070977557364'),
+        ),
+        block_number=10505913,
+        timestamp=Timestamp(1595376667),
+        tx_hash='0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410',
+        log_index=92,
+    ), AaveEvent(
+        event_type='interest',
+        asset=A_ADAI,
+        value=Balance(
+            amount=FVal('88.663672238882760399'),
+            usd_value=FVal('88.663672238882760399'),
+        ),
+        block_number=10718983,
+        timestamp=Timestamp(1598217272),
+        tx_hash='0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486',
+        log_index=97,
+    ), AaveEvent(
+        event_type='withdrawal',
+        asset=A_DAI,
+        value=Balance(
+            amount=FVal('7968.408929477087756071'),
+            usd_value=FVal('7968.408929477087756071'),
+        ),
+        block_number=10718983,
+        timestamp=Timestamp(1598217272),
+        tx_hash='0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486',
+        log_index=102,
     ),
 ]


### PR DESCRIPTION
Aave should now retrieve all historical events and not only interest events.

Fix #1491 