### PR TITLE
Respect date format in CSV export and add setting for local vs UTC time in display and export

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`2146` Date format will now respect user choice in CSV export, logging output and other backend related locations. Also adding a new option to control whether those dates should be displayed/exported in local or UTC time.
 * :feature:`2159` Users now won't see empty tables for blockchains without accounts.
 * :feature:`2155` Users can now additionally filter the uniswap liquidity pools using a pool filter.
 * :feature:`1865` Users will now see an explanation of the current stage of the profit/loss report's progress along with the completion percentage.

--- a/frontend/app/src/data/converters.ts
+++ b/frontend/app/src/data/converters.ts
@@ -29,7 +29,8 @@ export const convertToGeneralSettings = (
   anonymousUsageAnalytics: settings.submit_usage_analytics,
   krakenAccountType: settings.kraken_account_type,
   activeModules: settings.active_modules,
-  btcDerivationGapLimit: settings.btc_derivation_gap_limit
+  btcDerivationGapLimit: settings.btc_derivation_gap_limit,
+  displayDateInLocaltime: settings.display_date_in_localtime
 });
 
 export const convertToAccountingSettings = (

--- a/frontend/app/src/data/defaults.ts
+++ b/frontend/app/src/data/defaults.ts
@@ -14,6 +14,7 @@ export class Defaults {
   static KRAKEN_DEFAULT_ACCOUNT_TYPE = 'starter';
   static DEFAULT_QUERY_PERIOD = 5;
   static BTC_DERIVATION_GAP_LIMIT = 20;
+  static DISPLAY_DATE_IN_LOCALTIME = true;
 }
 
 export const EXCHANGE_POLONIEX = 'poloniex';

--- a/frontend/app/src/data/factories.ts
+++ b/frontend/app/src/data/factories.ts
@@ -16,7 +16,8 @@ export const defaultGeneralSettings = (): GeneralSettings => ({
   selectedCurrency: currencies[0],
   krakenAccountType: Defaults.KRAKEN_DEFAULT_ACCOUNT_TYPE,
   activeModules: [],
-  btcDerivationGapLimit: Defaults.BTC_DERIVATION_GAP_LIMIT
+  btcDerivationGapLimit: Defaults.BTC_DERIVATION_GAP_LIMIT,
+  displayDateInLocaltime: Defaults.DISPLAY_DATE_IN_LOCALTIME
 });
 
 export const defaultAccountingSettings = (): AccountingSettings => ({

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -541,6 +541,7 @@
       "balance_saving_frequency": "Balance data saving frequency in hours",
       "btc_derivation_gap": "BTC derivation gap limit",
       "date_display_format": "Date display format",
+      "display_date_in_localtime": "Display date in localtime and not in UTC in CSV export, backend logs and other locations",
       "rpc_endpoint": "Ethereum Node RPC Endpoint",
       "ksm_rpc_endpoint": "Kusama Node RPC Endpoint"
     },
@@ -558,6 +559,10 @@
       },
       "anonymized_logs": {
         "error": "Error setting anonymized logs"
+      },
+      "display_date_in_localtime": {
+          "success": "Succesfully set the display date in local time setting",
+        "error": "Error setting the display date in local time setting"
       },
       "balance_frequency": {
         "error": "Error setting balance save frequency to {frequency}",

--- a/frontend/app/src/model/action-result.ts
+++ b/frontend/app/src/model/action-result.ts
@@ -34,6 +34,7 @@ export interface DBSettings {
   readonly account_for_assets_movements: boolean;
   readonly btc_derivation_gap_limit: number;
   readonly calculate_past_cost_basis: boolean;
+  readonly display_date_in_localtime: boolean;
 }
 
 interface ApiKey {

--- a/frontend/app/src/typing/types.ts
+++ b/frontend/app/src/typing/types.ts
@@ -25,6 +25,7 @@ export interface GeneralSettings {
   readonly krakenAccountType: string;
   readonly activeModules: SupportedModules[];
   readonly btcDerivationGapLimit: number;
+  readonly displayDateInLocaltime: boolean;
 }
 
 export interface AccountingSettings {
@@ -127,6 +128,7 @@ interface SettingsPayload {
   account_for_assets_movements: boolean;
   btc_derivation_gap_limit: number;
   calculate_past_cost_basis: boolean;
+  display_date_in_localtime: boolean;
 }
 
 export type ExternalServiceName = 'etherscan' | 'cryptocompare';

--- a/frontend/app/src/views/settings/GeneralSettings.vue
+++ b/frontend/app/src/views/settings/GeneralSettings.vue
@@ -50,6 +50,20 @@
               @change="onDateDisplayFormatChange($event)"
             />
 
+            <v-switch
+              v-model="displayDateInLocaltime"
+              class="general-settings__fields__display-date-in-localtime"
+              color="primary"
+              :label="$t('general_settings.labels.display_date_in_localtime')"
+              :success-messages="
+                settingsMessages[DISPLAY_DATE_IN_LOCALTIME].success
+              "
+              :error-messages="
+                settingsMessages[DISPLAY_DATE_IN_LOCALTIME].error
+              "
+              @change="onDisplayDateInLocaltimeChange($event)"
+            />
+
             <v-text-field
               v-model="btcDerivationGapLimit"
               class="general-settings__fields__btc-derivation-gap"
@@ -284,6 +298,7 @@ const SETTING_SCRAMBLE_DATA = 'scrambleData';
 const SETTING_TIMEFRAME = 'timeframe';
 const SETTING_QUERY_PERIOD = 'queryPeriod';
 const SETTING_BTC_DERIVATION_GAP_LIMIT = 'btcDerivationGapLimit';
+const SETTING_DISPLAY_DATE_IN_LOCALTIME = 'displayDateInLocaltime';
 
 const SETTINGS = [
   SETTING_FLOATING_PRECISION,
@@ -300,7 +315,8 @@ const SETTINGS = [
   SETTING_SCRAMBLE_DATA,
   SETTING_TIMEFRAME,
   SETTING_QUERY_PERIOD,
-  SETTING_BTC_DERIVATION_GAP_LIMIT
+  SETTING_BTC_DERIVATION_GAP_LIMIT,
+  SETTING_DISPLAY_DATE_IN_LOCALTIME
 ] as const;
 
 type SettingsEntries = typeof SETTINGS[number];
@@ -349,6 +365,7 @@ export default class General extends Settings {
   updateSetting!: (payload: FrontendSettingsPayload) => Promise<ActionStatus>;
   queryPeriod: string = '5';
   btcDerivationGapLimit: string = '20';
+  displayDateInLocaltime: boolean = true;
 
   readonly settingsMessages: GeneralSettingsMessages = settingsMessages();
   readonly FLOATING_PRECISION = SETTING_FLOATING_PRECISION;
@@ -366,6 +383,7 @@ export default class General extends Settings {
   readonly TIMEFRAME = SETTING_TIMEFRAME;
   readonly QUERY_PERIOD = SETTING_QUERY_PERIOD;
   readonly BTC_DERIVATION_GAP_LIMIT = SETTING_BTC_DERIVATION_GAP_LIMIT;
+  readonly DISPLAY_DATE_IN_LOCALTIME = SETTING_DISPLAY_DATE_IN_LOCALTIME;
 
   historicDateMenu: boolean = false;
   date: string = '';
@@ -628,6 +646,21 @@ export default class General extends Settings {
     await this.update(
       { submit_usage_analytics: enabled },
       SETTING_ANONYMOUS_USAGE_ANALYTICS,
+      message
+    );
+  }
+
+  async onDisplayDateInLocaltimeChange(enabled: boolean) {
+    const message: BaseMessage = {
+      success: '',
+      error: `${this.$t(
+        'general_settings.validation.display_date_in_localtime.error'
+      )}`
+    };
+
+    await this.update(
+      { display_date_in_localtime: enabled },
+      SETTING_DISPLAY_DATE_IN_LOCALTIME,
       message
     );
   }

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -59,7 +59,11 @@ class Accountant():
         self.db = db
         profit_currency = db.get_main_currency()
         self.msg_aggregator = msg_aggregator
-        self.csvexporter = CSVExporter(profit_currency, user_directory, create_csv)
+        self.csvexporter = CSVExporter(
+            database=db,
+            user_directory=user_directory,
+            create_csv=create_csv,
+        )
         self.events = TaxableEvents(self.csvexporter, profit_currency)
 
         self.asset_movement_fees = FVal(0)
@@ -283,7 +287,7 @@ class Accountant():
         self.start_ts = start_ts
         self.eth_transactions_gas_costs = FVal(0)
         self.asset_movement_fees = FVal(0)
-        self.csvexporter.reset_csv_lists()
+        self.csvexporter.reset()
 
         # Ask the DB for the settings once at the start of processing so we got the
         # same settings through the entire task

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -40,7 +40,6 @@ from rotkehlchen.utils.accounting import (
     action_get_timestamp,
     action_get_type,
 )
-from rotkehlchen.utils.misc import timestamp_to_date
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -55,7 +54,6 @@ class Accountant():
             msg_aggregator: MessagesAggregator,
             create_csv: bool,
     ) -> None:
-        log.debug('Initializing Accountant')
         self.db = db
         profit_currency = db.get_main_currency()
         self.msg_aggregator = msg_aggregator
@@ -337,7 +335,7 @@ class Accountant():
                 ts = action_get_timestamp(action)
                 self.msg_aggregator.add_error(
                     f'Skipping action at '
-                    f'{timestamp_to_date(ts, formatstr="%d/%m/%Y, %H:%M:%S")} '
+                    f'{self.csvexporter.timestamp_to_date(ts)} '
                     f'during history processing due to an asset unknown to '
                     f'cryptocompare being involved. Check logs for details',
                 )
@@ -350,7 +348,7 @@ class Accountant():
                 ts = action_get_timestamp(action)
                 self.msg_aggregator.add_error(
                     f'Skipping action at '
-                    f'{timestamp_to_date(ts, formatstr="%d/%m/%Y, %H:%M:%S")} '
+                    f'{self.csvexporter.timestamp_to_date(ts)} '
                     f'during history processing due to inability to find a price '
                     f'at that point in time: {str(e)}. Check the logs for more details',
                 )
@@ -363,7 +361,7 @@ class Accountant():
                 ts = action_get_timestamp(action)
                 self.msg_aggregator.add_error(
                     f'Skipping action at '
-                    f'{timestamp_to_date(ts, formatstr="%d/%m/%Y, %H:%M:%S")} '
+                    f'{self.csvexporter.timestamp_to_date(ts)} '
                     f'during history processing due to inability to reach an external '
                     f'service at that point in time: {str(e)}. Check the logs for more details',
                 )

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -200,7 +200,7 @@ class TaxableEvents():
             if not self.reduce_asset_amount(asset=A_ETC, amount=sold_amount):
                 log.critical(
                     'No documented buy found for ETC (ETH equivalent) before {}'.format(
-                        timestamp_to_date(timestamp, formatstr='%d/%m/%Y %H:%M:%S'),
+                        self.csv_exporter.timestamp_to_date(timestamp),
                     ),
                 )
 
@@ -208,7 +208,7 @@ class TaxableEvents():
             if not self.reduce_asset_amount(asset=A_BCH, amount=sold_amount):
                 log.critical(
                     'No documented buy found for BCH (BTC equivalent) before {}'.format(
-                        timestamp_to_date(timestamp, formatstr='%d/%m/%Y %H:%M:%S'),
+                        self.csv_exporter.timestamp_to_date(timestamp),
                     ),
                 )
 
@@ -724,7 +724,7 @@ class TaxableEvents():
             log.critical(
                 'No documented buy found for "{}" before {}'.format(
                     selling_asset,
-                    timestamp_to_date(timestamp, formatstr='%d/%m/%Y %H:%M:%S'),
+                    self.csv_exporter.timestamp_to_date(timestamp),
                 ),
             )
             # That means we had no documented buy for that asset. This is not good
@@ -743,7 +743,7 @@ class TaxableEvents():
             adjusted_amount = selling_amount - taxfree_amount
             log.critical(
                 f'Not enough documented buys found for "{selling_asset}" before '
-                f'{timestamp_to_date(timestamp, formatstr="%d/%m/%Y %H:%M:%S")}.'
+                f'{self.csv_exporter.timestamp_to_date(timestamp)}.'
                 f'Only found buys for {taxable_amount + taxfree_amount} {selling_asset}',
             )
             return adjusted_amount, taxable_bought_cost, taxfree_bought_cost
@@ -850,7 +850,7 @@ class TaxableEvents():
             if not result:
                 log.critical(
                     f'No documented buy found for {margin.pl_currency} before '
-                    f'{timestamp_to_date(margin.close_time, formatstr="%d/%m/%Y %H:%M:%S")}',
+                    f'{self.csv_exporter.timestamp_to_date(margin.close_time),}',
                 )
 
         # Reduce the fee_currency asset
@@ -935,7 +935,7 @@ class TaxableEvents():
             if not result:
                 log.critical(
                     f'No documented buy found for {action.asset} before '
-                    f'{timestamp_to_date(action.timestamp, formatstr="%d/%m/%Y %H:%M:%S")}',
+                    f'{self.csv_exporter.timestamp_to_date(action.timestamp)}',
                 )
 
         if action.timestamp > self.query_start_ts:

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -788,6 +788,7 @@ class ModifiableSettingsSchema(Schema):
         missing=None,
     )
     calculate_past_cost_basis = fields.Bool(missing=None)
+    display_date_in_localtime = fields.Bool(missing=None)
 
     @validates_schema  # type: ignore
     def validate_settings_schema(  # pylint: disable=no-self-use
@@ -828,6 +829,7 @@ class ModifiableSettingsSchema(Schema):
             account_for_assets_movements=data['account_for_assets_movements'],
             btc_derivation_gap_limit=data['btc_derivation_gap_limit'],
             calculate_past_cost_basis=data['calculate_past_cost_basis'],
+            display_date_in_localtime=data['display_date_in_localtime'],
         )
 
 

--- a/rotkehlchen/csv_exporter.py
+++ b/rotkehlchen/csv_exporter.py
@@ -83,6 +83,7 @@ class CSVExporter():
         self.profit_currency = self.database.get_main_currency()
         db_settings = self.database.get_settings()
         self.dateformat = db_settings.date_display_format
+        self.datelocaltime = db_settings.display_date_in_localtime
         if self.create_csv:
             self.trades_csv: List[Dict[str, Any]] = []
             self.loan_profits_csv: List[Dict[str, Any]] = []
@@ -95,8 +96,12 @@ class CSVExporter():
             self.all_events_csv: List[Dict[str, Any]] = []
             self.all_events = []
 
-    def _timestamp_to_date(self, timestamp: Timestamp) -> str:
-        return timestamp_to_date(timestamp, formatstr=self.dateformat)
+    def timestamp_to_date(self, timestamp: Timestamp) -> str:
+        return timestamp_to_date(
+            timestamp,
+            formatstr=self.dateformat,
+            treat_as_local=self.datelocaltime,
+        )
 
     def add_to_allevents(
             self,
@@ -157,7 +162,7 @@ class CSVExporter():
         self.all_events.append(entry)
         new_entry = entry.copy()
         new_entry['net_profit_or_loss'] = net_profit_or_loss_csv
-        new_entry['time'] = self._timestamp_to_date(timestamp)
+        new_entry['time'] = self.timestamp_to_date(timestamp)
         new_entry[f'paid_in_{self.profit_currency.identifier}'] = paid_in_profit_currency
         key = f'taxable_received_in_{self.profit_currency.identifier}'
         new_entry[key] = taxable_received_in_profit_currency
@@ -199,7 +204,7 @@ class CSVExporter():
             'taxable_bought_cost_in_{}'.format(self.profit_currency.identifier): 'not applicable',
             'taxable_gain_in_{}'.format(self.profit_currency.identifier): FVal(0),
             'taxable_profit_loss_in_{}'.format(self.profit_currency.identifier): FVal(0),
-            'time': self._timestamp_to_date(timestamp),
+            'time': self.timestamp_to_date(timestamp),
             'is_virtual': is_virtual,
         })
         self.add_to_allevents(
@@ -262,7 +267,7 @@ class CSVExporter():
             f'taxable_bought_cost_in_{self.profit_currency.identifier}': taxable_bought_cost,
             f'taxable_gain_in_{self.profit_currency.identifier}': taxable_profit_received,
             f'taxable_profit_loss_in_{self.profit_currency.identifier}': taxable_profit_formula,
-            'time': self._timestamp_to_date(timestamp),
+            'time': self.timestamp_to_date(timestamp),
             'is_virtual': is_virtual,
         })
         paid_in_profit_currency = ZERO
@@ -302,7 +307,7 @@ class CSVExporter():
             f'price_in_{self.profit_currency.identifier}': rate_in_profit_currency,
             f'fee_in_{self.profit_currency.identifier}': total_fee_in_profit_currency,
             f'loss_in_{self.profit_currency.identifier}': loss_formula,
-            'time': self._timestamp_to_date(timestamp),
+            'time': self.timestamp_to_date(timestamp),
         })
         paid_in_profit_currency = amount * rate_in_profit_currency + total_fee_in_profit_currency
         self.add_to_allevents(
@@ -332,8 +337,8 @@ class CSVExporter():
 
         self.loan_profits_csv.append({
             'location': str(location),
-            'open_time': self._timestamp_to_date(open_time),
-            'close_time': self._timestamp_to_date(close_time),
+            'open_time': self.timestamp_to_date(open_time),
+            'close_time': self.timestamp_to_date(close_time),
             'gained_asset': gained_asset.identifier,
             'gained_amount': gained_amount,
             'lent_amount': lent_amount,
@@ -369,7 +374,7 @@ class CSVExporter():
         self.margin_positions_csv.append({
             'name': margin_notes,
             'location': str(location),
-            'time': self._timestamp_to_date(timestamp),
+            'time': self.timestamp_to_date(timestamp),
             'gain_loss_asset': gain_loss_asset.identifier,
             'gain_loss_amount': gain_loss_amount,
             f'profit_loss_in_{self.profit_currency.identifier}': gain_loss_in_profit_currency,
@@ -399,7 +404,7 @@ class CSVExporter():
             return
 
         self.asset_movements_csv.append({
-            'time': self._timestamp_to_date(timestamp),
+            'time': self.timestamp_to_date(timestamp),
             'exchange': str(exchange),
             'type': str(category),
             'moving_asset': asset.identifier,
@@ -429,7 +434,7 @@ class CSVExporter():
             return
 
         self.tx_gas_costs_csv.append({
-            'time': self._timestamp_to_date(timestamp),
+            'time': self.timestamp_to_date(timestamp),
             'transaction_hash': transaction_hash.hex(),
             'eth_burned_as_gas': eth_burned_as_gas,
             f'cost_in_{self.profit_currency.identifier}': eth_burned_as_gas * rate,
@@ -451,7 +456,7 @@ class CSVExporter():
             return
 
         self.defi_events_csv.append({
-            'time': self._timestamp_to_date(event.timestamp),
+            'time': self.timestamp_to_date(event.timestamp),
             'type': str(event.event_type),
             'asset': str(event.asset),
             'amount': str(event.amount),
@@ -496,7 +501,7 @@ class CSVExporter():
             return
 
         self.ledger_actions_csv.append({
-            'time': self._timestamp_to_date(action.timestamp),
+            'time': self.timestamp_to_date(action.timestamp),
             'type': str(action.action_type),
             'location': str(action.location),
             'asset': str(action.asset),

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -216,7 +216,7 @@ class DataHandler():
         log.info('Decompress and decrypt DB')
 
         # First make a backup of the DB we are about to replace
-        date = timestamp_to_date(ts=ts_now(), formatstr='%Y_%m_%d_%H_%M_%S')
+        date = timestamp_to_date(ts=ts_now(), formatstr='%Y_%m_%d_%H_%M_%S', treat_as_local=True)
         shutil.copyfile(
             self.data_directory / self.username / 'rotkehlchen.db',
             self.data_directory / self.username / f'rotkehlchen_db_{date}.backup',

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -26,6 +26,7 @@ DEFAULT_ACTIVE_MODULES = AVAILABLE_MODULES
 DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS = True
 DEFAULT_BTC_DERIVATION_GAP_LIMIT = 20
 DEFAULT_CALCULATE_PAST_COST_BASIS = True
+DEFAULT_DISPLAY_DATE_IN_LOCALTIME = True
 
 
 class DBSettings(NamedTuple):
@@ -52,6 +53,7 @@ class DBSettings(NamedTuple):
     account_for_assets_movements: bool = DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS
     btc_derivation_gap_limit: int = DEFAULT_BTC_DERIVATION_GAP_LIMIT
     calculate_past_cost_basis: bool = DEFAULT_CALCULATE_PAST_COST_BASIS
+    display_date_in_localtime: bool = DEFAULT_DISPLAY_DATE_IN_LOCALTIME
 
 
 class ModifiableDBSettings(NamedTuple):
@@ -73,6 +75,7 @@ class ModifiableDBSettings(NamedTuple):
     account_for_assets_movements: Optional[bool] = None
     btc_derivation_gap_limit: Optional[int] = None
     calculate_past_cost_basis: Optional[bool] = None
+    display_date_in_localtime: Optional[bool] = None
 
     def serialize(self) -> Dict[str, Any]:
         settings_dict = {}
@@ -118,6 +121,7 @@ BOOLEAN_KEYS = (
     'submit_usage_analytics',
     'account_for_assets_movements',
     'calculate_past_cost_basis',
+    'display_date_in_localtime',
 )
 INTEGER_KEYS = (
     'version',

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -960,7 +960,11 @@ class Cryptocompare(ExternalServiceWithApiKey):
             raise NoPriceForGivenTimestamp(
                 from_asset=from_asset,
                 to_asset=to_asset,
-                date=timestamp_to_date(timestamp, formatstr='%d/%m/%Y, %H:%M:%S'),
+                date=timestamp_to_date(
+                    timestamp,
+                    formatstr='%d/%m/%Y, %H:%M:%S',
+                    treat_as_local=True,
+                ),
             )
 
         log.debug(

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -159,5 +159,5 @@ class PriceHistorian():
         raise NoPriceForGivenTimestamp(
             from_asset=from_asset,
             to_asset=to_asset,
-            date=timestamp_to_date(timestamp, formatstr='%d/%m/%Y, %H:%M:%S'),
+            date=timestamp_to_date(timestamp, formatstr='%d/%m/%Y, %H:%M:%S', treat_as_local=True),
         )

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -21,6 +21,7 @@ from rotkehlchen.db.settings import (
     DEFAULT_BALANCE_SAVE_FREQUENCY,
     DEFAULT_BTC_DERIVATION_GAP_LIMIT,
     DEFAULT_CALCULATE_PAST_COST_BASIS,
+    DEFAULT_DISPLAY_DATE_IN_LOCALTIME,
     DEFAULT_DATE_DISPLAY_FORMAT,
     DEFAULT_INCLUDE_CRYPTO2CRYPTO,
     DEFAULT_INCLUDE_GAS_COSTS,
@@ -284,6 +285,7 @@ def test_writing_fetching_data(data_dir, username):
         'account_for_assets_movements': DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS,
         'btc_derivation_gap_limit': DEFAULT_BTC_DERIVATION_GAP_LIMIT,
         'calculate_past_cost_basis': DEFAULT_CALCULATE_PAST_COST_BASIS,
+        'display_date_in_localtime': DEFAULT_DISPLAY_DATE_IN_LOCALTIME,
     }
     assert len(expected_dict) == len(DBSettings()), 'One or more settings are missing'
 

--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -19,6 +19,7 @@ from rotkehlchen.utils.misc import (
     combine_stat_dicts,
     convert_to_int,
     iso8601ts_to_timestamp,
+    timestamp_to_date,
 )
 from rotkehlchen.utils.version_check import check_if_version_up_to_date
 
@@ -338,3 +339,8 @@ def test_generate_address_via_create2(
         init_code=HexStr(init_code),
     )
     assert contract_address == to_checksum_address(expected_contract_address)
+
+
+def test_timestamp_to_date():
+    date = timestamp_to_date(1611395717, formatstr='%d/%m/%Y %H:%M:%S %Z')
+    assert not date.endswith(' '), 'Make sure %Z empty string is removed'

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -96,8 +96,16 @@ def satoshis_to_btc(satoshis: Union[int, FVal]) -> FVal:
     return satoshis * FVal('0.00000001')
 
 
-def timestamp_to_date(ts: Timestamp, formatstr: str = '%d/%m/%Y %H:%M:%S') -> str:
-    return datetime.datetime.utcfromtimestamp(ts).strftime(formatstr)
+def timestamp_to_date(
+        ts: Timestamp,
+        formatstr: str = '%d/%m/%Y %H:%M:%S',
+        treat_as_local: bool = False,
+) -> str:
+    """Transforms a timestamp to a datesring depending on given formatstr and UTC/local choice"""
+    if treat_as_local is False:
+        return datetime.datetime.utcfromtimestamp(ts).strftime(formatstr)
+    # else localtime
+    return datetime.datetime.fromtimestamp(ts).strftime(formatstr)
 
 
 def from_wei(wei_value: FVal) -> FVal:

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -103,9 +103,12 @@ def timestamp_to_date(
 ) -> str:
     """Transforms a timestamp to a datesring depending on given formatstr and UTC/local choice"""
     if treat_as_local is False:
-        return datetime.datetime.utcfromtimestamp(ts).strftime(formatstr)
-    # else localtime
-    return datetime.datetime.fromtimestamp(ts).strftime(formatstr)
+        date = datetime.datetime.utcfromtimestamp(ts).strftime(formatstr)
+    else:  # localtime
+        date = datetime.datetime.fromtimestamp(ts).strftime(formatstr)
+
+    # Depending on the formatstr we could have empty strings at the end. Strip them.
+    return date.rstrip()
 
 
 def from_wei(wei_value: FVal) -> FVal:


### PR DESCRIPTION
Fix #2146

- The CSV export format should now respect the date display format option
- Added a new setting (now on by default) that if enabled will do all exports and most (not all yet) of the log outputs of dates in local format and not UTC. By changing the setting you can revert back to UTC