### PR TITLE
Fixes invalid date on graph tooltip

### DIFF
--- a/frontend/app/src/components/dashboard/NetworthChart.vue
+++ b/frontend/app/src/components/dashboard/NetworthChart.vue
@@ -281,7 +281,7 @@ export default class NetWorthChart extends Vue {
         BigNumber.ROUND_DOWN
       );
 
-      const time = dayjs(item.label, 'MMM DD, YYYY, h:mm:ss a').format(
+      const time = dayjs(item.label).format(
         this.activeTimeframe.tooltipTimeFormat
       );
 

--- a/frontend/app/src/premium/setup-interface.ts
+++ b/frontend/app/src/premium/setup-interface.ts
@@ -18,8 +18,8 @@ const date: DateUtilities = {
   epoch(): number {
     return dayjs().unix();
   },
-  format(date: string, oldFormat: string, newFormat: string): string {
-    return dayjs(date, oldFormat).format(newFormat);
+  format(date: string, _: string, newFormat: string): string {
+    return dayjs(date).format(newFormat);
   },
   now(format: string): string {
     return dayjs().format(format);


### PR DESCRIPTION
It seems that specifying the format results in an invalid date with dayjs but it can still properly parse the date if you completely remove the format.