### PR TITLE
Ton of fixes and improvements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -826,6 +826,7 @@ Query the current exchange rate for select assets
    :statuscode 200: The exchange rates have been sucesfully returned
    :statuscode 400: Provided JSON is in some way malformed. Empty currencies list given
    :statuscode 500: Internal Rotki error
+   :statuscode 502: An external service used in the query such as cryptocompare/coingecko could not be reached or returned unexpected response.
 
 
 Get a list of setup exchanges

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -208,6 +208,7 @@ class EthereumManager():
             self.greenlet_manager.spawn_and_track(
                 after_seconds=None,
                 task_name=f'Attempt connection to {str(node)} ethereum node',
+                exception_is_error=True,
                 method=self.attempt_connect,
                 name=node,
                 ethrpc_endpoint=node.endpoint(self.own_rpc_endpoint),

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -251,6 +251,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
                     greenlet_manager.spawn_and_track(
                         after_seconds=None,
                         task_name='Initialize Compound object',
+                        exception_is_error=True,
                         method=self._initialize_compound,
                         premium=premium,
                     )
@@ -290,6 +291,7 @@ class ChainManager(CacheableObject, LockableQueryObject):
             self.greenlet_manager.spawn_and_track(
                 after_seconds=None,
                 task_name=f'startup of {name}',
+                exception_is_error=True,
                 method=module.on_startup,
             )
 

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -38,6 +38,7 @@ from rotkehlchen.chain.ethereum.eth2 import (
     get_eth2_details,
     get_eth2_staking_deposits,
 )
+from rotkehlchen.errors import RemoteError
 from rotkehlchen.chain.ethereum.makerdao import MakerDAODSR, MakerDAOVaults
 from rotkehlchen.chain.ethereum.tokens import EthTokens
 from rotkehlchen.chain.ethereum.uniswap import Uniswap
@@ -1017,7 +1018,14 @@ class ChainManager(CacheableObject, LockableQueryObject):
                 if A_ETH2 in entry.assets:
                     del entry.assets[A_ETH2]
 
-        mapping = get_eth2_balances(self.beaconchain, addresses)
+        try:
+            mapping = get_eth2_balances(self.beaconchain, addresses)
+        except RemoteError as e:
+            self.msg_aggregator.add_error(
+                f'Did not manage to query beaconcha.in api for addresses due to {str(e)}.'
+                f' If you have Eth2 staked balances the final balance results may not be accurate',
+            )
+            mapping = {}
         for address, balance in mapping.items():
             self.balances.eth[address].assets[A_ETH2] = balance
             self.totals.assets[A_ETH2] += balance

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -20,7 +20,6 @@
     },
     "1INCH": {
         "coingecko": "1inch",
-        "cryptocompare": "",
         "ethereum_address": "0x111111111117dC0aa78b770fA6A738034120C302",
         "ethereum_token_decimals": 18,
         "name": "1INCH Token",
@@ -30,7 +29,6 @@
     },
     "1SG": {
         "coingecko": "1sg",
-        "cryptocompare": "",
         "ethereum_address": "0x0F72714B35a366285Df85886A2eE174601292A17",
         "ethereum_token_decimals": 18,
         "name": "1SG",
@@ -351,8 +349,8 @@
         "type": "ethereum token"
     },
     "AID-2": {
-        "coingecko": "aidcoin",
-        "cryptocompare": "",
+        "coingecko": "aidus",
+        "cryptocompare": "AIDUS",
         "ethereum_address": "0xD178b20c6007572bD1FD01D205cC20D32B4A6015",
         "ethereum_token_decimals": 18,
         "name": "AIDUS TOKEN",
@@ -399,7 +397,6 @@
     },
     "AKRO": {
         "coingecko": "akropolis",
-        "cryptocompare": "",
         "ethereum_address": "0x8Ab7404063Ec4DBcfd4598215992DC3F8EC853d7",
         "ethereum_token_decimals": 18,
         "name": "Akropolis",
@@ -416,7 +413,6 @@
     },
     "ALI": {
         "coingecko": "ailink-token",
-        "cryptocompare": "",
         "ethereum_address": "0x4289c043A12392F1027307fB58272D8EBd853912",
         "ethereum_token_decimals": 18,
         "name": "AiLink Token",
@@ -833,7 +829,6 @@
     },
     "AUDIO": {
         "coingecko": "audius",
-        "cryptocompare": "",
         "ethereum_address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
         "ethereum_token_decimals": 18,
         "name": "Audius",
@@ -1189,7 +1184,6 @@
     },
     "BCV": {
         "coingecko": "bcv",
-        "cryptocompare": "",
         "ethereum_address": "0x1014613E2B3CBc4d575054D4982E580d9b99d7B1",
         "ethereum_token_decimals": 8,
         "name": "BitCapitalVendor",
@@ -1467,7 +1461,7 @@
     },
     "BLOC-2": {
         "coingecko": "bloc-money",
-        "cryptocompare": "",
+        "cryptocompare": "BLOCM",
         "name": "BLOC.MONEY",
         "started": 1539736469,
         "symbol": "BLOC",
@@ -1601,7 +1595,7 @@
         "type": "own chain"
     },
     "BNC": {
-        "coingecko": "bnoincoin",
+        "coingecko": "",
         "cryptocompare": "",
         "ethereum_address": "0xEf51c9377FeB29856E61625cAf9390bD0B67eA18",
         "ethereum_token_decimals": 8,
@@ -1657,7 +1651,6 @@
     },
     "BORA": {
         "coingecko": "bora",
-        "cryptocompare": "",
         "ethereum_address": "0x26fb86579e371c7AEdc461b2DdEF0A8628c93d3B",
         "ethereum_token_decimals": 18,
         "name": "BORA",
@@ -1701,7 +1694,7 @@
     },
     "BOX": {
         "coingecko": "box-token",
-        "cryptocompare": "",
+        "cryptocompare": "BOXT",
         "ethereum_address": "0xe1A178B681BD05964d3e3Ed33AE731577d9d96dD",
         "ethereum_token_decimals": 18,
         "name": "BOX Token",
@@ -1721,7 +1714,6 @@
     },
     "BOXX": {
         "coingecko": "boxx",
-        "cryptocompare": "",
         "ethereum_address": "0x780116D91E5592E58a3b3c76A351571b39abCEc6",
         "ethereum_token_decimals": 15,
         "name": "Blockparty (BOXX Token)",
@@ -2084,7 +2076,6 @@
     },
     "BWX": {
         "coingecko": "blue-whale",
-        "cryptocompare": "",
         "ethereum_address": "0xbD168CbF9d3a375B38dC51A202B5E8a4E52069Ed",
         "ethereum_token_decimals": 18,
         "name": "Blue Whale Token",
@@ -2600,7 +2591,6 @@
     },
     "CLB": {
         "coingecko": "cloudbric",
-        "cryptocompare": "",
         "ethereum_address": "0xb1c1Cb8C7c1992dba24e628bF7d38E71daD46aeB",
         "ethereum_token_decimals": 18,
         "name": "Cloudbric",
@@ -2735,7 +2725,6 @@
     },
     "COCOS": {
         "coingecko": "cocos-bcx",
-        "cryptocompare": "",
         "ethereum_address": "0x0C6f5F7D555E7518f6841a79436BD2b1Eef03381",
         "ethereum_token_decimals": 18,
         "name": "Cocos-BCX",
@@ -3207,7 +3196,6 @@
     },
     "CZR": {
         "coingecko": "canonchain",
-        "cryptocompare": "",
         "ethereum_address": "0x0223fc70574214F65813fE336D870Ac47E147fAe",
         "ethereum_token_decimals": 18,
         "name": "CanonChain",
@@ -3217,7 +3205,6 @@
     },
     "DACS": {
         "coingecko": "dacsee",
-        "cryptocompare": "",
         "ethereum_address": "0xA31108E5BAB5494560Db34c95492658AF239357C",
         "ethereum_token_decimals": 18,
         "name": "DACSEE",
@@ -3426,7 +3413,6 @@
     },
     "DELTA": {
         "coingecko": "deltachain",
-        "cryptocompare": "",
         "ethereum_address": "0xDE1E0AE6101b46520cF66fDC0B1059c5cC3d106c",
         "ethereum_token_decimals": 8,
         "name": "DeltaChain",
@@ -3463,7 +3449,6 @@
     },
     "DEX": {
         "coingecko": "dex",
-        "cryptocompare": "",
         "ethereum_address": "0x497bAEF294c11a5f0f5Bea3f2AdB3073DB448B56",
         "ethereum_token_decimals": 18,
         "name": "DEX",
@@ -3750,7 +3735,6 @@
     },
     "DOUGH": {
         "coingecko": "piedao-dough-v2",
-        "cryptocompare": "",
         "ethereum_address": "0xad32A8e6220741182940c5aBF610bDE99E737b2D",
         "ethereum_token_decimals": 18,
         "name": "PieDAO DOUGH v2",
@@ -3960,7 +3944,6 @@
     },
     "DUCATO": {
         "coingecko": "ducato-protocol-token",
-        "cryptocompare": "",
         "ethereum_address": "0xa117ea1c0c85CEf648df2b6f40e50bb5475C228d",
         "ethereum_token_decimals": 18,
         "name": "DUCATO Protocol Token",
@@ -4432,7 +4415,6 @@
         "type": "ethereum token"
     },
     "ESD": {
-        "cryptocompare": "",
         "coingecko": "empty-set-dollar",
         "ethereum_address": "0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723",
         "ethereum_token_decimals": 18,
@@ -4723,7 +4705,6 @@
     },
     "FARM": {
         "coingecko": "harvest-finance",
-        "cryptocompare": "",
         "ethereum_address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
         "ethereum_token_decimals": 18,
         "name": "Harvest Finance",
@@ -5264,7 +5245,7 @@
     },
     "FX": {
         "coingecko": "fx-coin",
-        "cryptocompare": "",
+        "cryptocompare": "FUNX",
         "ethereum_address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
         "ethereum_token_decimals": 18,
         "name": "Function X",
@@ -5274,7 +5255,6 @@
     },
     "FXC": {
         "coingecko": "amp-token",
-        "cryptocompare": "",
         "ethereum_address": "0x4a57E687b9126435a9B19E4A802113e266AdeBde",
         "ethereum_token_decimals": 18,
         "name": "Flexacoin",
@@ -5463,7 +5443,7 @@
     },
     "GET-2": {
         "coingecko": "themis",
-        "cryptocompare": "",
+        "cryptocompare": "THEMIS",
         "ethereum_address": "0x60c68a87bE1E8a84144b543AAcfA77199cd3d024",
         "ethereum_token_decimals": 18,
         "name": "Themis",
@@ -5607,7 +5587,6 @@
     },
     "GOT-2": {
         "coingecko": "parkingo",
-        "cryptocompare": "",
         "ethereum_address": "0x613Fa2A6e6DAA70c659060E86bA1443D2679c9D7",
         "ethereum_token_decimals": 18,
         "name": "ParkinGo",
@@ -5677,7 +5656,6 @@
     },
     "GRT": {
         "coingecko": "the-graph",
-	"cryptocompare": "",
         "ethereum_address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
         "ethereum_token_decimals": 18,
         "name": "Graph Token",
@@ -5696,7 +5674,6 @@
     },
     "GSE": {
         "coingecko": "gsenetwork",
-        "cryptocompare": "",
         "ethereum_address": "0xe530441f4f73bDB6DC2fA5aF7c3fC5fD551Ec838",
         "ethereum_token_decimals": 4,
         "name": "GSENetwork",
@@ -6106,7 +6083,6 @@
     },
     "HXRO": {
         "coingecko": "hxro",
-        "cryptocompare": "",
         "ethereum_address": "0x4bD70556ae3F8a6eC6C4080A0C327B24325438f3",
         "ethereum_token_decimals": 18,
         "name": "Hxro",
@@ -6614,7 +6590,6 @@
     },
     "KAVA": {
         "coingecko": "kava",
-        "cryptocompare": "",
         "name": "Kava",
         "started": 1571980454,
         "symbol": "KAVA",
@@ -6769,7 +6744,7 @@
     },
     "KNT-2": {
         "coingecko": "knekted",
-        "cryptocompare": "",
+        "cryptocompare": "KNT",
         "ethereum_address": "0x7CC62d8E80Be9bEa3947F3443aD136f50f75b505",
         "ethereum_token_decimals": 18,
         "name": "Knekted",
@@ -6824,7 +6799,6 @@
     },
     "KWATT": {
         "coingecko": "4new",
-        "cryptocompare": "",
         "ethereum_address": "0x241bA672574A78a3A604CDd0a94429A73a84a324",
         "ethereum_token_decimals": 18,
         "name": "4NEW",
@@ -6933,7 +6907,6 @@
     },
     "LEMO": {
         "coingecko": "lemochain",
-        "cryptocompare": "",
         "ethereum_address": "0x60C24407d01782C2175D32fe7C8921ed732371D1",
         "ethereum_token_decimals": 18,
         "name": "LemoChain",
@@ -7126,7 +7099,6 @@
     },
     "LOCUS": {
         "coingecko": "locus-chain",
-        "cryptocompare": "",
         "ethereum_address": "0xC64500DD7B0f1794807e67802F8Abbf5F8Ffb054",
         "ethereum_token_decimals": 18,
         "name": "Locus Chain",
@@ -7320,7 +7292,6 @@
     },
     "MAS": {
         "coingecko": "midas-protocol",
-        "cryptocompare": "",
         "ethereum_address": "0x23Ccc43365D9dD3882eab88F43d515208f832430",
         "ethereum_token_decimals": 18,
         "name": "MidasProtocol",
@@ -7330,7 +7301,6 @@
     },
     "MATIC": {
         "coingecko": "matic-network",
-        "cryptocompare": "",
         "ethereum_address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
         "ethereum_token_decimals": 18,
         "name": "Matic Network",
@@ -7499,7 +7469,6 @@
     },
     "MESH": {
         "coingecko": "meshbox",
-        "cryptocompare": "",
         "ethereum_address": "0x01F2AcF2914860331C1Cb1a9AcecDa7475e06Af8",
         "ethereum_token_decimals": 18,
         "name": "MeshBox",
@@ -7724,7 +7693,6 @@
     },
     "MOC": {
         "coingecko": "mossland",
-        "cryptocompare": "",
         "ethereum_address": "0x865ec58b06bF6305B886793AA20A2da31D034E68",
         "ethereum_token_decimals": 18,
         "name": "Moss Coin",
@@ -9089,8 +9057,7 @@
         "type": "ethereum token"
     },
     "PLG": {
-        "coingecko": "plug",
-        "cryptocompare": "",
+        "coingecko": "pledgecamp",
         "ethereum_address": "0x85ca6710D0F1D511d130f6935eDDA88ACBD921bD",
         "ethereum_token_decimals": 18,
         "name": "Pledge Coin",
@@ -9397,7 +9364,6 @@
     },
     "PTON": {
         "coingecko": "foresting",
-        "cryptocompare": "",
         "ethereum_address": "0x4946583c5b86E01cCD30c71a05617D06E3E73060",
         "ethereum_token_decimals": 18,
         "name": "Foresting",
@@ -9435,7 +9401,7 @@
     },
     "PXL": {
         "coingecko": "piction-network",
-        "cryptocompare": "",
+        "cryptocompare": "PIXEL",
         "ethereum_address": "0xF88951D7B676798705fd3a362ba5B1DBca2B233b",
         "ethereum_token_decimals": 18,
         "name": "PIXEL",
@@ -9728,7 +9694,6 @@
     },
     "RED": {
         "coingecko": "red",
-        "cryptocompare": "",
         "ethereum_address": "0x76960Dccd5a1fe799F7c29bE9F19ceB4627aEb2f",
         "ethereum_token_decimals": 18,
         "name": "RED",
@@ -9955,7 +9920,7 @@
     },
     "RMC": {
         "active": false,
-        "coingecko": "russian-miner-coin",
+        "coingecko": "",
         "cryptocompare": "",
         "ended": 1524009600,
         "ethereum_address": "0x7Dc4f41294697a7903C4027f6Ac528C5d14cd7eB",
@@ -10050,8 +10015,7 @@
         "type": "ethereum token"
     },
     "RTH": {
-        "coingecko": "rutheneum",
-        "cryptocompare": "",
+        "coingecko": "rotharium",
         "ethereum_address": "0x3FD8f39A962eFDA04956981C31AB89FAB5FB8bC8",
         "ethereum_token_decimals": 18,
         "name": "Rotharium",
@@ -10686,7 +10650,6 @@
     },
     "SOLVE": {
         "coingecko": "solve-care",
-        "cryptocompare": "",
         "ethereum_address": "0x446C9033E7516D820cc9a2ce2d0B7328b579406F",
         "ethereum_token_decimals": 8,
         "name": "Solve.care",
@@ -10706,7 +10669,6 @@
     },
     "SOUL": {
         "coingecko": "phantasma",
-        "cryptocompare": "GOST",
         "name": "Phantasma",
         "started": 1527536682,
         "symbol": "SOUL",
@@ -10809,8 +10771,7 @@
     },
     "SPIN": {
         "active": true,
-        "coingecko": "spin-token",
-        "cryptocompare": "",
+        "coingecko": "spin-protocol",
         "ethereum_address": "0x4F22310C27eF39FEAA4A756027896DC382F0b5E2",
         "ethereum_token_decimals": 18,
         "name": "SPIN Protocol",
@@ -11348,7 +11309,6 @@
     },
     "TCNX": {
         "coingecko": "tercet-network",
-        "cryptocompare": "",
         "ethereum_address": "0x28d7F432d24ba6020d1cbD4f28BEDc5a82F24320",
         "ethereum_token_decimals": 18,
         "name": "Tercet Network",
@@ -11386,7 +11346,6 @@
     },
     "TEMCO": {
         "coingecko": "temco",
-        "cryptocompare": "",
         "ethereum_address": "0x2Fc246aA66F0da5bB1368F688548ecBBE9bdee5d",
         "ethereum_token_decimals": 18,
         "name": "TEMCO",
@@ -11491,7 +11450,7 @@
         "type": "ethereum token"
     },
     "TIC": {
-        "coingecko": "tictalk",
+        "coingecko": "thingschain",
         "cryptocompare": "",
         "ethereum_address": "0x72430A612Adc007c50e3b6946dBb1Bb0fd3101D1",
         "ethereum_token_decimals": 8,
@@ -11870,7 +11829,6 @@
     },
     "TTC": {
         "coingecko": "ttc-protocol",
-        "cryptocompare": "",
         "ethereum_address": "0x9389434852b94bbaD4c8AfEd5B7BDBc5Ff0c2275",
         "ethereum_token_decimals": 18,
         "name": "TTC Protocol",
@@ -11948,7 +11906,7 @@
     },
     "UCN": {
         "coingecko": "uchain",
-        "cryptocompare": "",
+        "cryptocompare": "UCH",
         "ethereum_address": "0xAAf37055188Feee4869dE63464937e683d61b2a1",
         "ethereum_token_decimals": 18,
         "name": "UChain",
@@ -12211,14 +12169,13 @@
     },
     "VBK": {
         "coingecko": "veriblock",
-        "cryptocompare": "",
         "name": "VeriBlock",
         "started": 1554490449,
         "symbol": "VBK",
         "type": "own chain"
     },
     "VD": {
-        "coingecko": "vindax-coin",
+        "coingecko": "",
         "cryptocompare": "",
         "ethereum_address": "0x9a9bB9b4b11BF8eccff84B58a6CCCCD4058A7f0D",
         "ethereum_token_decimals": 8,
@@ -12229,7 +12186,6 @@
     },
     "VDG": {
         "coingecko": "veridocglobal",
-        "cryptocompare": "",
         "ethereum_address": "0x57C75ECCc8557136D32619a191fBCDc88560d711",
         "ethereum_token_decimals": 0,
         "name": "VeriDocGlobal",
@@ -12623,7 +12579,6 @@
     },
     "WIKI": {
         "coingecko": "wiki-token",
-        "cryptocompare": "",
         "ethereum_address": "0x66BaD545596fb17a0B4ebDC003a85dEF10E8F6Ae",
         "ethereum_token_decimals": 18,
         "name": "Wiki Token",
@@ -13251,7 +13206,6 @@
     },
     "YEED": {
         "coingecko": "yggdrash",
-        "cryptocompare": "",
         "ethereum_address": "0xcA2796F9F61dc7b238Aab043971e49c6164DF375",
         "ethereum_token_decimals": 18,
         "name": "YGGDRASH",
@@ -14267,7 +14221,6 @@
     },
     "ZLOT": {
         "coingecko": "zlot",
-        "cryptocompare": "",
         "ethereum_address": "0xA8e7AD77C60eE6f30BaC54E2E7c0617Bd7B5A03E",
         "ethereum_token_decimals": 18,
         "name": "zLOT",
@@ -14550,7 +14503,6 @@
     },
     "TVK": {
         "coingecko": "terra-virtua-kolect",
-        "cryptocompare": "",
         "ethereum_address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
         "ethereum_token_decimals": 18,
         "name": "Terra Virtua Kolect",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -431,10 +431,12 @@
     },
     "ALPHA": {
         "coingecko": "alpha-finance",
+        "ethereum_address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
+        "ethereum_token_decimals": 18,
         "name": "Alpha Finance",
         "started": 1602288000,
         "symbol": "ALPHA",
-        "type": "binance token"
+        "type": "ethereum token and more"
     },
     "ALQO": {
         "coingecko": "alqo",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -4468,6 +4468,7 @@
     },
     "ETH2": {
         "coingecko": "ethereum",
+        "cryptocompare": "ETH",
         "name": "Staked ETH in Phase 0",
         "started": 1602667372,
         "symbol": "ETH",

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "5f7a37a0aa809b2a92f48a77e0d17d60", "version": 39}
+{"md5": "c46d9651c7a34f145b163d524b2b12ce", "version": 39}

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "353a2ab0cfcb2b85c92b65ec5e56308d", "version": 39}
+{"md5": "5f7a37a0aa809b2a92f48a77e0d17d60", "version": 39}

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -655,9 +655,9 @@ class Binance(ExchangeInterface):
     @protect_with_lock()
     @cache_response_timewise()
     def query_balances(self) -> Tuple[Optional[Dict], str]:
