### PR TITLE
Renames account label to name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`1662` Users are now able to manually input ledger actions such as Income, Donation, Loss, Expense, Dividends Income
 * :feature:`1866` The tax report is now named Profit and Loss Report.
+* :feature:`1466` The account label is now renamed to account name.
 * :bug:`1140` Users will now see the account balances sorted by label instead of hex when sorting the account column.
 * :feature:`1919` Rotki now supports Kusama blockchain. Users can import their Kusama addresses and see their KSM balances.
 * :feature:`1792` Users should now be able to see the accounting settings used when generating a tax report.

--- a/frontend/app/src/components/accounts/AccountBalanceTable.vue
+++ b/frontend/app/src/components/accounts/AccountBalanceTable.vue
@@ -47,7 +47,7 @@
       }}
     </template>
     <template #item.label="{ item }">
-      <v-row>
+      <v-row class="pt-3 pb-2">
         <v-col cols="12" class="account-balance-table__account">
           <labeled-address-display :account="item" />
           <span v-if="item.tags.length > 0" class="mt-2">

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -145,7 +145,8 @@ export default class LabeledAddressDisplay extends Mixins(ScrambleMixin) {
   }
 
   &__actions {
-    width: 60px;
+    width: 61px;
+    max-width: 65px;
   }
 }
 

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="d-flex flex-row labeled-address-display align-center">
     <v-tooltip top open-delay="400" :disabled="!truncated">
       <template #activator="{ on }">
         <span class="labeled-address-display__address" v-on="on">
@@ -19,39 +19,41 @@
       </template>
       <span> {{ address }} </span>
     </v-tooltip>
-    <div class="labeled-address-display__copy">
-      <v-tooltip top open-delay="400">
-        <template #activator="{ on, attrs }">
-          <v-btn
-            small
-            v-bind="attrs"
-            tile
-            icon
-            v-on="on"
-            @click="copy(address)"
-          >
-            <v-icon small>mdi-content-copy</v-icon>
-          </v-btn>
-        </template>
-        <span>{{ $t('labeled_address_display.copy') }}</span>
-      </v-tooltip>
-      <v-tooltip top open-delay="600">
-        <template #activator="{ on, attrs }">
-          <v-btn
-            small
-            icon
-            tile
-            v-bind="attrs"
-            target="_blank"
-            :href="$interop.isPackaged ? undefined : url"
-            v-on="on"
-            @click="openLink"
-          >
-            <v-icon small> mdi-launch </v-icon>
-          </v-btn>
-        </template>
-        <span>{{ $t('labeled_address_display.open_link') }}</span>
-      </v-tooltip>
+    <div class="labeled-address-display__actions">
+      <div class="labeled-address-display__copy">
+        <v-tooltip top open-delay="400">
+          <template #activator="{ on, attrs }">
+            <v-btn
+              small
+              v-bind="attrs"
+              tile
+              icon
+              v-on="on"
+              @click="copy(address)"
+            >
+              <v-icon small>mdi-content-copy</v-icon>
+            </v-btn>
+          </template>
+          <span>{{ $t('labeled_address_display.copy') }}</span>
+        </v-tooltip>
+        <v-tooltip top open-delay="600">
+          <template #activator="{ on, attrs }">
+            <v-btn
+              small
+              icon
+              tile
+              v-bind="attrs"
+              target="_blank"
+              :href="$interop.isPackaged ? undefined : url"
+              v-on="on"
+              @click="openLink"
+            >
+              <v-icon small> mdi-launch </v-icon>
+            </v-btn>
+          </template>
+          <span>{{ $t('labeled_address_display.open_link') }}</span>
+        </v-tooltip>
+      </div>
     </div>
   </div>
 </template>
@@ -82,10 +84,12 @@ export default class LabeledAddressDisplay extends Mixins(ScrambleMixin) {
   }
 
   get displayAddress(): string {
-    const address = truncateAddress(
-      this.address,
-      truncationPoints[this.$vuetify.breakpoint.name] ?? 4
-    );
+    const name =
+      this.account.label.length > 0 && this.$vuetify.breakpoint.mdAndDown
+        ? 'sm'
+        : this.$vuetify.breakpoint.name;
+    const length = truncationPoints[name] ?? 4;
+    const address = truncateAddress(this.address, length);
     this.truncated = address.includes('...');
     return address;
   }
@@ -109,6 +113,8 @@ export default class LabeledAddressDisplay extends Mixins(ScrambleMixin) {
 
 <style scoped lang="scss">
 .labeled-address-display {
+  max-height: 30px;
+
   &__address {
     font-weight: 500;
     padding-top: 6px;
@@ -136,6 +142,10 @@ export default class LabeledAddressDisplay extends Mixins(ScrambleMixin) {
       height: 30px;
       width: 30px;
     }
+  }
+
+  &__actions {
+    width: 60px;
   }
 }
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1369,7 +1369,7 @@
       "addresses_hint": "Insert multiple comma separated addresses",
       "blockchain": "Choose blockchain",
       "account": "Account",
-      "label": "Label",
+      "label": "Name",
       "btc": {
         "xpub": "XPUB",
         "derivation_path": "Derivation Path",


### PR DESCRIPTION
Closes #1466 

This is purely visual textual change. We can see if we want to proceed to more renaming in the future (update the backend entry and naming for consistency).

It also does some css fixes on the label address display to stop the buttons from breaking to the next row when resizing