### PR TITLE
Add only_cache argument to trades and deposit/withdrawals endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2404,7 +2404,7 @@ Dealing with trades
       GET /api/1/trades HTTP/1.1
       Host: localhost:5042
 
-      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "location": "external"}
+      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "location": "external", "only_cache": false}
 
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
@@ -2412,6 +2412,7 @@ Dealing with trades
    :param int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :param int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :param string location: Optionally filter trades by location. A valid location name has to be provided. If missing location filtering does not happen.
+   :param bool only_cache: Optional.If this is true then the equivalent exchange/location is not queried, but only what is already in the DB is returned.
 
    .. _trades_schema_section:
 
@@ -2646,11 +2647,12 @@ Querying asset movements
       GET /api/1/asset_movements HTTP/1.1
       Host: localhost:5042
 
-      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "location": "kraken"}
+      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "location": "kraken", "only_cache": false}
 
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson string location: Optionally filter trades by location. A valid location name has to be provided. Valid locations are for now only exchanges for deposits/widthrawals.
+   :param bool only_cache: Optional. If this is true then the equivalent exchange/location is not queried, but only what is already in the DB is returned.
 
 
    **Example Response**:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`1448` When querying trades, deposits and withdrawals the entries that have already been queried will now be instantly shown to the user, while waiting for the query of the latest entries to complete.
 * :feature:`1799` Modules will now be dynamically activated/deactivated at the moment the user modifies the settings from the frontend. Restarts of the app will no longer be necessary.
 * :bug:`2405` Legacy bitcoin address balances and xpub derivation should now work properly again after blockchain.info decided to yolo change their api response format.
 * :bug:`2400` Loopring balances should now be queried properly for users who own USDT.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -616,9 +616,15 @@ class RestAPI():
             from_ts: Timestamp,
             to_ts: Timestamp,
             location: Optional[Location],
+            only_cache: bool,
     ) -> Dict[str, Any]:
         try:
-            trades = self.rotkehlchen.query_trades(from_ts=from_ts, to_ts=to_ts, location=location)
+            trades = self.rotkehlchen.query_trades(
+                from_ts=from_ts,
+                to_ts=to_ts,
+                location=location,
+                only_cache=only_cache,
+            )
         except RemoteError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_GATEWAY}
 
@@ -660,6 +666,7 @@ class RestAPI():
             to_ts: Timestamp,
             location: Optional[Location],
             async_query: bool,
+            only_cache: bool,
     ) -> Response:
         if async_query:
             return self._query_async(
@@ -667,12 +674,14 @@ class RestAPI():
                 from_ts=from_ts,
                 to_ts=to_ts,
                 location=location,
+                only_cache=only_cache,
             )
 
         response = self._get_trades(
             from_ts=from_ts,
             to_ts=to_ts,
             location=location,
+            only_cache=only_cache,
         )
         status_code = _get_status_code_from_async_response(response)
         result_dict = {'result': response['result'], 'message': response['message']}
@@ -761,6 +770,7 @@ class RestAPI():
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
             location: Optional[Location],
+            only_cache: bool,
     ) -> Dict[str, Any]:
         msg = ''
         status_code = HTTPStatus.OK
@@ -770,6 +780,7 @@ class RestAPI():
                 from_ts=from_timestamp,
                 to_ts=to_timestamp,
                 location=location,
+                only_cache=only_cache,
             )
         except RemoteError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_GATEWAY}
@@ -801,6 +812,7 @@ class RestAPI():
             to_timestamp: Timestamp,
             location: Optional[Location],
             async_query: bool,
+            only_cache: bool,
     ) -> Response:
         if async_query:
             return self._query_async(
@@ -808,12 +820,14 @@ class RestAPI():
                 from_timestamp=from_timestamp,
                 to_timestamp=to_timestamp,
                 location=location,
+                only_cache=only_cache,
             )
 
         response = self._get_asset_movements(
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
             location=location,
+            only_cache=only_cache,
         )
         result_dict = {'result': response['result'], 'message': response['message']}
         status_code = _get_status_code_from_async_response(response)

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -695,6 +695,10 @@ class TimerangeLocationQuerySchema(Schema):
     async_query = fields.Boolean(missing=False)
 
 
