### PR TITLE
Added Bitfinex support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,32 @@ Changelog
   - `TrueFi Trust Token (TRU) <https://www.coingecko.com/en/coins/truefi>`__
   - `Mettalex (MTLX) <https://www.coingecko.com/en/coins/mettalex>`__
   - `Okex OKB Token (OKB) <https://www.coingecko.com/en/coins/okb>`__
+  - `Callisto Network (CLO) <https://www.coingecko.com/en/coins/callisto-network>`__
+  - `Ultra (UOS) <https://www.coingecko.com/en/coins/ultra>`__
+  - `Metaverse ETP (ETP) <https://www.coingecko.com/en/coins/metaverse-etp>`__
+  - `EOSDT (EOSDT) <https://www.coingecko.com/en/coins/eosdt>`__
+  - `Tether EUR (EURT) <https://www.cryptocompare.com/coins/eurt/overview>`__
+  - `LiquidApps (DAPP) <https://www.coingecko.com/en/coins/liquidapps>`__
+  - `V.SYSTEMS (VSYS) <https://www.coingecko.com/en/coins/v-systems>`__
+  - `Dragon Token (DT) <https://www.coingecko.com/en/coins/dragon-token>`__
+  - `CryptoFranc (XCHF) <https://www.coingecko.com/en/coins/cryptofranc>`__
+  - `Tether Gold (XAUT) <https://www.coingecko.com/en/coins/tether-gold>`__
+  - `XinFin (XDC) <https://www.coingecko.com/en/coins/xinfin>`__
+  - `RIF Token (RIF) <https://www.coingecko.com/en/coins/rif-token>`__
+  - `ZB Token (ZB) <https://www.coingecko.com/en/coins/zb-token>`__
+  - `RING X PLATFORM (RINGX) <https://www.coingecko.com/en/coins/ring-x-platform>`__
+  - `Hermez Network (HEZ) <https://www.coingecko.com/en/coins/hermez-network>`__
+  - `Essentia (ESS) <https://www.coingecko.com/en/coins/essentia>`__
+  - `Native Utility Token (NUT) <https://www.coingecko.com/en/coins/native-utility-token>`__
+  - `LEO Token (LEO) <https://www.coingecko.com/en/coins/leo-token>`__
+  - `Utopia Genesis Foundation (UOP) <https://www.coingecko.com/en/coins/utopia-genesis-foundation>`__
+  - `Rebitcoin (RBTC) <https://www.coingecko.com/en/coins/rebitcoin>`__
+  - `Data Transaction Token (XD) <https://www.coingecko.com/en/coins/data-transaction-token>`__
+  - `Ether Kingdoms Token (IMP) <https://www.coingecko.com/en/coins/ether-kingdoms-token>`__
+  - `Renrenbit (RRB) <https://www.coingecko.com/en/coins/renrenbit>`__
+  - `Tether CNH (CNHT) <https://www.cryptocompare.com/coins/cnht/overview>`__
+  - `Xriba (XRA) <https://www.coingecko.com/en/coins/xriba>`__
+  - `BTSE Token (BTSE) <https://www.coingecko.com/en/coins/btse-token>`__
 
 * :release:`1.10.1 <2020-12-16>`
 * :bug:`-` This release should fix the "Failed at database upgrade from version 21 to 22: arguments should be given at the first instantiation" error

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`438` Rotki now supports Bitfinex. Users can see their balances and import trades, deposits and withdrawals from that exchange. They are also taken into account in the tax report.
 * :feature:`1949` All time pickers now use a 24h format to avoid user confusion.
 * :feature:`1961` Users can configure the BTC address derivation gap limit.
 * :feature:`1955` Users can now set their main currency to Swiss Franc.

--- a/frontend/app/src/assets/images/bitfinex.svg
+++ b/frontend/app/src/assets/images/bitfinex.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="120"
+   height="120"
+   viewBox="0 0 31.749999 31.749999"
+   version="1.1"
+   id="svg446"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="bitfinex.svg">
+  <defs
+     id="defs440" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.86180571"
+     inkscape:cx="426.69788"
+     inkscape:cy="56.847669"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="3840"
+     inkscape:window-height="2130"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata443">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(357.06977,-214.71208)">
+    <g
+       id="g1701"
+       transform="translate(-206.63958,1.9843719)">
+      <path
+         style="fill:#97c554;fill-rule:nonzero;stroke:none;stroke-width:0.264583"
+         inkscape:connector-curvature="0"
+         d="m -147.27213,238.3694 c 1.26878,1.34364 8.23775,7.78352 19.17639,0.30954 7.90976,-6.15987 7.71215,-19.51473 6.95229,-23.54765 -0.26471,0.58693 -9.45213,20.70612 -26.12868,23.23811 z m 26.12762,-23.24152 c -0.0969,-0.04 -10.27316,-1.42742 -20.33323,5.05204 -6.24697,4.02353 -7.07274,9.91241 -6.78772,13.83641 14.62435,-1.63654 26.78921,-18.42706 27.12095,-18.88845 z"
+         id="Path-1-Copy-9" />
+      <path
+         style="fill:#709b30;fill-rule:nonzero;stroke:none;stroke-width:0.264583"
+         inkscape:connector-curvature="0"
+         d="m -121.14451,215.12788 c -0.0969,-0.04 -10.27316,-1.42742 -20.33323,5.05204 -6.24697,4.02353 -7.07274,9.91241 -6.78772,13.83641 14.62435,-1.63654 26.78921,-18.42706 27.12095,-18.88845 z"
+         id="Path-1-Copy-8" />
+    </g>
+  </g>
+</svg>

