### PR TITLE
Added Bitstamp support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`436` Rotki now supports Bitstamp. Users can see their balances and import trades, deposits and withdrawals from that exchange. They are also taken into account in the tax report.
 * :feature:`1611` Rotki can now import data and download the tax report csv when running in the browser.
 * :feature:`176` Add an accounting setting to make asset movements fees (deposits/withdrawals to/from exchanges) inclusion in the profit loss report configurable.
 * :feature:`1840` Better handling double crypto.com entries (dust_conversion, swap, ...) from csv export. Also crypto.com imported trades and asset movements now appear in the history UI component

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ typing-extensions==3.7.4.2
 base58check==1.0.2
 bech32==1.2.0
 gql==2.0.0
+uuid==1.30
 
 # For the rest api
 flask-cors==3.0.8
@@ -17,7 +18,6 @@ flask-restful==0.3.7
 flask==1.1.1
 marshmallow==3.2.1
 webargs==6.0.0
-
 
 #constraints
 setuptools==41.0.1  # constraint required by pyinstaller==3.5.0

--- a/rotkehlchen/data/importer.py
+++ b/rotkehlchen/data/importer.py
@@ -55,6 +55,8 @@ def exchange_row_to_location(entry: str) -> Location:
     # TODO: Check if this is the correct string for Gemini from cointracking
     elif entry == 'Gemini':
         return Location.GEMINI
