### PR TITLE
Amended GET current asset price, now it uses Inquirer().find_price

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -805,7 +805,7 @@ Query the current price of assets
 
 .. http:get:: /api/(version)/assets/prices/current
 
-   Querying this endpoint with a list of assets and a target asset will return a dictionary with the the price of the assets in the target asset currency. Providing an empty list or no target asset is an error.
+   Querying this endpoint with a list of assets and a target asset will return an object with the the price of the assets in the target asset currency. Providing an empty list or no target asset is an error.
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``.
@@ -820,11 +820,11 @@ Query the current price of assets
       {
           "assets": ["BTC", "ETH", "LINK", "USD", "EUR"],
           "target_asset": "USD",
-	  "ignore_cache": true,
+	      "ignore_cache": true
       }
 
-   :reqjson list assets: A list of assets to query their current price
-   :reqjson string target_asset: The asset of the price currency
+   :reqjson list assets: A list of assets to query their current price.
+   :reqjson string target_asset: The target asset against which to return the price of each asset in the list.
    :reqjson bool async_query: A boolean denoting whether the query should be made asynchronously or not. Missing defaults to false.
    :reqjson bool ignore_cache: A boolean denoting whether to ignore the current price query cache. Missing defaults to false.
 
@@ -852,7 +852,7 @@ Query the current price of assets
 
    :resjson object result: A JSON object that contains the price of the assets in the target asset currency.
    :resjson object assets: A map between an asset and its price.
-   :resjson string target_asset: The currency of the prices.
+   :resjson string target_asset: The target asset against which to return the price of each asset in the list.
    :statuscode 200: The USD prices have been sucesfully returned
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 500: Internal Rotki error
@@ -903,7 +903,7 @@ Query the historical price of assets
 
 .. http:get:: /api/(version)/assets/prices/historical
 
-   Querying this endpoint with a list of asset\/timestamp lists and a target asset will return a dictionary with the price of the assets at the given timestamp in the target asset currency. Providing an empty list or no target asset is an error.
+   Querying this endpoint with a list of lists of asset and timestamp, and a target asset will return an object with the price of the assets at the given timestamp in the target asset currency. Providing an empty list or no target asset is an error.
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``.
@@ -920,8 +920,8 @@ Query the historical price of assets
           "target_asset": "USD"
        }
 
-   :reqjson list assets_timestamp: A list of asset\/timestamp lists
-   :reqjson string target_asset: The asset of the price currency
+   :reqjson list assets_timestamp: A list of lists of asset and timestamp
+   :reqjson string target_asset: The target asset against which to return the price of each asset in the list
 
    **Example Response**:
 
@@ -951,7 +951,7 @@ Query the historical price of assets
 
    :resjson object result: A JSON object that contains the price of each asset for the given timestamp in the target asset currency.
    :resjson object assets: A map between an asset and a map that contains the asset price at the specific timestamp.
-   :resjson string target_asset: The currency of the prices.
+   :resjson string target_asset: The target asset against which to return the price of each asset in the list.
    :statuscode 200: The historical USD prices have been sucesfully returned
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 500: Internal Rotki error

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -820,7 +820,7 @@ Query the current price of assets
       {
           "assets": ["BTC", "ETH", "LINK", "USD", "EUR"],
           "target_asset": "USD",
-	      "ignore_cache": true
+          "ignore_cache": true
       }
 
    :reqjson list assets: A list of assets to query their current price.
@@ -1597,7 +1597,7 @@ Querying onchain balances
 
 .. http:get:: /api/(version)/balances/blockchains/(blockchain)/
 
-   Doing a GET on the blockchains balances endpoint will query on-chain balances for the accounts of the user. Doing a GET on a specific blockchain will query balances only for that chain. Available blockchain names are: ``BTC`` and ``ETH``.
+   Doing a GET on the blockchains balances endpoint will query on-chain balances for the accounts of the user. Doing a GET on a specific blockchain will query balances only for that chain. Available blockchain names are: ``BTC``, ``ETH`` and ``KSM``.
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``. Passing it as a query argument here would be given as: ``?async_query=true``.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -48,7 +48,7 @@ from rotkehlchen.chain.bitcoin.xpub import XpubManager
 from rotkehlchen.chain.ethereum.airdrops import check_airdrops
 from rotkehlchen.chain.ethereum.trades import AMMTrade, AMMTradeLocations
 from rotkehlchen.chain.ethereum.transactions import FREE_ETH_TX_LIMIT
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_USD
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.db.queried_addresses import QueriedAddresses
@@ -80,11 +80,11 @@ from rotkehlchen.premium.premium import PremiumCredentials
 from rotkehlchen.rotkehlchen import FREE_ASSET_MOVEMENTS_LIMIT, FREE_TRADES_LIMIT, Rotkehlchen
 from rotkehlchen.serialization.serialize import process_result, process_result_list
 from rotkehlchen.typing import (
+    AVAILABLE_MODULES,
     ApiKey,
     ApiSecret,
     AssetAmount,
     BlockchainAccountData,
-    AVAILABLE_MODULES,
     ChecksumEthAddress,
     EthereumTransaction,
     ExternalService,
@@ -2338,16 +2338,16 @@ class RestAPI():
             f'Querying the current {target_asset.identifier} price of these assets: '
             f'{", ".join([asset.identifier for asset in assets])}',
         )
