### PR TITLE
Small changes in the backend's initialization

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -20,7 +20,6 @@ from typing import (
 )
 
 import gevent
-from gevent.lock import Semaphore
 from typing_extensions import Literal
 
 from rotkehlchen.accounting.accountant import Accountant
@@ -114,6 +113,8 @@ class Rotkehlchen():
     def __init__(self, args: argparse.Namespace) -> None:
         """Initialize the Rotkehlchen object
 
+        This runs during backend initialization so it should be as light as possible.
+
         May Raise:
         - SystemPermissionError if the given data directory's permissions
         are not correct.
@@ -147,14 +148,6 @@ class Rotkehlchen():
         self.coingecko = Coingecko(data_directory=self.data_dir)
         self.icon_manager = IconManager(data_dir=self.data_dir, coingecko=self.coingecko)
         self.assets_updater = AssetsUpdater(self.msg_aggregator)
-        self.greenlet_manager.spawn_and_track(
-            after_seconds=None,
-            task_name='periodically_query_icons_until_all_cached',
-            exception_is_error=False,
-            method=self.icon_manager.periodically_query_icons_until_all_cached,
-            batch_size=ICONS_BATCH_SIZE,
-            sleep_time_secs=ICONS_QUERY_SLEEP,
-        )
         # Initialize the Inquirer singleton
         Inquirer(
             data_dir=self.data_dir,
@@ -319,6 +312,14 @@ class Rotkehlchen():
             premium_sync_manager=self.premium_sync_manager,
             chain_manager=self.chain_manager,
             exchange_manager=self.exchange_manager,
+        )
+        self.greenlet_manager.spawn_and_track(
+            after_seconds=5,
+            task_name='periodically_query_icons_until_all_cached',
+            exception_is_error=False,
+            method=self.icon_manager.periodically_query_icons_until_all_cached,
+            batch_size=ICONS_BATCH_SIZE,
+            sleep_time_secs=ICONS_QUERY_SLEEP,
         )
         self.user_is_logged_in = True
         log.debug('User unlocking complete')


### PR DESCRIPTION
May help a tiny bit in #2819 since this will make the backend initialization a bit faster.

I suspect the main culprit for the slower initialization in MacOS though is the way we handle the Global DB due to the very early initialization of a temporary one and then a cleanup and re-initialization .. all before the full init finishes: https://github.com/rotki/rotki/issues/2751