### PR TITLE
Extends premium components API

### DIFF
--- a/frontend/app/src/electron-main/ipc.ts
+++ b/frontend/app/src/electron-main/ipc.ts
@@ -1,4 +1,5 @@
 import { TimeUnit } from '@/components/dashboard/types';
+import { SupportedAsset } from '@/services/types-model';
 import { Level } from '@/utils/log-level';
 
 export const IPC_RESTART_BACKEND = 'RESTART_BACKEND' as const;
@@ -18,8 +19,13 @@ interface DateUtilities {
   epochStartSubtract(amount: number, unit: TimeUnit): number;
 }
 
+interface DataUtilities {
+  assetInfo(identifier: string): SupportedAsset | undefined;
+}
+
 export type ExposedUtilities = {
   readonly date: DateUtilities;
+  readonly data: DataUtilities;
 };
 
 type MetamaskImportError = {

--- a/frontend/app/src/utils/premium.ts
+++ b/frontend/app/src/utils/premium.ts
@@ -29,6 +29,7 @@ import AssetSelect from '@/components/inputs/AssetSelect.vue';
 import CardTitle from '@/components/typography/CardTitle.vue';
 import { DebugSettings, ExposedUtilities } from '@/electron-main/ipc';
 import { api } from '@/services/rotkehlchen-api';
+import store from '@/store/store';
 
 export const setupPremium = () => {
   window.Vue = Vue;
@@ -57,6 +58,11 @@ export const setupPremium = () => {
         },
         epochStartSubtract(amount: number, unit: TimeUnit): number {
           return moment().subtract(amount, unit).startOf(TIME_UNIT_DAY).unix();
+        }
+      },
+      data: {
+        assetInfo: (identifier: string) => {
+          return store.getters['balances/assetInfo'](identifier);
         }
       }
     }


### PR DESCRIPTION
Closes #2632 

This includes some api exposure to make it easier to refactor the assets in the future.
The rest of the fix is in premium components
