### PR TITLE
Instantiate gql RequestsHTTPTransport with retries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1761` Retry GraphQL requests when the API server fails.
 * :bug:`1803` After 25/11/2020 Compound's claimable COMP stopped appearing in the app due to a change in a smart contract we depend on. This has now been fixed and they should be detected properly again.
 * :bug:`1416` Request Binance deposits & withdraws using a 90 days window.
 * :bug:`1787` After 24/11/2020 some Infura users started getting a "query returned more than 10000 results" error when querying their balances. This should no longer happen.

--- a/rotkehlchen/chain/ethereum/graph.py
+++ b/rotkehlchen/chain/ethereum/graph.py
@@ -14,6 +14,7 @@ from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 log = logging.getLogger(__name__)
 
 
+MAX_RETRIES = 3
 GRAPH_QUERY_LIMIT = 1000
 RE_MULTIPLE_WHITESPACE = re.compile(r'\s+')
 
@@ -51,7 +52,7 @@ class Graph():
     def __init__(self, url: str) -> None:
         """
         - May raise requests.RequestException if there is a problem connecting to the subgraph"""
-        transport = RequestsHTTPTransport(url=url)
+        transport = RequestsHTTPTransport(url=url, retries=MAX_RETRIES)
         try:
             self.client = Client(transport=transport, fetch_schema_from_transport=True)
         except (requests.exceptions.RequestException) as e:


### PR DESCRIPTION
If The Graph is down responses have 502 or 504 status codes. This argument will force the gql transport to retry (up to 3 times).