### PR TITLE
Fixes Kucoin api query signing, skips sandbox tests, adds new assets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 
 * :feature:`-` Added support for the following tokens:
 
+  - `Bao Finance Token (BAO) <https://www.coingecko.com/en/coins/bao-finance>`__
   - `Sora Token (XOR) <https://www.coingecko.com/en/coins/sora>`__
   - `Banano (BAN) <https://www.coingecko.com/en/coins/banano>`__
   - `Redfox labs token (RFOX) <https://www.coingecko.com/en/coins/redfox-labs>`__

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 
 * :feature:`-` Added support for the following tokens:
 
+  - `Gunthy Token (GUNTHY) <https://www.coingecko.com/en/coins/gunthy>`__
   - `Bao Finance Token (BAO) <https://www.coingecko.com/en/coins/bao-finance>`__
   - `Sora Token (XOR) <https://www.coingecko.com/en/coins/sora>`__
   - `Banano (BAN) <https://www.coingecko.com/en/coins/banano>`__

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changelog
 * :feature:`-` Added support for the following tokens:
 
   - `Sora Token (XOR) <https://www.coingecko.com/en/coins/sora>`__
+  - `Banano (BAN) <https://www.coingecko.com/en/coins/banano>`__
   - `Redfox labs token (RFOX) <https://www.coingecko.com/en/coins/redfox-labs>`__
   - `BoringDAO (BOR) <https://www.coingecko.com/en/coins/boringdao>`__
   - `BoringDAO BTC (oBTC) <https://www.coingecko.com/en/coins/boringdao-btc>`__

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 
 * :feature:`-` Added support for the following tokens:
 
+  - `Sora Token (XOR) <https://www.coingecko.com/en/coins/sora>`__
   - `Redfox labs token (RFOX) <https://www.coingecko.com/en/coins/redfox-labs>`__
   - `BoringDAO (BOR) <https://www.coingecko.com/en/coins/boringdao>`__
   - `BoringDAO BTC (oBTC) <https://www.coingecko.com/en/coins/boringdao-btc>`__

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -13383,6 +13383,15 @@
         "symbol": "XNN",
         "type": "ethereum token"
     },
+    "XOR": {
+        "coingecko": "sora",
+        "ethereum_address": "0x40FD72257597aA14C7231A7B1aaa29Fce868F677",
+        "ethereum_token_decimals": 18,
+        "name": "Sora Token",
+        "started": 1571141236,
+        "symbol": "XOR",
+        "type": "ethereum token"
+    },
     "XOV": {
         "coingecko": "xov",
         "ethereum_address": "0x153eD9CC1b792979d2Bde0BBF45CC2A7e436a5F9",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -5951,6 +5951,16 @@
         "symbol": "GUESS",
         "type": "ethereum token"
     },
+    "GUNTHY": {
+        "coingecko": "gunthy",
+        "cryptocompare": "",
+        "ethereum_address": "0x3684b581dB1F94b721EE0022624329FEb16Ab653",
+        "ethereum_token_decimals": 18,
+        "name": "GUNTHY",
+        "started": 1545158465,
+        "symbol": "GUNTHY",
+        "type": "ethereum token"
+    },
     "GUP": {
         "coingecko": "matchpool",
         "ethereum_address": "0xf7B098298f7C69Fc14610bf71d5e02c60792894C",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1043,6 +1043,15 @@
         "symbol": "BAND",
         "type": "ethereum token"
     },
+    "BAO": {
+        "coingecko": "bao-finance",
+        "ethereum_address": "0x374CB8C27130E2c9E04F44303f3c8351B9De61C1",
+        "ethereum_token_decimals": 18,
+        "name": "BaoToken",
+        "started": 1606850780,
+        "symbol": "BAO",
+        "type": "ethereum token"
+    },
     "BAS": {
         "active": false,
         "coingecko": "bitasean",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1018,6 +1018,13 @@
         "symbol": "BAL",
         "type": "ethereum token"
     },
+    "BAN": {
+        "coingecko": "banano",
+        "name": "Avalanche",
+        "started": 1538352000,
+        "symbol": "BAN",
+        "type": "own chain"
+    },
     "BANCA": {
         "coingecko": "banca",
         "ethereum_address": "0x998b3B82bC9dBA173990Be7afb772788B5aCB8Bd",

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "fd5a4a1edd5d3c6f591734da0e8ce62c", "version": 60}
+{"md5": "6a8dba71c678a7541bd0352e6ec05c4c", "version": 61}

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -449,6 +449,7 @@ def test_deserialize_asset_movement_skipped(mock_kucoin, start_ts, end_ts, is_in
     assert reason == skip_reason
 
 
+@pytest.mark.skip('Fails with status code: 404 and text: KC-API-KEY not exists')
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
 def test_query_balances_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unused-argument
     assets_balance, msg = sandbox_kuckoin.query_balances()
@@ -473,6 +474,7 @@ def test_query_balances_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=u
     assert msg == ''
 
 
+@pytest.mark.skip('Fails with status code: 404 and text: KC-API-KEY not exists')
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
 def test_query_trades_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unused-argument
     """The sandbox account has 6 trades. Below a list of the trades and their

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -191,7 +191,7 @@ def test_coingecko_identifiers_are_reachable(data_dir):
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': 'fd5a4a1edd5d3c6f591734da0e8ce62c', 'version': 60}
+    last_meta = {'md5': '6a8dba71c678a7541bd0352e6ec05c4c', 'version': 61}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 


### PR DESCRIPTION
1. This PR fixes the API signing for Kucoin. It was wrong before. Kucoin passphrase needs to be signed with the secret. Taken from the basics section of their authentication docs: https://docs.kucoin.com/#authentication
2. Skips the sandbox api tests. They all fail with `status code: 404 and text: KC-API-KEY not exists`
3. Adds all the missing assets to fix #2369 