### PR TITLE
Introduce a module not activated screen for a few extra modules

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`1800` Users will now get greeted with a informational page when trying to access a page that requires a module to be activated.
 * :feature:`1692` IndependentReserve users will now be able to see their balances and have their deposit/withdrawal/trade history taken into account during profit/loss calculation.
 * :feature:`3025` Users will now see the percentage of each location when looking into an asset's details.
 * :feature:`2596` Users will now be able to create new tags directly from the tag selection input.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`1800` Users will now get greeted with a informational page when trying to access a page that requires a module to be activated.
+* :feature:`1800` Users will now be greeted with an informational notice when trying to access a page that requires a module to be activated.
 * :feature:`1692` IndependentReserve users will now be able to see their balances and have their deposit/withdrawal/trade history taken into account during profit/loss calculation.
 * :feature:`3025` Users will now see the percentage of each location when looking into an asset's details.
 * :feature:`2596` Users will now be able to create new tags directly from the tag selection input.

--- a/frontend/app/src/components/defi/ModuleNotActive.vue
+++ b/frontend/app/src/components/defi/ModuleNotActive.vue
@@ -11,16 +11,23 @@
       </v-row>
       <v-row align="center" justify="center" class="mt-16">
         <v-col cols="auto" class="text--secondary">
-          <i18n tag="span" path="module_not_active.not_active">
+          <i18n
+            tag="span"
+            path="module_not_active.not_active"
+            class="text-center"
+          >
             <template #link>
-              <v-btn
-                class="module-not-active__link font-weight-regular text-body-1"
+              <router-link
+                class="module-not-active__link font-weight-regular text-body-1 text-decoration-none"
                 text
                 to="/settings/defi"
                 small
               >
                 {{ $t('module_not_active.settings_link') }}
-              </v-btn>
+              </router-link>
+              <div v-if="modules.length > 1">
+                {{ $t('module_not_active.at_least_one') }}
+              </div>
             </template>
             <template #module>
               <span

--- a/frontend/app/src/components/defi/ModuleNotActive.vue
+++ b/frontend/app/src/components/defi/ModuleNotActive.vue
@@ -6,7 +6,7 @@
     <div class="module-not-active__container">
       <v-row align="center" justify="center">
         <v-col v-for="module in modules" :key="module" cols="auto">
-          <v-img max-width="82px" contain :src="icon(module)" />
+          <v-img width="82px" contain :src="icon(module)" />
         </v-col>
       </v-row>
       <v-row align="center" justify="center" class="mt-16">

--- a/frontend/app/src/components/defi/ModuleNotActive.vue
+++ b/frontend/app/src/components/defi/ModuleNotActive.vue
@@ -25,6 +25,8 @@
               >
                 {{ $t('module_not_active.settings_link') }}
               </router-link>
+            </template>
+            <template #text>
               <div v-if="modules.length > 1">
                 {{ $t('module_not_active.at_least_one') }}
               </div>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1145,8 +1145,9 @@
     }
   },
   "module_not_active": {
-    "not_active": "{module} module(s) is/are not activated. Please visit the {link} to activate it/them",
-    "settings_link": "Defi settings"
+    "not_active": "{module} module(s) not active. Please visit the {link}.",
+    "settings_link": "Defi settings",
+    "at_least_one": "You need to activate at least one of them"
   },
   "premium_credentials": {
     "label_enable": "Enable Premium",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1145,9 +1145,9 @@
     }
   },
   "module_not_active": {
-    "not_active": "{module} module(s) not active. Please visit the {link}.",
+    "not_active": "{module} module(s) not active. Please visit the {link}. {text}",
     "settings_link": "Defi settings",
-    "at_least_one": "You need to activate at least one of them"
+    "at_least_one": "You need to activate at least one of them."
   },
   "premium_credentials": {
     "label_enable": "Enable Premium",

--- a/frontend/app/src/mixins/defi-module-mixin.ts
+++ b/frontend/app/src/mixins/defi-module-mixin.ts
@@ -20,10 +20,20 @@ export default class DefiModuleMixin extends Vue {
   }
 
   get isUniswapEnabled(): boolean {
-    return this.activeModules.includes(MODULE_UNISWAP);
+    return this.isModuleEnabled(MODULE_UNISWAP);
   }
 
   get isBalancerEnabled(): boolean {
-    return this.activeModules.includes(MODULE_BALANCER);
+    return this.isModuleEnabled(MODULE_BALANCER);
+  }
+
+  isModuleEnabled(module: SupportedModules): boolean {
+    return this.activeModules.includes(module);
+  }
+
+  isAnyModuleEnabled(modules: SupportedModules[]): boolean {
+    return (
+      this.activeModules.filter(module => modules.includes(module)).length > 0
+    );
   }
 }