+    elif entry == 'Bitstamp':
+        return Location.BITSTAMP
     elif entry == 'ETH Transaction':
         raise UnsupportedCointrackingEntry(
             'Not importing ETH Transactions from Cointracking. Cointracking does not '

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -54,6 +54,8 @@ INSERT OR IGNORE INTO location(location, seq) VALUES ('O', 15);
 INSERT OR IGNORE INTO location(location, seq) VALUES ('P', 16);
 /* Uniswap */
 INSERT OR IGNORE INTO location(location, seq) VALUES ('Q', 17);
+/* Bitstamp */
+INSERT OR IGNORE INTO location(location, seq) VALUES ('R', 18);
 """
 
 # Custom enum table for AssetMovement categories (deposit/withdrawal)

--- a/rotkehlchen/exchanges/__init__.py
+++ b/rotkehlchen/exchanges/__init__.py
@@ -1,5 +1,6 @@
 from rotkehlchen.exchanges.binance import Binance  # noqa: F401
 from rotkehlchen.exchanges.bitmex import Bitmex  # noqa: F401
+from rotkehlchen.exchanges.bitstamp import Bitstamp  # noqa: F401
 from rotkehlchen.exchanges.bittrex import Bittrex  # noqa: F401
 from rotkehlchen.exchanges.coinbase import Coinbase  # noqa: F401
 from rotkehlchen.exchanges.coinbasepro import Coinbasepro  # noqa: F401

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -1,0 +1,715 @@
+import hashlib
+import hmac
+import logging
+import uuid
+from datetime import datetime
+from http import HTTPStatus
+from json.decoder import JSONDecodeError
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
+from urllib.parse import urlencode
+
+import requests
+from requests.adapters import Response
+from typing_extensions import Literal
+
+from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.errors import (
+    DeserializationError,
+    RemoteError,
+    SystemClockNotSyncedError,
+    UnknownAsset,
+    UnsupportedAsset,
+)
+from rotkehlchen.exchanges.data_structures import (
+    AssetMovement,
+    AssetMovementCategory,
+    Trade,
+    TradeType,
+)
+from rotkehlchen.exchanges.exchange import ExchangeInterface
+from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.serialization.deserialize import (
+    deserialize_asset_amount,
+    deserialize_fee,
+    deserialize_price,
+)
+from rotkehlchen.typing import ApiKey, ApiSecret, Location, Timestamp, TradePair
+from rotkehlchen.user_messages import MessagesAggregator
+from rotkehlchen.utils.interfaces import cache_response_timewise, protect_with_lock
+from rotkehlchen.utils.misc import iso8601ts_to_timestamp, ts_now_in_ms
+from rotkehlchen.utils.serialization import rlk_jsonloads_dict, rlk_jsonloads_list
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE = 'API0017'
+# More understandable explanation for API key-related errors than the default `reason`
+API_KEY_ERROR_CODE_ACTION = {
+    'API0001': 'Check your API key value.',
+    'API0002': 'The IP address has no permission to use this API key.',
+    'API0003': (
+        'Provided Bitstamp API key needs to have "Account balance" and "User transactions" '
+        'permission activated. Please log into your Bitstamp account and create a key with '
+        'the required permissions.'
+    ),
+    'API0006': 'Contact Bitstamp support to unfreeze your account',
+    'API0008': "Can't find a customer with selected API key.",
+    'API0011': 'Check that your API key string is correct.',
+}
+# Max limit for all API v2 endpoints
+API_MAX_LIMIT = 1000
+# user_transactions endpoint constants
+# Sort mode
+USER_TRANSACTION_SORTING_MODE = 'asc'
+# Starting `since_id`
+USER_TRANSACTION_MIN_SINCE_ID = 1
+# Trade type int
+USER_TRANSACTION_TRADE_TYPE = {2}
+# Asset movement type int: 0 - deposit, 1 - withdrawal
+USER_TRANSACTION_ASSET_MOVEMENT_TYPE = {0, 1}
+
+
+class TradePairData(NamedTuple):
+    pair: str
+    base_asset_symbol: str
+    quote_asset_symbol: str
+    base_asset: Asset
+    quote_asset: Asset
+    trade_pair: TradePair
+
+
+class Bitstamp(ExchangeInterface):
+    """Bitstamp exchange api docs:
+    https://www.bitstamp.net/api/
+
+    An unofficial python bitstamp package:
+    https://github.com/kmadac/bitstamp-python-client
+    """
+    def __init__(
+            self,
+            api_key: ApiKey,
+            secret: ApiSecret,
+            database: 'DBHandler',
+            msg_aggregator: MessagesAggregator,
+    ):
+        super(Bitstamp, self).__init__('bitstamp', api_key, secret, database)
+        self.base_uri = 'https://www.bitstamp.net/api'
+        self.msg_aggregator = msg_aggregator
+        # NB: X-Auth-Signature, X-Auth-Nonce, X-Auth-Timestamp and Content-Type per request
+        self.session.headers.update({
+            'X-Auth': f'BITSTAMP {self.api_key}',
+            'X-Auth-Version': 'v2',
+        })
+
+    @protect_with_lock()
+    @cache_response_timewise()
+    def query_balances(self) -> Tuple[Optional[Dict[Asset, Balance]], str]:
+        """Return the account balances on Bistamp
+
+        The balance endpoint returns a dict where the keys (str) are related to
+        assets and the values (str) amounts. The keys that end with `_balance`
+        contain the exact amount of an asset the account is holding (available
+        amount + orders amount, per asset).
+        """
+        response = self._api_query('balance')
+
+        if response.status_code != HTTPStatus.OK:
+            result, msg = self._process_unsuccessful_response(
+                response=response,
+                case='balances',
+            )
+            return result, msg
+        try:
+            response_dict = rlk_jsonloads_dict(response.text)
+        except JSONDecodeError:
+            msg = f'Bitstamp returned invalid JSON response: {response.text}.'
+            log.error(msg)
+            raise RemoteError(msg)
+
+        asset_balance: Dict[Asset, Balance] = {}
+        for entry, amount in response_dict.items():
+            amount = FVal(amount)
+            if not entry.endswith('_balance') or amount == ZERO:
+                continue
+
+            symbol = entry.split('_')[0]  # If no `_`, defaults to entry
+            try:
+                asset = Asset(symbol)
+            except (UnknownAsset, UnsupportedAsset) as e:
+                log.error(str(e))
+                asset_tag = 'unknown' if isinstance(e, UnknownAsset) else 'unsupported'
+                self.msg_aggregator.add_warning(
+                    f'Found {asset_tag} Bistamp asset {e.asset_name}. Ignoring its balance query.',
+                )
+                continue
+            try:
+                usd_price = Inquirer().find_usd_price(asset=asset)
+            except RemoteError as e:
+                log.error(str(e))
+                self.msg_aggregator.add_error(
+                    f'Error processing Bitstamp balance result due to inability to '
+                    f'query USD price: {str(e)}. Skipping balance entry.',
+                )
+                continue
+
+            asset_balance[asset] = Balance(
+                amount=amount,
+                usd_value=amount * usd_price,
+            )
+
+        return asset_balance, ''
+
+    def query_online_deposits_withdrawals(
+            self,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+    ) -> List[AssetMovement]:
+        """Return the account asset movements on Bitstamp.
+
+        NB: when `since_id` is used, the Bitstamp API v2 will return by default
+        1000 entries. However, we make it explicit.
+        Bitstamp support confirmed `since_id` at 1 can be used for requesting
+        user transactions since the beginning.
+        """
+        options = {
+            'limit': API_MAX_LIMIT,
+            'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+            'sort': USER_TRANSACTION_SORTING_MODE,
+            'offset': 0,
+        }
+        if start_ts != Timestamp(0):
+            db_asset_movements = self.db.get_asset_movements(
+                to_ts=start_ts,
+                location=str(Location.BITSTAMP),
+            )
+            # NB: sort asset_movements by int(link) in asc mode
+            db_asset_movements.sort(key=lambda asset_movement: int(asset_movement.link))
+            if db_asset_movements:
+                options.update({'since_id': int(db_asset_movements[-1].link) + 1})
+
+        asset_movements: List[AssetMovement] = self._api_query_paginated(
+            start_ts=start_ts,
+            end_ts=end_ts,
+            options=options,
+            case='asset_movements',
+        )
+        return asset_movements
+
+    def query_online_trade_history(
+            self,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+    ) -> List[Trade]:
+        """Return the account trades on Bitstamp.
+
+        NB: when `since_id` is used, the Bitstamp API v2 will return by default
+        1000 entries. However, we make it explicit.
+        Bitstamp support confirmed `since_id` at 1 can be used for requesting
+        user transactions since the beginning.
+        """
+        options = {
+            'limit': API_MAX_LIMIT,
+            'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+            'sort': USER_TRANSACTION_SORTING_MODE,
+            'offset': 0,
+        }
+        if start_ts != Timestamp(0):
+            db_trades = self.db.get_trades(
+                to_ts=start_ts,
+                location=Location.BITSTAMP,
+            )
+            # NB: sort trades by int(link) in asc mode
+            db_trades.sort(key=lambda trade: int(trade.link))
+            if db_trades:
+                options.update({'since_id': int(db_trades[-1].link) + 1})
+
+        trades: List[Trade] = self._api_query_paginated(
+            start_ts=start_ts,
+            end_ts=end_ts,
+            options=options,
+            case='trades',
+        )
+        return trades
+
+    def validate_api_key(self) -> Tuple[bool, str]:
+        """Validates that the Bitstamp API key is good for usage in Rotki
+
+        Makes sure that the following permissions are given to the key:
+        - Account balance
+        - User transactions
+        """
+        response = self._api_query('balance')
+
+        if response.status_code != HTTPStatus.OK:
+            result, msg = self._process_unsuccessful_response(
+                response=response,
+                case='validate_api_key',
+            )
+            return result, msg
+
+        return True, ''
+
+    def _api_query(
+            self,
+            endpoint: Literal['balance', 'user_transactions'],
+            method: Literal['post'] = 'post',
+            options: Optional[Dict[str, Any]] = None,
+    ) -> Response:
+        """Request a Bistamp API v2 endpoint (from `endpoint`).
+        """
+        call_options = options.copy() if options else {}
+        data = call_options or None
+        request_url = f'{self.base_uri}/v2/{endpoint}/'
+        query_params = ''
+        nonce = str(uuid.uuid4())
+        timestamp = str(ts_now_in_ms())
+        payload_string = urlencode(call_options)
+        content_type = '' if payload_string == '' else 'application/x-www-form-urlencoded'
+        message = (
+            'BITSTAMP '
+            f'{self.api_key}'
+            f'{method.upper()}'
+            f'{request_url.replace("https://", "")}'
+            f'{query_params}'
+            f'{content_type}'
+            f'{nonce}'
+            f'{timestamp}'
+            'v2'
+            f'{payload_string}'
+        )
+        signature = hmac.new(
+            self.secret,
+            msg=message.encode('utf-8'),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+
+        self.session.headers.update({
+            'X-Auth-Signature': signature,
+            'X-Auth-Nonce': nonce,
+            'X-Auth-Timestamp': timestamp,
+        })
+        if content_type:
+            self.session.headers.update({'Content-Type': content_type})
+
+        log.debug('Bitstamp API request', request_url=request_url)
+        try:
+            response = self.session.request(
+                method=method,
+                url=request_url,
+                data=data,
+            )
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(
+                f'Bitstamp {method} request at {request_url} connection error: {str(e)}.',
+            )
+
+        return response
+
+    @overload  # noqa: F811
+    def _api_query_paginated(  # pylint: disable=no-self-use
+            self,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+            options: Dict[str, Any],
+            case: Literal['trades'],
+    ) -> List[Trade]:
+        ...
+
+    @overload  # noqa: F811
+    def _api_query_paginated(  # pylint: disable=no-self-use
+            self,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+            options: Dict[str, Any],
+            case: Literal['asset_movements'],
+    ) -> List[AssetMovement]:
+        ...
+
+    def _api_query_paginated(
+            self,
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,
+            options: Dict[str, Any],
+            case: Literal['trades', 'asset_movements'],
+    ) -> Union[List[Trade], List[AssetMovement]]:
+        """Request a Bitstamp API v2 endpoint paginating via an options
+        attribute.
+
+        Currently it targets the "user_transactions" endpoint. For supporting
+        other endpoints some amendments should be done (e.g. request method,
+        loop that processes entities).
+
+        Pagination attribute criteria per endpoint:
+          - user_transactions:
+            * since_id: from <Trade>.id + 1 (if db trade exists), else 1
+            * limit: 1000 (API v2 default using `since_id`).
+            * sort: 'asc'
+        """
+        deserialization_method: Callable[[Dict[str, Any]], Union[Trade, AssetMovement]]
+        endpoint: Literal['user_transactions']
+        response_case: Literal['trades', 'asset_movements']
+        if case == 'trades':
+            endpoint = 'user_transactions'
+            raw_result_type_filter = USER_TRANSACTION_TRADE_TYPE
+            response_case = 'trades'
+            case_pretty = 'trade'
+            deserialization_method = self._deserialize_trade
+        elif case == 'asset_movements':
+            endpoint = 'user_transactions'
+            raw_result_type_filter = USER_TRANSACTION_ASSET_MOVEMENT_TYPE
+            response_case = 'asset_movements'
+            case_pretty = 'asset movement'
+            deserialization_method = self._deserialize_asset_movement
+        else:
+            raise AssertionError(f'Unexpected Bitstamp case: {case}.')
+
+        # Check required options per endpoint
+        if endpoint == 'user_transactions':
+            assert options['limit'] == API_MAX_LIMIT
+            assert options['since_id'] >= USER_TRANSACTION_MIN_SINCE_ID
+            assert options['sort'] == USER_TRANSACTION_SORTING_MODE
+            assert options['offset'] == 0
+
+        call_options = options.copy()
+        limit = options.get('limit', API_MAX_LIMIT)
+        results: Union[List[Trade], List[AssetMovement]] = []  # type: ignore
+        while True:
+            response = self._api_query(
+                endpoint=endpoint,
+                method='post',
+                options=call_options,
+            )
+            if response.status_code != HTTPStatus.OK:
+                return self._process_unsuccessful_response(
+                    response=response,
+                    case=response_case,
+                )
+            try:
+                response_list = rlk_jsonloads_list(response.text)
+            except JSONDecodeError:
+                msg = f'Bitstamp returned invalid JSON response: {response.text}.'
+                log.error(msg)
+                self.msg_aggregator.add_error(
+                    f'Got remote error while querying Bistamp trades: {msg}',
+                )
+                no_results: Union[List[Trade], List[AssetMovement]] = []  # type: ignore
+                return no_results
+
+            has_results = False
+            is_result_timesamp_gt_end_ts = False
+            result: Union[List, AssetMovement]
+            for raw_result in response_list:
+                if raw_result['type'] not in raw_result_type_filter:
+                    continue
+                try:
+                    result_timestamp = iso8601ts_to_timestamp(raw_result['datetime'])
+
+                    if result_timestamp > end_ts:
+                        is_result_timesamp_gt_end_ts = True  # prevent extra request
+                        break
+
+                    result = deserialization_method(raw_result)  # type: ignore
+
+                except DeserializationError as e:
+                    msg = str(e)
+                    log.error(
+                        f'Error processing a Bitstamp {case_pretty}.',
+                        raw_result=raw_result,
+                        error=msg,
+                    )
+                    self.msg_aggregator.add_error(
+                        f'Failed to deserialize a Bitstamp {case_pretty}. '
+                        f'Check logs for details. Ignoring it.',
+                    )
+
+                results.append(result)  # type: ignore
+                has_results = True  # NB: endpoint agnostic
+
+            if len(response_list) < limit or is_result_timesamp_gt_end_ts:
+                break
+
+            # NB: update pagination params per endpoint
+            if endpoint == 'user_transactions':
+                # NB: re-assign dict instead of update, prevent lose call args values
+                call_options = call_options.copy()
+                offset = 0 if has_results else call_options['offset'] + API_MAX_LIMIT
+                since_id = int(results[-1].link) + 1 if has_results else call_options['since_id']
+                call_options.update({
+                    'since_id': since_id,
+                    'offset': offset,
+                })
+
+        return results
+
+    @staticmethod
+    def _check_for_system_clock_not_synced_error(
+            error_code: Optional[int] = None,
+    ) -> None:
+        if error_code == API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE:
+            raise SystemClockNotSyncedError(
+                current_time=str(datetime.now()),
+                remote_server='Bitstamp',
+            )
+
+        return None
+
+    def _deserialize_asset_movement(
+            self,
+            raw_movement: Dict[str, Any],
+    ) -> AssetMovement:
+        """Process a deposit/withdrawal user transaction from Bitstamp and
+        deserialize it.
+
+        Can raise DeserializationError.
+
+        From Bitstamp documentation, deposits/withdrawals can have a fee
+        (the amount is expected to be in the currency involved)
+        https://www.bitstamp.net/fee-schedule/
+
+        Bitstamp support confirmed the following withdrawal JSON:
+        {
+            "fee": "0.00050000",
+            "btc_usd": "0.00",
+            "datetime": "2020-12-04 09:30:00.000000",
+            "usd": "0.0",
+            "btc": "-0.50000000",
+            "type": "1",
+            "id": 123456789,
+            "eur": "0.0"
+        }
+        NB: any asset key not related with the pair is discarded (e.g. 'eur').
+        """
+        type_ = raw_movement['type']
+        category: AssetMovementCategory
+        if type_ == 0:
+            category = AssetMovementCategory.DEPOSIT
+        elif type_ == 1:
+            category = AssetMovementCategory.WITHDRAWAL
+        else:
+            raise AssertionError(f'Unexpected Bitstamp asset movement case: {type_}.')
+
+        timestamp = iso8601ts_to_timestamp(raw_movement['datetime'])
+        trade_pair_data = self._get_trade_pair_data_from_transaction(raw_movement)
+        base_asset_amount = deserialize_asset_amount(
+            raw_movement[trade_pair_data.base_asset_symbol],
+        )
+        quote_asset_amount = deserialize_asset_amount(
+            raw_movement[trade_pair_data.quote_asset_symbol],
+        )
+        amount: FVal
+        fee_asset: Asset
+        if base_asset_amount != ZERO and quote_asset_amount == ZERO:
+            amount = base_asset_amount
+            fee_asset = trade_pair_data.base_asset
+        elif base_asset_amount == ZERO and quote_asset_amount != ZERO:
+            amount = quote_asset_amount
+            fee_asset = trade_pair_data.quote_asset
+        else:
+            raise DeserializationError(
+                'Could not deserialize Bitstamp asset movement from user transaction. '
+                f'Unexpected asset amount combination found in: {raw_movement}.',
+            )
+
+        asset_movement = AssetMovement(
+            timestamp=timestamp,
+            location=Location.BITSTAMP,
+            category=category,
+            address=None,  # requires query "crypto_transactions" endpoint
+            transaction_id=None,  # requires query "crypto_transactions" endpoint
+            asset=fee_asset,
+            amount=abs(amount),
+            fee_asset=fee_asset,
+            fee=deserialize_fee(raw_movement['fee']),
+            link=str(raw_movement['id']),
+        )
+        return asset_movement
+
+    def _deserialize_trade(
+            self,
+            raw_trade: Dict[str, Any],
+    ) -> Trade:
+        """Process a trade user transaction from Bitstamp and deserialize it.
+
+        Can raise DeserializationError.
+        """
+        timestamp = iso8601ts_to_timestamp(raw_trade['datetime'])
+        trade_pair_data = self._get_trade_pair_data_from_transaction(raw_trade)
+        base_asset_amount = deserialize_asset_amount(
+            raw_trade[trade_pair_data.base_asset_symbol],
+        )
+        quote_asset_amount = deserialize_asset_amount(
+            raw_trade[trade_pair_data.quote_asset_symbol],
+        )
+
+        if base_asset_amount >= ZERO:
+            trade_type = TradeType.BUY
+            amount = base_asset_amount
+            fee_currency = trade_pair_data.quote_asset
+        else:
+            trade_type = TradeType.SELL
+            amount = quote_asset_amount
+            fee_currency = trade_pair_data.base_asset
+
+        trade = Trade(
+            timestamp=timestamp,
+            location=Location.BITSTAMP,
+            pair=trade_pair_data.trade_pair,
+            trade_type=trade_type,
+            amount=amount,
+            rate=deserialize_price(raw_trade[trade_pair_data.pair]),
+            fee=deserialize_fee(raw_trade['fee']),
+            fee_currency=fee_currency,
+            link=str(raw_trade['id']),
+            notes='',
+        )
+        return trade
+
+    @staticmethod
+    def _get_trade_pair_data_from_transaction(raw_result: Dict[str, Any]) -> TradePairData:
+        """Given a user transaction that contains the base and quote assets'
+        symbol as keys, return the Bitstamp trade pair data (raw pair str,
+        base/quote assets raw symbols, and TradePair).
+
+        NB: any custom pair conversion (e.g. from Bitstamp asset symbol to world)
+        should happen here.
+
+        Can raise DeserializationError.
+        """
+        try:
+            pair = [key for key in raw_result.keys() if '_' in key and key != 'order_id'][0]
+        except IndexError:
+            raise DeserializationError(
+                'Could not deserialize Bitstamp trade pair from user transaction. '
+                f'Trade pair not found in: {raw_result}.',
+            )
+
+        # NB: `pair_get_assets()` is not used for simplifying the calls and
+        # storing the raw pair strings.
+        base_asset_symbol, quote_asset_symbol = pair.split('_')
+        try:
+            base_asset = Asset(base_asset_symbol)
+            quote_asset = Asset(quote_asset_symbol)
+        except (UnknownAsset, UnsupportedAsset) as e:
+            log.error(str(e))
+            asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
+            raise DeserializationError(
+                f'{asset_tag} {e.asset_name} found while processing trade pair.',
+            )
+
+        return TradePairData(
+            pair=pair,
+            base_asset_symbol=base_asset_symbol,
+            quote_asset_symbol=quote_asset_symbol,
+            base_asset=base_asset,
+            quote_asset=quote_asset,
+            trade_pair=TradePair(f'{base_asset.identifier}_{quote_asset.identifier}'),
+        )
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['validate_api_key'],
+    ) -> Tuple[bool, str]:
+        ...
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['balances'],
+    ) -> Tuple[Optional[Dict[Asset, Balance]], str]:
+        ...
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['trades'],
+    ) -> List[Trade]:
+        ...
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['asset_movements'],
+    ) -> List[AssetMovement]:
+        ...
+
+    def _process_unsuccessful_response(
+            self,
+            response: Response,
+            case: Literal['validate_api_key', 'balances', 'trades', 'asset_movements'],
+    ) -> Union[
+        List,
+        Tuple[bool, str],
+        Tuple[Optional[Dict[Asset, Balance]], str],
+    ]:
+        """This function processes not successful responses for the following
+        cases listed in `case`.
+        """
+        case_pretty = case.replace('_', ' ')  # human readable case
+        try:
+            response_dict = rlk_jsonloads_dict(response.text)
+        except JSONDecodeError:
+            msg = f'Bitstamp returned invalid JSON response: {response.text}.'
+            log.error(msg)
+
+            if case in {'validate_api_key', 'balances'}:
+                raise RemoteError(msg)
+            elif case in {'trades', 'asset_movements'}:
+                self.msg_aggregator.add_error(
+                    f'Got remote error while querying Bistamp {case_pretty}: {msg}',
+                )
+                return []
+            else:
+                raise AssertionError(f'Unexpected Bitstamp response_case: {case}.')
+
+        error_code = response_dict.get('code', None)
+        self._check_for_system_clock_not_synced_error(error_code)
+        # Errors related with the API key return a human readable message
+        if (
+            case == 'validate_api_key' and
+            error_code in set(API_KEY_ERROR_CODE_ACTION.keys())
+        ):
+            return False, API_KEY_ERROR_CODE_ACTION[response_dict['code']]
+
+        # Below any other error not related with the system clock or the API key
+        reason = response_dict.get('reason', None) or response.text
+        msg = (
+            f'Bitstamp query responded with error status code: {response.status_code} '
+            f'and text: {reason}.'
+        )
+        log.error(msg)
+
+        if case == 'validate_api_key':
+            raise RemoteError(msg)
+        if case == 'balances':
+            return None, msg
+        elif case in {'trades', 'asset_movements'}:
+            self.msg_aggregator.add_error(
+                f'Got remote error while querying Bistamp {case_pretty}: {msg}',
+            )
+            return []
+        else:
+            raise AssertionError(f'Unexpected Bitstamp response_case: {case}.')

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -47,11 +47,12 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
     deserialize_fee,
     deserialize_price,
+    deserialize_timestamp_from_bitstamp_date,
 )
 from rotkehlchen.typing import ApiKey, ApiSecret, Location, Timestamp, TradePair
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.interfaces import cache_response_timewise, protect_with_lock
-from rotkehlchen.utils.misc import iso8601ts_to_timestamp, ts_now_in_ms
+from rotkehlchen.utils.misc import ts_now_in_ms
 from rotkehlchen.utils.serialization import rlk_jsonloads_dict, rlk_jsonloads_list
 
 if TYPE_CHECKING:
@@ -424,7 +425,7 @@ class Bitstamp(ExchangeInterface):
                 if raw_result['type'] not in raw_result_type_filter:
                     continue
                 try:
-                    result_timestamp = iso8601ts_to_timestamp(raw_result['datetime'])
+                    result_timestamp = deserialize_timestamp_from_bitstamp_date(raw_result['datetime'])
 
                     if result_timestamp > end_ts:
                         is_result_timesamp_gt_end_ts = True  # prevent extra request
@@ -510,7 +511,7 @@ class Bitstamp(ExchangeInterface):
         else:
             raise AssertionError(f'Unexpected Bitstamp asset movement case: {type_}.')
 
-        timestamp = iso8601ts_to_timestamp(raw_movement['datetime'])
+        timestamp = deserialize_timestamp_from_bitstamp_date(raw_movement['datetime'])
         trade_pair_data = self._get_trade_pair_data_from_transaction(raw_movement)
         base_asset_amount = deserialize_asset_amount(
             raw_movement[trade_pair_data.base_asset_symbol],
@@ -554,7 +555,7 @@ class Bitstamp(ExchangeInterface):
 
         Can raise DeserializationError.
         """
-        timestamp = iso8601ts_to_timestamp(raw_trade['datetime'])
+        timestamp = deserialize_timestamp_from_bitstamp_date(raw_trade['datetime'])
         trade_pair_data = self._get_trade_pair_data_from_transaction(raw_trade)
         base_asset_amount = deserialize_asset_amount(
             raw_trade[trade_pair_data.base_asset_symbol],

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -120,6 +120,9 @@ class Bitstamp(ExchangeInterface):
             'X-Auth-Version': 'v2',
         })
 
