### PR TITLE
jsonloads_dict and list no longer raise an AssertionError

### DIFF
--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 import json
 import time
+from json.decoder import JSONDecodeError
 from unittest.mock import patch
 
 import pytest
@@ -20,6 +21,7 @@ from rotkehlchen.utils.misc import (
     timestamp_to_date,
 )
 from rotkehlchen.utils.mixins.cacheable import CacheableMixIn, cache_response_timewise
+from rotkehlchen.utils.serialization import jsonloads_dict, jsonloads_list
 from rotkehlchen.utils.version_check import check_if_version_up_to_date
 
 
@@ -336,3 +338,19 @@ def test_generate_address_via_create2(
 def test_timestamp_to_date():
     date = timestamp_to_date(1611395717, formatstr='%d/%m/%Y %H:%M:%S %Z')
     assert not date.endswith(' '), 'Make sure %Z empty string is removed'
+
+
+def test_jsonloads_dict():
+    result = jsonloads_dict('{"foo": 1, "boo": "value"}')
+    assert result == {'foo': 1, 'boo': 'value'}
+    with pytest.raises(JSONDecodeError) as e:
+        jsonloads_dict('["foo", "boo", 3]')
+    assert 'Returned json is not a dict' in str(e.value)
+
+
+def test_jsonloads_list():
+    result = jsonloads_list('["foo", "boo", 3]')
+    assert result == ["foo", "boo", 3]
+    with pytest.raises(JSONDecodeError) as e:
+        jsonloads_list('{"foo": 1, "boo": "value"}')
+    assert 'Returned json is not a list' in str(e.value)

--- a/rotkehlchen/utils/serialization.py
+++ b/rotkehlchen/utils/serialization.py
@@ -1,4 +1,5 @@
 import json
+from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Union
 
 from rotkehlchen.assets.asset import Asset
@@ -35,14 +36,18 @@ class RKLEncoder(json.JSONEncoder):
 
 
 def jsonloads_dict(data: str) -> Dict[str, Any]:
+    """Just like jsonloads but forces the result to be a Dict"""
     value = json.loads(data)
-    assert isinstance(value, dict)
+    if not isinstance(value, dict):
+        raise JSONDecodeError(msg='Returned json is not a dict', doc='{}', pos=0)
     return value
 
 
 def jsonloads_list(data: str) -> List:
+    """Just like jsonloads but forces the result to be a List"""
     value = json.loads(data)
-    assert isinstance(value, list)
+    if not isinstance(value, list):
+        raise JSONDecodeError(msg='Returned json is not a list', doc='{}', pos=0)
     return value
 
 


### PR DESCRIPTION
Instead they enforce either a dict or a list by raising a
JSONDecodeError if the result is not of the expected type.

AssertionErrors should never be raised for unexpected input from the
outside (as is with jsonloads_dict and list)