### PR TITLE
Add fees to withdrawals from binance

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :feature:`1549` Rotki premium users will now be able to switch to a dark mode and change the theme colors.
 * :feature:`1674` Add experimental support for BlockFi imports using CSV files.
 * :feature:`2224` Add experimental support for Nexo imports using CSV files.
+* :feature:`2475` Withdrawals from Binance and Binance US will now have their fee correctly imported.
 * :feature:`2844` Premium users will now be able to fetch their Uniswap v3 swaps.
 * :bug:`2850` User will now see a consistent naming of exchanges across the application.
 

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -932,9 +932,11 @@ class Binance(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             if 'insertTime' in raw_data:
                 category = AssetMovementCategory.DEPOSIT
                 time_key = 'insertTime'
+                fee = Fee(ZERO)
             else:
                 category = AssetMovementCategory.WITHDRAWAL
                 time_key = 'applyTime'
+                fee = Fee(deserialize_asset_amount(raw_data['transactionFee']))
 
             timestamp = deserialize_timestamp_from_binance(raw_data[time_key])
             asset = asset_from_binance(raw_data['asset'])
@@ -947,8 +949,7 @@ class Binance(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 asset=asset,
                 amount=deserialize_asset_amount_force_positive(raw_data['amount']),
                 fee_asset=asset,
-                # Binance does not include withdrawal fees neither in the API nor in their UI
-                fee=Fee(ZERO),
+                fee=fee,
                 link=str(raw_data['txId']),
             )
 

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -530,6 +530,7 @@ def test_binance_query_deposits_withdrawals_unexpected_data(function_scope_binan
         {
             "id":"7213fea8e94b4a5593d507237e5a555b",
             "amount": 0.04670582,
+            "transactionFee": 0.01,
             "address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
             "asset": "ETH",
             "txId": "0xdf33b22bdb2b28b1f75ccd201a4a4m6e7g83jy5fc5d5a9d1340961598cfcb0a1",

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -313,26 +313,30 @@ BINANCE_WITHDRAWALS_HISTORY_RESPONSE = """{
     "withdrawList": [
         {
             "id":"7213fea8e94b4a5593d507237e5a555b",
-            "amount": 1,
+            "withdrawOrderId": null,
+            "amount": 0.99,
+            "transactionFee": 0.01,
             "address": "0x6915f16f8791d0a1cc2bf47c13a6b2a92000504b",
             "asset": "ETH",
             "txId": "0xdf33b22bdb2b28b1f75ccd201a4a4m6e7g83jy5fc5d5a9d1340961598cfcb0a1",
-            "applyTime": 1508488245000,
+            "applyTime": 1508198532000,
             "status": 4
         },
         {
             "id":"7213fea8e94b4a5534ggsd237e5a555b",
-            "amount": 850.1,
-            "address": "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyVz8",
+            "withdrawOrderId": "withdrawtest",
+            "amount": 999.9999,
+            "transactionFee": 0.0001,
+            "address": "463tWEBn5XZJSxLU34r6g7h8jtxuNcDbjLSjkn3XAXHCbLrTTErJrBWYgHJQyrCwkNgYvyV3z8zctJLPCZy24jvb3NiTcTJ",
             "addressTag": "342341222",
             "txId": "b3c6219639c8ae3f9cf010cdc24fw7f7yt8j1e063f9b4bd1a05cb44c4b6e2509",
             "asset": "XMR",
-            "applyTime": 1508512521000,
+            "applyTime": 1508198532000,
             "status": 4
         }
     ],
     "success": true
-}"""
+}"""  # noqa: E501
 
 
 def assert_binance_balances_result(balances: Dict[str, Any]) -> None:
@@ -362,19 +366,19 @@ def assert_binance_asset_movements_result(movements: List[AssetMovement], locati
 
     assert movements[2].location == location
     assert movements[2].category == AssetMovementCategory.WITHDRAWAL
-    assert movements[2].timestamp == 1508488245
+    assert movements[2].timestamp == 1508198532
     assert isinstance(movements[2].asset, Asset)
     assert movements[2].asset == A_ETH
-    assert movements[2].amount == FVal('1')
-    assert movements[2].fee == ZERO
+    assert movements[2].amount == FVal('0.99')
+    assert movements[2].fee == FVal('0.01')
 
     assert movements[3].location == location
     assert movements[3].category == AssetMovementCategory.WITHDRAWAL
-    assert movements[3].timestamp == 1508512521
+    assert movements[3].timestamp == 1508198532
     assert isinstance(movements[3].asset, Asset)
     assert movements[3].asset == A_XMR
-    assert movements[3].amount == FVal('850.1')
-    assert movements[3].fee == ZERO
+    assert movements[3].amount == FVal('999.9999')
+    assert movements[3].fee == FVal('0.0001')
 
 
 def assert_poloniex_balances_result(balances: Dict[str, Any]) -> None:


### PR DESCRIPTION
Closes #2475 .One question I have is: in the [documentation](https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-user_data) they have for one of the fields `None` but I believe in the json response should be `null`. I've changed that for the tests but don't know if it is a bad assumption on my side. `None` raises an error in `json.loads`