### PR TITLE
Fix Kucoin trade history parsing edge case

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`2405` Legacy bitcoin address balances and xpub derivation should now work properly again after blockchain.info decided to yolo change their api response format.
 * :bug:`2400` Loopring balances should now be queried properly for users who own USDT.
+* :bug:`2398` An edge case of Kucoin historical trade query parsing is fixed. So now even users with some specific ids in their trades will be able to query history properly for Kucoin.
 
 * :feature:`-` Added support for the following tokens:
 

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -605,7 +605,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             rate=rate,
             fee=fee,
             fee_currency=fee_currency,
-            link=trade_id,
+            link=str(trade_id),
             notes='',
         )
         return trade

--- a/rotkehlchen/utils/serialization.py
+++ b/rotkehlchen/utils/serialization.py
@@ -87,6 +87,8 @@ def rkl_decode_value(
                 (k == 'name' and isinstance(value, (FVal, int))) or
                 (k == 'symbol' and isinstance(value, (FVal, int))) or
                 (k == 'baseAsset' and isinstance(value, (FVal, int))) or
+                (k == 'tradeId' and isinstance(value, (FVal, int))) or
+                (k == 'id' and isinstance(value, (FVal, int))) or
                 (k == 'quoteAsset' and isinstance(value, (FVal, int)))
             )
             if should_not_be_fval:


### PR DESCRIPTION
In some very specific edge cases Kucoin was returning a string id
which was parseable as a number and we were returning it as an fval
due to rlk_decode_value.

We are now ignoring the relevant kucoin attribute keys and also force
string there so this should not happen again.

Fix #2398