### PR TITLE
[WIP develop] AdEx refactor - Do not merge until AdEx subgraph v2 available

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,10 @@
 Changelog
 =========
 
+* :feature:`1911` AdEx queries for staking balances and historical events now use the new subgraph version.
 * :feature:`295` When creating external trades, users will now have the trade rate automatically fetched when such a rate exists.
 * :feature:`2240` Users now can select the supported assets from a dropdown when adding or editing external trades.
+* :bug:`2228` AdEx claim events now always have the proper token (e.g. ADX, DAI) and usd value.
 * :bug:`2294` Do not count MakerDAO Oasis proxy assets found by the DeFi SDK as it ends up double counting makerDAO vault deposits.
 * :bug:`2287` Rotki encrypted DB upload for premium users should now respect the user setting.
 

--- a/rotkehlchen/chain/ethereum/adex/graph.py
+++ b/rotkehlchen/chain/ethereum/adex/graph.py
@@ -73,7 +73,10 @@ CHANNEL_WITHDRAWS_QUERY = (
     ) {{
         id
         user
-        channelId
+        channel {{
+            channelId
+            tokenAddr
+        }}
         amount
         timestamp
     }}}}

--- a/rotkehlchen/chain/ethereum/adex/typing.py
+++ b/rotkehlchen/chain/ethereum/adex/typing.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
-from eth_typing import ChecksumAddress, HexStr
+from eth_typing import ChecksumAddress
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken
@@ -10,7 +10,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.typing import Timestamp
 
 # Pools data
-TOM_POOL_ID = HexStr('0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28')
+TOM_POOL_ID = '0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28'
 POOL_ID_POOL_NAME = {
     TOM_POOL_ID: 'Tom',
 }
@@ -55,28 +55,38 @@ class AdexEventType(Enum):
 
 
 @dataclass(init=True, repr=True)
-class Bond:
-    tx_hash: HexStr  # from bond.id
+class AdexEvent:
+    tx_hash: str
     address: ChecksumAddress
     identity_address: ChecksumAddress
     timestamp: Timestamp
