### PR TITLE
Query full event history when doing PnL report

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 * :bug:`2530` Poloniex should no longer display phantom LEND balances in rotki.
 * :bug:`2534` Aave v2 tokens not in Aave v1 should no longer have their balance double counted.
 * :bug:`2539` The effects of adding/editing/removing a ledger actions will no longer be lost if rotki restarts right after the operation.
-* :bug:`2541` Now cost basis will be correctly shown in the profit and loss report if the cost basis were calculated using actions outside the report period.
+* :bug:`2541` Now cost basis will be correctly shown in the profit and loss report if the cost basis were calculated using ledger actions outside the report period.
 
 * :feature:`-` Added support for the following tokens:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :bug:`2530` Poloniex should no longer display phantom LEND balances in rotki.
 * :bug:`2534` Aave v2 tokens not in Aave v1 should no longer have their balance double counted.
 * :bug:`2539` The effects of adding/editing/removing a ledger actions will no longer be lost if rotki restarts right after the operation.
+* :bug:`2541` Now cost basis will be correctly shown in the profit and loss report if the cost basis were calculated using actions outside the report period.
 
 * :feature:`-` Added support for the following tokens:
 

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -227,7 +227,7 @@ class EventsHistorian():
 
         # include the ledger actions
         self.processing_state_name = 'Querying ledger actions history'
-        ledger_actions, _ = self.query_ledger_actions(has_premium, from_ts=start_ts, to_ts=end_ts)
+        ledger_actions, _ = self.query_ledger_actions(has_premium, from_ts=None, to_ts=end_ts)
         step = self._increase_progress(step, total_steps)
 
         # include AMM trades: balancer, uniswap

--- a/rotkehlchen/tests/fixtures/history.py
+++ b/rotkehlchen/tests/fixtures/history.py
@@ -1,6 +1,5 @@
 import pytest
 
-from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.exchanges.manager import ExchangeManager
 from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
@@ -60,13 +59,7 @@ def price_historian(
 
 
 @pytest.fixture
-def events_historian(data_dir, function_scope_messages_aggregator, blockchain):
-    database = DBHandler(
-        user_data_dir=data_dir,
-        password='123',
-        msg_aggregator=function_scope_messages_aggregator,
-        initial_settings=None,
-    )
+def events_historian(database, data_dir, function_scope_messages_aggregator, blockchain):
     exchange_manager = ExchangeManager(msg_aggregator=function_scope_messages_aggregator)
     historian = EventsHistorian(
         user_directory=data_dir,

--- a/rotkehlchen/tests/unit/test_history.py
+++ b/rotkehlchen/tests/unit/test_history.py
@@ -1,8 +1,10 @@
-from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.accounting.structures import LedgerActionType
+from rotkehlchen.db.ledger_actions import DBLedgerActions
+from rotkehlchen.constants.assets import A_ETH, A_USDC
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events import limit_trade_list_to_period
-from rotkehlchen.typing import Location, TradeType
+from rotkehlchen.typing import Location, TradeType, Timestamp
 
 
 def test_limit_trade_list_to_period():
@@ -57,3 +59,54 @@ def test_limit_trade_list_to_period():
     assert limit_trade_list_to_period(full_list, 1459427707, 1459427707) == [trade1]
     assert limit_trade_list_to_period(full_list, 1469427707, 1469427707) == [trade2]
     assert limit_trade_list_to_period(full_list, 1479427707, 1479427707) == [trade3]
+
+
+def test_query_ledger_actions(events_historian, function_scope_messages_aggregator):
+    """
+    Create actions and query the events historian to check that the history
+    has events previous to the selected from_ts. This allows us to verify that
+    actions before one period are counted in the PnL report to calculate cost basis.
+    https://github.com/rotki/rotki/issues/2541
+    """
+
+    selected_timestamp = 10
+    db = DBLedgerActions(events_historian.db, function_scope_messages_aggregator)
+
+    db.add_ledger_action(
+        timestamp=selected_timestamp - 2,
+        action_type=LedgerActionType.INCOME,
+        location=Location.EXTERNAL,
+        amount=FVal(1),
+        asset=A_ETH,
+        link='',
+        notes='',
+    )
+
+    db.add_ledger_action(
+        timestamp=selected_timestamp + 3,
+        action_type=LedgerActionType.EXPENSE,
+        location=Location.EXTERNAL,
+        amount=FVal(0.5),
+        asset=A_ETH,
+        link='',
+        notes='',
+    )
+
+    db.add_ledger_action(
+        timestamp=selected_timestamp + 5,
+        action_type=LedgerActionType.INCOME,
+        location=Location.EXTERNAL,
+        amount=FVal(10),
+        asset=A_USDC,
+        link='',
+        notes='',
+    )
+
+    actions, length = events_historian.query_ledger_actions(
+        has_premium=True,
+        from_ts=None,
+        to_ts=Timestamp(selected_timestamp + 4),
+    )
+
+    assert any((action.timestamp < selected_timestamp for action in actions))
+    assert length == 2


### PR DESCRIPTION
Closes #2541

I added this if sentence because I saw this call https://github.com/rotki/rotki/blob/develop/rotkehlchen/api/rest.py#L844
and thought that might be a problem if someone calls this endpoint and expect just a range of timestamps.