### PR TITLE
Allows initialization of a token from all fields

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -31,7 +31,7 @@ from web3.exceptions import BadFunctionCallOutput
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import ActionType, Balance, BalanceType
 from rotkehlchen.api.v1.encoding import TradeSchema
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.typing import AssetType
 from rotkehlchen.balances.manual import (
@@ -45,7 +45,6 @@ from rotkehlchen.chain.bitcoin.xpub import XpubManager
 from rotkehlchen.chain.ethereum.airdrops import check_airdrops
 from rotkehlchen.chain.ethereum.trades import AMMTrade, AMMTradeLocations
 from rotkehlchen.chain.ethereum.transactions import FREE_ETH_TX_LIMIT
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
@@ -1410,8 +1409,8 @@ class RestAPI():
         )
 
     @require_loggedin_user()
-    def add_custom_ethereum_token(self, token: CustomEthereumToken) -> Response:
-        identifier = ethaddress_to_identifier(token.address)
+    def add_custom_ethereum_token(self, token: EthereumToken) -> Response:
+        identifier = ethaddress_to_identifier(token.ethereum_address)
         try:
             GlobalDBHandler().add_asset(
                 asset_id=identifier,
@@ -1431,7 +1430,7 @@ class RestAPI():
         )
 
     @staticmethod
-    def edit_custom_ethereum_token(token: CustomEthereumToken) -> Response:
+    def edit_custom_ethereum_token(token: EthereumToken) -> Response:
         try:
             identifier = GlobalDBHandler().edit_ethereum_token(token)
         except InputError as e:

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1396,7 +1396,7 @@ class RestAPI():
                 result = wrap_in_fail_result(f'Custom token with address {address} not found')
                 status_code = HTTPStatus.NOT_FOUND
             else:
-                result = _wrap_in_ok_result(token.serialize())
+                result = _wrap_in_ok_result(token.serialize_all_info())
                 status_code = HTTPStatus.OK
 
             return api_response(result, status_code)
@@ -1404,7 +1404,7 @@ class RestAPI():
         # else return all custom tokens
         tokens = GlobalDBHandler().get_ethereum_tokens()
         return api_response(
-            _wrap_in_ok_result([x.serialize() for x in tokens]),
+            _wrap_in_ok_result([x.serialize_all_info() for x in tokens]),
             status_code=HTTPStatus.OK,
             log_result=False,
         )

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -12,7 +12,7 @@ from werkzeug.datastructures import FileStorage
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType
 from rotkehlchen.accounting.structures import ActionType
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import Asset, EthereumToken, UnderlyingToken
 from rotkehlchen.assets.typing import AssetType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.bitcoin.hdkey import HDKey, XpubType
@@ -22,7 +22,6 @@ from rotkehlchen.chain.bitcoin.utils import (
     scriptpubkey_to_btc_address,
 )
 from rotkehlchen.chain.ethereum.manager import EthereumManager
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken, UnderlyingToken
 from rotkehlchen.chain.substrate.typing import KusamaAddress, SubstratePublicKey
 from rotkehlchen.chain.substrate.utils import (
     get_kusama_address_from_public_key,
@@ -1625,7 +1624,7 @@ class EthereumTokenSchema(Schema):
             self,
             data: Dict[str, Any],
             **_kwargs: Any,
-    ) -> CustomEthereumToken:
+    ) -> EthereumToken:
         given_underlying_tokens = data.pop('underlying_tokens', None)
         underlying_tokens = None
         if given_underlying_tokens is not None:
@@ -1635,8 +1634,7 @@ class EthereumTokenSchema(Schema):
                     address=entry['address'],
                     weight=entry['weight'],
                 ))
-        # TODO: How to give identifier here?
-        return CustomEthereumToken(**data, underlying_tokens=underlying_tokens)
+        return EthereumToken.initialize(**data, underlying_tokens=underlying_tokens)
 
 
 class ModifyEthereumTokenSchema(Schema):

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -86,7 +86,7 @@ from rotkehlchen.api.v1.encoding import (
     XpubPatchSchema,
 )
 from rotkehlchen.api.v1.parser import resource_parser
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.typing import AssetType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.bitcoin.xpub import XpubData
@@ -114,7 +114,6 @@ from rotkehlchen.typing import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.bitcoin.hdkey import HDKey
-    from rotkehlchen.chain.ethereum.typing import CustomEthereumToken
     from rotkehlchen.exchanges.kraken import KrakenAccountType
 
 
@@ -435,11 +434,11 @@ class EthereumAssetsResource(BaseResource):
         return self.rest_api.get_custom_ethereum_tokens(address=address)
 
     @use_kwargs(edit_schema, location='json')
-    def put(self, token: 'CustomEthereumToken') -> Response:
+    def put(self, token: EthereumToken) -> Response:
         return self.rest_api.add_custom_ethereum_token(token=token)
 
     @use_kwargs(edit_schema, location='json')
-    def patch(self, token: 'CustomEthereumToken') -> Response:
+    def patch(self, token: EthereumToken) -> Response:
         return self.rest_api.edit_custom_ethereum_token(token=token)
 
     @use_kwargs(delete_schema, location='json')

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -1,19 +1,40 @@
 from dataclasses import InitVar, dataclass, field
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type, TypeVar
 
 from rotkehlchen.constants.resolver import (
     ETHEREUM_DIRECTIVE,
     ETHEREUM_DIRECTIVE_LENGTH,
+    ethaddress_to_identifier,
     strethaddress_to_identifier,
 )
 from rotkehlchen.errors import DeserializationError, UnsupportedAsset
+from rotkehlchen.fval import FVal
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 
 from .typing import AssetType
 
