### PR TITLE
Fix non 0-100 percentage at tax report and first attempt at handling coingecko rate limiting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1946` There should no longer be a non 0-100 percentage in the tax report during the progress report.
 * :feature:`522` Users can connect to different backends from the frontend.
 * :bug:`2040` Balance snapshotting should now work again for Bitfinex and Bitstamp users.
 * :feature:`2056` Users can now control whether a profit loss report in a certain time range is allowed to go further in the past to calculate the real cost basis of assets or not. By default this setting is on.

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -64,9 +64,7 @@ class Accountant():
 
         self.asset_movement_fees = FVal(0)
         self.last_gas_price = 0
-
-        self.started_processing_timestamp = Timestamp(-1)
-        self.currently_processing_timestamp = Timestamp(-1)
+        self.reset_processing_timestamps()
 
     def __del__(self) -> None:
         del self.events
@@ -99,6 +97,10 @@ class Accountant():
 
         if settings.account_for_assets_movements is not None:
             self.events.account_for_assets_movements = settings.account_for_assets_movements
+
+    def reset_processing_timestamps(self) -> None:
+        self.started_processing_timestamp = Timestamp(-1)
+        self.currently_processing_timestamp = Timestamp(-1)
 
     def get_fee_in_profit_currency(self, trade: Trade) -> Fee:
         """Get the profit_currency rate of the fee of the given trade
@@ -422,7 +424,7 @@ class Accountant():
         May raise:
         - PriceQueryUnsupportedAsset if from/to asset is missing from price oracles
         - NoPriceForGivenTimestamp if we can't find a price for the asset in the given
-        timestamp from cryptocompare
+        timestamp from the price oracle
         - RemoteError if there is a problem reaching the price oracle server
         or with reading the response returned by the server
         """

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -500,6 +500,7 @@ class Rotkehlchen():
             start_ts: Timestamp,
             end_ts: Timestamp,
     ) -> Tuple[Dict[str, Any], str]:
+        self.accountant.reset_processing_timestamps()
         (
             error_or_empty,
             history,


### PR DESCRIPTION
Fix #1946

For the percentage it takes some time with the current implementation until something is shown but at least it should no longer be wrong (from the tests I run).

For coingecko rate limiting it is a kind of hopeful handling. Can still get failed responses due
to rate limiting, but limits them to an absolute minimum.

Need to think if a different approach should happen or if we need to
space the waiting until they reach 60 seconds (which could be kind of
an overkill).

At the moment the only place where rate limiting can happen is at the tax report. And with this approach maybe one or two actions will get skipped. But since coingecko historical prices are cached, when the tax report is run again, they would work.
