### PR TITLE
Makes the default sort order overridable

### DIFF
--- a/frontend/app/src/components/asset-manager/AssetTable.vue
+++ b/frontend/app/src/components/asset-manager/AssetTable.vue
@@ -31,6 +31,7 @@
       :expanded="expanded"
       item-key="identifier"
       sort-by="name"
+      :sort-desc="false"
       :search.sync="search"
     >
       <template #item.name="{ item }">

--- a/frontend/app/src/components/helper/DataTable.vue
+++ b/frontend/app/src/components/helper/DataTable.vue
@@ -1,7 +1,7 @@
 <template>
   <v-data-table
     v-bind="$attrs"
-    sort-desc
+    :sort-desc="sortDesc"
     must-sort
     :footer-props="footerProps"
     :items-per-page="itemsPerPage"
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator';
+import { Component, Mixins, Prop } from 'vue-property-decorator';
 import { mapState } from 'vuex';
 import { footerProps } from '@/config/datatable.common';
 import SettingsMixin from '@/mixins/settings-mixin';
@@ -34,6 +34,9 @@ import { ITEMS_PER_PAGE } from '@/store/settings/consts';
   }
 })
 export default class DataTable extends Mixins(SettingsMixin) {
+  @Prop({ required: false, default: true, type: Boolean })
+  sortDesc!: boolean;
+
   readonly footerProps = footerProps;
   itemsPerPage!: number;
 


### PR DESCRIPTION
@isidorosp noticed that the order in asset management was desc.

That was not intentional.