-if TYPE_CHECKING:
-    from rotkehlchen.chain.ethereum.typing import CustomEthereumTokenWithIdentifier
+UnderlyingTokenDBTuple = Tuple[str, str]
+
+
+class UnderlyingToken(NamedTuple):
+    """Represents an underlying token of a token
+
+    Is used for pool tokens, tokensets etc.
+    """
+    address: ChecksumEthAddress
+    weight: FVal  # Floating percentage from 0 to 1
+
+    def serialize(self) -> Dict[str, Any]:
+        return {'address': self.address, 'weight': str(self.weight * 100)}
+
+    @classmethod
+    def deserialize_from_db(cls, entry: UnderlyingTokenDBTuple) -> 'UnderlyingToken':
+        return UnderlyingToken(
+            address=entry[0],  # type: ignore
+            weight=FVal(entry[1]),
+        )
+
 
 WORLD_TO_BITTREX = {
     # In Rotkehlchen Bitswift is BITS-2 but in Bittrex it's BITS
@@ -330,6 +351,7 @@ WORLD_TO_COINBASE_PRO = {
 class Asset():
     identifier: str
     form_with_incomplete_data: InitVar[bool] = field(default=False)
+    direct_field_initialization: InitVar[bool] = field(default=False)
     name: str = field(init=False)
     symbol: str = field(init=False)
     asset_type: AssetType = field(init=False)
@@ -340,7 +362,11 @@ class Asset():
     cryptocompare: Optional[str] = field(init=False)
     coingecko: Optional[str] = field(init=False)
 
-    def __post_init__(self, form_with_incomplete_data: bool = False) -> None:
+    def __post_init__(
+            self,
+            form_with_incomplete_data: bool = False,
+            direct_field_initialization: bool = False,
+    ) -> None:
         """
         Asset post initialization
 
@@ -361,6 +387,9 @@ class Asset():
             raise DeserializationError(
                 'Tried to initialize an asset out of a non-string identifier',
             )
+
+        if direct_field_initialization:
+            return
 
         # TODO: figure out a way to move this out. Moved in here due to cyclic imports
         from rotkehlchen.assets.resolver import AssetResolver  # isort:skip  # noqa: E501  # pylint: disable=import-outside-toplevel
@@ -464,18 +493,45 @@ class Asset():
         raise ValueError(f'Invalid comparison of asset with {type(other)}')
 
 
+EthereumTokenDBTuple = Tuple[
+    str,                  # identifier
+    str,                  # address
+    Optional[int],        # decimals
+    Optional[str],        # name
+    Optional[str],        # symbol
+    Optional[int],        # started
+    Optional[str],        # swapped_for
+    Optional[str],        # coingecko
+    Optional[str],        # cryptocompare
+    Optional[str],        # protocol
+]
+
+
+# Create a generic variable that can be 'HasEthereumToken', or any subclass.
+Y = TypeVar('Y', bound='HasEthereumToken')
+
+
 @dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=True)
 class HasEthereumToken(Asset):
     """ Marker to denote assets having an Ethereum token address """
     ethereum_address: ChecksumEthAddress = field(init=False)
     decimals: int = field(init=False)
     protocol: str = field(init=False)
+    underlying_tokens: List[UnderlyingToken] = field(init=False)
 
-    def __post_init__(self, form_with_incomplete_data: bool = False) -> None:
+    def __post_init__(
+            self,
+            form_with_incomplete_data: bool = False,
+            direct_field_initialization: bool = False,
+    ) -> None:
+        if direct_field_initialization:
+            return
+
         object.__setattr__(self, 'identifier', ETHEREUM_DIRECTIVE + self.identifier)
         super().__post_init__(form_with_incomplete_data)
         # TODO: figure out a way to move this out. Moved in here due to cyclic imports
         from rotkehlchen.assets.resolver import AssetResolver  # isort:skip  # noqa: E501  # pylint: disable=import-outside-toplevel
+        from rotkehlchen.globaldb import GlobalDBHandler  # isort:skip  # noqa: E501  # pylint: disable=import-outside-toplevel
 
         data = AssetResolver().get_asset_data(self.identifier)  # pylint: disable=no-member
 
@@ -487,6 +543,64 @@ class HasEthereumToken(Asset):
         object.__setattr__(self, 'ethereum_address', data.ethereum_address)
         object.__setattr__(self, 'decimals', data.decimals)
         object.__setattr__(self, 'protocol', data.protocol)
+
+        underlying_tokens = GlobalDBHandler().fetch_underlying_tokens(data.ethereum_address)
+        object.__setattr__(self, 'underlying_tokens', underlying_tokens)
+
+    @classmethod
+    def initialize(
+            cls: Type[Y],
+            address: ChecksumEthAddress,
+            decimals: Optional[int] = None,
+            name: Optional[str] = None,
+            symbol: Optional[str] = None,
+            started: Optional[Timestamp] = None,
+            swapped_for: Optional[Asset] = None,
+            coingecko: Optional[str] = None,
+            cryptocompare: Optional[str] = None,
+            protocol: Optional[str] = None,
+            underlying_tokens: Optional[List[UnderlyingToken]] = None,
+    ) -> Y:
+        """Initialize a token from fields"""
+        token = cls('whatever', direct_field_initialization=True)
+        object.__setattr__(token, 'identifier', ethaddress_to_identifier(address))
+        object.__setattr__(token, 'name', name)
+        object.__setattr__(token, 'symbol', symbol)
+        object.__setattr__(token, 'asset_type', AssetType.ETHEREUM_TOKEN)
+        object.__setattr__(token, 'started', started)
+        object.__setattr__(token, 'forked', None)
+        object.__setattr__(token, 'swapped_for', swapped_for)
+        object.__setattr__(token, 'cryptocompare', cryptocompare)
+        object.__setattr__(token, 'coingecko', coingecko)
+        object.__setattr__(token, 'ethereum_address', address)
+        object.__setattr__(token, 'decimals', decimals)
+        object.__setattr__(token, 'protocol', protocol)
+        object.__setattr__(token, 'underlying_tokens', underlying_tokens)
+        return token
+
+    @classmethod
+    def deserialize_from_db(
+            cls: Type[Y],
+            entry: EthereumTokenDBTuple,
+            underlying_tokens: Optional[List[UnderlyingToken]] = None,
+    ) -> Y:
+        """May raise UnknownAsset if the swapped for asset can't be recognized
+
+        That error would be bad because it would mean somehow an unknown id made it into the DB
+        """
+        swapped_for = Asset(entry[6]) if entry[6] is not None else None
+        return cls.initialize(
+            address=entry[1],  # type: ignore
+            decimals=entry[2],
+            name=entry[3],
+            symbol=entry[4],
+            started=Timestamp(entry[5]),  # type: ignore
+            swapped_for=swapped_for,
+            coingecko=entry[7],
+            cryptocompare=entry[8],
+            protocol=entry[9],
+            underlying_tokens=underlying_tokens,
+        )
 
 
 # Create a generic variable that can be 'EthereumToken', or any subclass.
@@ -514,24 +628,3 @@ class EthereumToken(HasEthereumToken):
             return cls(identifier[ETHEREUM_DIRECTIVE_LENGTH:])
         except DeserializationError:
             return None
-
-    def to_custom_ethereum_token(self) -> 'CustomEthereumTokenWithIdentifier':
-        """TODO:This is just to satisfy its use in one place
-
-        Eventually these two data structures should be consolidated."""
-        # TODO: figure out a way to move this out. Moved in here due to cyclic imports
-        from rotkehlchen.chain.ethereum.typing import CustomEthereumTokenWithIdentifier  # isort:skip  # noqa: E501  # pylint: disable=import-outside-toplevel
-        swapped_for_asset = None if self.swapped_for is None else Asset(self.swapped_for)
-        return CustomEthereumTokenWithIdentifier(
-            identifier=self.identifier,
-            address=self.ethereum_address,
-            decimals=self.decimals,
-            name=self.name,
-            symbol=self.symbol,
-            started=self.started,
-            swapped_for=swapped_for_asset,
-            coingecko=self.coingecko,
-            cryptocompare=self.cryptocompare,
-            protocol=None,
-            underlying_tokens=None,
-        )

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -547,6 +547,22 @@ class HasEthereumToken(Asset):
         underlying_tokens = GlobalDBHandler().fetch_underlying_tokens(data.ethereum_address)
         object.__setattr__(self, 'underlying_tokens', underlying_tokens)
 
+    def serialize_all_info(self) -> Dict[str, Any]:
+        underlying_tokens = [x.serialize() for x in self.underlying_tokens] if self.underlying_tokens is not None else None  # noqa: E501
+        return {
+            'identifier': self.identifier,
+            'address': self.ethereum_address,
+            'decimals': self.decimals,
+            'name': self.name,
+            'symbol': self.symbol,
+            'started': self.started,
+            'swapped_for': self.swapped_for.identifier if self.swapped_for else None,
+            'coingecko': self.coingecko,
+            'cryptocompare': self.cryptocompare,
+            'protocol': self.protocol,
+            'underlying_tokens': underlying_tokens,
+        }
+
     @classmethod
     def initialize(
             cls: Type[Y],

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -5,10 +5,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.chain.ethereum.manager import EthereumManager, NodeName
-from rotkehlchen.chain.ethereum.typing import (
-    CustomEthereumTokenWithIdentifier,
-    string_to_ethereum_address,
-)
+from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.constants.ethereum import ETH_SCAN
 from rotkehlchen.constants.misc import ZERO
@@ -70,8 +67,8 @@ class EthTokens():
             self,
             address: ChecksumEthAddress,
             token_usd_price: Dict[EthereumToken, Price],
-            etherscan_chunks: List[List[CustomEthereumTokenWithIdentifier]],
-            other_chunks: List[List[CustomEthereumTokenWithIdentifier]],
+            etherscan_chunks: List[List[EthereumToken]],
+            other_chunks: List[List[EthereumToken]],
     ) -> Dict[EthereumToken, FVal]:
         balances: Dict[EthereumToken, FVal] = defaultdict(FVal)
         if self.ethereum.connected_to_any_web3():
@@ -156,7 +153,7 @@ class EthTokens():
                 balances = defaultdict(FVal)
                 self._get_tokens_balance_and_price(
                     address=address,
-                    tokens=[x.to_custom_ethereum_token() for x in saved_list],
+                    tokens=saved_list,
                     balances=balances,
                     token_usd_price=token_usd_price,
                     call_order=None,  # use defaults
@@ -169,7 +166,7 @@ class EthTokens():
     def _get_tokens_balance_and_price(
             self,
             address: ChecksumEthAddress,
-            tokens: List[CustomEthereumTokenWithIdentifier],
+            tokens: List[EthereumToken],
             balances: Dict[EthereumToken, FVal],
             token_usd_price: Dict[EthereumToken, Price],
             call_order: Optional[Sequence[NodeName]],
@@ -199,7 +196,7 @@ class EthTokens():
 
     def _get_multitoken_multiaccount_balance(
             self,
-            tokens: List[CustomEthereumTokenWithIdentifier],
+            tokens: List[EthereumToken],
             accounts: List[ChecksumEthAddress],
     ) -> Dict[str, Dict[ChecksumEthAddress, FVal]]:
         """Queries a list of accounts for balances of multiple tokens
@@ -222,7 +219,7 @@ class EthTokens():
         result = ETH_SCAN.call(
             ethereum=self.ethereum,
             method_name='tokensBalances',
-            arguments=[accounts, [x.address for x in tokens]],
+            arguments=[accounts, [x.ethereum_address for x in tokens]],
         )
         for acc_idx, account in enumerate(accounts):
             for tk_idx, token in enumerate(tokens):
@@ -235,7 +232,7 @@ class EthTokens():
 
     def _get_multitoken_account_balance(
             self,
-            tokens: List[CustomEthereumTokenWithIdentifier],
+            tokens: List[EthereumToken],
             account: ChecksumEthAddress,
             call_order: Optional[Sequence[NodeName]],
     ) -> Dict[str, FVal]:
@@ -259,7 +256,7 @@ class EthTokens():
         result = ETH_SCAN.call(
             ethereum=self.ethereum,
             method_name='tokensBalance',
-            arguments=[account, [x.address for x in tokens]],
+            arguments=[account, [x.ethereum_address for x in tokens]],
             call_order=call_order,
         )
         for tk_idx, token in enumerate(tokens):
@@ -267,7 +264,7 @@ class EthTokens():
             if token_amount != 0:
                 normalized_amount = token_normalized_value(token_amount, token)
                 log.debug(
-                    f'Found {token.symbol}({token.address}) token balance for '
+                    f'Found {token.symbol}({token.ethereum_address}) token balance for '
                     f'{account} and amount {normalized_amount}',
                 )
                 balances[token.identifier] = normalized_amount

--- a/rotkehlchen/chain/ethereum/typing.py
+++ b/rotkehlchen/chain/ethereum/typing.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from eth_typing import HexAddress, HexStr
 
 from rotkehlchen.accounting.structures import Balance
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
@@ -338,42 +338,7 @@ class Eth2Deposit(NamedTuple):
         )
 
 
-UnderlyingTokenDBTuple = Tuple[str, str]
-
-
-class UnderlyingToken(NamedTuple):
-    """Represents an underlying token of a token
-
-    Is used for pool tokens, tokensets etc.
-    """
-    address: ChecksumEthAddress
-    weight: FVal  # Floating percentage from 0 to 1
-
-    def serialize(self) -> Dict[str, Any]:
-        return {'address': self.address, 'weight': str(self.weight * 100)}
-
-    @classmethod
-    def deserialize_from_db(cls, entry: UnderlyingTokenDBTuple) -> 'UnderlyingToken':
-        return UnderlyingToken(
-            address=string_to_ethereum_address(entry[0]),
-            weight=FVal(entry[1]),
-        )
-
-
 CustomEthereumTokenDBTuple = Tuple[
-    str,                  # address
-    Optional[int],        # decimals
-    Optional[str],        # name
-    Optional[str],        # symbol
-    Optional[int],        # started
-    Optional[str],        # swapped_for
-    Optional[str],        # coingecko
-    Optional[str],        # cryptocompare
-    Optional[str],        # protocol
-]
-
-CustomEthereumTokenWithIdentifierDBTuple = Tuple[
-    str,                  # identifier
     str,                  # address
     Optional[int],        # decimals
     Optional[str],        # name
@@ -419,69 +384,3 @@ class CustomEthereumToken:
             result['underlying_tokens'] = [x.serialize() for x in self.underlying_tokens]
 
         return result
-
-
-# Not using inheritance here due to problems with:
-# Having to make identifier optional and some mypy warnings for incompatible overrides
-# https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
-class CustomEthereumTokenWithIdentifier():
-
-    identifier: str
-    address: ChecksumEthAddress
-    decimals: Optional[int] = None
-    name: Optional[str] = None
-    symbol: Optional[str] = None
-    started: Optional[Timestamp] = None
-    swapped_for: Optional[Asset] = None
-    coingecko: Optional[str] = None
-    cryptocompare: Optional[str] = None
-    protocol: Optional[str] = None
-    underlying_tokens: Optional[List[UnderlyingToken]] = None
-
-    def missing_basic_data(self) -> bool:
-        return self.name is None or self.symbol is None or self.decimals is None
-
-    def serialize(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
-            'identifier': self.identifier,
-            'address': self.address,
-            'decimals': self.decimals,
-            'name': self.name,
-            'symbol': self.symbol,
-            'started': self.started,
-            'swapped_for': self.swapped_for.identifier if self.swapped_for else None,
-            'coingecko': self.coingecko,
-            'cryptocompare': self.cryptocompare,
-            'protocol': self.protocol,
-            'underlying_tokens': None,
-        }
-        if self.underlying_tokens:
-            result['underlying_tokens'] = [x.serialize() for x in self.underlying_tokens]
-
-        return result
-
-    @classmethod
-    def deserialize_from_db(
-            cls,
-            entry: CustomEthereumTokenWithIdentifierDBTuple,
-            underlying_tokens: Optional[List[UnderlyingToken]] = None,
-    ) -> 'CustomEthereumTokenWithIdentifier':
-        """May raise UnknownAsset if the swapped for asset can't be recognized
-
-        That error would be bad because it would mean somehow an unknown id made it into the DB
-        """
-        swapped_for = Asset(entry[6]) if entry[6] is not None else None
-        return CustomEthereumTokenWithIdentifier(
-            identifier=entry[0],
-            address=string_to_ethereum_address(entry[1]),
-            decimals=entry[2],
-            name=entry[3],
-            symbol=entry[4],
-            started=Timestamp(entry[5]),  # type: ignore
-            swapped_for=swapped_for,
-            coingecko=entry[7],
-            cryptocompare=entry[8],
-            protocol=entry[9],
-            underlying_tokens=underlying_tokens,
-        )

--- a/rotkehlchen/chain/ethereum/typing.py
+++ b/rotkehlchen/chain/ethereum/typing.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from eth_typing import HexAddress, HexStr
 
 from rotkehlchen.accounting.structures import Balance
-from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
@@ -336,51 +334,3 @@ class Eth2Deposit(NamedTuple):
             str(self.value.usd_value),
             self.deposit_index,
         )
-
-
-CustomEthereumTokenDBTuple = Tuple[
-    str,                  # address
-    Optional[int],        # decimals
-    Optional[str],        # name
-    Optional[str],        # symbol
-    Optional[int],        # started
-    Optional[str],        # swapped_for
-    Optional[str],        # coingecko
-    Optional[str],        # cryptocompare
-    Optional[str],        # protocol
-]
-
-
-@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
-class CustomEthereumToken:
-    address: ChecksumEthAddress
-    decimals: Optional[int] = None
-    name: Optional[str] = None
-    symbol: Optional[str] = None
-    started: Optional[Timestamp] = None
-    swapped_for: Optional[Asset] = None
-    coingecko: Optional[str] = None
-    cryptocompare: Optional[str] = None
-    protocol: Optional[str] = None
-    underlying_tokens: Optional[List[UnderlyingToken]] = None
-
-    def missing_basic_data(self) -> bool:
-        return self.name is None or self.symbol is None or self.decimals is None
-
-    def serialize(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
-            'address': self.address,
-            'decimals': self.decimals,
-            'name': self.name,
-            'symbol': self.symbol,
-            'started': self.started,
-            'swapped_for': self.swapped_for.identifier if self.swapped_for else None,
-            'coingecko': self.coingecko,
-            'cryptocompare': self.cryptocompare,
-            'protocol': self.protocol,
-            'underlying_tokens': None,
-        }
-        if self.underlying_tokens:
-            result['underlying_tokens'] = [x.serialize() for x in self.underlying_tokens]
-
-        return result

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 from eth_utils import to_bytes, to_checksum_address
 from web3 import Web3
@@ -16,7 +16,6 @@ from rotkehlchen.utils.misc import hexstring_to_bytes
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager, NodeName
-    from rotkehlchen.chain.ethereum.typing import CustomEthereumTokenWithIdentifier
 
 ABI_CODEC = Web3().codec
 # TODO: remove this once web3.py updates ENS library for supporting multichain
@@ -53,10 +52,9 @@ def token_normalized_value_decimals(token_amount: int, token_decimals: int) -> F
 
 def token_normalized_value(
         token_amount: int,
-        token: Union[EthereumToken, 'CustomEthereumTokenWithIdentifier'],
+        token: EthereumToken,
 ) -> FVal:
-    # Here CustomEthereumToken should have decimals due to the basic info check
-    return token_normalized_value_decimals(token_amount, token.decimals)  # type: ignore
+    return token_normalized_value_decimals(token_amount, token.decimals)
 
 
 def asset_normalized_value(amount: int, asset: Asset) -> FVal:

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast,
 
 from typing_extensions import Literal
 
+from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.assets.typing import AssetData, AssetType
 from rotkehlchen.chain.ethereum.typing import (
     CustomEthereumToken,
-    CustomEthereumTokenWithIdentifier,
     UnderlyingToken,
     string_to_ethereum_address,
 )
@@ -382,7 +382,7 @@ class GlobalDBHandler():
         )
 
     @staticmethod
