### PR TITLE
Reduce unnecessary coingecko calls, usd price calls and some more improvements

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -387,9 +387,17 @@ class RestAPI():
 
             asset_rates[asset] = Price(FVal(1) / usd_price)
 
-        fiat_rates = Inquirer().get_fiat_usd_exchange_rates(fiat_currencies)
-        asset_rates.update(fiat_rates)
+        try:
+            fiat_rates = Inquirer().get_fiat_usd_exchange_rates(fiat_currencies)
+        except RemoteError as e:
+            return api_response(
+                wrap_in_fail_result(
+                    f'Failed to query usd price of fiat currencies due to {str(e)}',
+                ),
+                status_code=HTTPStatus.BAD_GATEWAY,
+            )
 
+        asset_rates.update(fiat_rates)
         res = process_result(asset_rates)
         return api_response(_wrap_in_ok_result(res), status_code=HTTPStatus.OK)
 

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -270,8 +270,8 @@ class Asset():
         May raise:
             - UnsupportedAsset() if the asset is not supported by coingecko
         """
-        coingecko_str = self.identifier if self.coingecko is None else self.coingecko
-        # There is an asset which should not be queried in cryptocompare
+        coingecko_str = '' if self.coingecko is None else self.coingecko
+        # This asset has no coingecko mapping
         if coingecko_str == '':
             raise UnsupportedAsset(f'{self.identifier} is not supported by coingecko')
         return coingecko_str

--- a/rotkehlchen/icons.py
+++ b/rotkehlchen/icons.py
@@ -9,7 +9,7 @@ from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.resolver import AssetResolver, asset_type_mapping
-from rotkehlchen.errors import RemoteError
+from rotkehlchen.errors import RemoteError, UnsupportedAsset
 from rotkehlchen.externalapis.coingecko import Coingecko, DELISTED_ASSETS
 from rotkehlchen.typing import AssetType
 from rotkehlchen.utils.hashing import file_md5
@@ -62,7 +62,7 @@ class IconManager():
 
         try:
             data = self.coingecko.asset_data(asset)
-        except RemoteError as e:
+        except (UnsupportedAsset, RemoteError) as e:
             log.warning(
                 f'Problem querying coingecko for asset data of {asset.identifier}: {str(e)}',
             )

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -1,8 +1,10 @@
+import pytest
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
 from rotkehlchen.externalapis.coingecko import CoingeckoAssetData, CoingeckoImageURLs
 from rotkehlchen.fval import FVal
 from rotkehlchen.typing import Price
+from rotkehlchen.errors import UnsupportedAsset
 
 
 def assert_coin_data_same(given, expected, compare_description=False):
@@ -46,6 +48,9 @@ def test_asset_data(session_coingecko):
     )
     data = session_coingecko.asset_data(Asset('YFI'))
     assert_coin_data_same(data, expected_data, compare_description=False)
+
+    with pytest.raises(UnsupportedAsset):
+        session_coingecko.asset_data(Asset('PRL'))
 
 
 def test_coingecko_historical_price(session_coingecko):

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -188,7 +188,7 @@ def create_inquirer(
     def mock_query_fiat_pair(base, quote):  # pylint: disable=unused-argument
         return FVal(1)
 
-    inquirer.query_fiat_pair = mock_query_fiat_pair  # type: ignore
+    inquirer._query_fiat_pair = mock_query_fiat_pair  # type: ignore
 
     return inquirer
 

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -45,7 +45,7 @@ def test_switching_to_backup_api(inquirer):
         return original_get(url)
 
     with patch('requests.get', side_effect=mock_exchanges_rateapi_fail):
-        result = inquirer.query_fiat_pair(A_USD, A_EUR)
+        result = inquirer._query_fiat_pair(A_USD, A_EUR)
         assert result and isinstance(result, FVal)
         assert count > 1, 'requests.get should have been called more than once'
 
@@ -57,11 +57,11 @@ def test_fiat_pair_caching(inquirer):
         return MockResponse(200, '{"rates":{"EUR":0.9165902841},"base":"USD","date":"2020-05-25"}')
 
     with patch('requests.get', side_effect=mock_exchanges_rate_api):
-        result = inquirer.query_fiat_pair(A_USD, A_EUR)
+        result = inquirer._query_fiat_pair(A_USD, A_EUR)
         assert result == FVal('0.9165902841')
 
     # Now outside the mocked response, we should get same value due to caching
-    assert inquirer.query_fiat_pair(A_USD, A_EUR) == FVal('0.9165902841')
+    assert inquirer._query_fiat_pair(A_USD, A_EUR) == FVal('0.9165902841')
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -81,11 +81,11 @@ def test_fallback_to_cached_values_within_a_month(inquirer):  # pylint: disable=
 
     with patch('requests.get', side_effect=mock_api_remote_fail):
         # We fail to find a response but then go back 15 days and find the cached response
-        result = inquirer.query_fiat_pair(A_EUR, A_JPY)
+        result = inquirer._query_fiat_pair(A_EUR, A_JPY)
         assert result == eurjpy_val
         # The cached response for EUR CNY is too old so we will fail here
-        with pytest.raises(ValueError):
-            result = inquirer.query_fiat_pair(A_EUR, A_CNY)
+        with pytest.raises(RemoteError):
+            result = inquirer._query_fiat_pair(A_EUR, A_CNY)
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])


### PR DESCRIPTION
- We were not handling the coingecko identifier recognition properly
so we actually had multiple calls to coingecko which did not work due
to the identifier being wrong
- Properly handle errors at fiat to fiat price queries
- Handle case of USD to USD price oracle call