### PR TITLE
Added support for Binance US

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,9 @@
 Changelog
 =========
 
+* :feature:`1515` Rotki now supports Binance US. Users can see their balances and import trades, deposits and withdrawals from that exchange. They are also taken into account in the tax report.
 * :feature:`1838` Allow users to input a beaconcha.in API key for better request limits: https://beaconcha.in/pricing
-* :feature:`-` Support MANA and AAVE in Kraken and also detect staked Kava and ETH2
+* :feature:`-` Support MANA and AAVE in Kraken and also detect staked Kava and ETH2.
 * :bug:`1916` Querying bitstamp trades should now work properly again.
 * :bug:`1917` Users can now properly login if they input the username after the password.
 

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -21,6 +21,7 @@ ONE = FVal(1)
 KRAKEN_BASE_URL = 'https://api.kraken.com'
 KRAKEN_API_VERSION = '0'
 BINANCE_BASE_URL = 'https://api.binance.com/'
+BINANCE_US_BASE_URL = 'https://api.binance.us/'
 # KRAKEN_BASE_URL = 'http://localhost:5001/kraken'
 # KRAKEN_API_VERSION = 'mock'
 # BINANCE_BASE_URL = 'http://localhost:5001/binance/api/'

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -56,6 +56,8 @@ INSERT OR IGNORE INTO location(location, seq) VALUES ('P', 16);
 INSERT OR IGNORE INTO location(location, seq) VALUES ('Q', 17);
 /* Bitstamp */
 INSERT OR IGNORE INTO location(location, seq) VALUES ('R', 18);
+/* Binance US */
+INSERT OR IGNORE INTO location(location, seq) VALUES ('S', 19);
 """
 
 # Custom enum table for AssetMovement categories (deposit/withdrawal)

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -359,6 +359,8 @@ def deserialize_location(symbol: str) -> Location:
         return Location.UNISWAP
     if symbol == 'bitstamp':
         return Location.BITSTAMP
+    if symbol == 'binance_us':
+        return Location.BINANCE_US
     # else
     raise DeserializationError(
         f'Failed to deserialize location symbol. Unknown symbol {symbol} for location',
@@ -455,6 +457,8 @@ def deserialize_location_from_db(symbol: str) -> Location:
         return Location.UNISWAP
     if symbol == 'R':
         return Location.BITSTAMP
+    if symbol == 'S':
+        return Location.BINANCE_US
     # else
     raise DeserializationError(
         f'Failed to deserialize location symbol. Unknown symbol {symbol} for location',

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -165,7 +165,7 @@ def test_query_history_remote_errors(rotkehlchen_api_server_with_exchanges):
     # For history processing tests look at test_accounting.py and
     # test_accounting_events.py
     assert 'invalid JSON' in data['message']
-    assert 'Binance' in data['message']
+    assert 'binance' in data['message']
     assert 'Bittrex' in data['message']
     assert 'Bitmex' in data['message']
     assert 'Kraken' in data['message']

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -186,7 +186,8 @@ def test_binance_assets_are_known(
             assert binance_asset in UNSUPPORTED_BINANCE_ASSETS
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
-                f'Found unknown asset {e.asset_name} in Binance. Support for it has to be added',
+                f'Found unknown asset {e.asset_name} in binance. '
+                f'Support for it has to be added',
             ))
 
 

--- a/rotkehlchen/tests/exchanges/test_binance_us.py
+++ b/rotkehlchen/tests/exchanges/test_binance_us.py
@@ -1,0 +1,45 @@
+import warnings as test_warnings
+
+from rotkehlchen.assets.converters import UNSUPPORTED_BINANCE_ASSETS, asset_from_binance
+from rotkehlchen.constants.misc import BINANCE_US_BASE_URL
+from rotkehlchen.errors import UnknownAsset, UnsupportedAsset
+from rotkehlchen.exchanges.binance import Binance
+from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
+from rotkehlchen.user_messages import MessagesAggregator
+
+
+def test_name():
+    exchange = Binance('a', b'a', object(), object(), uri=BINANCE_US_BASE_URL)
+    assert exchange.name == 'binance_us'
+
+
+def test_binance_assets_are_known(
+        database,
+        inquirer,  # pylint: disable=unused-argument
+):
+    # use a real binance instance so that we always get the latest data
+    binance = Binance(
+        api_key=make_api_key(),
+        secret=make_api_secret(),
+        database=database,
+        msg_aggregator=MessagesAggregator(),
+        uri=BINANCE_US_BASE_URL,
+    )
+
+    mapping = binance.symbols_to_pair
+    binance_assets = set()
+    for _, pair in mapping.items():
+        binance_assets.add(pair.binance_base_asset)
+        binance_assets.add(pair.binance_quote_asset)
+
+    sorted_assets = sorted(binance_assets)
+    for binance_asset in sorted_assets:
+        try:
+            _ = asset_from_binance(binance_asset)
+        except UnsupportedAsset:
+            assert binance_asset in UNSUPPORTED_BINANCE_ASSETS
+        except UnknownAsset as e:
+            test_warnings.warn(UserWarning(
+                f'Found unknown asset {e.asset_name} in binance_us. '
+                f'Support for it has to be added',
+            ))

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -305,6 +305,7 @@ class Location(Enum):
     CRYPTOCOM = 16
     UNISWAP = 17
     BITSTAMP = 18
+    BINANCE_US = 19
 
     def __str__(self) -> str:
         if self == Location.EXTERNAL:
@@ -343,6 +344,8 @@ class Location(Enum):
             return 'uniswap'
         if self == Location.BITSTAMP:
             return 'bitstamp'
+        if self == Location.BINANCE_US:
+            return 'binance_us'
         # else
         raise RuntimeError(f'Corrupt value {self} for Location -- Should never happen')
 
@@ -383,6 +386,8 @@ class Location(Enum):
             return 'Q'
         if self == Location.BITSTAMP:
             return 'R'
+        if self == Location.BINANCE_US:
+            return 'S'
         # else
         raise RuntimeError(f'Corrupt value {self} for Location -- Should never happen')
 


### PR DESCRIPTION
Work in progress (I want to see how the integration tests behave).
Pending to agree which tests implement for Binance US.

I've manually tested the "dual" implementation for Binance and works OK (get trades, balance, etc.).
All I've tested from Binance US are the assets symbols list (shared with Binance), and trying to validate the API keys (it fails as expected, but fails nicely, with our expected logging messages).

Closes #1515 