### PR TITLE
Fix asset updates from old db without an assets_version key

### DIFF
--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -53,9 +53,9 @@ def _replace_assets_from_db(
     INSERT INTO ethereum_tokens SELECT * FROM other_db.ethereum_tokens;
     INSERT INTO underlying_tokens_list SELECT * FROM other_db.underlying_tokens_list;
     INSERT INTO common_asset_details SELECT * FROM other_db.common_asset_details;
-    UPDATE settings SET value=(
-        SELECT value FROM other_db.settings WHERE name="{ASSETS_VERSION_KEY}"
-    ) WHERE name="{ASSETS_VERSION_KEY}";
+    INSERT OR REPLACE INTO settings(name, value) VALUES("{ASSETS_VERSION_KEY}",
+    (SELECT value FROM other_db.settings WHERE name="{ASSETS_VERSION_KEY}")
+    );
     PRAGMA foreign_keys = ON;
     DETACH DATABASE "other_db";
     """)


### PR DESCRIPTION
If the Global DB is upgraded from an old database without an
assets_version key then now the upgrade will always work and will not
be stuck in a loop.

The problem was that if the assets version key was missing we were
not entering it due to using an update statement. Now we use insert or replace