-        self.first_connection()
-        returned_balances: Dict = {}
         try:
+            self.first_connection()
+            returned_balances: Dict = {}
             returned_balances = self._query_spot_balances(returned_balances)
             returned_balances = self._query_lending_balances(returned_balances)
             returned_balances = self._query_cross_collateral_futures_balances(returned_balances)

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -1,4 +1,3 @@
-import glob
 import logging
 import os
 import re

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -236,14 +236,13 @@ class Cryptocompare(ExternalServiceWithApiKey):
         prefix = os.path.join(str(price_history_dir), PRICE_HISTORY_FILE_PREFIX)
         prefix = prefix.replace('\\', '\\\\')
         regex = re.compile(prefix + r'(.*)\.json')
-        files_list = glob.glob(prefix + '*.json')
 
-        for file_ in files_list:
-            file_ = file_.replace('\\\\', '\\')
-            match = regex.match(file_)
+        for file_ in price_history_dir.rglob(PRICE_HISTORY_FILE_PREFIX + '*.json'):
+            file_str = str(file_).replace('\\\\', '\\')
+            match = regex.match(file_str)
             assert match
             cache_key = PairCacheKey(match.group(1))
-            self.price_history_file[cache_key] = Path(file_)
+            self.price_history_file[cache_key] = file_
 
     def set_database(self, database: DBHandler) -> None:
         """If the cryptocompare instance was initialized without a DB this sets its DB"""

