### PR TITLE
Add backup exchange rate API and TWD fiat currency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Add support for New Taiwan Dollar (TWD) as a fiat currency
 * :feature:`2424` Users will now see a progress bar while the automatic update is downloading, and proper notification messages in case of failure.
 * :feature:`2515` Users will now be able to navigate back from the assets page using a button.
 * :bug:`2532` Users will now see the percentage sign display in the same line when editing underlying tokens.

--- a/frontend/app/src/data/currencies.ts
+++ b/frontend/app/src/data/currencies.ts
@@ -19,6 +19,7 @@ const CURRENCY_ETH = 'ETH';
 const CURRENCY_CHF = 'CHF';
 const CURRENCY_SGD = 'SGD';
 const CURRENCY_SEK = 'SEK';
+const CURRENCY_TWD = 'TWD';
 
 const SUPPORTED_CURRENCIES = [
   CURRENCY_USD,
@@ -37,6 +38,7 @@ const SUPPORTED_CURRENCIES = [
   CURRENCY_CHF,
   CURRENCY_SGD,
   CURRENCY_SEK,
+  CURRENCY_TWD,
   CURRENCY_BTC,
   CURRENCY_ETH
 ] as const;
@@ -60,6 +62,7 @@ export const currencies: Currency[] = [
   new Currency(i18n.t('currencies.chf').toString(), CURRENCY_CHF, 'Fr.'),
   new Currency(i18n.t('currencies.sgd').toString(), CURRENCY_SGD, 'S$'),
   new Currency(i18n.t('currencies.sek').toString(), CURRENCY_SEK, 'kr'),
+  new Currency(i18n.t('currencies.twd').toString(), CURRENCY_TWD, 'NT$'),
   new Currency('Bitcoin', CURRENCY_BTC, '₿'),
   new Currency('Ether', CURRENCY_ETH, 'Ξ')
 ];

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -145,6 +145,7 @@
     "sgd": "Singapore Dollar",
     "sek": "Swedish Krona",
     "try": "Turkish Lira",
+    "twd": "New Taiwan dollar",
     "usd": "United States Dollar",
     "zar": "South African Rand"
   },
@@ -166,7 +167,7 @@
       "weight": "Weight",
       "weight_percentage": "{weight} %"
     },
