### PR TITLE
Uses a different separator in CSV column

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ Changelog
 * :bug:`2674` Coinbasepro should now also properly parse historical market trades and not only limit ones. Also all fills will be separately shown and not just the executed orders.
 * :bug:`2656` Users of coinbase with a lot of assets or trades should now see all of them again. There should be no missing balances or trades thanks to a fix at query pagination.
 * :bug:`2690` Eth2 stakers that have very recently deposited and don't have a validator index yet will now be handled properly and their balance should be shown.
+* :bug:`2716` Users will now get a correct exported CSV file when a sell is matched with multiple acquisitions.
 
 * :release:`1.15.2 <2021-03-21>`
 * :bug:`1996` Querying coinbasepro deposits and withdrawals should now be much faster thanks to using their new API endpoints.

--- a/rotkehlchen/accounting/cost_basis.py
+++ b/rotkehlchen/accounting/cost_basis.py
@@ -137,7 +137,7 @@ class CostBasisInfo(NamedTuple):
         if len(self.matched_acquisitions) == 0:
             return value
 
-        value += f'Used: {",".join([x.to_string(converter) for x in self.matched_acquisitions])}'
+        value += f'Used: {"|".join([x.to_string(converter) for x in self.matched_acquisitions])}'
         return value
 
 


### PR DESCRIPTION
I looked for similar cases but couldn't find any, only this one.
I used the `|` separator since is not used in the elements being joined and I believe is visually clear when reading a line

Closes #2716 