--- a/rotkehlchen/greenlets.py
+++ b/rotkehlchen/greenlets.py
@@ -16,19 +16,25 @@ class GreenletManager():
         self.msg_aggregator = msg_aggregator
         self.greenlets: List[gevent.Greenlet] = []
 
-    def add(self, task_name: str, greenlet: gevent.Greenlet) -> None:
+    def add(self, task_name: str, greenlet: gevent.Greenlet, exception_is_error) -> None:
         greenlet.link_exception(self._handle_killed_greenlets)
         greenlet.task_name = task_name
+        greenlet.exception_is_error = task_name
         self.greenlets.append(greenlet)
 
     def clear(self) -> None:
         """Clears all tracked greenlets. To be called when logging out or shutting down"""
         gevent.killall(self.greenlets)
 
+    def clear_finished(self) -> None:
+        """Remove all finished tracked greenlets from the list"""
+        self.greenlets = [x for x in self.greenlets if not x.dead]
+
     def spawn_and_track(
             self,
             after_seconds: Optional[float],
             task_name: str,
+            exception_is_error: bool,
             method: Callable,
             **kwargs: Any,
     ) -> None:
@@ -36,19 +42,20 @@ class GreenletManager():
             greenlet = gevent.spawn(method, **kwargs)
         else:
             greenlet = gevent.spawn_later(after_seconds, method, **kwargs)
