### PR TITLE
Do not double count balance for Aave v2 tokens not in Aave v1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`2507` Users can now delete imported trades and deposit/withdrawals from crypto.com via the purge data UI.
 * :bug:`2530` Poloniex should no longer display phantom LEND balances in rotki.
+* :bug:`2534` Aave v2 tokens not in Aave v1 should no longer have their balance double counted.
 
 * :feature:`-` Added support for the following tokens:
 

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -122,6 +122,7 @@ ETH2_DETAILS_REQUERY_SECONDS = 600
 DEFI_PROTOCOLS_TO_SKIP_ASSETS = {
     # aTokens are already detected at token balance queries
     'Aave': True,  # True means all
+    'Aave V2': True,  # True means all
     # cTokens are already detected at token balance queries
     'Compound': True,  # True means all
     # Chitoken is in our all_assets.json


### PR DESCRIPTION
The usual issue of new asset we were already detecting suddenly also being detected
by zerion contract which is not supposed to detect balances.

The tricky part here is that this only occured for aTokens in v2 but
not in v1. Because those already in v1 were getting stopped by #2542.
That's why it was not noticed with our aDAI tests.