### PR TITLE
[WIP] Upgraded gql v2 to v3, refactored Graph module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ coincurve==13.0.0
 typing-extensions==3.7.4.2
 base58check==1.0.2
 bech32==1.2.0
-gql==2.0.0
+gql==3.0.0a5
 uuid==1.30
 
 # For the rest api

--- a/rotkehlchen/logging.py
+++ b/rotkehlchen/logging.py
@@ -213,3 +213,4 @@ def configure_logging(args: argparse.Namespace) -> None:
     if not args.logfromothermodules:
         logging.getLogger('urllib3').setLevel(logging.CRITICAL)
         logging.getLogger('urllib3.connectionpool').setLevel(logging.CRITICAL)
+        logging.getLogger('gql.transport.requests').setLevel(logging.CRITICAL)


### PR DESCRIPTION
The library `gql 3` is still in alpha/pre. As we are using the sync transport there hasn't been introduced any major refactor on our side. The "big" difference is that now we have more control on a failed request as gql v3 provides lots of exceptions. Besides `graphql-core` has been upgraded as well.

As this is a WIP/POC no tests have been implemented. 

Resources:
[gql 3 docs](https://gql.readthedocs.io/en/latest/intro.html)
[gql 3 GitHub](https://github.com/graphql-python/gql/tree/master)
[gql changelog](https://github.com/graphql-python/gql/releases)
[gql from v2 to v3 roadmap](https://github.com/graphql-python/gql/issues/62)
