### PR TITLE
This should probably fix the balances aggregation with bitfinex

### DIFF
--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -728,7 +728,7 @@ class Bitfinex(ExchangeInterface):
             self,
             response: Response,
             case: Literal['balances'],
-    ) -> Tuple[Optional[Dict[Asset, Balance]], str]:
+    ) -> Tuple[Optional[Dict[Asset, Dict[str, FVal]]], str]:
         ...
 
     @overload  # noqa: F811
@@ -754,7 +754,7 @@ class Bitfinex(ExchangeInterface):
     ) -> Union[
         List,
         Tuple[bool, str],
-        Tuple[Optional[Dict[Asset, Balance]], str],
+        Tuple[Optional[Dict[Asset, Dict[str, FVal]]], str],
     ]:
         """This function processes not successful responses for the cases listed
         in `case`.
@@ -806,7 +806,7 @@ class Bitfinex(ExchangeInterface):
 
     @protect_with_lock()
     @cache_response_timewise()
-    def query_balances(self) -> Tuple[Optional[Dict[Asset, Balance]], str]:
+    def query_balances(self) -> Tuple[Optional[Dict[Asset, Dict[str, FVal]]], str]:
         """Return the account exchange balances on Bitfinex
 
         The wallets endpoint returns a list where each item is a currency wallet.
@@ -890,7 +890,7 @@ class Bitfinex(ExchangeInterface):
                 usd_value=amount * usd_price,
             )
 
-        return dict(asset_balance), ''
+        return {a: b.to_dict() for a, b in asset_balance.items()}, ''
 
     def query_online_deposits_withdrawals(
             self,

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -198,27 +198,27 @@ def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disab
             Asset('EUR'): Balance(
                 amount=FVal('99.9999999'),
                 usd_value=FVal('149.99999985'),
-            ),
+            ).to_dict(),
             Asset('GLM'): Balance(
                 amount=FVal('0.0000001'),
                 usd_value=FVal('0.00000015'),
-            ),
+            ).to_dict(),
             Asset('LINK'): Balance(
                 amount=FVal('777.777777'),
                 usd_value=FVal('1166.6666655'),
-            ),
+            ).to_dict(),
             Asset('NEO'): Balance(
                 amount=FVal('1'),
                 usd_value=FVal('1.5'),
-            ),
+            ).to_dict(),
             Asset('USDT'): Balance(
                 amount=FVal('19790.1529257'),
                 usd_value=FVal('29685.22938855'),
-            ),
+            ).to_dict(),
             Asset('WBTC'): Balance(
                 amount=FVal('1'),
                 usd_value=FVal('1.5'),
-            ),
+            ).to_dict(),
         }
         assert msg == ''
 


### PR DESCRIPTION
Bitfinex query balances was returning a Dict of `Balance` items while
all other exchanges already return it serialized to a dict.

So this should probably fix the exception seen in #2040

We need to change this behaviour though. Made another issue: #2043