### PR TITLE
Exchange rates api call now rejects null input

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -863,7 +863,7 @@ Query the current exchange rate for select assets
 
 .. http:get:: /api/(version)/exchange_rates
 
-   Querying this endpoint with a list of strings representing some assets will return a dictionary of their current exchange rates compared to USD. If no list is given then the exchange rates of all currencies is returned. Providing an empty list is an error.
+   Querying this endpoint with a list of strings representing some assets will return a dictionary of their current exchange rates compared to USD.
 
    .. note::
       This endpoint also accepts parameters as query arguments. List as a query argument here would be given as: ``?currencies=EUR,CNY,GBP``

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -1398,7 +1398,7 @@ class DataImportSchema(Schema):
 
 
 class ExchangeRatesSchema(Schema):
-    currencies = DelimitedOrNormalList(AssetField(), missing=None)
+    currencies = DelimitedOrNormalList(AssetField(), required=True)
 
 
 class WatcherSchema(Schema):

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -196,7 +196,7 @@ class ExchangeRatesResource(BaseResource):
     get_schema = ExchangeRatesSchema()
 
     @use_kwargs(get_schema, location='json_and_query')  # type: ignore
-    def get(self, currencies: Optional[List[Asset]]) -> Response:
+    def get(self, currencies: List[Asset]) -> Response:
         return self.rest_api.get_exchange_rates(given_currencies=currencies)
 
 

--- a/rotkehlchen/constants/assets.py
+++ b/rotkehlchen/constants/assets.py
@@ -1,35 +1,6 @@
 from rotkehlchen.assets.asset import Asset, EthereumToken
 
 A_USD = Asset('USD')
-A_EUR = Asset('EUR')
-A_GBP = Asset('GBP')
-A_JPY = Asset('JPY')
-A_CNY = Asset('CNY')
-A_CAD = Asset('CAD')
-A_KRW = Asset('KRW')
-A_RUB = Asset('RUB')
-A_CHF = Asset('CHF')
-A_TRY = Asset('TRY')
-A_ZAR = Asset('ZAR')
-A_AUD = Asset('AUD')
-A_NZD = Asset('NZD')
-A_BRL = Asset('BRL')
-FIAT_CURRENCIES = (
-    A_USD,
-    A_EUR,
-    A_GBP,
-    A_JPY,
-    A_CNY,
-    A_CAD,
-    A_KRW,
-    A_RUB,
-    A_CHF,
-    A_TRY,
-    A_ZAR,
-    A_AUD,
-    A_NZD,
-    A_BRL,
-)
 
 S_BTC = 'BTC'
 S_ETH = 'ETH'

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -22,7 +22,6 @@ from rotkehlchen.constants.assets import (
     A_USDC,
     A_USDT,
     A_YFI,
-    FIAT_CURRENCIES,
 )
 from rotkehlchen.errors import (
     DeserializationError,
@@ -357,12 +356,8 @@ class Inquirer():
         return instance._query_oracle_instances(from_asset=asset, to_asset=A_USD)
 
     @staticmethod
-    def get_fiat_usd_exchange_rates(
-            currencies: Optional[Iterable[Asset]] = None,
-    ) -> Dict[Asset, Price]:
+    def get_fiat_usd_exchange_rates(currencies: Iterable[Asset]) -> Dict[Asset, Price]:
         rates = {A_USD: Price(FVal(1))}
-        if not currencies:
-            currencies = FIAT_CURRENCIES[1:]
         for currency in currencies:
             rates[currency] = Inquirer().query_fiat_pair(A_USD, currency)
         return rates

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -7,9 +7,9 @@ import pytest
 import requests
 
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
-from rotkehlchen.constants.assets import A_EUR
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import api_url_for, assert_error_response, assert_proper_response
+from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
 from rotkehlchen.typing import Location

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -9,7 +9,7 @@ import requests
 
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.bitcoin import get_bitcoin_addresses_balances
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
@@ -27,7 +27,7 @@ from rotkehlchen.tests.utils.blockchain import (
     assert_btc_balances_result,
     assert_eth_balances_result,
 )
-from rotkehlchen.tests.utils.constants import A_RDN
+from rotkehlchen.tests.utils.constants import A_EUR, A_RDN
 from rotkehlchen.tests.utils.exchanges import assert_binance_balances_result
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2
 from rotkehlchen.tests.utils.rotkehlchen import BalancesTestSetup, setup_balances

--- a/rotkehlchen/tests/api/test_exchange_rates_query.py
+++ b/rotkehlchen/tests/api/test_exchange_rates_query.py
@@ -3,9 +3,15 @@ from http import HTTPStatus
 import pytest
 import requests
 
-from rotkehlchen.constants.assets import A_BTC, A_ETH, FIAT_CURRENCIES
+from rotkehlchen.constants.assets import A_ETH, A_USD
 from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.api import api_url_for, assert_error_response, assert_proper_response
+from rotkehlchen.tests.utils.api import (
+    api_url_for,
+    assert_error_response,
+    assert_proper_response,
+    assert_proper_response_with_result,
+)
+from rotkehlchen.tests.utils.constants import A_EUR, A_KRW
 
 
 @pytest.mark.parametrize('start_with_logged_in_user', [False])
@@ -45,15 +51,8 @@ def test_querying_exchange_rates(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'exchangeratesresource') + '?currencies=' +
         ','.join(data['currencies']),
     )
