### PR TITLE
Ledger action CSV exports asset identifier and not name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2215` Ledger action CSV export now contains identifier and not asset name.
 * :bug:`2223` Manual balances with the blockchain tag will no longer be duplicated in the dashboard and blockchain account balances.
 
 * :release:`1.13.0 <2021-01-29>`

--- a/rotkehlchen/csv_exporter.py
+++ b/rotkehlchen/csv_exporter.py
@@ -504,7 +504,7 @@ class CSVExporter():
             'time': self.timestamp_to_date(action.timestamp),
             'type': str(action.action_type),
             'location': str(action.location),
-            'asset': str(action.asset),
+            'asset': action.asset.identifier,
             'amount': str(action.amount),
             f'profit_loss_in_{self.profit_currency.identifier}': profit_loss_in_profit_currency,
         })


### PR DESCRIPTION
Fix #2215 