### PR TITLE
Adds a logout button when greeted by a please logout error, automatically loads dashboard on refresh.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :feature:`2722` The sync conflict dialog dates will now be consistent with the user specified date format.
 * :feature:`3114` Users can easily check and manage which addresses are queried for each defi module directly from the respective module page.
 * :feature:`3069` When adding an asset coingecko/cryptocompare identifiers will now be validated and non-existing ones will be rejected.
+* :bug:`3145` Docker users will now have the ability to logout any other sessions when attempting to connect from a new browser window.
 * :bug:`2685` Invoking `--version` from the rotki backend binary in Windows should no longer raise a Permission error.
 
 * :release:`1.18.1 <2021-06-30>`

--- a/frontend/app/src/components/account-management/utils.ts
+++ b/frontend/app/src/components/account-management/utils.ts
@@ -1,5 +1,6 @@
 export const KEY_BACKEND_URL = 'rotki.backend_url';
 export const KEY_BACKEND_URL_SESSION_ONLY = 'rotki.backend_url_session';
+const KEY_LAST_LOGIN = 'rotki.last_login' as const;
 
 export type BackendSettings = {
   readonly url: string;
@@ -28,4 +29,16 @@ export function getBackendUrl(): BackendSettings {
     url,
     sessionOnly
   };
+}
+
+export function lastLogin(): string {
+  return localStorage.getItem(KEY_LAST_LOGIN) ?? '';
+}
+
+export function setLastLogin(username: string) {
+  if (!username) {
+    localStorage.removeItem(KEY_LAST_LOGIN);
+  } else {
+    localStorage.setItem(KEY_LAST_LOGIN, username);
+  }
 }

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1141,6 +1141,7 @@
     }
   },
   "login": {
+    "logout": "Logout",
     "custom_backend": {
       "session_only": "Save only for this session",
       "tooltip": "Connect to a different rotki backend",

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -144,6 +144,22 @@ export class RotkehlchenApi {
       .then(result => result[username] === 'loggedin');
   }
 
+  loggedUsers(): Promise<string[]> {
+    return this.axios
+      .get<ActionResult<AccountSession>>(`/users`)
+      .then(handleResponse)
+      .then(result => {
+        const loggedUsers: string[] = [];
+        for (const user in result) {
+          if (result[user] !== 'loggedin') {
+            continue;
+          }
+          loggedUsers.push(user);
+        }
+        return loggedUsers;
+      });
+  }
+
   logout(username: string): Promise<boolean> {
     return this.axios
       .patch<ActionResult<boolean>>(

--- a/frontend/app/src/store/session/actions.ts
+++ b/frontend/app/src/store/session/actions.ts
@@ -89,8 +89,8 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
     let exchanges: Exchange[];
 
     try {
-      const { username, create } = payload;
-      const isLogged = await api.checkIfLogged(username);
+      const { username, create, restore } = payload;
+      const isLogged = restore || (await api.checkIfLogged(username));
       if (isLogged && !state.syncConflict.message) {
         [settings, exchanges] = await Promise.all([
           api.getSettings(),
@@ -198,6 +198,19 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
       await dispatch('stop');
     } catch (e) {
       showError(e.message, 'Logout failed');
+    }
+  },
+  async logoutRemoteSession(): Promise<ActionStatus> {
+    try {
+      const loggedUsers = await api.loggedUsers();
+      for (let i = 0; i < loggedUsers.length; i++) {
+        const user = loggedUsers[i];
+        await api.logout(user);
+      }
+      return { success: true };
+    } catch (e) {
+      showError(e.message, 'Logout failed');
+      return { success: false, message: e.message };
     }
   },
   async stop({ commit }) {

--- a/frontend/app/src/typing/types.ts
+++ b/frontend/app/src/typing/types.ts
@@ -105,6 +105,7 @@ export interface UnlockPayload {
   readonly apiKey?: string;
   readonly apiSecret?: string;
   readonly submitUsageAnalytics?: boolean;
+  readonly restore?: boolean;
 }
 
 export type SettingsUpdate = {


### PR DESCRIPTION
Closes #3145

To test you can start the regular dev server (npm run electron serve) and attempt to connect to localhost:8080 from the browser.

After a successful login, a refresh on the browser should take you to a dashboard that loads like a fresh login.
If you attempt to log in from a second browser you should get an error with a logout button if you attempt to login with a new account.

After pressing the logout button you should be able to log in properly on the second browser window with the new account.

https://github.com/rotki/rotki/issues/3156 is a follow up issue