-    def _fetch_underlying_tokens(
+    def fetch_underlying_tokens(
             address: ChecksumEthAddress,
     ) -> Optional[List[UnderlyingToken]]:
         """Fetch underlying tokens for a token address if they exist"""
@@ -484,7 +484,7 @@ class GlobalDBHandler():
         return [x[0] for x in result]
 
     @staticmethod
-    def get_ethereum_token(address: ChecksumEthAddress) -> Optional[CustomEthereumTokenWithIdentifier]:  # noqa: E501
+    def get_ethereum_token(address: ChecksumEthAddress) -> Optional[EthereumToken]:  # noqa: E501
         """Gets all details for an ethereum token by its address
 
         If no token for the given address can be found None is returned.
@@ -502,22 +502,22 @@ class GlobalDBHandler():
             return None
 
         token_data = results[0]
-        underlying_tokens = GlobalDBHandler()._fetch_underlying_tokens(address)
+        underlying_tokens = GlobalDBHandler().fetch_underlying_tokens(address)
 
         try:
-            return CustomEthereumTokenWithIdentifier.deserialize_from_db(
+            return EthereumToken.deserialize_from_db(
                 entry=token_data,
                 underlying_tokens=underlying_tokens,
             )
         except UnknownAsset as e:
             log.error(
                 f'Found unknown swapped_for asset {str(e)} in '
-                f'the DB when deserializing a CustomEthereumToken',
+                f'the DB when deserializing an EthereumToken',
             )
             return None
 
     @staticmethod
-    def get_ethereum_tokens(exceptions: Optional[List[ChecksumEthAddress]] = None) -> List[CustomEthereumTokenWithIdentifier]:  # noqa: E501
+    def get_ethereum_tokens(exceptions: Optional[List[ChecksumEthAddress]] = None) -> List[EthereumToken]:  # noqa: E501
         """Gets all ethereum tokens from the DB
 
         Can also accept a list of addresses to ignore
@@ -539,14 +539,14 @@ class GlobalDBHandler():
         query = cursor.execute(querystr, bindings)
         tokens = []
         for entry in query:
-            underlying_tokens = GlobalDBHandler()._fetch_underlying_tokens(entry[1])
+            underlying_tokens = GlobalDBHandler().fetch_underlying_tokens(entry[1])
             try:
-                token = CustomEthereumTokenWithIdentifier.deserialize_from_db(entry, underlying_tokens)  # noqa: E501
+                token = EthereumToken.deserialize_from_db(entry, underlying_tokens)  # noqa: E501
                 tokens.append(token)
             except UnknownAsset as e:
                 log.error(
                     f'Found unknown swapped_for asset {str(e)} in '
-                    f'the DB when deserializing a CustomEthereumTokenWithIdentifier',
+                    f'the DB when deserializing an EthereumToken',
                 )
 
         return tokens

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -7,13 +7,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast,
 
 from typing_extensions import Literal
 
-from rotkehlchen.assets.asset import EthereumToken
+from rotkehlchen.assets.asset import EthereumToken, UnderlyingToken
 from rotkehlchen.assets.typing import AssetData, AssetType
-from rotkehlchen.chain.ethereum.typing import (
-    CustomEthereumToken,
-    UnderlyingToken,
-    string_to_ethereum_address,
-)
+from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import DeserializationError, InputError, UnknownAsset
 from rotkehlchen.globaldb.upgrades.v1_v2 import upgrade_ethereum_asset_ids
@@ -158,7 +154,7 @@ class GlobalDBHandler():
     def add_asset(
             asset_id: str,
             asset_type: AssetType,
-            data: Union[CustomEthereumToken, Dict[str, Any]],
+            data: Union[EthereumToken, Dict[str, Any]],
     ) -> None:
         """
         Add an asset in the DB. Either an ethereum token or a custom asset.
@@ -171,9 +167,9 @@ class GlobalDBHandler():
 
         details_id: Union[str, ChecksumEthAddress]
         if asset_type == AssetType.ETHEREUM_TOKEN:
-            token = cast(CustomEthereumToken, data)
+            token = cast(EthereumToken, data)
             GlobalDBHandler().add_ethereum_token_data(token)
-            details_id = token.address
+            details_id = token.ethereum_address
             name = token.name
             symbol = token.symbol
             started = token.started
@@ -411,7 +407,7 @@ class GlobalDBHandler():
         cursor = GlobalDBHandler()._conn.cursor()
         for underlying_token in underlying_tokens:
             # make sure underlying token address is tracked if not already there
-            asset_id = GlobalDBHandler.get_ethereum_token_identifier(underlying_token.address)
+            asset_id = GlobalDBHandler.get_ethereum_token_identifier(underlying_token.address)  # noqa: E501
             if asset_id is None:
                 try:  # underlying token does not exist. Track it
                     cursor.execute(
@@ -436,7 +432,11 @@ class GlobalDBHandler():
                 cursor.execute(
                     'INSERT INTO underlying_tokens_list(address, weight, parent_token_entry) '
                     'VALUES(?, ?, ?)',
-                    (underlying_token.address, str(underlying_token.weight), parent_token_address),
+                    (
+                        underlying_token.address,
+                        str(underlying_token.weight),
+                        parent_token_address,
+                    ),
                 )
             except sqlite3.IntegrityError as e:
                 connection.rollback()
@@ -552,7 +552,7 @@ class GlobalDBHandler():
         return tokens
 
     @staticmethod
-    def add_ethereum_token_data(entry: CustomEthereumToken) -> None:
+    def add_ethereum_token_data(entry: EthereumToken) -> None:
         """Adds ethereum token specific information into the global DB
 
         May raise InputError if the token already exists
@@ -564,30 +564,30 @@ class GlobalDBHandler():
                 'INSERT INTO '
                 'ethereum_tokens(address, decimals, protocol) '
                 'VALUES(?, ?, ?)',
-                (entry.address, entry.decimals, entry.protocol),
+                (entry.ethereum_address, entry.decimals, entry.protocol),
             )
         except sqlite3.IntegrityError as e:
             exception_msg = str(e)
             if 'FOREIGN KEY' in exception_msg:
                 # should not really happen since API should check for this
                 msg = (
-                    f'Ethereum token with address {entry.address} can not be put '
+                    f'Ethereum token with address {entry.ethereum_address} can not be put '
                     f'in the DB due to swapped for entry not existing'
                 )
             else:
