### PR TITLE
Add new token IHF (Invictus Hyperion Fund)

### DIFF
--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -6293,6 +6293,16 @@
         "symbol": "IGNIS",
         "type": "ardor token"
     },
+    "IHF": {
+        "coingecko": "invictus-hyprion-fund",
+        "cryptocompare": "",
+        "ethereum_address": "0xaF1250fa68D7DECD34fD75dE8742Bc03B29BD58e",
+        "ethereum_token_decimals": 18,
+        "name": "Invictus Hyperion Fund",
+        "started": 1526394640,
+        "symbol": "IHF",
+        "type": "ethereum token"
+    },
     "IHT": {
         "coingecko": "iht-real-estate-protocol",
         "ethereum_address": "0xEda8B016efA8b1161208Cf041cD86972eeE0F31E",

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "931775d33b57e0431c85538d658caa08", "version": 45}
+{"md5": "ad98cf96cf31804c286acb0a6367814e", "version": 46}


### PR DESCRIPTION
Note: coingecko uses a misspelled token ID: "hyperion" is missing the "e".

The coingecko and cryptocompare URLs are

https://api.coingecko.com/api/v3/coins/invictus-hyprion-fund
https://min-api.cryptocompare.com/data/pricehistorical?fsym=IHF&tsyms=USD