+class TimerangeLocationCacheQuerySchema(TimerangeLocationQuerySchema):
+    only_cache = fields.Boolean(missing=False)
+
+
 class TradeSchema(Schema):
     timestamp = TimestampField(required=True)
     location = LocationField(required=True)

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -58,6 +58,7 @@ from rotkehlchen.api.v1.encoding import (
     TagDeleteSchema,
     TagEditSchema,
     TagSchema,
+    TimerangeLocationCacheQuerySchema,
     TimerangeLocationQuerySchema,
     TradeDeleteSchema,
     TradePatchSchema,
@@ -367,7 +368,7 @@ class ManuallyTrackedBalancesResource(BaseResource):
 
 class TradesResource(BaseResource):
 
-    get_schema = TimerangeLocationQuerySchema()
+    get_schema = TimerangeLocationCacheQuerySchema()
     put_schema = TradeSchema()
     patch_schema = TradePatchSchema()
     delete_schema = TradeDeleteSchema()
@@ -379,12 +380,14 @@ class TradesResource(BaseResource):
             to_timestamp: Timestamp,
             location: Optional[Location],
             async_query: bool,
+            only_cache: bool,
     ) -> Response:
         return self.rest_api.get_trades(
             from_ts=from_timestamp,
             to_ts=to_timestamp,
             location=location,
             async_query=async_query,
+            only_cache=only_cache,
         )
 
     @use_kwargs(put_schema, location='json')  # type: ignore
@@ -450,7 +453,7 @@ class TradesResource(BaseResource):
 
 class AssetMovementsResource(BaseResource):
 
-    get_schema = TimerangeLocationQuerySchema()
+    get_schema = TimerangeLocationCacheQuerySchema()
 
     @use_kwargs(get_schema, location='json_and_query')  # type: ignore
     def get(
@@ -459,12 +462,14 @@ class AssetMovementsResource(BaseResource):
             to_timestamp: Timestamp,
             location: Optional[Location],
             async_query: bool,
+            only_cache: bool,
     ) -> Response:
         return self.rest_api.get_asset_movements(
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
             location=location,
             async_query=async_query,
+            only_cache=only_cache,
         )
 
 

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -228,6 +228,7 @@ class EventsHistorian():
                 addresses=self.chain_manager.queried_addresses_for_module('uniswap'),
                 from_timestamp=Timestamp(0),
                 to_timestamp=end_ts,
+                only_cache=False,
             )
             history.extend(uniswap_trades)
         step = self._increase_progress(step, total_steps)

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -630,9 +630,13 @@ class Rotkehlchen():
             from_ts: Timestamp,
             to_ts: Timestamp,
             location: Optional[Location],
+            only_cache: bool,
     ) -> TRADES_LIST:
         """Queries trades for the given location and time range.
         If no location is given then all external, all exchange and DEX trades are queried.
+
+        If only_cache is given then only trades cached in the DB are returned.
+        No service is queried.
 
         DEX Trades are queried only if the user has premium
         If the user does not have premium then a trade limit is applied.
@@ -642,11 +646,16 @@ class Rotkehlchen():
         """
         trades: TRADES_LIST
         if location is not None:
-            trades = self.query_location_trades(from_ts, to_ts, location)
+            trades = self.query_location_trades(from_ts, to_ts, location, only_cache)
         else:
-            trades = self.query_location_trades(from_ts, to_ts, Location.EXTERNAL)
+            trades = self.query_location_trades(from_ts, to_ts, Location.EXTERNAL, only_cache)
             # crypto.com is not an API key supported exchange but user can import from CSV
-            trades.extend(self.query_location_trades(from_ts, to_ts, Location.CRYPTOCOM))
+            trades.extend(self.query_location_trades(
+                from_ts=from_ts,
+                to_ts=to_ts,
+                location=Location.CRYPTOCOM,
+                only_cache=only_cache,
+            ))
             for name, exchange in self.exchange_manager.connected_exchanges.items():
                 exchange_trades = exchange.query_trade_history(start_ts=from_ts, end_ts=to_ts)
                 if self.premium is None:
@@ -668,6 +677,7 @@ class Rotkehlchen():
                             addresses=self.chain_manager.queried_addresses_for_module('uniswap'),
                             from_timestamp=from_ts,
                             to_timestamp=to_ts,
