### PR TITLE
Fix Bitstamp API requests and filtering by just to_ts

### DIFF
--- a/rotkehlchen/db/utils.py
+++ b/rotkehlchen/db/utils.py
@@ -81,27 +81,24 @@ def form_query_to_filter_timestamps(
         to_ts: Optional[Timestamp],
 ) -> Tuple[str, Union[Tuple, Tuple[Timestamp], Tuple[Timestamp, Timestamp]]]:
     """Formulates the query string and its bindings to filter for timestamps"""
-    bindings: Union[Tuple, Tuple[Timestamp], Tuple[Timestamp, Timestamp]] = ()
     got_from_ts = from_ts is not None
     got_to_ts = to_ts is not None
-    if (got_from_ts or got_to_ts):
-        if 'WHERE' not in query:
-            query += 'WHERE '
-        else:
-            query += 'AND '
+    if got_from_ts or got_to_ts:
+        query += 'WHERE' if 'WHERE' not in query else 'AND '
 
+    filters = []
+    bindings = []
     if got_from_ts:
-        query += f'{timestamp_attribute} >= ? '
-        bindings = (from_ts,)
-        if got_to_ts:
-            query += f'AND {timestamp_attribute} <= ? '
-            bindings = (from_ts, to_ts)
-    elif got_to_ts:
-        query += f'AND {timestamp_attribute} <= ? '
-        bindings = (to_ts,)
+        filters.append(f'{timestamp_attribute} >= ? ')
+        bindings.append(from_ts)
+    if got_to_ts:
+        filters.append(f'{timestamp_attribute} <= ? ')
+        bindings.append(to_ts)
 
+    query += 'AND '.join(filters)
     query += f'ORDER BY {timestamp_attribute} ASC;'
-    return query, bindings
+
+    return query, tuple(bindings)
 
 
 def deserialize_tags_from_db(val: Optional[str]) -> Optional[List[str]]:

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -115,7 +115,8 @@ class Bitstamp(ExchangeInterface):
         super().__init__('bitstamp', api_key, secret, database)
         self.base_uri = 'https://www.bitstamp.net/api'
         self.msg_aggregator = msg_aggregator
-        # NB: X-Auth-Signature, X-Auth-Nonce, X-Auth-Timestamp and Content-Type per request
+        # NB: X-Auth-Signature, X-Auth-Nonce, X-Auth-Timestamp & Content-Type change per request
+        # X-Auth and X-Auth-Version are constant
         self.session.headers.update({
             'X-Auth': f'BITSTAMP {self.api_key}',
             'X-Auth-Version': 'v2',
@@ -313,6 +314,8 @@ class Bitstamp(ExchangeInterface):
         })
         if content_type:
             self.session.headers.update({'Content-Type': content_type})
+        else:
+            self.session.headers.pop('Content-Type', None)
 
         log.debug('Bitstamp API request', request_url=request_url)
         try:

--- a/rotkehlchen/tests/fixtures/exchanges/bitstamp.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitstamp.py
@@ -1,6 +1,17 @@
 import pytest
 
 from rotkehlchen.tests.utils.exchanges import create_test_bitstamp
+from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
+
+
+@pytest.fixture
+def bitstamp_api_key():
+    return make_api_key()
+
+
+@pytest.fixture
+def bitstamp_api_secret():
+    return make_api_secret()
 
 
 @pytest.fixture
@@ -8,8 +19,12 @@ def mock_bitstamp(
         database,
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,
+        bitstamp_api_key,
+        bitstamp_api_secret,
 ):
     return create_test_bitstamp(
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
+        api_key=bitstamp_api_key,
+        secret=bitstamp_api_secret,
     )

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -309,9 +309,14 @@ def create_test_bitmex(
 def create_test_bitstamp(
         database,
         msg_aggregator,
-        api_key,
-        secret,
+        api_key=None,
+        secret=None,
 ) -> Bitstamp:
+    if api_key is None:
+        api_key = make_api_key()
+    if secret is None:
+        secret = make_api_secret()
+
     return Bitstamp(
         api_key=api_key,
         secret=secret,

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -309,10 +309,12 @@ def create_test_bitmex(
 def create_test_bitstamp(
         database,
         msg_aggregator,
+        api_key,
+        secret,
 ) -> Bitstamp:
     return Bitstamp(
-        api_key=make_api_key(),
-        secret=make_api_secret(),
+        api_key=api_key,
+        secret=secret,
         database=database,
         msg_aggregator=msg_aggregator,
     )


### PR DESCRIPTION
- Polluted header with a `Content-Type` from previous requests.
- `form_query_to_filter_timestamps` prepends an `AND ` when `to_ts` is the only param.

Closes #1916 