### PR TITLE
Addressed unsyc system clock for Bittrex exchange

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`1801` Users that have the uniswap module deactivated will now see a proper message about the module status instead of a loading page.
 * :bug:`1798` Log level settings now are properly saved and the users are not required to set them on every run.
+* :bug:`1785` Inform the user when they try to setup Bittrex with their system clock not in sync.
 * :bug:`1761` Retry GraphQL requests when the API server fails.
 * :bug:`1809` Token balances should now always be saved in the balances snapshot. Also an edge case that rarely caused the ethereum balances to be queried twice should be now fixed.
 * :bug:`1803` After 25/11/2020 Compound's claimable COMP stopped appearing in the app due to a change in a smart contract we depend on. This has now been fixed and they should be detected properly again.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -41,9 +41,9 @@ from rotkehlchen.errors import (
     PremiumAuthenticationError,
     RemoteError,
     RotkehlchenPermissionError,
+    SystemClockNotSyncedError,
     SystemPermissionError,
     TagConstraintError,
-    UnsyncSystemClockError,
 )
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES
@@ -400,11 +400,12 @@ class RestAPI():
         msg = ''
         try:
             result, msg = self.rotkehlchen.setup_exchange(name, api_key, api_secret, passphrase)
-        except UnsyncSystemClockError as e:
+        except SystemClockNotSyncedError as e:
             msg = str(e)
             status_code = HTTPStatus.CONFLICT
         else:
             if not result:
+                result = None
                 status_code = HTTPStatus.CONFLICT
         return api_response(_wrap_in_result(result, msg), status_code=status_code)
 

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -52,6 +52,21 @@ class RemoteError(Exception):
     pass
 
 
+class UnsyncSystemClockError(RemoteError):
+    """Raised when the system clock is not synchronized via Internet and
+    remote APIs return an error code regarding the current timestamp sent.
+    """
+    def __init__(self, current_time: str, remote_server: Optional[str] = None) -> None:
+        self.current_time = current_time  # As str datetime
+        self.remote_server = remote_server  # Remote server name
+        msg_remote_server = f'{self.remote_server} server' if self.remote_server else 'server'
+        super().__init__(
+            f'Invalid provided current time: {self.current_time}. '
+            f'Local system clock is not sync with the {msg_remote_server}. '
+            f"Please, try syncing your system's clock.",
+        )
+
+
 class PriceQueryUnsupportedAsset(Exception):
     def __init__(self, asset_name: str) -> None:
         self.asset_name = asset_name

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -52,7 +52,7 @@ class RemoteError(Exception):
     pass
 
 
-class UnsyncSystemClockError(RemoteError):
+class SystemClockNotSyncedError(RemoteError):
     """Raised when the system clock is not synchronized via Internet and
     remote APIs return an error code regarding the current timestamp sent.
     """
@@ -61,8 +61,7 @@ class UnsyncSystemClockError(RemoteError):
         self.remote_server = remote_server  # Remote server name
         msg_remote_server = f'{self.remote_server} server' if self.remote_server else 'server'
         super().__init__(
-            f'Invalid provided current time: {self.current_time}. '
-            f'Local system clock is not sync with the {msg_remote_server}. '
+            f'Local system clock {self.current_time} is not sync with the {msg_remote_server}. '
             f"Please, try syncing your system's clock.",
         )
 

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -8,7 +8,12 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import UNSUPPORTED_BITTREX_ASSETS, asset_from_bittrex
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.errors import UnknownAsset, UnsupportedAsset, UnsyncSystemClockError
+from rotkehlchen.errors import (
+    RemoteError,
+    SystemClockNotSyncedError,
+    UnknownAsset,
+    UnsupportedAsset,
+)
 from rotkehlchen.exchanges.bittrex import Bittrex
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
@@ -524,22 +529,52 @@ def test_bittrex_query_deposits_withdrawals_unexpected_data(bittrex):
     )
 
 
