### PR TITLE
Don't allow zero amounts to make it in sell events during accounting

### DIFF
--- a/.github/workflows/rotki_packaging.yaml
+++ b/.github/workflows/rotki_packaging.yaml
@@ -34,6 +34,7 @@ jobs:
             - **Linux**
               - [AppImage](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x86_64-${{ env.RELEASE_VERSION }}.AppImage)
               - [Tar with executable](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x64-${{ env.RELEASE_VERSION }}.tar.xz)
+              - [deb package](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_amd64-${{ env.RELEASE_VERSION }}.deb)
             - **OSX**
               - [DMG](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin-${{ env.RELEASE_VERSION }}.dmg)
               - [ZIP](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin-${{ env.RELEASE_VERSION }}.zip)
@@ -45,6 +46,7 @@ jobs:
             - **Linux**
               - [AppImage checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x86_64-${{ env.RELEASE_VERSION }}.AppImage.sha512)
               - [Tar with executable checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x64-${{ env.RELEASE_VERSION }}.tar.xz.sha512)
+              - [deb package](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_amd64-${{ env.RELEASE_VERSION }}.deb.sha512)
             - **OSX**
               - [DMG checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin-${{ env.RELEASE_VERSION }}.dmg.sha512)
               - [ZIP checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin-${{ env.RELEASE_VERSION }}.zip.sha512)

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -270,6 +270,12 @@ class TaxableEvents():
             gain_in_profit_currency = with_bought_asset_gain
 
         sold_amount = trade_rate * bought_amount
+        if sold_amount == ZERO:
+            logger.error(
+                f'Not adding a virtual sell event. Could not calculate it from '
+                f'trade_rate * bought_amount = {trade_rate} * {bought_amount}',
+            )
+            return
 
         sold_asset_rate_in_profit_currency = self.get_rate_in_profit_currency(
             paid_with_asset,
@@ -491,6 +497,14 @@ class TaxableEvents():
             receiving_asset and not receiving_asset.is_fiat()
         )
         if skip_trade:
+            return
+
+        if selling_amount == ZERO:
+            logger.error(
+                f'Skipping sell trade of {selling_asset.identifier} for '
+                f'{receiving_asset.identifier if receiving_asset else "nothing"} at {timestamp}'
+                f' since the selling amount is 0',
+            )
             return
 
         logger.debug(

--- a/rotkehlchen/chain/ethereum/adex/adex.py
+++ b/rotkehlchen/chain/ethereum/adex/adex.py
@@ -902,7 +902,14 @@ class Adex(EthereumModule):
 
         # Update token property for each channel withdraw event
         for channel_withdraw in channel_withdraws:
-            channel_withdraw.token = channel_id_token.get(channel_withdraw.channel_id, None)
+            token = channel_id_token.get(channel_withdraw.channel_id, None)
+            if token is None:
+                log.error(
+                    f'Could not find a channel in the channel id to token mapping.'
+                    f'Channel withdraw with tx_hash {channel_withdraw.tx_hash} '
+                    f'will have no token and usd value',
+                )
+            channel_withdraw.token = token
 
         return None
 

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -449,6 +449,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                         is_result_timesamp_gt_end_ts = True  # prevent extra request
                         break
 
+                    log.debug(f'Attempting to deserialize bitstamp {case_pretty}: {raw_result}')
                     result = deserialization_method(raw_result)
 
                 except DeserializationError as e:

--- a/rotkehlchen/tests/api/test_adex.py
+++ b/rotkehlchen/tests/api/test_adex.py
@@ -17,7 +17,6 @@ from rotkehlchen.tests.utils.api import (
     assert_simple_ok_response,
     wait_for_async_task,
 )
-from rotkehlchen.constants.assets import A_ADX
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
 from rotkehlchen.chain.ethereum.adex.typing import Bond, ChannelWithdraw, Unbond
@@ -144,6 +143,7 @@ def test_get_events(
     identity_address = '0x2a6c38D16BFdc7b4a20f1F982c058F07BDCe9204'
     tom_pool_id = '0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28'
     bond_id = '0x540cab9883923c01e657d5da4ca5674b6e4626b4a148224635495502d674c7c5'
+    channel_id = '0x30d87bab0ef1e7f8b4c3b894ca2beed41bbd54c481f31e5791c1e855c9dbf4ba'
     result = result[ADEX_TEST_ADDR]
     expected_events = [Bond(
         tx_hash='0x9989f47c6c0a761f98f910ac24e2438d858be96c12124a13be4bb4b3150c55ea',
@@ -160,10 +160,10 @@ def test_get_events(
         address=ADEX_TEST_ADDR,
         identity_address=identity_address,
         timestamp=1607453764,
-        channel_id='',
+        channel_id=channel_id,
         pool_id=tom_pool_id,
-        value=Balance(FVal('5056.894263641728544592'), FVal('10113.788527283457089184')),
-        token=A_ADX,
+        value=Balance(FVal('5056.894263641728544592'), FVal('0')),
+        token=None,
     ), Unbond(
         tx_hash='0xa9ee91af823c0173fc5ada908ff9fe3f4d7c84a2c9da795f0889b3f4ace75b13',
         address=ADEX_TEST_ADDR,


### PR DESCRIPTION
If a zero amount makes it into a sell even during accounting then an error is logged and it is skipped. This should avoid the division by zero error seen in #2220 

Also:

- Adds the debian package to the built binary template
- Adds a debug log for each raw bistramp trade/asset movement.