--- a/frontend/app/src/views/defi/DecentralizedBorrowing.vue
+++ b/frontend/app/src/views/defi/DecentralizedBorrowing.vue
@@ -1,13 +1,34 @@
 <template>
-  <borrowing />
+  <module-not-active v-if="!anyModuleEnabled" :modules="modules" />
+  <borrowing v-else />
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Mixins } from 'vue-property-decorator';
 import Borrowing from '@/components/defi/Borrowing.vue';
+import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
+import DefiModuleMixin from '@/mixins/defi-module-mixin';
+import {
+  MODULE_AAVE,
+  MODULE_COMPOUND,
+  MODULE_MAKERDAO_VAULTS,
+  MODULE_YEARN
+} from '@/services/session/consts';
+import { SupportedModules } from '@/services/session/types';
 
 @Component({
-  components: { Borrowing }
+  components: { ModuleNotActive, Borrowing }
 })
-export default class DecentralizedBorrowing extends Vue {}
+export default class DecentralizedBorrowing extends Mixins(DefiModuleMixin) {
+  readonly modules: SupportedModules[] = [
+    MODULE_AAVE,
+    MODULE_COMPOUND,
+    MODULE_MAKERDAO_VAULTS,
+    MODULE_YEARN
+  ];
+
+  get anyModuleEnabled(): boolean {
+    return this.isAnyModuleEnabled(this.modules);
+  }
+}
 </script>

--- a/frontend/app/src/views/defi/deposits/Protocols.vue
+++ b/frontend/app/src/views/defi/deposits/Protocols.vue
@@ -1,13 +1,34 @@
 <template>
-  <lending />
+  <module-not-active v-if="!anyModuleEnabled" :modules="modules" />
+  <lending v-else />
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Mixins } from 'vue-property-decorator';
 import Lending from '@/components/defi/Lending.vue';
+import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
+import DefiModuleMixin from '@/mixins/defi-module-mixin';
+import {
+  MODULE_AAVE,
+  MODULE_COMPOUND,
+  MODULE_MAKERDAO_DSR,
+  MODULE_YEARN
+} from '@/services/session/consts';
+import { SupportedModules } from '@/services/session/types';
 
 @Component({
-  components: { Lending }
+  components: { ModuleNotActive, Lending }
 })
-export default class Protocols extends Vue {}
+export default class Protocols extends Mixins(DefiModuleMixin) {
+  readonly modules: SupportedModules[] = [
+    MODULE_AAVE,
+    MODULE_COMPOUND,
+    MODULE_MAKERDAO_DSR,
+    MODULE_YEARN
+  ];
+
+  get anyModuleEnabled(): boolean {
+    return this.isAnyModuleEnabled(this.modules);
+  }
+}
 </script>

--- a/frontend/app/src/views/staking/AdexPage.vue
+++ b/frontend/app/src/views/staking/AdexPage.vue
@@ -41,6 +41,9 @@ export default class AdexPage extends Mixins(StatusMixin, DefiModuleMixin) {
   }
 
   async mounted() {
+    if (!this.moduleEnabled) {
+      return;
+    }
     await this.fetchAdex(false);
   }
 }

--- a/frontend/app/src/views/staking/AdexPage.vue
+++ b/frontend/app/src/views/staking/AdexPage.vue
@@ -1,5 +1,6 @@
 <template>
