### PR TITLE
Fixed Binance api_query logic for retry case (status_code 429)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :bug:`1846` AMPL token balance should no longer be double counted
+* :bug:`1849` Binance queries should no longer randomly fail with invalid signature.
+* :bug:`1846` AMPL token balance should no longer be double counted.
 
 * :release:`1.9.1 <2020-11-29>`
 * :feature:`1716` Rotki can now also query data from the following ethereum open nodes:

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -231,13 +231,15 @@ class Binance(ExchangeInterface):
 
     def api_query(self, method: str, options: Optional[Dict] = None) -> Union[List, Dict]:
         call_options = options.copy() if options else {}
-        backoff = self.initial_backoff
 
         while True:
             with self.nonce_lock:
                 # Protect this region with a lock since binance will reject
                 # non-increasing nonces. So if two greenlets come in here at
                 # the same time one of them will fail
+                if 'signature' in call_options:
+                    del call_options['signature']
+
                 if method in V3_ENDPOINTS or method in WAPI_ENDPOINTS:
                     api_version = 3
                     # Recommended recvWindows is 5000 but we get timeouts with it
@@ -257,15 +259,13 @@ class Binance(ExchangeInterface):
                 apistr = 'wapi/' if method in WAPI_ENDPOINTS else 'api/'
                 request_url = f'{self.uri}{apistr}v{str(api_version)}/{method}?'
                 request_url += urlencode(call_options)
-
                 log.debug('Binance API request', request_url=request_url)
                 try:
                     response = self.session.get(request_url)
                 except requests.exceptions.RequestException as e:
                     raise RemoteError(f'Binance API request failed due to {str(e)}')
 
-            limit_ban = response.status_code == 429 and backoff > self.backoff_limit
-            if limit_ban or response.status_code not in (200, 429):
+            if response.status_code not in (200, 429):
                 code = 'no code found'
                 msg = 'no message found'
                 try:
@@ -286,13 +286,15 @@ class Binance(ExchangeInterface):
                         msg,
                     ))
             elif response.status_code == 429:
