### PR TITLE
Upgrade mypy to 0902

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 lint:
 	flake8 rotkehlchen/ tools/data_faker
+	yes | mypy rotkehlchen/ tools/data_faker --install-types || true
 	mypy rotkehlchen/ tools/data_faker
 	pylint --rcfile .pylint.rc rotkehlchen/ tools/data_faker
 

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,4 +1,4 @@
-mypy==0.812
+mypy==0.902
 mypy-extensions==0.4.3
 pylint==2.8.3
 astroid==2.5.6  # engine of pylint, upgrade them together

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -767,7 +767,7 @@ class Balancer(EthereumModule):
         for event_type in BalancerBPTEventType:
             self._get_balancer_aggregated_events_data_by_event_type(
                 address_to_events_data=address_to_events_data,
-                event_type=event_type,  # type: ignore # looping enum members and literals
+                event_type=event_type,
                 balancer_pools=balancer_pools,
                 balancer_events=balancer_events,
                 pool_addr_to_token_addr_to_index=pool_addr_to_token_addr_to_index,


### PR DESCRIPTION
This is a big upgrade and changes the way mypy stubs are handled.

Also we got a hacky way of installing missing stubs in the CI. See 2nd commit.