### PR TITLE
Introduces automatic refresh setting for balances and prices

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`916` Users will have the option to set an automatic balance refresh period.
 * :feature:`2379` Premium users will now be able to see their daily ETH2 staking details, how much they gained in ETH and fiat value. Furthermore they will be able to take it into account in the PnL report.
 * :feature:`2384` Users will now see their loopring balances on dashboard nested underneath the Ethereum balances.
 * :feature:`1448` When querying trades, deposits and withdrawals the entries that have already been queried will now be instantly shown to the user, while waiting for the query of the latest entries to complete.

--- a/frontend/app/src/components/settings/FrontendSettings.vue
+++ b/frontend/app/src/components/settings/FrontendSettings.vue
@@ -1,0 +1,185 @@
+<template>
+  <setting-category>
+    <template #title>
+      {{ $t('frontend_settings.title') }}
+    </template>
+    <v-switch
+      v-model="scrambleData"
+      class="general-settings__fields__scramble-data"
+      :label="$t('frontend_settings.label.scramble')"
+      :success-messages="settingsMessages[SCRAMBLE_DATA].success"
+      :error-messages="settingsMessages[SCRAMBLE_DATA].error"
+      @change="onScrambleDataChange($event)"
+    />
+    <time-frame-settings
+      :message="settingsMessages[TIMEFRAME]"
+      :value="defaultGraphTimeframe"
+      @timeframe-change="onTimeframeChange"
+    />
+    <v-text-field
+      v-model="queryPeriod"
+      class="general-settings__fields__periodic-client-query-period"
+      :label="$t('frontend_settings.label.query_period')"
+      :hint="$t('frontend_settings.label.query_period_hint')"
+      type="number"
+      min="5"
+      max="3600"
+      :success-messages="settingsMessages[QUERY_PERIOD].success"
+      :error-messages="settingsMessages[QUERY_PERIOD].error"
+      @change="onQueryPeriodChange($event)"
+    />
+  </setting-category>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator';
+import TimeFrameSettings from '@/components/settings/general/TimeFrameSettings.vue';
+import SettingCategory from '@/components/settings/SettingCategory.vue';
+import {
+  BaseMessage,
+  makeMessage,
+  settingsMessages
+} from '@/components/settings/utils';
+import SettingsMixin from '@/mixins/settings-mixin';
+import { monitor } from '@/services/monitoring';
+import {
+  QUERY_PERIOD,
+  TIMEFRAME_ALL,
+  TIMEFRAME_SETTING
+} from '@/store/settings/consts';
+import {
+  FrontendSettingsPayload,
+  TimeFrameSetting
+} from '@/store/settings/types';
+
+const SETTING_SCRAMBLE_DATA = 'scrambleData';
+const SETTING_TIMEFRAME = 'timeframe';
+const SETTING_QUERY_PERIOD = 'queryPeriod';
+
+const SETTINGS = [
+  SETTING_SCRAMBLE_DATA,
+  SETTING_TIMEFRAME,
+  SETTING_QUERY_PERIOD
+] as const;
+
+type SettingsEntries = typeof SETTINGS[number];
+
+@Component({
+  components: { TimeFrameSettings, SettingCategory }
+})
+export default class FrontendSettings extends Mixins<
+  SettingsMixin<SettingsEntries>
+>(SettingsMixin) {
+  queryPeriod: string = '5';
+  scrambleData: boolean = false;
+  defaultGraphTimeframe: TimeFrameSetting = TIMEFRAME_ALL;
+
+  readonly SCRAMBLE_DATA = SETTING_SCRAMBLE_DATA;
+  readonly TIMEFRAME = SETTING_TIMEFRAME;
+  readonly QUERY_PERIOD = SETTING_QUERY_PERIOD;
+
+  async onTimeframeChange(timeframe: TimeFrameSetting) {
+    const payload: FrontendSettingsPayload = {
+      [TIMEFRAME_SETTING]: timeframe
+    };
+
+    const messages: BaseMessage = {
+      success: this.$t('frontend_settings.validation.timeframe.success', {
+        timeframe: timeframe
+      }).toString(),
+      error: this.$t('frontend_settings.validation.timeframe.error').toString()
+    };
+
+    const { success } = await this.modifyFrontendSetting(
+      payload,
+      SETTING_TIMEFRAME,
+      messages
+    );
+
+    if (success) {
+      this.defaultGraphTimeframe = timeframe;
+    }
+  }
+
+  async onQueryPeriodChange(queryPeriod: string) {
+    const period = parseInt(queryPeriod);
+    if (period < 5 || period > 3600) {
+      const message = `${this.$t(
+        'frontend_settings.validation.periodic_query.invalid_period',
+        {
+          start: 5,
+          end: 3600
+        }
+      )}`;
+      this.validateSettingChange(
+        SETTING_QUERY_PERIOD,
+        'error',
+        `${this.$t('frontend_settings.validation.periodic_query.error', {
+          message
+        })}`
+      );
+      this.queryPeriod = this.$store.state.settings![QUERY_PERIOD].toString();
+      return;
+    }
+
+    const message = makeMessage(
+      this.$t('frontend_settings.validation.periodic_query.error').toString(),
+      this.$t('frontend_settings.validation.periodic_query.success', {
+        period
+      }).toString()
+    );
+
+    const { success } = await this.modifyFrontendSetting(
+      {
+        [QUERY_PERIOD]: period
+      },
+      SETTING_QUERY_PERIOD,
+      message
+    );
+
+    if (success) {
+      monitor.stop();
+      monitor.start();
+    }
+  }
+
+  onScrambleDataChange(enabled: boolean) {
+    const { commit } = this.$store;
+    const previousValue = this.$store.state.session.scrambleData;
+
+    let success: boolean = false;
+    let message: string | undefined;
+
+    try {
+      commit('session/scrambleData', enabled);
+      success = true;
+    } catch (error) {
+      this.scrambleData = previousValue;
+      message = error.message;
+    }
+
+    this.validateSettingChange(
+      SETTING_SCRAMBLE_DATA,
+      success ? 'success' : 'error',
+      success
+        ? ''
+        : `${this.$t('frontend_settings.validation.scramble.error', {
+            message
+          })}`
+    );
+  }
+
+  created() {
+    this.settingsMessages = settingsMessages(SETTINGS);
+  }
+
+  mounted() {
+    const state = this.$store.state;
+    this.scrambleData = state.session.scrambleData;
+    this.defaultGraphTimeframe = state.settings![TIMEFRAME_SETTING];
+    this.queryPeriod = state.settings![QUERY_PERIOD].toString();
+  }
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/frontend/app/src/components/settings/FrontendSettings.vue
+++ b/frontend/app/src/components/settings/FrontendSettings.vue
@@ -185,8 +185,7 @@ export default class FrontendSettings extends Mixins<
     );
 
     if (success) {
-      monitor.stop();
-      monitor.start();
+      monitor.restart();
     }
   }
 