--- a/frontend/app/src/components/history/consts.ts
+++ b/frontend/app/src/components/history/consts.ts
@@ -2,6 +2,7 @@ import { TradeLocationData } from '@/components/history/type';
 import {
   EXCHANGE_BINANCE,
   EXCHANGE_BINANCE_US,
+  EXCHANGE_BITFINEX,
   EXCHANGE_BITMEX,
   EXCHANGE_BITSTAMP,
   EXCHANGE_BITTREX,
@@ -46,6 +47,11 @@ export const tradeLocations: TradeLocationData[] = [
     identifier: EXCHANGE_BITTREX,
     name: 'Bittrex',
     icon: require('@/assets/images/bittrex.png')
+  },
+  {
+    identifier: EXCHANGE_BITFINEX,
+    name: 'Bitfinex',
+    icon: require('@/assets/images/bitfinex.svg')
   },
   {
     identifier: EXCHANGE_GEMINI,

--- a/frontend/app/src/data/defaults.ts
+++ b/frontend/app/src/data/defaults.ts
@@ -18,6 +18,7 @@ export const EXCHANGE_POLONIEX = 'poloniex';
 export const EXCHANGE_KRAKEN = 'kraken';
 export const EXCHANGE_BITTREX = 'bittrex';
 export const EXCHANGE_BITMEX = 'bitmex';
+export const EXCHANGE_BITFINEX = 'bitfinex';
 export const EXCHANGE_BINANCE = 'binance';
 export const EXCHANGE_COINBASE = 'coinbase';
 export const EXCHANGE_COINBASEPRO = 'coinbasepro';
@@ -40,6 +41,7 @@ export const exchanges = [
   EXCHANGE_KRAKEN,
   EXCHANGE_BITTREX,
   EXCHANGE_BITMEX,
+  EXCHANGE_BITFINEX,
   EXCHANGE_BINANCE,
   EXCHANGE_BINANCE_US,
   EXCHANGE_COINBASE,

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -160,6 +160,7 @@ WORLD_TO_BITFINEX = {
     'CNY': 'CNH',
     'DOGE': 'DOG',
     'REPV2': 'REP',
+    'TRIO': 'TRI',
     'ZB': 'ZBT',
 }
 

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -155,6 +155,14 @@ WORLD_TO_BINANCE = {
     'BETH': 'ETH2',
 }
 
+WORLD_TO_BITFINEX = {
+    'BCH': 'BCHABC',
+    'CNY': 'CNH',
+    'DOGE': 'DOG',
+    'REPV2': 'REP',
+    'ZB': 'ZBT',
+}
+
 
 @total_ordering
 @dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=True)

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -233,6 +233,9 @@ class Asset():
     def to_kraken(self) -> str:
         return WORLD_TO_KRAKEN[self.identifier]
 
+    def to_bitfinex(self) -> str:
+        return WORLD_TO_BITFINEX.get(self.identifier, self.identifier)
+
     def to_bittrex(self) -> str:
         return WORLD_TO_BITTREX.get(self.identifier, self.identifier)
 

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from rotkehlchen.assets.asset import (
     WORLD_TO_BINANCE,
@@ -532,6 +532,27 @@ def asset_from_poloniex(poloniex_name: str) -> Asset:
 
     our_name = POLONIEX_TO_WORLD.get(poloniex_name, poloniex_name)
     return Asset(our_name)
+
+
+def asset_from_bitfinex(
+        bitfinex_name: str,
+        currency_map: Dict[str, str],
+        is_currency_map_updated: bool = True,
+) -> Asset:
+    """Currency map coming from `<Bitfinex>._query_currency_map()` is already
+    updated with BITFINEX_TO_WORLD (prevent updating it on each call)
+    """
+    if not isinstance(bitfinex_name, str):
+        raise DeserializationError(f'Got non-string type {type(bitfinex_name)} for bitfinex asset')
+
+    if bitfinex_name in UNSUPPORTED_BITFINEX_ASSETS:
+        raise UnsupportedAsset(bitfinex_name)
+
+    if is_currency_map_updated is False:
+        currency_map.update(BITFINEX_TO_WORLD)
+
+    name = currency_map.get(bitfinex_name, bitfinex_name)
+    return Asset(name)
 
 
 def asset_from_bittrex(bittrex_name: str) -> Asset:

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -453,6 +453,7 @@ UNSUPPORTED_BINANCE_ASSETS = (
 UNSUPPORTED_BITFINEX_ASSETS = (
     'BCHN',  # https://www.bitfinex.com/posts/566  no cryptocompare/coingecko data
     'B21X',  # no cryptocompare/coingecko data
+    'GTX',  # no cryptocompare/coingecko data (GT, Gate.io token)
     'IQX',  # no cryptocompare/coingecko data (EOS token)
 )
 

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from rotkehlchen.assets.asset import (
     WORLD_TO_BINANCE,
+    WORLD_TO_BITFINEX,
     WORLD_TO_BITTREX,
     WORLD_TO_KRAKEN,
     WORLD_TO_POLONIEX,
@@ -449,10 +450,28 @@ UNSUPPORTED_BINANCE_ASSETS = (
     'UAH',  # no cryptocompare/coingecko data
 )
 
+UNSUPPORTED_BITFINEX_ASSETS = (
+    'BCHN',  # https://www.bitfinex.com/posts/566  no cryptocompare/coingecko data
+    'B21X',  # no cryptocompare/coingecko data
+    'IQX',  # no cryptocompare/coingecko data (EOS token)
+)
+
+# Exchange symbols that are clearly for testing purposes. They appear in all
+# these places: supported currencies list, supported exchange pairs list and
+# currency map.
+BITFINEX_EXCHANGE_TEST_ASSETS = (
+    'AAA',
+    'BBB',
+    'TESTBTC',
+    'TESTUSD',
+    'TESTUSDT',
+)
+
 
 POLONIEX_TO_WORLD = {v: k for k, v in WORLD_TO_POLONIEX.items()}
 BITTREX_TO_WORLD = {v: k for k, v in WORLD_TO_BITTREX.items()}
 BINANCE_TO_WORLD = {v: k for k, v in WORLD_TO_BINANCE.items()}
+BITFINEX_TO_WORLD = {v: k for k, v in WORLD_TO_BITFINEX.items()}
 KRAKEN_TO_WORLD = {v: k for k, v in WORLD_TO_KRAKEN.items()}
 
 RENAMED_BINANCE_ASSETS = {

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -12831,7 +12831,8 @@
         "name": "XinFin Network",
         "started": 1498608000,
         "symbol": "XDCE",
-        "type": "ethereum token"
+        "type": "ethereum token",
+        "swapped_for": "XDC"
     },
     "XDN": {
         "coingecko": "digitalnote",
@@ -14238,6 +14239,243 @@
         "name": "tBTC",
         "started": 1600188723,
         "symbol": "TBTC",
+        "type": "ethereum token"
+    },
+    "CLO": {
+        "coingecko": "callisto-network",
+        "name": "Callisto Network",
+        "started": 1575590400,
+        "symbol": "CLO",
+        "type": "own chain"
+    },
+    "UOS": {
+        "coingecko": "ultra",
+        "ethereum_address": "0xD13c7342e1ef687C5ad21b27c2b65D772cAb5C8c",
+        "ethereum_token_decimals": 4,
+        "name": "Ultra",
+        "started": 1563321887,
+        "symbol": "UOS",
+        "type": "ethereum token"
+    },
+    "ETP": {
+        "coingecko": "metaverse-etp",
+        "name": "Metaverse ETP",
+        "started": 1513209600,
+        "symbol": "ETP",
+        "type": "own chain"
+    },
+    "EOSDT": {
+        "coingecko": "eosdt",
+        "name": "EOSDT",
+        "started": 1606089600,
+        "symbol": "EOSDT",
+        "type": "own chain"
+    },
+    "USDK": {
+        "coingecko": "usdk",
+        "ethereum_address": "0x1c48f86ae57291F7686349F12601910BD8D470bb",
+        "ethereum_token_decimals": 18,
+        "name": "USDK",
+        "started": 1557991300,
+        "symbol": "USDK",
+        "type": "ethereum token"
+    },
+    "RRT": {
+        "coingecko": "recovery-right-token",
+        "name": "Recovery Right Token",
+        "started": 1513209600,
+        "symbol": "RRT",
+        "type": "own chain"
+    },
+    "EURT": {
+        "coingecko": "",
+        "ethereum_address": "0xAbdf147870235FcFC34153828c769A70B3FAe01F",
+        "ethereum_token_decimals": 6,
+        "name": "Tether EUR",
+        "started": 1514821711,
+        "symbol": "EURT",
+        "type": "ethereum token"
+    },
+    "DAPP": {
+        "coingecko": "liquidapps",
+        "name": "LiquidApps",
+        "started": 1602979200,
+        "symbol": "DAPP",
+        "type": "own chain"
+    },
+    "VSYS": {
+        "coingecko": "v-systems",
+        "name": "V.SYSTEMS",
+        "started": 1551916800,
+        "symbol": "VSYS",
+        "type": "own chain"
+    },
+    "DT": {
+        "coingecko": "dragon-token",
+        "cryptocompare": "",
+        "ethereum_address": "0x1da015eA4AD2d3e5586E54b9fB0682Ca3CA8A17a",
+        "ethereum_token_decimals": 8,
+        "name": "Dragon Token",
+        "started": 1525258292,
+        "symbol": "DT",
+        "type": "ethereum token"
+    },
+    "XCHF": {
+        "coingecko": "cryptofranc",
+        "ethereum_address": "0xB4272071eCAdd69d933AdcD19cA99fe80664fc08",
+        "ethereum_token_decimals": 18,
+        "name": "CryptoFranc",
+        "started": 1540888325,
+        "symbol": "XCHF",
+        "type": "ethereum token"
+    },
+    "XAUT": {
+        "coingecko": "tether-gold",
+        "ethereum_address": "0x4922a015c4407F87432B179bb209e125432E4a2A",
+        "ethereum_token_decimals": 6,
+        "name": "Tether Gold",
+        "started": 1578500586,
+        "symbol": "XAUT",
+        "type": "ethereum token"
+    },
+    "XDC": {
+        "coingecko": "xinfin",
+        "name": "XinFin",
+        "started": 1585699200,
+        "symbol": "XDC",
+        "type": "own chain"
+    },
+    "RIF": {
+        "coingecko": "rif-token",
+        "name": "RIF Token",
+        "started": 1516147200,
+        "symbol": "RIF",
+        "type": "own chain"
+    },
+    "ZB": {
+        "coingecko": "zb-token",
+        "ethereum_address": "0xBd0793332e9fB844A52a205A233EF27a5b34B927",
+        "ethereum_token_decimals": 18,
+        "name": "ZB Token",
+        "started": 1529751168,
+        "symbol": "ZB",
+        "type": "ethereum token"
+    },
+    "RINGX": {
+        "coingecko": "ring-x-platform",
+        "ethereum_address": "0x7F86C782EC802ac402e0369d2E6d500256F7abC5",
+        "ethereum_token_decimals": 18,
+        "name": "RING X PLATFORM",
+        "started": 1588230484,
+        "symbol": "RINGX",
+        "type": "ethereum token"
+    },
+    "HEZ": {
+        "coingecko": "hermez-network",
+        "ethereum_address": "0xEEF9f339514298C6A857EfCfC1A762aF84438dEE",
+        "ethereum_token_decimals": 18,
+        "name": "Hermez Network",
+        "started": 1602717322,
+        "symbol": "HEZ",
+        "type": "ethereum token"
+    },
+    "ESS": {
+        "coingecko": "essentia",
+        "ethereum_address": "0xfc05987bd2be489ACCF0f509E44B0145d68240f7",
+        "ethereum_token_decimals": 18,
+        "name": "Essentia",
+        "started": 1529792284,
+        "symbol": "ESS",
+        "type": "ethereum token"
+    },
+    "NUT": {
+        "coingecko": "native-utility-token",
+        "name": "Native Utility Token",
+        "started": 1581033600,
+        "symbol": "NUT",
+        "type": "own chain"
+    },
+    "LEO": {
+        "coingecko": "leo-token",
+        "ethereum_address": "0x2AF5D2aD76741191D15Dfe7bF6aC92d4Bd912Ca3",
+        "ethereum_token_decimals": 18,
+        "name": "LEO Token",
+        "started": 1558444909,
+        "symbol": "LEO",
+        "type": "ethereum token and more"
+    },
+    "UOP": {
+        "coingecko": "utopia-genesis-foundation",
+        "cryptocompare": "",
+        "ethereum_address": "0xE4AE84448DB5CFE1DaF1e6fb172b469c161CB85F",
+        "ethereum_token_decimals": 18,
+        "name": "Utopia Genesis Foundation",
+        "started": 1607431737,
+        "symbol": "UOP",
+        "type": "ethereum token"
+    },
+    "RBTC": {
+        "coingecko": "rebitcoin",
+        "ethereum_address": "0x7f65BE7FAd0c22813e51746E7e8f13a20bAa9411",
+        "ethereum_token_decimals": 18,
+        "name": "Rebitcoin",
+        "started": 1546473600,
+        "symbol": "RBTC",
+        "type": "ethereum token"
+    },
+    "XD": {
+        "coingecko": "data-transaction-token",
+        "ethereum_address": "0x24DCc881E7Dd730546834452F21872D5cb4b5293",
+        "ethereum_token_decimals": 18,
+        "name": "Data Transaction Token",
+        "started": 1523950865,
+        "symbol": "XD",
+        "type": "ethereum token"
+    },
+    "IMP": {
+        "coingecko": "ether-kingdoms-token",
+        "cryptocompare": "impt",
+        "ethereum_address": "0x48FF53777F747cFB694101222a944dE070c15D36",
+        "ethereum_token_decimals": 7,
+        "name": "Ether Kingdoms Token",
+        "started": 1525513729,
+        "symbol": "IMP",
+        "type": "ethereum token"
+    },
+    "RRB": {
+        "coingecko": "renrenbit",
+        "ethereum_address": "0x02f02e0cA8a521EF73daA9C45353b9fBEFc5Ee10",
+        "ethereum_token_decimals": 8,
+        "name": "Renrenbit",
+        "started": 1563461989,
+        "symbol": "RRB",
+        "type": "ethereum token"
+    },
+    "CNHT": {
+        "coingecko": "",
+        "ethereum_address": "0x6E109E9dD7Fa1a58BC3eff667e8e41fC3cc07AEF",
+        "ethereum_token_decimals": 6,
+        "name": "Tether CNH",
+        "started": 1555159152,
+        "symbol": "CNHT",
+        "type": "ethereum token"
+    },
+    "XRA": {
+        "coingecko": "xriba",
+        "ethereum_address": "0x7025baB2EC90410de37F488d1298204cd4D6b29d",
+        "ethereum_token_decimals": 18,
+        "name": "Xriba",
+        "started": 1519159592,
+        "symbol": "XRA",
+        "type": "ethereum token"
+    },
+    "BTSE": {
+        "coingecko": "btse-token",
+        "ethereum_address": "0x666d875C600AA06AC1cf15641361dEC3b00432Ef",
+        "ethereum_token_decimals": 8,
+        "name": "BTSE Token",
+        "started": 1599041294,
+        "symbol": "BTSE",
         "type": "ethereum token"
     }
 }

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -14477,5 +14477,14 @@
         "started": 1599041294,
         "symbol": "BTSE",
         "type": "ethereum token"
+    },
+    "SYN": {
+        "coingecko": "synlev",
+        "ethereum_address": "0x1695936d6a953df699C38CA21c2140d497C08BD9",
+        "ethereum_token_decimals": 18,
+        "name": "SynLev",
+        "started": 1597091217,
+        "symbol": "SYN",
+        "type": "ethereum token"
     }
 }

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -14242,7 +14242,7 @@
         "type": "ethereum token"
     },
     "CLO": {
-        "coingecko": "callisto-network",
+        "coingecko": "callisto",
         "name": "Callisto Network",
         "started": 1575590400,
         "symbol": "CLO",
@@ -14265,7 +14265,7 @@
         "type": "own chain"
     },
     "EOSDT": {
-        "coingecko": "eosdt",
+        "coingecko": "equilibrium-eosdt",
         "name": "EOSDT",
         "started": 1606089600,
         "symbol": "EOSDT",
@@ -14297,7 +14297,7 @@
         "type": "ethereum token"
     },
     "DAPP": {
-        "coingecko": "liquidapps",
+        "coingecko": "dapp",
         "name": "LiquidApps",
         "started": 1602979200,
         "symbol": "DAPP",
@@ -14339,7 +14339,7 @@
         "type": "ethereum token"
     },
     "XDC": {
-        "coingecko": "xinfin",
+        "coingecko": "xdce-crowd-sale",
         "name": "XinFin",
         "started": 1585699200,
         "symbol": "XDC",
@@ -14371,7 +14371,7 @@
         "type": "ethereum token"
     },
     "HEZ": {
-        "coingecko": "hermez-network",
+        "coingecko": "hermez-network-token",
         "ethereum_address": "0xEEF9f339514298C6A857EfCfC1A762aF84438dEE",
         "ethereum_token_decimals": 18,
         "name": "Hermez Network",
@@ -14424,7 +14424,7 @@
         "type": "ethereum token"
     },
     "XD": {
-        "coingecko": "data-transaction-token",
+        "coingecko": "scroll-token",
         "ethereum_address": "0x24DCc881E7Dd730546834452F21872D5cb4b5293",
         "ethereum_token_decimals": 18,
         "name": "Data Transaction Token",

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "6cfa2a350084f7db34a3247234d3829b", "version": 36}
+{"md5": "662dad7cf1914aa91676ea7d1fea4ab7", "version": 36}

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "9b7bd26f50a53f3feabf0a6364c7cb65", "version": 35}
+{"md5": "6cfa2a350084f7db34a3247234d3829b", "version": 36}

--- a/rotkehlchen/data/importer.py
+++ b/rotkehlchen/data/importer.py
@@ -57,6 +57,8 @@ def exchange_row_to_location(entry: str) -> Location:
         return Location.GEMINI
     if entry == 'Bitstamp':
         return Location.BITSTAMP
