### PR TITLE
Rotate rotki backend logs and set max size

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`2939` Rotki logs will now persist after restart. Number of logs and maximum size for all logs of a run can be now specified.
 * :feature:`1800` Users will now be greeted with an informational notice when trying to access a page that requires a module to be activated.
 * :feature:`1692` IndependentReserve users will now be able to see their balances and have their deposit/withdrawal/trade history taken into account during profit/loss calculation.
 * :feature:`3025` Users will now see the percentage of each location when looking into an asset's details.

--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -906,8 +906,10 @@ Create or edit if it exists a file with the name ``rotki_config.json`` in the sa
       "loglevel": "debug",
       "logfromothermodules": false,
       "log-dir": "/path/to/dir",
-      "data-dir": "/path/to/dir"
-      "sleep-secs": 20
+      "data-dir": "/path/to/dir",
+      "sleep-secs": 20,
+      "max_size_in_mb_all_logs": 500,
+      "max_logfiles_num": 2
   }
 
 The above arguments are:
@@ -917,6 +919,8 @@ The above arguments are:
 - **log-dir**: The name for the log directory.
 - **data-dir**: The path to the directory where all rotki data will be saved. Default depends on the user's OS. Check next section
 - **sleep-secs**: This is the amount of seconds that the main loop of rotki sleeps for. Default is 20.
+- **max_size_in_mb_all_logs**: This is the maximum size in megabytes all logs of a single run can have
+- **max_logfiles_num**: This is the maximum number of backup (rotated) logs a single run can have.
 
 
 .. _rotki_data_directory:

--- a/rotkehlchen/args.py
+++ b/rotkehlchen/args.py
@@ -4,6 +4,9 @@ from typing import Any, List, Sequence, Union
 
 from rotkehlchen.utils.misc import get_system_spec
 
+DEFAULT_MAX_LOG_SIZE_IN_MB = 300
+DEFAULT_MAX_LOG_BACKUP_FILES = 3
+
 
 class CommandAction(argparse.Action):
     """Interprets the positional argument as a command if that command exists"""
@@ -97,6 +100,18 @@ def app_args(prog: str, description: str) -> argparse.ArgumentParser:
             'logging system will also be visible.'
         ),
         action='store_true',