-    "validation":  {
+    "validation": {
       "non_empty": "Please set a weight value",
       "address_non_empty": "Address cannot be empty",
       "not_valid": "The specified weight does not seem like a valid value",

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -14,6 +14,8 @@ EV_MARGIN_CLOSE = EventType('margin_position_close')
 EV_DEFI = EventType('defi_event')
 EV_LEDGER_ACTION = EventType('ledger_action')
 
+CURRENCYCONVERTER_API_KEY = '7ad371210f296db27c19'
+
 ZERO = FVal(0)
 ONE = FVal(1)
 

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -9397,7 +9397,7 @@
         "started": 1606768910,
         "symbol": "PIPT",
         "type": "ethereum token"
-       },
+    },
     "PIRL": {
         "coingecko": "pirl",
         "name": "Pirl",
@@ -13447,7 +13447,7 @@
         "coingecko": "dfinance",
         "cryptocompare": "",
         "ethereum_address": "0xE4E822C0d5b329E8BB637972467d2E313824eFA0",
-        "ethereum_token_decimals": 18 ,
+        "ethereum_token_decimals": 18,
         "name": "dfinance",
         "started": 1599068086,
         "symbol": "XFI",
@@ -15506,6 +15506,11 @@
         "started": 1601302213,
         "symbol": "DEXE",
         "type": "ethereum token"
+    },
+    "TWD": {
+        "name": "New Taiwan Dollar",
+        "symbol": "TWD",
+        "type": "fiat"
     },
     "TWT": {
         "coingecko": "trust-wallet-token",

--- a/rotkehlchen/data/all_assets.meta
+++ b/rotkehlchen/data/all_assets.meta
@@ -1,1 +1,1 @@
-{"md5": "271b43b7fcb2ae995260a869adcf8e48", "version": 71}
+{"md5": "bd4e22bc1bd65aef857bdbf9137b37d9", "version": 71}

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -10,7 +10,7 @@ import requests
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.ethereum.defi.price import handle_defi_price_query
-from rotkehlchen.constants import ZERO
+from rotkehlchen.constants import CURRENCYCONVERTER_API_KEY, ZERO
 from rotkehlchen.constants.assets import (
     A_ALINK,
     A_BTC,
@@ -174,6 +174,31 @@ def _query_exchanges_rateapi(base: Asset, quote: Asset) -> Optional[Price]:
     ):
         log.error(
             'Querying api.exchangeratesapi.io for fiat pair failed',
+            base_currency=base.identifier,
+            quote_currency=quote.identifier,
+        )
+        return None
+
+
+def _query_currency_converterapi(base: Asset, quote: Asset) -> Optional[Price]:
+    assert base.is_fiat(), 'fiat currency should have been provided'
+    assert quote.is_fiat(), 'fiat currency should have been provided'
+    log.debug(
+        'Query free.currencyconverterapi.com fiat pair',
+        base_currency=base.identifier,
+        quote_currency=quote.identifier,
+    )
+    pair = f'{base.identifier}_{quote.identifier}'
+    querystr = (
+        f'https://free.currconv.com/api/v7/convert?'
+        f'q={pair}&compact=ultra&apiKey={CURRENCYCONVERTER_API_KEY}'
+    )
+    try:
+        resp = request_get_dict(querystr)
+        return Price(FVal(resp[pair]))
+    except (ValueError, RemoteError, KeyError, UnableToDecryptRemoteData):
+        log.error(
+            'Querying free.currencyconverterapi.com fiat pair failed',
             base_currency=base.identifier,
             quote_currency=quote.identifier,
         )
@@ -499,7 +524,8 @@ class Inquirer():
             return price
 
         price = _query_exchanges_rateapi(base, quote)
-        # TODO: Find another backup API for fiat exchange rates
+        if price is None:
+            price = _query_currency_converterapi(base, quote)
 
         if price is None:
             # Search the cache for any price in the last month

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -244,7 +244,7 @@ def test_coingecko_identifiers_are_reachable(data_dir):
 def test_assets_json_meta():
     """Test that all_assets.json md5 matches and that if md5 changes since last
     time then version is also bumped"""
-    last_meta = {'md5': '271b43b7fcb2ae995260a869adcf8e48', 'version': 71}
+    last_meta = {'md5': 'bd4e22bc1bd65aef857bdbf9137b37d9', 'version': 71}
     data_dir = Path(__file__).resolve().parent.parent.parent / 'data'
     data_md5 = file_md5(data_dir / 'all_assets.json')
 

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +16,7 @@ from rotkehlchen.inquirer import (
     CURRENT_PRICE_CACHE_SECS,
     DEFAULT_CURRENT_PRICE_ORACLES_ORDER,
     CurrentPriceOracle,
+    _query_currency_converterapi,
     _query_exchanges_rateapi,
 )
 from rotkehlchen.tests.utils.constants import A_CNY, A_EUR, A_GBP, A_JPY
@@ -23,15 +25,24 @@ from rotkehlchen.typing import Price
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
 
+@pytest.mark.skipif(
+    'CI' in os.environ,
+    reason='some of these APIs frequently become unavailable',
+)
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_query_realtime_price_apis(inquirer):
+    result = _query_currency_converterapi(A_USD, A_EUR)
+    assert result and isinstance(result, FVal)
     result = _query_exchanges_rateapi(A_USD, A_GBP)
     assert result and isinstance(result, FVal)
     result = inquirer.query_historical_fiat_exchange_rates(A_USD, A_CNY, 1411603200)
     assert result == FVal('6.1371932033')
 
 
-@pytest.mark.skip('The backup FIAT exchange rate API shut down. Unskip if new is found')
+@pytest.mark.skipif(
+    'CI' in os.environ,
+    reason='some of these APIs frequently become unavailable',
+)
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_switching_to_backup_api(inquirer):

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -25,10 +24,6 @@ from rotkehlchen.typing import Price
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
 
-@pytest.mark.skipif(
-    'CI' in os.environ,
-    reason='some of these APIs frequently become unavailable',
-)
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_query_realtime_price_apis(inquirer):
     result = _query_currency_converterapi(A_USD, A_EUR)
@@ -39,10 +34,6 @@ def test_query_realtime_price_apis(inquirer):
     assert result == FVal('6.1371932033')
 
 
-@pytest.mark.skipif(
-    'CI' in os.environ,
-    reason='some of these APIs frequently become unavailable',
-)
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_switching_to_backup_api(inquirer):


### PR DESCRIPTION
Closes #1036

[currencyconverterapi](https://www.currencyconverterapi.com/docs) has been updated to v7 and seems to be working fine
Revert 5af0a8b and update API endpoint and query parameters

Also add TWD as a fiat currency, since it depends on this backup API (main [exchangeratesapi](https://exchangeratesapi.io/) doesn't have this currency) I've added it along this PR