### PR TITLE
Properly add api key arg for cryptocompare in case of no other args

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2244` Fix edge case where using a cryptocompare api key could result in the all coins endpoint to error if no cache already existed.
 * :bug:`2215` Ledger action CSV export now contains identifier and not asset name.
 * :bug:`2223` Manual balances with the blockchain tag will no longer be duplicated in the dashboard and blockchain account balances.
 

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -312,7 +312,8 @@ class Cryptocompare(ExternalServiceWithApiKey):
         log.debug('Querying cryptocompare', url=querystr)
         api_key = self._get_api_key()
         if api_key:
-            querystr += f'&api_key={api_key}'
+            querystr += '?' if '?' not in querystr else '&'
+            querystr += f'api_key={api_key}'
 
         tries = CRYPTOCOMPARE_QUERY_RETRY_TIMES
         while tries >= 0:

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -429,3 +429,17 @@ def test_keep_special_histohour_cases_up_to_date(cryptocompare):
                 f'with a smaller timestamp.'
             )
             test_warnings.warn(UserWarning(warning_msg))
+
+
+@pytest.mark.parametrize('include_cryptocompare_key', [True])
+def test_cryptocompare_query_with_api_key(cryptocompare):
+    """Just try to query cryptocompare endpoints with an api key
+
+    Regression test for https://github.com/rotki/rotki/issues/2244
+    """
+    # call to an endpoint without any args
+    response = cryptocompare._api_query('v2/news/')
+    assert response and isinstance(response, list)
+    # call to endpoint with args
+    price = cryptocompare.query_current_price(A_ETH, A_USD)
+    assert price is not None


### PR DESCRIPTION
Fix #2244 