### PR TITLE
Fix kusama balance queries in v1.12.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2116` Kusama user balance query should now work properly in all cases.
 * :bug:`2113` Iconomi exchange users should now no longer get an error when pulling deposits/withdrawals history
 
 * :release:`1.12.1 <2021-01-16>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`2113` Iconomi exchange users should now no longer get an error when pulling deposits/withdrawals history
+
 * :release:`1.12.1 <2021-01-16>`
 * :bug:`-` Fix the problem introduced with rotki v1.12.0 for OSX users that made them unable to run the app.
 

--- a/rotkehlchen/chain/ethereum/adex/typing.py
+++ b/rotkehlchen/chain/ethereum/adex/typing.py
@@ -51,7 +51,7 @@ class AdexEventType(Enum):
             return 'withdraw request'
         if self == AdexEventType.CHANNEL_WITHDRAW:
             return 'claim'
-        raise AttributeError(f'Corrupt value {self} for EventType -- Should never happen')
+        raise AssertionError(f'Corrupt value {self} for EventType -- Should never happen')
 
 
 @dataclass(init=True, repr=True)

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -138,7 +138,7 @@ class SubstrateManager():
         https://docs.api.subscan.io
         """
         if chain not in SubstrateChain:
-            raise AttributeError(f'Unexpected SubstrateManager chain: {chain}')
+            raise AssertionError(f'Unexpected SubstrateManager chain: {chain}')
 
         log.debug(f'Initializing {chain} manager')
         self.chain = chain

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -410,7 +410,7 @@ class SubstrateManager():
         except requests.exceptions.RequestException as e:
             message = (
                 f'{self.chain} could not connect to node at endpoint: {endpoint}. '
-                f'Connection error: {str(e)}.',
+                f'Connection error: {str(e)}.'
             )
             log.error(message)
             raise RemoteError(message) from e
@@ -444,7 +444,7 @@ class SubstrateManager():
             message = (
                 f'{self.chain} chain metadata request was not successful. '
                 f'Response status code: {response.status_code}. '
-                f'Response text: {response.text}.',
+                f'Response text: {response.text}.'
             )
             log.error(message)
             raise RemoteError(message)
@@ -453,7 +453,7 @@ class SubstrateManager():
         except JSONDecodeError as e:
             message = (
                 f'{self.chain} chain metadata request returned invalid JSON '
-                f'response: {response.text}.',
+                f'response: {response.text}.'
             )
             log.error(message)
             raise RemoteError(message) from e

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -415,7 +415,12 @@ class SubstrateManager():
             log.error(message)
             raise RemoteError(message) from e
         except (FileNotFoundError, ValueError, TypeError) as e:
-            raise AttributeError('Invalid SubstrateInterface instantiation') from e
+            message = (
+                f'{self.chain} could not connect to node at endpoint: {endpoint}. '
+                f'Unexpected error during SubstrateInterface instantiation: {str(e)}.'
+            )
+            log.error(message)
+            raise RemoteError('Invalid SubstrateInterface instantiation') from e
 
         return node_interface
 

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -35,7 +35,6 @@ class ExchangeInterface(CacheableObject, LockableQueryObject):
             secret: ApiSecret,
             database: 'DBHandler',
     ):
-        print('Exchange interface ctor called')
         assert isinstance(api_key, T_ApiKey), (
             'api key for {} should be a string'.format(name)
         )

--- a/tools/pyinstaller_hooks/hook-scalecodec.py
+++ b/tools/pyinstaller_hooks/hook-scalecodec.py
@@ -1,0 +1,5 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+# scalecodec has a lot of json files from which it loads the types
+# we need to make sure pyinstaller bundles them in the created binary
+datas = collect_data_files('scalecodec')


### PR DESCRIPTION
The fix is simple. It happened only in packaged mode since we were not including the extra data that https://github.com/polkascan/py-scale-codec requires while packaging with pyinstaller.

https://github.com/polkascan/py-substrate-interface/ uses py-scale-codec for determining various types of substrate chains. These data are in json files and are not pulled into the binary by default when pyinstaller packages rotki and py-substrate-interface.

The added hook packages the json files and solves the problem.

Fix #2116