### PR TITLE
Add noop methods for all unimplemented exchange interface methods

### DIFF
--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -192,7 +192,7 @@ def create_binance_symbols_to_pair(exchange_data: Dict[str, Any]) -> Dict[str, B
     return symbols_to_pair
 
 
-class Binance(ExchangeInterface):
+class Binance(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     """This class supports:
       - Binance: when instantiated with default uri, equals BINANCE_BASE_URL.
       - Binance US: when instantiated with uri equals BINANCE_US_BASE_URL.

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -17,6 +17,7 @@ from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset, UnsupportedAsset
 from rotkehlchen.exchanges.data_structures import (
     AssetMovement,
+    MarginPosition,
     Trade,
     TradeType,
     trade_pair_from_assets,
@@ -920,3 +921,10 @@ class Binance(ExchangeInterface):
                 movements.append(movement)
 
         return movements
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for binance

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -11,7 +11,14 @@ from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.errors import RemoteError
-from rotkehlchen.exchanges.data_structures import Location, Price, Trade, TradePair
+from rotkehlchen.exchanges.data_structures import (
+    AssetMovement,
+    Location,
+    MarginPosition,
+    Price,
+    Trade,
+    TradePair,
+)
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -273,3 +280,17 @@ class Bitcoinde(ExchangeInterface):
             trades.append(trade_from_bitcoinde(tx))
 
         return trades
+
+    def query_online_deposits_withdrawals(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[AssetMovement]:
+        return []  # noop for bitcoinde
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for bitcoinde

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -101,7 +101,7 @@ def trade_from_bitcoinde(raw_trade: Dict) -> Trade:
     )
 
 
-class Bitcoinde(ExchangeInterface):
+class Bitcoinde(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     def __init__(
             self,
             api_key: ApiKey,

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -124,7 +124,7 @@ class ErrorResponseData(NamedTuple):
     reason: Optional[str] = None
 
 
-class Bitfinex(ExchangeInterface):
+class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     """Bitfinex exchange api docs:
     https://docs.bitfinex.com/docs
     """

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -44,7 +44,7 @@ from rotkehlchen.errors import (
     UnknownAsset,
     UnsupportedAsset,
 )
-from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
+from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
@@ -994,3 +994,10 @@ class Bitfinex(ExchangeInterface):
             return result, msg
 
         return True, ''
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for bitfinex

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -11,7 +11,7 @@ import requests
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset
-from rotkehlchen.exchanges.data_structures import AssetMovement, Location, MarginPosition
+from rotkehlchen.exchanges.data_structures import AssetMovement, Location, MarginPosition, Trade
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
 from rotkehlchen.fval import FVal
@@ -340,3 +340,6 @@ class Bitmex(ExchangeInterface):
                 )
                 continue
         return movements
+
+    def query_online_trade_history(self, start_ts: Timestamp, end_ts: Timestamp) -> List[Trade]:
+        return []  # noop for bitmex

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -87,7 +87,7 @@ def trade_from_bitmex(bitmex_trade: Dict) -> MarginPosition:
     )
 
 
-class Bitmex(ExchangeInterface):
+class Bitmex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     def __init__(
             self,
             api_key: ApiKey,

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -99,7 +99,7 @@ class TradePairData(NamedTuple):
     trade_pair: TradePair
 
 
-class Bitstamp(ExchangeInterface):
+class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     """Bitstamp exchange api docs:
     https://www.bitstamp.net/api/
 

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -36,6 +36,7 @@ from rotkehlchen.errors import (
 from rotkehlchen.exchanges.data_structures import (
     AssetMovement,
     AssetMovementCategory,
+    MarginPosition,
     Trade,
     TradeType,
 )
@@ -732,3 +733,10 @@ class Bitstamp(ExchangeInterface):
             return []
 
         raise AssertionError(f'Unexpected Bitstamp response_case: {case}.')
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for bitstamp

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -153,7 +153,7 @@ def trade_from_bittrex(bittrex_trade: Dict[str, Any]) -> Trade:
     )
 
 
-class Bittrex(ExchangeInterface):
+class Bittrex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     def __init__(
             self,
             api_key: ApiKey,

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -24,7 +24,12 @@ from rotkehlchen.errors import (
     UnprocessableTradePair,
     UnsupportedAsset,
 )
-from rotkehlchen.exchanges.data_structures import AssetMovement, Trade, get_pair_position_asset
+from rotkehlchen.exchanges.data_structures import (
+    AssetMovement,
+    MarginPosition,
+    Trade,
+    get_pair_position_asset,
+)
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
 from rotkehlchen.fval import FVal
@@ -534,3 +539,10 @@ class Bittrex(ExchangeInterface):
                 movements.append(movement)
 
         return movements
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for bittrex

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -12,7 +12,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_coinbase
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset, UnsupportedAsset
-from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
+from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
 from rotkehlchen.inquirer import Inquirer
@@ -577,3 +577,10 @@ class Coinbase(ExchangeInterface):
                 movements.append(movement)
 
         return movements
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for coinbase

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -97,7 +97,7 @@ class CoinbasePermissionError(Exception):
     pass
 
 
-class Coinbase(ExchangeInterface):
+class Coinbase(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     def __init__(
             self,

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -27,7 +27,7 @@ from rotkehlchen.errors import (
     UnprocessableTradePair,
     UnsupportedAsset,
 )
-from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
+from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -617,3 +617,10 @@ class Coinbasepro(ExchangeInterface):
                 trades.extend(self._read_trades(filepath))
 
         return trades
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for coinbasepro

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -77,7 +77,7 @@ class CoinbaseProPermissionError(Exception):
     pass
 
 
-class Coinbasepro(ExchangeInterface):
+class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     def __init__(
             self,

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -35,6 +35,7 @@ class ExchangeInterface(CacheableObject, LockableQueryObject):
             secret: ApiSecret,
             database: 'DBHandler',
     ):
+        print('Exchange interface ctor called')
         assert isinstance(api_key, T_ApiKey), (
             'api key for {} should be a string'.format(name)
         )

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -149,14 +149,10 @@ class ExchangeInterface(CacheableObject, LockableQueryObject):
         for query_start_ts, query_end_ts in ranges_to_query:
             # If we have a time frame we have not asked the exchange for trades then
             # go ahead and do that now
-            try:
-                new_trades.extend(self.query_online_trade_history(
-                    start_ts=query_start_ts,
-                    end_ts=query_end_ts,
-                ))
-            except NotImplementedError:
-                msg = 'query_online_trade_history should only not be implemented by bitmex'
-                assert self.name == 'bitmex', msg
+            new_trades.extend(self.query_online_trade_history(
+                start_ts=query_start_ts,
+                end_ts=query_end_ts,
+            ))
 
         # make sure to add them to the DB
         if new_trades != []:
@@ -193,13 +189,10 @@ class ExchangeInterface(CacheableObject, LockableQueryObject):
         )
         new_positions = []
         for query_start_ts, query_end_ts in ranges_to_query:
-            try:
-                new_positions.extend(self.query_online_margin_history(
-                    start_ts=query_start_ts,
-                    end_ts=query_end_ts,
-                ))
-            except NotImplementedError:
-                pass
+            new_positions.extend(self.query_online_margin_history(
+                start_ts=query_start_ts,
+                end_ts=query_end_ts,
+            ))
 
         # make sure to add them to the DB
         if new_positions != []:

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -82,7 +82,7 @@ def gemini_symbol_to_pair(symbol: str) -> TradePair:
     return TradePair(f'{base_asset.identifier}_{quote_asset.identifier}')
 
 
-class Gemini(ExchangeInterface):
+class Gemini(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     def __init__(
             self,

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -13,7 +13,7 @@ from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.constants.timing import QUERY_RETRY_TIMES, GLOBAL_REQUESTS_TIMEOUT
+from rotkehlchen.constants.timing import GLOBAL_REQUESTS_TIMEOUT, QUERY_RETRY_TIMES
 from rotkehlchen.errors import (
     DeserializationError,
     RemoteError,
@@ -21,7 +21,7 @@ from rotkehlchen.errors import (
     UnprocessableTradePair,
     UnsupportedAsset,
 )
-from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
+from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
 from rotkehlchen.inquirer import Inquirer
@@ -533,3 +533,10 @@ class Gemini(ExchangeInterface):
             movements.append(movement)
 
         return movements
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for gemini

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -90,7 +90,7 @@ def trade_from_iconomi(raw_trade: Dict) -> Trade:
     )
 
 
-class Iconomi(ExchangeInterface):
+class Iconomi(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     def __init__(
             self,
             api_key: ApiKey,

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -13,7 +13,15 @@ from typing_extensions import Literal
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import ICONOMI_TO_WORLD, UNSUPPORTED_ICONOMI_ASSETS
 from rotkehlchen.errors import RemoteError, UnknownAsset, UnsupportedAsset
-from rotkehlchen.exchanges.data_structures import Location, Price, Trade, TradePair, TradeType
+from rotkehlchen.exchanges.data_structures import (
+    AssetMovement,
+    Location,
+    MarginPosition,
+    Price,
+    Trade,
+    TradePair,
+    TradeType,
+)
 from rotkehlchen.exchanges.exchange import ExchangeInterface
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -202,7 +210,7 @@ class Iconomi(ExchangeInterface):
             return None, msg
 
         if resp_info['currency'] != 'USD':
-            raise NotImplementedError("API did not return values in USD")
+            raise RemoteError('Iconomi API did not return values in USD')
 
         for balance_info in resp_info['assetList']:
             ticker = balance_info['ticker']
@@ -293,3 +301,17 @@ class Iconomi(ExchangeInterface):
             tickers.append(asset_info['ticker'])
 
         return tickers
+
+    def query_online_deposits_withdrawals(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[AssetMovement]:
+        return []  # noop for iconomi
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for iconomi

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -27,6 +27,7 @@ from rotkehlchen.errors import (
 )
 from rotkehlchen.exchanges.data_structures import (
     AssetMovement,
+    MarginPosition,
     Trade,
     get_pair_position_asset,
     trade_pair_from_assets,
@@ -752,3 +753,10 @@ class Kraken(ExchangeInterface):
                 continue
 
         return movements
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for kraken

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -293,7 +293,7 @@ class KrakenAccountType(Enum):
         raise DeserializationError(f'Tried to deserialized invalid kraken account type: {symbol}')
 
 
-class Kraken(ExchangeInterface):
+class Kraken(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     def __init__(
             self,
             api_key: ApiKey,

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -26,6 +26,7 @@ from rotkehlchen.errors import (
 from rotkehlchen.exchanges.data_structures import (
     AssetMovement,
     Loan,
+    MarginPosition,
     Trade,
     TradeType,
     invert_pair,
@@ -771,3 +772,10 @@ class Poloniex(ExchangeInterface):
                 movements.append(asset_movement)
 
         return movements
+
+    def query_online_margin_history(
+            self,  # pylint: disable=no-self-use
+            start_ts: Timestamp,  # pylint: disable=unused-argument
+            end_ts: Timestamp,  # pylint: disable=unused-argument
+    ) -> List[MarginPosition]:
+        return []  # noop for poloniex

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -218,7 +218,7 @@ def _post_process(before: Dict) -> Dict:
     return after
 
 
-class Poloniex(ExchangeInterface):
+class Poloniex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     def __init__(
             self,

--- a/rotkehlchen/tests/exchanges/test_manager.py
+++ b/rotkehlchen/tests/exchanges/test_manager.py
@@ -1,0 +1,33 @@
+import inspect
+from importlib import import_module
+
+from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES, ExchangeManager
+
+EXCHANGE_METHODS_TO_CHECK = (
+    'query_balances',
+    'query_online_trade_history',
+    'query_online_deposits_withdrawals',
+    'query_online_margin_history',
+)
+
+
+def test_all_methods_implemented():
+    """Tests all methods needed by the exchange interface are implemented by all exchanges"""
+
+    for name in SUPPORTED_EXCHANGES:
+        module_name = ExchangeManager._get_exchange_module_name(name)
+        try:
+            module = import_module(f'rotkehlchen.exchanges.{module_name}')
+        except ModuleNotFoundError:
+            # This should never happen
+            raise AssertionError(
+                f'Tried to initialize unknown exchange {name}. Should never happen.',
+            ) from None
+
+        exchange_object = getattr(module, module_name.capitalize())
+        members = inspect.getmembers(exchange_object)
+        methods = [x for x in members if x[0] in EXCHANGE_METHODS_TO_CHECK]
+        for method_name, method in methods:
+            code = inspect.getsource(method)
+            msg = f'{method_name} for exchange {name} is not implemented'
+            assert 'raise NotImplementedError' not in code, msg


### PR DESCRIPTION
Also add test to detect that no supported exchange object has a
NotImplemented method to avoid a similar bug hitting us again.

Fix #2113