### PR TITLE
Fixes bug with MakerDAO on Defi overview

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3133` Users will now properly see a MakerDAO entry in the Defi Overview.
 * :bug:`3118` Users will now be able to properly connect to the dockerized backend through the app. (It will not work if the docker container is a previous release).
 * :bug:`3101` Editing ethereum token details via the asset manager in the frontend should now work properly again.
 * :bug:`3100` FTX API keys with permission for subaccounts only will now be correctly validated.

--- a/frontend/app/src/store/defi/getters.ts
+++ b/frontend/app/src/store/defi/getters.ts
@@ -1078,7 +1078,11 @@ export const getters: Getters<DefiState, DefiGetters, RotkehlchenState, any> = {
       }
     }
 
-    if (status === Status.LOADED || status === Status.REFRESHING) {
+    const overviewStatus = status(Section.DEFI_OVERVIEW);
+    if (
+      overviewStatus === Status.LOADED ||
+      overviewStatus === Status.REFRESHING
+    ) {
       const filter: SupportedDefiProtocols[] = [DEFI_MAKERDAO];
       const { totalCollateralUsd, totalDebt } = loanSummary(filter);
       summary[DEFI_MAKERDAO] = {


### PR DESCRIPTION
Closes #3133 

This only addresses the bug of not appearing. 
Since we discussed about splitting the DSR/Vaults into two different entries @LefterisJP could you create an issue so that we can schedule it for 1.19?