### PR TITLE
Bump to v1.8.1, new tokens and coingecko current price query

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.0
+current_version = 1.8.1
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Changelog
   - `New Bitshares (NBS) <https://www.coingecko.com/en/coins/new-bitshares>`__
   - `Sun Token (SUN) <https://www.coingecko.com/en/coins/sun-token>`__
   - `CBDao (BREE) <https://www.coingecko.com/en/coins/cbdao>`__
+  - `Concentrated Voting Power (CVP) <https://www.coingecko.com/en/coins/powerpool-concentrated-voting-power>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.8.1 <2020-10-05>`
 * :feature:`1532` Users can now easily open links to external block explorers for their tracked blockchain addresses.
 * :bug:`1530` Truncation of account addresses will now dynamically change based on the screen width.
 * :feature:`224` Coingecko is now used for current price queries if cryptocompare fails. This will allow more tokens to be displayed.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,7 @@ Changelog
   - `Rio DeFi (RFUEL) <https://www.coingecko.com/en/coins/rio-defi>`__
   - `Value Liquidity (VALUE) <https://www.coingecko.com/en/coins/value-liquidity>`__
   - `Beowulf (BWF) <https://www.coingecko.com/en/coins/beowulf>`__
+  - `GSTCoin (GST) <https://www.coingecko.com/en/coins/gstcoin>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Changelog
   - `YAMv3 (YAM) <https://www.coingecko.com/en/coins/yam>`__
   - `Avalanche (AVAX) <https://www.coingecko.com/en/coins/avalanche>`__
   - `BakeryToken (BAKE) <https://www.coingecko.com/en/coins/bakerytoken>`__
+  - `Burger Swap (BURGER) <https://www.coingecko.com/en/coins/burger-swap>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`1532` Users can now easily open links to external block explorers for their tracked blockchain addresses.
 * :bug:`1530` Truncation of account addresses will now dynamically change based on the screen width.
+* :feature:`224` Coingecko is now used for current price queries if cryptocompare fails. This will allow more tokens to be displayed.
 * :feature:`1523` Trailing or leading whitespace in pasted addresses and api keys will now be properly removed.
 * :feature:`1501` Assets that have been added to the ignore list will now be hidden from the dashboard.
 * :bug:`1533` Premium Yearn vaults users should now be able to see a USD PNL per vault they used during the tax report.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,7 @@ Changelog
   - `Moji Experience Points (MEXP) <https://www.coingecko.com/en/coins/moji-experience-points>`__
   - `Polkastarter (POLS) <https://www.coingecko.com/en/coins/polkastarter>`__
   - `Rarible (RARI) <https://www.coingecko.com/en/coins/rarible>`__
+  - `Rio DeFi (RFUEL) <https://www.coingecko.com/en/coins/rio-defi>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Changelog
   - `Aavegotchi (GHST) <https://www.coingecko.com/en/coins/aavegotchi>`__
   - `Moji Experience Points (MEXP) <https://www.coingecko.com/en/coins/moji-experience-points>`__
   - `Polkastarter (POLS) <https://www.coingecko.com/en/coins/polkastarter>`__
+  - `Rarible (RARI) <https://www.coingecko.com/en/coins/rarible>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ Changelog
   - `Beowulf (BWF) <https://www.coingecko.com/en/coins/beowulf>`__
   - `GSTCoin (GST) <https://www.coingecko.com/en/coins/gstcoin>`__
   - `Keep Token (KEEP) <https://www.coingecko.com/en/coins/keep-network>`__
+  - `Aave Token (AAVE) <https://www.coingecko.com/en/coins/aave>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Changelog
   - `Sun Token (SUN) <https://www.coingecko.com/en/coins/sun-token>`__
   - `CBDao (BREE) <https://www.coingecko.com/en/coins/cbdao>`__
   - `Concentrated Voting Power (CVP) <https://www.coingecko.com/en/coins/powerpool-concentrated-voting-power>`__
+  - `dHedge DAO Token (DHT) <https://www.coingecko.com/en/coins/dhedge-dao>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
   - `BakeryToken (BAKE) <https://www.coingecko.com/en/coins/bakerytoken>`__
   - `Burger Swap (BURGER) <https://www.coingecko.com/en/coins/burger-swap>`__
   - `Pancake Swap (CAKE) <https://www.coingecko.com/en/coins/pancakeswap>`__
