### PR TITLE
Fix out of gas error during zerion sdk query for open nodes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1969` Users who were using open nodes only and were seeing an out of gas error during defi balances query, should be able to query defi balances properly again.
 * :bug:`1287` Querying bitmex balances should now work properly again.
 * :bug:`1916` Querying bitstamp trades should now work properly again.
 * :bug:`1917` Users can now properly login if they input the username after the password.

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -393,7 +393,7 @@ class EthereumManager():
         # no node in the call order list was succesfully queried
         raise RemoteError(
             f'Failed to query {str(method)} after trying the following '
-            f'nodes: {[str(x) for x in call_order]}',
+            f'nodes: {[str(x) for x in call_order]}. Check logs for details.',
         )
 
     def _get_latest_block_number(self, web3: Optional[Web3]) -> int:

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -327,7 +327,7 @@ def test_query_all_balances_ignore_cache(
             else:
                 assert fn.call_count == 2, msg
         msg = 'etherscan call count should have doubled after forced token detection'
-        expected_count = full_query_etherscan_count * 2 - len(ethereum_accounts) - 1
+        expected_count = full_query_etherscan_count * 2 - len(ethereum_accounts) * 3 - 1
         assert etherscan_mock.call_count == expected_count, msg
 
 

--- a/rotkehlchen/tests/unit/test_zerionsdk.py
+++ b/rotkehlchen/tests/unit/test_zerionsdk.py
@@ -2,10 +2,15 @@ import warnings as test_warnings
 
 import pytest
 
-from rotkehlchen.chain.ethereum.defi.zerionsdk import ZerionSDK
+from rotkehlchen.chain.ethereum.defi.zerionsdk import KNOWN_ZERION_PROTOCOL_NAMES, ZerionSDK
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.ethereum import (
+    ETHEREUM_TEST_PARAMETERS,
+    wait_until_all_nodes_connected,
+)
 
 
+@pytest.mark.parametrize(*ETHEREUM_TEST_PARAMETERS)
 @pytest.mark.parametrize('mocked_current_prices', [{
     'SNX': FVal('1'),
     'cUSDT': FVal('1'),
@@ -15,6 +20,8 @@ def test_query_all_protocol_balances_for_account(
         ethereum_manager,
         function_scope_messages_aggregator,
         inquirer,  # pylint: disable=unused-argument
+        ethereum_manager_connect_at_start,
+        call_order,  # pylint: disable=unused-argument
 ):
     """Simple test that we can get balances for various defi protocols via zerion
 
@@ -25,8 +32,13 @@ def test_query_all_protocol_balances_for_account(
     certain balance in a few DeFi protocols and does not change them. This way
     we can have something stable to check again.
     """
+    wait_until_all_nodes_connected(
+        ethereum_manager_connect_at_start=ethereum_manager_connect_at_start,
+        ethereum=ethereum_manager,
+    )
     zerion = ZerionSDK(ethereum_manager, function_scope_messages_aggregator)
     balances = zerion.all_balances_for_account('0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662')
+
     if len(balances) == 0:
         test_warnings.warn(UserWarning('Test account for DeFi balances has no balances'))
         return
@@ -36,77 +48,6 @@ def test_query_all_protocol_balances_for_account(
     assert len(errors) == 0
     warnings = function_scope_messages_aggregator.consume_warnings()
     assert len(warnings) == 0
-
-
-KNOWN_ZERION_PROTOCOL_NAMES = (
-    'Curve • Vesting',
-    'Curve • Liquidity Gauges',
-    'ygov.finance (v1)',
-    'ygov.finance (v2)',
-    'mStable • Staking',
-    'Swerve • Liquidity Gauges',
-    'Pickle Finance • Farms',
-    'Pickle Finance • Staking',
-    'Aave • Staking',
-    'C.R.E.A.M. • Staking',
-    'Compound Governance',
-    'zlot.finance',
-    'FinNexus',
-    'Pickle Finance',
-    'DODO',
-    'Berezka',
-    'bZx',
-    'C.R.E.A.M.',
-    'Swerve',
-    'SashimiSwap',
-    'Harvest',
-    'Harvest • Profit Sharing',
-    'KIMCHI',
-    'SushiSwap',
-    'Nexus Mutual',
-    'Mooniswap',
-    'Matic',
-    'Aragon',
-    'Melon',
-    'yearn.finance • Vaults',
-    'KeeperDAO',
-    'mStable',
-    'KyberDAO',
-    'DDEX • Spot',
-    'DDEX • Margin',
-    'DDEX • Lending',
-    'Ampleforth',
-    'Maker Governance',
-    'Gnosis Protocol',
-    'Chi Gastoken by 1inch',
-    'Idle • Risk-Adjusted',
-    'Aave • Uniswap Market',
-    'Uniswap V2',
-    'PieDAO',
-    'Multi-Collateral Dai',
-    'Bancor',
-    'DeFi Money Market',
-    'TokenSets',
-    '0x Staking',
-    'Uniswap V1',
-    'Synthetix',
-    'PoolTogether',
-    'Dai Savings Rate',
-    'Chai',
-    'iearn.finance (v3)',
-    'iearn.finance (v2)',
-    'Idle',
-    'Idle • Early Rewards',
-    'dYdX',
-    'Curve',
-    'Compound',
-    'Balancer',
-    'Aave',
-    'SnowSwap',
-    'Aave V2',
-    'Aave V2 • Variable Debt',
-    'Aave V2 • Stable Debt',
-)
 
 
 def test_protocol_names_are_known(

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -241,6 +241,23 @@ def mock_etherscan_query(
                 args = []
                 result = '0x' + web3.codec.encode_abi(output_types, [args]).hex()
                 response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
+            elif 'data=0x85c6a7930' in url:  # getProtocolBalances
+                data = url.split('data=')[1]
+                if '&apikey' in data:
+                    data = data.split('&apikey')[0]
+
+                fn_abi = contract._find_matching_fn_abi(
+                    fn_identifier='getProtocolBalances',
+                    args=['address', ['some', 'protocol', 'names']],
+                )
+                input_types = get_abi_input_types(fn_abi)
+                output_types = get_abi_output_types(fn_abi)
+                decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
+                # TODO: This here always returns empty response. If/when we want to
+                # mock it for etherscan, this is where we do it
+                args = []
+                result = '0x' + web3.codec.encode_abi(output_types, [args]).hex()
+                response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
             else:
                 raise AssertionError(f'Unexpected etherscan call during tests: {url}')
         elif f'api.etherscan.io/api?module=proxy&action=eth_call&to={ETH_SCAN.address}' in url:


### PR DESCRIPTION
Fix #1969

by splitting the zerionsdk getBalances query to multiple smaller
queries (atm hardcoded 2) of per protocol balances. Essentially
splitting the known protocol list to 2 sublists.