### PR TITLE
Properly parse non BTC/USD Bitstamp deposit/withdrawals

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2232` Bitstamp users should now be able to see all their deposit/withdrawals. It's recommended to purge all bitstamp data and re-query it for this to properly work.
 * :bug:`1928` rotki premium DB sync will now work after entering api keys for the first time even without a restart.
 * :bug:`2294` Do not count MakerDAO Oasis proxy assets found by the DeFi SDK as it ends up double counting makerDAO vault deposits.
 * :bug:`2287` Rotki encrypted DB upload for premium users should now respect the user setting.

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -90,6 +90,23 @@ USER_TRANSACTION_TRADE_TYPE = {2}
 # Asset movement type int: 0 - deposit, 1 - withdrawal
 USER_TRANSACTION_ASSET_MOVEMENT_TYPE = {0, 1}
 
+# from https://www.bitstamp.net/api/#user-transactions
+BITSTAMP_ASSET_MOVEMENT_SYMBOLS = (
+    'usd',
+    'eur',
+    'btc',
+    'xrp',
+    'gbp',
+    'ltc',
+    'eth',
+    'bch',
+    'xlm',
+    'pax',
+    'link',
+    'omg',
+    'usdc',
+)
+
 
 class TradePairData(NamedTuple):
     pair: str
@@ -494,8 +511,8 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 remote_server='Bitstamp',
             )
 
+    @staticmethod
     def _deserialize_asset_movement(
-            self,
             raw_movement: Dict[str, Any],
     ) -> AssetMovement:
         """Process a deposit/withdrawal user transaction from Bitstamp and
@@ -507,18 +524,8 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
         (the amount is expected to be in the currency involved)
         https://www.bitstamp.net/fee-schedule/
 
-        Bitstamp support confirmed the following withdrawal JSON:
-        {
-            "fee": "0.00050000",
-            "btc_usd": "0.00",
-            "datetime": "2020-12-04 09:30:00.000000",
-            "usd": "0.0",
-            "btc": "-0.50000000",
-            "type": "1",
-            "id": 123456789,
-            "eur": "0.0"
-        }
-        NB: any asset key not related with the pair is discarded (e.g. 'eur').
+        Endpoint docs:
+        https://www.bitstamp.net/api/#user-transactions
         """
         type_ = raw_movement['type']
         category: AssetMovementCategory
@@ -530,22 +537,15 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             raise AssertionError(f'Unexpected Bitstamp asset movement case: {type_}.')
 
         timestamp = deserialize_timestamp_from_bitstamp_date(raw_movement['datetime'])
-        trade_pair_data = self._get_trade_pair_data_from_transaction(raw_movement)
-        base_asset_amount = deserialize_asset_amount(
-            raw_movement[trade_pair_data.base_asset_symbol],
-        )
-        quote_asset_amount = deserialize_asset_amount(
-            raw_movement[trade_pair_data.quote_asset_symbol],
-        )
         amount: FVal
         fee_asset: Asset
-        if base_asset_amount != ZERO and quote_asset_amount == ZERO:
-            amount = base_asset_amount
-            fee_asset = trade_pair_data.base_asset
-        elif base_asset_amount == ZERO and quote_asset_amount != ZERO:
-            amount = quote_asset_amount
-            fee_asset = trade_pair_data.quote_asset
-        else:
+        for symbol in BITSTAMP_ASSET_MOVEMENT_SYMBOLS:
+            amount = deserialize_asset_amount(raw_movement.get(symbol, '0'))
+            if amount != ZERO:
+                fee_asset = Asset(symbol)
+                break
+
+        if amount == ZERO:
             raise DeserializationError(
                 'Could not deserialize Bitstamp asset movement from user transaction. '
                 f'Unexpected asset amount combination found in: {raw_movement}.',

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -798,6 +798,33 @@ def test_deserialize_asset_movement_deposit(mock_bitstamp):
     expected_movement = mock_bitstamp._deserialize_asset_movement(raw_movement)
     assert movement == expected_movement
 
+    raw_movement = {
+        'id': 3,
+        'type': 0,
+        'datetime': '2018-03-21 06:46:06.559877',
+        'btc': '0',
+        'usd': '0.00000000',
+        'btc_usd': '0.00',
+        'fee': '0.1',
+        'order_id': 2,
+        'gbp': '1000.51',
+    }
+    asset = Asset('GBP')
+    movement = AssetMovement(
+        timestamp=1521614766,
+        location=Location.BITSTAMP,
+        category=AssetMovementCategory.DEPOSIT,
+        address=None,
+        transaction_id=None,
+        asset=asset,
+        amount=FVal('1000.51'),
+        fee_asset=asset,
+        fee=Fee(FVal('0.1')),
+        link='3',
+    )
+    expected_movement = mock_bitstamp._deserialize_asset_movement(raw_movement)
+    assert movement == expected_movement
+
 
 def test_deserialize_asset_movement_withdrawal(mock_bitstamp):
     raw_movement = {
@@ -822,6 +849,33 @@ def test_deserialize_asset_movement_withdrawal(mock_bitstamp):
         amount=FVal('10000'),
         fee_asset=asset,
         fee=Fee(FVal('50')),
+        link='5',
+    )
+    expected_movement = mock_bitstamp._deserialize_asset_movement(raw_movement)
+    assert movement == expected_movement
+
+    raw_movement = {
+        'id': 5,
+        'type': 1,
+        'datetime': '2018-03-21 06:46:06.559877',
+        'btc': '0',
+        'usd': '0',
+        'btc_usd': '0.00',
+        'fee': '0.1',
+        'order_id': 2,
+        'eur': '500',
+    }
+    asset = Asset('EUR')
+    movement = AssetMovement(
+        timestamp=1521614766,
+        location=Location.BITSTAMP,
+        category=AssetMovementCategory.WITHDRAWAL,
+        address=None,
+        transaction_id=None,
+        asset=asset,
+        amount=FVal('500'),
+        fee_asset=asset,
+        fee=Fee(FVal('0.1')),
         link='5',
     )
     expected_movement = mock_bitstamp._deserialize_asset_movement(raw_movement)


### PR DESCRIPTION
Before this patch the only kind of bitstamp deposit/withdrawal that we could parse is BTC or USD ones. Anything else failed with the error seen in #2232.

Fix #2232

After this is included in a release users should purge all their bitstamp data to be sure that all deposit/withdrawals are included for bitstamp.