### PR TITLE
Missing conversions from json

### DIFF
--- a/rotkehlchen/tests/unit/test_loopring.py
+++ b/rotkehlchen/tests/unit/test_loopring.py
@@ -1,5 +1,38 @@
+from unittest.mock import patch
+
+import pytest
+
 from rotkehlchen.db.loopring import DBLoopring
+from rotkehlchen.chain.ethereum.modules.l2.loopring import Loopring
+from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.factories import make_ethereum_address
+from rotkehlchen.tests.utils.mock import MockResponse
+
+
+@pytest.fixture(scope='function', name='temp_loopring')
+def fixture_temp_loopring(function_scope_messages_aggregator, database, ethereum_manager):
+    return Loopring(
+        database=database,
+        msg_aggregator=function_scope_messages_aggregator,
+        ethereum_manager=ethereum_manager,
+        premium=None,
+    )
+
+
+def patch_loopring(loopring):
+    def mock_requests_get(_url):
+        response = (
+            '[{"tokenId":0,"total":"8427006149700000000","locked":"0",'
+            '"pending":{"withdraw":"0","deposit":"0"}},'
+            '{"tokenId": 1, "total": "435974889000000000000", "locked": "0",'
+            '"pending": {"withdraw": "0", "deposit": "0"}},'
+            '{"tokenId":5,"total":"0","locked":"0","pending":{"withdraw":"0","deposit":"0"}},'
+            '{"tokenId":70,"total":"2829249920000000000","locked":"0",'
+            '"pending":{"withdraw":"0","deposit":"0"}}]'
+        )
+        return MockResponse(200, response)
+
+    return patch.object(loopring.session, 'get', wraps=mock_requests_get)
 
 
 def test_loopring_accountid_mapping(database):
@@ -20,3 +53,17 @@ def test_loopring_accountid_mapping(database):
 
     db.remove_accountid_mapping(addr1)
     assert db.get_accountid_mapping(addr1) is None
+
+
+def test_query_balances(temp_loopring, inquirer):  # pylint: disable=W0613
+    """Test the get account balances and check that all the conversions
+    are done correctly.
+    """
+    loopring = temp_loopring
+    patched_loopring = patch_loopring(loopring)
+
+    with patched_loopring:
+        result = loopring.get_account_balances(1)
+        assert result['ETH'].amount == FVal(8.4270061497)
+        assert result['LRC'].amount == FVal(435.974889)
+        assert result['DPI'].amount == FVal(2.82924992)

--- a/rotkehlchen/tests/unit/test_loopring.py
+++ b/rotkehlchen/tests/unit/test_loopring.py
@@ -10,7 +10,7 @@ from rotkehlchen.tests.utils.mock import MockResponse
 
 
 @pytest.fixture(scope='function', name='temp_loopring')
-def fixture_temp_loopring(function_scope_messages_aggregator, database, ethereum_manager):
+def mock_loopring(function_scope_messages_aggregator, database, ethereum_manager):
     return Loopring(
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
@@ -63,7 +63,7 @@ def test_query_balances(temp_loopring, inquirer):  # pylint: disable=W0613
     patched_loopring = patch_loopring(loopring)
 
     with patched_loopring:
-        result = loopring.get_account_balances(1)
+        result = loopring.get_account_balances(account_id=1)
         assert result['ETH'].amount == FVal(8.4270061497)
         assert result['LRC'].amount == FVal(435.974889)
         assert result['DPI'].amount == FVal(2.82924992)


### PR DESCRIPTION
Add two missing conversions from string representation to integer/FVal.

- One was making a test fail sometimes.
- The other affected loopring in the develop branch