### PR TITLE
Handle unhandled Substrate exception

### DIFF
--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -9,7 +9,7 @@ import gevent
 import requests
 from requests.adapters import Response
 from substrateinterface import SubstrateInterface
-from substrateinterface.exceptions import SubstrateRequestException
+from substrateinterface.exceptions import BlockNotFound, SubstrateRequestException
 from typing_extensions import Literal
 from websocket import WebSocketException
 
@@ -297,6 +297,7 @@ class SubstrateManager():
                 ValueError,
                 WebSocketException,
                 gevent.Timeout,
+                BlockNotFound,
         ) as e:
             msg = str(e)
             if isinstance(e, gevent.Timeout):


### PR DESCRIPTION
Saw this in v1.17.2

```
2021-06-11T07:39:29.447Z: Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/api/rest.py", line 271, in _do_query_async
  File "rotkehlchen/api/rest.py", line 638, in _query_blockchain_balances
  File "rotkehlchen/utils/mixins/lockable.py", line 40, in wrapper
  File "rotkehlchen/utils/mixins/cacheable.py", line 73, in wrapper
  File "rotkehlchen/chain/manager.py", line 486, in query_balances
  File "rotkehlchen/utils/mixins/lockable.py", line 40, in wrapper
  File "rotkehlchen/utils/mixins/cacheable.py", line 73, in wrapper
  File "rotkehlchen/chain/manager.py", line 531, in query_kusama_balances
  File "rotkehlchen/chain/substrate/manager.py", line 571, in get_accounts_balance
  File "rotkehlchen/chain/substrate/manager.py", line 89, in wrapper
  File "rotkehlchen/chain/substrate/manager.py", line 554, in get_account_balance
  File "rotkehlchen/chain/substrate/manager.py", line 292, in _get_account_balance
  File "site-packages/substrateinterface/base.py", line 1396, in query
  File "site-packages/substrateinterface/base.py", line 1077, in init_runtime
substrateinterface.exceptions.BlockNotFound: Block not found for "0xc8a7eb2a610bde569eb245ff5cbd6e226c5a62543ffa3a3a1e988dfd551139aa"
2021-06-11T07:37:07Z <Greenlet at 0x7f6ae852a830: <bound method RestAPI._do_query_async of <rotkehlchen.api.rest.RestAPI object at 0x7f6af0d26a90>>('_query_blockchain_balances', 7, blockchain=<SupportedBlockchain.KUSAMA: 'KSM'>, ignore_cache=False)> failed with BlockNotFound
```