### PR TITLE
Removes redundant version checks

### DIFF
--- a/frontend/app/src/components/AccountManagement.vue
+++ b/frontend/app/src/components/AccountManagement.vue
@@ -164,7 +164,6 @@ export default class AccountManagement extends Vue {
       deleteBackendUrl();
       await this.startBackendWithLogLevel(this.loglevel);
     }
-    await this.$store.dispatch('version');
   }
 
   async startBackendWithLogLevel(level: Level) {
@@ -172,7 +171,6 @@ export default class AccountManagement extends Vue {
     await this.$store.commit('setConnected', false);
     await this.$interop.restartBackend(level);
     await this.$store.dispatch('connect');
-    await this.$store.dispatch('version');
   }
 
   async login(credentials: Credentials) {


### PR DESCRIPTION
Since #2828 the version check happens after a successful ping inside `connect`

https://github.com/rotki/rotki/blob/3850b556a568e1d409cc8bb28d623997fc747851/frontend/app/src/store/store.ts#L119