### PR TITLE
Bitcoin.de: Add BTC nominated trading pairs as well, closes #2168

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 * :bug:`2117` Users can now properly dismiss notifications with long tiles, or dismiss all the pending notifications at once.
 * :bug:`2024` Multiple crypto.com csv import debited entries with same timestamp will be handled correctly.
 * :bug:`2135` Users will now properly see the correct accounting settings when creating a profit/loss report.
-* :bug:`2168` Rokti was not able to import IOTA trades from Bitcoin.de.
+* :bug:`2168` Bitcoin.de users will now be able to properly import IOTA trades.
 
 * :release:`1.12.2 <2021-01-18>`
 * :bug:`2120` Rotki should now display the action datetime when editing a ledger action.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`2117` Users can now properly dismiss notifications with long tiles, or dismiss all the pending notifications at once.
 * :bug:`2024` Multiple crypto.com csv import debited entries with same timestamp will be handled correctly.
 * :bug:`2135` Users will now properly see the correct accounting settings when creating a profit/loss report.
+* :bug:`2168` Rokti was not able to import IOTA trades from Bitcoin.de.
 
 * :release:`1.12.2 <2021-01-18>`
 * :bug:`2120` Rotki should now display the action datetime when editing a ledger action.

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -10,7 +10,7 @@ import requests
 from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.errors import RemoteError, DeserializationError
+from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset
 from rotkehlchen.exchanges.data_structures import (
     AssetMovement,
     Location,
@@ -290,7 +290,7 @@ class Bitcoinde(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 continue
             try:
                 trades.append(trade_from_bitcoinde(tx))
-            except UnknownAsset as e: 
+            except UnknownAsset as e:
                 self.msg_aggregator.add_warning(
                     f'Found bitcoin.de trade with unknown asset '
                     f'{e.asset_name}. Ignoring it.',

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -41,7 +41,8 @@ log = RotkehlchenLogsAdapter(logger)
 # This corresponds to md5('') and is used in signature generation
 MD5_EMPTY_STR = 'd41d8cd98f00b204e9800998ecf8427e'
 
-# Pairs can be found in Basic API doc: https://www.bitcoin.de/de/api/marketplace
+# Pairs can be found in Basic API doc:
+# https://www.bitcoin.de/en/api/tapi/v4/docu#handelspaarliste_c2f
 BITCOINDE_TRADING_PAIRS = (
     'btceur',
     'bcheur',
@@ -49,6 +50,10 @@ BITCOINDE_TRADING_PAIRS = (
     'etheur',
     'bsveur',
     'ltceur',
+    'iotabtc',
+    'dashbtc',
+    'gntbtc',
+    'ltcbtc',
 )
 
 
@@ -57,8 +62,14 @@ def bitcoinde_asset(asset: str) -> Asset:
 
 
 def bitcoinde_pair_to_world(pair: str) -> Tuple[Asset, Asset]:
-    tx_asset = bitcoinde_asset(pair[:3])
-    native_asset = bitcoinde_asset(pair[3:])
+    if len(pair) == 6:
+        tx_asset = bitcoinde_asset(pair[:3])
+        native_asset = bitcoinde_asset(pair[3:])
+    elif len(pair) in (7, 8):
+        tx_asset = bitcoinde_asset(pair[:4])
+        native_asset = bitcoinde_asset(pair[4:])
+    else:
+        raise ValueError(f'Invalid pair: {pair}')
     return tx_asset, native_asset
 
 

--- a/rotkehlchen/tests/exchanges/test_bitcoinde.py
+++ b/rotkehlchen/tests/exchanges/test_bitcoinde.py
@@ -1,7 +1,10 @@
 from unittest.mock import patch
 
+import pytest
+
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.errors import DeserializationError, UnknownAsset
 from rotkehlchen.exchanges.bitcoinde import (
     BITCOINDE_TRADING_PAIRS,
     Bitcoinde,
@@ -80,3 +83,11 @@ def test_query_trade_history(function_scope_bitcoinde):
 def test_bitcoinde_trading_pairs():
     for pair in BITCOINDE_TRADING_PAIRS:
         _ = bitcoinde_pair_to_world(pair)
+
+
+def test_bitcoinde_invalid_trading_pair():
+    with pytest.raises(UnknownAsset):
+        _ = bitcoinde_pair_to_world('000btc')
+
+    with pytest.raises(DeserializationError):
+        _ = bitcoinde_pair_to_world('invalidpair')


### PR DESCRIPTION
This will enable the IOTA pair to be recognized. I can't test this because I don't have any IOTA in Bitcoin.de. But all pairs will be checked during the tests. 

There is no special mapping required. The "IOT" error came from wrong parsing of the pair string and is fixed with this PR.