### PR TITLE
FIX: history query for yearn vaults v2

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
@@ -201,7 +201,11 @@ class YearnVaultsV2(EthereumModule):
 
         for address, new_events in new_events_addresses.items():
             # Query events from db for address
-            db_events = self.database.get_all_yearn_vaults_v2_events(address=address)
+            db_events = self.database.get_yearn_vaults_v2_events(
+                address=address,
+                from_block=from_block,
+                to_block=to_block,
+            )
             # Flatten the data into a unique list
             events = list(new_events['deposits'])
             events.extend(new_events['withdrawals'])
@@ -215,15 +219,19 @@ class YearnVaultsV2(EthereumModule):
                     to_block=to_block,
                 )
                 continue
+            self.database.add_yearn_vaults_events(address, events)
 
+        for address in addresses:
+            all_events = self.database.get_yearn_vaults_v2_events(
+                address=address,
+                from_block=from_block,
+                to_block=to_block,
+            )
             vaults_histories: Dict[str, YearnVaultHistory] = {}
             # Dict that stores vault token symbol and their events + total pnl
             vaults: Dict[str, Dict[str, List[YearnVaultEvent]]] = defaultdict(
                 lambda: defaultdict(list),
             )
-            self.database.add_yearn_vaults_events(address, events)
-            all_events = db_events + events
-
             for event in all_events:
                 if event.event_type == 'deposit':
                     vault_token_symbol = event.to_asset.identifier

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1284,11 +1284,17 @@ class DBHandler:
                 log.warning(msg, data=result)
         return events
 
-    def get_all_yearn_vaults_v2_events(self, address: ChecksumEthAddress) -> List[YearnVaultEvent]:
+    def get_yearn_vaults_v2_events(
+        self,
+        address: ChecksumEthAddress,
+        from_block: int,
+        to_block: int,
+    ) -> List[YearnVaultEvent]:
         cursor = self.conn.cursor()
         query = cursor.execute(
-            'SELECT * from yearn_vaults_events WHERE address=? AND version=2;',
-            (address, ),
+            'SELECT * from yearn_vaults_events WHERE address=? AND version=2 '
+            'AND block_number BETWEEN ? AND ?',
+            (address, from_block, to_block),
         )
         events = []
         for result in query:

--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -629,7 +629,7 @@ def test_query_yearn_vault_v2_history(rotkehlchen_api_server, ethereum_accounts)
             result = assert_proper_response_with_result(response)
 
     # Make sure some data was saved in the DB after first call
-    events = rotki.data.db.get_all_yearn_vaults_v2_events(TEST_V2_ACC2)
+    events = rotki.data.db.get_yearn_vaults_v2_events(TEST_V2_ACC2, 0, 12770065)
     assert len(events) >= 11
 
     result = result[TEST_V2_ACC2]
@@ -647,5 +647,5 @@ def test_query_yearn_vault_v2_history(rotkehlchen_api_server, ethereum_accounts)
         module_name='yearn_vaults_v2',
     ))
     assert_simple_ok_response(response)
-    events = rotki.data.db.get_all_yearn_vaults_v2_events(TEST_V2_ACC2)
+    events = rotki.data.db.get_yearn_vaults_v2_events(TEST_V2_ACC2, 0, 12770065)
     assert len(events) == 0


### PR DESCRIPTION
**Tested that this in fact solves the issue querying information in the kelsos PR**

There was an issue where history for addresses will be empty.
The reason is that we avoid querying the subgraph if it was recently queried
and there was a logic to only query information from database for addresses queried
in the subgraph call.

The effect was that if an adress was recently queried it won't retrieve information
from the database and the result would be empty