### PR TITLE
Correctly ignore ledger actions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`2875` Invalid ENS names should now provide a proper error when provided to rotki.
+* :bug:`2888` Ledger actions selected to be ignored in the profit and loss report will now be correctly ignored.
 
 * :release:`1.16.2 <2021-05-08>`
 * :bug:`-` If a DeFi event provides zero amount of an asset to a user the PnL report should now work properly again.

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -450,12 +450,12 @@ class Accountant():
             action: TaxableAction,
             action_type: str,
             ignored_actionids_mapping: Dict[ActionType, List[str]],
-    ) -> Tuple[bool, Any]:
+    ) -> Tuple[bool, Optional[str]]:
         # TODO: These ifs/mappings of action type str to the enum
         # are only due to mix of new and old code. They should be removed and only
         # the enum should be used everywhere eventually
         should_ignore = False
-        identifier: Optional[Any] = None
+        identifier: Optional[str] = None
         if action_type == 'trade':
             trade = cast(Trade, action)
             identifier = trade.identifier
@@ -477,7 +477,9 @@ class Accountant():
 
         elif action_type == 'ledger_action':
             ledger_action = cast(LedgerAction, action)
-            identifier = ledger_action.identifier
+            # Ignored actions have TEXT type in the database but
+            # ledger actions have int as type for identifier
+            identifier = str(ledger_action.identifier)
             should_ignore = identifier in ignored_actionids_mapping.get(
                 ActionType.LEDGER_ACTION, [],
             )

--- a/rotkehlchen/tests/api/test_ignored_actions.py
+++ b/rotkehlchen/tests/api/test_ignored_actions.py
@@ -4,11 +4,15 @@ from typing import List, Tuple
 import pytest
 import requests
 
+from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType
+from rotkehlchen.constants.assets import A_DAI, A_ETH, A_USD
+from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response_with_result,
 )
+from rotkehlchen.typing import Location
 
 
 def _populate_ignored_actions(rotkehlchen_api_server) -> List[Tuple[str, List[str]]]:
@@ -150,3 +154,57 @@ def test_remove_ignored_actions(rotkehlchen_api_server):
         'ledger action': ['1', '2', '3'],
         'trade': ['1', '2', '3'],
     }
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [0])
+def test_ignore_ledger_actions_in_accountant(rotkehlchen_api_server, accountant):
+    """Test that ignored ledger actions are correctly ignored by the accountant"""
+    ledger_actions_list = [
+        LedgerAction(
+            identifier=1,
+            timestamp=1467279735,
+            action_type=LedgerActionType.INCOME,
+            location=Location.BLOCKCHAIN,
+            amount=FVal(1000),
+            asset=A_ETH,
+            rate=FVal(100),
+            rate_asset=A_USD,
+            link=None,
+            notes=None,
+        ), LedgerAction(
+            identifier=2,
+            timestamp=1467279735,
+            action_type=LedgerActionType.EXPENSE,
+            location=Location.BLOCKCHAIN,
+            amount=FVal(5),
+            asset=A_DAI,
+            rate=None,
+            rate_asset=None,
+            link='foo',
+            notes='boo',
+        ),
+    ]
+
+    # Set the server to ignore second ledger action
+    response = requests.put(
+        api_url_for(
+            rotkehlchen_api_server,
+            'ignoredactionsresource',
+        ), json={'action_type': 'ledger action', 'action_ids': ['2']},
+    )
+    result = assert_proper_response_with_result(response)
+    assert result == {'ledger action': ['2']}
+
+    # Retrieve ignored actions mapping. Should contain 2
+    ignored_actions = accountant.db.get_ignored_action_ids(action_type=None)
+    ignored = []
+    # Call the should_ignore method used in the accountant
+    for action in ledger_actions_list:
+        should_ignore, _ = accountant._should_ignore_action(
+            action=action,
+            action_type='ledger_action',
+            ignored_actionids_mapping=ignored_actions,
+        )
+        ignored.append(should_ignore)
+
+    assert ignored == [False, True]


### PR DESCRIPTION
Closes #2888

Ledger actions were not correctly ignored in the PnL report because the ignored actions as represented in the database are string but ledger actions have int type. As we were comparing string and int we couldn't find the ledger action in the list to ignore (`1 != '1'`)