### PR TITLE
Fixes text wrapping on various tables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Users will now see the total worth contained in the card for bigger amounts.
+* :bug:`2239` Amounts in the dashboard should now appear in single line for users.
 * :bug:`2244` Fix edge case where using a cryptocompare api key could result in the all coins endpoint to error if no cache already existed.
 * :bug:`2215` Ledger action CSV export now contains identifier and not asset name.
 * :bug:`2223` Manual balances with the blockchain tag will no longer be duplicated in the dashboard and blockchain account balances.

--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -166,7 +166,8 @@ export default class DashboardAssetTable extends Vue {
     return [
       {
         text: this.$tc('dashboard_asset_table.headers.asset'),
-        value: 'asset'
+        value: 'asset',
+        cellClass: 'asset-info'
       },
       {
         text: this.$t('dashboard_asset_table.headers.price', {
@@ -180,20 +181,22 @@ export default class DashboardAssetTable extends Vue {
         text: this.$tc('dashboard_asset_table.headers.amount'),
         value: 'amount',
         align: 'end',
-        width: '100%'
+        cellClass: 'asset-divider'
       },
       {
         text: this.$t('dashboard_asset_table.headers.value', {
           symbol: this.currencySymbol ?? CURRENCY_USD
         }).toString(),
         value: 'usdValue',
-        align: 'end'
+        align: 'end',
+        class: 'text-no-wrap'
       },
       {
         text: this.$tc('dashboard_asset_table.headers.percentage'),
         value: 'percentage',
         align: 'end',
-        width: '120px',
+        cellClass: 'asset-percentage',
+        class: 'text-no-wrap',
         sortable: false
       }
     ];
@@ -206,6 +209,30 @@ export default class DashboardAssetTable extends Vue {
 </script>
 
 <style scoped lang="scss">
+::v-deep {
+  .asset-divider {
+    width: 100%;
+
+    @media (min-width: 2000px) {
+      width: 50%;
+    }
+  }
+
+  .asset-info {
+    @media (min-width: 2000px) {
+      width: 300px;
+    }
+  }
+
+  .asset-percentage {
+    width: 120px;
+
+    @media (min-width: 2000px) {
+      width: 200px;
+    }
+  }
+}
+
 .dashboard-asset-table {
   &__search {
     max-width: 450px;

--- a/frontend/app/src/components/display/AmountDisplay.vue
+++ b/frontend/app/src/components/display/AmountDisplay.vue
@@ -31,7 +31,11 @@
         "
       >
         <template #activator="{ on, attrs }">
-          <span class="amount-display__value" v-bind="attrs" v-on="on">
+          <span
+            class="amount-display__value text-no-wrap"
+            v-bind="attrs"
+            v-on="on"
+          >
             {{ formattedValue }}
           </span>
         </template>

--- a/frontend/app/src/components/helper/AssetDetails.vue
+++ b/frontend/app/src/components/helper/AssetDetails.vue
@@ -6,7 +6,12 @@
         {{ symbol }}
       </span>
       <span class="grey--text asset-details__details__subtitle">
-        {{ name }}
+        <v-tooltip open-delay="400" top :disabled="$vuetify.breakpoint.lgAndUp">
+          <template #activator="{ on, attrs }">
+            <span v-bind="attrs" v-on="on">{{ name }}</span>
+          </template>
+          <span> {{ fullName }}</span>
+        </v-tooltip>
       </span>
     </span>
   </span>
@@ -39,9 +44,27 @@ export default class AssetDetails extends Vue {
     return details ? details.symbol : this.asset;
   }
 
-  get name(): string {
+  get fullName(): string {
     const details = this.details;
     return details ? details.name : this.asset;
+  }
+
+  get name(): string {
+    const name = this.fullName;
+
+    const truncLength = 7;
+    const xsOnly = this.$vuetify.breakpoint.mdAndDown;
+    const length = name.length;
+
+    if (!xsOnly || (length <= truncLength * 2 && xsOnly)) {
+      return name;
+    }
+
+    return (
+      name.slice(0, truncLength) +
+      '...' +
+      name.slice(length - truncLength, length)
+    );
   }
 
   get details(): SupportedAsset {

--- a/frontend/app/src/components/settings/AccountAssetBalances.vue
+++ b/frontend/app/src/components/settings/AccountAssetBalances.vue
@@ -83,24 +83,32 @@ import { AssetBalances, AssetPrices } from '@/store/balances/types';
 export default class AccountAssetBalances extends Vue {
   readonly footerProps = footerProps;
   readonly headers = [
-    { text: this.$tc('account_asset_balance.headers.asset'), value: 'asset' },
+    {
+      text: this.$tc('account_asset_balance.headers.asset'),
+      class: 'text-no-wrap',
+      value: 'asset',
+      cellClass: 'asset-info'
+    },
     {
       text: this.$t('account_asset_balance.headers.price', {
         symbol: CURRENCY_USD
       }).toString(),
+      class: 'text-no-wrap',
+      align: 'end',
       value: 'price'
     },
     {
       text: this.$tc('account_asset_balance.headers.amount'),
       value: 'amount',
-      width: '100%',
+      class: 'text-no-wrap',
+      cellClass: 'asset-divider',
       align: 'end'
     },
     {
       text: this.$tc('account_asset_balance.headers.value'),
       value: 'usdValue',
       align: 'end',
-      cellClass: 'user-holding user-asset-value'
+      class: 'text-no-wrap'
     }
   ];
 
@@ -118,12 +126,18 @@ export default class AccountAssetBalances extends Vue {
 
 <style scoped lang="scss">
 ::v-deep {
-  .user-holding {
-    background-color: rgba(226, 226, 227, 0.2);
+  .asset-divider {
+    width: 100%;
+
+    @media (min-width: 2000px) {
+      width: 50%;
+    }
   }
 
-  .user-asset-value {
-    min-width: 150px;
+  .asset-info {
+    @media (min-width: 2000px) {
+      width: 200px;
+    }
   }
 }
 

--- a/frontend/app/src/components/settings/AssetBalances.vue
+++ b/frontend/app/src/components/settings/AssetBalances.vue
@@ -128,19 +128,24 @@ export default class AssetBalances extends Vue {
     return [
       {
         text: this.$t('asset_balances.headers.asset').toString(),
-        value: 'asset'
+        value: 'asset',
+        class: 'text-no-wrap',
+        cellClass: 'asset-info'
       },
       {
         text: this.$t('asset_balances.headers.price', {
           symbol: this.symbol ?? CURRENCY_USD
         }).toString(),
-        value: 'price'
+        value: 'price',
+        align: 'end',
+        class: 'text-no-wrap'
       },
       {
         text: this.$t('asset_balances.headers.amount').toString(),
         value: 'amount',
         align: 'end',
-        width: '100%'
+        class: 'text-no-wrap',
+        cellClass: 'asset-divider'
       },
       {
         text: this.$t('asset_balances.headers.value', {
@@ -148,7 +153,8 @@ export default class AssetBalances extends Vue {
         }).toString(),
         value: 'usdValue',
         align: 'end',
-        cellClass: 'user-asset-value'
+        cellClass: 'user-asset-value',
+        class: 'text-no-wrap'
       }
     ];
   }
@@ -157,8 +163,18 @@ export default class AssetBalances extends Vue {
 
 <style scoped lang="scss">
 ::v-deep {
-  .user-asset-value {
-    min-width: 150px;
+  .asset-divider {
+    width: 100%;
+
+    @media (min-width: 2000px) {
+      width: 50%;
+    }
+  }
+
+  .asset-info {
+    @media (min-width: 2000px) {
+      width: 200px;
+    }
   }
 }
 


### PR DESCRIPTION
- Amounts should not wrap anymore
- Asset info should truncate on smaller screen sizes
- Asset tables now have a bit more space between columns on larger screens

Closes #2239