-                if backoff > self.backoff_limit:
-                    break
-                # Binance has limits and if we hit them we should backoff
-                # https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#limits
-                log.debug('Got 429 from Binance. Backing off', seconds=backoff)
-                gevent.sleep(backoff)
-                backoff = backoff * 2
+                # Binance has limits and if we hit them we should backoff.
+                # A Retry-After header is sent with a 418 or 429 responses and
+                # will give the number of seconds required to wait, in the case
+                # of a 429, to prevent a ban, or, in the case of a 418, until
+                # the ban is over.
+                # https://binance-docs.github.io/apidocs/spot/en/#limits
+                retry_after = int(response.headers.get('retry-after', '0'))
+                log.debug('Got 429 from Binance. Backing off', seconds=retry_after)
+                gevent.sleep(retry_after)
                 continue
             else:
                 # success

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -129,8 +129,7 @@ EXPECTED_4193_TXS = [{
 def test_query_transactions(rotkehlchen_api_server):
     """Test that querying the ethereum transactions endpoint works as expected
 
-    This test uses real data. Found an ethereum address that has very few transactions
-    and hopefully won't have more. If it does we can adjust the test.
+    This test uses real data.
     """
     async_query = random.choice([False, True])
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -151,8 +150,19 @@ def test_query_transactions(rotkehlchen_api_server):
     expected_result = EXPECTED_AFB7_TXS + EXPECTED_4193_TXS
     expected_result.sort(key=lambda x: x['timestamp'])
     expected_result.reverse()
-    assert result['entries'] == expected_result
-    assert result['entries_found'] == len(expected_result)
+
+    # Make sure that all of the transactions we expect are there and in order
+    # There can be more transactions (since the address can make more)
+    # but this check ignores them
+    previous_index = 0
+    for entry in expected_result:
+        assert entry in result['entries']
+        entry_idx = result['entries'].index(entry)
+        if previous_index != 0:
+            assert entry_idx == previous_index + 1
+        previous_index = entry_idx
+
+    assert result['entries_found'] >= len(expected_result)
     assert result['entries_limit'] == FREE_ETH_TX_LIMIT
 
     # Check that transactions per address and in a specific time range can be

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -1,6 +1,9 @@
+import hashlib
+import hmac
 import warnings as test_warnings
 from datetime import datetime
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
+from urllib.parse import urlencode
 
 import pytest
 
@@ -23,6 +26,7 @@ from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import AssetMovementCategory, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
+from rotkehlchen.utils.misc import ts_now_in_ms
 
 
 def test_name():
@@ -149,32 +153,6 @@ exchange_info_mock_text = '''{
     "icebergAllowed": false
     }]
 }'''
-
-
-def test_binance_backoff_after_429(function_scope_binance):
-    count = 0
-    binance = function_scope_binance
-
-    def mock_429(url):  # pylint: disable=unused-argument
-        nonlocal count
-        if count < 2:
-            response = MockResponse(429, '{"code": -1103, "msg": "Too many requests"}')
-        else:
-            response = MockResponse(200, exchange_info_mock_text)
-        count += 1
-        return response
-
-    binance.initial_backoff = 0.5
-    binance.backoff_limit = 2
-    with patch.object(binance.session, 'get', side_effect=mock_429):
-        # test that after 2 429 cals we finally succeed in the API call
-        result = binance.api_query('exchangeInfo')
-        assert 'timezone' in result
-
-        # Test the backoff_limit properly returns an error when hit
-        count = -9999999
-        with pytest.raises(RemoteError):
-            binance.api_query('exchangeInfo')
 
 
 def test_binance_assets_are_known(
@@ -790,3 +768,67 @@ def test_api_query_dict_calls_with_time_delta(function_scope_binance):
                 end_ts=Timestamp(end_ts),
             )
             assert mock_api_query_dict.call_args_list == expected_calls
+
+
+@pytest.mark.freeze_time(datetime(2020, 11, 24, 3, 14, 15))
+def test_api_query_retry_on_status_code_429(function_scope_binance):
+    """Test when Binance API returns 429 and the request is retried, the
+    signature is not polluted by any attribute from the previous call.
+
+    It also tests getting the `retry-after` seconds to backoff from the
+    response header.
+
+    NB: basically remove `call_options['signature']`.
+    """
+    binance = function_scope_binance
+    offset_ms = 1000
+    call_options = {
+        'fromId': 0,
+        'limit': 1000,
+        'symbol': 'BUSDUSDT',
+        'recvWindow': 10000,
+        'timestamp': str(ts_now_in_ms() + offset_ms),
+    }
+    signature = hmac.new(
+        binance.secret,
+        urlencode(call_options).encode('utf-8'),
+        hashlib.sha256,
+    ).hexdigest()
+    call_options['signature'] = signature
+    base_url = 'https://api.binance.com/api/v3/myTrades?'
+    exp_request_url = base_url + urlencode(call_options)
+
+    # NB: both calls must have the same signature (time frozen)
+    expected_calls = [call(exp_request_url), call(exp_request_url)]
+
+    def get_mocked_response():
+        responses = [
+            MockResponse(429, '[]', headers={'retry-after': '1'}),
+            MockResponse(418, '{"code": "XXX", "msg": "msg"}'),
+        ]
+        for response in responses:
+            yield response
+
+    def mock_response(url):  # pylint: disable=unused-argument
+        return next(get_response)
+
+    get_response = get_mocked_response()
+
+    # NB: force to break the loop after 2 requests by lowering the `self.backoff_limit`
+    backoff_limit_ = MagicMock(return_value=7)
+    offset_ms_ = MagicMock(return_value=1000)
+    session_get = MagicMock(side_effect=mock_response)
+    with patch.object(binance, 'backoff_limit', new_callable=backoff_limit_):
+        with patch.object(binance, 'offset_ms', new_callable=offset_ms_):
+            with patch.object(binance.session, 'get', side_effect=session_get) as mock_session_get:
+                with pytest.raises(RemoteError) as e:
+                    binance.api_query(
+                        method='myTrades',
+                        options={
+                            'fromId': 0,
+                            'limit': 1000,
+                            'symbol': 'BUSDUSDT',
+                        },
+                    )
+    assert 'myTrades failed with HTTP status code: 418' in str(e.value)
+    assert mock_session_get.call_args_list == expected_calls

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -6,11 +6,17 @@ from hexbytes import HexBytes
 
 
 class MockResponse():
-    def __init__(self, status_code: int, text: str) -> None:
+    def __init__(
+            self,
+            status_code: int,
+            text: str,
+            headers: Dict['str', Any] = None,
+    ) -> None:
         self.status_code = status_code
         self.text = text
         self.content = text.encode()
         self.url = 'http://someurl.com'
+        self.headers = headers or {}
 
     def json(self) -> Dict[str, Any]:
         return json.loads(self.text)


### PR DESCRIPTION
[References](https://binance-docs.github.io/apidocs/spot/en/#limits)

Closes #1849 