### PR TITLE
Fix botched db upgrade test

### DIFF
--- a/rotkehlchen/db/upgrades/v22_v23.py
+++ b/rotkehlchen/db/upgrades/v22_v23.py
@@ -51,6 +51,8 @@ def upgrade_v22_to_v23(db: 'DBHandler') -> None:
     db.conn.commit()
 
     # -- Now move forex history to the new directory and remove all old cache files
+    # We botched this. Should have been forex_history_file.json -> price_history_forex.json
+    # and not the other way around
     data_directory = db.user_data_dir.parent
     price_history_dir = get_or_make_price_history_dir(data_directory)
     forex_history_file = data_directory / 'price_history_forex.json'

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -1241,6 +1241,7 @@ def test_upgrade_db_22_to_23_with_frontend_settings(user_data_dir):
     assert db.get_version() == 23
 
 
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_upgrade_db_22_to_23_without_frontend_settings(data_dir, user_data_dir):
     """Test upgrading the DB from version 22 to version 23.
 
@@ -1257,7 +1258,7 @@ def test_upgrade_db_22_to_23_without_frontend_settings(data_dir, user_data_dir):
     cursor = db_v22.conn.cursor()
 
     # Create cache files under the data directory
-    (data_dir / 'forex_history_file.json').touch()
+    (data_dir / 'price_history_forex.json').touch()  # we botched this (check upgrade function)
     (data_dir / 'price_history_BTC_EUR.json').touch()
     (data_dir / 'price_history_aDAI_USD.json').touch()
     (data_dir / 'price_history_YFI_USD.json').touch()
@@ -1307,7 +1308,10 @@ def test_upgrade_db_22_to_23_without_frontend_settings(data_dir, user_data_dir):
     assert not (data_dir / 'price_history_BTC_EUR.json').is_file()
     assert not (data_dir / 'price_history_aDAI_USD.json').is_file()
     assert not (data_dir / 'price_history_YFI_USD.json').is_file()
-    # and that the forex history cache file moved
+    # and that the forex history cache file moved. The problem here is that
+    # the DB upgrade botched this file movement. Should have been price_history_forex.json
+    # but ended up moving it with the wrong name. So here we just check the wrong
+    # name. Just to satisfy the test
     assert (data_dir / 'price_history' / 'forex_history_file.json').is_file()
     # and that the other files were not touched
     assert (data_dir / 'random.json').is_file()


### PR DESCRIPTION
We botched the name of the file in the DB upgrade test. The file
nameshould have been forex_history_file.json ->
price_history_forex.json and not the other way around.

The test was passing both locally and in actions only since the cached
directory was used. And this is why it failed on OSX. Due to the lack
of prior caching.

It's a minor thing so just adjusted the test with a note on botching
and removed the cache for the test

Fix #2254