### PR TITLE
Added logic for storing ETH2 deposits in DB and only request on-chain deposits further in time.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,7 @@ pytest==5.2.4
 bump2version==0.5.8
 pytest-cov==2.7.1
 psutil==5.7.0
+pytest-freezegun==0.4.2
 
 -r requirements_docs.txt
 

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -951,6 +951,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
                 addresses=list(self.balances.eth.keys()),
                 has_premium=self.premium is not None,
                 msg_aggregator=self.msg_aggregator,
+                database=self.database,
             )
 
             if address not in result.totals:
@@ -972,6 +973,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
                 addresses=list(self.balances.eth.keys()),
                 has_premium=self.premium is not None,
                 msg_aggregator=self.msg_aggregator,
+                database=self.database,
             )
 
             # and now that we queried it update the chain manager's balances

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -21,6 +21,7 @@ from rotkehlchen.chain.bitcoin.xpub import (
     XpubDerivedAddressData,
     deserialize_derivation_path_for_db,
 )
+from rotkehlchen.chain.ethereum.eth2 import ETH2_DEPOSITS_PREFIX, Eth2Deposit
 from rotkehlchen.chain.ethereum.structures import (
     AaveEvent,
     YearnVault,
@@ -2044,6 +2045,9 @@ class DBHandler:
         cursor.execute(
             f'DELETE FROM used_query_ranges WHERE name="{UNISWAP_TRADES_PREFIX}_{address}";',
         )
+        cursor.execute(
+            f'DELETE FROM used_query_ranges WHERE name="{ETH2_DEPOSITS_PREFIX}_{address}";',
+        )
         cursor.execute('DELETE FROM ethereum_accounts_details WHERE account = ?', (address,))
         cursor.execute('DELETE FROM aave_events WHERE address = ?', (address,))
         cursor.execute('DELETE FROM uniswap_events WHERE address=?;', (address,))
@@ -2069,6 +2073,7 @@ class DBHandler:
             other_eth_accounts,
         )
         cursor.execute('DELETE FROM amm_swaps WHERE address=?;', (address,))
+        cursor.execute('DELETE FROM eth2_deposits WHERE from_address=?;', (address,))
 
         self.conn.commit()
         self.update_last_write()
@@ -2327,6 +2332,82 @@ class DBHandler:
             return False, 'Tried to delete non-existing AMM swap'
         self.conn.commit()
         return True, ''
+
+    def add_eth2_deposits(self, deposits: Sequence[Eth2Deposit]) -> None:
+        """Inserts a list of Eth2Deposit
+        """
+        query = (
+            """
+            INSERT INTO eth2_deposits (
+                tx_hash,
+                log_index,
+                from_address,
+                timestamp,
+                pubkey,
+                withdrawal_credentials,
+                value,
+                validator_index
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """
+        )
+        cursor = self.conn.cursor()
+        for deposit in deposits:
+            deposit_tuple = deposit.to_db_tuple()
+            try:
+                cursor.execute(query, deposit_tuple)
+            except sqlcipher.IntegrityError:  # pylint: disable=no-member
+                self.msg_aggregator.add_warning(
+                    f'Tried to add an ETH2 deposit that already exists in the DB. '
+                    f'Deposit data: {deposit_tuple}. Skipping deposit.',
+                )
+                continue
+
+        self.conn.commit()
+        self.update_last_write()
+
+    def delete_eth2_deposits(self) -> None:
+        """Delete all historical ETH2 eth2_deposits data"""
+        cursor = self.conn.cursor()
+        cursor.execute('DELETE FROM eth2_deposits;')
+        cursor.execute(f'DELETE FROM used_query_ranges WHERE name LIKE "{ETH2_DEPOSITS_PREFIX}%";')
+        self.conn.commit()
+        self.update_last_write()
+
+    def get_eth2_deposits(
+            self,
+            from_ts: Optional[Timestamp] = None,
+            to_ts: Optional[Timestamp] = None,
+            address: Optional[ChecksumEthAddress] = None,
+    ) -> List[Eth2Deposit]:
+        """Returns a list of Eth2Deposit filtered by time and address
+        """
+        cursor = self.conn.cursor()
+        query = (
+            'SELECT '
+            'tx_hash, '
+            'log_index, '
+            'from_address, '
+            'timestamp, '
+            'pubkey, '
+            'withdrawal_credentials, '
+            'value, '
+            'validator_index '
+            'FROM eth2_deposits '
+        )
+        # Timestamp filters are omitted, done via `form_query_to_filter_timestamps`
+        filters = []
+        if address is not None:
+            filters.append(f'from_address="{address}" ')
+
+        if filters:
+            query += 'WHERE '
+            query += 'AND '.join(filters)
+
+        query, bindings = form_query_to_filter_timestamps(query, 'timestamp', from_ts, to_ts)
+        results = cursor.execute(query, bindings)
+
+        return [Eth2Deposit.deserialize_from_db(deposit_tuple) for deposit_tuple in results]
 
     def set_rotkehlchen_premium(self, credentials: PremiumCredentials) -> None:
         """Save the rotki premium credentials in the DB"""

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -364,10 +364,24 @@ CREATE TABLE IF NOT EXISTS uniswap_events (
 );
 """
 
+DB_CREATE_ETH2_DEPOSITS = """
+CREATE TABLE IF NOT EXISTS eth2_deposits (
+    tx_hash VARCHAR[42] NOT NULL,
+    log_index INTEGER NOT NULL,
+    from_address VARCHAR[42] NOT NULL,
+    timestamp INTEGER NOT NULL,
+    pubkey TEXT NOT NULL,
+    withdrawal_credentials TEXT NOT NULL,
+    value TEXT NOT NULL,
+    validator_index INTEGER NOT NULL,
+    PRIMARY KEY (tx_hash, log_index)
+);
+"""
+
 DB_SCRIPT_CREATE_TABLES = """
 PRAGMA foreign_keys=off;
 BEGIN TRANSACTION;
-{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}
+{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}
 COMMIT;
 PRAGMA foreign_keys=on;
 """.format(
@@ -397,4 +411,5 @@ PRAGMA foreign_keys=on;
     DB_CREATE_XPUB_MAPPINGS,
     DB_CREATE_AMM_SWAPS,
     DB_CREATE_UNISWAP_EVENTS,
+    DB_CREATE_ETH2_DEPOSITS,
 )

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -307,7 +307,12 @@ def test_query_all_balances_ignore_cache(
         msg = 'call count should increase since cache should have been ignored'
         assert all(fn.call_count == 2 for fn in function_call_counters), msg
         msg = 'etherscan call count should have doubled after forced token detection'
-        expected_count = full_query_etherscan_count * 2 - len(ethereum_accounts)
+        # NB: Subtract `get_eth2_staked_amount()` calls not done due to
+        # REQUEST_DELTA_TS constraint for cache ignoring request case.
+        eth2_calls_count = 14
+        expected_count = (
+            full_query_etherscan_count * 2 - len(ethereum_accounts) - eth2_calls_count
+        )
         assert etherscan_mock.call_count == expected_count, msg
 
 

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -94,6 +94,7 @@ TABLES_AT_INIT = [
     'xpub_mappings',
     'amm_swaps',
     'uniswap_events',
+    'eth2_deposits',
 ]
 
 


### PR DESCRIPTION
Done:
- Extended functionality for storing on-chain requested deposits and only request new ones.
- Refactored existing tests, e.g. adding real timestamps, using `freezegun` (pip requirement) for faking current time and bypassing `datetime.now()`, etc.

Relates to #1721 