### PR TITLE
Fix Coinbase pagination

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Changelog
 * :bug:`2643` Beaconcha.in api key should now be properly used if given by the user
 * :bug:`2614` Uniswap users should no longer have missing trades in their uniswap history.
 * :bug:`2674` Coinbasepro should now also properly parse historical market trades and not only limit ones. Also all fills will be separately shown and not just the executed orders.
+* :bug:`2656` Users of coinbase with a lot of assets or trades should now see all of them again. There should be no missing balances or trades thanks to a fix at query pagination.
 
 * :release:`1.15.2 <2021-03-21>`
 * :bug:`1996` Querying coinbasepro deposits and withdrawals should now be much faster thanks to using their new API endpoints.

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -349,8 +349,8 @@ class Coinbase(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
         final_data = json_ret['data']
 
-        # If we got pagination and this is the first query, gather all the subsequent queries
-        if 'pagination' in json_ret and not pagination_next_uri and not ignore_pagination:
+        # If we got pagination recursively gather all the subsequent queries
+        if 'pagination' in json_ret and not ignore_pagination:
             if 'next_uri' not in json_ret['pagination']:
                 raise RemoteError('Coinbase json response contained no "next_uri" key')
 


### PR DESCRIPTION
Api queries should now do more than one pagination queries (if
needed). Due to an extra if check, before we were only doing one
paginated query.

Fix #2656 