### PR TITLE
Properly store rotki api credentials during new account creation without sync

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`2835` Eth2 users with a very big number of validators should no longer get a 429 error.
+* :bug:`2846` Premium users who create a new account with premium api credentials that have no saved DB in the server to sync with will have these credentials properly saved in the DB right after creation. At re-login the premium subscription should be properly recognized and the credentials should not need to be input again.
 * :bug:`2821` Users will now be able to properly scroll through the asset when conflicts appear during the asset database upgrade.
 * :bug:`2837` Binance US users will now be able to see the correct location for their trades and deposits/withdrawals. It should no longer be Binance. To reflect those changes Binance US data should be purged and then requeried. To see how to purge data for an exchange look here: https://rotki.readthedocs.io/en/latest/usage_guide.html#purging-data
 * :bug:`2819` Users using macOS will no longer be stuck at "connecting to backend".

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -284,25 +284,18 @@ class PremiumSyncManager():
 
             if sync_approval == 'yes':
                 log.info('User approved data sync from server')
-                if self._sync_data_from_server_and_replace_local()[0]:
-                    if create_new:
-                        # if we successfully synced data from the server and this is
-                        # a new account, make sure the api keys are properly stored
-                        # in the DB
-                        self.data.db.set_rotkehlchen_premium(self.premium.credentials)
+                self._sync_data_from_server_and_replace_local()  # this may raise due to password
 
             else:
                 log.debug('Could sync data from server but user refused')
         elif result.can_sync == CanSync.YES:
             log.info('User approved data sync from server')
-            if self._sync_data_from_server_and_replace_local()[0]:
-                if create_new:
-                    # if we successfully synced data from the server and this is
-                    # a new account, make sure the api keys are properly stored
-                    # in the DB
-                    self.data.db.set_rotkehlchen_premium(self.premium.credentials)
+            self._sync_data_from_server_and_replace_local()  # this may raise due to password
 
-        # else result.can_sync was no, so we do nothing
+        if create_new:
+            # if this is a new account, make sure the api keys are properly stored
+            # in the DB
+            self.data.db.set_rotkehlchen_premium(self.premium.credentials)
 
         # Success, return premium
         return self.premium

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -391,7 +391,10 @@ def test_try_premium_at_start_first_time_no_previous_db(
         db_password,
         rotki_premium_credentials,
 ):
-    """Regression test for https://github.com/rotki/rotki/issues/1571"""
+    """Regression test for:
+    - https://github.com/rotki/rotki/issues/1571
+    - https://github.com/rotki/rotki/issues/2846
+    """
     setup_starting_environment(
         rotkehlchen_instance=rotkehlchen_instance,
         username=username,
@@ -405,6 +408,12 @@ def test_try_premium_at_start_first_time_no_previous_db(
     )
     # DB should not have changed and no exception raised
     assert rotkehlchen_instance.data.db.get_main_currency() == DEFAULT_TESTS_MAIN_CURRENCY
+    # DB should have the given rotki premium credentials saved in it since premium
+    # was succesfully initialized
+    credentials = rotkehlchen_instance.data.db.get_rotkehlchen_premium()
+    assert credentials is not None
+    assert credentials.api_key == rotki_premium_credentials.api_key
+    assert credentials.api_secret == rotki_premium_credentials.api_secret
 
 
 def test_premium_credentials():


### PR DESCRIPTION
Fix #2846

If a new local rotki account is created and has premium api keys given
during creation and these keys have no DB saved in the server to sync
with we now save the credentials properly in the DB.

This will result in not asking for the keys again next time user logs in.