### PR TITLE
Use POST instead of GET for historical asset price endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -901,7 +901,7 @@ Query the current exchange rate for select assets
 Query the historical price of assets
 ======================================
 
-.. http:get:: /api/(version)/assets/prices/historical
+.. http:post:: /api/(version)/assets/prices/historical
 
    Querying this endpoint with a list of lists of asset and timestamp, and a target asset will return an object with the price of the assets at the given timestamp in the target asset currency. Providing an empty list or no target asset is an error.
 
@@ -912,7 +912,7 @@ Query the historical price of assets
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/assets/prices/historical HTTP/1.1
+      POST /api/1/assets/prices/historical HTTP/1.1
       Host: localhost:5042
 
        {

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1281,10 +1281,10 @@ class CurrentAssetsPriceResource(BaseResource):
 
 class HistoricalAssetsPriceResource(BaseResource):
 
-    get_schema = HistoricalAssetsPriceSchema()
+    post_schema = HistoricalAssetsPriceSchema()
 
-    @use_kwargs(get_schema, location='json_and_query')  # type: ignore
-    def get(
+    @use_kwargs(post_schema, location='json')  # type: ignore
+    def post(
             self,
             assets_timestamp: List[Tuple[Asset, Timestamp]],
             target_asset: Asset,

--- a/rotkehlchen/tests/api/test_historical_assets_price.py
+++ b/rotkehlchen/tests/api/test_historical_assets_price.py
@@ -33,7 +33,7 @@ def test_get_historical_assets_price(rotkehlchen_api_server):
     at the given timestamp.
     """
     async_query = random.choice([False, True])
-    response = requests.get(
+    response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
             "historicalassetspriceresource",


### PR DESCRIPTION
Reason being the formulation of the query string is hard (we don't
know how to and would need to spend time to look it up) with nested arrays.