### PR TITLE
Get exchange rates api endpoint can now be queried async

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -874,6 +874,9 @@ Query the current exchange rate for select assets
    .. note::
       This endpoint also accepts parameters as query arguments. List as a query argument here would be given as: ``?currencies=EUR,CNY,GBP``
 
+   .. note::
+      This endpoint can also be queried asynchronously by using ``"async_query": true``.
+
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests
@@ -881,7 +884,7 @@ Query the current exchange rate for select assets
       GET /api/1/exchange_rates HTTP/1.1
       Host: localhost:5042
 
-      {"currencies": ["EUR", "CNY", "GBP", "BTC"]}
+      {"async_query": true, "currencies": ["EUR", "CNY", "GBP", "BTC"]}
 
    :query strings-list currencies: A comma separated list of currencies to query. e.g.: /api/1/fiat_exchange_rates?currencies=EUR,CNY,GBP
    :reqjson list currencies: A list of assets to query
@@ -898,11 +901,10 @@ Query the current exchange rate for select assets
           "message": ""
       }
 
-   :resjson object result: A JSON object with each element being an asset symbol and each value its USD exchange rate.
+   :resjson object result: A JSON object with each element being an asset symbol and each value its USD exchange rate. If a particular asset could not have its price queried, it will return a zero price.
    :statuscode 200: The exchange rates have been sucesfully returned
    :statuscode 400: Provided JSON is in some way malformed. Empty currencies list given
    :statuscode 500: Internal Rotki error
-   :statuscode 502: An external service used in the query such as cryptocompare/coingecko could not be reached or returned unexpected response.
 
 Query the historical price of assets
 ======================================

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -1558,6 +1558,7 @@ class AssetIconUploadSchema(Schema):
 
 
 class ExchangeRatesSchema(Schema):
+    async_query = fields.Boolean(missing=False)
     currencies = DelimitedOrNormalList(AssetField(), required=True)
 
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -220,8 +220,8 @@ class ExchangeRatesResource(BaseResource):
     get_schema = ExchangeRatesSchema()
 
     @use_kwargs(get_schema, location='json_and_query')  # type: ignore
-    def get(self, currencies: List[Asset]) -> Response:
-        return self.rest_api.get_exchange_rates(given_currencies=currencies)
+    def get(self, currencies: List[Asset], async_query: bool) -> Response:
+        return self.rest_api.get_exchange_rates(given_currencies=currencies, async_query=async_query)  # noqa: E501
 
 
 class ExchangesResource(BaseResource):

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -363,10 +363,14 @@ class Inquirer():
     def get_fiat_usd_exchange_rates(currencies: Iterable[Asset]) -> Dict[Asset, Price]:
         """Gets the USD exchange rate of any of the given assets
 
-        May raise RemoteError due to _query_fiat_pair"""
+        In case of failure to query a rate it's returned as zero"""
         rates = {A_USD: Price(FVal(1))}
         for currency in currencies:
-            rates[currency] = Inquirer()._query_fiat_pair(A_USD, currency)
+            try:
+                rates[currency] = Inquirer()._query_fiat_pair(A_USD, currency)
+            except RemoteError:
+                rates[currency] = Price(ZERO)
+
         return rates
 
     @staticmethod


### PR DESCRIPTION
Also if any single currency's usd rate can not be queried then it's
rate is returned as zero and the entire endpoint query does not fail.

A user warning is also registered in that case via the msg_aggregator.