### PR TITLE
premium DB sync will work after api key insertion without restart

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1928` rotki premium DB sync will now work after entering api keys for the first time even without a restart.
 * :bug:`2294` Do not count MakerDAO Oasis proxy assets found by the DeFi SDK as it ends up double counting makerDAO vault deposits.
 * :bug:`2287` Rotki encrypted DB upload for premium users should now respect the user setting.
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -362,6 +362,7 @@ class Rotkehlchen():
             self.premium.set_credentials(credentials)
         else:
             self.premium = premium_create_and_verify(credentials)
+            self.premium_sync_manager.premium = self.premium
 
         self.data.db.set_rotkehlchen_premium(credentials)
 


### PR DESCRIPTION
Fix #1928