+                            only_cache=only_cache,
                         ),
                     )
 
@@ -680,6 +690,7 @@ class Rotkehlchen():
             from_ts: Timestamp,
             to_ts: Timestamp,
             location: Location,
+            only_cache: bool,
     ) -> TRADES_LIST:
         # clear the trades queried for this location
         self.actions_per_location['trade'][location] = 0
@@ -699,6 +710,7 @@ class Rotkehlchen():
                         addresses=self.chain_manager.queried_addresses_for_module('uniswap'),
                         from_timestamp=from_ts,
                         to_timestamp=to_ts,
+                        only_cache=only_cache,
                     )
         else:
             # should only be an exchange
@@ -710,7 +722,11 @@ class Rotkehlchen():
                 )
                 return []
 
-            location_trades = exchange.query_trade_history(start_ts=from_ts, end_ts=to_ts)
+            location_trades = exchange.query_trade_history(
+                start_ts=from_ts,
+                end_ts=to_ts,
+                only_cache=only_cache,
+            )
 
         trades: TRADES_LIST = []
         if self.premium is None:
@@ -840,6 +856,7 @@ class Rotkehlchen():
             to_ts: Timestamp,
             all_movements: List[AssetMovement],
             exchange: Union[ExchangeInterface, Location],
+            only_cache: bool,
     ) -> List[AssetMovement]:
         if isinstance(exchange, ExchangeInterface):
             location = deserialize_location(exchange.name)
@@ -848,6 +865,7 @@ class Rotkehlchen():
             location_movements = exchange.query_deposits_withdrawals(
                 start_ts=from_ts,
                 end_ts=to_ts,
+                only_cache=only_cache,
             )
         else:
             assert isinstance(exchange, Location), 'only a location should make it here'
@@ -880,10 +898,12 @@ class Rotkehlchen():
             from_ts: Timestamp,
             to_ts: Timestamp,
             location: Optional[Location],
