### PR TITLE
Bump to v1.16.0 plus other changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.15.2
+current_version = 1.16.0
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.16.0 <2021-04-21>`
 * :feature:`2671` Rotki will now detect Adex V5 staked balances
 * :feature:`2714` Add support for a3CRV Curve pool
 * :feature:`2210` All price history caches are now moved to the global database. The price history sub-directory of the rotki data directory is now deleted. This should optimize price history querying and save disk space.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2018-2021, Rotki Solutions GmbH'
 author = 'The rotki team'
 
 # The short X.Y version
-version = '1.15.2'
+version = '1.16.0'
 # The full version, including alpha/beta/rc tags
-release = '1.15.2'
+release = '1.16.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "author": "Rotki Solutions GmbH <info@rotki.com>",
   "scripts": {

--- a/rotkehlchen/chain/ethereum/defi/zerionsdk.py
+++ b/rotkehlchen/chain/ethereum/defi/zerionsdk.py
@@ -120,7 +120,10 @@ def _is_token_non_standard(symbol: str, address: ChecksumEthAddress) -> bool:
     if symbol in ('UNI-V2', 'pDAI'):
         return True
 
-    if address in ('0xCb2286d9471cc185281c4f763d34A962ED212962',):  # Sushi LP token
+    if address in (
+            '0xCb2286d9471cc185281c4f763d34A962ED212962',  # Sushi LP token
+            '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',  # Special ETH address for aave v1, compound and Chi gas token  # noqa: E501
+    ):
         return True
 
     return False

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -551,20 +551,7 @@ class SubstrateManager():
         - RemoteError: `request_available_nodes()` fails to request after
         trying with all the available nodes.
         """
-        try:
-            balance = self._get_account_balance(
-                account=account,
-                node_interface=node_interface,
-            )
-        except RemoteError as e:
-            self.msg_aggregator.add_error(
-                f'Got remote error while querying {self.chain} '
-                f'{self.chain_properties.token.identifier} balance for account '
-                f'{account}: {str(e)}.',
-            )
-            raise
-
-        return balance
+        return self._get_account_balance(account=account, node_interface=node_interface)
 
     def get_accounts_balance(
             self,

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -381,16 +381,24 @@ class SubstrateManager():
 
     def _get_last_block(self, node_interface: SubstrateInterface) -> BlockNumber:
         """Return the chain height.
+
+        May raise:
+        - RemoteError if there is an error
         """
         log.debug(f'{self.chain} querying last block', url=node_interface.url)
         try:
             last_block = node_interface.get_block_number(
                 block_hash=node_interface.get_chain_head(),
             )
+            if last_block is None:  # For some reason a node can rarely return None as last block
+                raise SubstrateRequestException(
+                    f'{self.chain} node failed to request last block. Returned None',
+                )
         except (
-            requests.exceptions.RequestException,
-            SubstrateRequestException,
-            WebSocketException,
+                requests.exceptions.RequestException,
+                SubstrateRequestException,
+                WebSocketException,
+                ValueError,
         ) as e:
             message = (
                 f'{self.chain} failed to request last block '

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -5,11 +5,7 @@ from typing import TYPE_CHECKING, List, Optional
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.errors import (
-    NoPriceForGivenTimestamp,
-    PriceQueryUnsupportedAsset,
-    RemoteError,
-)
+from rotkehlchen.errors import NoPriceForGivenTimestamp, PriceQueryUnsupportedAsset, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -64,7 +60,7 @@ def query_usd_price_zero_if_error(
         )
     except (RemoteError, NoPriceForGivenTimestamp):
         msg_aggregator.add_error(
-            f'Could not query usd price for {asset.identifier} and time {time} '
+            f'Could not query usd price for {str(asset)} and time {time} '
             f'when processing {location}. Using zero price',
         )
         usd_price = Price(ZERO)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ directory = pathlib.Path(__file__).parent
 requirements = directory.joinpath('requirements.txt').read_text()
 requirements = [str(r) for r in parse_requirements(requirements)]
 
-version = '1.15.2'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.16.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='rotkehlchen',


### PR DESCRIPTION
- Handle returning None for kusama last block
- More readable error for inability to find price for asset at time
- Handle 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE in defi sdk result
- Don't send a user error if a single node's kusama query fails