### PR TITLE
Introduces a new download endpoint, adds upload support to import

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`1611` Rotki can now import data and download the tax report csv when running in the browser.
 * :feature:`176` Add an accounting setting to make asset movements fees (deposits/withdrawals to/from exchanges) inclusion in the profit loss report configurable.
 * :feature:`1840` Better handling double crypto.com entries (dust_conversion, swap, ...) from csv export.
 * :feature:`1605` User funds in Binance's futures wallet should now also be included in Rotki

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 * :feature:`1611` Rotki can now import data and download the tax report csv when running in the browser.
 * :feature:`176` Add an accounting setting to make asset movements fees (deposits/withdrawals to/from exchanges) inclusion in the profit loss report configurable.
-* :feature:`1840` Better handling double crypto.com entries (dust_conversion, swap, ...) from csv export.
+* :feature:`1840` Better handling double crypto.com entries (dust_conversion, swap, ...) from csv export. Also crypto.com imported trades and asset movements now appear in the history UI component
 * :feature:`1605` User funds in Binance's futures wallet should now also be included in Rotki
 
 * :release:`1.9.1 <2020-11-29>`

--- a/frontend/app/.eslintrc.js
+++ b/frontend/app/.eslintrc.js
@@ -119,7 +119,7 @@ module.exports = {
       'error',
       {
         html: {
-          void: 'never',
+          void: 'always',
           normal: 'always',
           component: 'always'
         },

--- a/frontend/app/src/background.ts
+++ b/frontend/app/src/background.ts
@@ -323,10 +323,6 @@ app.on('ready', async () => {
     }
     shell.openExternal(args);
   });
-  ipcMain.on('OPEN_FILE', async (event, args) => {
-    const file = await select(args, 'openFile');
-    event.sender.send('OPEN_FILE', file);
-  });
   ipcMain.on('OPEN_DIRECTORY', async (event, args) => {
     const directory = await select(args, 'openDirectory');
     event.sender.send('OPEN_DIRECTORY', directory);

--- a/frontend/app/src/components/history/consts.ts
+++ b/frontend/app/src/components/history/consts.ts
@@ -1,52 +1,69 @@
 import { TradeLocationData } from '@/components/history/type';
+import {
+  EXCHANGE_BINANCE,
+  EXCHANGE_BITMEX,
+  EXCHANGE_BITTREX,
+  EXCHANGE_COINBASE,
+  EXCHANGE_COINBASEPRO,
+  EXCHANGE_CRYPTOCOM,
+  EXCHANGE_GEMINI,
+  EXCHANGE_KRAKEN,
+  EXCHANGE_POLONIEX,
+  EXCHANGE_UNISWAP
+} from '@/data/defaults';
 import { TradeLocation } from '@/services/history/types';
 import { assert } from '@/utils/assertions';
 
 export const tradeLocations: TradeLocationData[] = [
   {
-    identifier: 'kraken',
+    identifier: EXCHANGE_KRAKEN,
     name: 'Kraken',
     icon: require('@/assets/images/kraken.png')
   },
   {
-    identifier: 'poloniex',
+    identifier: EXCHANGE_POLONIEX,
     name: 'Poloniex',
     icon: require('@/assets/images/poloniex.png')
   },
   {
-    identifier: 'bitmex',
+    identifier: EXCHANGE_BITMEX,
     name: 'Bitmex',
     icon: require('@/assets/images/bitmex.png')
   },
   {
-    identifier: 'binance',
+    identifier: EXCHANGE_BINANCE,
     name: 'Binance',
     icon: require('@/assets/images/binance.png')
   },
   {
-    identifier: 'bittrex',
+    identifier: EXCHANGE_BITTREX,
     name: 'Bittrex',
     icon: require('@/assets/images/bittrex.png')
   },
   {
-    identifier: 'gemini',
+    identifier: EXCHANGE_GEMINI,
     name: 'Gemini',
     icon: require('@/assets/images/gemini.png')
   },
   {
-    identifier: 'coinbase',
+    identifier: EXCHANGE_COINBASE,
     name: 'Coinbase',
     icon: require('@/assets/images/coinbase.png')
   },
   {
-    identifier: 'coinbasepro',
+    identifier: EXCHANGE_COINBASEPRO,
     name: 'Coinbase Pro',
     icon: require('@/assets/images/coinbasepro.png')
   },
   {
-    identifier: 'uniswap',
+    identifier: EXCHANGE_UNISWAP,
     name: 'Uniswap',
     icon: require('@/assets/images/defi/uniswap.svg')
+  },
+  {
+    identifier: EXCHANGE_CRYPTOCOM,
+    name: 'Crypto.com',
+    icon: require('@/assets/images/crypto.com.png')
   },
   {
     identifier: 'external',

--- a/frontend/app/src/components/import/FileUpload.vue
+++ b/frontend/app/src/components/import/FileUpload.vue
@@ -1,0 +1,170 @@
+<template>
+  <v-row>
+    <v-col>
+      <div
+        class="file-upload__drop"
+        :class="active ? 'file-upload__drop--active' : null"
+        @dragover.prevent
+        @drop="onDrop"
+        @dragenter="onEnter"
+        @dragleave="onLeave"
+      >
+        <div
+          v-if="error"
+          class="d-flex flex-column align-center justify-center"
+        >
+          <v-btn icon small class="align-self-end" @click="error = ''">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+          <v-icon x-large color="error">mdi-alert-circle</v-icon>
+          <span class="error--text mt-2">{{ error }}</span>
+        </div>
+        <div
+          v-else-if="!uploaded"
+          class="d-flex flex-column align-center justify-center"
+        >
+          <v-icon x-large color="primary">mdi-upload</v-icon>
+          <input
+            ref="select"
+            type="file"
+            accept=".csv"
+            hidden
+            @change="onSelect"
+          />
+          <i18n
+            path="file_upload.drop_area"
+            class="mt-2 caption text--secondary d-flex flex-column"
+            tag="div"
+          >
+            <v-btn
+              class="mt-2"
+              color="primary"
+              small
+              text
+              outlined
+              @click="$refs.select.click()"
+              v-text="$t('file_upload.select_file')"
+            />
+          </i18n>
+        </div>
+        <div v-else class="d-flex flex-column align-center justify-center">
+          <v-icon x-large color="primary">mdi-check-circle</v-icon>
+          <div class="mt-2" v-text="$t('file_upload.import_complete')" />
+        </div>
+      </div>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+@Component({})
+export default class FileUpload extends Vue {
+  @Prop({ required: true, type: String })
+  source!: string;
+
+  error: string = '';
+  active: boolean = false;
+  count: number = 0;
+  uploaded = false;
+
+  done() {
+    this.uploaded = true;
+    setTimeout(() => {
+      this.uploaded = false;
+    }, 4000);
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    this.active = false;
+    if (!event.dataTransfer?.files?.length) {
+      return;
+    }
+
+    this.upload(event.dataTransfer.files);
+  }
+
+  onEnter(event: DragEvent) {
+    event.preventDefault();
+    this.count++;
+    this.active = true;
+  }
+
+  onLeave(event: DragEvent) {
+    event.preventDefault();
+    this.count--;
+
+    if (this.count === 0) {
+      this.active = false;
+    }
+  }
+
+  onSelect(event: Event) {
+    const target = event.target as HTMLInputElement;
+    if (!target || !target.files) {
+      return;
+    }
+    this.upload(target.files);
+  }
+
+  onError(message: string) {
+    this.error = message;
+    this.count = 0;
+    this.active = false;
+  }
+
+  async uploadPackaged(file: string) {
+    try {
+      await this.$api.importDataFrom(this.source, file);
+      this.done();
+    } catch (e) {
+      this.onError(e.message);
+    }
+  }
+
+  upload(files: FileList) {
+    if (this.error || this.uploaded) {
+      return;
+    }
+
+    if (files.length !== 1) {
+      this.onError(this.$tc('file_upload.many_files_selected'));
+      return;
+    }
+
+    if (!files[0].name.endsWith('.csv')) {
+      this.onError(this.$tc('file_upload.only_csv'));
+      return;
+    }
+
+    if (this.$interop.isPackaged) {
+      this.uploadPackaged(files[0].path);
+    } else {
+      const formData = new FormData();
+      formData.append('source', this.source);
+      formData.append('file', files[0]);
+      this.$api
+        .importFile(formData)
+        .catch(({ message }) => this.onError(message))
+        .then(this.done);
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.file-upload {
+  &__drop {
+    padding: 12px;
+    border: var(--v-rotki-light-grey-darken1) solid thin;
+    width: 100%;
+    border-radius: 4px;
+
+    &--active {
+      background-color: #f9f9f9;
+    }
+  }
+}
+</style>

--- a/frontend/app/src/components/settings/AssetBalances.vue
+++ b/frontend/app/src/components/settings/AssetBalances.vue
@@ -23,9 +23,10 @@
       </template>
       <template #item.usdValue="{ item }">
         <amount-display
-          fiat-currency="USD"
-          :value="item.usdValue"
           show-currency="symbol"
+          :fiat-currency="item.asset"
+          :amount="item.amount"
+          :value="item.usdValue"
         />
       </template>
       <template v-if="balances.length > 0" #body.append>

--- a/frontend/app/src/data/defaults.ts
+++ b/frontend/app/src/data/defaults.ts
@@ -12,13 +12,27 @@ export class Defaults {
   static KRAKEN_DEFAULT_ACCOUNT_TYPE = 'starter';
 }
 
+export const EXCHANGE_POLONIEX = 'poloniex';
+export const EXCHANGE_KRAKEN = 'kraken';
+export const EXCHANGE_BITTREX = 'bittrex';
+export const EXCHANGE_BITMEX = 'bitmex';
+export const EXCHANGE_BINANCE = 'binance';
+export const EXCHANGE_COINBASE = 'coinbase';
+export const EXCHANGE_COINBASEPRO = 'coinbasepro';
+export const EXCHANGE_GEMINI = 'gemini';
+export const EXCHANGE_CRYPTOCOM = 'crypto.com';
+
+export const EXCHANGE_UNISWAP = 'uniswap';
+export const TRADE_LOCATION_EXTERNAL = 'external';
+
 export const exchanges = [
-  'poloniex',
-  'kraken',
-  'bittrex',
-  'bitmex',
-  'binance',
-  'coinbase',
-  'coinbasepro',
-  'gemini'
+  EXCHANGE_POLONIEX,
+  EXCHANGE_KRAKEN,
+  EXCHANGE_BITTREX,
+  EXCHANGE_BITMEX,
+  EXCHANGE_BINANCE,
+  EXCHANGE_COINBASE,
+  EXCHANGE_COINBASEPRO,
+  EXCHANGE_GEMINI,
+  EXCHANGE_CRYPTOCOM
 ] as const;

--- a/frontend/app/src/electron-interop.ts
+++ b/frontend/app/src/electron-interop.ts
@@ -1,4 +1,3 @@
-import { api } from '@/services/rotkehlchen-api';
 import { assert } from '@/utils/assertions';
 import { Level } from '@/utils/log-level';
 
@@ -11,14 +10,6 @@ export class ElectronInterop {
 
   get isPackaged(): boolean {
     return this.packagedApp;
-  }
-
-  get downloadCSV(): string | null {
-    if (this.isPackaged) {
-      return null;
-    }
-
-    return api.csvDownloadUrl;
   }
 
   navigateToPremium() {

--- a/frontend/app/src/electron-interop.ts
+++ b/frontend/app/src/electron-interop.ts
@@ -1,3 +1,4 @@
+import { api } from '@/services/rotkehlchen-api';
 import { assert } from '@/utils/assertions';
 import { Level } from '@/utils/log-level';
 
@@ -10,6 +11,14 @@ export class ElectronInterop {
 
   get isPackaged(): boolean {
     return this.packagedApp;
+  }
+
+  get downloadCSV(): string | null {
+    if (this.isPackaged) {
+      return null;
+    }
+
+    return api.csvDownloadUrl;
   }
 
   navigateToPremium() {

--- a/frontend/app/src/electron-interop.ts
+++ b/frontend/app/src/electron-interop.ts
@@ -28,10 +28,6 @@ export class ElectronInterop {
     return (await window.interop?.openDirectory(title)) ?? undefined;
   }
 
-  async openFile(title: string): Promise<string | undefined> {
-    return (await window.interop?.openFile(title)) ?? undefined;
-  }
-
   openUrl(url: string) {
     window.interop?.openUrl(url);
   }

--- a/frontend/app/src/electron-main/ipc.ts
+++ b/frontend/app/src/electron-main/ipc.ts
@@ -18,7 +18,6 @@ export interface Interop {
   openUrl(url: string): Promise<void>;
   closeApp(): void;
   listenForErrors(callback: (backendOutput: string) => void): void;
-  openFile(title: string): Promise<undefined | string>;
   openDirectory(title: string): Promise<undefined | string>;
   premiumUserLoggedIn(premiumUser: boolean): Promise<undefined | boolean>;
   monitorDebugSettings(): void;

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -893,6 +893,7 @@
     "get_premium": "@:common.visit_website"
   },
   "tax_report": {
+    "download_csv": "Download CSV",
     "title": "Tax Report",
     "export_csv": "Export CSV",
     "loading_message": "Please wait while your report is generated...",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -43,6 +43,13 @@
   "dex_trades": {
     "loading": "@:common.loading.please_wait DEX Trades are @:common.loading.getting_loaded"
   },
+  "file_upload": {
+    "drop_area": "Drop the csv file or {0}",
+    "import_complete": "Import was completed successfully.",
+    "select_file": "Select file",
+    "many_files_selected": "One one csv file must be selected",
+    "only_csv": "Only csv files are allowed"
+  },
   "helpers": {
     "refresh_header": {
       "tooltip": "Refresh {title} data"
@@ -894,7 +901,31 @@
     "csv_export_error": "There was an error with Export"
   },
   "import_data": {
-    "title": "Import Data"
+    "cointracking": {
+      "line_one": "Trades/deposits/withdrawals from Cointracking do not include fees.",
+      "line_two": "All trades imported from Cointracking will always be considered as buys due to the way the data are represented.",
+      "line_three": "ETH/BTC Transactions are treated as deposits/withdrawals so they are not imported in rotki. To import ETH transactions simply input your accounts in {0} and they will be imported automatically for you.",
+      "link": "Blockchain Accounts/Balances",
+      "name": "cointracking",
+      "note": " Important notes for importing data from {0}'s CSV exports.",
+      "preferred": "For the above reasons it's preferred to directly connect your exchanges in order to import data from there. If you do not do that a lot of accuracy is lost."
+    },
+    "cryptocom": {
+      "line_one": "[Early stage] This import script may miss some transactions types, like withdrawals. Since we can't have an exhaustive list of every type, we develop it using what we know at the time. If you think that import script can be improved and you can help providing more data types, {0}.",
+      "line_one_link": "please let us know",
+      "line_two": "{0} If you want to connect your Crypto.com Exchange account, please wait until we support it and then connect to it as an exchange.",
+      "line_two_warning": "It only concerns the Crypto.com mobile application.",
+      "line_three": "Trades/deposits/withdrawals from crypto.com do not include fees details. They are waived at the moment (August 2020) or they are handled in the traded amount.",
+      "line_four": "Only transactions are imported here (for tax report), if you want the assets be displayed in your Rotki balances, you have to add them manually as manual balances: {0}",
+      "line_four_link": "Manual Accounts/Balances",
+      "name": "crypto.com mobile app",
+      "note": "Important notes for importing data from {0}'s CSV exports."
+    },
+    "description": "You can manually import data from the services below by clicking on the respective logo",
+    "title": "Import Data",
+    "notice": "{warning} Those platforms could change their format in a backwards incompatible way quite often. As such this import may stop working. If that happens {link} and we will see what we can do.",
+    "notice_warning": "⚠️Important notice ⚠️:",
+    "notice_link": "open an issue with rotki"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -894,6 +894,7 @@
   },
   "tax_report": {
     "download_csv": "Download CSV",
+    "download_failed": "Download of report is not possible",
     "title": "Tax Report",
     "export_csv": "Export CSV",
     "loading_message": "Please wait while your report is generated...",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -922,7 +922,7 @@
       "name": "crypto.com mobile app",
       "note": "Important notes for importing data from {0}'s CSV exports."
     },
-    "description": "You can manually import data from the services below by clicking on the respective logo",
+    "description": "You can manually import data from the services below by dragging the file on the respective area or clicking the select button.",
     "title": "Import Data",
     "notice": "{warning} Those platforms could change their format in a backwards incompatible way quite often. As such this import may stop working. If that happens {link} and we will see what we can do.",
     "notice_warning": "⚠️Important notice ⚠️:",

--- a/frontend/app/src/preload.ts
+++ b/frontend/app/src/preload.ts
@@ -26,7 +26,6 @@ if (isDevelopment) {
 contextBridge.exposeInMainWorld('interop', {
   openUrl: (url: string) => ipcRenderer.send('OPEN_URL', url),
   closeApp: () => ipcRenderer.send('CLOSE_APP'),
-  openFile: (title: string) => ipcAction('OPEN_FILE', title),
   openDirectory: (title: string) => ipcAction('OPEN_DIRECTORY', title),
   premiumUserLoggedIn: (premiumUser: boolean) =>
     ipcRenderer.send('PREMIUM_USER_LOGGED_IN', premiumUser),

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -96,6 +96,10 @@ export class RotkehlchenApi {
     return this._history;
   }
 
+  get csvDownloadUrl(): string {
+    return `${this.axios.defaults.baseURL}/history/download`;
+  }
+
   setup(serverUrl: string) {
     this.axios = axios.create({
       baseURL: `${serverUrl}/api/1/`,

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -831,6 +831,17 @@ export class RotkehlchenApi {
       })
       .then(handleResponse);
   }
+
+  importFile(data: FormData) {
+    return this.axios
+      .post<ActionResult<boolean>>('/import', data, {
+        validateStatus: validStatus,
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      })
+      .then(handleResponse);
+  }
 }
 
 export const api = new RotkehlchenApi();

--- a/frontend/app/src/store/history/actions.ts
+++ b/frontend/app/src/store/history/actions.ts
@@ -1,6 +1,7 @@
 import { Transaction } from 'electron';
 import { ActionTree } from 'vuex';
 import { exchangeName } from '@/components/history/consts';
+import { EXCHANGE_CRYPTOCOM, TRADE_LOCATION_EXTERNAL } from '@/data/defaults';
 import i18n from '@/i18n';
 import { createTask, taskCompletion, TaskMeta } from '@/model/task';
 import { TaskType } from '@/model/task-type';
@@ -67,7 +68,11 @@ export const actions: ActionTree<HistoryState, RotkehlchenState> = {
     setStatus(refresh ? Status.REFRESHING : Status.LOADING);
 
     const { connectedExchanges } = balances!;
-    const locations: TradeLocation[] = [...connectedExchanges, 'external'];
+    const locations: TradeLocation[] = [
+      ...connectedExchanges,
+      TRADE_LOCATION_EXTERNAL,
+      EXCHANGE_CRYPTOCOM
+    ];
 
     const fetchLocation: (
       location: TradeLocation
@@ -253,7 +258,7 @@ export const actions: ActionTree<HistoryState, RotkehlchenState> = {
     };
 
     await Promise.all(
-      locations.map(location =>
+      ([...locations, EXCHANGE_CRYPTOCOM] as TradeLocation[]).map(location =>
         fetchLocation(location).catch(e => onError(location, e.message))
       )
     );

--- a/frontend/app/src/views/ImportData.vue
+++ b/frontend/app/src/views/ImportData.vue
@@ -1,123 +1,118 @@
 <template>
   <v-container>
     <base-page-header :text="$t('import_data.title')" />
-    <v-row>
-      <v-col cols="12">
+    <v-card outlined>
+      <v-card-text>
         <v-row>
           <v-col cols="12">
-            You can manually import data from the services below by clicking on
-            the respective logo
-          </v-col>
-          <v-col cols="12">
-            <strong> ⚠️Important notice ⚠️:</strong> Those platforms could
-            change their format in a backwards incompatible way quite often. As
-            such this import may stop working. If that happens
-            <external-link
-              url="https://github.com/rotki/rotki/issues/new/choose"
-            >
-              open an issue with rotki
-            </external-link>
-            and we will see what we can do.
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col cols="12">
-            <v-img
-              max-width="200"
-              class="import-data__cointracking-info elevation-1"
-              :src="require('../assets/images/import/cointracking_info.png')"
-              @click="importData('cointracking.info')"
-            />
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col cols="12">
-            Important notes for importing data from
-            <strong>cointracking</strong>'s CSV exports.
-            <ul>
-              <li>
-                Trades/deposits/withdrawals from Cointracking do not include
-                fees.
-              </li>
-              <li>
-                All trades imported from Cointracking will always be considered
-                as buys due to the way the data are represented.
-              </li>
-              <li>
-                ETH/BTC Transactions are treated as deposits/withdrawals so they
-                are not imported in Rotkehlchen. To import ETH transactions
-                simply input your accounts in
-                <router-link to="/accounts-balance">
-                  Blockchain Accounts/Balances
-                </router-link>
-                and they will be imported automatically for you.
-              </li>
-            </ul>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col cols="12">
-            For the above reasons it's preferred to directly connect your
-            exchanges in order to import data from there. If you do not do that
-            a lot of accuracy is lost.
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col cols="12">
-            <div
-              class="import-data__crypto-com elevation-1"
-              @click="importData('crypto.com')"
-            >
-              <v-img
-                max-width="200"
-                :src="require('../assets/images/import/crypto_com.png')"
+            <v-row>
+              <v-col cols="12" v-text="$t('import_data.description')" />
+              <v-col cols="12">
+                <i18n tag="span" path="import_data.notice">
+                  <template #warning>
+                    <strong v-text="$t('import_data.notice_warning')" />
+                  </template>
+                  <template #link>
+                    <external-link
+                      url="https://github.com/rotki/rotki/issues/new/choose"
+                      v-text="$t('import_data.notice_link')"
+                    />
+                  </template>
+                </i18n>
+              </v-col>
+            </v-row>
+            <v-divider class="mt-1" />
+            <v-row>
+              <v-col cols="12">
+                <v-img
+                  max-width="200"
+                  class="import-data__cointracking-info"
+                  :src="require('@/assets/images/import/cointracking_info.png')"
+                />
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <file-upload source="cointracking.info" />
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="12">
+                <i18n tag="span" path="import_data.cointracking.note">
+                  <strong v-text="$t('import_data.cointracking.name')" />
+                </i18n>
+                <ul>
+                  <li>{{ $t('import_data.cointracking.line_one') }}</li>
+                  <li>{{ $t('import_data.cointracking.line_two') }}</li>
+                  <i18n path="import_data.cointracking.line_three">
+                    <router-link
+                      to="/accounts-balance"
+                      v-text="$t('import_data.cointracking.link')"
+                    />
+                  </i18n>
+                </ul>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col
+                cols="12"
+                v-text="$t('import_data.cointracking.preferred')"
               />
-            </div>
+            </v-row>
+            <v-divider class="mt-1" />
+            <v-row>
+              <v-col cols="12">
+                <div class="import-data__crypto-com">
+                  <v-img
+                    max-width="200"
+                    :src="require('@/assets/images/import/crypto_com.png')"
+                  />
+                </div>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <file-upload source="crypto.com" />
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="12">
+                <i18n tag="span" path="import_data.cryptocom.note">
+                  <strong v-text="$t('import_data.cryptocom.name')" />
+                </i18n>
+
+                <ul>
+                  <li>
+                    <i18n tag="span" path="import_data.cryptocom.line_one">
+                      <external-link
+                        url="https://github.com/rotki/rotki/issues/new/choose"
+                        v-text="$t('import_data.cryptocom.line_one_link')"
+                      />
+                    </i18n>
+                  </li>
+                  <li>
+                    <i18n tag="span" path="import_data.cryptocom.line_two">
+                      <strong
+                        v-text="$t('import_data.cryptocom.line_two_warning')"
+                      />
+                    </i18n>
+                  </li>
+                  <li v-text="$t('import_data.cryptocom.line_three')" />
+                  <li>
+                    <i18n path="import_data.cryptocom.line_four" tag="span">
+                      <router-link
+                        to="/accounts-balance/manual-balances"
+                        v-text="$t('import_data.cryptocom.line_four_link')"
+                      />
+                    </i18n>
+                  </li>
+                </ul>
+              </v-col>
+            </v-row>
           </v-col>
         </v-row>
-        <v-row>
-          <v-col cols="12">
-            Important notes for importing data from
-            <strong>crypto.com mobile app</strong>'s CSV exports.
-            <ul>
-              <li>
-                [Early stage] This import script may miss some transactions
-                types, like withdrawals. Since we can't have an exhaustive list
-                of every type, we develop it using what we know at the time. If
-                you think that import script can be improved and you can help
-                providing more data types,
-                <external-link
-                  url="https://github.com/rotki/rotki/issues/new/choose"
-                >
-                  please let us know
-                </external-link>
-                .
-              </li>
-              <li>
-                <strong>
-                  It only concerns the Crypto.com mobile application.
-                </strong>
-                If you want to connect your Crypto.com Exchange account, please
-                wait until we support it and then connect to it as an exchange.
-              </li>
-              <li>
-                Trades/deposits/withdrawals from crypto.com do not include fees
-                details. They are waived at the moment (August 2020) or they are
-                handled in the traded amount.
-              </li>
-              <li>
-                Only transactions are imported here (for tax report), if you
-                want the assets be displayed in your Rotki balances, you have to
-                add them manually as manual balances:
-                <router-link to="/accounts-balance/manual-balances">
-                  Manual Accounts/Balances
-                </router-link>
-              </li>
-            </ul>
-          </v-col>
-        </v-row>
-      </v-col>
-    </v-row>
+      </v-card-text>
+    </v-card>
   </v-container>
 </template>
 
@@ -125,32 +120,12 @@
 import { Component, Vue } from 'vue-property-decorator';
 import BasePageHeader from '@/components/base/BasePageHeader.vue';
 import ExternalLink from '@/components/helper/ExternalLink.vue';
-import { Message } from '@/store/types';
+import FileUpload from '@/components/import/FileUpload.vue';
 
 @Component({
-  components: { BasePageHeader, ExternalLink }
+  components: { FileUpload, BasePageHeader, ExternalLink }
 })
-export default class ImportData extends Vue {
-  async importData(importType: string) {
-    try {
-      const file = await this.$interop.openFile('Select a file');
-      if (!file) {
-        return;
-      }
-      await this.$api.importDataFrom(importType, file);
-      this.$store.commit('setMessage', {
-        success: true,
-        title: 'Import successful',
-        description: `Data imported from ${importType} export file successfully`
-      } as Message);
-    } catch (e) {
-      this.$store.commit('setMessage', {
-        title: 'Import failed',
-        description: e.message
-      } as Message);
-    }
-  }
-}
+export default class ImportData extends Vue {}
 </script>
 
 <style scoped lang="scss">
@@ -158,16 +133,6 @@ export default class ImportData extends Vue {
   &__crypto-com {
     max-width: 200px;
     padding: 10px;
-
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
-  &__cointracking-info {
-    &:hover {
-      cursor: pointer;
-    }
   }
 }
 </style>

--- a/frontend/app/src/views/TaxReport.vue
+++ b/frontend/app/src/views/TaxReport.vue
@@ -7,8 +7,6 @@
         class="tax-report__export-csv"
         depressed
         color="primary"
-        :target="$interop.isPackaged ? null : '_blank'"
-        :href="$interop.downloadCSV"
         @click="exportCSV()"
       >
         {{
@@ -72,19 +70,31 @@ export default class TaxReport extends Vue {
 
   async exportCSV() {
     try {
-      const directory = await this.$interop.openDirectory(
-        this.$tc('tax_report.select_directory')
-      );
-      if (!directory) {
-        return;
+      if (this.$interop.isPackaged) {
+        const directory = await this.$interop.openDirectory(
+          this.$tc('tax_report.select_directory')
+        );
+        if (!directory) {
+          return;
+        }
+        await this.$store.dispatch('reports/createCSV', directory);
+      } else {
+        const { success, message } = await this.$api.downloadCSV();
+        if (!success) {
+          this.showMessage(message);
+        }
       }
-      await this.$store.dispatch('reports/createCSV', directory);
     } catch (e) {
-      this.$store.commit('setMessage', {
-        title: this.$tc('tax_report.csv_export_error'),
-        description: e.message
-      } as Message);
+      const description = e.message;
+      this.showMessage(description);
     }
+  }
+
+  private showMessage(description) {
+    this.$store.commit('setMessage', {
+      title: this.$tc('tax_report.csv_export_error'),
+      description: description
+    } as Message);
   }
 }
 </script>

--- a/frontend/app/src/views/TaxReport.vue
+++ b/frontend/app/src/views/TaxReport.vue
@@ -7,9 +7,15 @@
         class="tax-report__export-csv"
         depressed
         color="primary"
+        :target="$interop.isPackaged ? null : '_blank'"
+        :href="$interop.downloadCSV"
         @click="exportCSV()"
       >
-        {{ $t('tax_report.export_csv') }}
+        {{
+          $interop.isPackaged
+            ? $t('tax_report.export_csv')
+            : $t('tax_report.download_csv')
+        }}
       </v-btn>
       <tax-report-overview class="tax-report__section" />
       <tax-report-events class="tax-report__section" />

--- a/frontend/app/src/views/TaxReport.vue
+++ b/frontend/app/src/views/TaxReport.vue
@@ -81,7 +81,7 @@ export default class TaxReport extends Vue {
       } else {
         const { success, message } = await this.$api.downloadCSV();
         if (!success) {
-          this.showMessage(message);
+          this.showMessage(message ?? this.$tc('tax_report.download_failed'));
         }
       }
     } catch (e) {
@@ -90,7 +90,7 @@ export default class TaxReport extends Vue {
     }
   }
 
-  private showMessage(description) {
+  private showMessage(description: string) {
     this.$store.commit('setMessage', {
       title: this.$tc('tax_report.csv_export_error'),
       description: description

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1507,9 +1507,15 @@ class RestAPI():
             filepath: Path,
     ) -> Response:
         if source == 'cointracking.info':
-            self.rotkehlchen.data_importer.import_cointracking_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_cointracking_csv(filepath)
+            if not success:
+                result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
+                return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         elif source == 'crypto.com':
-            self.rotkehlchen.data_importer.import_cryptocom_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_cryptocom_csv(filepath)
+            if not success:
+                result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
+                return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
     def _get_eth2_stake(self) -> Dict[str, Any]:

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -37,6 +37,7 @@ from rotkehlchen.api.v1.resources import (
     ExchangesResource,
     ExternalServicesResource,
     FiatExchangeRatesResource,
+    HistoryDownloadingResource,
     HistoryExportingResource,
     HistoryProcessingResource,
     IgnoredAssetsResource,
@@ -127,6 +128,7 @@ URLS_V1: URLS = [
     ('/periodic/', PeriodicDataResource),
     ('/history/', HistoryProcessingResource),
     ('/history/export/', HistoryExportingResource),
+    ('/history/download/', HistoryDownloadingResource),
     ('/queried_addresses', QueriedAddressesResource),
     ('/blockchains/ETH/transactions', EthereumTransactionsResource),
     (

--- a/rotkehlchen/csv_exporter.py
+++ b/rotkehlchen/csv_exporter.py
@@ -1,5 +1,4 @@
 import csv
-from os import remove
 from tempfile import mkdtemp
 from zipfile import ZipFile
 
@@ -516,6 +515,8 @@ class CSVExporter():
     def create_zip(self) -> Optional[str]:
         if not self.create_csv:
             return None
+
+        # TODO: Find a way to properly delete the directory after send is complete
         dirpath = Path(mkdtemp())
         success, _ = self.create_files(dirpath)
         if not success:
@@ -538,6 +539,6 @@ class CSVExporter():
                     continue
 
                 csv_zip.write(path, filename)
-                remove(path)
+                path.unlink()
 
         return csv_zip.filename

--- a/rotkehlchen/csv_exporter.py
+++ b/rotkehlchen/csv_exporter.py
@@ -1,4 +1,8 @@
 import csv
+from os import remove
+from tempfile import mkdtemp
+from zipfile import ZipFile
+
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -508,3 +512,32 @@ class CSVExporter():
             return False, str(e)
 
         return True, ''
+
+    def create_zip(self) -> Optional[str]:
+        if not self.create_csv:
+            return None
+        dirpath = Path(mkdtemp())
+        success, _ = self.create_files(dirpath)
+        if not success:
+            return None
+
+        files: List[Tuple[Path, str]] = [
+            (dirpath / FILENAME_TRADES_CSV, FILENAME_TRADES_CSV),
+            (dirpath / FILENAME_LOAN_PROFITS_CSV, FILENAME_LOAN_PROFITS_CSV),
+            (dirpath / FILENAME_ASSET_MOVEMENTS_CSV, FILENAME_ASSET_MOVEMENTS_CSV),
+            (dirpath / FILENAME_GAS_CSV, FILENAME_GAS_CSV),
+            (dirpath / FILENAME_MARGIN_CSV, FILENAME_MARGIN_CSV),
+            (dirpath / FILENAME_LOAN_SETTLEMENTS_CSV, FILENAME_LOAN_SETTLEMENTS_CSV),
+            (dirpath / FILENAME_DEFI_EVENTS_CSV, FILENAME_DEFI_EVENTS_CSV),
+            (dirpath / FILENAME_ALL_CSV, FILENAME_ALL_CSV),
+        ]
+
+        with ZipFile(dirpath / 'csv.zip', 'w') as csv_zip:
+            for path, filename in files:
+                if not path.exists():
+                    continue
+
+                csv_zip.write(path, filename)
+                remove(path)
+
+        return csv_zip.filename

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -808,12 +808,13 @@ class Rotkehlchen():
         else:
             assert isinstance(exchange, Location), 'only a location should make it here'
             assert exchange == Location.CRYPTOCOM, 'only cryptocom should make it here'
+            location = exchange
             # cryptocom has no exchange integration but we may have DB entries
-            self.actions_per_location['asset_movement'][exchange] = 0
+            self.actions_per_location['asset_movement'][location] = 0
             location_movements = self.data.db.get_asset_movements(
                 from_ts=from_ts,
                 to_ts=to_ts,
-                location=str(exchange),
+                location=str(location),
             )
 
         movements: List[AssetMovement] = []
@@ -825,7 +826,8 @@ class Rotkehlchen():
                 all_actions=all_movements,
             )
         else:
-            movements = location_movements
+            all_movements.extend(location_movements)
+            movements = all_movements
 
         return movements
 
@@ -874,12 +876,12 @@ class Rotkehlchen():
                 exchange=Location.CRYPTOCOM,
             )
             for _, exchange in self.exchange_manager.connected_exchanges.items():
-                movements.extend(self._query_exchange_asset_movements(
+                self._query_exchange_asset_movements(
                     from_ts=from_ts,
                     to_ts=to_ts,
                     all_movements=movements,
                     exchange=exchange,
-                ))
+                )
 
         # return movements with most recent first
         movements.sort(key=lambda x: x.timestamp, reverse=True)

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -597,6 +597,8 @@ class Rotkehlchen():
             trades = self.query_location_trades(from_ts, to_ts, location)
         else:
             trades = self.query_location_trades(from_ts, to_ts, Location.EXTERNAL)
+            # crypto.com is not an API key supported exchange but user can import from CSV
+            trades.extend(self.query_location_trades(from_ts, to_ts, Location.CRYPTOCOM))
             for name, exchange in self.exchange_manager.connected_exchanges.items():
                 exchange_trades = exchange.query_trade_history(start_ts=from_ts, end_ts=to_ts)
                 if self.premium is None:
@@ -635,7 +637,7 @@ class Rotkehlchen():
         self.actions_per_location['trade'][location] = 0
 
         location_trades: TRADES_LIST
-        if location == Location.EXTERNAL:
+        if location in (Location.EXTERNAL, Location.CRYPTOCOM):
             location_trades = self.data.db.get_trades(  # type: ignore  # list invariance
                 from_ts=from_ts,
                 to_ts=to_ts,
@@ -793,12 +795,26 @@ class Rotkehlchen():
             from_ts: Timestamp,
             to_ts: Timestamp,
             all_movements: List[AssetMovement],
-            exchange: ExchangeInterface,
+            exchange: Union[ExchangeInterface, Location],
     ) -> List[AssetMovement]:
-        location = deserialize_location(exchange.name)
-        # clear the asset movements queried for this exchange
-        self.actions_per_location['asset_movement'][location] = 0
-        location_movements = exchange.query_deposits_withdrawals(start_ts=from_ts, end_ts=to_ts)
+        if isinstance(exchange, ExchangeInterface):
+            location = deserialize_location(exchange.name)
+            # clear the asset movements queried for this exchange
+            self.actions_per_location['asset_movement'][location] = 0
+            location_movements = exchange.query_deposits_withdrawals(
+                start_ts=from_ts,
+                end_ts=to_ts,
+            )
+        else:
+            assert isinstance(exchange, Location), 'only a location should make it here'
+            assert exchange == Location.CRYPTOCOM, 'only cryptocom should make it here'
+            # cryptocom has no exchange integration but we may have DB entries
+            self.actions_per_location['asset_movement'][exchange] = 0
+            location_movements = self.data.db.get_asset_movements(
+                from_ts=from_ts,
+                to_ts=to_ts,
+                location=str(exchange),
+            )
 
         movements: List[AssetMovement] = []
         if self.premium is None:
@@ -828,27 +844,42 @@ class Rotkehlchen():
         """
         movements: List[AssetMovement] = []
         if location is not None:
-            exchange = self.exchange_manager.get(str(location))
-            if not exchange:
-                logger.warn(
-                    f'Tried to query deposits/withdrawals from {location} which is either not an '
-                    f'exchange or not an exchange the user has connected to',
+            if location == Location.CRYPTOCOM:
+                movements = self._query_exchange_asset_movements(
+                    from_ts=from_ts,
+                    to_ts=to_ts,
+                    all_movements=movements,
+                    exchange=Location.CRYPTOCOM,
                 )
-                return []
-            movements = self._query_exchange_asset_movements(
-                from_ts=from_ts,
-                to_ts=to_ts,
-                all_movements=movements,
-                exchange=exchange,
-            )
-        else:
-            for _, exchange in self.exchange_manager.connected_exchanges.items():
+            else:
+                exchange = self.exchange_manager.get(str(location))
+                if not exchange:
+                    logger.warn(
+                        f'Tried to query deposits/withdrawals from {location} which is either '
+                        f'not at exchange or not an exchange the user has connected to',
+                    )
+                    return []
                 movements = self._query_exchange_asset_movements(
                     from_ts=from_ts,
                     to_ts=to_ts,
                     all_movements=movements,
                     exchange=exchange,
                 )
+        else:
+            # cryptocom has no exchange integration but we may have DB entries due to csv import
+            movements = self._query_exchange_asset_movements(
+                from_ts=from_ts,
+                to_ts=to_ts,
+                all_movements=movements,
+                exchange=Location.CRYPTOCOM,
+            )
+            for _, exchange in self.exchange_manager.connected_exchanges.items():
+                movements.extend(self._query_exchange_asset_movements(
+                    from_ts=from_ts,
+                    to_ts=to_ts,
+                    all_movements=movements,
+                    exchange=exchange,
+                ))
 
         # return movements with most recent first
         movements.sort(key=lambda x: x.timestamp, reverse=True)


### PR DESCRIPTION
Closes #1611 

Testing the import:
`curl -v -X POST -H "Content-Type: multipart/form-data" -F "source=crypto.com" -F "file=@cryptocom_trades_list.csv" http://localhost:4242/api/1/import`

for the download you can open it in the browser after generating the report going to `http://localhost:4242/api/1/history/download` in the browser should start downloading a report.zip. The zip should contain any csv files generated