### PR TITLE
Support Balance across query balances endpoint

### DIFF
--- a/rotkehlchen/accounting/structures.py
+++ b/rotkehlchen/accounting/structures.py
@@ -122,6 +122,16 @@ class Balance:
             usd_value=self.usd_value + other.usd_value,
         )
 
+    def __radd__(self, other: Any) -> 'Balance':
+        if other == 0:
+            return self
+
+        other = _evaluate_balance_input(other, 'addition')
+        return Balance(
+            amount=self.amount + other.amount,
+            usd_value=self.usd_value + other.usd_value,
+        )
+
     def __sub__(self, other: Any) -> 'Balance':
         other = _evaluate_balance_input(other, 'subtraction')
         return Balance(
@@ -175,6 +185,16 @@ class BalanceSheet:
         return BalanceSheet(
             assets=combine_dicts(self.assets, other.assets, op=operator.add),
             liabilities=combine_dicts(self.liabilities, other.liabilities, op=operator.add),
+        )
+
+    def __radd__(self, other: Any) -> 'BalanceSheet':
+        if other == 0:
+            return self
+
+        other = _evaluate_balance_sheet_input(other, 'addition')
+        return BalanceSheet(
+            assets=self.assets + other.assets,
+            liabilities=self.liabilities + other.liabilities,
         )
 
     def __sub__(self, other: Any) -> 'BalanceSheet':

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -11,6 +11,7 @@ from requests.adapters import Response
 from substrateinterface import SubstrateInterface
 from substrateinterface.exceptions import SubstrateRequestException
 from typing_extensions import Literal
+from websocket import WebSocketException
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.misc import ZERO
@@ -286,6 +287,7 @@ class SubstrateManager():
             requests.exceptions.RequestException,
             SubstrateRequestException,
             ValueError,
+            WebSocketException,
         ) as e:
             message = (
                 f'{self.chain} failed to request {self.chain_properties.token.identifier} account '
@@ -315,7 +317,11 @@ class SubstrateManager():
         log.debug(f'{self.chain} querying chain ID', url=node_interface.url)
         try:
             chain_id = node_interface.chain
-        except (requests.exceptions.RequestException, SubstrateRequestException) as e:
+        except (
+            requests.exceptions.RequestException,
+            SubstrateRequestException,
+            WebSocketException,
+        ) as e:
             message = (
                 f'{self.chain} failed to request chain ID '
                 f'at endpoint: {node_interface.url} due to: {str(e)}.'
@@ -335,7 +341,11 @@ class SubstrateManager():
         log.debug(f'{self.chain} querying chain properties', url=node_interface.url)
         try:
             properties = node_interface.properties
-        except (requests.exceptions.RequestException, SubstrateRequestException) as e:
+        except (
+            requests.exceptions.RequestException,
+            SubstrateRequestException,
+            WebSocketException,
+        ) as e:
             message = (
                 f'{self.chain} failed to request chain properties '
                 f'at endpoint: {node_interface.url} due to: {str(e)}.'
@@ -374,6 +384,7 @@ class SubstrateManager():
             # https://github.com/polkascan/py-substrate-interface/issues/68
             TypeError,
             ValueError,
+            WebSocketException,
         ) as e:
             message = (
                 f'{self.chain} failed to request last block '
@@ -407,7 +418,7 @@ class SubstrateManager():
                 url=endpoint,
                 type_registry_preset=si_attributes.type_registry_preset,
             )
-        except requests.exceptions.RequestException as e:
+        except (requests.exceptions.RequestException, WebSocketException) as e:
             message = (
                 f'{self.chain} could not connect to node at endpoint: {endpoint}. '
                 f'Connection error: {str(e)}.'

--- a/rotkehlchen/chain/substrate/typing.py
+++ b/rotkehlchen/chain/substrate/typing.py
@@ -15,12 +15,15 @@ class KusamaNodeName(Enum):
     """
     OWN = 0
     PARITY = 1
+    WEB3_FOUNDATION = 2
 
     def __str__(self) -> str:
         if self == KusamaNodeName.OWN:
             return 'own node'
         if self == KusamaNodeName.PARITY:
             return 'parity'
+        if self == KusamaNodeName.WEB3_FOUNDATION:
+            return 'web3 foundation'
         raise AssertionError(f'Unexpected KusamaNodeName: {self}')
 
     def endpoint(self) -> str:
@@ -31,6 +34,8 @@ class KusamaNodeName(Enum):
             )
         if self == KusamaNodeName.PARITY:
             return 'https://kusama-rpc.polkadot.io/'
+        if self == KusamaNodeName.WEB3_FOUNDATION:
+            return 'wss://cc3-5.kusama.network/'
         raise AssertionError(f'Unexpected KusamaNodeName: {self}')
 
 

--- a/rotkehlchen/chain/substrate/utils.py
+++ b/rotkehlchen/chain/substrate/utils.py
@@ -5,8 +5,9 @@ from .typing import KusamaNodeName, SubstrateChain
 KUSAMA_NODES_TO_CONNECT_AT_START = (
     KusamaNodeName.OWN,
     KusamaNodeName.PARITY,
+    KusamaNodeName.WEB3_FOUNDATION,
 )
-KUSAMA_NODE_CONNECTION_TIMEOUT = 5
+KUSAMA_NODE_CONNECTION_TIMEOUT = 10
 
 
 def is_valid_kusama_address(value: str) -> bool:

--- a/rotkehlchen/exchanges/__init__.py
+++ b/rotkehlchen/exchanges/__init__.py
@@ -4,7 +4,7 @@ from rotkehlchen.exchanges.bitstamp import Bitstamp  # noqa: F401
 from rotkehlchen.exchanges.bittrex import Bittrex  # noqa: F401
 from rotkehlchen.exchanges.coinbase import Coinbase  # noqa: F401
 from rotkehlchen.exchanges.coinbasepro import Coinbasepro  # noqa: F401
-from rotkehlchen.exchanges.exchange import ExchangeInterface  # noqa: F401
+from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances  # noqa: F401
 from rotkehlchen.exchanges.gemini import Gemini  # noqa: F401
 from rotkehlchen.exchanges.kraken import Kraken  # noqa: F401
 from rotkehlchen.exchanges.poloniex import Poloniex  # noqa: F401

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -214,7 +214,7 @@ class Bitcoinde(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             return False, str(e)
 
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
-        asset_balance: Dict[Asset, Balance] = {}
+        assets_balance: Dict[Asset, Balance] = {}
         try:
             resp_info = self._api_query('get', 'account')
         except RemoteError as e:
@@ -237,12 +237,12 @@ class Bitcoinde(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 continue
 
             amount = FVal(balance['total_amount'])
-            asset_balance[asset] = Balance(
+            assets_balance[asset] = Balance(
                 amount=amount,
                 usd_value=amount * usd_price,
             )
 
-        return asset_balance, ''
+        return assets_balance, ''
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 import requests
 from typing_extensions import Literal
 
+from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.exchanges.data_structures import (
@@ -19,7 +20,7 @@ from rotkehlchen.exchanges.data_structures import (
     Trade,
     TradePair,
 )
-from rotkehlchen.exchanges.exchange import ExchangeInterface
+from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
@@ -212,8 +213,8 @@ class Bitcoinde(ExchangeInterface):  # lgtm[py/missing-call-to-init]
         except RemoteError as e:
             return False, str(e)
 
-    def query_balances(self, **kwargs: Any) -> Tuple[Optional[Dict[Asset, Dict[str, Any]]], str]:
-        balances = {}
+    def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
+        asset_balance: Dict[Asset, Balance] = {}
         try:
             resp_info = self._api_query('get', 'account')
         except RemoteError as e:
@@ -235,12 +236,13 @@ class Bitcoinde(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 )
                 continue
 
-            balances[asset] = {
-                'amount': balance['total_amount'],
-                'usd_value': balance['total_amount'] * usd_price,
-            }
+            amount = FVal(balance['total_amount'])
+            asset_balance[asset] = Balance(
+                amount=amount,
+                usd_value=amount * usd_price,
+            )
 
-        return balances, ''
+        return asset_balance, ''
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -886,7 +886,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
         # Wallet items indices
         currency_index = 1
         balance_index = 2
-        asset_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
+        assets_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
         for wallet in response_list:
             if len(wallet) < API_WALLET_MIN_RESULT_LENGTH or wallet[balance_index] <= 0:
                 log.error(
@@ -923,12 +923,12 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 continue
 
             amount = FVal(wallet[balance_index])
-            asset_balance[asset] += Balance(
+            assets_balance[asset] += Balance(
                 amount=amount,
                 usd_value=amount * usd_price,
             )
 
-        return dict(asset_balance), ''
+        return dict(assets_balance), ''
 
     def query_online_deposits_withdrawals(
             self,

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -45,7 +45,7 @@ from rotkehlchen.errors import (
     UnsupportedAsset,
 )
 from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
-from rotkehlchen.exchanges.exchange import ExchangeInterface
+from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -724,7 +724,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             self,
             response: Response,
             case: Literal['balances'],
-    ) -> Tuple[Optional[Dict[Asset, Dict[str, FVal]]], str]:
+    ) -> ExchangeQueryBalances:
         ...
 
     @overload  # noqa: F811
@@ -750,7 +750,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Union[
         List,
         Tuple[bool, str],
-        Tuple[Optional[Dict[Asset, Dict[str, FVal]]], str],
+        ExchangeQueryBalances,
     ]:
         """This function processes not successful responses for the cases listed
         in `case`.
@@ -856,7 +856,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     @protect_with_lock()
     @cache_response_timewise()
-    def query_balances(self) -> Tuple[Optional[Dict[Asset, Dict[str, FVal]]], str]:
+    def query_balances(self) -> ExchangeQueryBalances:
         """Return the account exchange balances on Bitfinex
 
         The wallets endpoint returns a list where each item is a currency wallet.
@@ -928,7 +928,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 usd_value=amount * usd_price,
             )
 
-        return {a: b.to_dict() for a, b in asset_balance.items()}, ''
+        return dict(asset_balance), ''
 
     def query_online_deposits_withdrawals(
             self,

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -152,7 +152,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             log.error(msg)
             raise RemoteError(msg) from e
 
-        asset_balance: Dict[Asset, Balance] = {}
+        assets_balance: Dict[Asset, Balance] = {}
         for entry, amount in response_dict.items():
             amount = FVal(amount)
             if not entry.endswith('_balance') or amount == ZERO:
@@ -189,12 +189,12 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 )
                 continue
 
-            asset_balance[asset] = Balance(
+            assets_balance[asset] = Balance(
                 amount=amount,
                 usd_value=amount * usd_price,
             )
 
-        return dict(asset_balance), ''
+        return assets_balance, ''
 
     def query_online_deposits_withdrawals(
             self,

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -279,7 +279,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             log.error(msg)
             return None, msg
 
-        asset_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
+        assets_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
         for account in accounts:
             try:
                 amount = deserialize_asset_amount(account['balance'])
@@ -298,7 +298,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                     )
                     continue
 
-                asset_balance[asset] += Balance(
+                assets_balance[asset] += Balance(
                     amount=amount,
                     usd_value=amount * usd_price,
                 )
@@ -329,7 +329,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 )
                 continue
 
-        return dict(asset_balance), ''
+        return dict(assets_balance), ''
 
     def _get_products_ids(self) -> List[str]:
         """Gets a list of all product ids (markets) offered by coinbase PRO

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -7,15 +7,28 @@ import logging
 import os
 import time
 from base64 import b64decode, b64encode
+from collections import defaultdict
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 import gevent
 import requests
 from typing_extensions import Literal
 
+from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_coinbase
 from rotkehlchen.constants.misc import ZERO
@@ -28,7 +41,7 @@ from rotkehlchen.errors import (
     UnsupportedAsset,
 )
 from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
-from rotkehlchen.exchanges.exchange import ExchangeInterface
+from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
@@ -258,7 +271,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     @protect_with_lock()
     @cache_response_timewise()
-    def query_balances(self) -> Tuple[Optional[Dict[Asset, Dict[str, Any]]], str]:
+    def query_balances(self) -> ExchangeQueryBalances:
         try:
             accounts = self._api_query('accounts')
         except (CoinbaseProPermissionError, RemoteError) as e:
@@ -266,7 +279,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             log.error(msg)
             return None, msg
 
-        returned_balances: Dict[Asset, Dict[str, Any]] = {}
+        asset_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
         for account in accounts:
             try:
                 amount = deserialize_asset_amount(account['balance'])
@@ -285,15 +298,10 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                     )
                     continue
 
-                if asset in returned_balances:
-                    amount = returned_balances[asset]['amount'] + amount
-                else:
-                    returned_balances[asset] = {}
-
-                returned_balances[asset]['amount'] = amount
-                usd_value = returned_balances[asset]['amount'] * usd_price
-                returned_balances[asset]['usd_value'] = usd_value
-
+                asset_balance[asset] += Balance(
+                    amount=amount,
+                    usd_value=amount * usd_price,
+                )
             except UnknownAsset as e:
                 self.msg_aggregator.add_warning(
                     f'Found coinbase pro balance result with unknown asset '
@@ -321,7 +329,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 )
                 continue
 
-        return returned_balances, ''
+        return dict(asset_balance), ''
 
     def _get_products_ids(self) -> List[str]:
         """Gets a list of all product ids (markets) offered by coinbase PRO

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -199,7 +199,7 @@ class Iconomi(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             return False, 'Provided API Key is invalid'
 
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
-        asset_balance: Dict[Asset, Balance] = {}
+        assets_balance: Dict[Asset, Balance] = {}
         try:
             resp_info = self._api_query('get', 'user/balance')
         except RemoteError as e:
@@ -231,8 +231,8 @@ class Iconomi(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                     continue
 
                 amount = FVal(balance_info['balance'])
-                asset_balance[asset] = Balance(
-                    amount=balance_info['balance'],
+                assets_balance[asset] = Balance(
+                    amount=amount,
                     usd_value=amount * usd_price,
                 )
             except (UnknownAsset, UnsupportedAsset) as e:
@@ -249,7 +249,7 @@ class Iconomi(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 f' Ignoring its balance query.',
             )
 
-        return asset_balance, ''
+        return assets_balance, ''
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -6,8 +6,9 @@ import hmac
 import json
 import logging
 import time
+from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 import gevent
@@ -15,6 +16,8 @@ import requests
 from gevent.lock import Semaphore
 from requests import Response
 
+from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import KRAKEN_TO_WORLD, asset_from_kraken
 from rotkehlchen.constants import KRAKEN_API_VERSION, KRAKEN_BASE_URL
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_ETH2
@@ -32,7 +35,7 @@ from rotkehlchen.exchanges.data_structures import (
     get_pair_position_asset,
     trade_pair_from_assets,
 )
-from rotkehlchen.exchanges.exchange import ExchangeInterface
+from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -498,7 +501,7 @@ class Kraken(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     # ---- General exchanges interface ----
     @protect_with_lock()
     @cache_response_timewise()
-    def query_balances(self) -> Tuple[Optional[dict], str]:
+    def query_balances(self) -> ExchangeQueryBalances:
         try:
             old_balances = self.api_query('Balance', req={})
         except RemoteError as e:
@@ -513,14 +516,14 @@ class Kraken(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 log.error(msg)
                 return None, msg
 
-        balances = {}
-        for k, v in old_balances.items():
-            v = FVal(v)
-            if v == FVal(0):
+        asset_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
+        for kraken_name, amount_ in old_balances.items():
+            amount = FVal(amount_)
+            if amount == ZERO:
                 continue
 
             try:
-                our_asset = asset_from_kraken(k)
+                our_asset = asset_from_kraken(kraken_name)
             except UnknownAsset as e:
                 self.msg_aggregator.add_warning(
                     f'Found unsupported/unknown kraken asset {e.asset_name}. '
@@ -529,17 +532,14 @@ class Kraken(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 continue
             except DeserializationError:
                 self.msg_aggregator.add_error(
-                    f'Found kraken asset with non-string type {type(k)}. '
+                    f'Found kraken asset with non-string type {type(kraken_name)}. '
                     f' Ignoring its balance query.',
                 )
                 continue
 
-            entry = {}
-            entry['amount'] = v
-            if k == 'KFEE':
+            balance = Balance(amount=amount)
+            if our_asset.identifier != 'KFEE':
                 # There is no price value for KFEE. TODO: Shouldn't we then just skip the balance?
-                entry['usd_value'] = ZERO
-            else:
                 try:
                     usd_price = Inquirer().find_usd_price(our_asset)
                 except RemoteError as e:
@@ -548,24 +548,19 @@ class Kraken(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                         f'query USD price: {str(e)}. Skipping balance entry',
                     )
                     continue
-                entry['usd_value'] = FVal(v * usd_price)
 
-            if our_asset not in balances:
-                balances[our_asset] = entry
-            else:  # Some assets may appear twice in kraken balance query for different locations
-                # Spot/staking for example
-                balances[our_asset]['amount'] += entry['amount']
-                balances[our_asset]['usd_value'] += entry['usd_value']
+                balance.usd_value = balance.amount * usd_price
 
+            asset_balance[our_asset] += balance
             log.debug(
                 'kraken balance query result',
                 sensitive_log=True,
                 currency=our_asset,
-                amount=entry['amount'],
-                usd_value=entry['usd_value'],
+                amount=balance.amount,
+                usd_value=balance.usd_value,
             )
 
-        return balances, ''
+        return dict(asset_balance), ''
 
     def query_until_finished(
             self,

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -460,7 +460,7 @@ class Poloniex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             log.error(msg)
             return None, msg
 
-        asset_balance: Dict[Asset, Balance] = {}
+        assets_balance: Dict[Asset, Balance] = {}
         for poloniex_asset, v in resp.items():
             available = FVal(v['available'])
             on_orders = FVal(v['onOrders'])
@@ -501,7 +501,7 @@ class Poloniex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
                 amount = available + on_orders
                 usd_value = amount * usd_price
-                asset_balance[asset] = Balance(
+                assets_balance[asset] = Balance(
                     amount=amount,
                     usd_value=usd_value,
                 )
@@ -513,7 +513,7 @@ class Poloniex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                     usd_value=usd_value,
                 )
 
-        return asset_balance, ''
+        return assets_balance, ''
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -743,15 +743,15 @@ class Rotkehlchen():
         balances = account_for_manually_tracked_balances(db=self.data.db, balances=balances)
 
         # Calculate usd totals
-        asset_total_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
+        assets_total_balance: DefaultDict[Asset, Balance] = defaultdict(Balance)
         total_usd_per_location: Dict[str, FVal] = {}
         for location, asset_balance in balances.items():
             total_usd_per_location[location] = ZERO
             for asset, balance in asset_balance.items():
-                asset_total_balance[asset] += balance
+                assets_total_balance[asset] += balance
                 total_usd_per_location[location] += balance.usd_value
 
-        net_usd = sum((balance.usd_value for _, balance in asset_total_balance.items()), ZERO)
+        net_usd = sum((balance.usd_value for _, balance in assets_total_balance.items()), ZERO)
         liabilities_total_usd = sum((liability.usd_value for _, liability in liabilities.items()), ZERO)  # noqa: E501
         net_usd -= liabilities_total_usd
 
@@ -768,15 +768,15 @@ class Rotkehlchen():
             }
 
         # Calculate 'percentage_of_net_value' per asset
-        asset_total_balance_as_dict: Dict[Asset, Dict[str, Any]] = {
-            asset: balance.to_dict() for asset, balance in asset_total_balance.items()
+        assets_total_balance_as_dict: Dict[Asset, Dict[str, Any]] = {
+            asset: balance.to_dict() for asset, balance in assets_total_balance.items()
         }
         liabilities_as_dict: Dict[Asset, Dict[str, Any]] = {
             asset: balance.to_dict() for asset, balance in liabilities.items()
         }
-        for asset, balance_dict in asset_total_balance_as_dict.items():
+        for asset, balance_dict in assets_total_balance_as_dict.items():
             percentage = (balance_dict['usd_value'] / net_usd).to_percentage() if net_usd != ZERO else '0%'  # noqa: E501
-            asset_total_balance_as_dict[asset]['percentage_of_net_value'] = percentage
+            assets_total_balance_as_dict[asset]['percentage_of_net_value'] = percentage
 
         for asset, balance_dict in liabilities_as_dict.items():
             percentage = (balance_dict['usd_value'] / net_usd).to_percentage() if net_usd != ZERO else '0%'  # noqa: E501
@@ -784,7 +784,7 @@ class Rotkehlchen():
 
         # Compose balances response
         result_dict = {
-            'assets': asset_total_balance_as_dict,
+            'assets': assets_total_balance_as_dict,
             'liabilities': liabilities_as_dict,
             'location': location_stats,
             'net_usd': net_usd,

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -199,11 +199,11 @@ def test_binance_query_balances_include_features(function_scope_binance):
 
     assert msg == ''
     assert len(balances) == 5
-    assert balances[A_BTC]['amount'] == FVal('4723847.39208129')
-    assert balances[A_ETH]['amount'] == FVal('4763368.68006011')
-    assert balances[A_BUSD]['amount'] == FVal('7.49283144')
-    assert balances[A_USDT]['amount'] == FVal('201.01')
-    assert balances[A_DOT]['amount'] == FVal('500.55')
+    assert balances[A_BTC].amount == FVal('4723847.39208129')
+    assert balances[A_ETH].amount == FVal('4763368.68006011')
+    assert balances[A_BUSD].amount == FVal('7.49283144')
+    assert balances[A_USDT].amount == FVal('201.01')
+    assert balances[A_DOT].amount == FVal('500.55')
 
     warnings = binance.msg_aggregator.consume_warnings()
     assert len(warnings) == 2

--- a/rotkehlchen/tests/exchanges/test_bitcoinde.py
+++ b/rotkehlchen/tests/exchanges/test_bitcoinde.py
@@ -35,8 +35,8 @@ def test_bitcoinde_query_balances_unknown_asset(function_scope_bitcoinde):
 
     assert msg == ''
     assert len(balances) == 6
-    assert balances[A_ETH]['amount'] == FVal('32.0')
-    assert balances[A_BTC]['amount'] == FVal('0.5')
+    assert balances[A_ETH].amount == FVal('32.0')
+    assert balances[A_BTC].amount == FVal('0.5')
 
     warnings = bitcoinde.msg_aggregator.consume_warnings()
     assert len(warnings) == 0

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -199,27 +199,27 @@ def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disab
             Asset('EUR'): Balance(
                 amount=FVal('99.9999999'),
                 usd_value=FVal('149.99999985'),
-            ).to_dict(),
+            ),
             Asset('GLM'): Balance(
                 amount=FVal('0.0000001'),
                 usd_value=FVal('0.00000015'),
-            ).to_dict(),
+            ),
             Asset('LINK'): Balance(
                 amount=FVal('777.777777'),
                 usd_value=FVal('1166.6666655'),
-            ).to_dict(),
+            ),
             Asset('NEO'): Balance(
                 amount=FVal('1'),
                 usd_value=FVal('1.5'),
-            ).to_dict(),
+            ),
             Asset('USDT'): Balance(
                 amount=FVal('19790.1529257'),
                 usd_value=FVal('29685.22938855'),
-            ).to_dict(),
+            ),
             Asset('WBTC'): Balance(
                 amount=FVal('1'),
                 usd_value=FVal('1.5'),
-            ).to_dict(),
+            ),
         }
         assert msg == ''
 

--- a/rotkehlchen/tests/exchanges/test_bitmex.py
+++ b/rotkehlchen/tests/exchanges/test_bitmex.py
@@ -299,3 +299,17 @@ def test_bitmex_margin_history(sandbox_bitmex):
         ),
     ]
     assert result == resulting_margin_positions
+
+
+def test_bitmex_query_balances(sandbox_bitmex):
+    mock_response = {'amount': 123456789}
+    with patch.object(sandbox_bitmex, '_api_query_dict', return_value=mock_response):
+        balances, msg = sandbox_bitmex.query_balances()
+
+    assert msg == ''
+    assert len(balances) == 1
+    assert balances[A_BTC].amount == FVal('1.23456789')
+    assert balances[A_BTC].usd_value == FVal('1.851851835')
+
+    warnings = sandbox_bitmex.msg_aggregator.consume_warnings()
+    assert len(warnings) == 0

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 import requests
 
+from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_bitstamp
 from rotkehlchen.errors import RemoteError, SystemClockNotSyncedError, UnknownAsset
@@ -273,14 +274,14 @@ def test_query_balances_asset_balance(mock_bitstamp, inquirer):  # pylint: disab
     with patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response):
         asset_balance, msg = mock_bitstamp.query_balances()
         assert asset_balance == {
-            Asset('ETH'): {
-                'amount': FVal('32'),
-                'usd_value': FVal('48'),
-            },
-            Asset('LINK'): {
-                'amount': FVal('1000'),
-                'usd_value': FVal('1500'),
-            },
+            Asset('ETH'): Balance(
+                amount=FVal('32'),
+                usd_value=FVal('48'),
+            ),
+            Asset('LINK'): Balance(
+                amount=FVal('1000'),
+                usd_value=FVal('1500'),
+            ),
         }
         assert msg == ''
 

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -91,8 +91,8 @@ def test_bittrex_query_balances_unknown_asset(bittrex):
 
     assert msg == ''
     assert len(balances) == 2
-    assert balances[A_BTC]['amount'] == FVal('5.0')
-    assert balances[A_ETH]['amount'] == FVal('10.0')
+    assert balances[A_BTC].amount == FVal('5.0')
+    assert balances[A_ETH].amount == FVal('10.0')
 
     warnings = bittrex.msg_aggregator.consume_warnings()
     assert len(warnings) == 2

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -90,10 +90,10 @@ def test_coinbase_query_balances(function_scope_coinbase):
 
     assert msg == ''
     assert len(balances) == 2
-    assert balances[A_BTC]['amount'] == FVal('5.23')
-    assert balances[A_ETH]['amount'] == FVal('39.59')
-    assert 'usd_value' in balances[A_ETH]
-    assert 'usd_value' in balances[A_BTC]
+    assert balances[A_BTC].amount == FVal('5.23')
+    assert balances[A_BTC].usd_value == FVal('7.8450000000')
+    assert balances[A_ETH].amount == FVal('39.59')
+    assert balances[A_ETH].usd_value == FVal('59.385000000')
 
     warnings = coinbase.msg_aggregator.consume_warnings()
     errors = coinbase.msg_aggregator.consume_errors()
@@ -146,8 +146,8 @@ def test_coinbase_query_balances_unexpected_data(function_scope_coinbase):
             assert len(errors) == 0
             assert msg == ''
             assert len(balances) == 1
-            assert balances[A_BTC]['amount'] == FVal('4')
-            assert 'usd_value' in balances[A_BTC]
+            assert balances[A_BTC].amount == FVal('4')
+            assert balances[A_BTC].usd_value == FVal('6')
         else:
             assert len(warnings) == expected_warnings_num
             assert len(errors) == expected_errors_num

--- a/rotkehlchen/tests/exchanges/test_coinbasepro.py
+++ b/rotkehlchen/tests/exchanges/test_coinbasepro.py
@@ -280,10 +280,10 @@ def test_query_balances(function_scope_coinbasepro):
 
     assert message == ''
     assert len(balances) == 2
-    assert balances[A_BAT]['amount'] == FVal('10.5')
-    assert balances[A_BAT]['usd_value'] is not None
-    assert balances[A_ETH]['amount'] == FVal('2.5')
-    assert balances[A_ETH]['usd_value'] is not None
+    assert balances[A_BAT].amount == FVal('10.5')
+    assert balances[A_BAT].usd_value == FVal('15.75')
+    assert balances[A_ETH].amount == FVal('2.5')
+    assert balances[A_ETH].usd_value == FVal('3.75')
 
 
 def test_query_balances_unknown_asset(function_scope_coinbasepro):
@@ -295,8 +295,8 @@ def test_query_balances_unknown_asset(function_scope_coinbasepro):
 
     assert message == ''
     assert len(balances) == 1
-    assert balances[A_ETH]['amount'] == FVal('2.5')
-    assert balances[A_ETH]['usd_value'] is not None
+    assert balances[A_ETH].amount == FVal('2.5')
+    assert balances[A_ETH].usd_value == FVal('3.75')
 
     warnings = cb.msg_aggregator.consume_warnings()
     assert len(warnings) == 1
@@ -338,8 +338,8 @@ def test_query_balances_keyerror_response(function_scope_coinbasepro):
 
     assert message == ''
     assert len(balances) == 1
-    assert balances[A_ETH]['amount'] == FVal('2.5')
-    assert balances[A_ETH]['usd_value'] is not None
+    assert balances[A_ETH].amount == FVal('2.5')
+    assert balances[A_ETH].usd_value is not None
 
     warnings = cb.msg_aggregator.consume_warnings()
     assert len(warnings) == 0

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -96,18 +96,18 @@ def test_gemini_query_balances(sandbox_gemini):
     assert msg == ''
     assert len(balances) == 6
 
-    assert balances[A_USD]['amount'] == FVal('523384.71365986583339')
-    assert balances[A_USD]['usd_value'] == balances[A_USD]['amount']
-    assert balances[A_ETH]['amount'] == FVal('19985.07921584')
-    assert balances[A_ETH]['usd_value'] > ZERO
-    assert balances[A_LTC]['amount'] == FVal('20000')
-    assert balances[A_LTC]['usd_value'] > ZERO
-    assert balances[A_BTC]['amount'] == FVal('888.7177526197')
-    assert balances[A_BTC]['usd_value'] > ZERO
-    assert balances[A_ZEC]['amount'] == FVal('20000')
-    assert balances[A_ZEC]['usd_value'] > ZERO
-    assert balances[A_BCH]['amount'] == FVal('20000')
-    assert balances[A_BCH]['usd_value'] > ZERO
+    assert balances[A_USD].amount == FVal('523384.71365986583339')
+    assert balances[A_USD].usd_value == balances[A_USD].amount
+    assert balances[A_ETH].amount == FVal('19985.07921584')
+    assert balances[A_ETH].usd_value > ZERO
+    assert balances[A_LTC].amount == FVal('20000')
+    assert balances[A_LTC].usd_value > ZERO
+    assert balances[A_BTC].amount == FVal('888.7177526197')
+    assert balances[A_BTC].usd_value > ZERO
+    assert balances[A_ZEC].amount == FVal('20000')
+    assert balances[A_ZEC].usd_value > ZERO
+    assert balances[A_BCH].amount == FVal('20000')
+    assert balances[A_BCH].usd_value > ZERO
 
 
 def test_gemini_query_trades(sandbox_gemini):

--- a/rotkehlchen/tests/exchanges/test_iconomi.py
+++ b/rotkehlchen/tests/exchanges/test_iconomi.py
@@ -39,8 +39,10 @@ def test_iconomi_query_balances_unknown_asset(function_scope_iconomi):
 
     assert msg == ''
     assert len(balances) == 3
-    assert balances[A_ETH]['amount'] == FVal('32.0')
-    assert balances[Asset('REP')]['amount'] == FVal('0.5314532451')
+    assert balances[A_ETH].amount == FVal('32.0')
+    assert balances[A_ETH].usd_value == FVal('48.0')
+    assert balances[Asset('REP')].amount == FVal('0.5314532451')
+    assert balances[Asset('REP')].usd_value == FVal('0.79717986765')
 
     warnings = iconomi.msg_aggregator.consume_warnings()
     assert len(warnings) == 2

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import KRAKEN_TO_WORLD, asset_from_kraken
 from rotkehlchen.constants.assets import A_BTC, A_ETH
@@ -63,8 +64,7 @@ def test_querying_balances(function_scope_kraken):
     assert isinstance(result, dict)
     for asset, entry in result.items():
         assert isinstance(asset, Asset)
-        assert 'usd_value' in entry
-        assert 'amount' in entry
+        assert isinstance(entry, Balance)
 
 
 def test_querying_trade_history(function_scope_kraken):
@@ -143,8 +143,10 @@ def test_kraken_query_balances_unknown_asset(function_scope_kraken):
 
     assert msg == ''
     assert len(balances) == 2
-    assert balances[A_BTC]['amount'] == FVal('5.0')
-    assert balances[A_ETH]['amount'] == FVal('10.0')
+    assert balances[A_BTC].amount == FVal('5.0')
+    assert balances[A_BTC].usd_value == FVal('7.5')
+    assert balances[A_ETH].amount == FVal('10.0')
+    assert balances[A_ETH].usd_value == FVal('15.0')
 
     warnings = kraken.msg_aggregator.consume_warnings()
     assert len(warnings) == 1

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -365,8 +365,10 @@ def test_poloniex_query_balances_unknown_asset(function_scope_poloniex):
 
     assert msg == ''
     assert len(balances) == 2
-    assert balances[A_BTC]['amount'] == FVal('5.5')
-    assert balances[A_ETH]['amount'] == FVal('11.0')
+    assert balances[A_BTC].amount == FVal('5.5')
+    assert balances[A_BTC].usd_value == FVal('8.25')
+    assert balances[A_ETH].amount == FVal('11.0')
+    assert balances[A_ETH].usd_value == FVal('16.5')
 
     warnings = poloniex.msg_aggregator.consume_warnings()
     assert len(warnings) == 2

--- a/rotkehlchen/tests/unit/test_structures.py
+++ b/rotkehlchen/tests/unit/test_structures.py
@@ -35,6 +35,18 @@ def test_balance_addition():
         result = a + {'amount': 1, 'usd_value': 'dsad'}
 
 
+def test_balance_raddition():
+    a = Balance(amount=FVal('1.5'), usd_value=FVal('1.6'))
+    b = Balance(amount=FVal('2.5'), usd_value=FVal('2.7'))
+    c = Balance(amount=FVal('3'), usd_value=FVal('3.21'))
+
+    result = sum([a, b, c])
+
+    assert isinstance(result, Balance)
+    assert result.amount == FVal('7')
+    assert result.usd_value == FVal('7.51')
+
+
 def test_balance_sheet_addition():
     a = BalanceSheet(
         assets={
@@ -70,6 +82,46 @@ def test_balance_sheet_addition():
         },
     )
     assert a + b == c
+
+
+def test_balance_sheet_raddition():
+    a = BalanceSheet(
+        assets={
+            A_USD: Balance(amount=FVal('2'), usd_value=FVal('2')),
+            A_ETH: Balance(amount=FVal('1.5'), usd_value=FVal('450')),
+        },
+        liabilities={
+            A_DAI: Balance(amount=FVal('5'), usd_value=FVal('5.1')),
+            A_ETH: Balance(amount=FVal('0.5'), usd_value=FVal('150')),
+        },
+    )
+    b = BalanceSheet(
+        assets={
+            A_EUR: Balance(amount=FVal('3'), usd_value=FVal('3.5')),
+            A_ETH: Balance(amount=FVal('3'), usd_value=FVal('900')),
+            A_BTC: Balance(amount=FVal('1'), usd_value=FVal('10000')),
+        },
+        liabilities={
+            A_DAI: Balance(amount=FVal('10'), usd_value=FVal('10.2')),
+        },
+    )
+    c = BalanceSheet(
+        assets={
+            A_EUR: Balance(amount=FVal('3'), usd_value=FVal('3.5')),
+            A_USD: Balance(amount=FVal('2'), usd_value=FVal('2')),
+            A_ETH: Balance(amount=FVal('4.5'), usd_value=FVal('1350')),
+            A_BTC: Balance(amount=FVal('1'), usd_value=FVal('10000')),
+        },
+        liabilities={
+            A_DAI: Balance(amount=FVal('15'), usd_value=FVal('15.3')),
+            A_ETH: Balance(amount=FVal('0.5'), usd_value=FVal('150')),
+        },
+    )
+
+    result = sum([a, b])
+
+    assert isinstance(result, BalanceSheet)
+    assert result == c
 
 
 def test_default_balance_sheet():

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -18,7 +18,7 @@ import requests
 from eth_utils.address import to_checksum_address
 from rlp.sedes import big_endian_int
 
-from rotkehlchen.constants import GLOBAL_REQUESTS_TIMEOUT, ZERO, PRICE_HISTORY_DIR
+from rotkehlchen.constants import GLOBAL_REQUESTS_TIMEOUT, PRICE_HISTORY_DIR, ZERO
 from rotkehlchen.constants.timing import QUERY_RETRY_TIMES
 from rotkehlchen.errors import (
     ConversionError,

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -166,17 +166,6 @@ def dict_get_sumof(d: Dict[str, Dict[str, FVal]], attribute: str) -> FVal:
     return sum_
 
 
-def merge_dicts(*dict_args: Dict) -> Dict:
-    """
-    Given any number of dicts, shallow copy and merge into a new dict,
-    precedence goes to key value pairs in latter dicts.
-    """
-    result = {}
-    for dictionary in dict_args:
-        result.update(dictionary)
-    return result
-
-
 def retry_calls(
         times: int,
         location: str,


### PR DESCRIPTION
Batch of improvements:
- Exchanges `query_balances` return now `Tuple[Optional[Dict[Asset, Balance]], str]` (as type `ExchangeQueryBalances` (incl. tests)
- Rotki API `query_balances` has been refactored for supporting as far as possible `Balance` and `BalanceSheet`.
- Added `__radd__` for `Balance` and `BalanceSheet` (incl. tests).
- Increased Kusama timeout to 10s.
- Tested that when querying the KSM balances fail the balances snapshot is not taken.

