### PR TITLE
Added custom retries logic in Graph

### DIFF
--- a/rotkehlchen/chain/ethereum/graph.py
+++ b/rotkehlchen/chain/ethereum/graph.py
@@ -56,7 +56,7 @@ class Graph():
         - May raise requests.RequestException if there is a problem connecting to the subgraph"""
         transport = RequestsHTTPTransport(url=url)
         try:
-            self.client = Client(transport=transport)
+            self.client = Client(transport=transport, fetch_schema_from_transport=False)
         except (requests.exceptions.RequestException) as e:
             raise RemoteError(f'Failed to connect to the graph at {url} due to {str(e)}') from e
 
@@ -88,7 +88,7 @@ class Graph():
             except (requests.exceptions.RequestException, Exception) as e:
                 # NB: the lack of a good API error handling by The Graph combined
                 # with gql v2 raising bare exceptions doesn't allow us to act
-                # better on failed requests. Currently all triggers the retry logic.
+                # better on failed requests. Currently all trigger the retry logic.
                 # TODO: upgrade to gql v3 and amend this code on any improvement
                 # The Graph does on its API error handling.
                 exc_msg = str(e)

--- a/rotkehlchen/tests/unit/test_graph.py
+++ b/rotkehlchen/tests/unit/test_graph.py
@@ -1,0 +1,146 @@
+from contextlib import ExitStack
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests import HTTPError, Response
+
+from rotkehlchen.chain.ethereum.graph import RETRY_STATUS_CODES, Graph, format_query_indentation
+from rotkehlchen.constants.timing import QUERY_RETRY_TIMES
+from rotkehlchen.errors import RemoteError
+
+TEST_URL_1 = 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2'
+TEST_QUERY_1 = (
+    """
+    tokenDayDatas
+    (
+        first: $limit,
+    ) {{
+        date
+        token {{
+            id
+        }}
+        priceUSD
+    }}}}
+    """
+)
+
+
+def test_error_response_not_retry():
+    """Test failed request without a retry status code does not trigger the
+    retry logic.
+
+    The exception message raised mimics the one raised by gql v2 in the worst
+    case scenario: when the response JSON does not have "data" nor "errors".
+    The method `RequestsHTTPTransport.execute()` is throws this exception.
+    """
+    graph = Graph(TEST_URL_1)
+    param_types = {'$limit': 'Int!'}
+    param_values = {'limit': 1}
+    querystr = format_query_indentation(TEST_QUERY_1.format())
+
+    # Mimic gql v2 error message
+    client = MagicMock()
+    response = Response()
+    response.url = TEST_URL_1
+    response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
+    response.reason = 'whatever reason'
+    error_msg = (
+        f'{response.status_code} Server Error: {response.reason} for url: {response.url}'
+    )
+    client.execute.side_effect = HTTPError(error_msg, response=response)
+
+    backoff_factor_patch = patch(
+        'rotkehlchen.chain.ethereum.graph.RETRY_BACKOFF_FACTOR',
+        return_value=0,
+    )
+    client_patch = patch.object(graph, 'client', new=client)
+
+    with ExitStack() as stack:
+        stack.enter_context(backoff_factor_patch)
+        stack.enter_context(client_patch)
+        with pytest.raises(RemoteError) as e:
+            graph.query(
+                querystr=querystr,
+                param_types=param_types,
+                param_values=param_values,
+            )
+
+    assert client.execute.call_count == 1
+    assert 'Failed to query the graph for' in str(e.value)
+
+
+@pytest.mark.parametrize('status_code', list(RETRY_STATUS_CODES))
+def test_error_response_retry(status_code):
+    """Test failed request with a retry status code triggers the retries logic.
+
+    The exception message raised mimics the one raised by gql v2 in the worst
+    case scenario: when the response JSON does not have "data" nor "errors".
+    The method `RequestsHTTPTransport.execute()` is throws this exception.
+    """
+    graph = Graph(TEST_URL_1)
+    param_types = {'$limit': 'Int!'}
+    param_values = {'limit': 1}
+    querystr = format_query_indentation(TEST_QUERY_1.format())
+
+    # Mimic gql v2 error message
+    client = MagicMock()
+    response = Response()
+    response.url = TEST_URL_1
+    response.status_code = status_code.value
+    response.reason = 'whatever reason'
+    error_msg = (
+        f'{response.status_code} Server Error: {response.reason} for url: {response.url}'
+    )
+    client.execute.side_effect = HTTPError(error_msg, response=response)
+
+    backoff_factor_patch = patch(
+        'rotkehlchen.chain.ethereum.graph.RETRY_BACKOFF_FACTOR',
+        new=0,
+    )
+    client_patch = patch.object(graph, 'client', new=client)
+
+    with ExitStack() as stack:
+        stack.enter_context(backoff_factor_patch)
+        stack.enter_context(client_patch)
+        with pytest.raises(RemoteError) as e:
+            graph.query(
+                querystr=querystr,
+                param_types=param_types,
+                param_values=param_values,
+            )
+
+    assert client.execute.call_count == QUERY_RETRY_TIMES
+    assert 'No retries left' in str(e.value)
+
+
+def test_success_result():
+    """Test a successful response returns result as expected
+    """
+    expected_result = {"schema": [{"data1"}, {"data2"}]}
+
+    graph = Graph(TEST_URL_1)
+    param_types = {'$limit': 'Int!'}
+    param_values = {'limit': 1}
+    querystr = format_query_indentation(TEST_QUERY_1.format())
+
+    client = MagicMock()
+    client.execute.return_value = expected_result
+
+    backoff_factor_patch = patch(
+        'rotkehlchen.chain.ethereum.graph.RETRY_BACKOFF_FACTOR',
+        return_value=0,
+    )
+    client_patch = patch.object(graph, 'client', new=client)
+
+    with ExitStack() as stack:
+        stack.enter_context(backoff_factor_patch)
+        stack.enter_context(client_patch)
+        result = graph.query(
+            querystr=querystr,
+            param_types=param_types,
+            param_values=param_values,
+        )
+
+    assert client.execute.call_count == 1
+    assert result == expected_result


### PR DESCRIPTION
Definitely retry via `HTTPAdapter` in `gql.transport.requests.RequestsHTTPTransport` does not work for us. I wonder if it is related with gevent.

In case of a failed request, `client.execute()` is expected to raise an exception whose message contains the status code. Is this status code the one responsible of triggering or not the retry logic.