### PR TITLE
Fix Kucoin deposit, withdrawals and trades retrieval

### DIFF
--- a/rotkehlchen/constants/timing.py
+++ b/rotkehlchen/constants/timing.py
@@ -5,6 +5,8 @@ BCH_BSV_FORK_TS = 1542304352  # 2018-11-15 18:52:00 UTC
 ROTKEHLCHEN_SERVER_TIMEOUT = 5
 GLOBAL_REQUESTS_TIMEOUT = 5  # perhaps consolidate this and the one above?
 
+WEEK_IN_SECONDS = 24 * 3600 * 7
+MONTH_IN_SECONDS = WEEK_IN_SECONDS * 4
 YEAR_IN_SECONDS = 31536000  # 60 * 60 * 24 * 365
 
 # For queries that are attempted multiple times:

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -219,9 +219,10 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             request_url = f'{self.base_uri}/{api_path}'
             message = f'{timestamp}{method}/{api_path}'
             if case in (KucoinCase.TRADES, KucoinCase.DEPOSITS, KucoinCase.WITHDRAWALS):
-                urlencoded_options = urlencode(call_options)
-                request_url = f'{request_url}?{urlencoded_options}'
-                message = f'{message}?{urlencoded_options}'
+                if call_options != {}:
+                    urlencoded_options = urlencode(call_options)
+                    request_url = f'{request_url}?{urlencoded_options}'
+                    message = f'{message}?{urlencoded_options}'
 
             signature = base64.b64encode(
                 hmac.new(

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -522,7 +522,8 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 return None, SkipReason.INNER_MOVEMENT
 
             address = raw_result['address']
-            transaction_id = raw_result['walletTxId']
+            # The transaction id can have an @ which we should just get rid of
+            transaction_id = raw_result['walletTxId'].split('@')[0]
             amount = deserialize_asset_amount(raw_result['amount'])
             fee = deserialize_fee(raw_result['fee'])
             fee_currency_symbol = raw_result['currency']
@@ -572,7 +573,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             amount = deserialize_asset_amount(raw_result['size'])
             rate = deserialize_price(raw_result['price'])
             fee = deserialize_fee(raw_result['fee'])
-            trade_id = raw_result['tradeId']
+            trade_id = raw_result['id']
             fee_currency_symbol = raw_result['feeCurrency']
             trade_pair_symbol = raw_result['symbol']
         except KeyError as e:

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -194,16 +194,19 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
         if case == KucoinCase.BALANCES:
             api_path = 'api/v1/accounts'
         elif case == KucoinCase.DEPOSITS:
+            assert isinstance(options, dict)
             if options['startAt'] < API_V2_TIMESTART_MS:
                 api_path = 'api/v1/hist-deposits'
             else:
                 api_path = 'api/v1/deposits'
         elif case == KucoinCase.WITHDRAWALS:
+            assert isinstance(options, dict)
             if options['startAt'] < API_V2_TIMESTART_MS:
                 api_path = 'api/v1/hist-withdrawals'
             else:
                 api_path = 'api/v1/withdrawals'
         elif case == KucoinCase.TRADES:
+            assert isinstance(options, dict)
             if options['startAt'] < API_V2_TIMESTART_MS:
                 api_path = 'api/v1/hist-orders'
             else:
@@ -366,9 +369,10 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 except (
                     DeserializationError, UnknownAsset, UnprocessableTradePair, UnsupportedAsset,
                 ) as e:
+                    error_msg = str(e)
                     log.error(
                         f'Failed to deserialize a kucoin {case} result',
-                        error=str(e),
+                        error=error_msg,
                         raw_result=raw_result,
                     )
                     if isinstance(e, (UnknownAsset, UnsupportedAsset)):
@@ -573,7 +577,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             amount = deserialize_asset_amount(raw_result['size'])
             rate = deserialize_price(raw_result['price'])
             fee = deserialize_fee(raw_result['fee'])
-            trade_id = raw_result['id']
+            trade_id = raw_result.get('id', raw_result['tradeId'])
             fee_currency_symbol = raw_result['feeCurrency']
             trade_pair_symbol = raw_result['symbol']
         except KeyError as e:

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -89,5 +89,7 @@ def test_query_eth2_info(rotkehlchen_api_server, ethereum_accounts):
     assert details[0]['public_key'] == expected_pubkey
     for duration in ('1d', '1w', '1m', '1y'):
         performance = details[0][f'performance_{duration}']
-        assert FVal(performance['amount']) >= ZERO
-        assert FVal(performance['usd_value']) >= ZERO
+        # Can't assert for positive since they may go offline for a day and the test will fail
+        # https://twitter.com/LefterisJP/status/1361091757274972160
+        assert FVal(performance['amount']) is not None
+        assert FVal(performance['usd_value']) is not None

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -232,7 +232,7 @@ def test_deserialize_accounts_balances(mock_kucoin, inquirer):  # pylint: disabl
     }
 
 
-def test_deserialize_trade_buy(mock_kucoin):
+def test_deserialize_v2_trade_buy(mock_kucoin):
     raw_result = {
         'symbol': 'KCS-USDT',
         'tradeId': '601da9faf1297d0007efd712',
@@ -268,12 +268,13 @@ def test_deserialize_trade_buy(mock_kucoin):
         raw_result=raw_result,
         start_ts=Timestamp(0),
         end_ts=Timestamp(1612556794),
+        case=KucoinCase.TRADES,
     )
     assert trade == expected_trade
     assert reason is None
 
 
-def test_deserialize_trade_sell(mock_kucoin):
+def test_deserialize_v2_trade_sell(mock_kucoin):
     raw_result = {
         'symbol': 'BCHSV-USDT',
         'tradeId': '601da995e0ee8b00063a075c',
@@ -309,6 +310,40 @@ def test_deserialize_trade_sell(mock_kucoin):
         raw_result=raw_result,
         start_ts=Timestamp(0),
         end_ts=Timestamp(1612556794),
+        case=KucoinCase.TRADES,
+    )
+    assert trade == expected_trade
+    assert reason is None
+
+
+def test_deserialize_v1_trade(mock_kucoin):
+    raw_result = {
+        'id': 'xxxx',
+        'symbol': 'NANO-ETH',
+        'dealPrice': '0.015743',
+        'dealValue': '0.00003441',
+        'amount': '0.002186',
+        'fee': '0.00000003',
+        'side': 'sell',
+        'createdAt': 1520471876,
+    }
+    expected_trade = Trade(
+        timestamp=Timestamp(1520471876),
+        location=Location.KUCOIN,
+        pair=TradePair('NANO_ETH'),
+        trade_type=TradeType.SELL,
+        amount=AssetAmount(FVal('0.002186')),
+        rate=Price(FVal('0.015743')),
+        fee=Fee(FVal('0.00000003')),
+        fee_currency=Asset('ETH'),
+        link='xxxx',
+        notes='',
+    )
+    trade, reason = mock_kucoin._deserialize_trade(
+        raw_result=raw_result,
+        start_ts=Timestamp(0),
+        end_ts=Timestamp(1612556794),
+        case=KucoinCase.OLD_TRADES,
     )
     assert trade == expected_trade
     assert reason is None
@@ -342,6 +377,7 @@ def test_deserialize_trade_skipped(mock_kucoin, start_ts, end_ts, skip_reason):
         raw_result=raw_result,
         start_ts=Timestamp(start_ts),
         end_ts=Timestamp(end_ts),
+        case=KucoinCase.TRADES,
     )
     assert trade is None
     assert reason == skip_reason

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -108,6 +108,7 @@ def test_api_query_retries_request(mock_kucoin):
                 'currentPage': 1,
                 'pageSize': 500,
                 'tradeType': 'TRADE',
+                'startAt': 1504224000000,
             },
             case=KucoinCase.TRADES,
         )


### PR DESCRIPTION
This fixes deposit/withdrawals most probably for all time ranges.

~~Still not sure about trades. It seems to only return trades for users who have had recent trades (since end of 2019?). And not for users who have had trades in 2018. Pending to figure out if this is a kucoin limitation.~~

It seems you need to query a specific trade method for old trades. Same as we do with deposits and withdrawals ... but there the timestamps are in seconds not milliseconds. Go figure.