-  <progress-screen v-if="loading">
+  <module-not-active v-if="!moduleEnabled" :modules="module" />
+  <progress-screen v-else-if="loading">
     <template #message>
       {{ $t('adex_page.loading') }}
     </template>
@@ -14,22 +15,30 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
 import { mapActions } from 'vuex';
+import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
 import ProgressScreen from '@/components/helper/ProgressScreen.vue';
+import DefiModuleMixin from '@/mixins/defi-module-mixin';
 import StatusMixin from '@/mixins/status-mixin';
 import { AdexStaking } from '@/premium/premium';
+import { MODULE_ADEX } from '@/services/session/consts';
 import { Section } from '@/store/const';
 
 @Component({
-  components: { AdexStaking, ProgressScreen },
+  components: { ModuleNotActive, AdexStaking, ProgressScreen },
   methods: {
     ...mapActions('staking', ['fetchAdex'])
   }
 })
-export default class AdexPage extends Mixins(StatusMixin) {
+export default class AdexPage extends Mixins(StatusMixin, DefiModuleMixin) {
+  readonly module = [MODULE_ADEX];
   section = Section.STAKING_ADEX;
   secondSection = Section.STAKING_ADEX_HISTORY;
 
   fetchAdex!: (refresh: boolean) => Promise<void>;
+
+  get moduleEnabled(): boolean {
+    return this.isModuleEnabled(MODULE_ADEX);
+  }
 
   async mounted() {
     await this.fetchAdex(false);

--- a/frontend/app/src/views/staking/Eth2Page.vue
+++ b/frontend/app/src/views/staking/Eth2Page.vue
@@ -43,6 +43,9 @@ export default class Eth2Page extends Mixins(StatusMixin, DefiModuleMixin) {
   }
 
   async mounted() {
+    if (!this.moduleEnabled) {
+      return;
+    }
     await this.fetchStakingDetails(false);
   }
 }

--- a/frontend/app/src/views/staking/Eth2Page.vue
+++ b/frontend/app/src/views/staking/Eth2Page.vue
@@ -1,6 +1,7 @@
 <template>
   <v-container>
-    <progress-screen v-if="loading">
+    <module-not-active v-if="!moduleEnabled" :modules="module" />
+    <progress-screen v-else-if="loading">
       <template #message>
         {{ $t('eth2page.loading') }}
       </template>
@@ -17,21 +18,29 @@
 import { Component, Mixins } from 'vue-property-decorator';
 
 import { mapActions } from 'vuex';
+import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
 import ProgressScreen from '@/components/helper/ProgressScreen.vue';
+import DefiModuleMixin from '@/mixins/defi-module-mixin';
 import StatusMixin from '@/mixins/status-mixin';
 import { Eth2Staking } from '@/premium/premium';
+import { MODULE_ETH2 } from '@/services/session/consts';
 import { Section } from '@/store/const';
 
 @Component({
-  components: { ProgressScreen, Eth2Staking },
+  components: { ModuleNotActive, ProgressScreen, Eth2Staking },
   methods: {
     ...mapActions('staking', ['fetchStakingDetails'])
   }
 })
-export default class Eth2Page extends Mixins(StatusMixin) {
+export default class Eth2Page extends Mixins(StatusMixin, DefiModuleMixin) {
+  readonly module = [MODULE_ETH2];
   readonly section = Section.STAKING_ETH2;
   readonly secondSection = Section.STAKING_ETH2_DEPOSITS;
   fetchStakingDetails!: (refresh: boolean) => Promise<void>;
+
+  get moduleEnabled(): boolean {
+    return this.isModuleEnabled(MODULE_ETH2);
+  }
 
   async mounted() {
     await this.fetchStakingDetails(false);


### PR DESCRIPTION
Closes #1800

- Adds the informational screen that will display if non of the defi modules (compound/yearn/makerdao (dsr on lending/vaults on borrowing)/aave) for defi borrowing and lending.
- Adds the same screen for eth2/adex staking