### PR TITLE
Introduces deb generation in packaging ci flow

### DIFF
--- a/.github/workflows/rotki_packaging.yaml
+++ b/.github/workflows/rotki_packaging.yaml
@@ -127,6 +127,15 @@ jobs:
           asset_path: ${{ steps.packaging.outputs.archive_checksum }}
           asset_name: ${{ steps.packaging.outputs.archive_checksum_name }}
           asset_content_type: text/plain
+      - name: Upload deb sha512 checksum file
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_draft.outputs.upload_url }}
+          asset_path: ${{ steps.packaging.outputs.deb_checksum }}
+          asset_name: ${{ steps.packaging.outputs.deb_checksum_name }}
+          asset_content_type: text/plain
 
   osx:
     env:

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -2,7 +2,7 @@
   "name": "rotki",
   "version": "1.11.0",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
-  "author": "Rotki Solutions GmbH",
+  "author": "Rotki Solutions GmbH <info@rotki.com>",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/frontend/app/vue.config.js
+++ b/frontend/app/vue.config.js
@@ -75,7 +75,7 @@ module.exports = {
           icon: 'src/assets/images/rotki.ico'
         },
         linux: {
-          target: ['AppImage', 'tar.xz'],
+          target: ['AppImage', 'tar.xz', 'deb'],
           icon: 'srs/assets/images/rotki_1024x1024.png',
           category: 'Finance'
         },

--- a/package.sh
+++ b/package.sh
@@ -140,6 +140,7 @@ cd frontend/app/dist || exit 1
 if [[ "$PLATFORM" == "linux" ]]; then
   generate_checksum "$PLATFORM" "*AppImage" APPIMAGE_CHECKSUM
   generate_checksum "$PLATFORM" "*.tar.xz" TAR_CHECKSUM
+  generate_checksum "$PLATFORM" "*.deb" DEB_CHECKSUM
 
   if [[ -n "${CI-}" ]]; then
     echo "::set-output name=binary::$GENERATED_APPIMAGE"
@@ -148,6 +149,8 @@ if [[ "$PLATFORM" == "linux" ]]; then
     echo "::set-output name=binary_checksum_name::${APPIMAGE_CHECKSUM##*/}"
     echo "::set-output name=archive_checksum::$TAR_CHECKSUM"
     echo "::set-output name=archive_checksum_name::${TAR_CHECKSUM##*/}"
+    echo "::set-output name=deb_checksum::$DEB_CHECKSUM"
+    echo "::set-output name=deb_checksum_name::${DEB_CHECKSUM##*/}"
   fi
 
   export APPIMAGE_CHECKSUM


### PR DESCRIPTION
Closes #27

I did another testing on a fresh ubuntu 20.10 installation and the deb seems to work fine, along with the desktop entry and icons.