+    if entry == 'Bitfinex':
+        return Location.BITFINEX
     if entry == 'ETH Transaction':
         raise UnsupportedCointrackingEntry(
             'Not importing ETH Transactions from Cointracking. Cointracking does not '

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -58,6 +58,8 @@ INSERT OR IGNORE INTO location(location, seq) VALUES ('Q', 17);
 INSERT OR IGNORE INTO location(location, seq) VALUES ('R', 18);
 /* Binance US */
 INSERT OR IGNORE INTO location(location, seq) VALUES ('S', 19);
+/* Bitfinex */
+INSERT OR IGNORE INTO location(location, seq) VALUES ('T', 20);
 """
 
 # Custom enum table for AssetMovement categories (deposit/withdrawal)

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -742,7 +742,7 @@ class Bitfinex(ExchangeInterface):
     @protect_with_lock()
     @cache_response_timewise()
     def query_balances(self) -> Tuple[Optional[Dict[Asset, Balance]], str]:
-        """Return the account balances on Bitfinex
+        """Return the account exchange balances on Bitfinex
 
         The wallets endpoint returns a list where each item is a currency wallet.
         Each currency wallet has type (i.e. exchange, margin, funding), currency,

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -1,0 +1,772 @@
+import hashlib
+import hmac
+import logging
+import re
+from datetime import datetime
+from http import HTTPStatus
+from json.decoder import JSONDecodeError
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
+from urllib.parse import urlencode
+
+import requests
+from requests.adapters import Response
+from typing_extensions import Literal
+
+from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.errors import (
+    DeserializationError,
+    RemoteError,
+    SystemClockNotSyncedError,
+    UnknownAsset,
+    UnsupportedAsset,
+)
+from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
+from rotkehlchen.exchanges.exchange import ExchangeInterface
+from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.serialization.deserialize import (
+    deserialize_asset_amount,
+    deserialize_fee,
+    deserialize_price,
+)
+from rotkehlchen.typing import (
+    ApiKey,
+    ApiSecret,
+    AssetAmount,
+    AssetMovementCategory,
+    Fee,
+    Location,
+    Timestamp,
+    TradePair,
+    TradeType,
+)
+from rotkehlchen.user_messages import MessagesAggregator
+from rotkehlchen.utils.interfaces import cache_response_timewise, protect_with_lock
+from rotkehlchen.utils.misc import ts_now_in_ms
+from rotkehlchen.utils.serialization import rlk_jsonloads_list
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+# Error codes that we handle nicely
+API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE = 10114  # small nonce (from timestamp in ms)
+API_KEY_ERROR_CODE = 10100
+# Max limits for all API v2 endpoints
+API_TRADES_MAX_LIMIT = 2500
+API_MOVEMENTS_MAX_LIMIT = 1000
+# Sorting mode
+API_TRADES_SORTING_MODE = 1  # ascending
+API_MOVEMENTS_SORTING_MODE = 1  # ascending, TBC
+# Minimum response item length per endpoint
+API_TRADES_MIN_ENTRY_LENGTH = 11
+API_MOVEMENTS_MIN_ENTRY_LENGTH = 22
+
+DeserializationMethod = Callable[..., Union[Trade, AssetMovement]]  # ... due to keyword args
+
+
+class CurrencyMapResponse(NamedTuple):
+    success: bool
+    response: Response
+    currency_map: Dict[str, str]
+
+
+class ErrorResponseData(NamedTuple):
+    error_code: Optional[int] = None
+    reason: Optional[str] = None
+
+
+class Bitfinex(ExchangeInterface):
+    """Bitfinex exchange api docs:
+    https://docs.bitfinex.com/docs
+    """
+    def __init__(
+            self,
+            api_key: ApiKey,
+            secret: ApiSecret,
+            database: 'DBHandler',
+            msg_aggregator: MessagesAggregator,
+    ):
+        super().__init__(str(Location.BITFINEX), api_key, secret, database)
+        self.base_uri = 'https://api.bitfinex.com'
+        self.msg_aggregator = msg_aggregator
+        # Constant headers: 'bfx-nonce', 'bfx-signature'
+        # Variable headers: 'Content-Type', 'bfx-apikey'
+        self.session.headers.update({
+            'bfx-apikey': self.api_key,
+        })
+
+    def _api_query(
+            self,
+            endpoint: Literal['configs_map_currency_symbol', 'movements', 'trades', 'wallets'],
+            options: Optional[Dict[str, Any]] = None,
+    ) -> Response:
+        """Request a Bitfinex API v2 endpoint (from `endpoint`).
+        """
+        call_options = options.copy() if options else {}
+        for header in ('Content-Type', 'bfx-nonce', 'bfx-signature'):
+            self.session.headers.pop(header, None)
+
+        if endpoint == 'configs_map_currency_symbol':
+            method = 'get'
+            api_path = 'v2/conf/pub:map:currency:sym'
+            request_url = f'{self.base_uri}/{api_path}'
+        elif endpoint == 'movements':
+            method = 'post'
+            api_path = 'v2/auth/r/movements/hist'
+            request_url = f'{self.base_uri}/{api_path}?{urlencode(call_options)}'
+        elif endpoint == 'trades':
+            method = 'post'
+            api_path = 'v2/auth/r/trades/hist'
+            request_url = f'{self.base_uri}/{api_path}?{urlencode(call_options)}'
+        elif endpoint == 'wallets':
+            method = 'post'
+            api_path = 'v2/auth/r/wallets'
+            request_url = f'{self.base_uri}/{api_path}'
+        else:
+            raise AssertionError(f'Unexpected {self.name} endpoint type: {endpoint}')
+
+        if endpoint in {'movements', 'trades', 'wallets'}:
+            nonce = str(ts_now_in_ms() + 20_000)  # prevent small nonce
+            message = f'/api/{api_path}{nonce}'
+            signature = hmac.new(
+                self.secret,
+                msg=message.encode('utf-8'),
+                digestmod=hashlib.sha384,
+            ).hexdigest()
+            self.session.headers.update({
+                'Content-Type': 'application/json',
+                'bfx-nonce': nonce,
+                'bfx-signature': signature,
+            })
+
+        log.debug(f'{self.name} API request', request_url=request_url)
+        try:
+            response = self.session.request(
+                method=method,
+                url=request_url,
+            )
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(
+                f'{self.name} {method} request at {request_url} connection error: {str(e)}.',
+            ) from e
+
+        return response
+
+    @overload  # noqa: F811
+    def _api_query_paginated(  # pylint: disable=no-self-use
+            self,
+            options: Dict[str, Any],
+            case: Literal['trades'],
+            currency_map: Dict[str, str],
+    ) -> List[Trade]:
+        ...
+
+    @overload  # noqa: F811
+    def _api_query_paginated(  # pylint: disable=no-self-use
+            self,
+            options: Dict[str, Any],
+            case: Literal['asset_movements'],
+            currency_map: Dict[str, str],
+    ) -> List[AssetMovement]:
+        ...
+
+    def _api_query_paginated(
+            self,
+            options: Dict[str, Any],
+            case: Literal['trades', 'asset_movements'],
+            currency_map: Dict[str, str],
+    ) -> Union[List[Trade], List[AssetMovement]]:
+        """Request a Bitfinex API v2 endpoint paginating via an options
+        attribute.
+
+        Pagination attribute criteria per endpoint:
+          - trades: from `start_ts` to `end_ts` (as offset) with limit 2500.
+          - movements: from `start_ts` to `end_ts` (as offset) with limit 1000.
+        """
+        deserialization_method: DeserializationMethod
+        endpoint: Literal['trades', 'movements']
+        response_case: Literal['trades', 'asset_movements']
+        if case == 'trades':
+            endpoint = 'trades'
+            response_case = 'trades'
+            case_pretty = 'trade'
+            deserialization_method = self._deserialize_trade
+            expected_raw_result_length = API_TRADES_MIN_ENTRY_LENGTH
+            id_index = 0
+            timestamp_index = 2
+        elif case == 'asset_movements':
+            endpoint = 'movements'
+            response_case = 'asset_movements'
+            case_pretty = 'asset movement'
+            deserialization_method = self._deserialize_asset_movement
+            expected_raw_result_length = API_MOVEMENTS_MIN_ENTRY_LENGTH
+            id_index = 0
+            timestamp_index = 5
+        else:
+            raise AssertionError(f'Unexpected {self.name} case: {case}')
+
+        call_options = options.copy()
+        limit = options['limit']
+        results: Union[List[Trade], List[AssetMovement]] = []  # type: ignore # bug list nothing
+        last_result_id = None
+        last_result_timestamp = None
+        while True:
+            response = self._api_query(
+                endpoint=endpoint,
+                options=call_options,
+            )
+            if response.status_code != HTTPStatus.OK:
+                return self._process_unsuccessful_response(
+                    response=response,
+                    case=response_case,
+                )
+            try:
+                response_list = rlk_jsonloads_list(response.text)
+            except JSONDecodeError:
+                msg = f'{self.name} returned invalid JSON response: {response.text}.'
+                log.error(msg)
+                self.msg_aggregator.add_error(
+                    f'Got remote error while querying Bistamp trades: {msg}',
+                )
+                return []  # type: ignore # bug list nothing
+
+            for raw_result in response_list:
+                if len(raw_result) < expected_raw_result_length:
+                    log.error(
+                        f'Error processing a {self.name} {case}. Found less items than expected',
+                        raw_result=raw_result,
+                    )
+                    self.msg_aggregator.add_error(
+                        f'Failed to deserialize a {self.name} {case_pretty}. '
+                        f'Check logs for details. Ignoring it.',
+                    )
+                    continue
+
+                if raw_result[timestamp_index] > options['end']:
+                    log.debug(
+                        f'Unexpected result requesting {self.name} {case_pretty}. '
+                        f'Entry timestamp {raw_result[timestamp_index]} is greater than '
+                        f'end filter {options["end"]}. Stop requesting.',
+                        raw_result=raw_result,
+                    )
+                    break
+
+                if (
+                    results and
+                    raw_result[id_index] <= last_result_id and
+                    raw_result[timestamp_index] <= last_result_timestamp
+                ):
+                    log.debug(
+                        f'Skipped {self.name} {case_pretty}. Entry already processed',
+                        raw_result=raw_result,
+                    )
+                    continue
+
+                # Only asset movements: skip if raw_result status is not 'COMPLETED'
+                if case == 'asset_movements' and raw_result[9] != 'COMPLETED':
+                    log.debug(
+                        f'Skipped {self.name} {case_pretty}. Status is not completed',
+                        raw_result=raw_result,
+                    )
+                    continue
+
+                try:
+                    result = deserialization_method(
+                        raw_result=raw_result,
+                        currency_map=currency_map,
+                    )
+                except DeserializationError as e:
+                    msg = str(e)
+                    log.error(
+                        f'Error processing a {self.name} {case_pretty}.',
+                        raw_result=raw_result,
+                        error=msg,
+                    )
+                    self.msg_aggregator.add_error(
+                        f'Failed to deserialize a {self.name} {case_pretty}. '
+                        f'Check logs for details. Ignoring it.',
+                    )
+                    continue
+                else:
+                    results.append(result)  # type: ignore # type is known
+                    last_result_id = raw_result[id_index]
+                    last_result_timestamp = raw_result[timestamp_index]
+
+            if len(response_list) < limit:
+                break
+
+            # Update pagination params per endpoint
+            # NB: re-assign dict instead of update, prevent lose call args values
+            call_options = call_options.copy()
+            call_options.update({
+                'start': results[-1].timestamp * 1000,
+            })
+
+        return results
+
+    def _check_for_system_clock_not_synced_error(
+            self,
+            error_code: Optional[int] = None,
+    ) -> None:
+        if error_code == API_SYSTEM_CLOCK_NOT_SYNCED_ERROR_CODE:
+            raise SystemClockNotSyncedError(
+                current_time=str(datetime.now()),
+                remote_server=f'{self.name}',
+            )
+
+    @staticmethod
+    def _deserialize_asset_movement(
+            raw_result: List[Any],
+            currency_map: Dict[str, str],
+    ) -> AssetMovement:
+        """Process an asset movement (i.e. deposit or withdrawal) from Bitfinex
+        and deserialize it.
+
+        Bitfinex support confirmed the following in regards to
+        DESTINATION_ADDRESS and TRANSACTION_ID:
+          - Fiat movement: both attributes won't show any value.
+          - Cryptocurrency movement: address and tx id on the blockchain.
+
+        Timestamp is from MTS_STARTED (when the movement was created), and not
+        from MTS_UPDATED (when it was completed/cancelled).
+
+        Can raise DeserializationError.
+
+        Schema reference in:
+        https://docs.bitfinex.com/reference#rest-auth-movements
+        """
+        if raw_result[9] != 'COMPLETED':
+            raise DeserializationError(
+                f'Unexpected bitfinex movement with status: {raw_result[5]}. '
+                f'Only completed movements are processed. Raw movement: {raw_result}',
+            )
+        bfx_asset_symbol = raw_result[1]
+        asset_symbol = currency_map.get(bfx_asset_symbol, bfx_asset_symbol)
+        try:
+            fee_asset = Asset(asset_symbol)
+        except (UnknownAsset, UnsupportedAsset) as e:
+            asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
+            raise DeserializationError(
+                f'{asset_tag} {e.asset_name} found while processing movement asset '
+                f'due to: {str(e)}',
+            ) from e
+
+        amount = deserialize_asset_amount(raw_result[12])
+        category = (
+            AssetMovementCategory.DEPOSIT
+            if amount > ZERO
+            else AssetMovementCategory.WITHDRAWAL
+        )
+        address = None
+        transaction_id = None
+        if fee_asset.is_fiat() is False:
+            address = raw_result[16]
+            transaction_id = raw_result[20]
+
+        asset_movement = AssetMovement(
+            timestamp=Timestamp(int(raw_result[5] / 1000)),
+            location=Location.BITFINEX,
+            category=category,
+            address=address,
+            transaction_id=transaction_id,
+            asset=fee_asset,
+            amount=abs(amount),
+            fee_asset=fee_asset,
+            fee=Fee(abs(deserialize_fee(raw_result[13]))),
+            link=str(raw_result[0]),
+        )
+        return asset_movement
+
+    @staticmethod
+    def _deserialize_trade(
+            raw_result: List[Any],
+            currency_map: Dict[str, str],
+    ) -> Trade:
+        """Process a trade result from Bitfinex and deserialize it.
+
+        The base and quote assets are instantiated using the `fee_currency_symbol`
+        (from raw_result[10]) over the pair (from raw_result[1]).
+
+        Known pairs format: 'ETHUST', 'ETH:UST'.
+
+        Can raise DeserializationError.
+
+        Schema reference in:
+        https://docs.bitfinex.com/reference#rest-auth-trades
+        """
+        amount = deserialize_asset_amount(raw_result[4])
+        trade_type = TradeType.BUY if amount >= ZERO else TradeType.SELL
+        bfx_pair = raw_result[1]
+        bfx_fee_currency_symbol = raw_result[10]
+        if bfx_pair.startswith(bfx_fee_currency_symbol):
+            regex = re.compile(fr'^({bfx_fee_currency_symbol})\W*(\w+)$')
+        elif bfx_pair.endswith(bfx_fee_currency_symbol):
+            regex = re.compile(fr'^(\w+)\W*({bfx_fee_currency_symbol})$')
+        else:
+            raise DeserializationError(
+                f'Could not deserialize bitfinex trade pair {raw_result[1]} '
+                f'using fee_currency symbol {bfx_fee_currency_symbol}. '
+                f'Raw trade: {raw_result}',
+            )
+
+        match = regex.match(bfx_pair)
+        if match is None:
+            raise DeserializationError(
+                f'Unexpected error deserializing bitfinex trade pair: {raw_result[1]} '
+                f'using fee_currency symbol {bfx_fee_currency_symbol}. '
+                f'Trade pair does not match the pattern. Raw trade: {raw_result}',
+            )
+
+        bfx_base_asset_symbol, bfx_quote_asset_symbol = match.groups()
+        base_asset_symbol = currency_map.get(bfx_base_asset_symbol, bfx_base_asset_symbol)
+        quote_asset_symbol = currency_map.get(bfx_quote_asset_symbol, bfx_quote_asset_symbol)
+        try:
+            base_asset = Asset(base_asset_symbol)
+            quote_asset = Asset(quote_asset_symbol)
+        except (UnknownAsset, UnsupportedAsset) as e:
+            asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
+            raise DeserializationError(
+                f'{asset_tag} {e.asset_name} found while processing trade pair due to: {str(e)}',
+            ) from e
+
+        trade = Trade(
+            timestamp=Timestamp(int(raw_result[2] / 1000)),
+            location=Location.BITFINEX,
+            pair=TradePair(f'{base_asset.identifier}_{quote_asset.identifier}'),
+            trade_type=trade_type,
+            amount=AssetAmount(abs(amount)),
+            rate=deserialize_price(raw_result[5]),
+            fee=Fee(abs(deserialize_fee(raw_result[9]))),
+            fee_currency=quote_asset if trade_type == TradeType.BUY else base_asset,
+            link=str(raw_result[0]),
+            notes='',
+        )
+        return trade
+
+    @staticmethod
+    def _get_error_response_data(response_list: List[Any]) -> ErrorResponseData:
+        """Given an error response, return the error code and the reason.
+        """
+        error_code = None
+        reason = None
+        if len(response_list) > 1:
+            error_code = response_list[1]
+        if len(response_list) > 2:
+            reason = response_list[2]
+
+        return ErrorResponseData(
+            error_code=error_code,
+            reason=reason,
+        )
+
+    def _query_currency_map(self) -> CurrencyMapResponse:
+        """Queries the list that maps standard currency symbols with the version
+        of the Bitfinex API.
+
+        Result format is: [[[<bitfinex_symbol>, <symbol>], ...]]
+
+        May raise IndexError if the list is empty.
+        """
+        was_successful = True
+        currency_map = {}
+        response = self._api_query('configs_map_currency_symbol')
+
+        if response.status_code != HTTPStatus.OK:
+            was_successful = False
+            log.error(f'{self.name} currency map query failed. Check further logs')
+        else:
+            try:
+                response_list = rlk_jsonloads_list(response.text)
+            except JSONDecodeError:
+                was_successful = False
+                log.error(
+                    f'{self.name} currency map returned invalid JSON response. Check further logs',
+                )
+            else:
+                currency_map = dict(response_list[0])
+
+        return CurrencyMapResponse(
+            success=was_successful,
+            response=response,
+            currency_map=currency_map,
+        )
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['validate_api_key'],
+    ) -> Tuple[bool, str]:
+        ...
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['balances'],
+    ) -> Tuple[Optional[Dict[Asset, Balance]], str]:
+        ...
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['trades'],
+    ) -> List[Trade]:
+        ...
+
+    @overload  # noqa: F811
+    def _process_unsuccessful_response(  # pylint: disable=no-self-use
+            self,
+            response: Response,
+            case: Literal['asset_movements'],
+    ) -> List[AssetMovement]:
+        ...
+
+    def _process_unsuccessful_response(
+            self,
+            response: Response,
+            case: Literal['validate_api_key', 'balances', 'trades', 'asset_movements'],
+    ) -> Union[
+        List,
+        Tuple[bool, str],
+        Tuple[Optional[Dict[Asset, Balance]], str],
+    ]:
+        """This function processes not successful responses for the following
+        cases listed in `case`.
+        """
+        try:
+            response_list = rlk_jsonloads_list(response.text)
+        except JSONDecodeError as e:
+            msg = f'{self.name} returned invalid JSON response: {response.text}.'
+            log.error(msg)
+
+            if case in {'validate_api_key', 'balances'}:
+                raise RemoteError(msg) from e
+            if case in {'trades', 'asset_movements'}:
+                self.msg_aggregator.add_error(
+                    f'Got remote error while querying {self.name} {case}: {msg}',
+                )
+                return []
+
+            raise AssertionError(f'Unexpected {self.name} response_case: {case}') from e
+
+        error_data = self._get_error_response_data(response_list)
+        self._check_for_system_clock_not_synced_error(error_data.error_code)
+        # Errors related with the API key return a human readable message
+        if case == 'validate_api_key' and error_data.error_code == API_KEY_ERROR_CODE:
+            return False, 'Provided API key or secret is invalid'
+
+        # Below any other error not related with the system clock or the API key
+        reason = error_data.reason or response.text
+        msg = (
+            f'{self.name} query responded with error status code: {response.status_code} '
+            f'and text: {reason}.'
+        )
+        log.error(msg)
+
+        if case == 'validate_api_key':
+            raise RemoteError(msg)
+        if case == 'balances':
+            return None, msg
+        if case in {'trades', 'asset_movements'}:
+            self.msg_aggregator.add_error(
+                f'Got remote error while querying {self.name} {case}: {msg}',
+            )
+            return []
+
+        raise AssertionError(f'Unexpected {self.name} response_case: {case}')
+
+    def first_connection(self) -> None:
+        self.first_connection_made = True
+
+    @protect_with_lock()
+    @cache_response_timewise()
+    def query_balances(self) -> Tuple[Optional[Dict[Asset, Balance]], str]:
+        """Return the account balances on Bitfinex
+
+        The wallets endpoint returns a list where each item is a currency wallet.
+        Each currency wallet has type (i.e. exchange, margin, funding), currency,
+        balance, etc. Currencies (tickers) are in Bitfinex format and must be
+        standardized.
+
+        Endpoint documentation:
+        https://docs.bitfinex.com/reference#rest-auth-wallets
+        """
+        try:
+            currency_map_response = self._query_currency_map()
+        except IndexError:
+            msg = f'Error processing {self.name} currency map. Response is empty'
+            log.error(msg)
+            return None, msg
+
+        if currency_map_response.success is False:
+            result, msg = self._process_unsuccessful_response(
+                response=currency_map_response.response,
+                case='balances',
+            )
+            return result, msg
+
+        response = self._api_query('wallets')
+        if response.status_code != HTTPStatus.OK:
+            result, msg = self._process_unsuccessful_response(
+                response=response,
+                case='balances',
+            )
+            return result, msg
+        try:
+            response_list = rlk_jsonloads_list(response.text)
+        except JSONDecodeError as e:
+            msg = f'{self.name} returned invalid JSON response: {response.text}.'
+            log.error(msg)
+            raise RemoteError(msg) from e
+
+        asset_balance: Dict[Asset, Balance] = {}
+        for wallet in response_list:
+            if len(wallet) < 3 or wallet[0] != 'exchange' or wallet[2] <= 0:
+                continue
+
+            amount = FVal(wallet[2])
+            symbol = currency_map_response.currency_map.get(wallet[1], wallet[1])
+            try:
+                asset = Asset(symbol)
+            except (UnknownAsset, UnsupportedAsset) as e:
+                asset_tag = 'unknown' if isinstance(e, UnknownAsset) else 'unsupported'
+                self.msg_aggregator.add_warning(
+                    f'Found {asset_tag} {self.name} asset {e.asset_name} due to: {str(e)}. '
+                    f'Ignoring its balance query.',
+                )
+                continue
+            try:
+                usd_price = Inquirer().find_usd_price(asset=asset)
+            except RemoteError as e:
+                self.msg_aggregator.add_error(
+                    f'Error processing {self.name} balance result due to inability to '
+                    f'query USD price: {str(e)}. Skipping balance entry.',
+                )
+                continue
+
+            asset_balance[asset] = Balance(
+                amount=amount,
+                usd_value=amount * usd_price,
+            )
+
+        return asset_balance, ''
+
+    def query_online_deposits_withdrawals(
+            self,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+    ) -> List[AssetMovement]:
+        """Return the account deposits and withdrawals on Bitfinex.
+
+        Endpoint documentation:
+        https://docs.bitfinex.com/reference#rest-auth-movements
+
+        TODO: Check if 'sort' by ascending works.
+        I got in touch with Bitfinex support asking about the default
+        sorting mode, as per their documentation this endpoint does not accept
+        a 'sort' query parameter and it is unknown in which mode the results
+        come.
+        They email me back confirming sorting is in descending mode and that I
+        could try using the 'sort' query parameter.
+        """
+        try:
+            currency_map_response = self._query_currency_map()
+        except IndexError:
+            self.msg_aggregator.add_error(
+                f'Error processing {self.name} currency map. Response is empty',
+            )
+            return []
+
+        if currency_map_response.success is False:
+            return self._process_unsuccessful_response(
+                response=currency_map_response.response,
+                case='asset_movements',
+            )
+
+        options = {
+            'start': start_ts * 1000,
+            'end': end_ts * 1000,
+            'limit': API_MOVEMENTS_MAX_LIMIT,
+            'sort': API_MOVEMENTS_SORTING_MODE,
+        }
+        asset_movements: List[AssetMovement] = self._api_query_paginated(
+            options=options,
+            case='asset_movements',
+            currency_map=currency_map_response.currency_map,
+        )
+        return asset_movements
+
+    def query_online_trade_history(
+            self,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+    ) -> List[Trade]:
+        """Return the account trades on Bitfinex.
+
+        Endpoint documentation:
+        https://docs.bitfinex.com/reference#rest-auth-trades
+        """
+        try:
+            currency_map_response = self._query_currency_map()
+        except IndexError:
+            self.msg_aggregator.add_error(
+                f'Error processing {self.name} currency map. Response is empty',
+            )
+            return []
+
+        if currency_map_response.success is False:
+            return self._process_unsuccessful_response(
+                response=currency_map_response.response,
+                case='trades',
+            )
+
+        options = {
+            'start': start_ts * 1000,
+            'end': end_ts * 1000,
+            'limit': API_TRADES_MAX_LIMIT,
+            'sort': API_TRADES_SORTING_MODE,
+        }
+        trades: List[Trade] = self._api_query_paginated(
+            options=options,
+            case='trades',
+            currency_map=currency_map_response.currency_map,
+        )
+        return trades
+
+    def validate_api_key(self) -> Tuple[bool, str]:
+        """Validates that the Bitfinex API key is good for usage in Rotki.
+
+        Makes sure that the following permissions are given to the key:
+        - Account History: get historical balances entries and trade information.
+        - Wallets: get wallet balances and addresses.
+        """
+        response = self._api_query('wallets')
+
+        if response.status_code != HTTPStatus.OK:
+            result, msg = self._process_unsuccessful_response(
+                response=response,
+                case='validate_api_key',
+            )
+            return result, msg
+
+        return True, ''

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -423,7 +423,7 @@ class Bitstamp(ExchangeInterface):
 
             has_results = False
             is_result_timesamp_gt_end_ts = False
-            result: Union[List, AssetMovement]
+            result: Union[Trade, AssetMovement]
             for raw_result in response_list:
                 if raw_result['type'] not in raw_result_type_filter:
                     continue
@@ -436,7 +436,7 @@ class Bitstamp(ExchangeInterface):
                         is_result_timesamp_gt_end_ts = True  # prevent extra request
                         break
 
-                    result = deserialization_method(raw_result)  # type: ignore
+                    result = deserialization_method(raw_result)
 
                 except DeserializationError as e:
                     msg = str(e)

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -25,6 +25,7 @@ SUPPORTED_EXCHANGES = [
     'gemini',
     'bitstamp',
     'binance_us',
+    'bitfinex',
 ]
 
 

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -361,6 +361,8 @@ def deserialize_location(symbol: str) -> Location:
         return Location.BITSTAMP
     if symbol == 'binance_us':
         return Location.BINANCE_US
+    if symbol == 'bitfinex':
+        return Location.BITFINEX
     # else
     raise DeserializationError(
         f'Failed to deserialize location symbol. Unknown symbol {symbol} for location',
@@ -459,6 +461,8 @@ def deserialize_location_from_db(symbol: str) -> Location:
         return Location.BITSTAMP
     if symbol == 'S':
         return Location.BINANCE_US
+    if symbol == 'T':
+        return Location.BITFINEX
     # else
     raise DeserializationError(
         f'Failed to deserialize location symbol. Unknown symbol {symbol} for location',

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -10,6 +10,7 @@ import requests
 from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.db.ranges import DBQueryRanges
 from rotkehlchen.errors import SystemClockNotSyncedError
+from rotkehlchen.exchanges.bitfinex import API_KEY_ERROR_MESSAGE as BITFINEX_API_KEY_ERROR_MESSAGE
 from rotkehlchen.exchanges.bitstamp import (
     API_KEY_ERROR_CODE_ACTION as BITSTAMP_API_KEY_ERROR_CODE_ACTION,
 )
@@ -118,6 +119,7 @@ def test_setup_exchange(rotkehlchen_api_server):
                 'Provided API Secret is invalid',
                 'Provided Gemini API key needs to have "Auditor" permission activated',
                 BITSTAMP_API_KEY_ERROR_CODE_ACTION['API0011'],
+                BITFINEX_API_KEY_ERROR_MESSAGE,
             ],
             status_code=HTTPStatus.CONFLICT,
         )

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -67,6 +67,14 @@ API_KEYPAIR_COINBASE_VALIDATION_PATCH = patch(
     return_value=(True, ''),
 )
 
+SYSTEM_CLOCK_NOT_SYNCED_RESPONSE_BITFINEX = patch(
+    'rotkehlchen.exchanges.bitfinex.Bitfinex.validate_api_key',
+    side_effect=SystemClockNotSyncedError(
+        current_time=str(datetime.now()),
+        remote_server='Bitfinex',
+    ),
+)
+
 SYSTEM_CLOCK_NOT_SYNCED_RESPONSE_BITTREX = patch(
     'rotkehlchen.exchanges.bittrex.Bittrex._check_for_system_clock_not_synced_error',
     side_effect=SystemClockNotSyncedError(
@@ -167,6 +175,10 @@ def test_setup_exchange(rotkehlchen_api_server):
     (
         {'name': 'bitstamp', 'api_key': 'ddddd', 'api_secret': 'fffff'},
         SYSTEM_CLOCK_NOT_SYNCED_RESPONSE_BITSTAMP,
+    ),
+    (
+        {'name': 'bitfinex', 'api_key': 'ddddd', 'api_secret': 'fffff'},
+        SYSTEM_CLOCK_NOT_SYNCED_RESPONSE_BITFINEX,
     ),
 ])
 def test_setup_exchange_raises_system_clock_not_synced_error(

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -14,12 +14,7 @@ from rotkehlchen.assets.converters import (
     UNSUPPORTED_BITFINEX_ASSETS,
     asset_from_bitfinex,
 )
-from rotkehlchen.errors import (
-    RemoteError,
-    SystemClockNotSyncedError,
-    UnknownAsset,
-    UnsupportedAsset,
-)
+from rotkehlchen.errors import SystemClockNotSyncedError, UnknownAsset, UnsupportedAsset
 from rotkehlchen.exchanges.bitfinex import (
     API_KEY_ERROR_CODE,
     API_KEY_ERROR_MESSAGE,
@@ -256,14 +251,12 @@ def test_api_query_paginated_stops_requesting(mock_bitfinex):
         stack.enter_context(api_request_retry_times_patch)
         stack.enter_context(api_request_retry_after_seconds_patch)
         stack.enter_context(api_query_patch)
-        with pytest.raises(RemoteError) as e:
-            mock_bitfinex._api_query_paginated(
-                options={'limit': 2},
-                case='trades',
-                currency_map={},
-            )
-        expected_msg = f'{mock_bitfinex.name} trades request failed after retrying 0 times.'
-        assert expected_msg in str(e.value)
+        result = mock_bitfinex._api_query_paginated(
+            options={'limit': 2},
+            case='trades',
+            currency_map={},
+        )
+        assert result == []
 
 
 def test_api_query_paginated_retries_request(mock_bitfinex):

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -148,7 +148,6 @@ def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disab
       type (i.e. exchange, margin and funding).
       - The balance of an asset in UNSUPPORTED_BITFINEX_ASSETS is skipped.
       - The asset ticker is standardized (e.g. WBT to WBTC, UST to USDT).
-      - The balance of an asset that can't get its USD price is skipped.
     """
     response = Response()
     response.status_code = HTTPStatus.OK
@@ -610,8 +609,7 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
 
 
 @pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
-# def test_query_online_trade_history_case_2(mock_bitfinex):
-def test_pepe(mock_bitfinex):
+def test_query_online_trade_history_case_2(mock_bitfinex):
     """Test pagination logic for trades works as expected when a request
     returns a result already processed in the previous request.
 

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -58,7 +58,7 @@ def test_bitfinex_exchange_assets_are_known(mock_bitfinex):
             f'Response status code: {response.status_code}. '
             f'Response text: {response.text}. Xfailing this test',
         ))
-        pytest.xfail('xfailing this test')
+        pytest.xfail('Failed to request {mock_bitfinex.name} currencies list')
 
     exchange_pairs_response = mock_bitfinex._query_exchange_pairs()
     if exchange_pairs_response.success is False:
@@ -68,7 +68,7 @@ def test_bitfinex_exchange_assets_are_known(mock_bitfinex):
             f'Response status code: {response.status_code}. '
             f'Response text: {response.text}. Xfailing this test',
         ))
-        pytest.xfail('xfailing this test')
+        pytest.xfail('Failed to request {mock_bitfinex.name} exchange pairs list')
 
     currency_map_response = mock_bitfinex._query_currency_map()
     if currency_map_response.success is False:
@@ -78,7 +78,7 @@ def test_bitfinex_exchange_assets_are_known(mock_bitfinex):
             f'Response status code: {response.status_code}. '
             f'Response text: {response.text}. Xfailing this test',
         ))
-        pytest.xfail('xfailing this test')
+        pytest.xfail('Failed to request {mock_bitfinex.name} currency map')
 
     test_assets = set(BITFINEX_EXCHANGE_TEST_ASSETS)
     unsupported_assets = set(UNSUPPORTED_BITFINEX_ASSETS)
@@ -318,7 +318,7 @@ def test_deserialize_trade_buy(mock_bitfinex):
     }
     raw_result = [
         399251013,
-        'WBT:UST',
+        'tWBT:UST',
         1573485493000,
         33963608932,
         0.26334268,
@@ -352,7 +352,7 @@ def test_deserialize_trade_sell(mock_bitfinex):
     currency_map = {'UST': 'USDt'}
     raw_result = [
         399251013,
-        'ETHUST',
+        'tETHUST',
         1573485493000,
         33963608932,
         -0.26334268,
@@ -413,7 +413,7 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
     trade_1 = """
     [
         1,
-        "ETH:UST",
+        "tETH:UST",
         1606899600000,
         10,
         0.26334268,
@@ -429,7 +429,7 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
     trade_2 = """
     [
         2,
-        "ETH:UST",
+        "tETH:UST",
         1606901400000,
         20,
         -0.26334268,
@@ -445,7 +445,7 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
     trade_3 = """
     [
         3,
-        "WBTUSD",
+        "tWBTUSD",
         1606932000000,
         30,
         10000.00000000,
@@ -461,7 +461,7 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
     trade_4 = """
     [
         4,
-        "WBTUSD",
+        "tWBTUSD",
         1606986000000,
         40,
         -10000.00000000,
@@ -477,7 +477,7 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
     trade_5 = """
     [
         5,
-        "ETH:EUR",
+        "tETH:EUR",
         1606996801000,
         50,
         -0.26334268,
@@ -638,7 +638,7 @@ def test_query_online_trade_history_case_2(mock_bitfinex):
     trade_1 = """
     [
         1,
-        "ETH:UST",
+        "tETH:UST",
         1606899600000,
         10,
         0.26334268,
@@ -654,7 +654,7 @@ def test_query_online_trade_history_case_2(mock_bitfinex):
     trade_2 = """
     [
         2,
-        "ETH:UST",
+        "tETH:UST",
         1606901400000,
         20,
         -0.26334268,
@@ -670,7 +670,7 @@ def test_query_online_trade_history_case_2(mock_bitfinex):
     trade_3 = """
     [
         3,
-        "WBTUSD",
+        "tWBTUSD",
         1606932000000,
         30,
         10000.00000000,
@@ -686,7 +686,7 @@ def test_query_online_trade_history_case_2(mock_bitfinex):
     trade_4 = """
     [
         4,
-        "WBTUSD",
+        "tWBTUSD",
         1606986000000,
         40,
         -10000.00000000,
@@ -889,6 +889,7 @@ def test_query_online_deposits_withdrawals_case_1(mock_bitfinex):
     request does not return a result already processed.
 
     Other things tested:
+      - Results are sorted by id in ascending mode.
       - Skip result when status is not 'COMPLETED'.
       - Stop requesting (break the loop) when result timestamp is greater than
       'end_ts'.
@@ -1050,7 +1051,6 @@ def test_query_online_deposits_withdrawals_case_1(mock_bitfinex):
                 'start': 0,
                 'end': 1606996800000,
                 'limit': 2,
-                'sort': 1,
             },
         ),
         call(
@@ -1059,7 +1059,6 @@ def test_query_online_deposits_withdrawals_case_1(mock_bitfinex):
                 'start': 1606901400000,
                 'end': 1606996800000,
                 'limit': 2,
-                'sort': 1,
             },
         ),
         call(
@@ -1068,15 +1067,14 @@ def test_query_online_deposits_withdrawals_case_1(mock_bitfinex):
                 'start': 1606986000000,
                 'end': 1606996800000,
                 'limit': 2,
-                'sort': 1,
             },
         ),
     ]
 
     def get_paginated_response():
         results = [
-            f'[{movement_1},{movement_2}]',
-            f'[{movement_3},{movement_4}]',
+            f'[{movement_2},{movement_1}]',
+            f'[{movement_4},{movement_3}]',
             f'[{movement_5}]',
         ]
         for result_ in results:
@@ -1287,9 +1285,9 @@ def test_query_online_deposits_withdrawals_case_2(mock_bitfinex):
 
     def get_paginated_response():
         results = [
-            f'[{movement_1},{movement_2}]',
-            f'[{movement_1},{movement_2}]',
-            f'[{movement_2},{movement_3}]',
+            f'[{movement_2},{movement_1}]',
+            f'[{movement_2},{movement_1}]',
+            f'[{movement_3},{movement_2}]',
             f'[{movement_4}]',
         ]
         for result_ in results:

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -1,0 +1,1197 @@
+from contextlib import ExitStack
+from datetime import datetime
+from http import HTTPStatus
+from unittest.mock import call, patch
+
+import pytest
+from requests import Response
+
+from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.errors import SystemClockNotSyncedError
+from rotkehlchen.exchanges.bitfinex import Bitfinex, CurrencyMapResponse
+from rotkehlchen.exchanges.data_structures import AssetMovement, Trade, TradeType
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.typing import (
+    AssetAmount,
+    AssetMovementCategory,
+    Fee,
+    Location,
+    Price,
+    Timestamp,
+    TradePair,
+)
+
+
+def test_name():
+    exchange = Bitfinex('a', b'a', object(), object())
+    assert exchange.name == str(Location.BITFINEX)
+
+
+def test_validate_api_key_system_clock_not_synced_error_code(mock_bitfinex):
+    """Test the error code related with the local system clock not being synced
+    raises SystemClockNotSyncedError.
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            '["error", 10114, "nonce: small"]',
+        )
+
+    with patch.object(mock_bitfinex, '_api_query', side_effect=mock_api_query_response):
+        with pytest.raises(SystemClockNotSyncedError):
+            mock_bitfinex.validate_api_key()
+
+
+def test_validate_api_key_invalid_key(mock_bitfinex):
+    """Test the error code related with an invalid API key/secret returns the
+    tuple (False, <invalid api key error message>).
+    """
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            '["error", 10100, "apikey: invalid"]',
+        )
+
+    with patch.object(mock_bitfinex, '_api_query', side_effect=mock_api_query_response):
+        result, msg = mock_bitfinex.validate_api_key()
+
+        assert result is False
+        assert msg == 'Provided API key or secret is invalid'
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [True])
+def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disable=unused-argument
+    """Test an entry that can't get its USD price is skipped
+    """
+    response = Response()
+    response.status_code = HTTPStatus.OK
+    currency_map_response = CurrencyMapResponse(
+        success=True,
+        response=response,
+        currency_map={
+            'UST': 'USDt',
+            'GNT': 'GLM',
+        },
+    )
+    balances_data = (
+        """
+        [
+            ["exchange"],
+            ["exchange", "UST"],
+            ["exchange", "", 12345],
+            ["exchange", "WBT", 0.0000000],
+            ["margin", "UST", 19788.6529257],
+            ["exchange", "", 19788.6529257],
+            ["exchange", "UST", 19788.6529257],
+            ["exchange", "LINK", 777.777777],
+            ["exchange", "GNT", 0.0000001],
+            ["exchange", "EUR", 99.9999999]
+        ]
+        """
+    )
+
+    def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, balances_data)
+
+    currency_map_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_query_currency_map',
+        return_value=currency_map_response,
+    )
+    balances_query_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_api_query',
+        side_effect=mock_api_query_response,
+    )
+    with ExitStack() as stack:
+        stack.enter_context(currency_map_patch)
+        stack.enter_context(balances_query_patch)
+        asset_balance, msg = mock_bitfinex.query_balances()
+
+        assert asset_balance == {
+            Asset('USDT'): Balance(
+                amount=FVal('19788.6529257'),
+                usd_value=FVal('29682.97938855'),
+            ),
+            Asset('LINK'): Balance(
+                amount=FVal('777.777777'),
+                usd_value=FVal('1166.6666655'),
+            ),
+            Asset('GLM'): Balance(
+                amount=FVal('0.0000001'),
+                usd_value=FVal('0.00000015'),
+            ),
+            Asset('EUR'): Balance(
+                amount=FVal('99.9999999'),
+                usd_value=FVal('149.99999985'),
+            ),
+        }
+        assert msg == ''
+
+
+def test_deserialize_trade_buy(mock_bitfinex):
+    currency_map = {
+        'WBT': 'WBTC',
+        'UST': 'USDt',
+    }
+    raw_result = [
+        399251013,
+        'WBT:UST',
+        1573485493000,
+        33963608932,
+        0.26334268,
+        187.37,
+        'LIMIT',
+        None,
+        -1,
+        -0.09868591,
+        'UST',
+    ]
+    expected_trade = Trade(
+        timestamp=Timestamp(1573485493),
+        location=Location.BITFINEX,
+        pair=TradePair('WBTC_USDT'),
+        trade_type=TradeType.BUY,
+        amount=AssetAmount(FVal('0.26334268')),
+        rate=Price(FVal('187.37')),
+        fee=Fee(FVal('0.09868591')),
+        fee_currency=Asset('USDT'),
+        link='399251013',
+        notes='',
+    )
+    trade = mock_bitfinex._deserialize_trade(
+        raw_result=raw_result,
+        currency_map=currency_map,
+    )
+    assert trade == expected_trade
+
+
+def test_deserialize_trade_sell(mock_bitfinex):
+    currency_map = {'UST': 'USDt'}
+    raw_result = [
+        399251013,
+        'ETHUST',
+        1573485493000,
+        33963608932,
+        -0.26334268,
+        187.37,
+        'LIMIT',
+        None,
+        -1,
+        -0.09868591,
+        'UST',
+    ]
+    expected_trade = Trade(
+        timestamp=Timestamp(1573485493),
+        location=Location.BITFINEX,
+        pair=TradePair('ETH_USDT'),
+        trade_type=TradeType.SELL,
+        amount=AssetAmount(FVal('0.26334268')),
+        rate=Price(FVal('187.37')),
+        fee=Fee(FVal('0.09868591')),
+        fee_currency=Asset('ETH'),
+        link='399251013',
+        notes='',
+    )
+    trade = mock_bitfinex._deserialize_trade(
+        raw_result=raw_result,
+        currency_map=currency_map,
+    )
+    assert trade == expected_trade
+
+
+@pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
+def test_query_online_trade_history_case_1(mock_bitfinex):
+    """Test pagination logic for trades works as expected when each request
+    does not return an entry already processed.
+
+    Other things tested:
+      - Stop requesting (break the loop) when entry timestamp is greater than
+      'end_ts'.
+      - '_api_query' call arguments.
+
+    First request: 2 results
+    Second request: 2 results
+    Third request: 1 result, out of time range (its timestamp is gt 'end_ts')
+
+    Trades with id 1 to 4 are expected to be returned.
+    """
+    api_limit = 2
+    response = Response()
+    response.status_code = HTTPStatus.OK
+    currency_map_response = CurrencyMapResponse(
+        success=True,
+        response=response,
+        currency_map={
+            'UST': 'USDt',
+            'WBT': 'WBTC',
+        },
+    )
+    # Buy ETH with USDT
+    trade_1 = """
+    [
+        1,
+        "ETH:UST",
+        1606899600000,
+        10,
+        0.26334268,
+        187.37,
+        "LIMIT",
+        null,
+        -1,
+        -0.09868591,
+        "UST"
+    ]
+    """
+    # Sell ETH for USDT
+    trade_2 = """
+    [
+        2,
+        "ETH:UST",
+        1606901400000,
+        20,
+        -0.26334268,
+        187.37,
+        "LIMIT",
+        null,
+        -1,
+        -0.09868591,
+        "ETH"
+    ]
+    """
+    # Buy WBTC for USD
+    trade_3 = """
+    [
+        3,
+        "WBTUSD",
+        1606932000000,
+        30,
+        10000.00000000,
+        0.00005000,
+        "LIMIT",
+        null,
+        -1,
+        -20.00000000,
+        "USD"
+    ]
+    """
+    # Sell WBTC for USD
+    trade_4 = """
+    [
+        4,
+        "WBTUSD",
+        1606986000000,
+        40,
+        -10000.00000000,
+        0.00005000,
+        "LIMIT",
+        null,
+        -1,
+        -20.00000000,
+        "WBT"
+    ]
+    """
+    # Sell ETH for EUR, outside time range (gt 'end_ts')
+    trade_5 = """
+    [
+        5,
+        "ETH:EUR",
+        1606996801000,
+        50,
+        -0.26334268,
+        163.29,
+        "LIMIT",
+        null,
+        -1,
+        -0.09868591,
+        "ETH"
+    ]
+    """
+    expected_calls = [
+        call(
+            endpoint='trades',
+            options={
+                'start': 0,
+                'end': 1606996800000,
+                'limit': 2,
+                'sort': 1,
+            },
+        ),
+        call(
+            endpoint='trades',
+            options={
+                'start': 1606901400000,
+                'end': 1606996800000,
+                'limit': 2,
+                'sort': 1,
+            },
+        ),
+        call(
+            endpoint='trades',
+            options={
+                'start': 1606986000000,
+                'end': 1606996800000,
+                'limit': 2,
+                'sort': 1,
+            },
+        ),
+    ]
+
+    def get_paginated_response():
+        results = [
+            f'[{trade_1},{trade_2}]',
+            f'[{trade_3},{trade_4}]',
+            f'[{trade_5}]',
+        ]
+        for result_ in results:
+            yield result_
+
+    def mock_api_query_response(endpoint, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, next(get_response))
+
+    get_response = get_paginated_response()
+    currency_map_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_query_currency_map',
+        return_value=currency_map_response,
+    )
+    api_limit_patch = patch(
+        target='rotkehlchen.exchanges.bitfinex.API_TRADES_MAX_LIMIT',
+        new=api_limit,
+    )
+    api_query_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_api_query',
+        side_effect=mock_api_query_response,
+    )
+    with ExitStack() as stack:
+        stack.enter_context(api_limit_patch)
+        stack.enter_context(currency_map_patch)
+        api_query_mock = stack.enter_context(api_query_patch)
+        trades = mock_bitfinex.query_online_trade_history(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(int(datetime.now().timestamp())),
+        )
+        assert api_query_mock.call_args_list == expected_calls
+        expected_trades = [
+            Trade(
+                timestamp=Timestamp(1606899600),
+                location=Location.BITFINEX,
+                pair=TradePair('ETH_USDT'),
+                trade_type=TradeType.BUY,
+                amount=AssetAmount(FVal('0.26334268')),
+                rate=Price(FVal('187.37')),
+                fee=Fee(FVal('0.09868591')),
+                fee_currency=Asset('USDT'),
+                link='1',
+                notes='',
+            ),
+            Trade(
+                timestamp=Timestamp(1606901400),
+                location=Location.BITFINEX,
+                pair=TradePair('ETH_USDT'),
+                trade_type=TradeType.SELL,
+                amount=AssetAmount(FVal('0.26334268')),
+                rate=Price(FVal('187.37')),
+                fee=Fee(FVal('0.09868591')),
+                fee_currency=Asset('ETH'),
+                link='2',
+                notes='',
+            ),
+            Trade(
+                timestamp=Timestamp(1606932000),
+                location=Location.BITFINEX,
+                pair=TradePair('WBTC_USD'),
+                trade_type=TradeType.BUY,
+                amount=AssetAmount(FVal('10000.0')),
+                rate=Price(FVal('0.00005')),
+                fee=Fee(FVal('20.0')),
+                fee_currency=Asset('USD'),
+                link='3',
+                notes='',
+            ),
+            Trade(
+                timestamp=Timestamp(1606986000),
+                location=Location.BITFINEX,
+                pair=TradePair('WBTC_USD'),
+                trade_type=TradeType.SELL,
+                amount=AssetAmount(FVal('10000.0')),
+                rate=Price(FVal('0.00005')),
+                fee=Fee(FVal('20.0')),
+                fee_currency=Asset('WBTC'),
+                link='4',
+                notes='',
+            ),
+        ]
+        assert trades == expected_trades
+
+
+@pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
+# def test_query_online_trade_history_case_2(mock_bitfinex):
+def test_pepe(mock_bitfinex):
+    """Test pagination logic for trades works as expected when a request
+    returns an entry already processed in the previous request.
+
+    Other things tested:
+      - Stop requesting when number of entries is less than limit.
+
+    First request: 2 results
+    Second request: 2 results, both trades are repeated from the 1st request.
+    Third request: 2 results, first trade is repeated from the 2nd request.
+    Fourth request: 1 result
+
+    Trades with id 1 to 4 are expected to be returned.
+    """
+    api_limit = 2
+    response = Response()
+    response.status_code = HTTPStatus.OK
+    currency_map_response = CurrencyMapResponse(
+        success=True,
+        response=response,
+        currency_map={
+            'UST': 'USDt',
+            'WBT': 'WBTC',
+        },
+    )
+    # Buy ETH with USDT
+    trade_1 = """
+    [
+        1,
+        "ETH:UST",
+        1606899600000,
+        10,
+        0.26334268,
+        187.37,
+        "LIMIT",
+        null,
+        -1,
+        -0.09868591,
+        "UST"
+    ]
+    """
+    # Sell ETH for USDT
+    trade_2 = """
+    [
+        2,
+        "ETH:UST",
+        1606901400000,
+        20,
+        -0.26334268,
+        187.37,
+        "LIMIT",
+        null,
+        -1,
+        -0.09868591,
+        "ETH"
+    ]
+    """
+    # Buy WBTC for USD
+    trade_3 = """
+    [
+        3,
+        "WBTUSD",
+        1606932000000,
+        30,
+        10000.00000000,
+        0.00005000,
+        "LIMIT",
+        null,
+        -1,
+        -20.00000000,
+        "USD"
+    ]
+    """
+    # Sell WBTC for USD
+    trade_4 = """
+    [
+        4,
+        "WBTUSD",
+        1606986000000,
+        40,
+        -10000.00000000,
+        0.00005000,
+        "LIMIT",
+        null,
+        -1,
+        -20.00000000,
+        "WBT"
+    ]
+    """
+
+    def get_paginated_response():
+        results = [
+            f'[{trade_1},{trade_2}]',
+            f'[{trade_1},{trade_2}]',  # repeated line
+            f'[{trade_2},{trade_3}]',  # contains repeated
+            f'[{trade_4}]',
+        ]
+        for result_ in results:
+            yield result_
+
+    def mock_api_query_response(endpoint, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, next(get_response))
+
+    get_response = get_paginated_response()
+    currency_map_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_query_currency_map',
+        return_value=currency_map_response,
+    )
+    api_limit_patch = patch(
+        target='rotkehlchen.exchanges.bitfinex.API_TRADES_MAX_LIMIT',
+        new=api_limit,
+    )
+    api_query_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_api_query',
+        side_effect=mock_api_query_response,
+    )
+    with ExitStack() as stack:
+        stack.enter_context(api_limit_patch)
+        stack.enter_context(currency_map_patch)
+        stack.enter_context(api_query_patch)
+        trades = mock_bitfinex.query_online_trade_history(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(int(datetime.now().timestamp())),
+        )
+        expected_trades = [
+            Trade(
+                timestamp=Timestamp(1606899600),
+                location=Location.BITFINEX,
+                pair=TradePair('ETH_USDT'),
+                trade_type=TradeType.BUY,
+                amount=AssetAmount(FVal('0.26334268')),
+                rate=Price(FVal('187.37')),
+                fee=Fee(FVal('0.09868591')),
+                fee_currency=Asset('USDT'),
+                link='1',
+                notes='',
+            ),
+            Trade(
+                timestamp=Timestamp(1606901400),
+                location=Location.BITFINEX,
+                pair=TradePair('ETH_USDT'),
+                trade_type=TradeType.SELL,
+                amount=AssetAmount(FVal('0.26334268')),
+                rate=Price(FVal('187.37')),
+                fee=Fee(FVal('0.09868591')),
+                fee_currency=Asset('ETH'),
+                link='2',
+                notes='',
+            ),
+            Trade(
+                timestamp=Timestamp(1606932000),
+                location=Location.BITFINEX,
+                pair=TradePair('WBTC_USD'),
+                trade_type=TradeType.BUY,
+                amount=AssetAmount(FVal('10000.0')),
+                rate=Price(FVal('0.00005')),
+                fee=Fee(FVal('20.0')),
+                fee_currency=Asset('USD'),
+                link='3',
+                notes='',
+            ),
+            Trade(
+                timestamp=Timestamp(1606986000),
+                location=Location.BITFINEX,
+                pair=TradePair('WBTC_USD'),
+                trade_type=TradeType.SELL,
+                amount=AssetAmount(FVal('10000.0')),
+                rate=Price(FVal('0.00005')),
+                fee=Fee(FVal('20.0')),
+                fee_currency=Asset('WBTC'),
+                link='4',
+                notes='',
+            ),
+        ]
+        assert trades == expected_trades
+
+
+def test_deserialize_asset_movement_deposit(mock_bitfinex):
+    currency_map = {'WBT': 'WBTC'}
+    raw_result = [
+        13105603,
+        'WBT',
+        'Wrapped Bitcoin',
+        None,
+        None,
+        1569348774000,
+        1569348774000,
+        None,
+        None,
+        'COMPLETED',
+        None,
+        None,
+        0.26300954,
+        -0.00135,
+        None,
+        None,
+        'DESTINATION_ADDRESS',
+        None,
+        None,
+        None,
+        'TRANSACTION_ID',
+        None,
+    ]
+    fee_asset = Asset('WBTC')
+    expected_asset_movement = AssetMovement(
+        timestamp=Timestamp(1569348774),
+        location=Location.BITFINEX,
+        category=AssetMovementCategory.DEPOSIT,
+        address='DESTINATION_ADDRESS',
+        transaction_id='TRANSACTION_ID',
+        asset=fee_asset,
+        amount=FVal('0.26300954'),
+        fee_asset=fee_asset,
+        fee=Fee(FVal('0.00135')),
+        link=str(13105603),
+    )
+    asset_movement = mock_bitfinex._deserialize_asset_movement(
+        raw_result=raw_result,
+        currency_map=currency_map,
+    )
+    assert asset_movement == expected_asset_movement
+
+
+def test_deserialize_asset_movement_withdrawal(mock_bitfinex):
+    """Test also both 'address' and 'transaction_id' are None for fiat
+    movements.
+    """
+    currency_map = {}
+    raw_result = [
+        13105603,
+        'EUR',
+        'Euro',
+        None,
+        None,
+        1569348774000,
+        1569348774000,
+        None,
+        None,
+        'COMPLETED',
+        None,
+        None,
+        -0.26300954,
+        -0.00135,
+        None,
+        None,
+        'DESTINATION_ADDRESS',
+        None,
+        None,
+        None,
+        'TRANSACTION_ID',
+        None,
+    ]
+    fee_asset = Asset('EUR')
+    expected_asset_movement = AssetMovement(
+        timestamp=Timestamp(1569348774),
+        location=Location.BITFINEX,
+        category=AssetMovementCategory.WITHDRAWAL,
+        address=None,
+        transaction_id=None,
+        asset=fee_asset,
+        amount=FVal('0.26300954'),
+        fee_asset=fee_asset,
+        fee=Fee(FVal('0.00135')),
+        link=str(13105603),
+    )
+    asset_movement = mock_bitfinex._deserialize_asset_movement(
+        raw_result=raw_result,
+        currency_map=currency_map,
+    )
+    assert asset_movement == expected_asset_movement
+
+
+@pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
+def test_query_online_deposits_withdrawals_case_1(mock_bitfinex):
+    """Test pagination logic for asset movements works as expected when each
+    request does not return an entry already processed.
+
+    Other things tested:
+      - Skip entry when status is not 'COMPLETED'.
+      - Stop requesting (break the loop) when entry timestamp is greater than
+      'end_ts'.
+      - '_api_query' call arguments.
+
+    First request: 2 results
+    Second request: 2 results, 1 not completed.
+    Third request: 1 result, out of time range (its timestamp is gt 'end_ts')
+
+    Movements with id 1, 2 and 4 are expected to be returned.
+    """
+    api_limit = 2
+    response = Response()
+    response.status_code = HTTPStatus.OK
+    currency_map_response = CurrencyMapResponse(
+        success=True,
+        response=response,
+        currency_map={'WBT': 'WBTC'},
+    )
+    # Deposit WBTC
+    movement_1 = """
+    [
+        1,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606899600000,
+        1606899700000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+    # Withdraw WBTC
+    movement_2 = """
+    [
+        2,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606901400000,
+        1606901500000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        -0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+    # Deposit WBTC, not completed
+    movement_3 = """
+    [
+        3,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606932000000,
+        1606932100000,
+        null,
+        null,
+        "WHATEVER",
+        null,
+        null,
+        0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+    # Withdraw EUR
+    movement_4 = """
+    [
+        4,
+        "EUR",
+        "Euro",
+        null,
+        null,
+        1606986000000,
+        1606986100000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        -0.26300954,
+        -0.00135,
+        null,
+        null,
+        "",
+        null,
+        null,
+        null,
+        "",
+        null
+    ]
+    """
+    # Deposit WBTC, outside time range (gt 'end_ts')
+    movement_5 = """
+    [
+        5,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606996801000,
+        1606996901000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+    expected_calls = [
+        call(
+            endpoint='movements',
+            options={
+                'start': 0,
+                'end': 1606996800000,
+                'limit': 2,
+                'sort': 1,
+            },
+        ),
+        call(
+            endpoint='movements',
+            options={
+                'start': 1606901400000,
+                'end': 1606996800000,
+                'limit': 2,
+                'sort': 1,
+            },
+        ),
+        call(
+            endpoint='movements',
+            options={
+                'start': 1606986000000,
+                'end': 1606996800000,
+                'limit': 2,
+                'sort': 1,
+            },
+        ),
+    ]
+
+    def get_paginated_response():
+        results = [
+            f'[{movement_1},{movement_2}]',
+            f'[{movement_3},{movement_4}]',
+            f'[{movement_5}]',
+        ]
+        for result_ in results:
+            yield result_
+
+    def mock_api_query_response(endpoint, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, next(get_response))
+
+    get_response = get_paginated_response()
+    currency_map_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_query_currency_map',
+        return_value=currency_map_response,
+    )
+    api_limit_patch = patch(
+        target='rotkehlchen.exchanges.bitfinex.API_MOVEMENTS_MAX_LIMIT',
+        new=api_limit,
+    )
+    api_query_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_api_query',
+        side_effect=mock_api_query_response,
+    )
+    with ExitStack() as stack:
+        stack.enter_context(api_limit_patch)
+        stack.enter_context(currency_map_patch)
+        api_query_mock = stack.enter_context(api_query_patch)
+        asset_movements = mock_bitfinex.query_online_deposits_withdrawals(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(int(datetime.now().timestamp())),
+        )
+        assert api_query_mock.call_args_list == expected_calls
+
+        wbtc_fee_asset = Asset('WBTC')
+        eur_fee_asset = Asset('EUR')
+        expected_asset_movements = [
+            AssetMovement(
+                timestamp=Timestamp(1606899600),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.DEPOSIT,
+                address='DESTINATION_ADDRESS',
+                transaction_id='TRANSACTION_ID',
+                asset=wbtc_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=wbtc_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(1),
+            ),
+            AssetMovement(
+                timestamp=Timestamp(1606901400),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.WITHDRAWAL,
+                address='DESTINATION_ADDRESS',
+                transaction_id='TRANSACTION_ID',
+                asset=wbtc_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=wbtc_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(2),
+            ),
+            AssetMovement(
+                timestamp=Timestamp(1606986000),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.WITHDRAWAL,
+                address=None,
+                transaction_id=None,
+                asset=eur_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=eur_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(4),
+            ),
+        ]
+        assert asset_movements == expected_asset_movements
+
+
+@pytest.mark.freeze_time(datetime(2020, 12, 3, 12, 0, 0))
+def test_query_online_deposits_withdrawals_case_2(mock_bitfinex):
+    """Test pagination logic for asset movements works as expected when a
+    request returns an entry already processed in the previous request.
+
+    Other things tested:
+      - Stop requesting when number of entries is less than limit.
+
+    First request: 2 results
+    Second request: 2 results, both movements are repeated from the 1st request.
+    Third request: 2 results, first movement is repeated from the 2nd request.
+    Fourth request: 1 result
+
+    Trades with id 1 to 4 are expected to be returned.
+    """
+    api_limit = 2
+    response = Response()
+    response.status_code = HTTPStatus.OK
+    currency_map_response = CurrencyMapResponse(
+        success=True,
+        response=response,
+        currency_map={'WBT': 'WBTC'},
+    )
+    # Deposit WBTC
+    movement_1 = """
+    [
+        1,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606899600000,
+        1606899700000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+    # Withdraw WBTC
+    movement_2 = """
+    [
+        2,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606901400000,
+        1606901500000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        -0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+    # Withdraw EUR
+    movement_3 = """
+    [
+        3,
+        "EUR",
+        "Euro",
+        null,
+        null,
+        1606986000000,
+        1606986100000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        -0.26300954,
+        -0.00135,
+        null,
+        null,
+        "",
+        null,
+        null,
+        null,
+        "",
+        null
+    ]
+    """
+    # Deposit WBTC
+    movement_4 = """
+    [
+        4,
+        "WBT",
+        "Wrapped Bitcoin",
+        null,
+        null,
+        1606996800000,
+        1606996900000,
+        null,
+        null,
+        "COMPLETED",
+        null,
+        null,
+        0.26300954,
+        -0.00135,
+        null,
+        null,
+        "DESTINATION_ADDRESS",
+        null,
+        null,
+        null,
+        "TRANSACTION_ID",
+        null
+    ]
+    """
+
+    def get_paginated_response():
+        results = [
+            f'[{movement_1},{movement_2}]',
+            f'[{movement_1},{movement_2}]',
+            f'[{movement_2},{movement_3}]',
+            f'[{movement_4}]',
+        ]
+        for result_ in results:
+            yield result_
+
+    def mock_api_query_response(endpoint, options):  # pylint: disable=unused-argument
+        return MockResponse(HTTPStatus.OK, next(get_response))
+
+    get_response = get_paginated_response()
+    currency_map_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_query_currency_map',
+        return_value=currency_map_response,
+    )
+    api_limit_patch = patch(
+        target='rotkehlchen.exchanges.bitfinex.API_MOVEMENTS_MAX_LIMIT',
+        new=api_limit,
+    )
+    api_query_patch = patch.object(
+        target=mock_bitfinex,
+        attribute='_api_query',
+        side_effect=mock_api_query_response,
+    )
+    with ExitStack() as stack:
+        stack.enter_context(api_limit_patch)
+        stack.enter_context(currency_map_patch)
+        stack.enter_context(api_query_patch)
+        asset_movements = mock_bitfinex.query_online_deposits_withdrawals(
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(int(datetime.now().timestamp())),
+        )
+        wbtc_fee_asset = Asset('WBTC')
+        eur_fee_asset = Asset('EUR')
+        expected_asset_movements = [
+            AssetMovement(
+                timestamp=Timestamp(1606899600),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.DEPOSIT,
+                address='DESTINATION_ADDRESS',
+                transaction_id='TRANSACTION_ID',
+                asset=wbtc_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=wbtc_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(1),
+            ),
+            AssetMovement(
+                timestamp=Timestamp(1606901400),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.WITHDRAWAL,
+                address='DESTINATION_ADDRESS',
+                transaction_id='TRANSACTION_ID',
+                asset=wbtc_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=wbtc_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(2),
+            ),
+            AssetMovement(
+                timestamp=Timestamp(1606986000),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.WITHDRAWAL,
+                address=None,
+                transaction_id=None,
+                asset=eur_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=eur_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(3),
+            ),
+            AssetMovement(
+                timestamp=Timestamp(1606996800),
+                location=Location.BITFINEX,
+                category=AssetMovementCategory.DEPOSIT,
+                address='DESTINATION_ADDRESS',
+                transaction_id='TRANSACTION_ID',
+                asset=wbtc_fee_asset,
+                amount=FVal('0.26300954'),
+                fee_asset=wbtc_fee_asset,
+                fee=Fee(FVal('0.00135')),
+                link=str(4),
+            ),
+        ]
+        assert asset_movements == expected_asset_movements

--- a/rotkehlchen/tests/fixtures/__init__.py
+++ b/rotkehlchen/tests/fixtures/__init__.py
@@ -7,6 +7,7 @@ from rotkehlchen.tests.fixtures.assets import *
 from rotkehlchen.tests.fixtures.blockchain import *
 from rotkehlchen.tests.fixtures.db import *
 from rotkehlchen.tests.fixtures.exchanges.binance import *
+from rotkehlchen.tests.fixtures.exchanges.bitfinex import *
 from rotkehlchen.tests.fixtures.exchanges.bitmex import *
 from rotkehlchen.tests.fixtures.exchanges.bitstamp import *
 from rotkehlchen.tests.fixtures.exchanges.bittrex import *

--- a/rotkehlchen/tests/fixtures/exchanges/bitfinex.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitfinex.py
@@ -1,0 +1,30 @@
+import pytest
+
+from rotkehlchen.tests.utils.exchanges import create_test_bitfinex
+from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
+
+
+@pytest.fixture(name='bitfinex_api_key')
+def fixture_bitfinex_api_key():
+    return make_api_key()
+
+
+@pytest.fixture(name='bitfinex_api_secret')
+def fixture_bitfinex_api_secret():
+    return make_api_secret()
+
+
+@pytest.fixture
+def mock_bitfinex(
+        database,
+        inquirer,  # pylint: disable=unused-argument
+        function_scope_messages_aggregator,
+        bitfinex_api_key,
+        bitfinex_api_secret,
+):
+    return create_test_bitfinex(
+        database=database,
+        msg_aggregator=function_scope_messages_aggregator,
+        api_key=bitfinex_api_key,
+        secret=bitfinex_api_secret,
+    )

--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -61,4 +61,5 @@ def added_exchanges():
         'coinbasepro',
         'gemini',
         'bitstamp',
+        'bitfinex',
     )

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -217,7 +217,7 @@ def test_coingecko_identifiers_are_reachable():
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '9b7bd26f50a53f3feabf0a6364c7cb65', 'version': 35}
+    last_meta = {'md5': '6cfa2a350084f7db34a3247234d3829b', 'version': 36}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -217,7 +217,7 @@ def test_coingecko_identifiers_are_reachable():
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '6cfa2a350084f7db34a3247234d3829b', 'version': 36}
+    last_meta = {'md5': '662dad7cf1914aa91676ea7d1fea4ab7', 'version': 36}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.exchanges.binance import Binance, create_binance_symbols_to_pair
+from rotkehlchen.exchanges.bitfinex import Bitfinex
 from rotkehlchen.exchanges.bitmex import Bitmex
 from rotkehlchen.exchanges.bitstamp import Bitstamp
 from rotkehlchen.exchanges.bittrex import Bittrex
@@ -320,6 +321,25 @@ def create_test_binance(
     binance._symbols_to_pair = create_binance_symbols_to_pair(json_data)
     binance.first_connection_made = True
     return binance
+
+
+def create_test_bitfinex(
+        database,
+        msg_aggregator,
+        api_key=None,
+        secret=None,
+) -> Bitfinex:
+    if api_key is None:
+        api_key = make_api_key()
+    if secret is None:
+        secret = make_api_secret()
+
+    return Bitfinex(
+        api_key=api_key,
+        secret=secret,
+        database=database,
+        msg_aggregator=msg_aggregator,
+    )
 
 
 def create_test_bitmex(

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -306,6 +306,7 @@ class Location(Enum):
     UNISWAP = 17
     BITSTAMP = 18
     BINANCE_US = 19
+    BITFINEX = 20
 
     def __str__(self) -> str:
         if self == Location.EXTERNAL:
@@ -346,6 +347,8 @@ class Location(Enum):
             return 'bitstamp'
         if self == Location.BINANCE_US:
             return 'binance_us'
+        if self == Location.BITFINEX:
+            return 'bitfinex'
         # else
         raise RuntimeError(f'Corrupt value {self} for Location -- Should never happen')
 
@@ -388,6 +391,8 @@ class Location(Enum):
             return 'R'
         if self == Location.BINANCE_US:
             return 'S'
+        if self == Location.BITFINEX:
+            return 'T'
         # else
         raise RuntimeError(f'Corrupt value {self} for Location -- Should never happen')
 


### PR DESCRIPTION
- [X] Pending to extend `_api_query_paginated()` for supporting rate limits. Unit tested.
- [X] Pending check whether we need to add a special case in `converters.py` for Bitfinex (~~I don't think so~~, hell yes).
- [X] Added test for discovering exchange assets not supported yet by Rotki (`test_bitfinex_exchange_assets_are_known`).

Closes #438 