+    def first_connection(self) -> None:
+        self.first_connection_made = True
+
     @protect_with_lock()
     @cache_response_timewise()
     def query_balances(self) -> Tuple[Optional[Dict[Asset, Balance]], str]:

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -22,6 +22,7 @@ SUPPORTED_EXCHANGES = [
     'coinbase',
     'coinbasepro',
     'gemini',
+    'bitstamp',
 ]
 
 

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -335,6 +335,8 @@ def deserialize_location(symbol: str) -> Location:
         return Location.CRYPTOCOM
     elif symbol == 'uniswap':
         return Location.UNISWAP
+    elif symbol == 'bitstamp':
+        return Location.BITSTAMP
     else:
         raise DeserializationError(
             f'Failed to deserialize location symbol. Unknown symbol {symbol} for location',
@@ -429,6 +431,8 @@ def deserialize_location_from_db(symbol: str) -> Location:
         return Location.CRYPTOCOM
     elif symbol == 'Q':
         return Location.UNISWAP
+    elif symbol == 'R':
+        return Location.BITSTAMP
     else:
         raise DeserializationError(
             f'Failed to deserialize location symbol. Unknown symbol {symbol} for location',

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -143,6 +143,23 @@ def deserialize_timestamp_from_poloniex_date(date: str) -> Timestamp:
     )
 
 
+def deserialize_timestamp_from_bitstamp_date(date: str) -> Timestamp:
+    """Deserializes a timestamp from a bitstamp api query result date entry
+
+    The bitstamp dates follow the %Y-%m-%d %H:%M:%S format but are in UTC time
+    and not local time so can't use iso8601ts_to_timestamp() directly since that
+    would interpet them as local time.
+
+    Can throw DeserializationError if the data is not as expected
+    """
+    return deserialize_timestamp_from_date(
+        date,
+        '%Y-%m-%d %H:%M:%S',
+        'bitstamp',
+        skip_milliseconds=True,
+    )
+
+
 def deserialize_timestamp_from_kraken(time: Union[str, FVal, int]) -> Timestamp:
     """Deserializes a timestamp from a kraken api query result entry
     Kraken has timestamps in floating point strings. Example: '1561161486.3056'.

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -1,0 +1,839 @@
+from datetime import datetime, timedelta
+from http import HTTPStatus
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.errors import RemoteError, SystemClockNotSyncedError
+from rotkehlchen.exchanges.bitstamp import (
+    API_KEY_ERROR_CODE_ACTION,
+    API_MAX_LIMIT,
+    API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE,
+    USER_TRANSACTION_MIN_SINCE_ID,
+    USER_TRANSACTION_SORTING_MODE,
+)
+from rotkehlchen.exchanges.data_structures import (
+    AssetMovement,
+    AssetMovementCategory,
+    Trade,
+    TradeType,
+)
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.typing import Fee, Location, Timestamp, TradePair
+
+
+def test_validate_api_key__invalid_json(mock_bitstamp):
+    """Test when status code is not 200, an invalid JSON response raises
+    RemoteError.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.FORBIDDEN, '{"key"}')
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(RemoteError):
+            mock_bitstamp.validate_api_key()
+
+
+def test_validate_api_key__system_clock_not_synced_error_code(mock_bitstamp):
+    """Test the error code related with the local system clock not being synced
+    raises SystemClockNotSyncedError.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.FORBIDDEN,
+            f'{{"code": "{API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE}", "reason": "whatever"}}',
+        )
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(SystemClockNotSyncedError):
+            mock_bitstamp.validate_api_key()
+
+
+@pytest.mark.parametrize('code', API_KEY_ERROR_CODE_ACTION.keys())
+def test_validate_api_key__api_key_error_code(
+        mock_bitstamp,
+        code,
+):
+    """Test an error code related with the API key ones returns a tuple with
+    False (result) and a user friendly message (reason,
+    from API_KEY_ERROR_CODE_ACTION values).
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.FORBIDDEN,
+            f'{{"code": "{code}", "reason": "whatever"}}',
+        )
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        result, msg = mock_bitstamp.validate_api_key()
+
+    assert result is False
+    assert msg == API_KEY_ERROR_CODE_ACTION[code]
+
+
+@pytest.mark.parametrize('response, has_reason', (
+    ('{"code": "APIXXX", "reason": "has reason"}', True),
+    ('{"code": "APIXXX", "text": "has text"}', False),
+))
+def test_validate_api_key__non_related_error_code(
+        mock_bitstamp,
+        response,
+        has_reason,
+):
+    """Test an error code unrelated with the API key ones or the system clock
+    not synced one raises RemoteError.
+
+    Test as well the exception message contains either the response reason
+    or the response as text.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.FORBIDDEN, response)
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(RemoteError) as e:
+            mock_bitstamp.validate_api_key()
+
+        exp_reason = 'has reason' if has_reason else 'has text'
+        assert exp_reason in str(e.value)
+
+
+def test_validate_api_key__success(mock_bitstamp):
+    """Test when status code is 200 the response is a tuple with True (result)
+    and an empty message.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, '')
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        result, msg = mock_bitstamp.validate_api_key()
+
+    assert result is True
+    assert msg == ''
+
+
+def test_query_balances__invalid_json(mock_bitstamp):
+    """Test an invalid JSON response raises RemoteError.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, '{"key"}')
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(RemoteError):
+            mock_bitstamp.query_balances()
+
+
+def test_query_balances__system_clock_not_synced_error_code(mock_bitstamp):
+    """Test the error code related with the local system clock not being synced
+    raises SystemClockNotSyncedError.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.FORBIDDEN,
+            f'{{"code": "{API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE}", "reason": "whatever"}}',
+        )
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(SystemClockNotSyncedError):
+            mock_bitstamp.query_balances()
+
+
+@pytest.mark.parametrize('response, has_reason', (
+    ('{"code": "APIXXX", "reason": "has reason"}', True),
+    ('{"code": "APIXXX", "text": "has text"}', False),
+))
+def test_query_balances__non_related_error_code(
+        mock_bitstamp,
+        response,
+        has_reason,
+):
+    """Test an error code unrelated with the system clock not synced one
+    returns a tuple with None (result) and a message (reason, from 'reason'
+    response value or `response.text`).
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.FORBIDDEN, response)
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        result, msg = mock_bitstamp.query_balances()
+
+    assert result is None
+    exp_reason = 'has reason' if has_reason else 'has text'
+    assert exp_reason in msg
+
+
+def test_query_balances__skips_not_balance_entry(mock_bitstamp):
+    """Test an entry that doesn't end with `_balance` is skipped
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, '{"link_available": "1.00000000"}')
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        assert mock_bitstamp.query_balances() == ({}, '')
+
+
+def test_query_balances__skipped_not_asset_entry(mock_bitstamp):
+    """Test an entry that can't instantiate Asset is skipped
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, '{"bbbrrrlink_balance": "1.00000000"}')
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        assert mock_bitstamp.query_balances() == ({}, '')
+
+
+def test_query_balances__skips_inquirer_error(mock_bitstamp):
+    """Test an entry that can't get its USD price because of a remote error is
+    skipped
+    """
+    inquirer = MagicMock()
+    inquirer.find_usd_price.side_effect = RemoteError('test')
+
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, '{"link_balance": "1.00000000"}')
+
+    with patch('rotkehlchen.exchanges.bitstamp.Inquirer', return_value=inquirer):
+        with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+            assert mock_bitstamp.query_balances() == ({}, '')
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [True])
+def test_query_balances__asset_balance(mock_bitstamp, inquirer):  # pylint: disable=unused-argument
+    """Test an entry that can't get its USD price is skipped
+    """
+    balances_data = (
+        """
+        {
+            "eth_available": "0.00000000",
+            "eth_balance": "32.00000000",
+            "eth_reserved": "0.00000000",
+            "eth_withdrawal_fee": "0.04000000",
+            "link_available": "0.00000000",
+            "link_balance": "1000.00000000",
+            "link_reserved": "0.00000000",
+            "link_withdrawal_fee": "0.25000000",
+            "xrp_available": "0.00000000",
+            "xrp_balance": "0.00000000",
+            "xrp_reserved": "0.00000000",
+            "xrp_withdrawal_fee": "0.02000000"
+        }
+        """
+    )
+
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, balances_data)
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        asset_balance, msg = mock_bitstamp.query_balances()
+        assert asset_balance == {
+            Asset('ETH'): Balance(
+                amount=FVal('32'),
+                usd_value=FVal('48'),
+            ),
+            Asset('LINK'): Balance(
+                amount=FVal('1000'),
+                usd_value=FVal('1500'),
+            ),
+        }
+        assert msg == ''
+
+
+def test_deserialize_trade_buy(mock_bitstamp):
+    raw_trade = {
+        'id': 2,
+        'type': 2,
+        'datetime': '2020-12-02 09:30:00',
+        'btc': '0.50000000',
+        'usd': '-10000.00000000',
+        'btc_usd': '0.00005000',
+        'fee': '20.00000000',
+        'order_id': 2,
+    }
+    expected_trade = Trade(
+        timestamp=1606901400,
+        location=Location.BITSTAMP,
+        pair=TradePair('BTC_USD'),
+        trade_type=TradeType.BUY,
+        amount=FVal("0.50000000"),
+        rate=FVal("0.00005000"),
+        fee=FVal("20.00000000"),
+        fee_currency=Asset('USD'),
+        link='2',
+        notes='',
+    )
+    trade = mock_bitstamp._deserialize_trade(raw_trade)
+    assert trade == expected_trade
+
+
+def test_deserialize_trade_sell(mock_bitstamp):
+    raw_trade = {
+        'id': 5,
+        'type': 2,
+        'datetime': '2020-12-03 11:30:00',
+        'eur': '-1.00000000',
+        'usd': '1.22000000',
+        'eur_usd': '0.81967213',
+        'fee': '0.00610000',
+        'order_id': 3,
+    }
+    expected_trade = Trade(
+        timestamp=1606995000,
+        location=Location.BITSTAMP,
+        pair=TradePair('EUR_USD'),
+        trade_type=TradeType.SELL,
+        amount=FVal("1.22000000"),
+        rate=FVal("0.81967213"),
+        fee=FVal("0.00610000"),
+        fee_currency=Asset('EUR'),
+        link='5',
+        notes='',
+    )
+    trade = mock_bitstamp._deserialize_trade(raw_trade)
+    assert trade == expected_trade
+
+
+@pytest.mark.parametrize('option', ['limit', 'since_id', 'sort', 'offset'])
+def test_api_query_paginated__user_transactions_required_options(mock_bitstamp, option):
+    """Test calling the 'user_transactions' endpoint requires a set of specific
+    options.
+    """
+    options = {
+        'limit': API_MAX_LIMIT,
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+    del options[option]
+    with pytest.raises(KeyError):
+        mock_bitstamp._api_query_paginated(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(1),
+            options=options,
+            case='trades',
+        )
+
+
+@pytest.mark.parametrize('option', ['limit', 'since_id', 'sort', 'offset'])
+def test_api_query_paginated__user_transactions_required_options_values(mock_bitstamp, option):
+    """Test calling the 'user_transactions' endpoint requires a set of specific
+    options.
+    """
+    options = {
+        'limit': API_MAX_LIMIT,
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+    options[option] = -1
+    with pytest.raises(AssertionError):
+        mock_bitstamp._api_query_paginated(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(1),
+            options=options,
+            case='trades',
+        )
+
+
+def test_api_query_paginated__system_clock_not_synced_error_code(mock_bitstamp):
+    """Test the error code related with the local system clock not being synced
+    raises SystemClockNotSyncedError.
+    """
+    options = {
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'limit': API_MAX_LIMIT,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+
+    def mock_api_query_response(endpoint, method, options):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.FORBIDDEN,
+            f'{{"code": "{API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE}", "reason": "whatever"}}',
+        )
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(SystemClockNotSyncedError):
+            mock_bitstamp._api_query_paginated(
+                start_ts=Timestamp(0),
+                end_ts=Timestamp(1),
+                options=options,
+                case='trades',
+            )
+
+
+def test_api_query_paginated__invalid_json(mock_bitstamp):
+    """Test an invalid JSON response returns empty list.
+    """
+    options = {
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'limit': API_MAX_LIMIT,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+
+    def mock_api_query_response(endpoint, method, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, '[{"key"}]')
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        result = mock_bitstamp._api_query_paginated(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(1),
+            options=options,
+            case='trades',
+        )
+        assert result == []
+
+
+@pytest.mark.parametrize('response', (
+    '{"code": "APIXXX", "reason": "has reason"}',
+    '{"code": "APIXXX", "text": "has text"}',
+))
+def test_api_query_paginated__non_related_error_code(mock_bitstamp, response):
+    """Test an error code unrelated with the system clock not synced one
+    returns a an empty list.
+    """
+    options = {
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'limit': API_MAX_LIMIT,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+
+    def mock_api_query_response(endpoint, method, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.FORBIDDEN, response)
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        result = mock_bitstamp._api_query_paginated(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(1),
+            options=options,
+            case='trades',
+        )
+
+    assert result == []
+
+
+def test_api_query_paginated__skips_different_type_result(mock_bitstamp):
+    """Test results whose type is not in `raw_result_type_filter` are skipped
+    """
+    options = {
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'limit': API_MAX_LIMIT,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+
+    def mock_api_query_response(endpoint, method, options):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.OK,
+            '[{"type": "whatever"}, {"type": 23}]',
+        )
+
+    with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
+        result = mock_bitstamp._api_query_paginated(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(1),
+            options=options,
+            case='trades',
+        )
+
+    assert result == []
+
+
+def test_api_query_paginated__stops_timestamp_gt_end_ts(mock_bitstamp):
+    """Test the method stops processing results when a result timestamp is gt
+    `end_ts`.
+    """
+    api_limit = 2
+    now = datetime.now().replace(microsecond=0)
+    gt_now = now + timedelta(seconds=1)
+    now_ts = int(now.timestamp())
+    gt_now_iso = gt_now.isoformat()
+    options = {
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'limit': api_limit,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+    expected_calls = [
+        call(
+            endpoint='user_transactions',
+            method='post',
+            options={
+                'since_id': 1,
+                'limit': 2,
+                'sort': 'asc',
+                'offset': 0,
+            },
+        ),
+    ]
+
+    def mock_api_query_response(endpoint, method, options):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.OK,
+            f'[{{"type": 14, "datetime": "{gt_now_iso}"}}]',
+        )
+
+    with patch(
+        'rotkehlchen.exchanges.bitstamp.API_MAX_LIMIT',
+        new_callable=MagicMock(return_value=api_limit),
+    ):
+        with patch.object(
+            mock_bitstamp,
+            '_api_query',
+            side_effect=mock_api_query_response,
+        ) as mock_api_query:
+            result = mock_bitstamp._api_query_paginated(
+                start_ts=Timestamp(0),
+                end_ts=Timestamp(now_ts),
+                options=options,
+                case='trades',
+            )
+            assert mock_api_query.call_args_list == expected_calls
+    assert result == []
+
+
+@pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
+def test_api_query_paginated__trades_pagination(mock_bitstamp):
+    """Test pagination logic for trades works as expected.
+
+    First request: 2 results, 1 valid trade (id 2)
+    Second request: 2 results, no trades
+    Third request: 2 results, 1 valid trade (id 5) and 1 invalid trade (id 6)
+
+    Trades with id 2 and 5 are expected to be returned.
+    """
+    # Not a trade
+    user_transaction_1 = """
+    {
+        "id": 1,
+        "type": -1,
+        "datetime": "2020-12-02 09:00:00"
+    }
+    """
+    # First trade, buy BTC with USD, within timestamp range
+    user_transaction_2 = """
+    {
+        "id": 2,
+        "type": 2,
+        "datetime": "2020-12-02 09:30:00",
+        "btc": "0.50000000",
+        "usd": "-10000.00000000",
+        "btc_usd": "0.00005000",
+        "fee": "20.00000000",
+        "order_id": 2
+    }
+    """
+    # Not a trade
+    user_transaction_3 = """
+    {
+        "id": 3,
+        "type": -1,
+        "datetime": "2020-12-02 18:00:00"
+    }
+    """
+    # Not a trade
+    user_transaction_4 = """
+    {
+        "id": 4,
+        "type": -1,
+        "datetime": "2020-12-03 9:00:00"
+    }
+    """
+    # Second trade, sell EUR for USD, within timestamp range
+    user_transaction_5 = """
+    {
+        "id": 5,
+        "type": 2,
+        "datetime": "2020-12-03 11:30:00",
+        "eur": "-1.00000000",
+        "usd": "1.22000000",
+        "eur_usd": "0.81967213",
+        "fee": "0.00610000",
+        "order_id": 3
+    }
+    """
+    # Third trade, buy ETH with USDC, out of timestamp range
+    user_transaction_6 = """
+    {
+        "id": 6,
+        "type": 2,
+        "datetime": "2020-12-03 12:00:01",
+        "eth": "1.00000000",
+        "usdc": "-750.00000000",
+        "eth_usdc": "0.00133333",
+        "fee": "3.75000000",
+        "order_id": 1
+    }
+    """
+    api_limit = 2
+    now = datetime.now()
+    now_ts = int(now.timestamp())
+    options = {
+        'since_id': USER_TRANSACTION_MIN_SINCE_ID,
+        'limit': api_limit,
+        'sort': USER_TRANSACTION_SORTING_MODE,
+        'offset': 0,
+    }
+    expected_calls = [
+        call(
+            endpoint='user_transactions',
+            method='post',
+            options={
+                'since_id': 1,
+                'limit': 2,
+                'sort': 'asc',
+                'offset': 0,
+            },
+        ),
+        call(
+            endpoint='user_transactions',
+            method='post',
+            options={
+                'since_id': 3,
+                'limit': 2,
+                'sort': 'asc',
+                'offset': 0,
+            },
+        ),
+        call(
+            endpoint='user_transactions',
+            method='post',
+            options={
+                'since_id': 3,
+                'limit': 2,
+                'sort': 'asc',
+                'offset': 2,
+            },
+        ),
+    ]
+
+    def get_paginated_response():
+        results = [
+            f'[{user_transaction_1},{user_transaction_2}]',
+            f'[{user_transaction_3},{user_transaction_4}]',
+            f'[{user_transaction_5},{user_transaction_6}]',
+        ]
+        for result_ in results:
+            yield result_
+
+    def mock_api_query_response(endpoint, method, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, next(get_response))
+
+    get_response = get_paginated_response()
+
+    with patch(
+        'rotkehlchen.exchanges.bitstamp.API_MAX_LIMIT',
+        new_callable=MagicMock(return_value=api_limit),
+    ):
+        with patch.object(
+            mock_bitstamp,
+            '_api_query',
+            side_effect=mock_api_query_response,
+        ) as mock_api_query:
+            result = mock_bitstamp._api_query_paginated(
+                start_ts=Timestamp(0),
+                end_ts=Timestamp(now_ts),
+                options=options,
+                case='trades',
+            )
+            assert mock_api_query.call_args_list == expected_calls
+
+    expected_result = [
+        Trade(
+            timestamp=1606901400,
+            location=Location.BITSTAMP,
+            pair=TradePair('BTC_USD'),
+            trade_type=TradeType.BUY,
+            amount=FVal("0.50000000"),
+            rate=FVal("0.00005000"),
+            fee=FVal("20.00000000"),
+            fee_currency=Asset('USD'),
+            link='2',
+            notes='',
+        ),
+        Trade(
+            timestamp=1606995000,
+            location=Location.BITSTAMP,
+            pair=TradePair('EUR_USD'),
+            trade_type=TradeType.SELL,
+            amount=FVal("1.22000000"),
+            rate=FVal("0.81967213"),
+            fee=FVal("0.00610000"),
+            fee_currency=Asset('EUR'),
+            link='5',
+            notes='',
+        ),
+    ]
+    assert result == expected_result
+
+
+@pytest.mark.parametrize('start_ts, since_id', [(0, 1), (1, 6)])
+def test_query_online_trade_history(mock_bitstamp, start_ts, since_id):
+    """Test `since_id` value will change depending on `start_ts` value.
+    Also tests `db_trades` are sorted by `link` (as int) in ascending mode.
+    """
+    trades = [
+        Trade(
+            timestamp=1606995000,
+            location=Location.BITSTAMP,
+            pair=TradePair('EUR_USD'),
+            trade_type=TradeType.SELL,
+            amount=FVal("1.22000000"),
+            rate=FVal("0.81967213"),
+            fee=FVal("0.00610000"),
+            fee_currency=Asset('EUR'),
+            link='5',
+            notes='',
+        ),
+        Trade(
+            timestamp=1606901400,
+            location=Location.BITSTAMP,
+            pair=TradePair('BTC_USD'),
+            trade_type=TradeType.BUY,
+            amount=FVal("0.50000000"),
+            rate=FVal("0.00005000"),
+            fee=FVal("20.00000000"),
+            fee_currency=Asset('USD'),
+            link='2',
+            notes='',
+        ),
+    ]
+    database = MagicMock()
+    database.get_trades.return_value = trades
+
+    expected_call = call(
+        start_ts=start_ts,
+        end_ts=2,
+        options={
+            'since_id': since_id,
+            'limit': 1000,
+            'sort': 'asc',
+            'offset': 0,
+        },
+        case='trades',
+    )
+    with patch.object(mock_bitstamp, 'db', new_callable=MagicMock(return_value=database)):
+        with patch.object(mock_bitstamp, '_api_query_paginated') as mock_api_query_paginated:
+            mock_bitstamp.query_online_trade_history(
+                start_ts=Timestamp(start_ts),
+                end_ts=Timestamp(2),
+            )
+            assert mock_api_query_paginated.call_args == expected_call
+
+
+def test_deserialize_asset_movement_deposit(mock_bitstamp):
+    raw_movement = {
+        'id': 2,
+        'type': 0,
+        'datetime': '2020-12-02 09:30:00',
+        'btc': '0.50000000',
+        'usd': '0.00000000',
+        'btc_usd': '0.00',
+        'fee': '0.00050000',
+        'order_id': 2,
+        'eur': "0.00",
+    }
+    asset = Asset('BTC')
+    movement = AssetMovement(
+        timestamp=1606901400,
+        location=Location.BITSTAMP,
+        category=AssetMovementCategory.DEPOSIT,
+        address=None,
+        transaction_id=None,
+        asset=asset,
+        amount=FVal('0.5'),
+        fee_asset=asset,
+        fee=Fee(FVal('0.0005')),
+        link='2',
+    )
+    expected_movement = mock_bitstamp._deserialize_asset_movement(raw_movement)
+    assert movement == expected_movement
+
+
+def test_deserialize_asset_movement_withdrawal(mock_bitstamp):
+    raw_movement = {
+        'id': 5,
+        'type': 1,
+        'datetime': '2020-12-02 09:30:00',
+        'btc': '0.00000000',
+        'usd': '-10000.00000000',
+        'btc_usd': '0.00',
+        'fee': '50.00000000',
+        'order_id': 2,
+        'eur': "0.00",
+    }
+    asset = Asset('USD')
+    movement = AssetMovement(
+        timestamp=1606901400,
+        location=Location.BITSTAMP,
+        category=AssetMovementCategory.WITHDRAWAL,
+        address=None,
+        transaction_id=None,
+        asset=asset,
+        amount=FVal('10000'),
+        fee_asset=asset,
+        fee=Fee(FVal('50')),
+        link='5',
+    )
+    expected_movement = mock_bitstamp._deserialize_asset_movement(raw_movement)
+    assert movement == expected_movement
+
+
+@pytest.mark.parametrize('start_ts, since_id', [(0, 1), (1, 6)])
+def test_query_online_deposits_withdrawals(mock_bitstamp, start_ts, since_id):
+    """Test `since_id` value will change depending on `start_ts` value.
+    Also tests `db_asset_movements` are sorted by `link` (as int) in ascending
+    mode.
+    """
+    asset_btc = Asset('BTC')
+    asset_usd = Asset('USD')
+    movements = [
+        AssetMovement(
+            timestamp=1606901400,
+            location=Location.BITSTAMP,
+            category=AssetMovementCategory.WITHDRAWAL,
+            address=None,
+            transaction_id=None,
+            asset=asset_usd,
+            amount=FVal('10000'),
+            fee_asset=asset_usd,
+            fee=Fee(FVal('50')),
+            link='5',
+        ),
+        AssetMovement(
+            timestamp=1606901400,
+            location=Location.BITSTAMP,
+            category=AssetMovementCategory.DEPOSIT,
+            address=None,
+            transaction_id=None,
+            asset=asset_btc,
+            amount=FVal('0.5'),
+            fee_asset=asset_btc,
+            fee=Fee(FVal('0.0005')),
+            link='2',
+        ),
+    ]
+    database = MagicMock()
+    database.get_asset_movements.return_value = movements
+
+    expected_call = call(
+        start_ts=start_ts,
+        end_ts=2,
+        options={
+            'since_id': since_id,
+            'limit': 1000,
+            'sort': 'asc',
+            'offset': 0,
+        },
+        case='asset_movements',
+    )
+    with patch.object(mock_bitstamp, 'db', new_callable=MagicMock(return_value=database)):
+        with patch.object(mock_bitstamp, '_api_query_paginated') as mock_api_query_paginated:
+            mock_bitstamp.query_online_deposits_withdrawals(
+                start_ts=Timestamp(start_ts),
+                end_ts=Timestamp(2),
+            )
+            assert mock_api_query_paginated.call_args == expected_call

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -25,7 +25,7 @@ from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import Fee, Location, Timestamp, TradePair
 
 
-def test_validate_api_key__invalid_json(mock_bitstamp):
+def test_validate_api_key_invalid_json(mock_bitstamp):
     """Test when status code is not 200, an invalid JSON response raises
     RemoteError.
     """
@@ -37,7 +37,7 @@ def test_validate_api_key__invalid_json(mock_bitstamp):
             mock_bitstamp.validate_api_key()
 
 
-def test_validate_api_key__system_clock_not_synced_error_code(mock_bitstamp):
+def test_validate_api_key_system_clock_not_synced_error_code(mock_bitstamp):
     """Test the error code related with the local system clock not being synced
     raises SystemClockNotSyncedError.
     """
@@ -53,7 +53,7 @@ def test_validate_api_key__system_clock_not_synced_error_code(mock_bitstamp):
 
 
 @pytest.mark.parametrize('code', API_KEY_ERROR_CODE_ACTION.keys())
-def test_validate_api_key__api_key_error_code(
+def test_validate_api_key_api_key_error_code(
         mock_bitstamp,
         code,
 ):
@@ -78,7 +78,7 @@ def test_validate_api_key__api_key_error_code(
     ('{"code": "APIXXX", "reason": "has reason"}', True),
     ('{"code": "APIXXX", "text": "has text"}', False),
 ))
-def test_validate_api_key__non_related_error_code(
+def test_validate_api_key_non_related_error_code(
         mock_bitstamp,
         response,
         has_reason,
@@ -100,7 +100,7 @@ def test_validate_api_key__non_related_error_code(
         assert exp_reason in str(e.value)
 
 
-def test_validate_api_key__success(mock_bitstamp):
+def test_validate_api_key_success(mock_bitstamp):
     """Test when status code is 200 the response is a tuple with True (result)
     and an empty message.
     """
@@ -114,7 +114,7 @@ def test_validate_api_key__success(mock_bitstamp):
     assert msg == ''
 
 
-def test_query_balances__invalid_json(mock_bitstamp):
+def test_query_balances_invalid_json(mock_bitstamp):
     """Test an invalid JSON response raises RemoteError.
     """
     def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
@@ -125,7 +125,7 @@ def test_query_balances__invalid_json(mock_bitstamp):
             mock_bitstamp.query_balances()
 
 
-def test_query_balances__system_clock_not_synced_error_code(mock_bitstamp):
+def test_query_balances_system_clock_not_synced_error_code(mock_bitstamp):
     """Test the error code related with the local system clock not being synced
     raises SystemClockNotSyncedError.
     """
@@ -144,7 +144,7 @@ def test_query_balances__system_clock_not_synced_error_code(mock_bitstamp):
     ('{"code": "APIXXX", "reason": "has reason"}', True),
     ('{"code": "APIXXX", "text": "has text"}', False),
 ))
-def test_query_balances__non_related_error_code(
+def test_query_balances_non_related_error_code(
         mock_bitstamp,
         response,
         has_reason,
@@ -164,7 +164,7 @@ def test_query_balances__non_related_error_code(
     assert exp_reason in msg
 
 
-def test_query_balances__skips_not_balance_entry(mock_bitstamp):
+def test_query_balances_skips_not_balance_entry(mock_bitstamp):
     """Test an entry that doesn't end with `_balance` is skipped
     """
     def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
@@ -174,7 +174,7 @@ def test_query_balances__skips_not_balance_entry(mock_bitstamp):
         assert mock_bitstamp.query_balances() == ({}, '')
 
 
-def test_query_balances__skipped_not_asset_entry(mock_bitstamp):
+def test_query_balances_skipped_not_asset_entry(mock_bitstamp):
     """Test an entry that can't instantiate Asset is skipped
     """
     def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
@@ -184,7 +184,7 @@ def test_query_balances__skipped_not_asset_entry(mock_bitstamp):
         assert mock_bitstamp.query_balances() == ({}, '')
 
 
-def test_query_balances__skips_inquirer_error(mock_bitstamp):
+def test_query_balances_skips_inquirer_error(mock_bitstamp):
     """Test an entry that can't get its USD price because of a remote error is
     skipped
     """
@@ -200,7 +200,7 @@ def test_query_balances__skips_inquirer_error(mock_bitstamp):
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_query_balances__asset_balance(mock_bitstamp, inquirer):  # pylint: disable=unused-argument
+def test_query_balances_asset_balance(mock_bitstamp, inquirer):  # pylint: disable=unused-argument
     """Test an entry that can't get its USD price is skipped
     """
     balances_data = (
@@ -295,7 +295,7 @@ def test_deserialize_trade_sell(mock_bitstamp):
 
 
 @pytest.mark.parametrize('option', ['limit', 'since_id', 'sort', 'offset'])
-def test_api_query_paginated__user_transactions_required_options(mock_bitstamp, option):
+def test_api_query_paginated_user_transactions_required_options(mock_bitstamp, option):
     """Test calling the 'user_transactions' endpoint requires a set of specific
     options.
     """
@@ -316,7 +316,7 @@ def test_api_query_paginated__user_transactions_required_options(mock_bitstamp, 
 
 
 @pytest.mark.parametrize('option', ['limit', 'since_id', 'sort', 'offset'])
-def test_api_query_paginated__user_transactions_required_options_values(mock_bitstamp, option):
+def test_api_query_paginated_user_transactions_required_options_values(mock_bitstamp, option):
     """Test calling the 'user_transactions' endpoint requires a set of specific
     options.
     """
@@ -336,7 +336,7 @@ def test_api_query_paginated__user_transactions_required_options_values(mock_bit
         )
 
 
-def test_api_query_paginated__system_clock_not_synced_error_code(mock_bitstamp):
+def test_api_query_paginated_system_clock_not_synced_error_code(mock_bitstamp):
     """Test the error code related with the local system clock not being synced
     raises SystemClockNotSyncedError.
     """
@@ -363,7 +363,7 @@ def test_api_query_paginated__system_clock_not_synced_error_code(mock_bitstamp):
             )
 
 
-def test_api_query_paginated__invalid_json(mock_bitstamp):
+def test_api_query_paginated_invalid_json(mock_bitstamp):
     """Test an invalid JSON response returns empty list.
     """
     options = {
@@ -390,7 +390,7 @@ def test_api_query_paginated__invalid_json(mock_bitstamp):
     '{"code": "APIXXX", "reason": "has reason"}',
     '{"code": "APIXXX", "text": "has text"}',
 ))
-def test_api_query_paginated__non_related_error_code(mock_bitstamp, response):
+def test_api_query_paginated_non_related_error_code(mock_bitstamp, response):
     """Test an error code unrelated with the system clock not synced one
     returns a an empty list.
     """
@@ -415,7 +415,7 @@ def test_api_query_paginated__non_related_error_code(mock_bitstamp, response):
     assert result == []
 
 
-def test_api_query_paginated__skips_different_type_result(mock_bitstamp):
+def test_api_query_paginated_skips_different_type_result(mock_bitstamp):
     """Test results whose type is not in `raw_result_type_filter` are skipped
     """
     options = {
@@ -442,7 +442,7 @@ def test_api_query_paginated__skips_different_type_result(mock_bitstamp):
     assert result == []
 
 
-def test_api_query_paginated__stops_timestamp_gt_end_ts(mock_bitstamp):
+def test_api_query_paginated_stops_timestamp_gt_end_ts(mock_bitstamp):
     """Test the method stops processing results when a result timestamp is gt
     `end_ts`.
     """
@@ -496,7 +496,7 @@ def test_api_query_paginated__stops_timestamp_gt_end_ts(mock_bitstamp):
 
 
 @pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
-def test_api_query_paginated__trades_pagination(mock_bitstamp):
+def test_api_query_paginated_trades_pagination(mock_bitstamp):
     """Test pagination logic for trades works as expected.
 
     First request: 2 results, 1 valid trade (id 2)