-                msg = f'Ethereum token with address {entry.address} already exists in the DB'
+                msg = f'Ethereum token with address {entry.ethereum_address} already exists in the DB'  # noqa: E501
             raise InputError(msg) from e
 
         if entry.underlying_tokens is not None:
             GlobalDBHandler()._add_underlying_tokens(
                 connection=connection,
-                parent_token_address=entry.address,
+                parent_token_address=entry.ethereum_address,
                 underlying_tokens=entry.underlying_tokens,
             )
 
     @staticmethod
     def edit_ethereum_token(
-            entry: CustomEthereumToken,
+            entry: EthereumToken,
     ) -> str:
         """Edits an ethereum token entry in the DB
 
@@ -608,41 +608,41 @@ class GlobalDBHandler():
                     entry.swapped_for.identifier if entry.swapped_for else None,
                     entry.coingecko,
                     entry.cryptocompare,
-                    ethaddress_to_identifier(entry.address),
+                    ethaddress_to_identifier(entry.ethereum_address),
                 ),
             )
             cursor.execute(
                 'UPDATE ethereum_tokens SET decimals=?, protocol=? WHERE address = ?',
-                (entry.decimals, entry.protocol, entry.address),
+                (entry.decimals, entry.protocol, entry.ethereum_address),
             )
         except sqlite3.IntegrityError as e:
             raise InputError(
-                f'Failed to update DB entry for ethereum token with address {entry.address} '
+                f'Failed to update DB entry for ethereum token with address {entry.ethereum_address} '  # noqa: E501
                 f'due to a constraint being hit. Make sure the new values are valid ',
             ) from e
 
         if cursor.rowcount != 1:
             raise InputError(
-                f'Tried to edit non existing ethereum token with address {entry.address}',
+                f'Tried to edit non existing ethereum token with address {entry.ethereum_address}',
             )
 
         # Since this is editing, make sure no underlying tokens exist
         cursor.execute(
             'DELETE from underlying_tokens_list WHERE parent_token_entry=?',
-            (entry.address,),
+            (entry.ethereum_address,),
         )
         if entry.underlying_tokens is not None:  # and now add any if needed
             GlobalDBHandler()._add_underlying_tokens(
                 connection=connection,
-                parent_token_address=entry.address,
+                parent_token_address=entry.ethereum_address,
                 underlying_tokens=entry.underlying_tokens,
             )
 
-        rotki_id = GlobalDBHandler().get_ethereum_token_identifier(entry.address)
+        rotki_id = GlobalDBHandler().get_ethereum_token_identifier(entry.ethereum_address)
         if rotki_id is None:
             connection.rollback()
             raise InputError(
-                f'Unexpected DB state. Ethereum token {entry.address} exists in the DB '
+                f'Unexpected DB state. Ethereum token {entry.ethereum_address} exists in the DB '
                 f'but its corresponding asset entry was not found.',
             )
 

--- a/rotkehlchen/tests/api/test_assets_updates.py
+++ b/rotkehlchen/tests/api/test_assets_updates.py
@@ -10,7 +10,6 @@ import requests
 
 from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.typing import AssetType
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
 from rotkehlchen.errors import UnknownAsset
 from rotkehlchen.globaldb.handler import GLOBAL_DB_VERSION
@@ -197,7 +196,7 @@ INSERT INTO ethereum_tokens(address, decimals, protocol) VALUES("0x1B175474E8909
     globaldb.add_asset(  # add a conflicting token
         asset_id='_ceth_0x1B175474E89094C44Da98b954EedeAC495271d0F',
         asset_type=AssetType.ETHEREUM_TOKEN,
-        data=CustomEthereumToken(
+        data=EthereumToken.initialize(
             address=ChecksumEthAddress('0x1B175474E89094C44Da98b954EedeAC495271d0F'),
             decimals=12,
             name='Conflicting token',

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -9,9 +9,8 @@ import pytest
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.accounting.structures import BalanceType
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.typing import AssetType
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.old_create import OLD_DB_SCRIPT_CREATE_TABLES
@@ -1791,7 +1790,7 @@ def test_upgrade_db_25_to_26(globaldb, user_data_dir, have_kraken, have_kraken_s
     globaldb.add_asset(
         asset_id='_ceth_0x48Fb253446873234F2fEBbF9BdeAA72d9d387f94',
         asset_type=AssetType.ETHEREUM_TOKEN,
-        data=CustomEthereumToken(
+        data=EthereumToken.initialize(
             address=ChecksumEthAddress('0x48Fb253446873234F2fEBbF9BdeAA72d9d387f94'),
             decimals=18,
             name='foo',

--- a/rotkehlchen/tests/fixtures/assets.py
+++ b/rotkehlchen/tests/fixtures/assets.py
@@ -72,7 +72,7 @@ def asset_resolver(
     # add any custom ethereum tokens given by the fixtures for a test
     if custom_ethereum_tokens is not None:
         for entry in custom_ethereum_tokens:
-            asset_id = ETHEREUM_DIRECTIVE + entry.address
+            asset_id = ETHEREUM_DIRECTIVE + entry.ethereum_address
             globaldb.add_asset(asset_id=asset_id, asset_type=AssetType.ETHEREUM_TOKEN, data=entry)
 
     return resolver

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -4,8 +4,8 @@ from typing import List, Optional
 
 import pytest
 
+from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.assets.resolver import AssetResolver
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb import GlobalDBHandler
@@ -15,7 +15,7 @@ from rotkehlchen.typing import Price, Timestamp
 
 
 @pytest.fixture(name='custom_ethereum_tokens')
-def fixture_custom_ethereum_tokens() -> Optional[List[CustomEthereumToken]]:
+def fixture_custom_ethereum_tokens() -> Optional[List[EthereumToken]]:
     return None
 
 

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -15,6 +15,7 @@ from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import InputError, UnknownAsset
 from rotkehlchen.externalapis.coingecko import DELISTED_ASSETS, Coingecko
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.typing import Timestamp
 from rotkehlchen.utils.hashing import file_md5
 
 
@@ -374,3 +375,15 @@ def test_get_ethereum_token():
         symbol='DOT',
         ethereum_address='0xA379B8204A49A72FF9703e18eE61402FAfCCdD60',
     ), 'symbol of normal chain (polkadot here) should result in unknown token'
+
+
+def test_intialize_token_from_fields():
+    token = EthereumToken.initialize(
+        address='0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        decimals=18,
+        name='Multi Collateral Dai',
+        symbol='DAI',
+        started=Timestamp(1573672677),
+        coingecko='dai',
+    )
+    assert token == A_DAI

--- a/rotkehlchen/tests/unit/test_globaldb.py
+++ b/rotkehlchen/tests/unit/test_globaldb.py
@@ -4,10 +4,10 @@ from shutil import copyfile
 
 import pytest
 
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.typing import AssetData, AssetType
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken, string_to_ethereum_address
+from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.constants.assets import A_BAT
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import InputError
@@ -22,8 +22,8 @@ from rotkehlchen.tests.utils.globaldb import INITIAL_TOKENS
 @pytest.mark.parametrize('custom_ethereum_tokens', [INITIAL_TOKENS])
 def test_get_ethereum_token_identifier(globaldb):
     assert globaldb.get_ethereum_token_identifier('0xnotexistingaddress') is None
-    token_0_id = globaldb.get_ethereum_token_identifier(INITIAL_TOKENS[0].address)
-    assert token_0_id == ethaddress_to_identifier(INITIAL_TOKENS[0].address)
+    token_0_id = globaldb.get_ethereum_token_identifier(INITIAL_TOKENS[0].ethereum_address)
+    assert token_0_id == ethaddress_to_identifier(INITIAL_TOKENS[0].ethereum_address)
 
 
 def test_open_new_globaldb_with_old_rotki(tmpdir_factory):
@@ -56,9 +56,9 @@ def test_add_edit_token_with_wrong_swapped_for(globaldb):
     """
     # To unit test it we need to even hack it a bit. Make a new token, add it in the DB
     # then delete it and then try to add a new one referencing the old one. Since we