-        self.add(task_name, greenlet)
+        self.add(task_name, greenlet, exception_is_error)
 
     def _handle_killed_greenlets(self, greenlet: gevent.Greenlet) -> None:
         if not greenlet.exception:
             log.error('went in handle_killed_greenlets without an exception')
             return
 
-        try:
-            task_name = f'Task for {greenlet.task_name}'
-        except AttributeError:
-            task_name = 'Unknown task'
-
+        exception_is_error = getattr(greenlet, 'exception_is_error', True)
+        task_name = getattr(greenlet, 'task_name', 'Unknown task')
         first_line = f'{task_name} died with exception: {greenlet.exception}'
+        if not exception_is_error:
+            log.warning(f'{first_line} but that is not treated as an error')
+            return
+
         msg = (
             f'{first_line}.\n'
             f'Exception Name: {greenlet.exc_info[0]}\nException Info: {greenlet.exc_info[1]}'

--- a/rotkehlchen/greenlets.py
+++ b/rotkehlchen/greenlets.py
@@ -16,10 +16,10 @@ class GreenletManager():
         self.msg_aggregator = msg_aggregator
         self.greenlets: List[gevent.Greenlet] = []
 
-    def add(self, task_name: str, greenlet: gevent.Greenlet, exception_is_error) -> None:
+    def add(self, task_name: str, greenlet: gevent.Greenlet, exception_is_error: bool) -> None:
         greenlet.link_exception(self._handle_killed_greenlets)
         greenlet.task_name = task_name
-        greenlet.exception_is_error = task_name
+        greenlet.exception_is_error = exception_is_error
         self.greenlets.append(greenlet)
 
     def clear(self) -> None:

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -130,15 +130,16 @@ class PriceHistorian():
 
         instance = PriceHistorian()
         price = None
-        try:
-            price = instance._cryptocompare.query_historical_price(
-                from_asset=from_asset,
-                to_asset=to_asset,
-                timestamp=timestamp,
-            )
-        except (PriceQueryUnsupportedAsset, NoPriceForGivenTimestamp, RemoteError):
-            # then use coingecko
-            pass
+        if Inquirer()._cryptocompare.rate_limited_in_last() is False:
+            try:
+                price = instance._cryptocompare.query_historical_price(
+                    from_asset=from_asset,
+                    to_asset=to_asset,
+                    timestamp=timestamp,
+                )
+            except (PriceQueryUnsupportedAsset, NoPriceForGivenTimestamp, RemoteError):
+                # then use coingecko
+                pass
 
         if price and price != Price(ZERO):
             return price

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -230,12 +230,14 @@ class Inquirer():
 
             return Price(usd_price)
 
-        try:
-            price = Inquirer()._cryptocompare_find_usd_price(asset)
-        except RemoteError:
-            price = Price(ZERO)
+        price = None
+        if Inquirer()._cryptocompare.rate_limited_in_last() is False:
+            try:
+                price = Inquirer()._cryptocompare_find_usd_price(asset)
+            except RemoteError:
+                pass
 
-        if price == Price(ZERO):
+        if price is None or price == Price(ZERO):
             try:
                 price = Inquirer()._coingecko.simple_price(from_asset=asset, to_asset=A_USD)
             except RemoteError as e:
@@ -243,6 +245,7 @@ class Inquirer():
                     f'Coingecko usd price query for {asset.identifier} failed due to {str(e)}',
                 )
                 price = Price(ZERO)
