### PR TITLE
Catch all requests errors (timeout, SSL etc), plus misc fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1777` Free users will now be able to load uniswap LP balances properly again.
 * :bug:`1726` When querying Compound history for COMP claimed around the start of COMP issuance, zero price warnings should no longer be emitted.
 * :bug:`1801` Users that have the uniswap module deactivated will now see a proper message about the module status instead of a loading page.
 * :bug:`1798` Log level settings now are properly saved and the users are not required to set them on every run.

--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -80,7 +80,7 @@ def _get_latest_assets(data_directory: Path) -> Dict[str, Any]:
             return json.loads(remote_asset_data)
 
         # else, same as all error cases use the current one
-    except (requests.exceptions.ConnectionError, KeyError, json.decoder.JSONDecodeError):
+    except (requests.exceptions.RequestException, KeyError, json.decoder.JSONDecodeError):
         pass
 
     if our_downloaded_meta.is_file():

--- a/rotkehlchen/chain/bitcoin/__init__.py
+++ b/rotkehlchen/chain/bitcoin/__init__.py
@@ -43,7 +43,7 @@ def get_bitcoin_addresses_balances(accounts: List[BTCAddress]) -> Dict[BTCAddres
             for idx, entry in enumerate(btc_resp['addresses']):
                 balances[accounts[idx]] = satoshis_to_btc(FVal(entry['final_balance']))
     except (
-            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
             UnableToDecryptRemoteData,
             requests.exceptions.Timeout,
     ) as e:
@@ -109,7 +109,7 @@ def have_bitcoin_transactions(accounts: List[BTCAddress]) -> Dict[BTCAddress, Tu
             source = 'blockchain.info'
             have_transactions = _check_blockchaininfo_for_transactions(accounts)
     except (
-            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
             UnableToDecryptRemoteData,
             requests.exceptions.Timeout,
     ) as e:

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -263,7 +263,7 @@ class EthereumManager():
             ens = ENS(provider)
             web3 = Web3(provider, ens=ens)
             web3.middleware_onion.inject(http_retry_request_middleware, layer=0)
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.RequestException:
             message = f'Failed to connect to ethereum node {name} at endpoint {ethrpc_endpoint}'
             log.warning(message)
             return False, message

--- a/rotkehlchen/chain/ethereum/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/uniswap/utils.py
@@ -172,7 +172,7 @@ def get_latest_lp_addresses(data_directory: Path) -> List[ChecksumEthAddress]:
             return json.loads(remote_data)
 
         # else, same as all error cases use the current one
-    except (requests.exceptions.ConnectionError, KeyError, json.decoder.JSONDecodeError):
+    except (requests.exceptions.RequestException, KeyError, json.decoder.JSONDecodeError):
         pass
 
     if our_downloaded_meta.is_file():

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -261,7 +261,7 @@ class Binance(ExchangeInterface):
                 log.debug('Binance API request', request_url=request_url)
                 try:
                     response = self.session.get(request_url)
-                except requests.exceptions.ConnectionError as e:
+                except requests.exceptions.RequestException as e:
                     raise RemoteError(f'Binance API request failed due to {str(e)}')
 
             limit_ban = response.status_code == 429 and backoff > self.backoff_limit

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -172,7 +172,7 @@ class Bitmex(ExchangeInterface):
         log.debug('Bitmex API Query', verb=verb, request_url=request_url)
         try:
             response = getattr(self.session, verb)(request_url, data=data)
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             raise RemoteError(f'Bitmex API request failed due to {str(e)}')
 
         if response.status_code not in (200, 401):

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -290,7 +290,7 @@ class Bittrex(ExchangeInterface):
                 url=request_url,
                 json=options if method != 'get' else None,
             )
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             raise RemoteError(f'Bittrex API request failed due to {str(e)}')
 
         return response

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -275,7 +275,7 @@ class Coinbase(ExchangeInterface):
         full_url = self.base_uri + request_url
         try:
             response = self.session.get(full_url)
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             raise RemoteError(f'Coinbase API request failed due to {str(e)}')
 
         if response.status_code == 403:

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -205,7 +205,7 @@ class Coinbasepro(ExchangeInterface):
                     full_url,
                     data=stringified_options,
                 )
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 raise RemoteError(
                     f'Coinbase Pro {request_method} query at '
                     f'{full_url} connection error: {str(e)}',

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -172,7 +172,7 @@ class Gemini(ExchangeInterface):
 
             try:
                 response = self.session.request(method=method, url=url)
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 raise RemoteError(f'Gemini {method} query at {url} connection error: {str(e)}')
 
             if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -395,7 +395,7 @@ class Kraken(ExchangeInterface):
         urlpath = f'{KRAKEN_BASE_URL}/{KRAKEN_API_VERSION}/public/{method}'
         try:
             response = self.session.post(urlpath, data=req)
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             raise RemoteError(f'Kraken API request failed due to {str(e)}')
 
         self._manage_call_counter(method)
@@ -483,7 +483,7 @@ class Kraken(ExchangeInterface):
                     KRAKEN_BASE_URL + urlpath,
                     data=post_data.encode(),
                 )
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 raise RemoteError(f'Kraken API request failed due to {str(e)}')
             self._manage_call_counter(method)
 

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -319,7 +319,7 @@ class Poloniex(ExchangeInterface):
         while tries >= 0:
             try:
                 response = self._single_query(command, req)
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 raise RemoteError(f'Poloniex API request failed due to {str(e)}')
 
             if response is None:

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -136,7 +136,7 @@ class Coingecko():
             url += subpath
         try:
             response = self.session.get(f'{url}?{urlencode(options)}')
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             raise RemoteError(f'Coingecko API request failed due to {str(e)}')
 
         if response.status_code != 200:

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -266,7 +266,7 @@ class Cryptocompare(ExternalServiceWithApiKey):
         while tries >= 0:
             try:
                 response = self.session.get(querystr)
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 raise RemoteError(f'Cryptocompare API request failed due to {str(e)}')
 
             try:

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -171,7 +171,7 @@ class Etherscan(ExternalServiceWithApiKey):
         while backoff < backoff_limit:
             try:
                 response = self.session.get(query_str)
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 if 'Max retries exceeded with url' in str(e):
                     log.debug(
                         f'Got max retries exceeded from etherscan. Will '

--- a/rotkehlchen/externalapis/github.py
+++ b/rotkehlchen/externalapis/github.py
@@ -19,7 +19,7 @@ class Github():
         """
         try:
             response = requests.get(f'{self.prefix}{path}')
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             raise RemoteError(f'Failed to query Github: {str(e)}')
 
         if response.status_code != 200:

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -220,8 +220,8 @@ class Premium():
                 data=data,
                 timeout=ROTKEHLCHEN_SERVER_TIMEOUT,
             )
-        except requests.exceptions.ConnectionError:
-            raise RemoteError('Could not connect to rotki server')
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Could not connect to rotki server due to {str(e)}')
 
         return _process_dict_response(response)
 
@@ -244,8 +244,8 @@ class Premium():
                 data=data,
                 timeout=ROTKEHLCHEN_SERVER_TIMEOUT,
             )
-        except requests.exceptions.ConnectionError:
-            raise RemoteError('Could not connect to rotki server')
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Could not connect to rotki server due to {str(e)}')
 
         return _process_dict_response(response)
 
@@ -267,8 +267,8 @@ class Premium():
                 data=data,
                 timeout=ROTKEHLCHEN_SERVER_TIMEOUT,
             )
-        except requests.exceptions.ConnectionError:
-            raise RemoteError('Could not connect to rotki server')
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Could not connect to rotki server due to {str(e)}')
 
         result = _process_dict_response(response)
         metadata = RemoteMetadata(
@@ -296,8 +296,8 @@ class Premium():
                 data=data,
                 timeout=ROTKEHLCHEN_SERVER_TIMEOUT,
             )
-        except requests.exceptions.ConnectionError:
-            raise RemoteError('Could not connect to rotki server')
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Could not connect to rotki server due to {str(e)}')
 
         result = _process_dict_response(response)
         return result['data']
@@ -322,8 +322,8 @@ class Premium():
                 json=data,
                 timeout=ROTKEHLCHEN_SERVER_TIMEOUT,
             )
-        except requests.exceptions.ConnectionError:
-            raise RemoteError('Could not connect to rotki server')
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Could not connect to rotki server due to {str(e)}')
 
         return _decode_premium_json(response)
 

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -118,11 +118,11 @@ def test_cryptocompare_dao_query(cryptocompare):
     [{
         'asset': Asset('cDAI'),
         'expected_price1': FVal('0.02012010'),
-        'expected_price2': FVal('0'),  # Needs to be fixed -- mistake in cryptocompare data
+        'expected_price2': FVal('0.02033108'),
     }, {
         'asset': Asset('cBAT'),
         'expected_price1': FVal('0.003522603'),
-        'expected_price2': FVal('0.002723634'),
+        'expected_price2': FVal('0.002713524'),
     }, {
         'asset': Asset('cETH'),
         'expected_price1': FVal('2.903'),
@@ -130,15 +130,15 @@ def test_cryptocompare_dao_query(cryptocompare):
     }, {
         'asset': Asset('cREP'),
         'expected_price1': FVal('0.20105130'),
-        'expected_price2': FVal('0.16356648'),
+        'expected_price2': FVal('0.16380696'),
     }, {
         'asset': Asset('cUSDC'),
         'expected_price1': FVal('0.02085273'),
-        'expected_price2': FVal('0.02103101'),
+        'expected_price2': FVal('0.020944869'),
     }, {
         'asset': Asset('cWBTC'),
         'expected_price1': FVal('136.971575'),
-        'expected_price2': FVal('138.8820732'),
+        'expected_price2': FVal('99.411774'),
     }, {
         'asset': Asset('cZRX'),
         'expected_price1': FVal('0.004324785'),
@@ -235,9 +235,7 @@ def test_keep_special_histohour_cases_up_to_date(cryptocompare):
             limit=limit,
             to_timestamp=to_timestamp,
         )
-        try:
-            assert any(is_price_not_valid(price_data) for price_data in response['Data'])
-        except AssertionError:
+        if not any(is_price_not_valid(price_data) for price_data in response['Data']):
             warning_msg = (
                 f'Cryptocompare histohour API has non-zero prices for asset '
                 f'{asset.identifier} from {from_timestamp} to {to_timestamp}. '

--- a/rotkehlchen/usage_analytics.py
+++ b/rotkehlchen/usage_analytics.py
@@ -150,7 +150,7 @@ def maybe_submit_usage_analytics(should_submit: bool) -> None:
     analytics = create_usage_analytics()
     try:
         response = requests.put('https://rotki.com/api/1/usage_analytics', json=analytics)
-    except requests.exceptions.ConnectionError:
+    except requests.exceptions.RequestException:
         return None
 
     if response.status_code == HTTPStatus.NO_CONTENT:

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -209,7 +209,7 @@ def retry_calls(
 
             return result
 
-        except (requests.exceptions.ConnectionError) as e:
+        except requests.exceptions.RequestException as e:
             tries -= 1
             log.debug(
                 f'In retry_call for {location}-{method_name}. Got error {str(e)} '


### PR DESCRIPTION
- After reviewing a user's logs I noticed that some errors such as
Timeouts are not properly caught by our current logic. So I opt for
catching RequestException instead of ConnectionError to catch them all

- Cryptocompare test fixes

- Add missing changelog entry for 1777