### PR TITLE
If txId is missing in binance use id for the link field 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2999` If a binance withdrawal is missing the txId field rotki will now still be able to process it correctly.
 * :bug:`2993` If a sell of FIAT for crypto is made, which is effectively a buy of crypto with FIAT, complaints about the source of funds should no longer be generated.
 
 * :release:`1.17.1 <2021-05-26>`

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -939,17 +939,20 @@ class Binance(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
             timestamp = deserialize_timestamp_from_binance(raw_data[time_key])
             asset = asset_from_binance(raw_data['asset'])
+            tx_id = get_key_if_has_val(raw_data, 'txId')
+            internal_id = get_key_if_has_val(raw_data, 'id')
+            link_str = str(internal_id) if internal_id else str(tx_id) if tx_id else ''
             return AssetMovement(
                 location=self.location,
                 category=category,
                 address=deserialize_asset_movement_address(raw_data, 'address', asset),
-                transaction_id=get_key_if_has_val(raw_data, 'txId'),
+                transaction_id=tx_id,
                 timestamp=timestamp,
                 asset=asset,
                 amount=deserialize_asset_amount_force_positive(raw_data['amount']),
                 fee_asset=asset,
                 fee=fee,
-                link=str(raw_data['txId']),
+                link=link_str,
             )
 
         except UnknownAsset as e:


### PR DESCRIPTION
Fix #2999 