--- a/rotkehlchen/tests/fixtures/__init__.py
+++ b/rotkehlchen/tests/fixtures/__init__.py
@@ -8,6 +8,7 @@ from rotkehlchen.tests.fixtures.blockchain import *
 from rotkehlchen.tests.fixtures.db import *
 from rotkehlchen.tests.fixtures.exchanges.binance import *
 from rotkehlchen.tests.fixtures.exchanges.bitmex import *
+from rotkehlchen.tests.fixtures.exchanges.bitstamp import *
 from rotkehlchen.tests.fixtures.exchanges.bittrex import *
 from rotkehlchen.tests.fixtures.exchanges.coinbase import *
 from rotkehlchen.tests.fixtures.exchanges.coinbasepro import *

--- a/rotkehlchen/tests/fixtures/exchanges/bitstamp.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitstamp.py
@@ -1,0 +1,15 @@
+import pytest
+
+from rotkehlchen.tests.utils.exchanges import create_test_bitstamp
+
+
+@pytest.fixture
+def mock_bitstamp(
+        database,
+        inquirer,  # pylint: disable=unused-argument
+        function_scope_messages_aggregator,
+):
+    return create_test_bitstamp(
+        database=database,
+        msg_aggregator=function_scope_messages_aggregator,
+    )

--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -60,4 +60,5 @@ def added_exchanges():
         'coinbase',
         'coinbasepro',
         'gemini',
