### PR TITLE
Upgrade lint requirements

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -2,11 +2,11 @@ mypy==0.812
 mypy-extensions==0.4.3
 pylint==2.7.2
 astroid==2.5.1  # engine of pylint, upgrade them together
-flake8==3.8.4
+flake8==3.9.0
 flake8-commas==2.0.0
-flake8-bugbear==20.11.1
+flake8-bugbear==21.3.2
 flake8-tuple==0.4.1
-flake8-comprehensions==3.3.1
+flake8-comprehensions==3.4.0
 flake8-debugger==4.0.0
 flake8-executable==2.1.1
 flake8-mutable==1.2.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,7 +1,7 @@
 mypy==0.812
 mypy-extensions==0.4.3
-pylint==2.7.0
-astroid==2.5  # engine of pylint, upgrade them together
+pylint==2.7.2
+astroid==2.5.1  # engine of pylint, upgrade them together
 flake8==3.8.4
 flake8-commas==2.0.0
 flake8-bugbear==20.11.1

--- a/rotkehlchen/tests/pylint/test_lognokwargs.py
+++ b/rotkehlchen/tests/pylint/test_lognokwargs.py
@@ -19,8 +19,7 @@ def test_simple_logger_with_kwargs(pylint_test_linter):
 
         checker.visit_call(node)
         messages = checker.linter.release_messages()
-        # from pylint 2.7 it finds it 2 times. One for Logger and one for RootLogger
-        assert len(messages) == 2
+        assert len(messages) == 1
         for m in messages:
             assert m.msg_id == LOGNOKWARGS_SYMBOL
             assert m.node == node


### PR DESCRIPTION
Upgrading pylint and flake8. Mypy is up to date.

No new warnings generated.