### PR TITLE
Fixes a few bugs that would prevent a user to connect to the dockerized backend from the app

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3118` Users will now be able to properly connect to the dockerized backend through the app. (It will not work if the docker container is a previous release).
 * :bug:`3101` Editing ethereum token details via the asset manager in the frontend should now work properly again.
 * :bug:`3100` FTX API keys with permission for subaccounts only will now correctly validated.
 

--- a/frontend/app/src/components/AccountManagement.vue
+++ b/frontend/app/src/components/AccountManagement.vue
@@ -156,21 +156,10 @@ export default class AccountManagement extends Mixins(BackendMixin) {
 
   async backendChanged(url: string | null) {
     await this.$store.commit('setConnected', false);
-    const { success } = await this.$store.dispatch('connect', url);
-    if (!success) {
-      this.setMessage({
-        success: false,
-        description: this.$t(
-          'account_management.custom_backend.failed.description',
-          { url }
-        ).toString(),
-        title: this.$t(
-          'account_management.custom_backend.failed.title'
-        ).toString()
-      });
-      deleteBackendUrl();
+    if (!url) {
       await this.restartBackend();
     }
+    await this.$store.dispatch('connect', url);
   }
 
   async login(credentials: Credentials) {

--- a/frontend/app/src/components/account-management/ConnectionFailure.vue
+++ b/frontend/app/src/components/account-management/ConnectionFailure.vue
@@ -5,6 +5,9 @@
       {{ $t('connection_failure.message') }}
     </div>
     <div class="full-width d-flex mt-2">
+      <v-btn v-if="!$api.defaultBackend" text @click="toDefault">
+        {{ $t('connection_failure.default') }}
+      </v-btn>
       <v-spacer />
       <v-btn depressed @click="terminate">
         {{ $t('connection_failure.terminate') }}
@@ -17,11 +20,17 @@
 </template>
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
+import { deleteBackendUrl } from '@/components/account-management/utils';
 
 @Component({})
 export default class ConnectionFailure extends Vue {
   retry() {
-    this.$store.dispatch('connect');
+    this.$store.dispatch('connect', this.$api.serverUrl);
+  }
+
+  toDefault() {
+    deleteBackendUrl();
+    this.$store.dispatch('connect', null);
   }
 
   terminate() {

--- a/frontend/app/src/components/account-management/Login.vue
+++ b/frontend/app/src/components/account-management/Login.vue
@@ -72,6 +72,7 @@
                   :label="$t('login.custom_backend.label')"
                   :placeholder="$t('login.custom_backend.placeholder')"
                   :hint="$t('login.custom_backend.hint')"
+                  @keypress.enter="saveCustomBackend"
                 />
               </v-col>
               <v-col cols="auto">

--- a/frontend/app/src/components/helper/display/icons/AssetIcon.vue
+++ b/frontend/app/src/components/helper/display/icons/AssetIcon.vue
@@ -79,7 +79,7 @@ export default class AssetIcon extends Mixins(AssetMixin) {
     ) {
       return require(`@/assets/images/defi/weth.svg`);
     }
-    const url = `${process.env.VUE_APP_BACKEND_URL}/api/1/assets/${this.asset}/icon`;
+    const url = `${this.$api.serverUrl}/api/1/assets/${this.asset}/icon`;
     return this.changeable ? `${url}?t=${Date.now()}` : url;
   }
 }

--- a/frontend/app/src/components/history/LocationDisplay.vue
+++ b/frontend/app/src/components/history/LocationDisplay.vue
@@ -36,7 +36,7 @@ export default class LocationDisplay extends Mixins(AssetMixin) {
         identifier: this.identifier,
         exchange: false,
         imageIcon: true,
-        icon: `${process.env.VUE_APP_BACKEND_URL}/api/1/assets/${this.identifier}/icon`
+        icon: `${this.$api.serverUrl}/api/1/assets/${this.identifier}/icon`
       };
     }
 

--- a/frontend/app/src/components/import/FileUpload.vue
+++ b/frontend/app/src/components/import/FileUpload.vue
@@ -169,7 +169,7 @@ export default class FileUpload extends Vue {
       return;
     }
 
-    if (this.$interop.isPackaged) {
+    if (this.$interop.isPackaged && this.$api.defaultBackend) {
       this.uploadPackaged(files[0].path);
     } else {
       const formData = new FormData();

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -209,6 +209,7 @@
     "hint": "{conflicts} asset entries cannot be automatically updated. {remaining} remaining entry/ies require user input."
   },
   "connection_failure": {
+    "default": "Connect to default",
     "message": "A connection to the rotki backend was not possible, would you like to retry again?",
     "retry": "Retry",
     "terminate": "Terminate",
@@ -2539,12 +2540,6 @@
     "about_tooltip": "Show the application's about modal",
     "creation": {
       "error": "Account creation failed"
-    },
-    "custom_backend": {
-      "failed": {
-        "title": "Could not connect to custom backend",
-        "description": "Connection to {url} failed after 5 attempts"
-      }
     }
   },
   "privacy_notice": {

--- a/frontend/app/src/services/assets/asset-api.ts
+++ b/frontend/app/src/services/assets/asset-api.ts
@@ -149,7 +149,7 @@ export class AssetApi {
 
   async allAssets(): Promise<SupportedAssets> {
     return this.axios
-      .get<ActionResult<SupportedAssets>>('assets/all', {
+      .get<ActionResult<SupportedAssets>>('/assets/all', {
         validateStatus: validWithSessionAndExternalService,
         transformResponse: setupTransformer([], true)
       })

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -78,12 +78,22 @@ export class RotkehlchenApi {
   private _session: SessionApi;
   private _balances: BalancesApi;
   private _history: HistoryApi;
-  private readonly _assets: AssetApi;
+  private _assets: AssetApi;
+  private _serverUrl: string;
   private readonly baseTransformer = setupTransformer([]);
 
+  get serverUrl(): string {
+    return this._serverUrl;
+  }
+
+  get defaultBackend(): boolean {
+    return this._serverUrl === process.env.VUE_APP_BACKEND_URL;
+  }
+
   constructor() {
+    this._serverUrl = process.env.VUE_APP_BACKEND_URL!;
     this.axios = axios.create({
-      baseURL: `${process.env.VUE_APP_BACKEND_URL}/api/1/`,
+      baseURL: `${this.serverUrl}/api/1/`,
       timeout: 30000
     });
     this.baseTransformer = setupTransformer();
@@ -115,6 +125,7 @@ export class RotkehlchenApi {
   }
 
   setup(serverUrl: string) {
+    this._serverUrl = serverUrl;
     this.axios = axios.create({
       baseURL: `${serverUrl}/api/1/`,
       timeout: 30000
@@ -123,6 +134,7 @@ export class RotkehlchenApi {
     this._session = new SessionApi(this.axios);
     this._balances = new BalancesApi(this.axios);
     this._history = new HistoryApi(this.axios);
+    this._assets = new AssetApi(this.axios);
   }
 
   checkIfLogged(username: string): Promise<boolean> {

--- a/frontend/app/src/store/store.ts
+++ b/frontend/app/src/store/store.ts
@@ -22,6 +22,7 @@ import {
   Version
 } from '@/store/types';
 import { isLoading } from '@/store/utils';
+import { Nullable } from '@/types';
 
 Vue.use(Vuex);
 
@@ -101,21 +102,20 @@ const store: StoreOptions<RotkehlchenState> = {
         clearInterval(intervalId);
       }
 
-      function connectToDefaultBackend() {
-        const serverUrl = window.interop?.serverUrl();
-        const defaultServerUrl = process.env.VUE_APP_BACKEND_URL;
-        if (serverUrl && serverUrl !== defaultServerUrl) {
-          api.setup(serverUrl);
+      function updateApi(payload?: Nullable<string>) {
+        const interopServerUrl = window.interop?.serverUrl();
+        let backend = process.env.VUE_APP_BACKEND_URL!;
+        if (payload) {
+          backend = payload;
+        } else if (interopServerUrl) {
+          backend = interopServerUrl;
         }
+        api.setup(backend);
       }
 
       const attemptConnect = async function () {
         try {
-          if (!payload) {
-            connectToDefaultBackend();
-          } else {
-            api.setup(payload);
-          }
+          updateApi(payload);
 
           const connected = await api.ping();
           if (connected) {

--- a/frontend/app/src/views/ProfitLossReport.vue
+++ b/frontend/app/src/views/ProfitLossReport.vue
@@ -174,7 +174,7 @@ export default class ProfitLossReport extends Vue {
 
   async exportCSV() {
     try {
-      if (this.$interop.isPackaged) {
+      if (this.$interop.isPackaged && this.$api.defaultBackend) {
         const directory = await this.$interop.openDirectory(
           this.$t('profit_loss_report.select_directory').toString()
         );

--- a/frontend/app/tests/unit/components/display/account-display.spec.ts
+++ b/frontend/app/tests/unit/components/display/account-display.spec.ts
@@ -22,7 +22,7 @@ describe('AccountDisplay.vue', () => {
     return mount(AccountDisplay, {
       store,
       vuetify,
-      stubs: ['v-tooltip', 'crypto-icon'],
+      stubs: ['v-tooltip', 'asset-icon'],
       propsData: {
         account
       }

--- a/packaging/docker/docker-entrypoint.sh
+++ b/packaging/docker/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-exec /usr/sbin/rotki --api-port 4242 --data-dir /data/ --logfile /logs/rotki.log --api-cors http://localhost:8080 --api-host 0.0.0.0 &
+exec /usr/sbin/rotki --api-port 4242 --data-dir /data/ --logfile /logs/rotki.log --api-cors http://localhost:*/*,app://. --api-host 0.0.0.0 &
 
 status=$?
 if [ $status -ne 0 ]; then


### PR DESCRIPTION
Closes #3118 

To build the docker image for testing

```
docker buildx build --tag rotki:test .         
docker run -d --name rotki-test \ 
    -p 8084:80 \
    -v $HOME/.rotki/data:/data \
    -v $HOME/.rotki/logs:/logs \
    rotki:test
```

A build of the app from this branch is also needed, OS doesn't matter.

Verify that the frontend is accessible through `http://localhost:8084` and then start the app go to the backend settings and set the endpoint to `http://localhost:8084`