-    bond_id: HexStr
-    pool_id: HexStr
-    value: Balance
-    nonce: int
-    slashed_at: Timestamp  # from bond.slashedAtStart
 
     def serialize(self) -> Dict[str, Any]:
         return {
             'tx_hash': self.tx_hash,
             'identity_address': self.identity_address,
             'timestamp': self.timestamp,
+        }
+
+
+@dataclass(init=True, repr=True)
+class Bond(AdexEvent):
+    bond_id: str
+    pool_id: str
+    value: Balance
+    nonce: int
+    slashed_at: Timestamp  # from bond.slashedAtStart
+
+    def serialize(self) -> Dict[str, Any]:
+        common_properties = super().serialize()
+        common_properties.update({
             'bond_id': self.bond_id,
             'pool_id': self.pool_id,
             'pool_name': POOL_ID_POOL_NAME.get(self.pool_id, None),
             'value': self.value.serialize(),
             'event_type': str(AdexEventType.BOND),
-        }
+        })
+        return common_properties
 
     def to_db_tuple(self) -> AdexEventDBTuple:
         return (
@@ -98,26 +108,21 @@ class Bond:
 
 
 @dataclass(init=True, repr=True)
-class Unbond:
-    tx_hash: HexStr  # from unbond.id
-    address: ChecksumAddress
-    identity_address: ChecksumAddress
-    timestamp: Timestamp
-    bond_id: HexStr
+class Unbond(AdexEvent):
+    bond_id: str
     value: Balance  # from bond.amount
-    pool_id: HexStr = HexStr('')  # from bond.pool_id
+    pool_id: str = ''  # from bond.pool_id
 
     def serialize(self) -> Dict[str, Any]:
-        return {
-            'tx_hash': self.tx_hash,
-            'identity_address': self.identity_address,
-            'timestamp': self.timestamp,
+        common_properties = super().serialize()
+        common_properties.update({
             'bond_id': self.bond_id,
             'pool_id': self.pool_id,
             'pool_name': POOL_ID_POOL_NAME.get(self.pool_id, None),
             'value': self.value.serialize(),
             'event_type': str(AdexEventType.UNBOND),
-        }
+        })
+        return common_properties
 
     def to_db_tuple(self) -> AdexEventDBTuple:
         return (
@@ -139,27 +144,22 @@ class Unbond:
 
 
 @dataclass(init=True, repr=True)
-class UnbondRequest:
-    tx_hash: HexStr  # from unbond.id
-    address: ChecksumAddress
-    identity_address: ChecksumAddress
-    timestamp: Timestamp
-    bond_id: HexStr
+class UnbondRequest(AdexEvent):
+    bond_id: str
     unlock_at: Timestamp  # from unbondRequest.willUnlock
     value: Balance  # from bond.amount
-    pool_id: HexStr = HexStr('')  # from bond.pool_id
+    pool_id: str = ''  # from bond.pool_id
 
     def serialize(self) -> Dict[str, Any]:
-        return {
-            'tx_hash': self.tx_hash,
-            'identity_address': self.identity_address,
-            'timestamp': self.timestamp,
+        common_properties = super().serialize()
+        common_properties.update({
             'bond_id': self.bond_id,
             'pool_id': self.pool_id,
             'pool_name': POOL_ID_POOL_NAME.get(self.pool_id, None),
             'value': self.value.serialize(),
             'event_type': str(AdexEventType.UNBOND_REQUEST),
-        }
+        })
+        return common_properties
 
     def to_db_tuple(self) -> AdexEventDBTuple:
         return (
@@ -181,30 +181,24 @@ class UnbondRequest:
 
 
 @dataclass(init=True, repr=True)
-class ChannelWithdraw:
-    tx_hash: HexStr  # from channelWithdraw.id
-    address: ChecksumAddress
-    identity_address: ChecksumAddress
-    timestamp: Timestamp
+class ChannelWithdraw(AdexEvent):
     value: Balance
-    channel_id: HexStr
-    pool_id: HexStr
-    token: Optional[EthereumToken] = None
+    channel_id: str
+    pool_id: str
+    token: EthereumToken
 
     def serialize(self) -> Dict[str, Any]:
-        return {
-            'tx_hash': self.tx_hash,
-            'identity_address': self.identity_address,
-            'timestamp': self.timestamp,
+        common_properties = super().serialize()
+        common_properties.update({
             'pool_id': self.pool_id,
             'pool_name': POOL_ID_POOL_NAME.get(self.pool_id, None),
             'value': self.value.serialize(),
             'event_type': str(AdexEventType.CHANNEL_WITHDRAW),
-            'token': (self.token.serialize() if self.token is not None else None),
-        }
+            'token': self.token.serialize(),
+        })
+        return common_properties
 
     def to_db_tuple(self) -> AdexEventDBTuple:
-        token = self.token.serialize() if self.token is not None else None
         return (
             str(self.tx_hash),
             str(self.address),
@@ -219,16 +213,8 @@ class ChannelWithdraw:
             None,  # slashed_at
             None,  # unlocked_at
             str(self.channel_id),
-            token,
+            self.token.serialize(),
         )
-
-
-# Contains the events' (e.g. bond, unbond) common attributes
-class EventCoreData(NamedTuple):
-    tx_hash: HexStr
-    address: ChecksumAddress
-    identity_address: ChecksumAddress
-    timestamp: Timestamp
 
 
 class ADXStakingEvents(NamedTuple):
@@ -252,7 +238,7 @@ class UnclaimedReward(NamedTuple):
 
 
 class ADXStakingBalance(NamedTuple):
-    pool_id: HexStr
+    pool_id: str
     pool_name: Optional[str]
     adx_balance: Balance
     adx_unclaimed_balance: Balance
@@ -271,14 +257,12 @@ class ADXStakingBalance(NamedTuple):
 
 class TomPoolIncentive(NamedTuple):
     total_staked_amount: FVal  # from sum(currentTotalActiveStake)
-    total_reward_per_second: FVal  # from sum(currentRewardPerSecond)
-    period_ends_at: Timestamp  # from periodEnd
     apr: FVal  # from AdEx APY
 
 
 class ADXStakingDetail(NamedTuple):
     contract_address: ChecksumAddress  # From staking contract
-    pool_id: HexStr
+    pool_id: str
     pool_name: Optional[str]
     total_staked_amount: FVal
     apr: FVal

--- a/rotkehlchen/chain/ethereum/adex/utils.py
+++ b/rotkehlchen/chain/ethereum/adex/utils.py
@@ -1,7 +1,5 @@
 from typing import Union, cast
 
-from eth_typing import HexStr
-
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.errors import DeserializationError, UnknownAsset, UnsupportedAsset
@@ -39,8 +37,10 @@ DAI_AMOUNT_MANTISSA = FVal(10**18)
 
 # Tom pool fee rewards API constants
 TOM_POOL_FEE_REWARDS_API_URL = 'https://tom.adex.network/fee-rewards'
-PERIOD_END_AT_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+TOM_POOL_FEE_REWARDS_ADX_LEGACY_CHANNEL = '0x30d87bab0ef1e7f8b4c3b894ca2beed41bbd54c481f31e5791c1e855c9dbf4ba'  # noqa: E501
+TOM_POOL_PERIOD_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
+OUTSTANDING_REWARD_THRESHOLD = FVal('0.2')
 ADEX_EVENTS_PREFIX = 'adex_events'
 
 # Defines the expected order of the events given the same timestamp and sorting
@@ -82,11 +82,11 @@ def deserialize_adex_event_from_db(
             f'Failed to deserialize event type. Unknown event: {db_event_type}.',
         )
 
-    tx_hash = HexStr(event_tuple[0])
+    tx_hash = event_tuple[0]
     address = deserialize_ethereum_address(event_tuple[1])
     identity_address = deserialize_ethereum_address(event_tuple[2])
     timestamp = deserialize_timestamp(event_tuple[3])
-    pool_id = HexStr(event_tuple[5])
+    pool_id = event_tuple[5]
     amount = deserialize_asset_amount(event_tuple[6])
     usd_value = deserialize_asset_amount(event_tuple[7])
     value = Balance(amount=amount, usd_value=usd_value)
@@ -104,7 +104,7 @@ def deserialize_adex_event_from_db(
             timestamp=timestamp,
             pool_id=pool_id,
             value=value,
-            bond_id=HexStr(cast(str, event_tuple[8])),
+            bond_id=cast(str, event_tuple[8]),
             nonce=cast(int, event_tuple[9]),
             slashed_at=Timestamp(cast(int, event_tuple[10])),
         )
@@ -112,7 +112,7 @@ def deserialize_adex_event_from_db(
     if db_event_type == str(AdexEventType.UNBOND):
         if any(event_tuple[idx] is None for idx in (8,)):
             raise DeserializationError(
-                f'Failed to deserialize bond event. Unexpected data: {event_tuple}.',
+                f'Failed to deserialize unbond event. Unexpected data: {event_tuple}.',
             )
 
         return Unbond(
@@ -122,7 +122,7 @@ def deserialize_adex_event_from_db(
             timestamp=timestamp,
             pool_id=pool_id,
             value=value,
-            bond_id=HexStr(cast(str, event_tuple[8])),
+            bond_id=cast(str, event_tuple[8]),
         )
 
     if db_event_type == str(AdexEventType.UNBOND_REQUEST):
@@ -138,27 +138,24 @@ def deserialize_adex_event_from_db(
             timestamp=timestamp,
             pool_id=pool_id,
             value=value,
-            bond_id=HexStr(cast(str, event_tuple[8])),
+            bond_id=cast(str, event_tuple[8]),
             unlock_at=Timestamp(cast(int, event_tuple[11])),
         )
 
     if db_event_type == str(AdexEventType.CHANNEL_WITHDRAW):
-        # NB: `token` (event_tuple[13]) could be None, do not check below.
-        if any(event_tuple[idx] is None for idx in (12,)):
+        if any(event_tuple[idx] is None for idx in (12, 13)):
             raise DeserializationError(
-                f'Failed to deserialize unbond request event. Unexpected data: {event_tuple}.',
+                f'Failed to deserialize channel withdraw event. Unexpected data: {event_tuple}.',
             )
 
-        token = None
-        if event_tuple[13] is not None:
-            try:
-                token = EthereumToken(event_tuple[13])
-            except (UnknownAsset, UnsupportedAsset) as e:
-                asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
-                raise DeserializationError(
-                    f'{asset_tag} {e.asset_name} found while processing adex event. '
-                    f'Unexpected data: {event_tuple}',
-                ) from e
+        try:
+            token = EthereumToken(cast(str, event_tuple[13]))
+        except (UnknownAsset, UnsupportedAsset) as e:
+            asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
+            raise DeserializationError(
+                f'{asset_tag} {e.asset_name} found while processing adex event. '
+                f'Unexpected data: {event_tuple}',
+            ) from e
 
         return ChannelWithdraw(
             tx_hash=tx_hash,
@@ -167,7 +164,7 @@ def deserialize_adex_event_from_db(
             timestamp=timestamp,
             value=value,
             pool_id=pool_id,
-            channel_id=HexStr(cast(str, event_tuple[12])),
+            channel_id=cast(str, event_tuple[12]),
             token=token,
         )
 

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from eth_typing import HexAddress, HexStr
 from eth_utils import to_bytes, to_checksum_address
 from web3 import Web3
 from web3._utils.abi import exclude_indexed_event_inputs, normalize_event_input_types
@@ -112,9 +111,9 @@ def decode_event_data(data: str, event_abi: Dict[str, Any]) -> Tuple:
 
 
 def generate_address_via_create2(
-        address: HexAddress,
-        salt: HexStr,
-        init_code: HexStr,
+        address: str,
+        salt: str,
+        init_code: str,
 ) -> ChecksumEthAddress:
     """Python implementation of CREATE2 opcode.
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -9,7 +9,6 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
 
-from eth_typing import HexStr
 from pysqlcipher3 import dbapi2 as sqlcipher
 from typing_extensions import Literal
 
@@ -877,7 +876,7 @@ class DBHandler:
             from_timestamp: Optional[Timestamp] = None,
             to_timestamp: Optional[Timestamp] = None,
             address: Optional[ChecksumEthAddress] = None,
-            bond_id: Optional[HexStr] = None,
+            bond_id: Optional[str] = None,
             event_type: Optional[AdexEventType] = None,
     ) -> List[Union[Bond, Unbond, UnbondRequest, ChannelWithdraw]]:
         """Returns a list of AdEx events optionally filtered by time and address.

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -18,7 +18,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import EthereumTransaction, Location, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.accounting import action_get_timestamp
-from rotkehlchen.utils.misc import ts_now, timestamp_to_date
+from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.manager import ChainManager
@@ -401,6 +401,7 @@ class EventsHistorian():
                 reset_db_data=False,
                 from_timestamp=start_ts,
                 to_timestamp=end_ts,
+                is_pnl_report=True,
             )
             for _, adex_history in adx_mapping.items():
                 # The transaction hashes here are not accurate. Need to figure out
@@ -412,14 +413,14 @@ class EventsHistorian():
                         event_type=DefiEventType.ADEX_STAKE_PROFIT,
                         asset=A_ADX,
                         amount=adx_detail.adx_profit_loss.amount,
-                        tx_hashes=adex_tx_hashes,  # type: ignore
+                        tx_hashes=adex_tx_hashes,
                     ))
                     defi_events.append(DefiEvent(
                         timestamp=end_ts,
                         event_type=DefiEventType.ADEX_STAKE_PROFIT,
                         asset=A_DAI,
                         amount=adx_detail.dai_profit_loss.amount,
-                        tx_hashes=adex_tx_hashes,  # type: ignore
+                        tx_hashes=adex_tx_hashes,
                     ))
         step = self._increase_progress(step, total_steps)
 

--- a/rotkehlchen/tests/api/test_adex.py
+++ b/rotkehlchen/tests/api/test_adex.py
@@ -6,6 +6,9 @@ from http import HTTPStatus
 import pytest
 import requests
 
+from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.chain.ethereum.adex.typing import Bond, ChannelWithdraw, Unbond
+from rotkehlchen.constants.assets import A_ADX
 from rotkehlchen.fval import FVal
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
@@ -17,9 +20,7 @@ from rotkehlchen.tests.utils.api import (
     assert_simple_ok_response,
     wait_for_async_task,
 )
-from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
-from rotkehlchen.chain.ethereum.adex.typing import Bond, ChannelWithdraw, Unbond
 
 ADEX_TEST_ADDR = deserialize_ethereum_address('0x8Fe178db26ebA2eEdb22575265bf10A63c395a3d')
 
@@ -163,8 +164,8 @@ def test_get_events(
         timestamp=1607453764,
         channel_id=channel_id,
         pool_id=tom_pool_id,
-        value=Balance(FVal('5056.894263641728544592'), FVal('0')),
-        token=None,
+        value=Balance(FVal('5056.894263641728544592'), FVal('10113.788527283457089184')),
+        token=A_ADX,
     ), Unbond(
         tx_hash='0xa9ee91af823c0173fc5ada908ff9fe3f4d7c84a2c9da795f0889b3f4ace75b13',
         address=ADEX_TEST_ADDR,

--- a/rotkehlchen/tests/unit/test_adex.py
+++ b/rotkehlchen/tests/unit/test_adex.py
@@ -1,8 +1,22 @@
-from eth_typing import HexStr
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.chain.ethereum.adex.adex import Adex
-from rotkehlchen.chain.ethereum.adex.typing import TOM_POOL_ID
+from rotkehlchen.chain.ethereum.adex.typing import (
+    TOM_POOL_ID,
+    ADXStakingBalance,
+    ADXStakingEvents,
+    Bond,
+    ChannelWithdraw,
+    Unbond,
+)
+from rotkehlchen.constants.assets import A_ADX, A_DAI
+from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.typing import Timestamp
 
 TEST_ADDR = deserialize_ethereum_address('0x494B9728BECA6C03269c38Ed86179757F77Cc0dd')
 TEST_ADDR_USER_IDENTITY = deserialize_ethereum_address('0xaC29E71ACA2ff1C121673f0FC9d47e7616F692Ae')  # noqa: E501
@@ -36,7 +50,312 @@ def test_get_bond_id():
     bond_id = Adex._get_bond_id(
         identity_address=TEST_ADDR_USER_IDENTITY,
         amount=10661562521452745365522,
-        pool_id=HexStr(TOM_POOL_ID),
+        pool_id=TOM_POOL_ID,
         nonce=1596569185,
     )
     assert bond_id == expected_bond_id
+
+
+TEST_FIX_STAKING_EVENTS = ADXStakingEvents(
+    bonds=[
+        Bond(
+            tx_hash='1',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1604366004),
+            bond_id='0x540cab9883923c01e657d5da4ca5674b6e4626b4a148224635495502d674c7c5',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            value=Balance(
+                amount=FVal('100000'),
+                usd_value=FVal('21345.00000'),
+            ),
+            nonce=1604365948,
+            slashed_at=Timestamp(0),
+        ),
+        Bond(
+            tx_hash='2',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1607453764),
+            bond_id='0x16bb43690fe3764b15a2eb8d5e94e1ac13d6ef38e6c6f9d9f9c745eaff92d427',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            value=Balance(
+                amount=FVal('105056.894263641728544592'),
+                usd_value=FVal('29935.96202042471054878149040'),
+            ),
+            nonce=1604365948,
+            slashed_at=Timestamp(0),
+        ),
+        Bond(
+            tx_hash='3',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1607915796),
+            bond_id='0x30bd07a0cc0c9b94e2d10487c1053fc6a5043c41fb28dcfa3ff80a68013eb501',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            value=Balance(
+                amount=FVal('105843.792804312484410368'),
+                usd_value=FVal('28307.92238551337395555292160'),
+            ),
+            nonce=1604365948,
+            slashed_at=Timestamp(0),
+        ),
+    ],
+    unbonds=[
+        Unbond(
+            tx_hash='2',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1607453764),
+            bond_id='0x540cab9883923c01e657d5da4ca5674b6e4626b4a148224635495502d674c7c5',
+            value=Balance(
+                amount=FVal('100000'),
+                usd_value=FVal('28495.00000'),
+            ),
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+        ),
+        Unbond(
+            tx_hash='3',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1607915796),
+            bond_id='0x16bb43690fe3764b15a2eb8d5e94e1ac13d6ef38e6c6f9d9f9c745eaff92d427',
+            value=Balance(
+                amount=FVal('105056.894263641728544592'),
+                usd_value=FVal('28097.46637081098029925113040'),
+            ),
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+        ),
+    ],
+    unbond_requests=[],
+    channel_withdraws=[
+        # From AdEx subgraph
+        ChannelWithdraw(
+            tx_hash='2',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1607453764),
+            value=Balance(
+                amount=FVal('5056.894263641728544592'),
+                usd_value=FVal('1440.96202042471054878149040'),
+            ),
+            channel_id='0x30d87bab0ef1e7f8b4c3b894ca2beed41bbd54c481f31e5791c1e855c9dbf4ba',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            token=A_ADX,
+        ),
+        ChannelWithdraw(
+            tx_hash='3',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1607915796),
+            value=Balance(
+                amount=FVal('786.898540670755865776'),
+                usd_value=FVal('210.45601470239365630179120'),
+            ),
+            channel_id='0x30d87bab0ef1e7f8b4c3b894ca2beed41bbd54c481f31e5791c1e855c9dbf4ba',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            token=A_ADX,
+        ),
+        ChannelWithdraw(
+            tx_hash='4',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1610322797),
+            value=Balance(
+                amount=FVal('1939.339070905230671011'),
+                usd_value=FVal('687.59266758944953440695005'),
+            ),
+            channel_id='0x30d87bab0ef1e7f8b4c3b894ca2beed41bbd54c481f31e5791c1e855c9dbf4ba',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            token=A_ADX,
+        ),
+        # NB: missing from AdEx subgraph. Note channel_id are different
+        ChannelWithdraw(
+            tx_hash='4',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1610322797),
+            value=Balance(
+                amount=FVal('2455.145121212890626196'),
+                usd_value=FVal('870.4717027260302'),
+            ),
+            channel_id='0xd179d5f8f09812458535f5bf271c2c5affa26329f355537e6d6246879355fcc9',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            token=A_ADX,
+        ),
+        ChannelWithdraw(
+            tx_hash='4',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1610322797),
+            value=Balance(
+                amount=FVal('0.942403051800451729'),
+                usd_value=FVal('0.942403051800451729'),
+            ),
+            channel_id='0xc18bd3ea2b0b6018ac675fc86236e304ad11cbe03e6ce31bb66417a001bd7221',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            token=A_DAI,
+        ),
+        ChannelWithdraw(
+            tx_hash='4',
+            address=TEST_ADDR,
+            identity_address=TEST_ADDR_USER_IDENTITY,
+            timestamp=Timestamp(1610322797),
+            value=Balance(
+                amount=FVal('0.221231768887185282'),
+                usd_value=FVal('0.221231768887185282'),
+            ),
+            channel_id='0xaccd95e386de6650e222495f9f096dc926863c4f1cd786e732eca12b35807e47',
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            token=A_DAI,
+        ),
+    ],
+)
+TEST_FIX_IDENTITY_ADDRESS_MAP = {TEST_ADDR_USER_IDENTITY: TEST_ADDR}
+TEST_FIX_FEE_REWARDS = [
+    # DAI channel
+    {
+        'balances': {
+            TEST_ADDR_USER_IDENTITY: '686126927577621578',
+        },
+        'channelArgs': {
+            'tokenAddr': '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+            'validUntil': 1640995200,
+        },
+        'channelId': '0x654d40ca25aa111a8259dabcc7d2073c90803b884c5177e4193c0cc313ca70c9',
+    },
+    # Current ADX channel
+    {
+        'balances': {
+            TEST_ADDR: '6655456224419233586167',
+        },
+        'channelArgs': {
+            'tokenAddr': '0xADE00C28244d5CE17D72E40330B1c318cD12B7c3',
+            'validUntil': 1639440000,
+        },
+        'channelId': '0xd179d5f8f09812458535f5bf271c2c5affa26329f355537e6d6246879355fcc9',
+    },
+    # DAI channel
+    {
+        'balances': {
+            TEST_ADDR_USER_IDENTITY: '942403051800451729',
+        },
+        'channelArgs': {
+            'tokenAddr': '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+            'validUntil': 1638316800,
+        },
+        'channelId': '0xc18bd3ea2b0b6018ac675fc86236e304ad11cbe03e6ce31bb66417a001bd7221',
+    },
+    # DAI channel
+    {
+        'balances': {
+            TEST_ADDR_USER_IDENTITY: '221231768887185282',
+        },
+        'channelArgs': {
+            'tokenAddr': '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+            'validUntil': 1635724800,
+        },
+        'channelId': '0xaccd95e386de6650e222495f9f096dc926863c4f1cd786e732eca12b35807e47',
+    },
+    # DAI channel, user EOA/identity not in balances
+    {
+        'balances': {},
+        'channelArgs': {
+            'tokenAddr': '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+            'validUntil': 1633046400,
+        },
+        'channelId': '0x261ded3a41f1c7b7a249200a8b47c9f3f820f6830e67e068fc971bd630fa6892',
+    },
+    # ADX channel, validUntil expired
+    {
+        'balances': {
+            TEST_ADDR: '6655456224419233586167',
+        },
+        'channelArgs': {
+            'tokenAddr': '0xADE00C28244d5CE17D72E40330B1c318cD12B7c3',
+            'validUntil': 1612451055,  # 1s less than the frozen time of the test
+        },
+        'channelId': '0xd179d5f8f09812458535f5bf271c2c5affa26329f355537e6d6246879355fcc9',
+    },
+]
+TEST_FIX_EXPECTED_ADX_STAKING_BALANCE = {
+    TEST_ADDR: [
+        ADXStakingBalance(
+            pool_id='0x2ce0c96383fb229d9776f33846e983a956a7d95844fac57b180ed0071d93bb28',
+            pool_name='Tom',
+            adx_balance=Balance(
+                amount=FVal('110044.103907518827370339'),
+                usd_value=FVal('71368.77345690961293455124743'),
+            ),
+            adx_unclaimed_balance=Balance(
+                amount=FVal('4200.311103206342959971'),
+                usd_value=FVal('2724.099165051164107660312137'),
+            ),
+            dai_unclaimed_balance=Balance(
+                amount=FVal('0.686126927577621578'),
+                usd_value=FVal('0.686126927577621578'),
+            ),
+            contract_address=deserialize_ethereum_address(
+                '0x4846C6837ec670Bbd1f5b485471c8f64ECB9c534',
+            ),
+        ),
+    ],
+}
+
+
+@pytest.mark.freeze_time(datetime.fromtimestamp(1612451056))
+def test_calculate_staking_balances():
+    """Test the logic refactor works as expected as long as the subgraph returns
+    all the ChannelWithdraw events, and not only the ones related with the
+    legacy channel.
+
+    Expected results:
+      - ADX staked: 105843.79
+      - ADX unclaimed: 4200.31
+      - ADX balance: 110044.10 (staked + unclaimed)
+    """
+    with patch('rotkehlchen.chain.ethereum.adex.adex.Graph'):
+        adex = Adex(
+            ethereum_manager=MagicMock(),
+            database=MagicMock(),
+            premium=MagicMock(),
+            msg_aggregator=MagicMock(),
+        )
+        staking_balances = adex._calculate_staking_balances(
+            staking_events=TEST_FIX_STAKING_EVENTS,
+            identity_address_map=TEST_FIX_IDENTITY_ADDRESS_MAP,
+            fee_rewards=TEST_FIX_FEE_REWARDS,
+            adx_usd_price=FVal('0.648547'),
+            dai_usd_price=FVal('1'),
+        )
+    assert staking_balances == TEST_FIX_EXPECTED_ADX_STAKING_BALANCE
+
+
+@pytest.mark.freeze_time(datetime.fromtimestamp(1612451056))
+def test_calculate_staking_balances_is_pnl_report():
+    """Test 'is_pnl_report' argument is True, unclaimed ADX and DAI amounts are
+    not calculated and set to 0.
+    """
+    with patch('rotkehlchen.chain.ethereum.adex.adex.Graph'):
+        adex = Adex(
+            ethereum_manager=MagicMock(),
+            database=MagicMock(),
+            premium=MagicMock(),
+            msg_aggregator=MagicMock(),
+        )
+        staking_balances = adex._calculate_staking_balances(
+            staking_events=TEST_FIX_STAKING_EVENTS,
+            identity_address_map=TEST_FIX_IDENTITY_ADDRESS_MAP,
+            fee_rewards=TEST_FIX_FEE_REWARDS,
+            adx_usd_price=FVal('0.648547'),
+            dai_usd_price=FVal('1'),
+            is_pnl_report=True,
+        )
+
+    staking_balance = staking_balances[TEST_ADDR][0]
+    assert staking_balance.adx_balance == Balance(
+        amount=FVal('105843.792804312484410368'),
+        usd_value=FVal('68644.67429185844882689093530'),
+    )
+    assert staking_balance.adx_unclaimed_balance == Balance()
+    assert staking_balance.dai_unclaimed_balance == Balance()


### PR DESCRIPTION
The changes introduced by this branch are also present in #2278 branch (that branches off bugfixes).

Closes #1911
Closes #2214
Closes #2228

- Introduced common event `AdexEvent`

- Swapped HexStr and HexAddress with str

- Fixed comparison that triggers requesting new events for existing
addresses

- Aligned unclaimed amounts logic with latest AdEx implementation

- Supported new channelWithdraw schema and refactored logic for
relying as less as possible on the fee-rewards API. If it fails
due to a RemoteError or DeserializationError, unclaimed amounts
and pool performance will be set to 0.

- Supported PnL report

- Added unit test that checks calculate_staking_balances works as
expected once it gets the missinc channel withdraw events