+  - `Flamingo Finance (FLM) <https://www.coingecko.com/en/coins/flamingo-finance>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ Changelog
   - `Value Liquidity (VALUE) <https://www.coingecko.com/en/coins/value-liquidity>`__
   - `Beowulf (BWF) <https://www.coingecko.com/en/coins/beowulf>`__
   - `GSTCoin (GST) <https://www.coingecko.com/en/coins/gstcoin>`__
+  - `Keep Token (KEEP) <https://www.coingecko.com/en/coins/keep-network>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
   - `Burger Swap (BURGER) <https://www.coingecko.com/en/coins/burger-swap>`__
   - `Pancake Swap (CAKE) <https://www.coingecko.com/en/coins/pancakeswap>`__
   - `Flamingo Finance (FLM) <https://www.coingecko.com/en/coins/flamingo-finance>`__
+  - `Helium (HNT) <https://www.coingecko.com/en/coins/helium>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Changelog
   - `Helium (HNT) <https://www.coingecko.com/en/coins/helium>`__
   - `New Bitshares (NBS) <https://www.coingecko.com/en/coins/new-bitshares>`__
   - `Sun Token (SUN) <https://www.coingecko.com/en/coins/sun-token>`__
+  - `CBDao (BREE) <https://www.coingecko.com/en/coins/cbdao>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Changelog
   - `dHedge DAO Token (DHT) <https://www.coingecko.com/en/coins/dhedge-dao>`__
   - `Aavegotchi (GHST) <https://www.coingecko.com/en/coins/aavegotchi>`__
   - `Moji Experience Points (MEXP) <https://www.coingecko.com/en/coins/moji-experience-points>`__
+  - `Polkastarter (POLS) <https://www.coingecko.com/en/coins/polkastarter>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
   - `Compound Uni (cUNI) <https://www.coingecko.com/en/coins/compound-uniswap>`__
   - `YAMv3 (YAM) <https://www.coingecko.com/en/coins/yam>`__
   - `Avalanche (AVAX) <https://www.coingecko.com/en/coins/avalanche>`__
+  - `BakeryToken (BAKE) <https://www.coingecko.com/en/coins/bakerytoken>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Changelog
   - `Rarible (RARI) <https://www.coingecko.com/en/coins/rarible>`__
   - `Rio DeFi (RFUEL) <https://www.coingecko.com/en/coins/rio-defi>`__
   - `Value Liquidity (VALUE) <https://www.coingecko.com/en/coins/value-liquidity>`__
+  - `Beowulf (BWF) <https://www.coingecko.com/en/coins/beowulf>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Changelog
   - `Polkastarter (POLS) <https://www.coingecko.com/en/coins/polkastarter>`__
   - `Rarible (RARI) <https://www.coingecko.com/en/coins/rarible>`__
   - `Rio DeFi (RFUEL) <https://www.coingecko.com/en/coins/rio-defi>`__
+  - `Value Liquidity (VALUE) <https://www.coingecko.com/en/coins/value-liquidity>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Changelog
   - `Avalanche (AVAX) <https://www.coingecko.com/en/coins/avalanche>`__
   - `BakeryToken (BAKE) <https://www.coingecko.com/en/coins/bakerytoken>`__
   - `Burger Swap (BURGER) <https://www.coingecko.com/en/coins/burger-swap>`__
+  - `Pancake Swap (CAKE) <https://www.coingecko.com/en/coins/pancakeswap>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changelog
   - `Pancake Swap (CAKE) <https://www.coingecko.com/en/coins/pancakeswap>`__
   - `Flamingo Finance (FLM) <https://www.coingecko.com/en/coins/flamingo-finance>`__
   - `Helium (HNT) <https://www.coingecko.com/en/coins/helium>`__
+  - `New Bitshares (NBS) <https://www.coingecko.com/en/coins/new-bitshares>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Changelog
   - `CBDao (BREE) <https://www.coingecko.com/en/coins/cbdao>`__
   - `Concentrated Voting Power (CVP) <https://www.coingecko.com/en/coins/powerpool-concentrated-voting-power>`__
   - `dHedge DAO Token (DHT) <https://www.coingecko.com/en/coins/dhedge-dao>`__
+  - `Aavegotchi (GHST) <https://www.coingecko.com/en/coins/aavegotchi>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Changelog
   - `Concentrated Voting Power (CVP) <https://www.coingecko.com/en/coins/powerpool-concentrated-voting-power>`__
   - `dHedge DAO Token (DHT) <https://www.coingecko.com/en/coins/dhedge-dao>`__
   - `Aavegotchi (GHST) <https://www.coingecko.com/en/coins/aavegotchi>`__
