### PR TITLE
Fix xpub conversion for ypub and zpub

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4580,6 +4580,7 @@ Adding BTC xpubs
 
       {
           "xpub": "xpub68V4ZQQ62mea7ZUKn2urQu47Bdn2Wr7SxrBxBDDwE3kjytj361YBGSKDT4WoBrE5htrSB8eAMe59NPnKrcAbiv2veN5GQUmfdjRddD1Hxrk",
+	  "xpub_type": "p2sh_p2wpkh",
           "derivation_path": "m/0/0",
           "label": "my electrum xpub",
           "tags": ["public", "old"]
@@ -4587,6 +4588,7 @@ Adding BTC xpubs
 
    :reqjson string xpub: The extended public key to add
    :reqjsonarr string derivation_path: The derivation path from which to start deriving addresses relative to the xpub.
+   :reqjsonarr string[optional] xpub_type: An optional type to denote the type of the given xpub. If omitted the prefix xpub/ypub/zpub is used to determine the type. The valid xpub types are: ``"p2pkh"``, ``"p2sh_p2wpkh"`` and ``"wpkh"``.
    :reqjsonarr string[optional] label: An optional label to describe the new extended public key
    :reqjsonarr list[optional] tags: An optional list of tags to attach to the xpub
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`717` Uniswap v2 LP balances are now detected by Rotki. Faster balance queries, swaps history and LP events history is also supported for premium users. Finally uniswap trades are now taken into account in the profit/loss report for premium users.
+* :bug:`1664` Properly convert the given xpub to ypub if P2SH_P2WPKH and zpub if WPKH. This should address the problem of importing some types of xpubs for some users.
 * :bug:`1740` SNX token and some other token balances should no longer be double counted.
 * :feature:`1724` YFI and BAL are now supported as collateral for makerdao vaults.
 * :feature:`1694` Users are now able to track their ETH deposited in Eth2 beacon chain. Premium users can see more details about the activity and their staking gains in the staking menu.

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -496,6 +496,7 @@ export class RotkehlchenApi {
       ? {
           xpub: xpub.xpub,
           derivationPath: xpub.derivationPath ? xpub.derivationPath : undefined,
+          xpubType: xpub.xpubType ? xpub.xpubType : undefined,
           ...basePayload
         }
       : {

--- a/frontend/app/src/store/balances/types.d.ts
+++ b/frontend/app/src/store/balances/types.d.ts
@@ -58,6 +58,7 @@ export interface ExchangePayload {
 interface XpubPayload {
   readonly xpub: string;
   readonly derivationPath: string;
+  readonly xpubType: string;
 }
 
 export interface BlockchainAccountPayload extends AccountPayload {

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -54,8 +54,8 @@ from rotkehlchen.api.v1.encoding import (
     WatchersAddSchema,
     WatchersDeleteSchema,
     WatchersEditSchema,
+    XpubAddSchema,
     XpubPatchSchema,
-    XpubSchema,
 )
 from rotkehlchen.api.v1.parser import resource_parser
 from rotkehlchen.assets.asset import Asset
@@ -732,7 +732,7 @@ class BlockchainsAccountsResource(BaseResource):
 
 class BTCXpubResource(BaseResource):
 
-    put_schema = XpubSchema()
+    put_schema = XpubAddSchema()
     delete_schema = BaseXpubSchema()
     patch_schema = XpubPatchSchema()
 

--- a/rotkehlchen/chain/bitcoin/xpub.py
+++ b/rotkehlchen/chain/bitcoin/xpub.py
@@ -13,7 +13,7 @@ from rotkehlchen.typing import BlockchainAccountData, BTCAddress, SupportedBlock
 if TYPE_CHECKING:
     from rotkehlchen.chain.manager import BlockchainBalancesUpdate, ChainManager
 
-XPUB_ADDRESS_STEP = 10
+XPUB_ADDRESS_STEP = 20
 
 log = logging.getLogger(__name__)
 
@@ -81,6 +81,7 @@ def _derive_addresses_loop(
             batch_addresses.append((idx, child.address()))
 
         have_tx_mapping = have_bitcoin_transactions([x[1] for x in batch_addresses])
+        should_continue = False
         for idx, address in batch_addresses:
             have_tx, balance = have_tx_mapping[address]
             if have_tx:
@@ -90,8 +91,7 @@ def _derive_addresses_loop(
                     address=address,
                     balance=balance,
                 ))
-            else:
-                should_continue = False
+                should_continue = True
 
         # do one more pass and add any addresses with no transactions before the max index
         # this is so we can start new address generation from the max index later

--- a/rotkehlchen/tests/api/test_bitcoin.py
+++ b/rotkehlchen/tests/api/test_bitcoin.py
@@ -53,6 +53,7 @@ EXPECTED_XPUB_ADDESSES = [
     '1PUrJgftNnHvvqVyEsm9DiCDQuZHCn47fQ',
     '1Ps7bkbAfcEFKsUvFTNu61vNTGqTY25Lpz',
     '1Q61WZ6sixTvd8JaH2qimkXAWFBR2MdBwu',
+    '1DNg5csVnUkheYczaBECsfby8ZcmZkYnJK',
 ]
 
 

--- a/rotkehlchen/tests/unit/test_bitcoin.py
+++ b/rotkehlchen/tests/unit/test_bitcoin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rotkehlchen.chain.bitcoin.hdkey import HDKey
+from rotkehlchen.chain.bitcoin.hdkey import HDKey, XpubType
 from rotkehlchen.chain.bitcoin.utils import (
     is_valid_btc_address,
     is_valid_derivation_path,
@@ -104,6 +104,39 @@ def test_pubkey_to_bech32_address():
         witver=0,
     )
     assert address == 'bc1q7zxvguxdazzjd4m7d7ahlt03nnakc9fhxhskd5'
+
+
+def test_from_xpub_with_conversion():
+    legacy_xpub = 'xpub6CjniigyzMWgVDHvDpgvsroPkTJeqUbrHJaLHARHmAM8zuAbCjmHpp3QhKTcnnscd6iBDrqmABCJjnpwUW42cQjtvKjaEZRcShHKEVh35Y8'  # noqa: E501
+    legacy_xpub_hdkey = HDKey.from_xpub(xpub=legacy_xpub, path='m')
+
+    converted_ypub_hdkey = HDKey.from_xpub(
+        xpub=legacy_xpub,
+        xpub_type=XpubType.P2SH_P2WPKH,
+        path='m',
+    )
+    assert legacy_xpub_hdkey.network == converted_ypub_hdkey.network
+    assert legacy_xpub_hdkey.depth == converted_ypub_hdkey.depth
+    assert legacy_xpub_hdkey.parent_fingerprint == converted_ypub_hdkey.parent_fingerprint
+    assert legacy_xpub_hdkey.chain_code == converted_ypub_hdkey.chain_code
+    assert legacy_xpub_hdkey.fingerprint == converted_ypub_hdkey.fingerprint
+    assert legacy_xpub_hdkey.pubkey == converted_ypub_hdkey.pubkey
+    assert converted_ypub_hdkey.xpub == 'ypub6Xa42PMu934ALWV34BUZ5wttvRT6n6bMCR6Z4ZKB9Aj23zypTPvrSshYiXRCnhXY2jpyyLSKcqYrd5SWCCU3QeRVnfRzpUF6iRLxd55duzL'  # noqa: E501
+    assert converted_ypub_hdkey.hint == 'ypub'
+
+    converted_zpub_hdkey = HDKey.from_xpub(
+        xpub=legacy_xpub,
+        xpub_type=XpubType.WPKH,
+        path='m',
+    )
+    assert legacy_xpub_hdkey.network == converted_zpub_hdkey.network
+    assert legacy_xpub_hdkey.depth == converted_zpub_hdkey.depth
+    assert legacy_xpub_hdkey.parent_fingerprint == converted_zpub_hdkey.parent_fingerprint
+    assert legacy_xpub_hdkey.chain_code == converted_zpub_hdkey.chain_code
+    assert legacy_xpub_hdkey.fingerprint == converted_zpub_hdkey.fingerprint
+    assert legacy_xpub_hdkey.pubkey == converted_zpub_hdkey.pubkey
+    assert converted_zpub_hdkey.xpub == 'zpub6rQKL42pHibeBog9tYGBJ2zQ6PbYiiar7XcmqxD4XB6u76o3i46R4wMgjjNnncBTSNwnip2t5VuQWN44utt4Ct76f18RQP4az9Qc1eUEkSY'  # noqa: E501
+    assert converted_zpub_hdkey.hint == 'zpub'
 
 
 def test_xpub_to_addresses():


### PR DESCRIPTION
Fix #1664, at least for the xpubs we tried. In the end the given xpub
is transformed to:

- "xpub" prefixed xpub for P2PKH/legacy xpubs
- "ypub" prefixed xpub for p2sh-p2wpkh / segwit xpubs
- "zpub" prefixed xpub for wpkh / native segwit xpubs


@kelsos: STill left is for you to add the frontend change as dicussed on the phone.
Remove all changes you are doing to the xpub string from the frontend, send it as is, but also send the selected xpub type. As per the edited api docs.