+            only_cache: bool,
     ) -> List[AssetMovement]:
         """Queries AssetMovements for the given location and time range.
 
         If no location is given then all exchange asset movements are queried.
+        If only_cache is True then only what is already in the DB is returned.
         If the user does not have premium then a limit is applied.
         May raise:
         - RemoteError: If there are problems connecting to any of the remote exchanges
@@ -896,6 +916,7 @@ class Rotkehlchen():
                     to_ts=to_ts,
                     all_movements=movements,
                     exchange=Location.CRYPTOCOM,
+                    only_cache=only_cache,
                 )
             else:
                 exchange = self.exchange_manager.get(str(location))
@@ -910,6 +931,7 @@ class Rotkehlchen():
                     to_ts=to_ts,
                     all_movements=movements,
                     exchange=exchange,
+                    only_cache=only_cache,
                 )
         else:
             # cryptocom has no exchange integration but we may have DB entries due to csv import
@@ -918,6 +940,7 @@ class Rotkehlchen():
                 to_ts=to_ts,
                 all_movements=movements,
                 exchange=Location.CRYPTOCOM,
+                only_cache=only_cache,
             )
             for _, exchange in self.exchange_manager.connected_exchanges.items():
                 self._query_exchange_asset_movements(
@@ -925,6 +948,7 @@ class Rotkehlchen():
                     to_ts=to_ts,
                     all_movements=movements,
                     exchange=exchange,
+                    only_cache=only_cache,
                 )
 
         # return movements with most recent first

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -657,7 +657,11 @@ class Rotkehlchen():
                 only_cache=only_cache,
             ))
             for name, exchange in self.exchange_manager.connected_exchanges.items():
-                exchange_trades = exchange.query_trade_history(start_ts=from_ts, end_ts=to_ts)
+                exchange_trades = exchange.query_trade_history(
+                    start_ts=from_ts,
+                    end_ts=to_ts,
+                    only_cache=only_cache,
+                )
                 if self.premium is None:
                     trades = self._apply_actions_limit(
                         location=deserialize_location(name),

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -224,7 +224,7 @@ def test_binance_query_trade_history(function_scope_binance):
         return MockResponse(200, text)
 
     with patch.object(binance.session, 'get', side_effect=mock_my_trades):
-        trades = binance.query_trade_history(start_ts=0, end_ts=1564301134)
+        trades = binance.query_trade_history(start_ts=0, end_ts=1564301134, only_cache=False)
 
     expected_trade = Trade(
         timestamp=1499865549,

--- a/rotkehlchen/tests/exchanges/test_bitcoinde.py
+++ b/rotkehlchen/tests/exchanges/test_bitcoinde.py
@@ -57,6 +57,7 @@ def test_query_trade_history(function_scope_bitcoinde):
         trades = bitcoinde.query_trade_history(
             start_ts=0,
             end_ts=1565732120,
+            only_cache=False,
         )
 
     assert len(trades) == 2

--- a/rotkehlchen/tests/exchanges/test_bitmex.py
+++ b/rotkehlchen/tests/exchanges/test_bitmex.py
@@ -53,6 +53,7 @@ def test_bitmex_api_withdrawals_deposit_and_query_after_subquery(sandbox_bitmex)
     result = sandbox_bitmex.query_deposits_withdrawals(
         start_ts=1536492800,
         end_ts=1536492976,
+        only_cache=False,
     )
     assert len(result) == 0
 
@@ -62,6 +63,7 @@ def test_bitmex_api_withdrawals_deposit_and_query_after_subquery(sandbox_bitmex)
     result = sandbox_bitmex.query_deposits_withdrawals(
         start_ts=0,
         end_ts=now,
+        only_cache=False,
     )
     expected_result = [
         AssetMovement(

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -127,7 +127,7 @@ def test_bittrex_query_trade_history(bittrex):
         return response
 
     with patch.object(bittrex.session, 'request', side_effect=mock_order_history):
-        trades = bittrex.query_trade_history(start_ts=0, end_ts=1564301134)
+        trades = bittrex.query_trade_history(start_ts=0, end_ts=1564301134, only_cache=False)
 
     expected_trades = [Trade(
         timestamp=1392249600,
@@ -391,7 +391,11 @@ def test_bittrex_query_asset_movement_int_transaction_id(bittrex):
         return MockResponse(200, response_str)
 
     with patch.object(bittrex.session, 'request', side_effect=mock_get_deposit_withdrawal):
-        movements = bittrex.query_deposits_withdrawals(start_ts=0, end_ts=TEST_END_TS)
+        movements = bittrex.query_deposits_withdrawals(
+            start_ts=0,
+            end_ts=TEST_END_TS,
+            only_cache=False,
+        )
 
     errors = bittrex.msg_aggregator.consume_errors()
     warnings = bittrex.msg_aggregator.consume_warnings()

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -437,6 +437,7 @@ def test_coinbase_query_trade_history(function_scope_coinbase):
         trades = coinbase.query_trade_history(
             start_ts=0,
             end_ts=TEST_END_TS,
+            only_cache=False,
         )
 
     warnings = coinbase.msg_aggregator.consume_warnings()
@@ -472,6 +473,7 @@ def test_coinbase_query_trade_history(function_scope_coinbase):
         trades = coinbase.query_trade_history(
             start_ts=0,
             end_ts=1451606400,
+            only_cache=False,
         )
 
     warnings = coinbase.msg_aggregator.consume_warnings()

--- a/rotkehlchen/tests/exchanges/test_coinbasepro.py
+++ b/rotkehlchen/tests/exchanges/test_coinbasepro.py
@@ -369,7 +369,7 @@ def test_query_trade_history(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769)
+        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert len(trades) == 1
     assert trades[0] == EXPECTED_TRADE
@@ -386,7 +386,7 @@ def test_query_trade_history_unknown_assets(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769)
+        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert len(trades) == 1
     assert trades[0] == EXPECTED_TRADE
@@ -407,7 +407,7 @@ def test_query_trade_history_wrong_format(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769)
+        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert len(trades) == 1
     assert trades[0] == EXPECTED_TRADE
@@ -432,7 +432,7 @@ def test_query_trade_history_invalid_response(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769)
+        trades = cb.query_trade_history(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert len(trades) == 0
 
@@ -495,7 +495,7 @@ def test_query_asset_movements(function_scope_coinbasepro):
     cb = function_scope_coinbasepro
     cb_query_mock, get_mock = create_coinbasepro_query_mock(cb, original_get=requests.get)
     with cb_query_mock, get_mock:
-        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769)
+        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert movements == EXPECTED_MOVEMENTS
     warnings = cb.msg_aggregator.consume_warnings()
@@ -513,7 +513,7 @@ def test_query_asset_movements_unknown_assets(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769)
+        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert movements == EXPECTED_MOVEMENTS
     warnings = cb.msg_aggregator.consume_warnings()
@@ -533,7 +533,7 @@ def test_query_asset_movements_wrong_format(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769)
+        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert movements == EXPECTED_MOVEMENTS
     warnings = cb.msg_aggregator.consume_warnings()
@@ -555,7 +555,7 @@ def test_query_asset_movements_invalid_response(function_scope_coinbasepro):
         original_get=requests.get,
     )
     with cb_query_mock, get_mock:
-        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769)
+        movements = cb.query_deposits_withdrawals(start_ts=0, end_ts=1579449769, only_cache=False)
 
     assert movements == []
     warnings = cb.msg_aggregator.consume_warnings()

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -115,7 +115,11 @@ def test_gemini_query_trades(sandbox_gemini):
 
     Uses the Gemini sandbox
     """
