### PR TITLE
Recognize empty string as invalid BTC address

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -59,7 +59,10 @@ jobs:
             ${{ runner.os }}-node--ci-
       - name: Install dependencies
         working-directory: ./frontend/app
-        run: npm ci
+        run: |
+          if ! npm ci --exit-code; then
+            npm ci
+          fi
       - name: Lint code
         working-directory: ./frontend/app
         run: npm run lint:check

--- a/frontend/app/src/components/accounts/AccountBalanceTable.vue
+++ b/frontend/app/src/components/accounts/AccountBalanceTable.vue
@@ -224,7 +224,7 @@ export default class AccountBalanceTable extends Mixins(StatusMixin) {
       }
     } else {
       for (const { address } of this.visibleBalances) {
-        if (selection.includes(address)) {
+        if (!address || selection.includes(address)) {
           continue;
         }
         selection.push(address);
@@ -241,7 +241,7 @@ export default class AccountBalanceTable extends Mixins(StatusMixin) {
       if (index >= 0) {
         selection.splice(index, 1);
       }
-    } else if (!selection.includes(address)) {
+    } else if (!address && !selection.includes(address)) {
       selection.push(address);
     }
     this.addressesSelected(selection);

--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -34,10 +34,10 @@ def is_valid_base58_address(value: str) -> bool:
 
     try:
         abytes = base58check.b58decode(value)
-    except (ValueError):
+    except ValueError:
         return False
 
-    if not abytes[0] in (0x00, 0x05):
+    if len(abytes) == 0 or not abytes[0] in (0x00, 0x05):
         return False
 
     checksum = hashlib.sha256(hashlib.sha256(abytes[:-4]).digest()).digest()[:4]

--- a/rotkehlchen/tests/unit/test_bitcoin.py
+++ b/rotkehlchen/tests/unit/test_bitcoin.py
@@ -34,6 +34,7 @@ def test_is_valid_btc_address():
     assert is_valid_btc_address('BC1SW50QA3JX3S')
     assert is_valid_btc_address('bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj')
 
+    assert not is_valid_btc_address('')
     assert not is_valid_btc_address('foo')
     assert not is_valid_btc_address('18ddjB7HWTaxzvTbLp1nWvaixU3U2oTZ1')
     assert not is_valid_btc_address(


### PR DESCRIPTION
![2020-12-22_10-43](https://user-images.githubusercontent.com/1658405/102875718-78cb8200-4444-11eb-96c9-7ec5d559f479.png)


@kelsos as discussed in discord please add a fix for the frontend trying to delete an empty string account in this case ^