### PR TITLE
Introduces version bump script

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,8 +6,5 @@ tag = False
 [bumpversion:file:setup.py]
 serialize = {major}.{minor}.{patch}
 
-[bumpversion:file:frontend/app/package.json]
-serialize = {major}.{minor}.{patch}
-
 [bumpversion:file:docs/conf.py]
 serialize = {major}.{minor}.{patch}

--- a/tools/scripts/bump.sh
+++ b/tools/scripts/bump.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+  echo "usage: $0 [minor|major|patch]"
+  exit 1
+fi
+
+if [ "$1" != 'minor' ] && [ "$1" != 'major' ] && [ "$1" != 'patch' ]; then
+  echo "usage: $0 [minor|major|patch]"
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo 'Git working directory is not clean:'
+  git status
+  exit 1
+fi
+
+echo "Preparing $1 release"
+
+ROOT_DIR=$PWD
+cd ../ || exit 1
+
+if [ -d 'scripts' ]; then
+  cd .. || exit 1
+  ROOT_DIR=$PWD
+else
+  cd "$ROOT_DIR" || exit 1
+fi
+
+cd frontend/app || exit 1
+
+npm version --no-git-tag-version "$1"
+git add package.json
+git add package-lock.json
+
+cd "$ROOT_DIR" || exit 1
+
+bump2version --allow-dirty --config-file .bumpversion.cfg "$1"


### PR DESCRIPTION
Delegates the version bumping for `package.json` and `package-lock.json` to `npm version`

Usage `./tools/scripts/bump.sh [patch|minor|major]`

Closes #447