### PR TITLE
Exposes utility to premium components to honor user-selected date

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 * :feature:`1007` Coinbase exchange users will now be able to see asset conversions in their trade history.
 * :feature:`1334` FTX users will now be able to see their balances and have their deposit/withdrawal/trade history taken into account during profit/loss calculation.
 * :feature:`2332` Binance users will now be able to see their Binance Pool's assets in rotki.
+* :bug:`2626` Users will now properly see their specified date format when viewing various DeFi protocols and statistics.
 * :bug:`2479` Users will now see a < (less than) symbol in front of any amount with trailing decimals when rounding upwards is used.
 * :bug:`2610` Macos users will now be able to properly update every time using the auto-updater.
 * :bug:`2628` Users will now see the correct total asset value when visiting an asset's detail page for a second time.

--- a/frontend/app/src/premium/setup-interface.ts
+++ b/frontend/app/src/premium/setup-interface.ts
@@ -4,6 +4,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import { TIME_UNIT_DAY } from '@/components/dashboard/const';
 import { TimeUnit } from '@/components/dashboard/types';
+import { displayDateFormatter } from '@/data/date_formatter';
 import { registerComponents } from '@/premium/register-components';
 import { DataUtilities, DateUtilities } from '@/premium/types';
 import store from '@/store/store';
@@ -26,6 +27,12 @@ const date: DateUtilities = {
   },
   epochStartSubtract(amount: number, unit: TimeUnit): number {
     return moment().subtract(amount, unit).startOf(TIME_UNIT_DAY).unix();
+  },
+  toUserSelectedFormat(timestamp: number): string {
+    return displayDateFormatter.format(
+      new Date(timestamp * 1000),
+      store.getters['session/dateDisplayFormat']
+    );
   }
 };
 

--- a/frontend/app/src/premium/types.d.ts
+++ b/frontend/app/src/premium/types.d.ts
@@ -16,6 +16,7 @@ interface DateUtilities {
   epochToFormat(epoch: number, format: string): string;
   dateToEpoch(date: string, format: string): number;
   epochStartSubtract(amount: number, unit: TimeUnit): number;
+  toUserSelectedFormat(timestamp: number): string;
 }
 
 interface DataUtilities {


### PR DESCRIPTION
Closes #2626 
The premium component mr is the one that has the required changes.
In the statistics, this applies to the range hint and any error messages).

These changes do not apply to the date-picker component since this would be more complicated.
Also does not apply to the statistics tooltips since they follow a different format rule depending on the range.
