### PR TITLE
Show more errors to the user during PnL report

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Users will now get an error message if during the PnL report an acquisition date for a sold asset can't be found. Also if an action with an unknown token is processed. This way users will know that they need to manually add more data to rotki.
 * :feature:`-` The users can now optionally add a rate and rate asset when adding a ledger action.
 * :feature:`-` The external trade fee and fee currency are now optional and the users can skip them when adding a trade.
 * :feature:`929` Users can now select which rounding mode is used for displayed amounts via the frontend settings.

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -545,13 +545,13 @@ class Accountant():
             )
             return True, prev_time
 
-        if any(isinstance(x, UnknownEthereumToken) for x in action_assets):
-            log.debug(
-                'Ignoring action with unknown token',
-                action_type=action_type,
-                assets=[x.identifier for x in action_assets],
-            )
-            return True, prev_time
+        for x in action_assets:
+            if isinstance(x, UnknownEthereumToken):
+                self.msg_aggregator.add_error(
+                    f'Ignoring action {action_type} with unknown token asset {x}. '
+                    f'Add it as a token in rotki manually with a working price oracle to fix this',
+                )
+                return True, prev_time
 
         if any(x in ignored_assets for x in action_assets):
             log.debug(

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -35,7 +35,7 @@ class TaxableEvents():
         self.profit_currency = profit_currency
         # later customized via accountant._customize()
         self.taxable_ledger_actions: List[LedgerActionType] = []
-        self.cost_basis = CostBasisCalculator(csv_exporter, profit_currency)
+        self.cost_basis = CostBasisCalculator(csv_exporter, profit_currency, msg_aggregator)
 
         # If this flag is True when your asset is being forcefully sold as a
         # loan/margin settlement then profit/loss is also calculated before the entire
@@ -173,6 +173,9 @@ class TaxableEvents():
             sold_amount: FVal,
             timestamp: Timestamp,
     ) -> None:
+        # For now for those don't use inform_user_missing_acquisition since if those hit
+        # the preforked asset acquisition data is what's missing so user would getLogger
+        # two messages. So as an example one for missing ETH data and one for ETC data
         if sold_asset == A_ETH and timestamp < ETH_DAO_FORK_TS:
             if not self.cost_basis.reduce_asset_amount(asset=A_ETC, amount=sold_amount):
                 log.critical(

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -126,10 +126,11 @@ def test_query_history(rotkehlchen_api_server_with_exchanges):
     assert msg in warnings[12]
 
     errors = rotki.msg_aggregator.consume_errors()
-    assert len(errors) == 3
+    assert len(errors) == 4
     assert 'bittrex trade with unprocessable pair %$#%$#%#$%' in errors[0]
     assert 'kraken trade with unprocessable pair IDONTEXISTZEUR' in errors[1]
     assert 'kraken trade with unprocessable pair %$#%$#%$#%$#%$#%' in errors[2]
+    assert 'No documented acquisition found for Raiden Network Token before' in errors[3]  # noqa: E501
 
 
 @pytest.mark.parametrize(

--- a/rotkehlchen/utils/accounting.py
+++ b/rotkehlchen/utils/accounting.py
@@ -3,6 +3,7 @@ from typing import List, Union
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import DefiEvent
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.unknown_asset import UnknownEthereumToken
 from rotkehlchen.chain.ethereum.trades import AMMTrade
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.exchanges.data_structures import AssetMovement, Loan, MarginPosition, Trade
@@ -62,7 +63,7 @@ def action_get_type(action: TaxableAction) -> str:
     raise AssertionError(f'TaxableAction of unknown type {type(action)} encountered')
 
 
-def action_get_assets(action: TaxableAction) -> List[Asset]:
+def action_get_assets(action: TaxableAction) -> List[Union[Asset, UnknownEthereumToken]]:
     """Gets the assets involved in the action
 
     May raise:
@@ -71,7 +72,7 @@ def action_get_assets(action: TaxableAction) -> List[Asset]:
 
     """
     if isinstance(action, (Trade, AMMTrade)):
-        return [action.base_asset, action.quote_asset]  # type: ignore
+        return [action.base_asset, action.quote_asset]
     if isinstance(action, (AssetMovement, LedgerAction)):
         return [action.asset]
     if isinstance(action, DefiEvent):


### PR DESCRIPTION
This will create a lot more errors during the PnL report for some users but that's the right way to go for now at least until https://github.com/rotki/rotki/issues/1797 is implemented. Those error were just logged in the logs but not shown to the user. And if they happen the user does need to take action, so showing them to the user somehow is a requirement.

- If acquisition event for an asset can't be found then warn the user
during PnL report so they can add it manually or debug why it was not
automatically detected
- If an unknown token causes an action to not be processed during PnL
report warn the user so they can add the token manually.