+  - `Moji Experience Points (MEXP) <https://www.coingecko.com/en/coins/moji-experience-points>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changelog
   - `Flamingo Finance (FLM) <https://www.coingecko.com/en/coins/flamingo-finance>`__
   - `Helium (HNT) <https://www.coingecko.com/en/coins/helium>`__
   - `New Bitshares (NBS) <https://www.coingecko.com/en/coins/new-bitshares>`__
+  - `Sun Token (SUN) <https://www.coingecko.com/en/coins/sun-token>`__
 
 * :release:`1.8.0 <2020-09-23>`
 * :feature:`1498` Users can now select the protocol(s) when resetting the DeFi history cache.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2018-2020, Lefteris Karapetsas'
 author = 'Lefteris Karapetsas'
 
 # The short X.Y version
-version = '1.8.0'
+version = '1.8.1'
 # The full version, including alpha/beta/rc tags
-release = '1.8.0'
+release = '1.8.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "author": "The Rotki Team",
   "scripts": {

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -30,9 +30,6 @@ WORLD_TO_POLONIEX = {
     'AIR-2': 'AIR',
     # Decentr is DEC-2 for us but DEC in Poloniex
     'DEC-2': 'DEC',
-    # Poloniex listed BTCtalkcoin as BCC as it was its original ticker but the
-    # ticker later changes and it is now known to the world  as TALK
-    'TALK': 'BCC',
     # Poloniex delisted BCH and listed it as BCHABC after the Bitcoin Cash
     # ABC / SV fork. In Rotkehlchen we consider BCH to be the same as BCHABC
     'BCH': 'BCHABC',

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -328,6 +328,7 @@ UNSUPPORTED_POLONIEX_ASSETS = (
     'BVOL',
     'IBVOL',
     'XDOT',  # old polkadot before the split
+    'TALK',  # neither in coingecko nor cryptocompare
 )
 
 UNSUPPORTED_BITTREX_ASSETS = (
@@ -417,6 +418,10 @@ UNSUPPORTED_BINANCE_ASSETS = (
     '123',  # https://twitter.com/rotkiapp/status/1161977327078838272
     '456',  # https://twitter.com/rotkiapp/status/1161977327078838272
     'WRX',  # https://info.binance.com/en/currencies/WRX - not listed anywhere else
+    'SCRT',  # no cryptocompare data
+    'SPARTA',  # no cryptocompare data
+    'UNIDOWN',  # no cryptocompare/coingecko data
+    'UNIUP',  # no cryptocompare/coingecko data
 )
 
 

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -406,6 +406,7 @@ UNSUPPORTED_BITTREX_ASSETS = (
     'FME',
     'INX',
     'MFA',
+    'FCT2',  # neither in coingecko nor cryptocompare
 )
 
 

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -328,7 +328,7 @@ UNSUPPORTED_POLONIEX_ASSETS = (
     'BVOL',
     'IBVOL',
     'XDOT',  # old polkadot before the split
-    'TALK',  # neither in coingecko nor cryptocompare
+    'BCC',  # neither in coingecko nor cryptocompare
     'BTCTRON',  # neither in coingecko nor cryptocompare
     'FCT2',  # neither in coingecko nor cryptocompare
 )

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -329,6 +329,7 @@ UNSUPPORTED_POLONIEX_ASSETS = (
     'IBVOL',
     'XDOT',  # old polkadot before the split
     'TALK',  # neither in coingecko nor cryptocompare
+    'BTCTRON',  # neither in coingecko nor cryptocompare
 )
 
 UNSUPPORTED_BITTREX_ASSETS = (

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -330,6 +330,7 @@ UNSUPPORTED_POLONIEX_ASSETS = (
     'XDOT',  # old polkadot before the split
     'TALK',  # neither in coingecko nor cryptocompare
     'BTCTRON',  # neither in coingecko nor cryptocompare
+    'FCT2',  # neither in coingecko nor cryptocompare
 )
 
 UNSUPPORTED_BITTREX_ASSETS = (

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -5515,6 +5515,13 @@
         "symbol": "HNS",
         "type": "own chain"
     },
+    "HNT": {
+        "coingecko": "helium",
+        "name": "Helium",
+        "started": 1587168000,
+        "symbol": "HNT",
+        "type": "own chain"
+    },
     "HORSE": {
         "coingecko": "ethorse",
         "ethereum_address": "0x5B0751713b2527d7f002c0c4e2a37e1219610A6B",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1941,6 +1941,15 @@
         "symbol": "BUSD",
         "type": "ethereum token"
     },
+    "BWF": {
+        "coingecko": "beowulf",
+        "ethereum_address": "0xF7E04D8a32229B4cA63aA51eEA9979C7287FEa48",
+        "ethereum_token_decimals": 5,
+        "name": "Beowulf ",
+        "started": 1599476835,
+        "symbol": "BWF",
+        "type": "ethereum token"
+    },
     "BWX": {
         "coingecko": "blue-whale",
         "cryptocompare": "",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -3342,6 +3342,15 @@
         "symbol": "DGX",
         "type": "ethereum token"
     },
+    "DHT": {
+        "coingecko": "dhedge-dao",
+        "ethereum_address": "0xca1207647Ff814039530D7d35df0e1Dd2e91Fa84",
+        "ethereum_token_decimals": 17,
+        "name": "dHedge DAO Token ",
+        "started": 1599730531,
+        "symbol": "DHT",
+        "type": "ethereum token"
+    },
     "DIA": {
         "coingecko": "dia-data",
         "ethereum_address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -6172,6 +6172,15 @@
         "symbol": "KDC",
         "type": "own chain"
     },
+    "KEEP": {
+        "coingecko": "keep-network",
+        "ethereum_address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+        "ethereum_token_decimals": 18,
+        "name": "KEEP Token ",
+        "started": 1588042366,
+        "symbol": "KEEP",
+        "type": "ethereum token"
+    },
     "KEY": {
         "coingecko": "selfkey",
         "ethereum_address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9003,6 +9003,15 @@
         "symbol": "RADS",
         "type": "own chain"
     },
+    "RARI": {
+        "coingecko": "rarible",
+        "ethereum_address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
+        "ethereum_token_decimals": 18,
+        "name": "Rarible",
+        "started": 1594721646,
+        "symbol": "RARI",
+        "type": "ethereum token"
+    },
     "RATING": {
         "coingecko": "dprating",
         "ethereum_address": "0xE8663A64A96169ff4d95b4299E7ae9a76b905B31",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -839,6 +839,13 @@
         "symbol": "B2BX",
         "type": "ethereum token"
     },
+    "BAKE": {
+        "coingecko": "bakerytoken",
+        "name": "BakeryToken",
+        "started": 1600905600,
+        "symbol": "BAKE",
+        "type": "binance token"
+    },
     "BAL": {
         "coingecko": "balancer",
         "ethereum_address": "0xba100000625a3754423978a60c9317c58a424e3D",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9191,15 +9191,6 @@
         "symbol": "REP",
         "type": "ethereum token"
     },
-    "REP-old": {
-        "coingecko": "augur",
-        "ethereum_address": "0x48c80F1f4D53D5951e5D5438B54Cba84f29F32a5",
-        "ethereum_token_decimals": 18,
-        "name": "Augur old",
-        "started": 1416182400,
-        "symbol": "REP",
-        "type": "ethereum token"
-    },
     "REPV2": {
         "coingecko": "augur",
         "cryptocompare": "REP",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -2956,6 +2956,15 @@
         "symbol": "CVC",
         "type": "ethereum token"
     },
+    "CVP": {
+        "coingecko": "powerpool-concentrated-voting-power",
+        "ethereum_address": "0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
+        "ethereum_token_decimals": 18,
+        "name": "Concentrated Voting Power",
+        "started": 1597938312,
+        "symbol": "CVP",
+        "type": "ethereum token"
+    },
     "CVT": {
         "coingecko": "cybervein",
         "ethereum_address": "0xBe428c3867F05deA2A89Fc76a102b544eaC7f772",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -4527,6 +4527,13 @@
         "symbol": "FLIXX",
         "type": "ethereum token"
     },
+    "FLM": {
+        "coingecko": "flamingo-finance",
+        "name": "Flamingo finance",
+        "started": 1601251200,
+        "symbol": "FLM",
+        "type": "neo token"
+    },
     "FLO": {
         "coingecko": "flo",
         "name": "FLO",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -5061,6 +5061,15 @@
         "symbol": "GET",
         "type": "ethereum token"
     },
+    "GHST": {
+        "coingecko": "aavegotchi",
+        "ethereum_address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
+        "ethereum_token_decimals": 18,
+        "name": "Aavegotchi GHST Token",
+        "started": 1599986900,
+        "symbol": "GHST",
+        "type": "ethereum token"
+    },
     "GIM": {
         "active": false,
         "coingecko": "gimli",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -2036,6 +2036,13 @@
         "symbol": "CAIX",
         "type": "own chain"
     },
+    "CAKE": {
+        "coingecko": "pancakeswap",
+        "name": "Pancake Swap",
+        "started": 1601337600,
+        "symbol": "CAKE",
+        "type": "binance token"
+    },
     "CAN": {
         "coingecko": "canyacoin",
         "ethereum_address": "0x1d462414fe14cf489c7A21CaC78509f4bF8CD7c0",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -10326,6 +10326,13 @@
         "symbol": "SUKU",
         "type": "ethereum token"
     },
+    "SUN": {
+        "coingecko": "sun-token",
+        "name": "Sun Token",
+        "started": 1599696000,
+        "symbol": "SUN",
+        "type": "tron token"
+    },
     "SUR": {
         "coingecko": "suretly",
         "ethereum_address": "0xe120c1ECBfdFeA7F0A8f0Ee30063491E8c26fedf",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9219,6 +9219,15 @@
         "symbol": "RFR",
         "type": "ethereum token"
     },
+    "RFUEL": {
+        "coingecko": "rio-defi",
+        "ethereum_address": "0xaf9f549774ecEDbD0966C52f250aCc548D3F36E5",
+        "ethereum_token_decimals": 18,
+        "name": "Rio Fuel Token ",
+        "started": 1600840045,
+        "symbol": "RFUEL",
+        "type": "ethereum token"
+    },
     "RHOC": {
         "coingecko": "",
         "ethereum_address": "0x168296bb09e24A88805CB9c33356536B980D3fC5",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -7471,6 +7471,13 @@
         "symbol": "NBC",
         "type": "ethereum token"
     },
+    "NBS": {
+        "coingecko": "new-bitshares",
+        "name": "New Bitshare",
+        "started": 1600473600,
+        "symbol": "NBS",
+        "type": "own chain"
+    },
     "NCASH": {
         "coingecko": "nucleus-vision",
         "ethereum_address": "0x809826cceAb68c387726af962713b64Cb5Cb3CCA",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -5265,6 +5265,14 @@
         "symbol": "GSE",
         "type": "ethereum token"
     },
+    "GST": {
+        "coingecko": "gstcoin",
+        "cryptocompare": "GSTC",
+        "name": "GSTCoin",
+        "started": 1571356800,
+        "symbol": "GST",
+        "type": "own chain"
+    },
     "GTC": {
         "coingecko": "global-trust-coin",
         "ethereum_address": "0xB70835D7822eBB9426B56543E391846C107bd32C",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -64,6 +64,15 @@
         "symbol": "300",
         "type": "ethereum token"
     },
+    "AAVE": {
+        "coingecko": "aave",
+        "ethereum_address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "ethereum_token_decimals": 18,
+        "name": "Aave Token",
+        "started": 1600970788,
+        "symbol": "AAVE",
+        "type": "ethereum token"
+    },
     "ABBC": {
         "coingecko": "alibabacoin",
         "name": "ABBC Coin",
@@ -6474,6 +6483,7 @@
         "name": "ETHLend",
         "started": 1502755200,
         "symbol": "LEND",
+        "swapped_for": "AAVE",
         "type": "ethereum token"
     },
     "LEV": {

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -236,11 +236,21 @@
         "symbol": "ADT",
         "type": "ethereum token"
     },
-    "ADX": {
+    "ADXv1": {
         "coingecko": "adex",
         "ethereum_address": "0x4470BB87d77b963A013DB939BE332f927f2b992e",
         "ethereum_token_decimals": 4,
         "name": "AdEx",
+        "started": 1496102400,
+        "symbol": "ADX",
+        "swapped_for": "ADX",
+        "type": "ethereum token"
+    },
+    "ADX": {
+        "coingecko": "adex",
+        "ethereum_address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
+        "ethereum_token_decimals": 18,
+        "name": "AdEx Network",
         "started": 1496102400,
         "symbol": "ADX",
         "type": "ethereum token"

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -11476,6 +11476,15 @@
         "symbol": "UUU",
         "type": "ethereum token"
     },
+    "VALUE": {
+        "coingecko": "value-liquidity",
+        "ethereum_address": "0x49E833337ECe7aFE375e44F4E3e8481029218E5c",
+        "ethereum_token_decimals": 18,
+        "name": "Value Liquidity",
+        "started": 1600162155,
+        "symbol": "VALUE",
+        "type": "ethereum token"
+    },
     "VBK": {
         "coingecko": "veriblock",
         "cryptocompare": "",
@@ -12551,6 +12560,7 @@
         "name": "YFValue",
         "started": 1597602120,
         "symbol": "YFV",
+        "swapped_for": "VALUE",
         "type": "ethereum token"
     },
     "YOU": {

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1909,6 +1909,13 @@
         "symbol": "BULL",
         "type": "ethereum token"
     },
+    "BURGER": {
+        "coingecko": "burger-swap",
+        "name": "Burger Swap",
+        "started": 1600905600,
+        "symbol": "BURGER",
+        "type": "binance token"
+    },
     "BURST": {
         "coingecko": "burst",
         "name": "Burst",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1631,6 +1631,15 @@
         "symbol": "BRD",
         "type": "ethereum token"
     },
+    "BREE": {
+        "coingecko": "cbdao",
+        "ethereum_address": "0x4639cd8cd52EC1CF2E496a606ce28D8AfB1C792F",
+        "ethereum_token_decimals": 18,
+        "name": "CBDAO ",
+        "started": 1599219609,
+        "symbol": "BREE",
+        "type": "ethereum token"
+    },
     "BRK": {
         "coingecko": "",
         "name": "Breakout",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -8587,6 +8587,15 @@
         "symbol": "POLL",
         "type": "ethereum token"
     },
+    "POLS": {
+        "coingecko": "polkastarter",
+        "ethereum_address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
+        "ethereum_token_decimals": 18,
+        "name": "PolkastarterToken",
+        "started": 1601333180,
+        "symbol": "POLS",
+        "type": "ethereum token"
+    },
     "POLY": {
         "coingecko": "polymath-network",
         "cryptocompare": "POLYN",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -2074,7 +2074,7 @@
         "type": "own chain"
     },
     "CAKE": {
-        "coingecko": "pancakeswap",
+        "coingecko": "pancakeswap-token",
         "name": "Pancake Swap",
         "started": 1601337600,
         "symbol": "CAKE",
@@ -2985,7 +2985,7 @@
         "type": "ethereum token"
     },
     "CVP": {
-        "coingecko": "powerpool-concentrated-voting-power",
+        "coingecko": "concentrated-voting-power",
         "ethereum_address": "0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
         "ethereum_token_decimals": 18,
         "name": "Concentrated Voting Power",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -7015,6 +7015,15 @@
         "symbol": "METM",
         "type": "ethereum token"
     },
+    "MEXP": {
+        "coingecko": "moji-experience-points",
+        "ethereum_address": "0xDe201dAec04ba73166d9917Fdf08e1728E270F06",
+        "ethereum_token_decimals": 18,
+        "name": "MOJI Experience Points ",
+        "started": 1586610745,
+        "symbol": "MEXP",
+        "type": "ethereum token"
+    },
     "MFG": {
         "coingecko": "syncfab",
         "ethereum_address": "0x6710c63432A2De02954fc0f851db07146a6c0312",

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "98eccaded148ef3e88b5f34d583d5e89", "version": 16}
+{"md5": "4efcd83bc926a60b46574842b92c8766", "version": 17}

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -61,17 +61,21 @@ def gemini_symbol_to_pair(symbol: str) -> TradePair:
     """
     if len(symbol) == 6:
         base_asset = Asset(symbol[:3].upper())
-        quote_asset = Asset(symbol[3:6].upper())
+        quote_asset = Asset(symbol[3:].upper())
     elif len(symbol) == 7:
         try:
             base_asset = Asset(symbol[:4].upper())
-            quote_asset = Asset(symbol[4:7].upper())
+            quote_asset = Asset(symbol[4:].upper())
         except UnknownAsset:
             base_asset = Asset(symbol[:3].upper())
-            quote_asset = Asset(symbol[3:7].upper())
+            quote_asset = Asset(symbol[3:].upper())
     elif len(symbol) == 8:
-        base_asset = Asset(symbol[:4].upper())
-        quote_asset = Asset(symbol[4:8].upper())
+        if 'storj' in symbol:
+            base_asset = Asset(symbol[:5].upper())
+            quote_asset = Asset(symbol[5:].upper())
+        else:
+            base_asset = Asset(symbol[:4].upper())
+            quote_asset = Asset(symbol[4:].upper())
     else:
         raise UnprocessableTradePair(symbol)
 

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any, Dict, List, NamedTuple, Optional, Union, overload
 from urllib.parse import urlencode
 
@@ -6,8 +7,15 @@ import requests
 from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants import ZERO
 from rotkehlchen.errors import RemoteError
+from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.typing import Price
 from rotkehlchen.utils.serialization import rlk_jsonloads
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class CoingeckoImageURLs(NamedTuple):
@@ -22,6 +30,68 @@ class CoingeckoAssetData(NamedTuple):
     name: str
     description: str
     images: CoingeckoImageURLs
+
+
+COINGECKO_SIMPLE_VS_CURRENCIES = [
+    "btc",
+    "eth",
+    "ltc",
+    "bch",
+    "bnb",
+    "eos",
+    "xrp",
+    "xlm",
+    "link",
+    "dot",
+    "yfi",
+    "usd",
+    "aed",
+    "ars",
+    "aud",
+    "bdt",
+    "bhd",
+    "bmd",
+    "brl",
+    "cad",
+    "chf",
+    "clp",
+    "cny",
+    "czk",
+    "dkk",
+    "eur",
+    "gbp",
+    "hkd",
+    "huf",
+    "idr",
+    "ils",
+    "inr",
+    "jpy",
+    "krw",
+    "kwd",
+    "lkr",
+    "mmk",
+    "mxn",
+    "myr",
+    "nok",
+    "nzd",
+    "php",
+    "pkr",
+    "pln",
+    "rub",
+    "sar",
+    "sek",
+    "sgd",
+    "thb",
+    "try",
+    "twd",
+    "uah",
+    "vef",
+    "vnd",
+    "zar",
+    "xdr",
+    "xag",
+    "xau",
+]
 
 
 class Coingecko():
@@ -42,7 +112,7 @@ class Coingecko():
     @overload  # noqa: F811
     def _query(
             self,
-            module: Literal['coins'],
+            module: Literal['coins', 'simple/price'],
             subpath: Optional[str] = None,
             options: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
@@ -129,3 +199,45 @@ class Coingecko():
 
     def all_coins(self) -> List[Dict[str, Any]]:
         return self._query(module='coins/list')
+
+    def simple_price(self, from_asset: Asset, to_asset: Asset) -> Price:
+        """Returns a simple price for from_asset to to_asset in coingecko
+
+        Uses the simple/price endpoint of coingecko. If to_asset is not part of the
+        coingecko simple vs currencies or if from_asset is not supported in coingecko
+        price zero is returned.
+
+        May raise:
+        - RemoteError if there is a problem querying coingecko
+        """
+        vs_currency = to_asset.identifier.lower()
+        if vs_currency not in COINGECKO_SIMPLE_VS_CURRENCIES:
+            log.warning(
+                f'Tried to query coingecko simple price from {from_asset.identifier} '
+                f'to {to_asset.identifier}. But to_asset is not supported in simple price query',
+            )
+            return Price(ZERO)
+
+        if from_asset.coingecko is None:
+            log.warning(
+                f'Tried to query coingecko simple price from {from_asset.identifier} '
+                f'to {to_asset.identifier}. But from_asset is not supported in coingecko',
+            )
+            return Price(ZERO)
+
+        result = self._query(
+            module='simple/price',
+            options={
+                'ids': from_asset.coingecko,
+                'vs_currencies': vs_currency,
+            })
+
+        try:
+            return Price(FVal(result[from_asset.coingecko][vs_currency]))
+        except KeyError as e:
+            log.warning(
+                f'Queried coingecko simple price from {from_asset.identifier} '
+                f'to {to_asset.identifier}. But got key error for {str(e)} when '
+                f'processing the result.',
+            )
+            return Price(ZERO)

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -112,6 +112,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('CHI'): Asset('USDT'),
     Asset('BAKE'): Asset('BNB'),
     Asset('BURGER'): Asset('BNB'),
+    Asset('CAKE'): Asset('BNB'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -118,6 +118,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('MEXP'): Asset('USDT'),
     Asset('POLS'): Asset('USDT'),
     Asset('RARI'): Asset('USDT'),
+    Asset('VALUE'): Asset('USDT'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -117,6 +117,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('GHST'): Asset('USDT'),
     Asset('MEXP'): Asset('USDT'),
     Asset('POLS'): Asset('USDT'),
+    Asset('RARI'): Asset('USDT'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -116,6 +116,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('BREE'): Asset('USDT'),
     Asset('GHST'): Asset('USDT'),
     Asset('MEXP'): Asset('USDT'),
+    Asset('POLS'): Asset('USDT'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -110,6 +110,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('RVC'): Asset('USDT'),
     Asset('SDT'): Asset('USDT'),
     Asset('CHI'): Asset('USDT'),
+    Asset('BAKE'): Asset('BNB'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -113,6 +113,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('BAKE'): Asset('BNB'),
     Asset('BURGER'): Asset('BNB'),
     Asset('CAKE'): Asset('BNB'),
+    Asset('BREE'): Asset('USDT'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -111,6 +111,7 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('SDT'): Asset('USDT'),
     Asset('CHI'): Asset('USDT'),
     Asset('BAKE'): Asset('BNB'),
+    Asset('BURGER'): Asset('BNB'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -114,6 +114,8 @@ CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     Asset('BURGER'): Asset('BNB'),
     Asset('CAKE'): Asset('BNB'),
     Asset('BREE'): Asset('USDT'),
+    Asset('GHST'): Asset('USDT'),
+    Asset('MEXP'): Asset('USDT'),
 }
 CRYPTOCOMPARE_SPECIAL_CASES = CRYPTOCOMPARE_SPECIAL_CASES_MAPPING.keys()
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -126,7 +126,11 @@ class Rotkehlchen():
             sleep_time_secs=ICONS_QUERY_SLEEP,
         )
         # Initialize the Inquirer singleton
-        Inquirer(data_dir=self.data_dir, cryptocompare=self.cryptocompare)
+        Inquirer(
+            data_dir=self.data_dir,
+            cryptocompare=self.cryptocompare,
+            coingecko=self.coingecko,
+        )
         # Keeps how many trades we have found per location. Used for free user limiting
         self.actions_per_location: Dict[str, Dict[Location, int]] = {
             'trade': defaultdict(int),

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -8,6 +8,7 @@ import pytest
 
 from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.config import default_data_directory
+from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
@@ -144,7 +145,8 @@ def create_inquirer(data_directory, should_mock_current_price_queries, mocked_pr
     # Get a cryptocompare without a DB since invoking DB fixture here causes problems
     # of existing user for some tests
     cryptocompare = Cryptocompare(data_directory=data_directory, database=None)
-    inquirer = Inquirer(data_dir=data_directory, cryptocompare=cryptocompare)
+    gecko = Coingecko()
+    inquirer = Inquirer(data_dir=data_directory, cryptocompare=cryptocompare, coingecko=gecko)
     if not should_mock_current_price_queries:
         return inquirer
 

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -111,6 +111,7 @@ def test_coingecko_identifiers_are_reachable():
         'IPSX',
         'SHP',
         'WDC',
+        'BOST',
     ]
     coingecko = Coingecko()
     all_coins = coingecko.all_coins()
@@ -154,7 +155,7 @@ def test_coingecko_identifiers_are_reachable():
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '98eccaded148ef3e88b5f34d583d5e89', 'version': 16}
+    last_meta = {'md5': '4efcd83bc926a60b46574842b92c8766', 'version': 17}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -3,10 +3,13 @@ from unittest.mock import patch
 import pytest
 import requests
 
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_CNY, A_EUR, A_GBP, A_JPY, A_USD
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import _query_exchanges_rateapi
 from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.typing import Price
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
 
@@ -74,3 +77,14 @@ def test_fallback_to_cached_values_within_a_month(inquirer):  # pylint: disable=
         # The cached response for EUR CNY is too old so we will fail here
         with pytest.raises(ValueError):
             result = inquirer.query_fiat_pair(A_EUR, A_CNY)
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_fallback_to_coingecko(inquirer):  # pylint: disable=unused-argument
+    """Cryptocompare does not return current prices for some assets.
+    For those we are going to be using coingecko"""
+    price = inquirer.find_usd_price(Asset('RARI'))
+    assert price != Price(ZERO)
+    price = inquirer.find_usd_price(Asset('TLN'))
+    assert price != Price(ZERO)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requirements = list(set(
     if not requirement.lstrip().startswith('#')
 ))
 
-version = '1.8.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.8.1'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='rotkehlchen',


### PR DESCRIPTION
- Lots of new tokens
- Use coingecko as current price source if cryptocompare fails. Part of #224 
- Bump version to v1.8.1