### PR TITLE
Pull latest chain type registry when instantiating SubstrateInterface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ typing-extensions==3.7.4.3
 base58check==1.0.2
 bech32==1.2.0
 gql==2.0.0
-substrate-interface==0.11.8
+substrate-interface==0.11.16
 
 # For the rest api
 flask-cors==3.0.8

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -378,12 +378,6 @@ class SubstrateManager():
         except (
             requests.exceptions.RequestException,
             SubstrateRequestException,
-            # TODO: remove TypeError once py-susbtrate-interface `get_block_number`
-            # handles a None response. Keep ValueError just in case `get_chain_head`
-            # returns None.
-            # https://github.com/polkascan/py-substrate-interface/issues/68
-            TypeError,
-            ValueError,
             WebSocketException,
         ) as e:
             message = (
@@ -417,6 +411,7 @@ class SubstrateManager():
             node_interface = SubstrateInterface(
                 url=endpoint,
                 type_registry_preset=si_attributes.type_registry_preset,
+                use_remote_preset=True,
             )
         except (requests.exceptions.RequestException, WebSocketException) as e:
             message = (

--- a/rotkehlchen/chain/substrate/utils.py
+++ b/rotkehlchen/chain/substrate/utils.py
@@ -29,12 +29,25 @@ def is_valid_substrate_address(
 ) -> bool:
     """Validates a ss58 encoded substrate address for the given chain.
 
+    TODO: this function relies on py-scale-codec `ss58_decode()` for validating
+    that a str is a valid substrate address for the given chain. The recent
+    changes introduced on the py-scale-codec library have altered the behavior
+    of this function by validating positively any str starting with `0x`. An
+    issue has been opened regarding this matter (link below). Once py-scale-codec
+    implements its own address validation method this function may be no longer
+    needed. Issue:
+    https://github.com/polkascan/py-scale-codec/issues/27
+
     Polkascan ss58 utils documentation:
     https://github.com/polkascan/py-substrate-interface/blob/master/substrateinterface/utils/ss58.py  # noqa: E501
 
     External Address Format (SS58) documentation:
     https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58)
     """
+    if value.startswith('0x'):
+        # TODO: temporary patch for py-scale-codec/issue/27
+        return False
+
     if chain == SubstrateChain.KUSAMA:
         valid_ss58_format = 2
     else:
@@ -47,6 +60,7 @@ def is_valid_substrate_address(
         )
     except ValueError:
         return False
+
     return True
 
 

--- a/rotkehlchen/tests/unit/test_substrate_manager.py
+++ b/rotkehlchen/tests/unit/test_substrate_manager.py
@@ -49,7 +49,7 @@ def test_get_account_balance_invalid_account(kusama_manager):
     )
     account_balance_errors = [error for error in errors if error.startswith(user_error_msg)]
     for error in account_balance_errors:
-        assert 'Invalid Address type' in error
+        assert 'Invalid SS58 format' in error
 
     assert 'Kusama request failed after trying the following nodes' in str(e.value)
 
@@ -73,7 +73,7 @@ def test_get_accounts_balance_invalid_account(kusama_manager):
     )
     account_balance_errors = [error for error in errors if error.startswith(user_error_msg)]
     for error in account_balance_errors:
-        assert 'Invalid Address type' in error
+        assert 'Invalid SS58 format' in error
 
     assert 'Kusama request failed after trying the following nodes' in str(e.value)
 

--- a/tools/pyinstaller_hooks/hook-scalecodec.py
+++ b/tools/pyinstaller_hooks/hook-scalecodec.py
@@ -1,5 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-# scalecodec has a lot of json files from which it loads the types
-# we need to make sure pyinstaller bundles them in the created binary
-datas = collect_data_files('scalecodec')


### PR DESCRIPTION
[PIP] tag is because it upgrades `py-substrate-interface`.

Pending:
- Check if it works as expected after building the app, especially after rolling back the PyInstaller changes introduced by
#2118
- Optionally froze in our requirements.txt the `scalecodec` version. Probs this is a bad idea as long as py-susbstrate-interface does not freeze it too. Besides what really matters is to pull the latest type registry, as we do know with `use_remote_preset`.

Closes #2196 and #2340