+
         return price
 
     @staticmethod

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -130,6 +130,7 @@ class Rotkehlchen():
         self.greenlet_manager.spawn_and_track(
             after_seconds=None,
             task_name='periodically_query_icons_until_all_cached',
+            exception_is_error=False,
             method=self.icon_manager.periodically_query_icons_until_all_cached,
             batch_size=ICONS_BATCH_SIZE,
             sleep_time_secs=ICONS_QUERY_SLEEP,
@@ -219,6 +220,7 @@ class Rotkehlchen():
         self.greenlet_manager.spawn_and_track(
             after_seconds=None,
             task_name='submit_usage_analytics',
+            exception_is_error=False,
             method=maybe_submit_usage_analytics,
             should_submit=settings.submit_usage_analytics,
         )

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -362,7 +362,6 @@ class Rotkehlchen():
         self.main_loop_spawned = True
         return greenlet
 
-
     def main_loop(self) -> None:
         """Rotki main loop that fires often and runs the task manager's scheduler"""
         while self.shutdown_event.wait(timeout=MAIN_LOOP_SECS_DELAY) is not True:

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -51,7 +51,6 @@ class RotkehlchenServer():
             gevent.hub.signal(signal.SIGQUIT, self.shutdown)
         gevent.hub.signal(signal.SIGINT, self.shutdown)
         gevent.hub.signal(signal.SIGTERM, self.shutdown)
+        # The api server's RestAPI starts rotki main loop
         self.api_server.start(host=self.args.api_host, port=self.args.api_port)
-        # Start rotki's main loop
-        self.rotkehlchen.start()
         self.stop_event.wait()

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -53,9 +53,9 @@ class TaskManager():
     def _prepare_cryptocompare_queries(self) -> None:
         """Prepare the queries to do to cryptocompare
 
-        This is actually rather slow for many files, due to the json files ending
-        up being rather big and causing a lot of I/O. We also need to yield to
-        other greenlets in the loop, or else we end up starving everything else.
+        This would be really slow if the entire json cache files were read but we
+        have implemented get_cached_data_metadata to only read the relevant part of the file.
+        Before doing that we had to yield with gevent.sleep() at each loop iteration.
 
         Runs only once in the beginning and then has a number of queries prepared
         for the task manager to schedule
@@ -78,7 +78,6 @@ class TaskManager():
             if asset.cryptocompare == '' or main_currency.cryptocompare == '':
                 continue  # not supported in cryptocompare
 
-            gevent.sleep(1)  # yield to other greenlets to not starve their timeouts
             data = self.cryptocompare.get_cached_data_metadata(
                 from_asset=asset,
                 to_asset=main_currency,

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -215,6 +215,28 @@ def test_cryptocompare_dao_query(cryptocompare):
     assert price is not None
 
 
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_get_cached_data_metadata(data_dir, database):
+    """Test that the get_cached_data_metadata function works correctly
+    and returns just the metadata by reading part ofthe file
+    """
+    contents = """{"start_time": 1301536800, "end_time": 1301540400,
+    "data": [{"time": 1301536800, "close": 0.298, "high": 0.298, "low": 0.298, "open": 0.298,
+    "volumefrom": 0.298, "volumeto": 0.298}, {"time": 1301540400, "close": 0.298, "high": 0.298,
+    "low": 0.298, "open": 0.298, "volumefrom": 0.298, "volumeto": 0.298}]}"""
+    price_history_dir = get_or_make_price_history_dir(data_dir)
+    with open(price_history_dir / f'{PRICE_HISTORY_FILE_PREFIX}BTC_USD.json', 'w') as f:
+        f.write(contents)
+    cc = Cryptocompare(data_directory=data_dir, database=database)
+    result = cc.get_cached_data_metadata(
+        from_asset=A_BTC,
+        to_asset=A_USD,
+    )
+    assert result is not None
+    assert result[0] == 1301536800
+    assert result[1] == 1301540400
+
+
 @pytest.mark.skipif(
     'CI' in os.environ,
     reason='This test would contribute in cryptocompare rate limiting. No need to run often',

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -265,7 +265,7 @@ def test_coingecko_identifiers_are_reachable(data_dir):
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '5f7a37a0aa809b2a92f48a77e0d17d60', 'version': 39}
+    last_meta = {'md5': 'c46d9651c7a34f145b163d524b2b12ce', 'version': 39}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -66,6 +66,49 @@ def test_ethereum_tokens():
         EthereumToken('BTC')
 
 
+def test_cryptocompare_asset_support(cryptocompare):
+    """Try to detect if a token that we have as not supported by cryptocompare got added"""
+    cc_assets = cryptocompare.all_coins()
+    exceptions = (
+        'BKC',     # Bankcoin Cash but Balkan Coin in CC
+        'BNC',     # Bionic but Benja Coin in CC
+        'BTG-2',   # Bitgem but Bitcoin Gold in CC
+        'BTR',     # Bitether but Bither in CC
+        'CBC-2',   # Cashbery coin but Casino Betting Coin in CC
+        'CCN',     # CustomContractnetwork but CannaCoin in CC
+        'CMCT-2',  # Cyber Movie Chain but Crowd Machine in CC
+        'CORN-2',  # Cornichon but Corn in CC
+        'CTX',     # Centauri coin but CarTaxi in CC
+        'DIT',     # Direct insurance token but DitCoin in CC
+        'DRM',     # Dreamcoin but Dreamchain in CC
+        'DTX-2',   # Digital Ticks but Data Exchange in CC
+        'GNC',     # Galaxy network but Greencoin in CC
+        'KNT',     # Kora network but Knekted in CC
+        'LKY',     # Linkey but LuckyCoin in CC
+        'NTK-2',   # Netkoin but Neurotoken in CC
+        'PAN',     # Panvala but Pantos in CC
+        'PTT',     # Proton token but Pink Taxi Token in CC
+        'RMC',     # Remicoin but Russian Miner Coin in CC
+        'SOUL-2',  # Cryptosoul but Phantasma in CC
+        'TIC',     # Thingschain but True Investment Coin in CC
+        'TOK',     # TOKOK but Tokugawa Coin in CC
+        'VD',      # Bitcoin card but Vindax Coin in CC
+        'DT',      # Dragon Token but Dark Token in CC
+    )
+    for identifier, asset_data in AssetResolver().assets.items():
+        potential_support = (
+            asset_data.get('cryptocompare', None) == '' and
+            asset_data['symbol'] in cc_assets and
+            identifier not in exceptions
+        )
+        if potential_support:
+            msg = (
+                f'We have {identifier} as not supported by cryptocompare but '
+                f'the symbol appears in its supported assets'
+            )
+            test_warnings.warn(UserWarning(msg))
+
+
 def test_tokens_address_is_checksummed():
     """Test that all ethereum saved token asset addresses are checksummed"""
     for _, asset_data in AssetResolver().assets.items():
@@ -172,9 +215,11 @@ def test_coingecko_identifiers_are_reachable(data_dir):
         'CRBT',
         'EXC-2',
         'DT',
+        'CZR',
     ]
     coingecko = Coingecko(data_directory=data_dir)
     all_coins = coingecko.all_coins()
+
     for identifier, asset_data in AssetResolver().assets.items():
         if identifier in coins_delisted_from_coingecko:
             # data = coingecko.asset_data(Asset(identifier))
@@ -220,7 +265,7 @@ def test_coingecko_identifiers_are_reachable(data_dir):
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '353a2ab0cfcb2b85c92b65ec5e56308d', 'version': 39}
+    last_meta = {'md5': '5f7a37a0aa809b2a92f48a77e0d17d60', 'version': 39}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -7,7 +8,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_CNY, A_EUR, A_GBP, A_JPY, A_USD
 from rotkehlchen.fval import FVal
-from rotkehlchen.inquirer import _query_exchanges_rateapi
+from rotkehlchen.inquirer import CURRENT_PRICE_CACHE_SECS, _query_exchanges_rateapi
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import Price
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now
@@ -43,7 +44,7 @@ def test_switching_to_backup_api(inquirer):
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_caching(inquirer):
+def test_fiat_pair_caching(inquirer):
     def mock_exchanges_rate_api(url, timeout):  # pylint: disable=unused-argument
         return MockResponse(200, '{"rates":{"EUR":0.9165902841},"base":"USD","date":"2020-05-25"}')
 
@@ -88,3 +89,52 @@ def test_fallback_to_coingecko(inquirer):  # pylint: disable=unused-argument
     assert price != Price(ZERO)
     price = inquirer.find_usd_price(Asset('TLN'))
     assert price != Price(ZERO)
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_find_usd_price_cache(inquirer, freezer):  # pylint: disable=unused-argument
+    call_count = 0
+
+    def mock_query_price(from_asset, to_asset):
+        assert from_asset.identifier == 'ETH'
+        assert to_asset.identifier == 'USD'
+        nonlocal call_count
+        if call_count == 0:
+            price = {'USD': '1'}
+        elif call_count in (1, 2):
+            price = {'USD': '2'}
+        else:
+            raise AssertionError('Called too many times for this test')
+
+        call_count += 1
+        return price
+
+    cc_patch = patch.object(
+        inquirer._cryptocompare,
+        'query_endpoint_price',
+        wraps=mock_query_price,
+    )
+
+    with cc_patch as cc:
+        price = inquirer.find_usd_price(Asset('ETH'))
+        assert cc.call_count == 1
+        assert price == Price(FVal('1'))
+
+        # next time we run, make sure it's the cache
+        price = inquirer.find_usd_price(Asset('ETH'))
+        assert cc.call_count == 1
+        assert price == Price(FVal('1'))
+
+        # now move forward in time to invalidate the cache
+        freezer.move_to(datetime.fromtimestamp(ts_now() + CURRENT_PRICE_CACHE_SECS + 1))
+        price = inquirer.find_usd_price(Asset('ETH'))
+        assert cc.call_count == 2
+        assert price == Price(FVal('2'))
+
+        # also test that ignore_cache works
+        price = inquirer.find_usd_price(Asset('ETH'))
+        assert cc.call_count == 2
+        assert price == Price(FVal('2'))
+        price = inquirer.find_usd_price(Asset('ETH'), ignore_cache=True)
+        assert cc.call_count == 3
+        assert price == Price(FVal('2'))

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -376,9 +376,11 @@ def write_history_data_in_file(
     )
     with open(filepath, 'w') as outfile:
         history_dict: Dict[str, Any] = {}
-        history_dict['data'] = data
+        # From python 3.5 dict order should be preserved so we can expect
+        # start and end time to come before the data in the file
         history_dict['start_time'] = start_ts
         history_dict['end_time'] = end_ts
+        history_dict['data'] = data
         outfile.write(rlk_jsondumps(history_dict))
 
 


### PR DESCRIPTION
- Big improvements on how cryptocompare cache data is handled
- Big improvements on how many times cryptocompare is queried. We will no longer waste a ton of time to query prices from them if we get rate limited.
- Introduce cache for recent usd price queries in Inquirer - Fix #1989
- Don't fail entire balance query if beaconcha.in api fails to detect eth2 stakers
- More ...