### PR TITLE
Finally remove noqa: F811

### DIFF
--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -45,7 +45,7 @@ def get_ethereum_token(
     return ethereum_token
 
 
-@overload  # noqa: F811
+@overload
 def serialize_ethereum_token(
         ethereum_token: EthereumToken,
         unknown_ethereum_token_keys: SerializeAsDictKeys = UNKNOWN_TOKEN_KEYS,
@@ -53,7 +53,7 @@ def serialize_ethereum_token(
     ...
 
 
-@overload  # noqa: F811
+@overload
 def serialize_ethereum_token(
         ethereum_token: UnknownEthereumToken,
         unknown_ethereum_token_keys: SerializeAsDictKeys = UNKNOWN_TOKEN_KEYS,

--- a/rotkehlchen/chain/ethereum/modules/adex/adex.py
+++ b/rotkehlchen/chain/ethereum/modules/adex/adex.py
@@ -781,7 +781,7 @@ class Adex(EthereumModule):
         )
         return staking_events
 
-    @overload  # noqa: F811
+    @overload
     def _get_staking_events_graph(  # pylint: disable=no-self-use
             self,
             addresses: List[ChecksumEthAddress],
@@ -792,7 +792,7 @@ class Adex(EthereumModule):
     ) -> List[Bond]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _get_staking_events_graph(  # pylint: disable=no-self-use
             self,
             addresses: List[ChecksumEthAddress],
@@ -803,7 +803,7 @@ class Adex(EthereumModule):
     ) -> List[Unbond]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _get_staking_events_graph(  # pylint: disable=no-self-use
             self,
             addresses: List[ChecksumEthAddress],
@@ -814,7 +814,7 @@ class Adex(EthereumModule):
     ) -> List[UnbondRequest]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _get_staking_events_graph(  # pylint: disable=no-self-use
             self,
             addresses: List[ChecksumEthAddress],

--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -209,23 +209,23 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryObject):
         self.session.headers.update({'X-API-KEY': api_key})
         return True
 
-    @overload  # noqa: F811
-    def _api_query(  # noqa: F811 pylint: disable=no-self-use
+    @overload
+    def _api_query(  # pylint: disable=no-self-use
             self,
             endpoint: Literal['user/balances'],
             options: Optional[Dict[str, Any]],
     ) -> List[Dict[str, Any]]:
         ...
 
-    @overload  # noqa: F811
-    def _api_query(  # noqa: F811 pylint: disable=no-self-use
+    @overload
+    def _api_query(  # pylint: disable=no-self-use
             self,
             endpoint: Literal['account'],
             options: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         ...
 
-    def _api_query(  # noqa: F811
+    def _api_query(
             self,
             endpoint: str,
             options: Optional[Dict[str, Any]],

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -217,7 +217,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         return response
 
-    @overload  # noqa: F811
+    @overload
     def _api_query_paginated(  # pylint: disable=no-self-use
             self,
             options: Dict[str, Any],
@@ -225,7 +225,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _api_query_paginated(  # pylint: disable=no-self-use
             self,
             options: Dict[str, Any],
@@ -351,7 +351,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         return results
 
-    @overload  # noqa: F811
+    @overload
     def _deserialize_api_query_paginated_results(  # pylint: disable=no-self-use
             self,
             case: Literal['trades'],
@@ -361,7 +361,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _deserialize_api_query_paginated_results(  # pylint: disable=no-self-use
             self,
             case: Literal['asset_movements'],
@@ -702,7 +702,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             pairs=pairs,
         )
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -710,7 +710,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Tuple[bool, str]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -718,7 +718,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> ExchangeQueryBalances:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -726,7 +726,7 @@ class Bitfinex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -363,7 +363,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         return response
 
-    @overload  # noqa: F811
+    @overload
     def _api_query_paginated(  # pylint: disable=no-self-use
             self,
             start_ts: Timestamp,
@@ -373,7 +373,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _api_query_paginated(  # pylint: disable=no-self-use
             self,
             start_ts: Timestamp,
@@ -640,7 +640,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             trade_pair=TradePair(f'{base_asset.identifier}_{quote_asset.identifier}'),
         )
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -648,7 +648,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Tuple[bool, str]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -656,7 +656,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> ExchangeQueryBalances:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -664,7 +664,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -187,7 +187,7 @@ class Bittrex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             raise
         return True, ''
 
-    def api_query(  # noqa: F811
+    def api_query(
             self,
             endpoint: str,
             method: Literal['get', 'put', 'delete'] = 'get',

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -138,7 +138,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         return True, ''
 
-    @overload  # noqa: F811
+    @overload
     def _api_query(  # pylint: disable=no-self-use
             self,
             endpoint: Literal['accounts', 'products'],
@@ -147,8 +147,8 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Any]:
         ...
 
-    @overload  # noqa: F811
-    def _api_query(  # noqa: F811 pylint: disable=no-self-use
+    @overload
+    def _api_query(  # pylint: disable=no-self-use
             self,
             endpoint: Literal['reports'],
             request_method: Literal['GET', 'POST'] = 'GET',
@@ -156,8 +156,8 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Dict[str, Any]:
         ...
 
-    @overload  # noqa: F811
-    def _api_query(  # noqa: F811 pylint: disable=no-self-use
+    @overload
+    def _api_query(  # pylint: disable=no-self-use
             self,
             endpoint: str,
             request_method: Literal['GET', 'POST'] = 'GET',
@@ -165,7 +165,7 @@ class Coinbasepro(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Union[List[Any], Dict[str, Any]]:
         ...
 
-    def _api_query(  # noqa: F811
+    def _api_query(
             self,
             endpoint: str,
             request_method: Literal['GET', 'POST'] = 'GET',

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -219,7 +219,7 @@ class Gemini(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         return json_ret
 
-    @overload  # noqa: F811
+    @overload
     def _private_api_query(  # pylint: disable=no-self-use
             self,
             endpoint: Literal['roles'],
@@ -227,7 +227,7 @@ class Gemini(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Dict[str, Any]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _private_api_query(  # pylint: disable=no-self-use
             self,
             endpoint: Literal['balances', 'mytrades', 'transfers'],
@@ -235,7 +235,7 @@ class Gemini(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Any]:
         ...
 
-    def _private_api_query(  # noqa: F811
+    def _private_api_query(
             self,
             endpoint: str,
             options: Optional[Dict[str, Any]] = None,

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -279,7 +279,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         return response
 
-    @overload  # noqa: F811
+    @overload
     def _api_query_paginated(  # pylint: disable=no-self-use
             self,
             options: Dict[str, Any],
@@ -289,7 +289,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _api_query_paginated(  # pylint: disable=no-self-use
             self,
             options: Dict[str, Any],
@@ -612,7 +612,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
         )
         return trade
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -620,7 +620,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Tuple[bool, str]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -628,7 +628,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> ExchangeQueryBalances:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,
@@ -636,7 +636,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> List[Trade]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _process_unsuccessful_response(  # pylint: disable=no-self-use
             self,
             response: Response,

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -407,8 +407,8 @@ class Poloniex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Dict:
         ...
 
-    @overload  # noqa: F811
-    def return_trade_history(   # noqa: F811  # pylint: disable=unused-argument, no-self-use
+    @overload
+    def return_trade_history(  # pylint: disable=unused-argument, no-self-use
             self,
             currency_pair: Union[TradePair, str],
             start: Timestamp,
@@ -416,10 +416,7 @@ class Poloniex(ExchangeInterface):  # lgtm[py/missing-call-to-init]
     ) -> Union[Dict, List]:
         ...
 
-    # TODO: As soon as a pyflakes release is made including
-    # https://github.com/PyCQA/pyflakes/pull/435 then remove the noqa from here,
-    # above and from other place in codebase where overload is used likethis
-    def return_trade_history(  # noqa: F811
+    def return_trade_history(
             self,
             currency_pair: Union[TradePair, str],
             start: Timestamp,

--- a/rotkehlchen/externalapis/beaconchain.py
+++ b/rotkehlchen/externalapis/beaconchain.py
@@ -152,14 +152,14 @@ class BeaconChain(ExternalServiceWithApiKey):
 
         return balances
 
-    @overload  # noqa: F811
+    @overload
     def get_performance(
             self,
             indices_or_pubkeys: List[int],
     ) -> Dict[int, ValidatorPerformance]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def get_performance(
             self,
             indices_or_pubkeys: List[str],

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -238,7 +238,7 @@ class Coingecko():
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
         self.data_directory = data_directory
 
-    @overload  # noqa: F811
+    @overload
     def _query(
             self,
             module: Literal['coins/list'],
@@ -247,7 +247,7 @@ class Coingecko():
     ) -> List[Dict[str, Any]]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _query(
             self,
             module: Literal['coins', 'simple/price'],

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -88,7 +88,7 @@ class Etherscan(ExternalServiceWithApiKey):
         self.warning_given = False
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
 
-    @overload  # noqa: F811
+    @overload
     def _query(  # pylint: disable=no-self-use
             self,
             module: str,
@@ -103,7 +103,7 @@ class Etherscan(ExternalServiceWithApiKey):
     ) -> List[Dict[str, Any]]:
         ...
 
-    @overload  # noqa: F811
+    @overload
     def _query(  # pylint: disable=no-self-use
             self,
             module: str,
@@ -112,8 +112,8 @@ class Etherscan(ExternalServiceWithApiKey):
     ) -> Dict[str, Any]:
         ...
 
-    @overload  # noqa: F811
-    def _query(  # noqa: F811 pylint: disable=no-self-use
+    @overload
+    def _query(  # pylint: disable=no-self-use
             self,
             module: str,
             action: Literal[
@@ -127,8 +127,8 @@ class Etherscan(ExternalServiceWithApiKey):
     ) -> str:
         ...
 
-    @overload  # noqa: F811
-    def _query(  # noqa: F811 pylint: disable=no-self-use
+    @overload
+    def _query(  # pylint: disable=no-self-use
             self,
             module: str,
             action: Literal['getblocknobytime'],
@@ -136,7 +136,7 @@ class Etherscan(ExternalServiceWithApiKey):
     ) -> int:
         ...
 
-    def _query(  # noqa: F811
+    def _query(
             self,
             module: str,
             action: str,


### PR DESCRIPTION
We had this TODO for a long time. That when
https://github.com/PyCQA/pyflakes/pull/435 made it into a release we
could get rid of the noqa:F811 exceptions.

We have indeed upgraded pyflakes since then and now it's doable