### PR TITLE
Do not include yearn events out of PnL report range

### DIFF
--- a/rotkehlchen/history/trades.py
+++ b/rotkehlchen/history/trades.py
@@ -242,12 +242,14 @@ class TradesHistorian():
                 for _, vault_history in vault_mappings.items():
                     # For the vaults since we can't get historical values of vault tokens
                     # yet, for the purposes of the tax report count everything as USD
-                    defi_events.append(DefiEvent(
-                        timestamp=Timestamp(end_ts - 1),
-                        event_type=DefiEventType.YEARN_VAULTS_PNL,
-                        asset=A_USD,
-                        amount=vault_history.profit_loss.usd_value,
-                    ))
+                    for yearn_event in vault_history.events:
+                        if start_ts <= yearn_event.timestamp <= end_ts and yearn_event.realized_pnl is not None:  # noqa: E501
+                            defi_events.append(DefiEvent(
+                                timestamp=yearn_event.timestamp,
+                                event_type=DefiEventType.YEARN_VAULTS_PNL,
+                                asset=A_USD,
+                                amount=yearn_event.realized_pnl.usd_value,
+                            ))
 
         # include compound events
         if self.chain_manager.compound and has_premium:

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -1,9 +1,8 @@
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants.assets import A_BTC
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
 from rotkehlchen.externalapis.coingecko import CoingeckoAssetData, CoingeckoImageURLs
-from rotkehlchen.typing import Price
 from rotkehlchen.fval import FVal
-from rotkehlchen.constants.assets import A_ETH, A_EUR
+from rotkehlchen.typing import Price
 
 
 def assert_coin_data_same(given, expected, compare_description=False):
@@ -46,7 +45,7 @@ def test_asset_data(session_coingecko):
         ),
     )
     data = session_coingecko.asset_data(Asset('YFI'))
-    assert_coin_data_same(data, expected_data, compare_description=True)
+    assert_coin_data_same(data, expected_data, compare_description=False)
 
 
 def test_coingecko_historical_price(session_coingecko):

--- a/rotkehlchen/tests/integration/test_backend.py
+++ b/rotkehlchen/tests/integration/test_backend.py
@@ -19,8 +19,11 @@ def test_backend():
     timeout = 10
     with gevent.Timeout(timeout):
         try:
-            output = proc.stdout.readline().decode('utf-8')
-            assert 'Rotki API server is running at' in output
+            while True:
+                output = proc.stdout.readline().decode('utf-8')
+                if 'Rotki API server is running at' in output:
+                    break
+
             url = f'http://{output.split()[-1]}/api/1/version'
             response = requests.get(url)
             assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
Rotki should now properly only include yearn vault events within the requested time range for the PnL report.