-    trades = sandbox_gemini.query_trade_history(start_ts=0, end_ts=Timestamp(1584881354))
+    trades = sandbox_gemini.query_trade_history(
+        start_ts=0,
+        end_ts=Timestamp(1584881354),
+        only_cache=False,
+    )
     assert len(trades) == 2
     assert trades[0] == Trade(
         timestamp=Timestamp(1584720549),
@@ -149,7 +153,7 @@ def test_gemini_query_all_trades_pagination(sandbox_gemini):
 
     Uses the Gemini sandbox at which we've made quite a few test trades
     """
-    trades = sandbox_gemini.query_trade_history(start_ts=0, end_ts=ts_now())
+    trades = sandbox_gemini.query_trade_history(start_ts=0, end_ts=ts_now(), only_cache=False)
     identifiers = set()
     for trade in trades:
         assert trade.link not in identifiers, 'trade included multiple times in the results'
@@ -241,6 +245,7 @@ def test_gemini_query_deposits_withdrawals(sandbox_gemini):
         movements = sandbox_gemini.query_deposits_withdrawals(
             start_ts=0,
             end_ts=Timestamp(1584881354),
+            only_cache=False,
         )
 
     assert len(movements) == 6

--- a/rotkehlchen/tests/exchanges/test_iconomi.py
+++ b/rotkehlchen/tests/exchanges/test_iconomi.py
@@ -64,6 +64,7 @@ def test_query_trade_history(function_scope_iconomi):
         trades = iconomi.query_trade_history(
             start_ts=0,
             end_ts=1565732120,
+            only_cache=False,
         )
 
     assert len(trades) == 2

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -70,6 +70,7 @@ def test_querying_trade_history(function_scope_kraken):
     result = function_scope_kraken.query_trade_history(
         start_ts=1451606400,
         end_ts=now,
+        only_cache=False,
     )
     assert isinstance(result, list)
     assert len(result) != 0
@@ -83,6 +84,7 @@ def test_querying_deposits_withdrawals(function_scope_kraken):
     result = function_scope_kraken.query_deposits_withdrawals(
         start_ts=1451606400,
         end_ts=now,
+        only_cache=False,
     )
     assert isinstance(result, list)
     assert len(result) != 0
@@ -162,6 +164,7 @@ def test_kraken_query_deposit_withdrawals_unknown_asset(function_scope_kraken):
     movements = kraken.query_deposits_withdrawals(
         start_ts=1408994442,
         end_ts=1498994442,
+        only_cache=False,
     )
 
     assert len(movements) == 4

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -231,6 +231,7 @@ def test_query_trade_history(function_scope_poloniex):
         trades = poloniex.query_trade_history(
             start_ts=0,
             end_ts=1565732120,
+            only_cache=False,
         )
 
     assert len(trades) == 2


### PR DESCRIPTION
Fix #1448 by adding an extra argument to the trades and deposits/withdrawals endpoint to fetch only the results that are already cached in the DB.