### PR TITLE
[FIX] GET trades history for addresses without trades

### DIFF
--- a/rotkehlchen/chain/ethereum/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/uniswap/uniswap.py
@@ -400,7 +400,10 @@ class Uniswap(EthereumModule):
 
     @staticmethod
     def swaps_to_trades(swaps: List[AMMSwap]) -> List[AMMTrade]:
-        trades = []
+        trades: List[AMMTrade] = []
+        if not swaps:
+            return trades
+
         # sort by timestamp and then by log index
         swaps.sort(key=lambda trade: (trade.timestamp, -trade.log_index), reverse=True)
         last_tx_hash = swaps[0].tx_hash

--- a/rotkehlchen/tests/unit/uniswap/test_swaps_to_trades.py
+++ b/rotkehlchen/tests/unit/uniswap/test_swaps_to_trades.py
@@ -1,0 +1,4 @@
+def test_empty_list(uniswap_module):
+    """Test passing empty list of swaps returns empty list
+    """
+    assert uniswap_module.swaps_to_trades([]) == []


### PR DESCRIPTION
An easy one, if an address has `db_swaps` proceed with `swaps_to_trades()`. Problem was in this line for empty swaps list:
```python
    @staticmethod
    def swaps_to_trades(swaps: List[AMMSwap]) -> List[AMMTrade]:
        trades = []
        # sort by timestamp and then by log index
        swaps.sort(key=lambda trade: (trade.timestamp, -trade.log_index), reverse=True)
        last_tx_hash = swaps[0].tx_hash  # THIS
        current_swaps: List[AMMSwap] = []

```