-def test_bittrex_query_raises_unsync_system_clock_error(bittrex):
-    """Test that a request that returns an error code related with unsync
-    system clock raises UnsyncSystemClockError.
+@pytest.mark.parametrize('response, exception', [
+    (
+        MockResponse(HTTPStatus.OK, '{"result": "a result"}'),
+        None,
+    ),
+    (
+        MockResponse(HTTPStatus.UNAUTHORIZED, 'this is not a dict'),
+        RemoteError,
+    ),
+    (
+        MockResponse(HTTPStatus.UNAUTHORIZED, '{"code": "NOT_THE_EXPECTED_CODE"}'),
+        None,
+    ),
+    (
+        MockResponse(HTTPStatus.UNAUTHORIZED, '{"not_code": "INVALID_TIMESTAMP"}'),
+        None,
+    ),
+    (
+        MockResponse(HTTPStatus.UNAUTHORIZED, '{"code": "INVALID_TIMESTAMP"}'),
+        SystemClockNotSyncedError,
+    ),
+])
+def test_check_for_system_clock_not_synced_error(bittrex, response, exception):
+    """Test the function behavior depending on the response `status_code` and
+    `text` attributes.
+    """
+    if exception:
+        with pytest.raises(exception):
+            bittrex._check_for_system_clock_not_synced_error(response)
+    else:
+        assert bittrex._check_for_system_clock_not_synced_error(response) is None
 
-    NB: only for non-public endpoints.
+
+def test_api_query_raises_system_clock_not_synced_error(bittrex):
+    """Test that a request that returns an error code related with unsync
+    system clock raises SystemClockNotSyncedError.
     """
     def mock_response(url, method, json):  # pylint: disable=unused-argument
         response = MockResponse(HTTPStatus.UNAUTHORIZED, '{"code": "INVALID_TIMESTAMP"}')
         return response
 
     with patch.object(bittrex.session, 'request', side_effect=mock_response):
-        with pytest.raises(UnsyncSystemClockError) as e:
-            bittrex._single_api_query(
-                request_url=bittrex.uri,
-                options={},
+        with pytest.raises(SystemClockNotSyncedError) as e:
+            bittrex.api_query(
+                endpoint='endoint',
                 method='put',
-                public_endpoint=False,
+                options={},
             )
-        assert 'Invalid provided current time' in str(e.value)
+        assert 'Local system clock' in str(e.value)


### PR DESCRIPTION
Sorry for going round in circles on this.
I've implemented the `UnsyncSystemClockError` class, which subclasses `RemoteError` with the idea in mind of using it anywhere we do requests to remote servers that require to pass the current timestamp. Due to subclasses `RemoteError` it is handled right by the `query_balances` endpoint. Below the returning response:

**Setup an exchange**

```shell
$ http PUT http://localhost:5042/api/1/exchanges name=bittrex api_key=my_key api_secret=my_secret
HTTP/1.1 409 CONFLICT
Content-Length: 186
Content-Type: application/json
Date: Wed, 25 Nov 2020 17:32:14 GMT
mimetype: application/json

{
    "message": "Invalid provided current time: 2020-11-25 17:32:14.021000. Local system clock is not sync with the Bittrex server. Please, try syncing your system's clock.",
    "result": null
}
```

**Query balances**

```shell
$ http GET http://localhost:5042/api/1/exchanges/balances
HTTP/1.1 409 CONFLICT
Content-Length: 245
Content-Type: application/json
Date: Wed, 25 Nov 2020 17:16:33 GMT
mimetype: application/json

{
    "message": "Bittrex API request failed. Could not reach bittrex due to Invalid provided current time: 2020-11-25 17:16:33.723000. Local system clock is not sync with the Bittrex server. Please, try syncing your system's clock.",
    "result": null
}
```

**Query all balances**

```shell
[25/11/2020 17:47:04 GMT] DEBUG rotkehlchen.exchanges.bittrex: Bittrex v3 API query request_url=https://api.bittrex.com/v3/balances
[25/11/2020 17:47:04 GMT] ERROR rotkehlchen.exchanges.bittrex: Bittrex API request failed. Could not reach bittrex due to Invalid provided current time: 2020-11-25 17:47:04.013000. Local system clock is not sync with the Bittrex server. Please, try syncing your system's clock.
[25/11/2020 17:47:04 GMT] DEBUG rotkehlchen.rotkehlchen: query_balances data not saved allowed_to_save=False, problem_free=False
```
If this implementation passes the review, I can open an issue for standardising its usage across exchanges at least. For instance remove the case that deals with it in `binance.py`:
```python
    def validate_api_key(self) -> Tuple[bool, str]:
        try:
            # We know account endpoint returns a dict
            self.api_query_dict('account')
        except RemoteError as e:
            error = str(e)
            if 'API-key format invalid' in error:
                return False, 'Provided API Key is in invalid Format'
            elif 'Signature for this request is not valid' in error:
                return False, 'Provided API Secret is malformed'
            elif 'Invalid API-key, IP, or permissions for action' in error:
                return False, 'API Key does not match the given secret'
            elif 'Timestamp for this request was' in error:  # HERE
                return False, (
                    "Local system clock is not in sync with binance server. "
                    "Try syncing your system's clock"
                )
            else:
                raise
        return True, ''
```