### PR TITLE
Add support for QUICK (Quickswap) token

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ Changelog
 * :bug:`2443` Users who have no balances in Kraken and try to add an API key will now be able to set it up properly.
 * :bug:`2468` Users should no longer get an error when adding a real estate manual balance.
 
+* :feature:`-` Added support for the following tokens:
+
+  - `Quickswap (QUICK) <https://www.coingecko.com/en/coins/quick>` __
+
 * :release:`1.14.2 <2021-02-24>`
 * :bug:`2399` Users will now see a warning if the loopring module is not activated when adding an API key, and balances will be fetched automatically if it is.
 * :bug:`2151` Users will now see the datetime picker properly displaying the selected date when editing ledger actions.

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9977,6 +9977,15 @@
         "symbol": "QTUM",
         "type": "ethereum token"
     },
+    "QUICK": {
+        "coingecko": "quick",
+        "ethereum_address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
+        "ethereum_token_decimals": 18,
+        "name": "Quickswap",
+        "started": 1602167876,
+        "symbol": "QUICK",
+        "type": "ethereum token"
+    },
     "QUN": {
         "coingecko": "qunqun",
         "ethereum_address": "0x264Dc2DedCdcbb897561A57CBa5085CA416fb7b4",

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9982,7 +9982,7 @@
         "ethereum_address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
         "ethereum_token_decimals": 18,
         "name": "Quickswap",
-        "started": 1602167876,
+        "started": 1602175076,
         "symbol": "QUICK",
         "type": "ethereum token"
     },

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "f8983ca8d2fa3a54f03de32d1a966ff0", "version": 70}
+{"md5": "60a1cadffb7bae9265b36729442b7097", "version": 70}

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "818b121f8ddf1ad23e941257a565be71", "version": 69}
+{"md5": "f8983ca8d2fa3a54f03de32d1a966ff0", "version": 70}

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -244,7 +244,7 @@ def test_coingecko_identifiers_are_reachable(data_dir):
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '818b121f8ddf1ad23e941257a565be71', 'version': 69}
+    last_meta = {'md5': 'f8983ca8d2fa3a54f03de32d1a966ff0', 'version': 70}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -244,7 +244,7 @@ def test_coingecko_identifiers_are_reachable(data_dir):
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': 'f8983ca8d2fa3a54f03de32d1a966ff0', 'version': 70}
+    last_meta = {'md5': '60a1cadffb7bae9265b36729442b7097', 'version': 70}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 


### PR DESCRIPTION
QUICK is the token for Quickswap on Matic. While most of the tokens are currently on Matic, it *is* an ETH token (bridged to Matic). 