### PR TITLE
Some changes in the v25->v26 DB upgrade

### DIFF
--- a/rotkehlchen/tests/api/test_custom_assets.py
+++ b/rotkehlchen/tests/api/test_custom_assets.py
@@ -510,6 +510,10 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
         )
         result = assert_proper_response_with_result(response)
         assert result['balances'] == expected_balances
+        assert cursor.execute(
+            'SELECT COUNT(*) from manually_tracked_balances WHERE asset=?;',
+            (custom1_id,),
+        ).fetchone()[0] == 1
 
     response = requests.put(
         api_url_for(
@@ -535,6 +539,17 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
         assert cursor.execute(
             'SELECT COUNT(*) FROM assets WHERE identifier=?', (custom1_id,),
         ).fetchone()[0] == 0
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM assets WHERE identifier=?', ('ICP',),
+        ).fetchone()[0] == 1
+        assert cursor.execute(
+            'SELECT COUNT(*) from manually_tracked_balances WHERE asset=?;',
+            (custom1_id,),
+        ).fetchone()[0] == 0
+        assert cursor.execute(
+            'SELECT COUNT(*) from manually_tracked_balances WHERE asset=?;',
+            ('ICP',),
+        ).fetchone()[0] == 1
 
     # check the previous asset is not in globaldb owned assets
     assert global_cursor.execute(


### PR DESCRIPTION
Essentially do not delete any data during the upgrade. If there is an unknown asset, keep it only in the user DB. Can be fixed later with the replace asset functionality.



https://user-images.githubusercontent.com/1658405/119262768-bcd1d700-bbdc-11eb-965c-49843cee1643.mp4

