### PR TITLE
Handle rare cases of bittrex deposit/withdrawals with an integer as transaction id

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :bug:`2024` Multiple crypto.com csv import debited entries with same timestamp will be handled correctly.
 * :bug:`2135` Users will now properly see the correct accounting settings when creating a profit/loss report.
 * :bug:`2168` Bitcoin.de users will now be able to properly import IOTA trades.
+* :bug:`2175` Bittrex users with deposits/withdrawals of some edge case assets will now be able to properly process them.
 
 * :release:`1.12.2 <2021-01-18>`
 * :bug:`2120` Rotki should now display the action datetime when editing a ledger action.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1907,6 +1907,16 @@ class DBHandler:
                 except sqlcipher.InterfaceError:  # pylint: disable=no-member
                     log.critical(f'Interface error with tuple: {entry}')
 
+        except OverflowError:
+            self.msg_aggregator.add_error(
+                f'Failed to add "{tuple_type}" to the DB with overflow error. '
+                f'Check the logs for more details',
+            )
+            log.error(
+                f'Overflow error while trying to add "{tuple_type}" tuples to the'
+                f' DB. Tuples: {tuples} with query: {query}',
+            )
+
         self.conn.commit()
         self.update_last_write()
 

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -506,8 +506,8 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
         address = None
         transaction_id = None
         if fee_asset.is_fiat() is False:
-            address = raw_result[16]
-            transaction_id = raw_result[20]
+            address = str(raw_result[16])
+            transaction_id = str(raw_result[20])
 
         asset_movement = AssetMovement(
             timestamp=Timestamp(int(raw_result[5] / 1000)),

--- a/rotkehlchen/exchanges/utils.py
+++ b/rotkehlchen/exchanges/utils.py
@@ -7,10 +7,14 @@ from rotkehlchen.constants.assets import A_ETH
 
 
 def get_key_if_has_val(mapping: Dict[str, Any], key: str) -> Optional[str]:
-    """Gets the key from mapping if it exists and has a value (non empty string)"""
+    """Gets the key from mapping if it exists and has a value (non empty string)
+
+    The assumption here is that the value of the key is str. If it's not str
+    then this function will attempt to turn it into one.
+    """
     val = mapping.get(key, None)
     # empty string has falsy value
-    return val if val else None
+    return str(val) if val else None
 
 
 def deserialize_asset_movement_address(

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -78,7 +78,7 @@ class TaskManager():
             self.premium_sync_manager.maybe_upload_data_to_server,
             self._maybe_schedule_xpub_derivation,
             self._maybe_query_ethereum_transactions,
-            self._maybe_schedule_exchange_trade_query,
+            self._maybe_schedule_exchange_history_query,
         ]
 
     def _prepare_cryptocompare_queries(self) -> None:
@@ -202,8 +202,8 @@ class TaskManager():
         )
         self.last_eth_tx_query_ts[address] = now
 
-    def _maybe_schedule_exchange_trade_query(self) -> None:
-        """Schedules the exchange trades history query task if enough time has passed"""
+    def _maybe_schedule_exchange_history_query(self) -> None:
+        """Schedules the exchange history query task if enough time has passed"""
         if len(self.exchange_manager.connected_exchanges) == 0:
             return
 
@@ -216,7 +216,7 @@ class TaskManager():
             return
 
         exchange = random.choice(queriable_exchanges)
-        task_name = f'Query trades of {exchange.name} exchange'
+        task_name = f'Query history of {exchange.name} exchange'
         logger.debug(f'Scheduling task to {task_name}')
         self.greenlet_manager.spawn_and_track(
             after_seconds=None,

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -124,7 +124,7 @@ def test_maybe_schedule_xpub_derivation(task_manager, database):
 
 def test_maybe_schedule_exchange_query(task_manager, exchange_manager, poloniex):
     now = ts_now()
-    task_manager.potential_tasks = [task_manager._maybe_schedule_exchange_trade_query]
+    task_manager.potential_tasks = [task_manager._maybe_schedule_exchange_history_query]
 
     def mock_query_history(start_ts, end_ts):
         assert start_ts == 0


### PR DESCRIPTION
Fix #2175 

[Bittrex's api](https://bittrex.github.io/api/v3#definition-Order) states that a deposit/withdrawal's transaction id should always be a string.

But as seen by a user in #2175 that can in some rare cases be an integer which goes against their docs.

This PR handles that.