@@ -243,8 +242,7 @@ export default class FrontendSettings extends Mixins<
     );
     if (success) {
       this.refreshPeriod = refreshPeriod < 0 ? '' : period;
-      monitor.stop();
-      monitor.start();
+      monitor.restart();
     }
   }
 

--- a/frontend/app/src/components/settings/utils.ts
+++ b/frontend/app/src/components/settings/utils.ts
@@ -1,0 +1,19 @@
+export type BaseMessage = { success: string; error: string };
+
+export function makeMessage(error: string = '', success: string = '') {
+  return { success, error };
+}
+
+export type SettingsMessages<T extends string> = {
+  [setting in T]: BaseMessage;
+};
+
+export const settingsMessages: <T extends string>(
+  keys: ReadonlyArray<T>
+) => SettingsMessages<T> = <T extends string>(keys: ReadonlyArray<T>) => {
+  const settings: SettingsMessages<T> = {} as SettingsMessages<T>;
+  for (const setting of keys) {
+    settings[setting] = makeMessage();
+  }
+  return settings;
+};

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -615,10 +615,24 @@
     "default_timeframe_description": "Set the default time frame for the dashboard graph. This timeframe will be pre-selected upon login. By default it will remember the previous session's selection."
   },
   "frontend_settings": {
+    "hint": {
+      "refresh": "Select how often your balances will be automatically refreshed"
+    },
     "label": {
       "query_period": "Query period in seconds",
       "query_period_hint": "How often (in seconds) the backend will be checked for messages,",
+      "refresh": "Select the automatic refresh period",
       "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions."
+    },
+    "refresh": {
+      "1h": "1 hour",
+      "2h": "2 hours",
+      "30min": "30 minutes",
+      "none": "None"
+    },
+    "subtitle": {
+      "query": "Periodic status query",
+      "refresh": "Automatic balance refresh"
     },
     "title": "Frontend-only Settings",
     "validation": {
@@ -633,6 +647,10 @@
       },
       "scramble": {
         "error": "Error setting scramble mode: {message}"
+      },
+      "refresh_period": {
+        "error": "Failed to set the refresh period",
+        "success": "The refresh period was successfully changed"
       }
     }
   },

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -446,7 +446,7 @@
     "clear_error": "Clearing the cache for {fromAsset} to {toAsset} failed: {error}",
     "create_cache": "Cache Pair prices",
     "notification": {
-      "title":  "Price pair cache creation",
+      "title": "Price pair cache creation",
       "error": "The cache creation for pair {fromAsset} to {toAsset} on failed: {error}",
       "success": "The cache for pair {fromAsset} to {toAsset} on {source} was successfully created"
     },
@@ -614,6 +614,28 @@
     "default_timeframe": "Dashboard graph default timeframe",
     "default_timeframe_description": "Set the default time frame for the dashboard graph. This timeframe will be pre-selected upon login. By default it will remember the previous session's selection."
   },
+  "frontend_settings": {
+    "label": {
+      "query_period": "Query period in seconds",
+      "query_period_hint": "How often (in seconds) the backend will be checked for messages,",
+      "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions."
+    },
+    "title": "Frontend-only Settings",
+    "validation": {
+      "timeframe": {
+        "error": "Failed to set the default timeframe for the user",
+        "success": "Default timeframe set to {timeframe}"
+      },
+      "periodic_query": {
+        "error": "Error setting query period",
+        "success": "Query period set to {period} seconds",
+        "invalid_period": "Period must be between {start} and {end}"
+      },
+      "scramble": {
+        "error": "Error setting scramble mode: {message}"
+      }
+    }
+  },
   "general_settings": {
     "amount": {
       "label": {
@@ -630,14 +652,6 @@
         "main_currency": "Select Main Currency",
         "main_currency_subtitle": "Select as the main currency"
       }
-    },
-    "frontend": {
-      "label": {
-        "query_period": "Query period in seconds",
-        "query_period_hint": "How often (in seconds) the backend will be checked for messages,",
-        "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions."
-      },
-      "title": "Frontend-only Settings"
     },
     "labels": {
       "anonymized_logs": "Should logs be anonymized?",
@@ -698,9 +712,6 @@
         "success_unset": "The Kusama node RPC endpoint was successfully unset",
         "error": "There was an error setting the Kusama node RPC endpoint"
       },
-      "scramble": {
-        "error": "Error setting scramble mode: {message}"
-      },
       "thousand_separator": {
         "error": "Error setting thousand separator",
         "success": "Thousand separator set to {thousandSeparator}"
@@ -708,15 +719,6 @@
       "decimal_separator": {
         "error": "Error setting decimal separator",
         "success": "Decimal separator set to {decimalSeparator}"
-      },
-      "periodic_query": {
-        "error": "Error setting query period",
-        "success": "Query period set to {period} seconds",
-        "invalid_period": "Period must be between {start} and {end}"
-      },
-      "timeframe": {
-        "error": "Failed to set the default timeframe for the user",
-        "success": "Default timeframe set to {timeframe}"
       }
     }
   },
@@ -1885,6 +1887,14 @@
     }
   },
   "settings": {
+    "not_saved": "Setting not saved",
+    "saved": "Setting saved",
+    "tabs": {
+      "accounting": "Accounting",
+      "data_security": "Data & Security",
+      "defi": "Defi",
+      "general": "General"
+    },
     "title": "Settings"
   },
   "statistics": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -616,12 +616,13 @@
   },
   "frontend_settings": {
     "hint": {
-      "refresh": "Select how often your balances will be automatically refreshed"
+      "refresh": "How often (in minutes) your balances will be automatically refreshed"
     },
     "label": {
       "query_period": "Query period in seconds",
       "query_period_hint": "How often (in seconds) the backend will be checked for messages,",
-      "refresh": "Select the automatic refresh period",
+      "refresh": "Set the automatic refresh period",
+      "refresh_enabled": "Enabled",
       "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions."
     },
     "refresh": {
@@ -650,7 +651,8 @@
       },
       "refresh_period": {
         "error": "Failed to set the refresh period",
-        "success": "The refresh period was successfully changed"
+        "success": "Automatic refresh was successfully changed to every {period} min",
+        "success_disabled": "Automatic refresh was successfully deactivated"
       }
     }
   },

