### PR TITLE
Increase backend integration test timeout in MacOS

### DIFF
--- a/rotkehlchen/tests/integration/test_backend.py
+++ b/rotkehlchen/tests/integration/test_backend.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from http import HTTPStatus
 
 import gevent
@@ -17,6 +18,8 @@ def test_backend():
         stderr=subprocess.STDOUT,
     )
     timeout = 10
+    if sys.platform == 'darwin':
+        timeout = 30  # in macos the backend may take a long time to start
     with gevent.Timeout(timeout):
         try:
             while True:


### PR DESCRIPTION
Nightlies test run started failing on MacOS only. The python backend does indeed take a longer time to launch in MacOS so we need to increase the timeout for the test.

https://github.com/rotki/rotki/runs/2707112236?check_suite_focus=true