### PR TITLE
Adds minimum visual studio version to ps1

### DIFF
--- a/package.ps1
+++ b/package.ps1
@@ -94,7 +94,7 @@ Get-Childitem -Path Env:* | Foreach-Object {
     $BACKUP_ENV += $_
 }
 
-$vsPath = &(Join-Path ${env:ProgramFiles(x86)} "\Microsoft Visual Studio\Installer\vswhere.exe") -property installationpath
+$vsPath = &(Join-Path ${env:ProgramFiles(x86)} "\Microsoft Visual Studio\Installer\vswhere.exe") -version '[16.0,)' -property installationpath
 Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
 
 $arch = 64


### PR DESCRIPTION
Fixes an issue of the build script not running properly if both VS2017 and VS2019 are installed in the same machine.