### PR TITLE
Introduce data integrity check to fix broken DB ids

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3010` Fixes a bug when editing a trade that had a modified/replaced asset could fail with a "trade identifier not found" error.
 * :bug:`1403` When removing an ethereum account that has liabilities, they should now also be removed from the dashboard and from the blockchain accounts view.
 * :bug:`2998` If a new token is added in the rotki list of assets then the token detection cache is now invalidated so it will be detected when refreshing balances.
 * :bug:`2999` If a binance withdrawal is missing the txId field rotki will now still be able to process it correctly.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -7,7 +7,7 @@ import tempfile
 from collections import defaultdict
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union, cast
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 from typing_extensions import Literal
@@ -90,16 +90,12 @@ from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import PremiumCredentials
 from rotkehlchen.serialization.deserialize import (
     deserialize_action_type_from_db,
-    deserialize_asset_amount,
     deserialize_asset_movement_category_from_db,
-    deserialize_fee,
     deserialize_hex_color_code,
-    deserialize_optional,
     deserialize_timestamp,
     deserialize_trade_type_from_db,
 )
@@ -250,6 +246,7 @@ class DBHandler:
             self.set_settings(initial_settings)
         self.update_owned_assets_in_globaldb()
         self.add_globaldb_assetids()
+        self.ensure_data_integrity()
 
     def __del__(self) -> None:
         if hasattr(self, 'conn') and self.conn:
@@ -2468,18 +2465,7 @@ class DBHandler:
         The returned list is ordered from oldest to newest
         """
         cursor = self.conn.cursor()
-        query = (
-            'SELECT id,'
-            '  location,'
-            '  open_time,'
-            '  close_time,'
-            '  profit_loss,'
-            '  pl_currency,'
-            '  fee,'
-            '  fee_currency,'
-            '  link,'
-            '  notes FROM margin_positions '
-        )
+        query = 'SELECT * FROM margin_positions '
         if location is not None:
             query += f'WHERE location="{location.serialize_for_db()}" '
         query, bindings = form_query_to_filter_timestamps(query, 'close_time', from_ts, to_ts)
@@ -2488,21 +2474,7 @@ class DBHandler:
         margin_positions = []
         for result in results:
             try:
-                if result[2] == 0:
-                    open_time = None
-                else:
-                    open_time = deserialize_timestamp(result[2])
-                margin = MarginPosition(
-                    location=Location.deserialize_from_db(result[1]),
-                    open_time=open_time,
-                    close_time=deserialize_timestamp(result[3]),
-                    profit_loss=deserialize_asset_amount(result[4]),
-                    pl_currency=Asset(result[5]),
-                    fee=deserialize_fee(result[6]),
-                    fee_currency=Asset(result[7]),
-                    link=result[8],
-                    notes=result[9],
-                )
+                margin = MarginPosition.deserialize_from_db(result)
             except DeserializationError as e:
                 self.msg_aggregator.add_error(
                     f'Error deserializing margin position from the DB. '
@@ -2565,19 +2537,7 @@ class DBHandler:
         The returned list is ordered from oldest to newest
         """
         cursor = self.conn.cursor()
-        query = (
-            'SELECT id,'
-            '  location,'
-            '  category,'
-            '  time,'
-            '  asset,'
-            '  amount,'
-            '  fee_asset,'
-            '  fee,'
-            '  link,'
-            '  address,'
-            '  transaction_id FROM asset_movements '
-        )
+        query = 'SELECT * FROM asset_movements '
         if location is not None:
             query += f'WHERE location="{location.serialize_for_db()}" '
         query, bindings = form_query_to_filter_timestamps(query, 'time', from_ts, to_ts)
@@ -2586,20 +2546,7 @@ class DBHandler:
         asset_movements = []
         for result in results:
             try:
-                movement = AssetMovement(
-                    location=Location.deserialize_from_db(result[1]),
-                    category=deserialize_asset_movement_category_from_db(result[2]),
-                    timestamp=result[3],
-                    asset=Asset(result[4]),
-                    # TODO: should we also _force_positive here? I guess not since
-                    # we always make sure to save it as positive
-                    amount=deserialize_asset_amount(result[5]),
-                    fee_asset=Asset(result[6]),
-                    fee=deserialize_fee(result[7]),
-                    link=result[8],
-                    address=result[9],
-                    transaction_id=result[10],
-                )
+                movement = AssetMovement.deserialize_from_db(result)
             except DeserializationError as e:
                 self.msg_aggregator.add_error(
                     f'Error deserializing asset movement from the DB. '
@@ -2895,20 +2842,7 @@ class DBHandler:
         The returned list is ordered from oldest to newest
         """
         cursor = self.conn.cursor()
-        query = (
-            'SELECT id,'
-            '  time,'
-            '  location,'
-            '  base_asset,'
-            '  quote_asset,'
-            '  type,'
-            '  amount,'
-            '  rate,'
-            '  fee,'
-            '  fee_currency,'
-            '  link,'
-            '  notes FROM trades '
-        )
+        query = 'SELECT * FROM trades '
         if location is not None:
             query += f'WHERE location="{location.serialize_for_db()}" '
         query, bindings = form_query_to_filter_timestamps(query, 'time', from_ts, to_ts)
@@ -2917,19 +2851,7 @@ class DBHandler:
         trades = []
         for result in results:
             try:
-                trade = Trade(
-                    timestamp=deserialize_timestamp(result[1]),
-                    location=Location.deserialize_from_db(result[2]),
-                    base_asset=Asset(result[3]),
-                    quote_asset=Asset(result[4]),
-                    trade_type=deserialize_trade_type_from_db(result[5]),
-                    amount=deserialize_asset_amount(result[6]),
-                    rate=deserialize_price(result[7]),
-                    fee=deserialize_optional(result[8], deserialize_fee),
-                    fee_currency=deserialize_optional(result[9], Asset),
-                    link=result[10],
-                    notes=result[11],
-                )
+                trade = Trade.deserialize_from_db(result)
             except DeserializationError as e:
                 self.msg_aggregator.add_error(
                     f'Error deserializing trade from the DB. Skipping trade. Error was: {str(e)}',
@@ -3754,3 +3676,44 @@ class DBHandler:
 
         self.conn.commit()
         self.update_last_write()
+
+    def _ensure_data_integrity(
+            self,
+            table_name: str,
+            klass: Union[Type[Trade], Type[AssetMovement], Type[MarginPosition]],
+    ) -> None:
+        updates: List[Tuple[str, str]] = []
+        cursor = self.conn.cursor()
+        results = cursor.execute(f'SELECT * from {table_name};')
+        for result in results:
+            try:
+                obj = klass.deserialize_from_db(result)
+            except (DeserializationError, UnknownAsset):
+                continue
+
+            db_id = result[0]
+            actual_id = obj.identifier
+            if actual_id != db_id:
+                updates.append((actual_id, db_id))
+
+        if len(updates) != 0:
+            logger.debug(
+                f'Found {len(updates)} identifier discrepancies in the DB '
+                f'for {table_name}. Correcting...',
+            )
+            cursor.executemany(f'UPDATE {table_name} SET id = ? WHERE id =?;', updates)
+
+    def ensure_data_integrity(self) -> None:
+        """Runs some checks for data integrity of the DB that can't be verified by SQLite
+
+        For now it mostly tackles https://github.com/rotki/rotki/issues/3010 ,
+        the problem of identifiers of trades, asset movements and margin positions
+        changing and no longer corresponding to the calculated id.
+        """
+        start_time = ts_now()
+        logger.debug('Starting DB data integrity check')
+        self._ensure_data_integrity('trades', Trade)
+        self._ensure_data_integrity('asset_movements', AssetMovement)
+        self._ensure_data_integrity('margin_positions', MarginPosition)
+        self.conn.commit()
+        logger.debug(f'DB data integrity check finished after {ts_now() - start_time} seconds')

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -38,14 +38,14 @@ AssetMovementDBTuple = Tuple[
     str,  # id
     str,  # location
     str,  # category
-    int,  # timestamp
+    str,  # address
+    str,  # transaction_id
+    int,  # time
     str,  # asset
     str,  # amount
     str,  # fee_asset
     str,  # fee
     str,  # link
-    str,  # address
-    str,  # transaction_id
 ]
 
 
@@ -103,16 +103,16 @@ class AssetMovement(NamedTuple):
         return AssetMovement(
             location=Location.deserialize_from_db(entry[1]),
             category=deserialize_asset_movement_category_from_db(entry[2]),
-            timestamp=Timestamp(entry[3]),
-            asset=Asset(entry[4]),
+            address=entry[3],
+            transaction_id=entry[4],
+            timestamp=Timestamp(entry[5]),
+            asset=Asset(entry[6]),
             # TODO: should we also _force_positive here? I guess not since
             # we always make sure to save it as positive
-            amount=deserialize_asset_amount(entry[5]),
-            fee_asset=Asset(entry[6]),
-            fee=deserialize_fee(entry[7]),
-            link=entry[8],
-            address=entry[9],
-            transaction_id=entry[10],
+            amount=deserialize_asset_amount(entry[7]),
+            fee_asset=Asset(entry[8]),
+            fee=deserialize_fee(entry[9]),
+            link=entry[10],
         )
 
 

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.crypto import sha3
@@ -8,9 +8,12 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
+    deserialize_asset_movement_category_from_db,
     deserialize_fee,
+    deserialize_optional,
     deserialize_timestamp,
     deserialize_trade_type,
+    deserialize_trade_type_from_db,
 )
 from rotkehlchen.typing import (
     AssetAmount,
@@ -29,6 +32,21 @@ from rotkehlchen.user_messages import MessagesAggregator
 def hash_id(hashable: str) -> TradeID:
     id_bytes = sha3(hashable.encode())
     return TradeID(id_bytes.hex())
+
+
+AssetMovementDBTuple = Tuple[
+    str,  # id
+    str,  # location
+    str,  # category
+    int,  # timestamp
+    str,  # asset
+    str,  # amount
+    str,  # fee_asset
+    str,  # fee
+    str,  # link
+    str,  # address
+    str,  # transaction_id
+]
 
 
 class AssetMovement(NamedTuple):
@@ -75,6 +93,43 @@ class AssetMovement(NamedTuple):
         result = self._asdict()  # pylint: disable=no-member
         result['identifier'] = self.identifier
         return result
+
+    @classmethod
+    def deserialize_from_db(cls, entry: AssetMovementDBTuple) -> 'AssetMovement':
+        """May raise:
+            - DeserializationError
+            - UnknownAsset
+        """
+        return AssetMovement(
+            location=Location.deserialize_from_db(entry[1]),
+            category=deserialize_asset_movement_category_from_db(entry[2]),
+            timestamp=Timestamp(entry[3]),
+            asset=Asset(entry[4]),
+            # TODO: should we also _force_positive here? I guess not since
+            # we always make sure to save it as positive
+            amount=deserialize_asset_amount(entry[5]),
+            fee_asset=Asset(entry[6]),
+            fee=deserialize_fee(entry[7]),
+            link=entry[8],
+            address=entry[9],
+            transaction_id=entry[10],
+        )
+
+
+TradeDBTuple = Tuple[
+    str,  # id
+    int,  # time
+    str,  # location
+    str,  # base_asset
+    str,  # quote_asset
+    str,  # type
+    str,  # amount
+    str,  # rate
+    str,  # fee
+    str,  # fee_currency
+    str,  # link
+    str,  # notes
+]
 
 
 class Trade(NamedTuple):
@@ -154,6 +209,40 @@ class Trade(NamedTuple):
             f'and quote asset: {self.quote_asset.name}'
         )
 
+    @classmethod
+    def deserialize_from_db(cls, entry: TradeDBTuple) -> 'Trade':
+        """May raise:
+            - DeserializationError
+            - UnknownAsset
+        """
+        return Trade(
+            timestamp=deserialize_timestamp(entry[1]),
+            location=Location.deserialize_from_db(entry[2]),
+            base_asset=Asset(entry[3]),
+            quote_asset=Asset(entry[4]),
+            trade_type=deserialize_trade_type_from_db(entry[5]),
+            amount=deserialize_asset_amount(entry[6]),
+            rate=deserialize_price(entry[7]),
+            fee=deserialize_optional(entry[8], deserialize_fee),
+            fee_currency=deserialize_optional(entry[9], Asset),
+            link=entry[10],
+            notes=entry[11],
+        )
+
+
+MarginPositionDBTuple = Tuple[
+    str,  # id
+    str,  # location
+    int,  # open_time
+    int,  # close_time
+    str,  # profit_loss
+    str,  # pl_currency
+    str,  # fee
+    str,  # fee_currency
+    str,  # link
+    str,  # notes
+]
+
 
 class MarginPosition(NamedTuple):
     """We only support margin positions on poloniex and bitmex at the moment"""
@@ -196,6 +285,28 @@ class MarginPosition(NamedTuple):
             self.link
         )
         return hash_id(string)
+
+    @classmethod
+    def deserialize_from_db(cls, entry: MarginPositionDBTuple) -> 'MarginPosition':
+        """May raise:
+            - DeserializationError
+            - UnknownAsset
+        """
+        if entry[2] == 0:
+            open_time = None
+        else:
+            open_time = deserialize_timestamp(entry[2])
+        return MarginPosition(
+            location=Location.deserialize_from_db(entry[1]),
+            open_time=open_time,
+            close_time=deserialize_timestamp(entry[3]),
+            profit_loss=deserialize_asset_amount(entry[4]),
+            pl_currency=Asset(entry[5]),
+            fee=deserialize_fee(entry[6]),
+            fee_currency=Asset(entry[7]),
+            link=entry[8],
+            notes=entry[9],
+        )
 
 
 class Loan(NamedTuple):

--- a/rotkehlchen/tests/utils/database.py
+++ b/rotkehlchen/tests/utils/database.py
@@ -106,3 +106,11 @@ def mock_dbhandler_add_globaldb_assetids() -> _patch:
         'rotkehlchen.db.dbhandler.DBHandler.add_globaldb_assetids',
         lambda x: None,
     )
+
+
+def mock_dbhandler_ensura_data_integrity() -> _patch:
+    """Just make sure ensure_data_integrity oes nothing for older DB tests"""
+    return patch(
+        'rotkehlchen.db.dbhandler.DBHandler.ensure_data_integrity',
+        lambda x: None,
+    )


### PR DESCRIPTION
Fixes the bug described in #3010 by introducing a new check at DB initialization. In my DB this check takes ~1 second.

Does not refactor the way the ids work as described in the 2nd bullet point of #3010. This can either be skipped or done a lot later (perhaps another issue?). Since I can't think of a nice (and easy) way at the moment.