### PR TITLE
FTX ignored assets

### DIFF
--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -529,6 +529,8 @@ UNSUPPORTED_FTX_ASSETS = (
     'BYND',  # Beyond Meat Tokenized stock
     'CGC',  # Trade Canopy Growth Corp Tokenized stock
     'MRNA',  # Moderna Tokenized stock
+    'XRPMOON',  # no cryptocompare/coingecko data
+    'SRM_LOCKED',  # no cryptocompare/coingecko data
 )
 
 # https://api.kucoin.com/api/v1/currencies


### PR DESCRIPTION
For the XRPMOON I see this in the coingecko page

`Coin is inactive. Contact hello@coingecko.com if you think this is an error`

https://www.coingecko.com/es/monedas/10x-long-xrp-token