### PR TITLE
Fix changelog script

### DIFF
--- a/tools/scripts/generate_changelog.py
+++ b/tools/scripts/generate_changelog.py
@@ -48,7 +48,7 @@ def generate_changelog(version: str, path: str) -> str:
                     else:
                         changes['bugs'].append(text)
 
-            if start and 'release' in line:
+            if start and '* :release:' in line:
                 break
 
     result = [


### PR DESCRIPTION
If the word "release" appeared in a bug/feature entry the script
stopped. Noticed it when running it for v1.18.1.