### PR TITLE
Make asset movement inclusion optional with an accounting option

### DIFF
--- a/frontend/app/src/data/converters.ts
+++ b/frontend/app/src/data/converters.ts
@@ -36,5 +36,6 @@ export const convertToAccountingSettings = (
 ): AccountingSettings => ({
   taxFreeAfterPeriod: settings.taxfree_after_period,
   includeGasCosts: settings.include_gas_costs,
-  includeCrypto2Crypto: settings.include_crypto2crypto
+  includeCrypto2Crypto: settings.include_crypto2crypto,
+  accountForAssetsMovements: settings.account_for_assets_movements
 });

--- a/frontend/app/src/data/factories.ts
+++ b/frontend/app/src/data/factories.ts
@@ -21,5 +21,6 @@ export const defaultGeneralSettings = (): GeneralSettings => ({
 export const defaultAccountingSettings = (): AccountingSettings => ({
   includeCrypto2Crypto: true,
   includeGasCosts: true,
-  taxFreeAfterPeriod: null
+  taxFreeAfterPeriod: null,
+  accountForAssetsMovements: true
 });

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -839,7 +839,8 @@
       "crypto_to_crypto": "Take into account crypto to crypto trades",
       "gas_costs": "Take into account Ethereum gas costs",
       "tax_free": "Is there a tax free period?",
-      "tax_free_period": "Tax free after how many days"
+      "tax_free_period": "Tax free after how many days",
+      "account_for_assets_movements": "Take into account assets movements fees"
     }
   },
   "account_settings": {
@@ -863,12 +864,13 @@
     "messages": {
       "tax_free_period": "Tax free period set to {period} days",
       "tax_free": "Tax free period {enabled}",
-      "crypto_to_crypto": "Error setting crypto to crypto {message}",
+      "crypto_to_crypto": "Error setting crypto to crypto: {message}",
       "gas_costs": "Error setting Ethereum gas costs: {message}",
       "ignored_success": "{asset} added to ignored assets",
       "ignored_failure": "{asset} could not be added to ignored assets: {message}",
       "unignored_success": "{asset} removed from ignored assets",
-      "unignored_failure": "{asset} could not be removed from ignored assets: {message}"
+      "unignored_failure": "{asset} could not be removed from ignored assets: {message}",
+      "account_for_assets_movements": "Error setting account for assets movements: {message}"
     }
   },
   "settings": {

--- a/frontend/app/src/model/action-result.ts
+++ b/frontend/app/src/model/action-result.ts
@@ -31,6 +31,7 @@ export interface DBSettings {
   readonly kraken_account_type: string;
   readonly active_modules: SupportedModules[];
   readonly frontend_settings: string;
+  readonly account_for_assets_movements: boolean;
 }
 
 interface ApiKey {

--- a/frontend/app/src/typing/types.ts
+++ b/frontend/app/src/typing/types.ts
@@ -24,6 +24,7 @@ export interface AccountingSettings {
   readonly includeCrypto2Crypto: boolean;
   readonly includeGasCosts: boolean;
   readonly taxFreeAfterPeriod: number | null;
+  readonly accountForAssetsMovements: boolean;
 }
 
 export type AccountingSettingsUpdate = {
@@ -117,6 +118,7 @@ interface SettingsPayload {
   premium_should_sync: boolean;
   active_modules: SupportedModules[];
   frontend_settings: string;
+  account_for_assets_movements: boolean;
 }
 
 export type ExternalServiceName = 'etherscan' | 'cryptocompare';

--- a/frontend/app/src/views/settings/AccountingSettings.vue
+++ b/frontend/app/src/views/settings/AccountingSettings.vue
@@ -43,6 +43,21 @@
               type="number"
               @change="onTaxFreePeriodChange($event)"
             />
+            <v-switch
+              v-model="accountForAssetsMovements"
+              class="accounting-settings__account-for-assets-movements"
+              :success-messages="
+                settingsMessages['accountForAssetsMovements'].success
+              "
+              :error-messages="
+                settingsMessages['accountForAssetsMovements'].error
+              "
+              :label="
+                $t('accounting_settings.labels.account_for_assets_movements')
+              "
+              color="primary"
+              @change="onAccountForAssetsMovements($event)"
+            />
           </v-card-text>
         </v-card>
       </v-col>
@@ -149,6 +164,7 @@ export default class Accounting extends Settings {
   gasCosts: boolean = false;
   taxFreeAfterPeriod: number | null = null;
   taxFreePeriod: boolean = false;
+  accountForAssetsMovements: boolean = false;
 
   assetToIgnore: string = '';
   assetToRemove: string = '';
@@ -161,7 +177,8 @@ export default class Accounting extends Settings {
     taxFreePeriod: { success: '', error: '' },
     taxFreePeriodAfter: { success: '', error: '' },
     addIgnoreAsset: { success: '', error: '' },
-    remIgnoreAsset: { success: '', error: '' }
+    remIgnoreAsset: { success: '', error: '' },
+    accountForAssetsMovements: { success: '', error: '' }
   };
 
   taxFreeRules = [
@@ -182,6 +199,7 @@ export default class Accounting extends Settings {
       this.taxFreePeriod = false;
       this.taxFreeAfterPeriod = null;
     }
+    this.accountForAssetsMovements = this.accountingSettings.accountForAssetsMovements;
   }
 
   onTaxFreeChange(enabled: boolean) {
@@ -308,6 +326,33 @@ export default class Accounting extends Settings {
           this.$tc('account_settings.messages.gas_costs', 0, {
             message: reason.message
           })
+        );
+      });
+  }
+
+  onAccountForAssetsMovements(enabled: boolean) {
+    const { commit } = this.$store;
+
+    this.$api
+      .setSettings({ account_for_assets_movements: enabled })
+      .then(settings => {
+        commit('session/accountingSettings', {
+          ...this.accountingSettings,
+          accountForAssetsMovements: settings.account_for_assets_movements
+        });
+        this.validateSettingChange('accountForAssetsMovements', 'success');
+      })
+      .catch(reason => {
+        this.validateSettingChange(
+          'accountForAssetsMovements',
+          'error',
+          this.$tc(
+            'account_settings.messages.account_for_assets_movements',
+            0,
+            {
+              message: reason.message
+            }
+          )
         );
       });
   }

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -97,6 +97,9 @@ class Accountant():
         self.events.profit_currency = settings.main_currency
         self.csvexporter.profit_currency = settings.main_currency
 
+        if settings.account_for_assets_movements is not None:
+            self.events.account_for_assets_movements = settings.account_for_assets_movements
+
     def get_fee_in_profit_currency(self, trade: Trade) -> Fee:
         """Get the profit_currency rate of the fee of the given trade
 
@@ -129,7 +132,7 @@ class Accountant():
         if timestamp < self.start_ts:
             return
 
-        if movement.asset.identifier == 'KFEE':
+        if movement.asset.identifier == 'KFEE' or not self.events.account_for_assets_movements:
             # There is no reason to process deposits of KFEE for kraken as it has only value
             # internal to kraken and KFEE has no value and will error at cryptocompare price query
             return

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -32,6 +32,7 @@ class TaxableEvents():
 
         self._taxfree_after_period: Optional[int] = None
         self._include_crypto2crypto: Optional[bool] = None
+        self._account_for_assets_movements: Optional[bool] = None
 
     def reset(self, start_ts: Timestamp, end_ts: Timestamp) -> None:
         self.events = {}
@@ -62,6 +63,14 @@ class TaxableEvents():
         is_valid = isinstance(value, int) or value is None
         assert is_valid, 'set taxfree_after_period should only get int or None'
         self._taxfree_after_period = value
+
+    @property
+    def account_for_assets_movements(self) -> Optional[bool]:
+        return self._account_for_assets_movements
+
+    @account_for_assets_movements.setter
+    def account_for_assets_movements(self, value: Optional[bool]) -> None:
+        self._account_for_assets_movements = value
 
     def calculate_asset_details(self) -> Dict[Asset, Tuple[FVal, FVal]]:
         """ Calculates what amount of all assets has been untouched for a year and

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -719,6 +719,7 @@ class ModifiableSettingsSchema(Schema):
     kraken_account_type = KrakenAccountTypeField(missing=None)
     active_modules = fields.List(fields.String(), missing=None)
     frontend_settings = fields.String(missing=None)
+    account_for_assets_movements = fields.Bool(missing=None)
 
     @validates_schema  # type: ignore
     def validate_settings_schema(  # pylint: disable=no-self-use
@@ -759,6 +760,7 @@ class ModifiableSettingsSchema(Schema):
             kraken_account_type=data['kraken_account_type'],
             active_modules=data['active_modules'],
             frontend_settings=data['frontend_settings'],
+            account_for_assets_movements=data['account_for_assets_movements'],
         )
 
 

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -27,6 +27,7 @@ DEFAULT_CURRENCY_LOCATION = 'after'
 DEFAULT_SUBMIT_USAGE_ANALYTICS = True
 DEFAULT_KRAKEN_ACCOUNT_TYPE = KrakenAccountType.STARTER
 DEFAULT_ACTIVE_MODULES = AVAILABLE_MODULES
+DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS = True
 
 
 class DBSettings(NamedTuple):
@@ -53,6 +54,7 @@ class DBSettings(NamedTuple):
     kraken_account_type: KrakenAccountType = DEFAULT_KRAKEN_ACCOUNT_TYPE
     active_modules: List[str] = DEFAULT_ACTIVE_MODULES
     frontend_settings: str = ''
+    account_for_assets_movements: bool = DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS
 
 
 class ModifiableDBSettings(NamedTuple):
@@ -74,6 +76,7 @@ class ModifiableDBSettings(NamedTuple):
     kraken_account_type: Optional[KrakenAccountType] = None
     active_modules: Optional[List[str]] = None
     frontend_settings: Optional[str] = None
+    account_for_assets_movements: Optional[bool] = None
 
     def serialize(self) -> Dict[str, Any]:
         settings_dict = {}
@@ -178,6 +181,8 @@ def db_settings_from_dict(
             specified_args[key] = json.loads(value)
         elif key == 'frontend_settings':
             specified_args[key] = str(value)
+        elif key == 'account_for_assets_movements':
+            specified_args[key] = read_boolean(value)
         else:
             msg_aggregator.add_warning(
                 f'Unknown DB setting {key} given. Ignoring it. Should not '

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -31,6 +31,7 @@ from rotkehlchen.db.settings import (
     ROTKEHLCHEN_DB_VERSION,
     DBSettings,
     ModifiableDBSettings,
+    DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS,
 )
 from rotkehlchen.db.utils import AssetBalance, BlockchainAccounts, LocationData
 from rotkehlchen.errors import AuthenticationError, InputError
@@ -280,6 +281,7 @@ def test_writing_fetching_data(data_dir, username):
         'kraken_account_type': DEFAULT_KRAKEN_ACCOUNT_TYPE,
         'active_modules': DEFAULT_ACTIVE_MODULES,
         'frontend_settings': '',
+        'account_for_assets_movements': DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS,
     }
     assert len(expected_dict) == len(DBSettings()), 'One or more settings are missing'
 


### PR DESCRIPTION
Fix #176
Added switch in the accounting settings "Take into account assets movements fees"
Default value: true

Not really sure about the proper use of the new setting in:
rotkehlchen/accounting/accountant.py
line 132