### PR TITLE
Handle multiple debited rows for CDC csv import

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`2117` Users can now properly dismiss notifications with long tiles, or dismiss all the pending notifications at once.
+* :bug:`2024` Multiple crypto.com csv import debited entries with same timestamp will be handled correctly.
 * :bug:`2135` Users will now properly see the correct accounting settings when creating a profit/loss report.
 
 * :release:`1.12.2 <2021-01-18>`

--- a/rotkehlchen/data/importer.py
+++ b/rotkehlchen/data/importer.py
@@ -4,6 +4,7 @@ from itertools import count
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+from rotkehlchen.fval import FVal
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.constants.misc import ZERO
@@ -371,7 +372,7 @@ class DataImporter():
                     acc +
                     deserialize_asset_amount(row['Native Amount (in USD)']),
                 debited_rows,
-                0,
+                FVal('0'),
             )
 
             # If the value of the transaction is too small (< 0,01$),
@@ -392,9 +393,13 @@ class DataImporter():
                     base_asset = Asset(credited_row['Currency'])
                     quote_asset = Asset(debited_row['Currency'])
                     pair = TradePair(f'{base_asset.identifier}_{quote_asset.identifier}')
-                    part_of_total = 1 if len(debited_rows) == 1 else deserialize_asset_amount(
-                        debited_row['Native Amount (in USD)'],
-                    ) / total_debited_usd
+                    part_of_total = (
+                        FVal(1)
+                        if len(debited_rows) == 1
+                        else deserialize_asset_amount(
+                            debited_row["Native Amount (in USD)"],
+                        ) / total_debited_usd
+                    )
                     quote_amount_sold = deserialize_asset_amount(
                         debited_row['Amount'],
                     ) * part_of_total
@@ -408,7 +413,7 @@ class DataImporter():
                         location=Location.CRYPTOCOM,
                         pair=pair,
                         trade_type=TradeType.BUY,
-                        amount=base_amount_bought,
+                        amount=AssetAmount(base_amount_bought),
                         rate=rate,
                         fee=fee,
                         fee_currency=fee_currency,

--- a/rotkehlchen/tests/data/cryptocom_trades_list.csv
+++ b/rotkehlchen/tests/data/cryptocom_trades_list.csv
@@ -1,4 +1,7 @@
 ﻿Timestamp (UTC),Transaction Description,Currency,Amount,To Currency,To Amount,Native Currency,Native Amount,Native Amount (in USD),Transaction Kind
+2020-12-15 09:25:14,Convert Dust,CRO,193.02779901061902311,,,EUR,10.59,12.8794521,dust_conversion_credited
+2020-12-15 09:25:14,Convert Dust,UNI,-1.3387887,,,EUR,-5.84,-7.1025496,dust_conversion_debited
+2020-12-15 09:25:14,Convert Dust,DOT,-0.6295092,,,EUR,-4.8,-5.837712,dust_conversion_debited
 2020-12-01 14:39:25,Convert Dust,CRO,0.007231228760408149,,,EUR,0.0,0,dust_conversion_credited
 2020-12-01 14:39:25,Convert Dust,DAI,-0.00050680380674961,,,EUR,0.0,0,dust_conversion_debited
 2020-10-12 19:10:36,Transfer: Exchange -> App wallet,ETH,0.033,,,EUR,10.75,12.7743325,exchange_to_crypto_transfer

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -220,6 +220,28 @@ def assert_cryptocom_import_results(rotki: Rotkehlchen):
         fee_currency=A_USD,
         link='',
         notes=get_trade_note('Convert Dust'),
+    ), Trade(
+        timestamp=Timestamp(1608024314),
+        location=Location.CRYPTOCOM,
+        pair=TradePair('CRO_UNI'),
+        trade_type=TradeType.BUY,
+        amount=AssetAmount(FVal('105.9475889306405164438345865')),
+        rate=Price(FVal('144.1809293808791657040427665')),
+        fee=Fee(ZERO),
+        fee_currency=A_USD,
+        link='',
+        notes=get_trade_note('Convert Dust'),
+    ), Trade(
+        timestamp=Timestamp(1608024314),
+        location=Location.CRYPTOCOM,
+        pair=TradePair('CRO_DOT'),
+        trade_type=TradeType.BUY,
+        amount=AssetAmount(FVal('87.08021007997850666616541352')),
+        rate=Price(FVal('306.6322128582378511862892551')),
+        fee=Fee(ZERO),
+        fee_currency=A_USD,
+        link='',
+        notes=get_trade_note('Convert Dust'),
     )]
     assert expected_trades == trades
 


### PR DESCRIPTION
When doing actions like dust conversions through the app, we can convert many assets at one time. It will make CDC considered it like multiple debited rows associated to only one credited row (in CRO since we convert all dust to CRO).
It was quite tricky since we have to compute the percentage of total debited to be able to compute the correct rate for each asset and then consider adding a trade for each asset paired with CRO.
There is also a case that we can't handle, it's when we have multiple rows but the part or the total debited is too slow and considered as 0 by crypto.com. Those imports will be skipped. Is it possible to maybe display warnings about those cases?

Fix #2024