### PR TITLE
Speedup of some backend tests and removal of old test

### DIFF
--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -255,6 +255,8 @@ def test_query_all_balances_ignore_cache(
         stack.enter_context(setup.binance_patch)
         etherscan_mock = stack.enter_context(setup.etherscan_patch)
         stack.enter_context(setup.bitcoin_patch)
+        stack.enter_context(setup.ethtokens_max_chunks_patch)
+        stack.enter_context(setup.beaconchain_patch)
         function_call_counters = []
         function_call_counters.append(stack.enter_context(eth_query_patch))
         function_call_counters.append(stack.enter_context(btc_query_patch))

--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -425,7 +425,8 @@ def test_add_blockchain_accounts(
         btc_balances=['3000000', '5000000', '600000000'],
     )
     # add the new BTC account
-    with setup.bitcoin_patch:
+    with ExitStack() as stack:
+        setup.enter_blockchain_patches(stack)
         response = requests.put(api_url_for(
             rotkehlchen_api_server,
             "blockchainsaccountsresource",
@@ -478,16 +479,18 @@ def test_add_blockchain_accounts(
     )
 
     # now try to add an already existing account and see an error is returned
-    response = requests.put(api_url_for(
-        rotkehlchen_api_server,
-        "blockchainsaccountsresource",
-        blockchain='ETH',
-    ), json={'accounts': [{'address': ethereum_accounts[0]}]})
-    assert_error_response(
-        response=response,
-        status_code=HTTPStatus.BAD_REQUEST,
-        contained_in_msg=f"Blockchain account/s ['{ethereum_accounts[0]}'] already exist",
-    )
+    with ExitStack() as stack:
+        setup.enter_blockchain_patches(stack)
+        response = requests.put(api_url_for(
+            rotkehlchen_api_server,
+            "blockchainsaccountsresource",
+            blockchain='ETH',
+        ), json={'accounts': [{'address': ethereum_accounts[0]}]})
+        assert_error_response(
+            response=response,
+            status_code=HTTPStatus.BAD_REQUEST,
+            contained_in_msg=f"Blockchain account/s ['{ethereum_accounts[0]}'] already exist",
+        )
 
 
 @pytest.mark.parametrize('include_etherscan_key', [False])
@@ -1402,7 +1405,8 @@ def test_remove_blockchain_accounts(
         btc_balances=['3000000', '5000000'],
     )
     # remove the new BTC account
-    with setup.bitcoin_patch:
+    with ExitStack() as stack:
+        setup.enter_blockchain_patches(stack)
         response = requests.delete(api_url_for(
             rotkehlchen_api_server,
             "blockchainsaccountsresource",

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -29,7 +29,7 @@ def test_query_eth2_info(rotkehlchen_api_server, ethereum_accounts):
         rotki,
         ethereum_accounts=ethereum_accounts,
         btc_accounts=[],
-        original_queries=['logs', 'transactions', 'blocknobytime'],
+        original_queries=['logs', 'transactions', 'blocknobytime', 'beaconchain'],
     )
     with ExitStack() as stack:
         setup.enter_blockchain_patches(stack)

--- a/rotkehlchen/tests/integration/test_blockchain.py
+++ b/rotkehlchen/tests/integration/test_blockchain.py
@@ -13,7 +13,7 @@ from rotkehlchen.chain.ethereum.defi.structures import (
 )
 from rotkehlchen.constants.assets import A_BTC, A_DAI
 from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.blockchain import mock_etherscan_query
+from rotkehlchen.tests.utils.blockchain import mock_beaconchain, mock_etherscan_query
 from rotkehlchen.typing import SupportedBlockchain
 
 
@@ -27,53 +27,6 @@ def test_query_btc_balances(blockchain):
     blockchain.query_btc_balances()
     assert blockchain.totals.assets[A_BTC].usd_value is not None
     assert blockchain.totals.assets[A_BTC].amount is not None
-
-
-@pytest.mark.parametrize('number_of_eth_accounts', [0])
-def test_add_remove_account_assure_all_balances_not_always_queried(blockchain):
-    """Due to a programming mistake at addition and removal of blockchain accounts
-    after the first time all balances were queried every time. That slowed
-    everything down (https://github.com/rotki/rotki/issues/678).
-
-    This is a regression test for that behaviour
-
-    TODO: Is this still needed? Shouldn't it just be removed?
-    Had to add lots of mocks to make it not be a slow test
-    """
-    addr1 = '0xe188c6BEBB81b96A65aa20dDB9e2aef62627fa4c'
-    addr2 = '0x78a087fCf440315b843632cFd6FDE6E5adcCc2C2'
-    etherscan_patch = mock_etherscan_query(
-        eth_map={addr1: {'ETH': 1}, addr2: {'ETH': 2}},
-        etherscan=blockchain.ethereum.etherscan,
-        original_requests_get=requests.get,
-        original_queries=[],
-    )
-    ethtokens_max_chunks_patch = patch(
-        'rotkehlchen.chain.ethereum.tokens.ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH',
-        new=800,
-    )
-    with etherscan_patch, ethtokens_max_chunks_patch:
-        blockchain.add_blockchain_accounts(
-            blockchain=SupportedBlockchain.ETHEREUM,
-            accounts=[addr1],
-        )
-    assert addr1 in blockchain.accounts.eth
-
-    with etherscan_patch, ethtokens_max_chunks_patch, patch.object(blockchain, 'query_balances') as mock:  # noqa: E501
-        blockchain.remove_blockchain_accounts(
-            blockchain=SupportedBlockchain.ETHEREUM,
-            accounts=[addr1],
-        )
-
-    assert addr1 not in blockchain.accounts.eth
-    assert mock.call_count == 0, 'blockchain.query_balances() should not have been called'
-
-    addr2 = '0x78a087fCf440315b843632cFd6FDE6E5adcCc2C2'
-    with etherscan_patch, ethtokens_max_chunks_patch, patch.object(blockchain, 'query_balances') as mock:  # noqa: E501
-        blockchain.add_blockchain_accounts(
-            blockchain=SupportedBlockchain.ETHEREUM,
-            accounts=[addr2],
-        )
 
 
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
@@ -94,6 +47,7 @@ def test_multiple_concurrent_ethereum_blockchain_queries(blockchain):
         'rotkehlchen.chain.ethereum.tokens.ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH',
         new=800,
     )
+    beaconchain_patch = mock_beaconchain(blockchain.beaconchain)
 
     def mock_query_defi_balances():
         blockchain.defi_balances = {
@@ -147,7 +101,7 @@ def test_multiple_concurrent_ethereum_blockchain_queries(blockchain):
         )
     assert addr1 in blockchain.accounts.eth
 
-    with etherscan_patch, ethtokens_max_chunks_patch, defi_balances_mock, add_defi_mock:
+    with etherscan_patch, ethtokens_max_chunks_patch, defi_balances_mock, add_defi_mock, beaconchain_patch:  # noqa: E501
         greenlets = [
             gevent.spawn_later(0.01 * x, blockchain.query_ethereum_balances, False)
             for x in range(5)

--- a/rotkehlchen/tests/integration/test_blockchain.py
+++ b/rotkehlchen/tests/integration/test_blockchain.py
@@ -47,7 +47,11 @@ def test_multiple_concurrent_ethereum_blockchain_queries(blockchain):
         'rotkehlchen.chain.ethereum.tokens.ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH',
         new=800,
     )
-    beaconchain_patch = mock_beaconchain(blockchain.beaconchain)
+    beaconchain_patch = mock_beaconchain(
+        blockchain.beaconchain,
+        original_queries=None,
+        original_requests_get=requests.get,
+    )
 
     def mock_query_defi_balances():
         blockchain.defi_balances = {

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -10,9 +10,10 @@ from web3._utils.abi import get_abi_input_types, get_abi_output_types
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.chain.ethereum.defi.zerionsdk import ZERION_ADAPTER_ADDRESS
 from rotkehlchen.constants.assets import A_BTC
-from rotkehlchen.constants.ethereum import ETH_SCAN, ZERION_ABI
+from rotkehlchen.constants.ethereum import ETH_MULTICALL, ETH_SCAN, VOTE_ESCROWED_CRV, ZERION_ABI
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import DeserializationError
+from rotkehlchen.externalapis.beaconchain import BeaconChain
 from rotkehlchen.externalapis.etherscan import Etherscan
 from rotkehlchen.fval import FVal
 from rotkehlchen.rotkehlchen import Rotkehlchen
@@ -156,6 +157,19 @@ def _get_token(value: Any) -> Optional[EthereumToken]:
     return None
 
 
+def mock_beaconchain(beaconchain: BeaconChain):
+
+    def mock_requests_get(url, *args, **kwargs):  # pylint: disable=unused-argument
+        if 'validator' in url:  # all validators that belong to an eth1 address
+            response = '{"status":"OK","data":[]}'
+        else:
+            raise AssertionError(f'Unrecognized argument url for beaconchain mock in tests: {url}')
+
+        return MockResponse(200, response)
+
+    return patch.object(beaconchain.session, 'get', wraps=mock_requests_get)
+
+
 def mock_etherscan_query(
         eth_map: Dict[ChecksumEthAddress, Dict[Union[str, EthereumToken], Any]],
         etherscan: Etherscan,
@@ -276,6 +290,31 @@ def mock_etherscan_query(
                 response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
             else:
                 raise AssertionError(f'Unexpected etherscan call during tests: {url}')
+        elif f'api.etherscan.io/api?module=proxy&action=eth_call&to={VOTE_ESCROWED_CRV.address}' in url:  # noqa: E501
+            # always
+            pass
+        elif f'api.etherscan.io/api?module=proxy&action=eth_call&to={ETH_MULTICALL.address}' in url:  # noqa: E501
+            web3 = Web3()
+            contract = web3.eth.contract(address=ETH_MULTICALL.address, abi=ETH_MULTICALL.abi)
+            if 'data=0x252dba42' in url:  # aggregate
+                data = url.split('data=')[1]
+                if '&apikey' in data:
+                    data = data.split('&apikey')[0]
+
+                fn_abi = contract.functions.abi[1]
+                assert fn_abi['name'] == 'aggregate', 'Abi position of multicall aggregate changed'
+                input_types = get_abi_input_types(fn_abi)
+                output_types = get_abi_output_types(fn_abi)
+                decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
+                # For now the only mocked multicall is 32 bytes for the locked CRV in escrow
+                # When there is more we have to figure out a way to differentiate
+                # between them in mocking. Just return empty response here
+                args = [1, [b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' for x in decoded_input[0]]]  # noqa: E501
+                result = '0x' + web3.codec.encode_abi(output_types, args).hex()
+                response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
+            else:
+                raise AssertionError('Unexpected etherscan multicall during tests: {url}')
+
         elif f'api.etherscan.io/api?module=proxy&action=eth_call&to={ETH_SCAN.address}' in url:
             if 'ethscan' in original_queries:
                 return original_requests_get(url, *args, **kwargs)

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -157,9 +157,16 @@ def _get_token(value: Any) -> Optional[EthereumToken]:
     return None
 
 
-def mock_beaconchain(beaconchain: BeaconChain):
+def mock_beaconchain(
+        beaconchain: BeaconChain,
+        original_queries: Optional[List[str]],
+        original_requests_get,
+):
 
     def mock_requests_get(url, *args, **kwargs):  # pylint: disable=unused-argument
+        if original_queries is not None and 'beaconchain' in original_queries:
+            return original_requests_get(url, *args, **kwargs)
+
         if 'validator' in url:  # all validators that belong to an eth1 address
             response = '{"status":"OK","data":[]}'
         else:

--- a/rotkehlchen/tests/utils/rotkehlchen.py
+++ b/rotkehlchen/tests/utils/rotkehlchen.py
@@ -10,7 +10,11 @@ from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
 from rotkehlchen.db.utils import AssetBalance, LocationData
 from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.blockchain import mock_bitcoin_balances_query, mock_etherscan_query
+from rotkehlchen.tests.utils.blockchain import (
+    mock_beaconchain,
+    mock_bitcoin_balances_query,
+    mock_etherscan_query,
+)
 from rotkehlchen.tests.utils.constants import A_RDN, A_XMR
 from rotkehlchen.tests.utils.exchanges import (
     patch_binance_balances_query,
@@ -29,6 +33,7 @@ class BalancesTestSetup(NamedTuple):
     poloniex_patch: _patch
     binance_patch: _patch
     etherscan_patch: _patch
+    beaconchain_patch: _patch
     ethtokens_max_chunks_patch: _patch
     bitcoin_patch: _patch
 
@@ -46,6 +51,7 @@ class BalancesTestSetup(NamedTuple):
     def enter_ethereum_patches(self, stack: ExitStack):
         stack.enter_context(self.etherscan_patch)
         stack.enter_context(self.ethtokens_max_chunks_patch)
+        stack.enter_context(self.beaconchain_patch)
         return stack
 
 
@@ -130,6 +136,7 @@ def setup_balances(
         original_queries=original_queries,
         original_requests_get=requests.get,
     )
+    beaconchain_patch = mock_beaconchain(rotki.chain_manager.beaconchain)
     # For ethtoken detection we can have bigger chunk length during tests since it's mocked anyway
     ethtokens_max_chunks_patch = patch(
         'rotkehlchen.chain.ethereum.tokens.ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH',
@@ -161,6 +168,7 @@ def setup_balances(
         etherscan_patch=etherscan_patch,
         ethtokens_max_chunks_patch=ethtokens_max_chunks_patch,
         bitcoin_patch=bitcoin_patch,
+        beaconchain_patch=beaconchain_patch,
     )
 
 

--- a/rotkehlchen/tests/utils/rotkehlchen.py
+++ b/rotkehlchen/tests/utils/rotkehlchen.py
@@ -136,7 +136,11 @@ def setup_balances(
         original_queries=original_queries,
         original_requests_get=requests.get,
     )
-    beaconchain_patch = mock_beaconchain(rotki.chain_manager.beaconchain)
+    beaconchain_patch = mock_beaconchain(
+        beaconchain=rotki.chain_manager.beaconchain,
+        original_queries=original_queries,
+        original_requests_get=requests.get,
+    )
     # For ethtoken detection we can have bigger chunk length during tests since it's mocked anyway
     ethtokens_max_chunks_patch = patch(
         'rotkehlchen.chain.ethereum.tokens.ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH',


### PR DESCRIPTION
- Removed an old test
- Speed up many integration tests by figuring out a few places where
  real calls to etherscan were made that should be mocked and also
  introducing mocking of beaconchain api calls. It was called normally
  and was slowing down our tests considerably