### PR TITLE
Addressed deprecated eth_utils imports

### DIFF
--- a/rotkehlchen/chain/ethereum/adex/adex.py
+++ b/rotkehlchen/chain/ethereum/adex/adex.py
@@ -18,9 +18,8 @@ from typing import (
 )
 
 import requests
-from eth_typing.evm import ChecksumAddress
+from eth_typing import ChecksumAddress, HexAddress, HexStr
 from eth_utils import to_checksum_address
-from eth_utils.typing import HexAddress, HexStr
 from typing_extensions import Literal
 from web3 import Web3
 

--- a/rotkehlchen/chain/ethereum/adex/typing.py
+++ b/rotkehlchen/chain/ethereum/adex/typing.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
-from eth_typing.evm import ChecksumAddress
-from eth_utils.typing import HexStr
+from eth_typing import ChecksumAddress, HexStr
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken

--- a/rotkehlchen/chain/ethereum/adex/utils.py
+++ b/rotkehlchen/chain/ethereum/adex/utils.py
@@ -1,6 +1,6 @@
 from typing import Union, cast
 
-from eth_utils.typing import HexStr
+from eth_typing import HexStr
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
+from eth_typing import HexAddress, HexStr
 from eth_utils import to_bytes, to_checksum_address
-from eth_utils.typing import HexAddress, HexStr
 from web3 import Web3
 from web3._utils.abi import exclude_indexed_event_inputs, normalize_event_input_types
 from web3._utils.encoding import hexstr_if_str

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -8,7 +8,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
 
-from eth_utils.typing import HexStr
+from eth_typing import HexStr
 from pysqlcipher3 import dbapi2 as sqlcipher
 from typing_extensions import Literal
 

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union
 
-from eth_utils.typing import HexAddress, HexStr
+from eth_typing import HexAddress, HexStr
 
 from rotkehlchen.accounting.structures import LedgerActionType
 from rotkehlchen.assets.asset import Asset, EthereumToken

--- a/rotkehlchen/tests/unit/test_adex.py
+++ b/rotkehlchen/tests/unit/test_adex.py
@@ -1,4 +1,4 @@
-from eth_utils.typing import HexStr
+from eth_typing import HexStr
 
 from rotkehlchen.chain.ethereum.adex.adex import Adex
 from rotkehlchen.chain.ethereum.adex.typing import TOM_POOL_ID

--- a/rotkehlchen/tests/unit/test_unknown_asset.py
+++ b/rotkehlchen/tests/unit/test_unknown_asset.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 
-from eth_utils.typing import HexAddress, HexStr
+from eth_typing import HexAddress, HexStr
 
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.assets.unknown_asset import UnknownEthereumToken

--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -3,8 +3,8 @@ import time
 from unittest.mock import patch
 
 import pytest
+from eth_typing import HexAddress, HexStr
 from eth_utils import to_checksum_address
-from eth_utils.typing import HexAddress, HexStr
 from hexbytes import HexBytes
 
 from rotkehlchen.chain.ethereum.utils import generate_address_via_create2

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, NewType, Optional, Tuple, Union
 
-from eth_utils.typing import ChecksumAddress
+from eth_typing import ChecksumAddress
 from typing_extensions import Literal
 
 from rotkehlchen.chain.substrate.typing import KusamaAddress


### PR DESCRIPTION
Closes `eth_utils` warnings from #2061 