### PR TITLE
Fix AdEx and Uniswap logic that triggers events & trades requests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Uniswap module won't query events and trades prior the end date of the last used query range.
 * :bug:`2294` Do not count MakerDAO Oasis proxy assets found by the DeFi SDK as it ends up double counting makerDAO vault deposits.
 * :bug:`2287` Rotki encrypted DB upload for premium users should now respect the user setting.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,6 @@
 Changelog
 =========
 
-* :bug:`-` Uniswap module won't query events and trades prior the end date of the last used query range.
 * :bug:`2294` Do not count MakerDAO Oasis proxy assets found by the DeFi SDK as it ends up double counting makerDAO vault deposits.
 * :bug:`2287` Rotki encrypted DB upload for premium users should now respect the user setting.
 

--- a/rotkehlchen/chain/ethereum/adex/adex.py
+++ b/rotkehlchen/chain/ethereum/adex/adex.py
@@ -482,7 +482,7 @@ class Adex(EthereumModule):
             all_new_events.extend(new_events)
 
         # Request existing DB addresses' events
-        if existing_addresses and min_from_timestamp <= to_timestamp:
+        if existing_addresses and to_timestamp > min_from_timestamp:
             new_events = self._get_new_staking_events_graph(
                 addresses=addresses,
                 from_timestamp=min_from_timestamp,

--- a/rotkehlchen/chain/ethereum/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/uniswap/uniswap.py
@@ -463,7 +463,7 @@ class Uniswap(EthereumModule):
                 )
 
         # Request existing DB addresses' events
-        if existing_addresses and min_end_ts <= to_timestamp:
+        if existing_addresses and to_timestamp > min_end_ts:
             for address in existing_addresses:
                 for event_type in EventType:
                     address_new_events = self._get_events_graph(
@@ -659,7 +659,7 @@ class Uniswap(EthereumModule):
                 )
 
         # Request existing DB addresses' trades
-        if existing_addresses and min_end_ts <= to_timestamp:
+        if existing_addresses and to_timestamp > min_end_ts:
             address_new_trades = self._get_trades_graph(
                 addresses=existing_addresses,
                 start_ts=min_end_ts,


### PR DESCRIPTION
This applies only to existing addresses, new addresses will always request from `from_timestamp=0` to `to_timestamp=<now>`.

Example with addresses and last used query ranges:
Address 1: 1 - 10
Address 2: 1 - 9
Address 3: 1 - 8

Some examples of querying either events or trades for a specific time range.

## Example 1
from_timestamp=< less than to_timestamp >
to_timestamp=8

`min_from_timestamp = min(address 1..N "end timestamp" from last used query ranges, to_timestamp)` is `8`.
As `to_timestamp` (8) is not greater than `min_from_timestamp` (8), we do not request. 

Last used query range is not updated for any address

## Example 2
from_timestamp=< less than to_timestamp >
to_timestamp=9

`min_from_timestamp = min(address 1..N "end timestamp" from last used query ranges, to_timestamp)` is `8`.
As `to_timestamp` (9) is greater than `min_from_timestamp` (8), we do request, as we don't have the address 3 events at timestamp 9.

Last used query range is updated on each address with `(8, 9)`