### PR TITLE
bitfinex: use fee_asset from api instead of guessing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`2013` Show correct fee currency for Bitfinex trades.
+
 * :release:`1.11.0 <2020-12-30>`
 * :bug:`1929` Premium users will be able to see the proper balances after a force pull.
 * :feature:`438` Rotki now supports Bitfinex. Users can see their balances and import trades, deposits and withdrawals from that exchange. They are also taken into account in the tax report.

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -577,6 +577,10 @@ class Bitfinex(ExchangeInterface):
                 bitfinex_name=bfx_quote_asset_symbol,
                 currency_map=currency_map,
             )
+            fee_asset = asset_from_bitfinex(
+                bitfinex_name=bfx_fee_currency_symbol,
+                currency_map=currency_map,
+            )
         except (UnknownAsset, UnsupportedAsset) as e:
             asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
             raise DeserializationError(
@@ -591,7 +595,7 @@ class Bitfinex(ExchangeInterface):
             amount=AssetAmount(abs(amount)),
             rate=deserialize_price(raw_result[5]),
             fee=Fee(abs(deserialize_fee(raw_result[9]))),
-            fee_currency=quote_asset if trade_type == TradeType.BUY else base_asset,
+            fee_currency=fee_asset,
             link=str(raw_result[0]),
             notes='',
         )

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -364,7 +364,7 @@ def test_deserialize_trade_sell(mock_bitfinex):
         amount=AssetAmount(FVal('0.26334268')),
         rate=Price(FVal('187.37')),
         fee=Fee(FVal('0.09868591')),
-        fee_currency=Asset('ETH'),
+        fee_currency=Asset('USDT'),
         link='399251013',
         notes='',
     )


### PR DESCRIPTION
Fixes: #2013