### PR TITLE
FTX will use the account endpoint when a subaccount is provided to validate API keys

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`3101` Editing ethereum token details via the asset manager in the frontend should now work properly again.
+* :bug:`3100` FTX API keys with permission for subaccounts only will now correctly validated.
 
 * :release:`1.18.0 <2021-06-18>`
 * :feature:`2064` Users will now be able to close rotki to tray. When logged the tray icon will update based on the net worth value during the selected period (week, two weeks etc).

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -107,7 +107,7 @@ def test_setup_exchange(rotkehlchen_api_server):
                 BITSTAMP_API_KEY_ERROR_CODE_ACTION['API0011'],
                 BITFINEX_API_KEY_ERROR_MESSAGE,
                 KUCOIN_API_KEY_ERROR_CODE[400003],
-                'Bad combination of API Keys',
+                'Error validating API Keys',
                 'ApiKey has invalid value',
             ],
             status_code=HTTPStatus.CONFLICT,


### PR DESCRIPTION
Closes #3100

In order to test it I created an account in FTX and two pairs of keys, one only for a subaccount and one for the whole account.
Before the patch the keys for the subaccount failed to be verified and the other worked. Now it works in both cases