### PR TITLE
Better handling double crypto.com entries (dust_conversion, swap, ...)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`1840` Better handling double crypto.com entries (dust_conversion, swap, ...) from csv export.
+
 * :release:`1.9.1 <2020-11-29>`
 * :feature:`1716` Rotki can now also query data from the following ethereum open nodes:
   - 1inch

--- a/rotkehlchen/tests/data/cryptocom_trades_list.csv
+++ b/rotkehlchen/tests/data/cryptocom_trades_list.csv
@@ -1,4 +1,6 @@
 ﻿Timestamp (UTC),Transaction Description,Currency,Amount,To Currency,To Amount,Native Currency,Native Amount,Native Amount (in USD),Transaction Kind
+2020-12-01 14:39:25,Convert Dust,CRO,0.007231228760408149,,,EUR,0.0,0,dust_conversion_credited
+2020-12-01 14:39:25,Convert Dust,DAI,-0.00050680380674961,,,EUR,0.0,0,dust_conversion_debited
 2020-10-12 19:10:36,Transfer: Exchange -> App wallet,ETH,0.033,,,EUR,10.75,12.7743325,exchange_to_crypto_transfer
 2020-10-12 19:09:36,Transfer: App wallet -> Exchange,CRO,-161.73231782,,,EUR,-10.71,-12.7268001,crypto_to_exchange_transfer
 2020-10-12 18:09:36,Referral Bonus Reward,CRO,482.2566417,,,EUR,42.23,49.2763433,referral_bonus

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -164,7 +164,7 @@ def assert_cryptocom_import_results(rotki: Rotkehlchen):
         fee=Fee(ZERO),
         fee_currency=A_USD,
         link='',
-        notes=get_trade_note('Coin Swap'),
+        notes=get_trade_note('MCO/CRO Overall Swap'),
     ), Trade(
         timestamp=Timestamp(1596730165),
         location=Location.CRYPTOCOM,
@@ -175,7 +175,7 @@ def assert_cryptocom_import_results(rotki: Rotkehlchen):
         fee=Fee(ZERO),
         fee_currency=A_USD,
         link='',
-        notes=get_trade_note('Coin Swap'),
+        notes=get_trade_note('MCO/CRO Overall Swap'),
     ), Trade(
         timestamp=Timestamp(1599934176),
         location=Location.CRYPTOCOM,
@@ -209,6 +209,17 @@ def assert_cryptocom_import_results(rotki: Rotkehlchen):
         fee_currency=A_USD,
         link='',
         notes=get_trade_note('Referral Bonus Reward'),
+    ), Trade(
+        timestamp=Timestamp(1606833565),
+        location=Location.CRYPTOCOM,
+        pair=TradePair('CRO_DAI'),
+        trade_type=TradeType.BUY,
+        amount=AssetAmount(FVal('0.007231228760408149')),
+        rate=Price(FVal('14.26830000900286970270179629')),
+        fee=Fee(ZERO),
+        fee_currency=A_USD,
+        link='',
+        notes=get_trade_note('Convert Dust'),
     )]
     assert expected_trades == trades
 


### PR DESCRIPTION
Use a generic importer to handle those double entries so it can be used for other double entries types.

Also add crypto.com supercharger deposits/withdrawals to ignored entries.