### PR TITLE
Bump flask-restful

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ beautifulsoup4==4.9.3
 
 # For the rest api
 flask-cors==3.0.10
-git+git://github.com/flask-restful/flask-restful@fc9b34c39472284a57c50d94fec5b51fe8d71e14#egg=flask-restful
+flask-restful==0.3.9
 flask==2.0.0
 marshmallow==3.12.1
 webargs==8.0.0

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,7 @@ directory = pathlib.Path(__file__).parent
 # Load install_requires from requirements.txt.
 # https://stackoverflow.com/a/59971236/4651668
 requirements = directory.joinpath('requirements.txt').read_text()
-requirements = [x for x in requirements.split('\n') if not x.startswith('git+')]
 requirements = [str(r) for r in parse_requirements(requirements)]
-requirements.append('flask-restful')
-dependency_links = [
-    'git+git://github.com/flask-restful/flask-restful@fc9b34c39472284a57c50d94fec5b51fe8d71e14#egg=flask-restful'  # noqa: E501
-]
 
 version = '1.16.2'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
@@ -25,7 +20,7 @@ setup(
     author='Rotki Solutions GmbH',
     author_email='info@rotki.com',
     description='Acccounting, asset management and tax report helper for cryptocurrencies',
-    license='BSD-3',
+    license='AGPL-3',
     keywords='accounting tax-report portfolio asset-management cryptocurrencies',
     url='https://github.com/rotki/rotki',
     packages=find_packages('.'),
@@ -35,7 +30,6 @@ setup(
     },
     python_requires='>=3.6',
     install_requires=requirements,
-    dependency_links=dependency_links,
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     long_description=directory.joinpath('README.md').read_text(),


### PR DESCRIPTION
Thanks to https://github.com/flask-restful/flask-restful/issues/916 we
can bump the version and remove the pinning to a commit hash