### PR TITLE
Added starting timestamp and USD price for COMP via Cryptocompare

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`1726` Fixed COMP zero price warnings on Compound history events for COMP claimed.
+* :bug:`1726` When querying Compound history for COMP claimed around the start of COMP issuance, zero price warnings should no longer be emitted.
 * :bug:`1801` Users that have the uniswap module deactivated will now see a proper message about the module status instead of a loading page.
 * :bug:`1798` Log level settings now are properly saved and the users are not required to set them on every run.
 * :bug:`1785` Inform the user when they try to setup Bittrex with their system clock not in sync.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1726` Fixed COMP zero price warnings on Compound history events for COMP claimed.
 * :bug:`1801` Users that have the uniswap module deactivated will now see a proper message about the module status instead of a loading page.
 * :bug:`1798` Log level settings now are properly saved and the users are not required to set them on every run.
 * :bug:`1785` Inform the user when they try to setup Bittrex with their system clock not in sync.

--- a/rotkehlchen/chain/ethereum/compound.py
+++ b/rotkehlchen/chain/ethereum/compound.py
@@ -35,7 +35,6 @@ A_COMP = EthereumToken('COMP')
 COMPTROLLER_PROXY = EthereumConstants().contract('COMPTROLLER_PROXY')
 COMP_DEPLOYED_BLOCK = 9601359
 
-
 LEND_EVENTS_QUERY_PREFIX = """{graph_event_name}
 (where: {{blockTime_lte: $end_ts, blockTime_gte: $start_ts, {addr_position}: $address}}) {{
     id

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -154,8 +154,8 @@ class HistoHourAssetData(NamedTuple):
 # 0 price. Be aware `usd_price` is from the 'close' price in USD.
 CRYPTOCOMPARE_SPECIAL_HISTOHOUR_CASES: Dict[Asset, HistoHourAssetData] = {
     A_COMP: HistoHourAssetData(
-        timestamp=Timestamp(1592632800),
-        usd_price=Price(FVal('202.93')),
+        timestamp=Timestamp(1592629200),
+        usd_price=Price(FVal('239.13')),
     ),
 }
 
@@ -658,7 +658,7 @@ class Cryptocompare(ExternalServiceWithApiKey):
         (or viceversa) is a special histohour API case. If so, return the price
         based on the assets pair, otherwise return zero.
 
-        NB: special histohour API cases are the one where this Cryptocompare
+        NB: special histohour API cases are the ones where this Cryptocompare
         API returns zero prices per hour.
         """
         price = Price(ZERO)


### PR DESCRIPTION
Fix:
- Added the starting timestamp (as `COMP_STARTING_HISTOHOUR_TS`) from where requesting COMP usd price via cryptocompare histohour is "safe" (no zero prices after).
- Added as well the its usd price (as `COMP_STARTING_PRICE`, from the hour "close" price), that will be used for any timestamp lte `COMP_STARTING_HISTOHOUR_TS`.
- Added a warning log when the logic above is hit.

Tested with account `0x7780E86699e941254c8f4D9b7eB08FF7e96BBE10`.

Logs:
```shell
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.externalapis.cryptocompare: Querying cryptocompare for hourly historical price from_asset=yearn.finance, to_asset=United States Dollar, cryptocompare_hourquerylimit=2000, end_date=1452787200
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.externalapis.cryptocompare: Querying cryptocompare url=https://min-api.cryptocompare.com/data/v2/histohour?fsym=YFI&tsym=USDT&limit=2000&toTs=1452787200
[26/11/2020 19:33:16 GMT] WARNING rotkehlchen.chain.ethereum.compound: Query COMP usd price at time 1592524376 may return zero price. Setting usd price to 202.93, from time 1592632800.
[26/11/2020 19:33:16 GMT] WARNING rotkehlchen.chain.ethereum.compound: Query COMP usd price at time 1592539356 may return zero price. Setting usd price to 202.93, from time 1592632800.
[26/11/2020 19:33:16 GMT] WARNING rotkehlchen.chain.ethereum.compound: Query COMP usd price at time 1592540006 may return zero price. Setting usd price to 202.93, from time 1592632800.
[26/11/2020 19:33:16 GMT] WARNING rotkehlchen.chain.ethereum.compound: Query COMP usd price at time 1592625221 may return zero price. Setting usd price to 202.93, from time 1592632800.
[26/11/2020 19:33:16 GMT] WARNING rotkehlchen.chain.ethereum.compound: Query COMP usd price at time 1592625469 may return zero price. Setting usd price to 202.93, from time 1592632800.
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.history.price: Querying historical price from_asset=Compound, to_asset=United States Dollar, timestamp=1592690071
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.externalapis.cryptocompare: Retrieving historical price data from cryptocompare from_asset=Compound, to_asset=United States Dollar, timestamp=1592690071
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.externalapis.cryptocompare: Found cached price cache_key=COMP_USD, timestamp=1592690071
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.externalapis.cryptocompare: Got historical price from_asset=Compound, to_asset=United States Dollar, timestamp=1592690071, price=257.87
[26/11/2020 19:33:16 GMT] DEBUG rotkehlchen.history.price: Querying historical price from_asset=Compound, to_asset=United States Dollar, timestamp=1592690616
```
Closes #1726 