+        'bitstamp',
     )

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.exchanges.binance import Binance, create_binance_symbols_to_pair
 from rotkehlchen.exchanges.bitmex import Bitmex
+from rotkehlchen.exchanges.bitstamp import Bitstamp
 from rotkehlchen.exchanges.bittrex import Bittrex
 from rotkehlchen.exchanges.coinbase import Coinbase
 from rotkehlchen.exchanges.coinbasepro import Coinbasepro
@@ -265,6 +266,18 @@ def create_test_bitmex(
     )
     bitmex.first_connection_made = True
     return bitmex
+
+
+def create_test_bitstamp(
+        database,
+        msg_aggregator,
+) -> Bitstamp:
+    return Bitstamp(
+        api_key=make_api_key(),
+        secret=make_api_secret(),
+        database=database,
+        msg_aggregator=msg_aggregator,
+    )
 
 
 def create_test_bittrex(

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -302,6 +302,7 @@ class Location(Enum):
     COMMODITIES = 15
     CRYPTOCOM = 16
     UNISWAP = 17
+    BITSTAMP = 18
 
     def __str__(self) -> str:
         if self == Location.EXTERNAL:
@@ -338,6 +339,8 @@ class Location(Enum):
             return 'crypto.com'
         elif self == Location.UNISWAP:
             return 'uniswap'
+        elif self == Location.BITSTAMP:
+            return 'bitstamp'
 
         raise RuntimeError(f'Corrupt value {self} for Location -- Should never happen')
 
@@ -376,6 +379,8 @@ class Location(Enum):
             return 'P'
         elif self == Location.UNISWAP:
             return 'Q'
+        elif self == Location.BITSTAMP:
+            return 'R'
 
         raise RuntimeError(f'Corrupt value {self} for Location -- Should never happen')
 


### PR DESCRIPTION
Pending:
- [x] Wait for Bitstamp support answers regarding the deposit/withdrawal JSON, and nail down `_deserialize_asset_movement()`.
- [x] Test suite for asset movements.
- [x] Wait for Bitstamp support answers regarding requests time limit.

Related Bitstamp API clients:
https://godoc.org/github.com/thrasher-/gocryptotrader/exchanges/bitstamp#UserTransactions
https://github.com/kmadac/bitstamp-python-client/blob/master/bitstamp/client.py#L256

Closes #436 