### PR TITLE
Remove exchangerates api

### DIFF
--- a/rotkehlchen/externalapis/xratescom.py
+++ b/rotkehlchen/externalapis/xratescom.py
@@ -1,0 +1,101 @@
+import logging
+from typing import Dict
+
+import requests
+from bs4 import BeautifulSoup, SoupStrainer
+
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
+from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset
+from rotkehlchen.serialization.deserialize import deserialize_price
+from rotkehlchen.typing import Price, Timestamp
+from rotkehlchen.utils.misc import timestamp_to_date
+
+log = logging.getLogger(__name__)
+
+
+def _scrape_xratescom_exchange_rates(url: str) -> Dict[Asset, Price]:
+    """
+    Scrapes x-rates.com website for the exchange rates tables
+
+    May raise:
+    - RemoteError if we can't query x-rates.com
+    """
+    log.debug(f'Querying x-rates.com stats: {url}')
+    prices = {}
+    try:
+        response = requests.get(url=url, timeout=DEFAULT_TIMEOUT_TUPLE)
+    except requests.exceptions.RequestException as e:
+        raise RemoteError(f'x-rates.com request {url} failed due to {str(e)}') from e
+
+    if response.status_code != 200:
+        raise RemoteError(
+            f'x-rates.com request {url} failed with code: {response.status_code}'
+            f' and response: {response.text}',
+        )
+
+    soup = BeautifulSoup(
+        response.text,
+        'html.parser',
+        parse_only=SoupStrainer('table', {'class': 'tablesorter ratesTable'}),
+    )
+    if soup is None:
+        raise RemoteError('Could not find <table> while parsing x-rates stats page')
+    try:
+        tr = soup.table.tbody.tr
+    except AttributeError as e:
+        raise RemoteError('Could not find first <tr> while parsing x-rates.com page') from e
+
+    while tr is not None:
+        secondtd = tr.select('td:nth-of-type(2)')[0]
+        try:
+            href = secondtd.a['href']
+        except (AttributeError, KeyError) as e:
+            raise RemoteError('Could not find a href of 2nd td while parsing x-rates.com page') from e  # noqa: E501
+
+        parts = href.split('to=')
+        if len(parts) != 2:
+            raise RemoteError(f'Could not find to= in {href} while parsing x-rates.com page')
+
+        try:
+            to_asset = Asset(parts[1])
+            if not to_asset.is_fiat():
+                raise ValueError
+        except (UnknownAsset, ValueError):
+            log.debug(f'Skipping {parts[1]} asset because its not a known fiat asset while parsing x-rates.com page')  # noqa: E501
+            tr = tr.find_next_sibling()
+            continue
+
+        try:
+            price = deserialize_price(secondtd.a.text)
+        except DeserializationError as e:
+            log.debug(f'Could not parse x-rates.com rate of {to_asset.identifier} due to {str(e)}. Skipping ...')  # noqa: E501
+            tr = tr.find_next_sibling()
+            continue
+
+        prices[to_asset] = price
+        tr = tr.find_next_sibling()
+
+    return prices
+
+
+def get_current_xratescom_exchange_rates(from_currency: Asset) -> Dict[Asset, Price]:
+    """
+    Get the current exchanges rates of currency from x-rates.com
+
+    May raise:
+    - RemoteError if we can't query x-rates.com
+    """
+    url = f'https://www.x-rates.com/table/?from={from_currency.symbol}&amount=1'
+    return _scrape_xratescom_exchange_rates(url)
+
+
+def get_historical_xratescom_exchange_rates(from_asset: Asset, time: Timestamp) -> Dict[Asset, Price]:  # noqa: E501
+    """
+    Get the historical exchanges rates of a currency from x-rates.com
+
+    May raise RemoteError in case of unexpected data or no data found for timestamp
+    """
+    date = timestamp_to_date(time, formatstr='%Y-%m-%d')
+    url = f'https://www.x-rates.com/historical/?from={from_asset.symbol}&amount=1&date={date}'
+    return _scrape_xratescom_exchange_rates(url)

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -175,7 +175,7 @@ class PriceHistorian():
         if from_asset == to_asset:
             return Price(FVal('1'))
 
-        # Querying historical forex data is attempted first via exchangerates API,
+        # Querying historical forex data is attempted first via the external apis
         # and then via any price oracle that has fiat to fiat.
         if from_asset.is_fiat() and to_asset.is_fiat():
             price = Inquirer().query_historical_fiat_exchange_rates(

--- a/rotkehlchen/tests/external_apis/test_xratescom.py
+++ b/rotkehlchen/tests/external_apis/test_xratescom.py
@@ -1,0 +1,44 @@
+import pytest
+
+from rotkehlchen.constants.assets import A_USD
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.errors import RemoteError
+from rotkehlchen.externalapis.xratescom import (
+    get_current_xratescom_exchange_rates,
+    get_historical_xratescom_exchange_rates,
+)
+from rotkehlchen.tests.utils.constants import A_CNY, A_EUR
+
+
+def test_get_current_xratescom_exchange_rates():
+    rates_map = get_current_xratescom_exchange_rates(A_USD)
+    for asset, price in rates_map.items():
+        assert asset.is_fiat()
+        assert price is not None and price > ZERO
+
+    rates_map = get_current_xratescom_exchange_rates(A_CNY)
+    for asset, price in rates_map.items():
+        assert asset.is_fiat()
+        assert price is not None and price > ZERO
+
+
+def test_get_historical_xratescom_exchange_rates():
+
+    rates_map = get_historical_xratescom_exchange_rates(A_USD, 1459585352)
+    for asset, price in rates_map.items():
+        assert asset.is_fiat()
+        assert price is not None and price > ZERO
+        if asset == A_CNY:
+            usd_cny_price = price
+
+    rates_map = get_historical_xratescom_exchange_rates(A_CNY, 1459585352)
+    for asset, price in rates_map.items():
+        assert asset.is_fiat()
+        assert price is not None and price > ZERO
+        if asset == A_USD:
+            cny_usd_price = price
+
+    assert cny_usd_price.is_close(1 / usd_cny_price)
+
+    with pytest.raises(RemoteError):
+        get_historical_xratescom_exchange_rates(A_EUR, 512814152)


### PR DESCRIPTION
They introduced an API key and limits are 200 req/month. Not feasible.

Replaced with x-rates.com