--- a/frontend/app/src/mixins/settings-mixin.ts
+++ b/frontend/app/src/mixins/settings-mixin.ts
@@ -1,5 +1,8 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { mapActions, mapState } from 'vuex';
+import { BaseMessage, SettingsMessages } from '@/components/settings/utils';
+import i18n from '@/i18n';
+import { FrontendSettingsPayload } from '@/store/settings/types';
 import { ActionStatus } from '@/store/types';
 import {
   AccountingSettings,
@@ -7,16 +10,72 @@ import {
   SettingsUpdate
 } from '@/typing/types';
 
+type TargetState = keyof BaseMessage;
+
 @Component({
   computed: {
     ...mapState('session', ['generalSettings', 'accountingSettings'])
   },
   methods: {
-    ...mapActions('session', ['settingsUpdate'])
+    ...mapActions('session', ['settingsUpdate']),
+    ...mapActions('settings', ['updateSetting'])
   }
 })
-export default class SettingsMixin extends Vue {
+export default class SettingsMixin<T extends string> extends Vue {
+  private timeouts: { [setting: string]: any } = {};
+
   settingsUpdate!: (update: SettingsUpdate) => Promise<ActionStatus>;
+  updateSetting!: (payload: FrontendSettingsPayload) => Promise<ActionStatus>;
   generalSettings!: GeneralSettings;
   accountingSettings!: AccountingSettings;
+
+  settingsMessages: SettingsMessages<T> | null = null;
+
+  validateSettingChange(
+    targetSetting: T,
+    targetState: TargetState,
+    message: string = '',
+    timeOut: number = 5500
+  ) {
+    if (!(targetState === 'success' || targetState === 'error')) {
+      return;
+    }
+    if (this.timeouts[targetSetting]) {
+      clearTimeout(this.timeouts[targetSetting]);
+    }
+    const settingsMessage = this.settingsMessages?.[targetSetting];
+    if (!settingsMessage) {
+      return;
+    }
+    setTimeout(() => {
+      let validationMessage: string =
+        targetState === 'error'
+          ? i18n.t('settings.not_saved').toString()
+          : i18n.t('settings.saved').toString();
+      if (message) {
+        validationMessage += `: ${message}`;
+      }
+
+      settingsMessage[targetState] = validationMessage;
+    }, 200);
+    this.timeouts[targetSetting] = setTimeout(() => {
+      settingsMessage[targetState] = '';
+    }, timeOut);
+  }
+
+  async modifyFrontendSetting(
+    payload: FrontendSettingsPayload,
+    setting: T,
+    messages: BaseMessage
+  ): Promise<ActionStatus> {
+    const result = await this.updateSetting(payload);
+    const { success } = result;
+
+    this.validateSettingChange(
+      setting,
+      success ? 'success' : 'error',
+      success ? messages.success : messages.error
+    );
+    return result;
+  }
 }

--- a/frontend/app/src/mixins/settings-mixin.ts
+++ b/frontend/app/src/mixins/settings-mixin.ts
@@ -22,8 +22,6 @@ type TargetState = keyof BaseMessage;
   }
 })
 export default class SettingsMixin<T extends string> extends Vue {
-  private timeouts: { [setting: string]: any } = {};
-
   settingsUpdate!: (update: SettingsUpdate) => Promise<ActionStatus>;
   updateSetting!: (payload: FrontendSettingsPayload) => Promise<ActionStatus>;
   generalSettings!: GeneralSettings;
@@ -40,9 +38,7 @@ export default class SettingsMixin<T extends string> extends Vue {
     if (!(targetState === 'success' || targetState === 'error')) {
       return;
     }
-    if (this.timeouts[targetSetting]) {
-      clearTimeout(this.timeouts[targetSetting]);
-    }
+
     const settingsMessage = this.settingsMessages?.[targetSetting];
     if (!settingsMessage) {
       return;
@@ -58,7 +54,7 @@ export default class SettingsMixin<T extends string> extends Vue {
 
       settingsMessage[targetState] = validationMessage;
     }, 200);
-    this.timeouts[targetSetting] = setTimeout(() => {
+    setTimeout(() => {
       settingsMessage[targetState] = '';
     }, timeOut);
   }

--- a/frontend/app/src/services/monitoring.ts
+++ b/frontend/app/src/services/monitoring.ts
@@ -1,19 +1,38 @@
 import { taskManager } from '@/services/task-manager';
-import { QUERY_PERIOD } from '@/store/settings/consts';
+import {
+  QUERY_PERIOD,
+  REFRESH_1H,
+  REFRESH_2H,
+  REFRESH_30MIN,
+  REFRESH_NONE,
+  REFRESH_PERIOD
+} from '@/store/settings/consts';
 import store from '@/store/store';
 
-class Monitoring {
-  private monitoring?: NodeJS.Timer;
-  private taskMonitoring?: NodeJS.Timer;
-  private watcherMonitoring?: NodeJS.Timer;
+const PERIODIC = 'periodic';
+const TASK = 'task';
+const WATCHER = 'watcher';
+const BALANCES = 'balances';
 
-  private fetch() {
+class Monitoring {
+  private monitors: { [monitor: string]: any } = {};
+
+  private static fetch() {
     store.dispatch('notifications/consume');
     store.dispatch('session/periodicCheck');
   }
 
-  private fetchWatchers() {
+  private static fetchWatchers() {
     store.dispatch('session/fetchWatchers');
+  }
+
+  private static async fetchBalances() {
+    const dispatch = store.dispatch;
+    await dispatch('balances/fetchManualBalances');
+    await dispatch('balances/fetchBlockchainBalances', { ignoreCache: true });
+    await dispatch('balances/fetchLoopringBalances', true);
+    await dispatch('balances/fetchConnectedExchangeBalances');
+    await dispatch('balances/refreshPrices', true);
   }
 
   /**
@@ -21,39 +40,47 @@ class Monitoring {
    * client and updates the UI with the response.
    */
   start() {
-    if (!this.monitoring) {
-      this.fetch();
-      this.monitoring = setInterval(
-        this.fetch,
-        store.state.settings![QUERY_PERIOD] * 1000
+    const settings = store.state.settings!;
+
+    if (!this.monitors[PERIODIC]) {
+      Monitoring.fetch();
+      this.monitors[PERIODIC] = setInterval(
+        Monitoring.fetch,
+        settings[QUERY_PERIOD] * 1000
       );
     }
 
-    if (!this.taskMonitoring) {
+    if (!this.monitors[TASK]) {
       taskManager.monitor();
-      this.taskMonitoring = setInterval(() => taskManager.monitor(), 2000);
+      this.monitors[TASK] = setInterval(() => taskManager.monitor(), 2000);
     }
 
-    if (!this.watcherMonitoring) {
-      this.fetchWatchers();
+    if (!this.monitors[WATCHER]) {
+      Monitoring.fetchWatchers();
       // check for watchers every 6 minutes (approx. half the firing time
       // of the server-side watchers)
-      this.watcherMonitoring = setInterval(this.fetchWatchers, 360000);
+      this.monitors[WATCHER] = setInterval(Monitoring.fetchWatchers, 360000);
+    }
+
+    const refreshPeriod = settings[REFRESH_PERIOD];
+    if (refreshPeriod !== REFRESH_NONE && !this.monitors[BALANCES]) {
+      let period = 60 * 1000;
+      if (refreshPeriod === REFRESH_30MIN) {
+        period *= 30;
+      } else if (refreshPeriod === REFRESH_1H) {
+        period *= 120;
+      } else if (refreshPeriod === REFRESH_2H) {
+        period *= 240;
+      }
+
+      this.monitors[BALANCES] = setInterval(Monitoring.fetchBalances, period);
     }
   }
 
   stop() {
-    if (this.monitoring) {
-      clearInterval(this.monitoring);
-      this.monitoring = undefined;
-    }
-    if (this.taskMonitoring) {
-      clearInterval(this.taskMonitoring);
-      this.taskMonitoring = undefined;
-    }
-    if (this.watcherMonitoring) {
-      clearInterval(this.watcherMonitoring);
-      this.watcherMonitoring = undefined;
+    for (const key in this.monitors) {
+      clearInterval(this.monitors[key]);
+      delete this.monitors[key];
     }
   }
 }

--- a/frontend/app/src/services/monitoring.ts
+++ b/frontend/app/src/services/monitoring.ts
@@ -1,12 +1,6 @@
 import { taskManager } from '@/services/task-manager';
-import {
-  QUERY_PERIOD,
-  REFRESH_1H,
-  REFRESH_2H,
-  REFRESH_30MIN,
-  REFRESH_NONE,
-  REFRESH_PERIOD
-} from '@/store/settings/consts';
+import { QUERY_PERIOD, REFRESH_PERIOD } from '@/store/settings/consts';
+import { getPeriodInMs } from '@/store/settings/utils';
 import store from '@/store/store';
 
 const PERIODIC = 'periodic';
@@ -62,17 +56,8 @@ class Monitoring {
       this.monitors[WATCHER] = setInterval(Monitoring.fetchWatchers, 360000);
     }
 
-    const refreshPeriod = settings[REFRESH_PERIOD];
-    if (refreshPeriod !== REFRESH_NONE && !this.monitors[BALANCES]) {
-      let period = 60 * 1000;
-      if (refreshPeriod === REFRESH_30MIN) {
-        period *= 30;
-      } else if (refreshPeriod === REFRESH_1H) {
-        period *= 120;
-      } else if (refreshPeriod === REFRESH_2H) {
-        period *= 240;
-      }
-
+    const period = getPeriodInMs(settings[REFRESH_PERIOD]);
+    if (!this.monitors[BALANCES] && period > 0) {
       this.monitors[BALANCES] = setInterval(Monitoring.fetchBalances, period);
     }
   }

--- a/frontend/app/src/services/monitoring.ts
+++ b/frontend/app/src/services/monitoring.ts
@@ -32,11 +32,14 @@ class Monitoring {
    * This function is called periodically, queries some data from the
    * client and updates the UI with the response.
    */
-  start() {
+  start(restarting: boolean = false) {
     const settings = store.state.settings!;
 
     if (!this.monitors[PERIODIC]) {
-      Monitoring.fetch();
+      if (!restarting) {
+        Monitoring.fetch();
+      }
+
       this.monitors[PERIODIC] = setInterval(
         Monitoring.fetch,
         settings[QUERY_PERIOD] * 1000
@@ -44,12 +47,16 @@ class Monitoring {
     }
 
     if (!this.monitors[TASK]) {
-      taskManager.monitor();
+      if (!restarting) {
+        taskManager.monitor();
+      }
       this.monitors[TASK] = setInterval(() => taskManager.monitor(), 2000);
     }
 
     if (!this.monitors[WATCHER]) {
-      Monitoring.fetchWatchers();
+      if (!restarting) {
+        Monitoring.fetchWatchers();
+      }
       // check for watchers every 6 minutes (approx. half the firing time
       // of the server-side watchers)
       this.monitors[WATCHER] = setInterval(Monitoring.fetchWatchers, 360000);
@@ -66,6 +73,11 @@ class Monitoring {
       clearInterval(this.monitors[key]);
       delete this.monitors[key];
     }
+  }
+
+  restart() {
+    this.stop();
+    this.start(true);
   }
 }
 

--- a/frontend/app/src/services/monitoring.ts
+++ b/frontend/app/src/services/monitoring.ts
@@ -1,6 +1,5 @@
 import { taskManager } from '@/services/task-manager';
 import { QUERY_PERIOD, REFRESH_PERIOD } from '@/store/settings/consts';
-import { getPeriodInMs } from '@/store/settings/utils';
 import store from '@/store/store';
 
 const PERIODIC = 'periodic';
@@ -56,7 +55,7 @@ class Monitoring {
       this.monitors[WATCHER] = setInterval(Monitoring.fetchWatchers, 360000);
     }
 
-    const period = getPeriodInMs(settings[REFRESH_PERIOD]);
+    const period = settings[REFRESH_PERIOD] * 60 * 1000;
     if (!this.monitors[BALANCES] && period > 0) {
       this.monitors[BALANCES] = setInterval(Monitoring.fetchBalances, period);
     }

--- a/frontend/app/src/store/balances/actions.ts
+++ b/frontend/app/src/store/balances/actions.ts
@@ -155,6 +155,18 @@ export const actions: ActionTree<BalanceState, RotkehlchenState> = {
     await dispatch('accounts');
   },
 
+  async fetchConnectedExchangeBalances({
+    dispatch,
+    state: { connectedExchanges: exchanges }
+  }): Promise<void> {
+    for (const exchange of exchanges) {
+      await dispatch('fetchExchangeBalances', {
+        name: exchange,
+        ignoreCache: false
+      } as ExchangeBalancePayload);
+    }
+  },
+
   async fetchExchangeBalances(
     { commit, rootGetters },
     payload: ExchangeBalancePayload

--- a/frontend/app/src/store/settings/consts.ts
+++ b/frontend/app/src/store/settings/consts.ts
@@ -1,7 +1,7 @@
 export const DEFI_SETUP_DONE = 'defiSetupDone' as 'defiSetupDone';
 export const TIMEFRAME_SETTING = 'timeframeSetting' as 'timeframeSetting';
 export const LAST_KNOWN_TIMEFRAME = 'lastKnownTimeframe' as 'lastKnownTimeframe';
-export const QUERY_PERIOD = 'queryPeriod' as 'queryPeriod';
+export const QUERY_PERIOD = 'queryPeriod' as const;
 export const PROFIT_LOSS_PERIOD = 'profitLossReportPeriod' as 'profitLossReportPeriod';
 export const THOUSAND_SEPARATOR = 'thousandSeparator' as 'thousandSeparator';
 export const DECIMAL_SEPARATOR = 'decimalSeparator' as 'decimalSeparator';

--- a/frontend/app/src/store/settings/consts.ts
+++ b/frontend/app/src/store/settings/consts.ts
@@ -6,6 +6,7 @@ export const PROFIT_LOSS_PERIOD = 'profitLossReportPeriod' as 'profitLossReportP
 export const THOUSAND_SEPARATOR = 'thousandSeparator' as 'thousandSeparator';
 export const DECIMAL_SEPARATOR = 'decimalSeparator' as 'decimalSeparator';
 export const CURRENCY_LOCATION = 'currencyLocation' as 'currencyLocation';
+export const REFRESH_PERIOD = 'refreshPeriod' as const;
 
 export const TIMEFRAME_ALL = 'All';
 export const TIMEFRAME_YEAR = '1Y';
@@ -31,3 +32,15 @@ export const Q4 = 'Q4';
 export const ALL = 'ALL';
 
 export const QUARTERS = [Q1, Q2, Q3, Q4, ALL] as const;
+
+export const REFRESH_NONE = 'none';
+export const REFRESH_30MIN = '30min';
+export const REFRESH_1H = '1h';
+export const REFRESH_2H = '2h';
+
+export const PERIODS = [
+  REFRESH_NONE,
+  REFRESH_30MIN,
+  REFRESH_1H,
+  REFRESH_2H
+] as const;

--- a/frontend/app/src/store/settings/consts.ts
+++ b/frontend/app/src/store/settings/consts.ts
@@ -32,15 +32,3 @@ export const Q4 = 'Q4';
 export const ALL = 'ALL';
 
 export const QUARTERS = [Q1, Q2, Q3, Q4, ALL] as const;
-
-export const REFRESH_NONE = 'none';
-export const REFRESH_30MIN = '30min';
-export const REFRESH_1H = '1h';
-export const REFRESH_2H = '2h';
-
-export const PERIODS = [
-  REFRESH_NONE,
-  REFRESH_30MIN,
-  REFRESH_1H,
-  REFRESH_2H
-] as const;

--- a/frontend/app/src/store/settings/mutations.ts
+++ b/frontend/app/src/store/settings/mutations.ts
@@ -6,14 +6,16 @@ import {
   PROFIT_LOSS_PERIOD,
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
-  CURRENCY_LOCATION
+  CURRENCY_LOCATION,
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { defaultState } from '@/store/settings/state';
 import {
   SettingsState,
   ProfitLossTimeframe,
   TimeFramePeriod,
-  TimeFrameSetting
+  TimeFrameSetting,
+  RefreshPeriod
 } from '@/store/settings/types';
 import { Writeable } from '@/types';
 import { CurrencyLocation } from '@/typing/types';
@@ -27,6 +29,7 @@ type Mutations<S = SettingsState> = {
   [THOUSAND_SEPARATOR](state: S, separator: string): void;
   [DECIMAL_SEPARATOR](state: S, separator: string): void;
   [CURRENCY_LOCATION](state: S, location: CurrencyLocation): void;
+  [REFRESH_PERIOD](state: S, period: RefreshPeriod): void;
   restore(state: S, persisted: S): void;
   reset(state: S): void;
 };
@@ -67,6 +70,9 @@ export const mutations: Mutations = {
     location: CurrencyLocation
   ) {
     state[CURRENCY_LOCATION] = location;
+  },
+  [REFRESH_PERIOD](state: Writeable<SettingsState>, period: RefreshPeriod) {
+    state.refreshPeriod = period;
   },
   restore(state: SettingsState, persisted: SettingsState) {
     Object.assign(state, persisted);

--- a/frontend/app/src/store/settings/state.ts
+++ b/frontend/app/src/store/settings/state.ts
@@ -10,7 +10,9 @@ import {
   THOUSAND_SEPARATOR,
   TIMEFRAME_ALL,
   TIMEFRAME_REMEMBER,
-  TIMEFRAME_SETTING
+  TIMEFRAME_SETTING,
+  REFRESH_PERIOD,
+  REFRESH_NONE
 } from '@/store/settings/consts';
 import { SettingsState } from '@/store/settings/types';
 
@@ -25,7 +27,8 @@ export const defaultState: () => SettingsState = () => ({
   },
   [THOUSAND_SEPARATOR]: Defaults.DEFAULT_THOUSAND_SEPARATOR,
   [DECIMAL_SEPARATOR]: Defaults.DEFAULT_DECIMAL_SEPARATOR,
-  [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION
+  [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION,
+  [REFRESH_PERIOD]: REFRESH_NONE
 });
 
 export const state: SettingsState = defaultState();

--- a/frontend/app/src/store/settings/state.ts
+++ b/frontend/app/src/store/settings/state.ts
@@ -11,8 +11,7 @@ import {
   TIMEFRAME_ALL,
   TIMEFRAME_REMEMBER,
   TIMEFRAME_SETTING,
-  REFRESH_PERIOD,
-  REFRESH_NONE
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { SettingsState } from '@/store/settings/types';
 
@@ -28,7 +27,7 @@ export const defaultState: () => SettingsState = () => ({
   [THOUSAND_SEPARATOR]: Defaults.DEFAULT_THOUSAND_SEPARATOR,
   [DECIMAL_SEPARATOR]: Defaults.DEFAULT_DECIMAL_SEPARATOR,
   [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION,
-  [REFRESH_PERIOD]: REFRESH_NONE
+  [REFRESH_PERIOD]: -1
 });
 
 export const state: SettingsState = defaultState();

--- a/frontend/app/src/store/settings/types.d.ts
+++ b/frontend/app/src/store/settings/types.d.ts
@@ -10,7 +10,8 @@ import {
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
   CURRENCY_LOCATION,
-  REFRESH_PERIOD
+  REFRESH_PERIOD,
+  PERIODS
 } from '@/store/settings/consts';
 import { CurrencyLocation } from '@/typing/types';
 
@@ -24,7 +25,7 @@ export type ProfitLossTimeframe = {
   readonly quarter: Quarter;
 };
 
-export type RefreshPeriod = typeof REFRESH_PERIOD[number];
+export type RefreshPeriod = typeof PERIODS[number];
 
 export interface SettingsState {
   readonly [DEFI_SETUP_DONE]: boolean;

--- a/frontend/app/src/store/settings/types.d.ts
+++ b/frontend/app/src/store/settings/types.d.ts
@@ -9,7 +9,8 @@ import {
   QUARTERS,
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
-  CURRENCY_LOCATION
+  CURRENCY_LOCATION,
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { CurrencyLocation } from '@/typing/types';
 
@@ -23,6 +24,8 @@ export type ProfitLossTimeframe = {
   readonly quarter: Quarter;
 };
 
+export type RefreshPeriod = typeof REFRESH_PERIOD[number];
+
 export interface SettingsState {
   readonly [DEFI_SETUP_DONE]: boolean;
   readonly [TIMEFRAME_SETTING]: TimeFrameSetting;
@@ -32,6 +35,7 @@ export interface SettingsState {
   readonly [THOUSAND_SEPARATOR]: string;
   readonly [DECIMAL_SEPARATOR]: string;
   readonly [CURRENCY_LOCATION]: CurrencyLocation;
+  readonly [REFRESH_PERIOD]: RefreshPeriod;
 }
 
 export type FrontendSettingsPayload = {

--- a/frontend/app/src/store/settings/types.d.ts
+++ b/frontend/app/src/store/settings/types.d.ts
@@ -10,8 +10,7 @@ import {
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
   CURRENCY_LOCATION,
-  REFRESH_PERIOD,
-  PERIODS
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { CurrencyLocation } from '@/typing/types';
 
@@ -25,7 +24,7 @@ export type ProfitLossTimeframe = {
   readonly quarter: Quarter;
 };
 
-export type RefreshPeriod = typeof PERIODS[number];
+export type RefreshPeriod = number;
 
 export interface SettingsState {
   readonly [DEFI_SETUP_DONE]: boolean;

--- a/frontend/app/src/store/settings/utils.ts
+++ b/frontend/app/src/store/settings/utils.ts
@@ -1,18 +1,8 @@
 import { Commit } from 'vuex';
 import { axiosCamelCaseTransformer } from '@/services/axios-tranformers';
-import {
-  REFRESH_1H,
-  REFRESH_2H,
-  REFRESH_30MIN,
-  TIMEFRAME_TWO_WEEKS,
-  TIMEFRAME_WEEK
-} from '@/store/settings/consts';
+import { TIMEFRAME_TWO_WEEKS, TIMEFRAME_WEEK } from '@/store/settings/consts';
 import { defaultState } from '@/store/settings/state';
-import {
-  RefreshPeriod,
-  SettingsState,
-  TimeFrameSetting
-} from '@/store/settings/types';
+import { SettingsState, TimeFrameSetting } from '@/store/settings/types';
 import { Writeable } from '@/types';
 
 export function loadFrontendSettings(commit: Commit, value: string) {
@@ -40,17 +30,3 @@ export function loadFrontendSettings(commit: Commit, value: string) {
 export function isPeriodAllowed(period: TimeFrameSetting): boolean {
   return [TIMEFRAME_WEEK, TIMEFRAME_TWO_WEEKS].includes(period);
 }
-
-export const getPeriodInMs: (period: RefreshPeriod) => number = period => {
-  let ms = 60 * 1000;
-  if (period === REFRESH_30MIN) {
-    ms *= 30;
-  } else if (period === REFRESH_1H) {
-    ms *= 120;
-  } else if (period === REFRESH_2H) {
-    ms *= 240;
-  } else {
-    ms = -1;
-  }
-  return ms;
-};

--- a/frontend/app/src/store/settings/utils.ts
+++ b/frontend/app/src/store/settings/utils.ts
@@ -1,8 +1,18 @@
 import { Commit } from 'vuex';
 import { axiosCamelCaseTransformer } from '@/services/axios-tranformers';
-import { TIMEFRAME_TWO_WEEKS, TIMEFRAME_WEEK } from '@/store/settings/consts';
+import {
+  REFRESH_1H,
+  REFRESH_2H,
+  REFRESH_30MIN,
+  TIMEFRAME_TWO_WEEKS,
+  TIMEFRAME_WEEK
+} from '@/store/settings/consts';
 import { defaultState } from '@/store/settings/state';
-import { SettingsState, TimeFrameSetting } from '@/store/settings/types';
+import {
+  RefreshPeriod,
+  SettingsState,
+  TimeFrameSetting
+} from '@/store/settings/types';
 import { Writeable } from '@/types';
 
 export function loadFrontendSettings(commit: Commit, value: string) {
@@ -30,3 +40,17 @@ export function loadFrontendSettings(commit: Commit, value: string) {
 export function isPeriodAllowed(period: TimeFrameSetting): boolean {
   return [TIMEFRAME_WEEK, TIMEFRAME_TWO_WEEKS].includes(period);
 }
+
+export const getPeriodInMs: (period: RefreshPeriod) => number = period => {
+  let ms = 60 * 1000;
+  if (period === REFRESH_30MIN) {
+    ms *= 30;
+  } else if (period === REFRESH_1H) {
+    ms *= 120;
+  } else if (period === REFRESH_2H) {
+    ms *= 240;
+  } else {
+    ms = -1;
+  }
+  return ms;
+};

--- a/frontend/app/src/views/history/TradeHistory.vue
+++ b/frontend/app/src/views/history/TradeHistory.vue
@@ -33,7 +33,6 @@ import {
 import { FetchSource, TradeEntry } from '@/store/history/types';
 import { REFRESH_PERIOD } from '@/store/settings/consts';
 import { RefreshPeriod } from '@/store/settings/types';
-import { getPeriodInMs } from '@/store/settings/utils';
 
 @Component({
   components: {
@@ -82,7 +81,7 @@ export default class TradeHistory extends Mixins(StatusMixin) {
   }
 
   created() {
-    const period = getPeriodInMs(this[REFRESH_PERIOD]);
+    const period = this[REFRESH_PERIOD] * 60 * 1000;
     if (period > 0) {
       this.refreshInterval = setInterval(async () => this.refresh(), period);
     }

--- a/frontend/app/src/views/history/TradeHistory.vue
+++ b/frontend/app/src/views/history/TradeHistory.vue
@@ -17,7 +17,7 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { mapActions, mapGetters } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 import ProgressScreen from '@/components/helper/ProgressScreen.vue';
 import ClosedTrades from '@/components/history/ClosedTrades.vue';
 import OpenTrades from '@/components/history/OpenTrades.vue';
@@ -31,6 +31,9 @@ import {
   FETCH_REFRESH
 } from '@/store/history/consts';
 import { FetchSource, TradeEntry } from '@/store/history/types';
+import { REFRESH_PERIOD } from '@/store/settings/consts';
+import { RefreshPeriod } from '@/store/settings/types';
+import { getPeriodInMs } from '@/store/settings/utils';
 
 @Component({
   components: {
@@ -40,7 +43,8 @@ import { FetchSource, TradeEntry } from '@/store/history/types';
     OpenTrades
   },
   computed: {
-    ...mapGetters('history', ['trades'])
+    ...mapGetters('history', ['trades']),
+    ...mapState('settings', [REFRESH_PERIOD])
   },
   methods: {
     ...mapActions('history', ['fetchTrades', 'deleteExternalTrade']),
@@ -51,9 +55,11 @@ export default class TradeHistory extends Mixins(StatusMixin) {
   selectedLocation: TradeLocation | null = null;
   fetchTrades!: (payload: FetchSource) => Promise<void>;
   fetchUniswapTrades!: (refresh: boolean) => Promise<void>;
+  [REFRESH_PERIOD]!: RefreshPeriod;
   trades!: TradeEntry[];
   openTrades: TradeEntry[] = [];
   section = Section.TRADES;
+  refreshInterval: any;
 
   get preview(): boolean {
     return !!process.env.VUE_APP_TRADES_PREVIEW;
@@ -75,16 +81,36 @@ export default class TradeHistory extends Mixins(StatusMixin) {
     );
   }
 
-  async refresh() {
-    await this.fetchTrades(FETCH_REFRESH);
+  created() {
+    const period = getPeriodInMs(this[REFRESH_PERIOD]);
+    if (period > 0) {
+      this.refreshInterval = setInterval(async () => this.refresh(), period);
+    }
+  }
+
+  destroyed() {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+    }
   }
 
   async mounted() {
+    await this.load();
+  }
+
+  private async load() {
     await Promise.all([
       this.fetchTrades(FETCH_FROM_CACHE),
       this.fetchUniswapTrades(false)
     ]);
     await this.fetchTrades(FETCH_FROM_SOURCE);
+  }
+
+  private async refresh() {
+    await Promise.all([
+      this.fetchTrades(FETCH_REFRESH),
+      this.fetchUniswapTrades(true)
+    ]);
   }
 }
 </script>

--- a/frontend/app/src/views/settings/Settings.vue
+++ b/frontend/app/src/views/settings/Settings.vue
@@ -12,64 +12,28 @@ import TabNavigation, {
   TabContent
 } from '@/components/helper/TabNavigation.vue';
 
-export interface SettingsMessages {
-  [index: string]: {
-    success: string;
-    error: string;
-  };
-}
-
 @Component({
   components: { BasePageHeader, TabNavigation }
 })
 export default class Settings extends Vue {
   readonly settingsTabs: TabContent[] = [
     {
-      name: 'General',
+      name: this.$t('settings.tabs.general').toString(),
       routeTo: '/settings/general'
     },
     {
-      name: 'Accounting',
+      name: this.$t('settings.tabs.accounting').toString(),
       routeTo: '/settings/accounting'
     },
     {
-      name: 'Data & Security',
+      name: this.$t('settings.tabs.data_security').toString(),
       routeTo: '/settings/data-security'
     },
     {
-      name: 'Defi',
+      name: this.$t('settings.tabs.defi').toString(),
       routeTo: '/settings/defi'
     }
   ];
-
-  settingsMessages: SettingsMessages = {};
-
-  validateSettingChange(
-    targetSetting: string,
-    targetState: 'success' | 'error',
-    message: string = '',
-    timeOut: number = 5500
-  ) {
-    if (targetState === 'success' || targetState === 'error') {
-      setTimeout(() => {
-        let validationMessage: string;
-        if (targetState === 'error') {
-          validationMessage = 'Setting not saved';
-        } else {
-          validationMessage = 'Setting saved';
-        }
-
-        if (message) {
-          validationMessage += `: ${message}`;
-        }
-
-        this.settingsMessages[targetSetting][targetState] = validationMessage;
-      }, 200);
-      setTimeout(() => {
-        this.settingsMessages[targetSetting][targetState] = '';
-      }, timeOut);
-    }
-  }
 }
 </script>
 

--- a/frontend/app/tests/unit/store/settings/actions.spec.ts
+++ b/frontend/app/tests/unit/store/settings/actions.spec.ts
@@ -12,7 +12,9 @@ import {
   ALL,
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
-  CURRENCY_LOCATION
+  CURRENCY_LOCATION,
+  REFRESH_PERIOD,
+  REFRESH_NONE
 } from '@/store/settings/consts';
 import { FrontendSettingsPayload } from '@/store/settings/types';
 import store from '@/store/store';
@@ -43,7 +45,8 @@ describe('settings:actions', () => {
             },
             [THOUSAND_SEPARATOR]: Defaults.DEFAULT_THOUSAND_SEPARATOR,
             [DECIMAL_SEPARATOR]: Defaults.DEFAULT_DECIMAL_SEPARATOR,
-            [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION
+            [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION,
+            [REFRESH_PERIOD]: REFRESH_NONE
           })
         )
       })

--- a/frontend/app/tests/unit/store/settings/actions.spec.ts
+++ b/frontend/app/tests/unit/store/settings/actions.spec.ts
@@ -13,8 +13,7 @@ import {
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
   CURRENCY_LOCATION,
-  REFRESH_PERIOD,
-  REFRESH_NONE
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { FrontendSettingsPayload } from '@/store/settings/types';
 import store from '@/store/store';
@@ -46,7 +45,7 @@ describe('settings:actions', () => {
             [THOUSAND_SEPARATOR]: Defaults.DEFAULT_THOUSAND_SEPARATOR,
             [DECIMAL_SEPARATOR]: Defaults.DEFAULT_DECIMAL_SEPARATOR,
             [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION,
-            [REFRESH_PERIOD]: REFRESH_NONE
+            [REFRESH_PERIOD]: -1
           })
         )
       })

--- a/frontend/app/tests/unit/store/settings/mutations.spec.ts
+++ b/frontend/app/tests/unit/store/settings/mutations.spec.ts
@@ -10,8 +10,7 @@ import {
   TIMEFRAME_SETTING,
   TIMEFRAME_TWO_WEEKS,
   TIMEFRAME_YEAR,
-  REFRESH_PERIOD,
-  REFRESH_2H
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { SettingsState } from '@/store/settings/types';
 import store from '@/store/store';
@@ -31,7 +30,7 @@ describe('settings:mutations', () => {
       [CURRENCY_LOCATION]: CURRENCY_BEFORE,
       [THOUSAND_SEPARATOR]: '|',
       [DECIMAL_SEPARATOR]: '-',
-      [REFRESH_PERIOD]: REFRESH_2H
+      [REFRESH_PERIOD]: 120
     };
     store.commit('settings/restore', state);
     const settings = store.state.settings!;
@@ -46,6 +45,6 @@ describe('settings:mutations', () => {
     expect(settings[THOUSAND_SEPARATOR]).toBe('|');
     expect(settings[DECIMAL_SEPARATOR]).toBe('-');
     expect(settings[CURRENCY_LOCATION]).toBe(CURRENCY_BEFORE);
-    expect(settings[REFRESH_PERIOD]).toBe(REFRESH_2H);
+    expect(settings[REFRESH_PERIOD]).toBe(120);
   });
 });

--- a/frontend/app/tests/unit/store/settings/mutations.spec.ts
+++ b/frontend/app/tests/unit/store/settings/mutations.spec.ts
@@ -9,7 +9,9 @@ import {
   THOUSAND_SEPARATOR,
   TIMEFRAME_SETTING,
   TIMEFRAME_TWO_WEEKS,
-  TIMEFRAME_YEAR
+  TIMEFRAME_YEAR,
+  REFRESH_PERIOD,
+  REFRESH_2H
 } from '@/store/settings/consts';
 import { SettingsState } from '@/store/settings/types';
 import store from '@/store/store';
@@ -28,7 +30,8 @@ describe('settings:mutations', () => {
       },
       [CURRENCY_LOCATION]: CURRENCY_BEFORE,
       [THOUSAND_SEPARATOR]: '|',
-      [DECIMAL_SEPARATOR]: '-'
+      [DECIMAL_SEPARATOR]: '-',
+      [REFRESH_PERIOD]: REFRESH_2H
     };
     store.commit('settings/restore', state);
     const settings = store.state.settings!;
@@ -43,5 +46,6 @@ describe('settings:mutations', () => {
     expect(settings[THOUSAND_SEPARATOR]).toBe('|');
     expect(settings[DECIMAL_SEPARATOR]).toBe('-');
     expect(settings[CURRENCY_LOCATION]).toBe(CURRENCY_BEFORE);
+    expect(settings[REFRESH_PERIOD]).toBe(REFRESH_2H);
   });
 });

--- a/frontend/app/tests/unit/store/settings/utils.spec.ts
+++ b/frontend/app/tests/unit/store/settings/utils.spec.ts
@@ -11,8 +11,7 @@ import {
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
   CURRENCY_LOCATION,
-  REFRESH_PERIOD,
-  REFRESH_NONE
+  REFRESH_PERIOD
 } from '@/store/settings/consts';
 import { loadFrontendSettings } from '@/store/settings/utils';
 
@@ -63,7 +62,7 @@ describe('settings:utils', () => {
         [THOUSAND_SEPARATOR]: Defaults.DEFAULT_THOUSAND_SEPARATOR,
         [DECIMAL_SEPARATOR]: Defaults.DEFAULT_DECIMAL_SEPARATOR,
         [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION,
-        [REFRESH_PERIOD]: REFRESH_NONE
+        [REFRESH_PERIOD]: -1
       },
       { root: true }
     );

--- a/frontend/app/tests/unit/store/settings/utils.spec.ts
+++ b/frontend/app/tests/unit/store/settings/utils.spec.ts
@@ -10,7 +10,9 @@ import {
   ALL,
   THOUSAND_SEPARATOR,
   DECIMAL_SEPARATOR,
-  CURRENCY_LOCATION
+  CURRENCY_LOCATION,
+  REFRESH_PERIOD,
+  REFRESH_NONE
 } from '@/store/settings/consts';
 import { loadFrontendSettings } from '@/store/settings/utils';
 
@@ -60,7 +62,8 @@ describe('settings:utils', () => {
         },
         [THOUSAND_SEPARATOR]: Defaults.DEFAULT_THOUSAND_SEPARATOR,
         [DECIMAL_SEPARATOR]: Defaults.DEFAULT_DECIMAL_SEPARATOR,
-        [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION
+        [CURRENCY_LOCATION]: Defaults.DEFAULT_CURRENCY_LOCATION,
+        [REFRESH_PERIOD]: REFRESH_NONE
       },
       { root: true }
     );


### PR DESCRIPTION
Closes #916 

- Autorefreshes blockchain/looopring/manual/exchange balances and prices
- Selectable options are none/30m/1h/2h
- Remaining to add auto-refresh of trades if the user is looking at the trades