+    )
+    p.add_argument(
+        '--max-size-in-mb-all-logs',
+        help='This is the maximum size in megabytes that will be used for all rotki logs',
+        default=DEFAULT_MAX_LOG_SIZE_IN_MB,
+        type=int,
+    )
+    p.add_argument(
+        '--max-logfiles-num',
+        help='This is the maximum number of logfiles to keep',
+        default=DEFAULT_MAX_LOG_BACKUP_FILES,
+        type=int,
     )
     p.add_argument(
         'version',

--- a/rotkehlchen/chain/substrate/typing.py
+++ b/rotkehlchen/chain/substrate/typing.py
@@ -74,7 +74,7 @@ class SubstrateChain(Enum):
         the chains we introduce.
         """
         if self == SubstrateChain.KUSAMA:
-            return 'https://kusama.subscan.io/api'
+            return 'https://kusama.api.subscan.io/api'
         raise AssertionError(f'Unexpected Chain: {self}')
 
     def substrate_interface_attributes(self) -> SubstrateInterfaceAttributes:

--- a/rotkehlchen/logging.py
+++ b/rotkehlchen/logging.py
@@ -1,7 +1,10 @@
 import argparse
 import logging
 import re
+from pathlib import Path
 from typing import Any, Dict, MutableMapping, Tuple
+
+from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
 PYWSGI_RE = re.compile(r'\[(.*)\] ')
 
@@ -56,12 +59,28 @@ def configure_logging(args: argparse.Namespace) -> None:
         },
     }
 
+    if args.max_logfiles_num < 0:
+        backups_num = 0
+    else:
+        backups_num = args.max_logfiles_num - 1
+
     if args.logtarget == 'file':
         selected_handlers = ['file']
+        single_log_max_bytes = int(
+            (args.max_size_in_mb_all_logs * 1024 * 1000) / args.max_logfiles_num,
+        )
+        date = timestamp_to_date(
+            ts=ts_now(),
+            formatstr='%Y%m%d_%H%M%S',
+            treat_as_local=True,
+        )
+        given_filepath = Path(args.logfile)
         handlers['file'] = {
-            'class': 'logging.FileHandler',
-            'filename': args.logfile,
-            'mode': 'w',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': given_filepath.parent / f'{date}_{given_filepath.name}',
+            'mode': 'a',
+            'maxBytes': single_log_max_bytes,
+            'backupCount': backups_num,
             'level': loglevel,
             'formatter': 'default',
         }

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 import rotkehlchen.tests.utils.exchanges as exchange_tests
+from rotkehlchen.args import DEFAULT_MAX_LOG_BACKUP_FILES, DEFAULT_MAX_LOG_SIZE_IN_MB
 from rotkehlchen.db.settings import DBSettings
 from rotkehlchen.exchanges.manager import EXCHANGES_WITH_PASSPHRASE
 from rotkehlchen.history.price import PriceHistorian
@@ -69,12 +70,16 @@ def fixture_cli_args(data_dir, ethrpc_endpoint):
         'logtarget',
         'loglevel',
         'logfromothermodules',
+        'max_size_in_mb_all_logs',
+        'max_logfiles_num',
     ])
     args.loglevel = 'debug'
     args.logfromothermodules = False
     args.sleep_secs = 60
     args.data_dir = data_dir
     args.ethrpc_endpoint = ethrpc_endpoint
+    args.max_size_in_mb_all_logs = DEFAULT_MAX_LOG_SIZE_IN_MB
+    args.max_logfiles_num = DEFAULT_MAX_LOG_BACKUP_FILES
     return args
 
 

--- a/rotkehlchen/tests/unit/test_app.py
+++ b/rotkehlchen/tests/unit/test_app.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from rotkehlchen.errors import SystemPermissionError
-from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES, EXCHANGES_WITH_PASSPHRASE
+from rotkehlchen.exchanges.manager import EXCHANGES_WITH_PASSPHRASE, SUPPORTED_EXCHANGES
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
 from rotkehlchen.typing import Location
@@ -53,6 +53,13 @@ def test_initializing_exchanges(uninitialized_rotkehlchen):
 
 def test_initializing_rotki_with_datadir_with_wrong_permissions(cli_args, data_dir):
     os.chmod(data_dir, 0o200)
-    with pytest.raises(SystemPermissionError):
-        Rotkehlchen(args=cli_args)
-    os.chmod(data_dir, 0o777)
+    success = True
+    try:
+        with pytest.raises(SystemPermissionError):
+            Rotkehlchen(args=cli_args)
+    except Exception:  # pylint: disable=broad-except
+        success = False
+    finally:
+        os.chmod(data_dir, 0o777)
+
+    assert success is True

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -1,7 +1,6 @@
 import calendar
 import datetime
 import functools
-import logging
 import operator
 import platform
 import re
@@ -14,11 +13,7 @@ from eth_utils.address import to_checksum_address
 
 from rotkehlchen.errors import ConversionError, DeserializationError
 from rotkehlchen.fval import FVal
-from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, Fee, Timestamp, TimestampMS
-
-logger = logging.getLogger(__name__)
-log = RotkehlchenLogsAdapter(logger)
 
 
 def ts_now() -> Timestamp:


### PR DESCRIPTION
Fix #2939 Fix #2959

Hey @kelsos this will also need customization on the frontend side. By default with no other options I set it at 3 logs per run, max size of all 3, 300 MB, so 100 MB per log. Once a log fills up it's closed and next one is opened.

Is that what you wanted?

You can customize the number of logfiles to keep per run and max size of all log files:

```python
    p.add_argument(
        '--max-size-in-mb-all-logs',
        help='This is the maximum size in megabytes that will be used for all rotki logs',
        default=DEFAULT_MAX_LOG_SIZE_IN_MB,
        type=int,
    )
    p.add_argument(
        '--max-logfiles-num',
        help='This is the maximum number of logfiles to keep',
        default=DEFAULT_MAX_LOG_BACKUP_FILES,
        type=int,
    )
```