-        assets_price = {
-            asset: Inquirer().find_usd_price(asset, ignore_cache=ignore_cache) for asset in assets
-        }
-        if target_asset != A_USD:
-            target_asset_price = Inquirer().find_usd_price(target_asset, ignore_cache=ignore_cache)
-            for asset in assets_price.keys():
-                if asset != target_asset:
-                    assets_price[asset] = Price(assets_price[asset] / target_asset_price)
-                else:
-                    assets_price[asset] = Price(FVal('1'))
+        assets_price = {}
+        for asset in assets:
+            if asset != target_asset:
+                assets_price[asset] = Inquirer().find_price(
+                    from_asset=asset,
+                    to_asset=target_asset,
+                    ignore_cache=ignore_cache,
+                )
+            else:
+                assets_price[asset] = Price(FVal('1'))
 
         result = {
             'assets': assets_price,

--- a/rotkehlchen/chain/substrate/typing.py
+++ b/rotkehlchen/chain/substrate/typing.py
@@ -16,15 +16,12 @@ class KusamaNodeName(Enum):
     """
     OWN = 0
     PARITY = 1
-    WEB3_FOUNDATION = 2
 
     def __str__(self) -> str:
         if self == KusamaNodeName.OWN:
             return 'own node'
         if self == KusamaNodeName.PARITY:
             return 'parity'
-        if self == KusamaNodeName.WEB3_FOUNDATION:
-            return 'web3 foundation'
         raise AssertionError(f'Unexpected KusamaNodeName: {self}')
 
     def endpoint(self) -> str:
@@ -35,8 +32,6 @@ class KusamaNodeName(Enum):
             )
         if self == KusamaNodeName.PARITY:
             return 'https://kusama-rpc.polkadot.io/'
-        if self == KusamaNodeName.WEB3_FOUNDATION:
-            return 'wss://cc3-5.kusama.network/'
         raise AssertionError(f'Unexpected KusamaNodeName: {self}')
 
 

--- a/rotkehlchen/chain/substrate/utils.py
+++ b/rotkehlchen/chain/substrate/utils.py
@@ -12,7 +12,6 @@ from .typing import (
 KUSAMA_NODES_TO_CONNECT_AT_START = (
     KusamaNodeName.OWN,
     KusamaNodeName.PARITY,
-    KusamaNodeName.WEB3_FOUNDATION,
 )
 KUSAMA_NODE_CONNECTION_TIMEOUT = 10
 

--- a/rotkehlchen/tests/api/test_current_assets_price.py
+++ b/rotkehlchen/tests/api/test_current_assets_price.py
@@ -13,9 +13,8 @@ from rotkehlchen.tests.utils.api import (
 
 
 @pytest.mark.parametrize('mocked_current_prices', [{
-    'BTC': FVal('33183.98'),
-    'USD': FVal('1'),
-    'GBP': FVal('1.367'),
+    ('BTC', 'USD'): FVal('33183.98'),
+    ('GBP', 'USD'): FVal('1.367'),
 }])
 def test_get_current_assets_price_in_usd(rotkehlchen_api_server):
     async_query = random.choice([False, True])
@@ -44,9 +43,8 @@ def test_get_current_assets_price_in_usd(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('mocked_current_prices', [{
-    'BTC': FVal('33183.98'),
-    'USD': FVal('1'),
-    'GBP': FVal('1.367'),
+    ('USD', 'BTC'): FVal('0.00003013502298398202988309419184'),
+    ('GBP', 'BTC'): FVal('0.00004119457641910343485018976024'),
 }])
 def test_get_current_assets_price_in_btc(rotkehlchen_api_server):
 

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -171,6 +171,15 @@ def create_inquirer(
     if not should_mock_current_price_queries:
         return inquirer
 
+    def mock_find_price(
+            from_asset,
+            to_asset,
+            ignore_cache: bool = False,  # pylint: disable=unused-argument
+    ):
+        return mocked_prices.get((from_asset, to_asset), FVal('1.5'))
+
+    inquirer.find_price = mock_find_price  # type: ignore
+
     def mock_find_usd_price(asset, ignore_cache: bool = False):  # pylint: disable=unused-argument
         return mocked_prices.get(asset, FVal('1.5'))
 


### PR DESCRIPTION
Addresses the following (and pending) suggestions and issues from #2149 
- documentation (e.g. target_asset description, dictionary word)
- Usage of `Inquirer().find_usd_price`.
