### PR TITLE
Quick documentation fix

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -91,7 +91,10 @@ Python
 In order to run the python test suite, first make sure the virtual environment is activated, the developer requirements are installed, and then do:
 
 ::
+
     python pytestgeventwrapper.py -xs rotkehlchen/tests
+
+We require this wrapper as a drop-in replacement of pytest due to quirks of gevent and monkeypatching.
 
 For running the tests with a more specific usage and invocation, please refer to the `pytest <https://docs.pytest.org/en/stable/usage.html>`__ documentation.
 


### PR DESCRIPTION
Added empty line after `::`

@vnavascues tagging you here so you take a note of this. Restructured text is very specific in the way it does things with its syntax.

To make sure the docs are as you expect them you can also build them locally.

Go to the docs directory, do `make html` and then navigate in `build/html` and view the files with the browser.