-    # need to obtain a valid CustomEthereumToken object
+    # need to obtain a valid EthereumToken object
     address_to_delete = make_ethereum_address()
-    token_to_delete = CustomEthereumToken(
+    token_to_delete = EthereumToken.initialize(
         address=address_to_delete,
         decimals=18,
         name='willdell',
@@ -78,7 +78,7 @@ def test_add_edit_token_with_wrong_swapped_for(globaldb):
         globaldb.add_asset(
             asset_id='NEWID',
             asset_type=AssetType.ETHEREUM_TOKEN,
-            data=CustomEthereumToken(
+            data=EthereumToken.initialize(
                 address=make_ethereum_address(),
                 swapped_for=asset_to_delete,
             ),
@@ -86,7 +86,7 @@ def test_add_edit_token_with_wrong_swapped_for(globaldb):
 
     # now edit a new token with swapped_for pointing to a non existing token in the DB
     bat_custom = globaldb.get_ethereum_token(A_BAT.ethereum_address)
-    bat_custom = CustomEthereumToken(
+    bat_custom = EthereumToken.initialize(
         address=A_BAT.ethereum_address,
         decimals=A_BAT.decimals,
         name=A_BAT.name,

--- a/rotkehlchen/tests/unit/test_globaldb.py
+++ b/rotkehlchen/tests/unit/test_globaldb.py
@@ -1,21 +1,21 @@
 import itertools
+from pathlib import Path
+from shutil import copyfile
 
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.typing import AssetData, AssetType
 from rotkehlchen.chain.ethereum.typing import CustomEthereumToken, string_to_ethereum_address
 from rotkehlchen.constants.assets import A_BAT
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import InputError
+from rotkehlchen.globaldb.handler import GLOBAL_DB_VERSION
 from rotkehlchen.history.typing import HistoricalPriceOracle
+from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.tests.utils.globaldb import INITIAL_TOKENS
-from pathlib import Path
-from rotkehlchen.assets.resolver import AssetResolver
-from shutil import copyfile
-from rotkehlchen.globaldb.handler import GLOBAL_DB_VERSION
-from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -85,7 +85,7 @@ def test_add_edit_token_with_wrong_swapped_for(globaldb):
         )
 
     # now edit a new token with swapped_for pointing to a non existing token in the DB
-    bat_custom = A_BAT.to_custom_ethereum_token()
+    bat_custom = globaldb.get_ethereum_token(A_BAT.ethereum_address)
     bat_custom = CustomEthereumToken(
         address=A_BAT.ethereum_address,
         decimals=A_BAT.decimals,

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -5,11 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from rotkehlchen.assets.asset import Asset, EthereumToken
+from rotkehlchen.assets.asset import Asset, EthereumToken, UnderlyingToken
 from rotkehlchen.assets.typing import AssetType
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken, UnderlyingToken
 from rotkehlchen.constants import ZERO
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_USD, A_AAVE, A_LINK, A_CRV
+from rotkehlchen.constants.assets import A_AAVE, A_BTC, A_CRV, A_ETH, A_LINK, A_USD
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.externalapis.coingecko import Coingecko
@@ -28,7 +27,6 @@ from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import Price, Timestamp
 from rotkehlchen.utils.misc import ts_now
-
 
 UNDERLAYING_ASSET_PRICES = {
     A_AAVE: FVal('100'),
@@ -298,7 +296,7 @@ def test_find_usd_price_via_second_oracle(inquirer):
 def test_price_underlying_tokens(inquirer, globaldb):
     aave_weight, link_weight, crv_weight = FVal('0.6'), FVal('0.2'), FVal('0.2')
     address = make_ethereum_address()
-    token = CustomEthereumToken(
+    token = EthereumToken.initialize(
         address=address,
         decimals=18,
         name='Test',
@@ -324,7 +322,7 @@ def test_price_underlying_tokens(inquirer, globaldb):
 def test_find_uniswap_v2_lp_token_price(inquirer, globaldb, ethereum_manager):
     addess = '0xa2107FA5B38d9bbd2C461D6EDf11B11A50F6b974'
     inquirer.inject_ethereum(ethereum_manager)
-    token = CustomEthereumToken(
+    token = EthereumToken.initialize(
         address=addess,
         decimals=18,
         name='Uniswap LINK/ETH',

--- a/rotkehlchen/tests/utils/globaldb.py
+++ b/rotkehlchen/tests/utils/globaldb.py
@@ -1,4 +1,4 @@
-from rotkehlchen.chain.ethereum.typing import CustomEthereumToken, UnderlyingToken
+from rotkehlchen.assets.asset import EthereumToken, UnderlyingToken
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.constants import A_MKR
 from rotkehlchen.tests.utils.factories import make_ethereum_address
@@ -11,7 +11,7 @@ underlying_address3 = make_ethereum_address()
 custom_address1 = make_ethereum_address()
 custom_address2 = make_ethereum_address()
 INITIAL_TOKENS = [
-    CustomEthereumToken(
+    EthereumToken.initialize(
         address=custom_address1,
         decimals=4,
         name='Custom 1',
@@ -27,7 +27,7 @@ INITIAL_TOKENS = [
             UnderlyingToken(address=underlying_address3, weight=FVal('0.34')),
         ],
     ),
-    CustomEthereumToken(
+    EthereumToken.initialize(
         address=custom_address2,
         decimals=18,
         name='Custom 2',
@@ -36,15 +36,15 @@ INITIAL_TOKENS = [
 ]
 
 INITIAL_EXPECTED_TOKENS = [INITIAL_TOKENS[0]] + [
-    CustomEthereumToken(underlying_address1),
-    CustomEthereumToken(underlying_address2),
-    CustomEthereumToken(underlying_address3),
+    EthereumToken.initialize(underlying_address1),
+    EthereumToken.initialize(underlying_address2),
+    EthereumToken.initialize(underlying_address3),
 ] + [INITIAL_TOKENS[1]]
 
 
 underlying_address4 = make_ethereum_address()
 custom_address3 = make_ethereum_address()
-CUSTOM_TOKEN3 = CustomEthereumToken(
+CUSTOM_TOKEN3 = EthereumToken.initialize(
     address=custom_address3,
     decimals=15,
     name='Custom 3',


### PR DESCRIPTION
Same function can (and should be) created for all assets.

This change allows us to get rid of CustomEthereumTokenWithIdentifier
and simplify the code.


Probably the biggest win we have from this is that using such field initialization which does not read from the DB we can still have constant assets, just initialized by fields: https://github.com/rotki/rotki/issues/2751