-    assert_okay(response)
-
-    # Test with all currencies (give no input)
-    expected_currencies = list(FIAT_CURRENCIES) + [A_ETH, A_BTC]
-    response = requests.get(api_url_for(rotkehlchen_api_server, 'exchangeratesresource'))
-    assert_proper_response(response)
-    json_data = response.json()
-    assert json_data['message'] == ''
-    result = json_data['result']
+    result = assert_proper_response_with_result(response)
+    expected_currencies = [A_EUR, A_USD, A_KRW, A_ETH]
     assert len(result) == len(expected_currencies)
     for currency in expected_currencies:
         assert FVal(result[currency.identifier]) > 0

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 import requests
 
-from rotkehlchen.constants.assets import A_JPY
 from rotkehlchen.db.settings import DEFAULT_KRAKEN_ACCOUNT_TYPE, ROTKEHLCHEN_DB_VERSION, DBSettings
 from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.tests.utils.api import (
@@ -15,6 +14,7 @@ from rotkehlchen.tests.utils.api import (
     assert_proper_response_with_result,
     assert_simple_ok_response,
 )
+from rotkehlchen.tests.utils.constants import A_JPY
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.tests.utils.mock import MockWeb3
 from rotkehlchen.typing import ChecksumEthAddress, ModuleName

--- a/rotkehlchen/tests/api/test_statistics.py
+++ b/rotkehlchen/tests/api/test_statistics.py
@@ -7,11 +7,10 @@ import pytest
 import requests
 
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
-from rotkehlchen.constants.assets import A_EUR
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import api_url_for, assert_error_response, assert_proper_response
 from rotkehlchen.tests.utils.balances import get_asset_balance_total
-from rotkehlchen.tests.utils.constants import A_RDN
+from rotkehlchen.tests.utils.constants import A_EUR, A_RDN
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances

--- a/rotkehlchen/tests/api/test_trades.py
+++ b/rotkehlchen/tests/api/test_trades.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 import pytest
 import requests
 
-from rotkehlchen.constants.assets import A_EUR
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
 from rotkehlchen.rotkehlchen import FREE_TRADES_LIMIT
@@ -14,6 +13,7 @@ from rotkehlchen.tests.utils.api import (
     assert_proper_response,
     assert_proper_response_with_result,
 )
+from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.tests.utils.history import (
     assert_binance_trades_result,
     assert_poloniex_trades_result,

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -11,7 +11,7 @@ from rotkehlchen.accounting.structures import BalanceType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.constants import YEAR_IN_SECONDS
-from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_EUR, A_USD
+from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_USD
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.db.dbhandler import DBINFO_FILENAME, DBHandler, detect_sqlcipher_version
 from rotkehlchen.db.queried_addresses import QueriedAddresses
@@ -43,6 +43,7 @@ from rotkehlchen.premium.premium import PremiumCredentials
 from rotkehlchen.tests.utils.constants import (
     A_DAO,
     A_DOGE,
+    A_EUR,
     A_RDN,
     A_XMR,
     DEFAULT_TESTS_MAIN_CURRENCY,
@@ -55,6 +56,7 @@ from rotkehlchen.tests.utils.rotkehlchen import add_starting_balances
 from rotkehlchen.typing import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     AssetMovementCategory,
     BlockchainAccountData,
     EthereumTransaction,
@@ -62,12 +64,11 @@ from rotkehlchen.typing import (
     ExternalServiceApiCredentials,
     Fee,
     Location,
+    Price,
     SupportedBlockchain,
     Timestamp,
-    TradeType,
-    AssetAmount,
     TradePair,
-    Price,
+    TradeType,
 )
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now

--- a/rotkehlchen/tests/exchanges/test_bitcoinde.py
+++ b/rotkehlchen/tests/exchanges/test_bitcoinde.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.errors import DeserializationError, UnknownAsset
 from rotkehlchen.exchanges.bitcoinde import (
     BITCOINDE_TRADING_PAIRS,
@@ -11,6 +11,7 @@ from rotkehlchen.exchanges.bitcoinde import (
     bitcoinde_pair_to_world,
 )
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import Location, TradeType
 

--- a/rotkehlchen/tests/exchanges/test_iconomi.py
+++ b/rotkehlchen/tests/exchanges/test_iconomi.py
@@ -2,10 +2,11 @@ import warnings as test_warnings
 from unittest.mock import patch
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants.assets import A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.errors import UnknownAsset
 from rotkehlchen.exchanges.iconomi import Iconomi, iconomi_asset
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import Location, TradeType

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -1,7 +1,8 @@
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.externalapis.coingecko import CoingeckoAssetData, CoingeckoImageURLs
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.typing import Price
 
 

--- a/rotkehlchen/tests/integration/test_end_to_end_tax_report.py
+++ b/rotkehlchen/tests/integration/test_end_to_end_tax_report.py
@@ -1,11 +1,17 @@
 import pytest
 
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.accounting import accounting_history_process
-from rotkehlchen.tests.utils.constants import A_DASH, ETH_ADDRESS1, ETH_ADDRESS2, ETH_ADDRESS3
+from rotkehlchen.tests.utils.constants import (
+    A_DASH,
+    A_EUR,
+    ETH_ADDRESS1,
+    ETH_ADDRESS2,
+    ETH_ADDRESS3,
+)
 from rotkehlchen.tests.utils.history import prices
 from rotkehlchen.typing import (
     AssetAmount,

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import pytest
 
-from rotkehlchen.constants.assets import A_EUR, A_GBP
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.errors import (
     IncorrectApiKeyFormat,
@@ -11,7 +10,7 @@ from rotkehlchen.errors import (
     RotkehlchenPermissionError,
 )
 from rotkehlchen.premium.premium import PremiumCredentials
-from rotkehlchen.tests.utils.constants import DEFAULT_TESTS_MAIN_CURRENCY
+from rotkehlchen.tests.utils.constants import A_EUR, A_GBP, DEFAULT_TESTS_MAIN_CURRENCY
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.premium import (
     INVALID_BUT_BIGGER_REMOTE_DATA,

--- a/rotkehlchen/tests/integration/test_price_history.py
+++ b/rotkehlchen/tests/integration/test_price_history.py
@@ -1,10 +1,10 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants.assets import A_BTC, A_EUR, A_USD
+from rotkehlchen.constants.assets import A_BTC, A_USD
 from rotkehlchen.externalapis.cryptocompare import PRICE_HISTORY_FILE_PREFIX, Cryptocompare
 from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.constants import A_DASH, A_XMR
+from rotkehlchen.tests.utils.constants import A_DASH, A_EUR, A_XMR
 from rotkehlchen.utils.misc import get_or_make_price_history_dir
 
 

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -6,7 +6,7 @@ import requests
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO
-from rotkehlchen.constants.assets import A_CNY, A_EUR, A_GBP, A_JPY, A_USD
+from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
@@ -17,6 +17,7 @@ from rotkehlchen.inquirer import (
     CurrentPriceOracle,
     _query_exchanges_rateapi,
 )
+from rotkehlchen.tests.utils.constants import A_CNY, A_EUR, A_GBP, A_JPY
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import Price
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now

--- a/rotkehlchen/tests/unit/test_pairs.py
+++ b/rotkehlchen/tests/unit/test_pairs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.errors import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.exchanges.data_structures import (
     get_pair_position_asset,
@@ -9,7 +9,7 @@ from rotkehlchen.exchanges.data_structures import (
     trade_pair_from_assets,
 )
 from rotkehlchen.serialization.deserialize import get_pair_position_str, pair_get_assets
-from rotkehlchen.tests.utils.constants import A_RDN
+from rotkehlchen.tests.utils.constants import A_EUR, A_RDN
 from rotkehlchen.typing import TradePair
 
 

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from rotkehlchen.constants.assets import A_BTC, A_GBP, A_USD
+from rotkehlchen.constants.assets import A_BTC, A_USD
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import NoPriceForGivenTimestamp, PriceQueryUnsupportedAsset
 from rotkehlchen.externalapis.coingecko import Coingecko
@@ -14,6 +14,7 @@ from rotkehlchen.history.typing import (
     DEFAULT_HISTORICAL_PRICE_ORACLES_ORDER,
     HistoricalPriceOracle,
 )
+from rotkehlchen.tests.utils.constants import A_GBP
 from rotkehlchen.typing import Price, Timestamp
 
 

--- a/rotkehlchen/tests/unit/test_structures.py
+++ b/rotkehlchen/tests/unit/test_structures.py
@@ -1,9 +1,10 @@
 import pytest
 
 from rotkehlchen.accounting.structures import Balance, BalanceSheet
-from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_EUR, A_USD
+from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_USD
 from rotkehlchen.errors import InputError
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.constants import A_EUR
 
 
 def test_balance_addition():

--- a/rotkehlchen/tests/utils/constants.py
+++ b/rotkehlchen/tests/utils/constants.py
@@ -1,5 +1,4 @@
 from rotkehlchen.assets.asset import Asset, EthereumToken
-from rotkehlchen.constants.assets import A_EUR
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
 
 A_RDN = EthereumToken('RDN')
@@ -29,6 +28,9 @@ A_JPY = Asset('JPY')
 A_ZEC = Asset('ZEC')
 A_BUSD = Asset('BUSD')
 A_DOT = Asset('DOT')
+A_GBP = Asset('GBP')
+A_EUR = Asset('EUR')
+A_KRW = Asset('KRW')
 
 ETH_ADDRESS1 = deserialize_ethereum_address('0x5153493bB1E1642A63A098A65dD3913daBB6AE24')
 ETH_ADDRESS2 = deserialize_ethereum_address('0x4FED1fC4144c223aE3C1553be203cDFcbD38C581')

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -1,9 +1,9 @@
-from rotkehlchen.constants.assets import A_ETH, A_EUR, A_USD, A_DAI
+from rotkehlchen.constants.assets import A_DAI, A_ETH, A_USD
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
 from rotkehlchen.fval import FVal
 from rotkehlchen.rotkehlchen import Rotkehlchen
-from rotkehlchen.tests.utils.constants import A_XMR
+from rotkehlchen.tests.utils.constants import A_EUR, A_XMR
 from rotkehlchen.typing import (
     AssetAmount,
     AssetMovementCategory,

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -8,10 +8,9 @@ from unittest.mock import patch
 from typing_extensions import Literal
 
 from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
-from rotkehlchen.constants.assets import A_GBP
 from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.rotkehlchen import Rotkehlchen
-from rotkehlchen.tests.utils.constants import DEFAULT_TESTS_MAIN_CURRENCY
+from rotkehlchen.tests.utils.constants import A_GBP, DEFAULT_TESTS_MAIN_CURRENCY
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
 from rotkehlchen.tests.utils.mock import MockResponse
 

--- a/rotkehlchen/tests/utils/rotkehlchen.py
+++ b/rotkehlchen/tests/utils/rotkehlchen.py
@@ -7,7 +7,7 @@ import requests
 from rotkehlchen.accounting.structures import BalanceType
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.db.utils import AssetBalance, LocationData
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.blockchain import (
@@ -15,7 +15,7 @@ from rotkehlchen.tests.utils.blockchain import (
     mock_bitcoin_balances_query,
     mock_etherscan_query,
 )
-from rotkehlchen.tests.utils.constants import A_RDN, A_XMR
+from rotkehlchen.tests.utils.constants import A_EUR, A_RDN, A_XMR
 from rotkehlchen.tests.utils.exchanges import (
     patch_binance_balances_query,
     patch_poloniex_balances_query,

--- a/tools/asset_aggregator/__main__.py
+++ b/tools/asset_aggregator/__main__.py
@@ -23,8 +23,8 @@ from asset_aggregator.timerange_check import timerange_check
 from asset_aggregator.typeinfo_check import typeinfo_check
 
 from rotkehlchen.assets.resolver import AssetResolver
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.config import default_data_directory
-from rotkehlchen.constants.assets import FIAT_CURRENCIES
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.externalapis.coinmarketcap import Coinmarketcap, find_cmc_coin_data
 from rotkehlchen.externalapis.coinpaprika import (
@@ -54,7 +54,7 @@ def process_asset(
     token_address = None
     our_asset = our_data[asset_symbol]
     # Coin paprika does not have info on FIAT currencies
-    if asset_symbol in FIAT_CURRENCIES:
+    if Asset(asset_symbol).is_fiat():
         return our_data
 
     found_coin_id = find_paprika_coin_id(asset_symbol, paprika_coins_list)

--- a/tools/asset_aggregator/timerange_check.py
+++ b/tools/asset_aggregator/timerange_check.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 from asset_aggregator.utils import choose_multiple
 
-from rotkehlchen.constants.assets import FIAT_CURRENCIES
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.typing import EthAddress, Timestamp
 from rotkehlchen.utils.misc import (
     create_timestamp,
@@ -101,7 +101,7 @@ def timerange_check(
 
     Then compare to our data and provide choices to clean up the data.
     """
-    if asset_symbol in FIAT_CURRENCIES:
+    if Asset(asset_symbol).is_fiat():
         # Fiat does not have started date (or we don't care about it)
         return our_data
 

--- a/tools/data_faker/data_faker/actions.py
+++ b/tools/data_faker/data_faker/actions.py
@@ -4,11 +4,12 @@ from typing import Tuple
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
-from rotkehlchen.constants.assets import A_BTC, A_EUR, A_USD, FIAT_CURRENCIES
+from rotkehlchen.constants.assets import A_BTC, A_USD
 from rotkehlchen.exchanges.data_structures import Trade, TradeType
 from rotkehlchen.fval import FVal
 from rotkehlchen.history import PriceHistorian
 from rotkehlchen.serialization.deserialize import deserialize_location, pair_get_assets
+from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.typing import Location, Timestamp, TradePair
 
 STARTING_TIMESTAMP = 1464739200  # 01/06/2016
@@ -68,7 +69,7 @@ class ActionWriter():
             for exchange in ALLOWED_EXCHANGES:
                 timestamp, _, _ = self.get_next_ts()
 
-                skip_exchange = asset in FIAT_CURRENCIES and exchange != 'kraken'
+                skip_exchange = asset.is_fiat() and exchange != 'kraken'
 
                 if not skip_exchange:
                     getattr(self, exchange).deposit(
@@ -76,7 +77,7 @@ class ActionWriter():
                         amount=amount,
                         time=timestamp,
                     )
-                if asset in FIAT_CURRENCIES:
+                if asset.is_fiat():
                     self.rotki.data.db.add_manually_tracked_balances([ManuallyTrackedBalance(
                         asset=asset,
                         label=f'{asset.identifier} balance {timestamp}',


### PR DESCRIPTION
Plus we remove the unneeded FIAT_CURRENCIES list from the backend
code. Fiat assets have the `fiat` type in all_assets.json. Extra
classification is not needed.

Fix #2292