### PR TITLE
Add metadata for grants

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8597,28 +8597,37 @@ Gitcoin gather event data
       Content-Type: application/json
 
       {
-          "result": [{
-	      "timestamp": 1624791600,
-	      "amount": "0.00053",
-	      "asset": "ETH",
-	      "usd_value": "1.55",
-	      "grant_id": 149,
-	      "tx_id": "0x00298f72ad40167051e111e6dc2924de08cce7cf0ad00d04ad5a9e58426536a1",
-	      "tx_type": "ethereum",
-	      "clr_round": null,
-	  }, {
-	      "timestamp": 1624791600,
-	      "amount": "5",
-	      "asset": "_ceth_0x6B175474E89094C44Da98b954EedeAC495271d0F",
-	      "usd_value": "5.01",
-	      "grant_id": 149,
-	      "tx_id": "5612f84bc20cda25b911af39b792c973bdd5916b3b6868db2420b5dafd705a90",
-	      "tx_type": "zksync",
-	      "clr_round": 9,
-	  }],
+          "result": {
+              149: {
+                  "events": [{
+                      "timestamp": 1624791600,
+                      "amount": "0.00053",
+                      "asset": "ETH",
+                      "usd_value": "1.55",
+                      "grant_id": 149,
+                      "tx_id": "0x00298f72ad40167051e111e6dc2924de08cce7cf0ad00d04ad5a9e58426536a1",
+                      "tx_type": "ethereum",
+                      "clr_round": null,
+                  }, {
+                      "timestamp": 1624791600,
+                      "amount": "5",
+                      "asset": "_ceth_0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                      "usd_value": "5.01",
+                      "grant_id": 149,
+                      "tx_id": "5612f84bc20cda25b911af39b792c973bdd5916b3b6868db2420b5dafd705a90",
+                      "tx_type": "zksync",
+                      "clr_round": 9,
+                  }],
+                  "name": "rotki",
+		  "created_on": 1624791600
+             }
+          },
           "message": ""
       }
 
+   :resjson object result: A mapping of integer grant ids to events, grant name and created_on.
+   :resjson string name: The name of the grant
+   :resjson integer created_on: The timestamp the grant was created in
    :resjson integer timestamp: The timestamp of the event
    :resjson string amount: The amount donated in asset
    :resjson string asset: The identifier of the donated asset.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3143,7 +3143,7 @@ class RestAPI():
     ) -> Dict[str, Any]:
         api = GitcoinAPI(self.rotkehlchen.data.db)
         try:
-            actions = api.query_grant_history(
+            grantid_to_data = api.query_grant_history(
                 from_ts=from_timestamp,
                 to_ts=to_timestamp,
                 grant_id=grant_id,
@@ -3154,11 +3154,7 @@ class RestAPI():
         except InputError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_REQUEST}
 
-        serialized_result = []
-        for action in actions:
-            serialized_result.append(action.serialize_for_gitcoin())
-
-        return {'result': serialized_result, 'message': '', 'status_code': HTTPStatus.OK}
+        return {'result': grantid_to_data, 'message': '', 'status_code': HTTPStatus.OK}
 
     @require_premium_user(active_check=False)
     def get_gitcoin_events(

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -427,6 +427,14 @@ CREATE TABLE IF NOT EXISTS ledger_actions_gitcoin_data (
 );
 """  # noqa: E501
 
+DB_CREATE_GITCOIN_GRANT_METADATA = """
+CREATE TABLE IF NOT EXISTS gitcoin_grant_metadata (
+    grant_id INTEGER NOT NULL PRIMARY KEY,
+    grant_name TEXT NOT NULL,
+    created_on INTEGER NOT NULL
+);
+"""
+
 DB_CREATE_ETHEREUM_TRANSACTIONS = """
 CREATE TABLE IF NOT EXISTS ethereum_transactions (
     tx_hash BLOB,
@@ -587,7 +595,7 @@ CREATE TABLE IF NOT EXISTS balancer_events (
 DB_SCRIPT_CREATE_TABLES = """
 PRAGMA foreign_keys=off;
 BEGIN TRANSACTION;
-{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}
+{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}
 COMMIT;
 PRAGMA foreign_keys=on;
 """.format(
@@ -629,4 +637,5 @@ PRAGMA foreign_keys=on;
     DB_CREATE_BALANCER_EVENTS,
     DB_CREATE_LEDGER_ACTIONS_GITCOIN_DATA,
     DB_CREATE_GITCOIN_TX_TYPE,
+    DB_CREATE_GITCOIN_GRANT_METADATA,
 )

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -124,6 +124,7 @@ TABLES_AT_INIT = [
     'balancer_events',
     'ledger_actions_gitcoin_data',
     'gitcoin_tx_type',
+    'gitcoin_grant_metadata',
 ]
 
 

--- a/rotkehlchen/tests/db/test_ledger_actions.py
+++ b/rotkehlchen/tests/db/test_ledger_actions.py
@@ -1,0 +1,28 @@
+from rotkehlchen.db.ledger_actions import DBLedgerActions, GitcoinGrantMetadata
+
+
+def test_gitcoin_metadata(database):
+    db = DBLedgerActions(database, database.msg_aggregator)
+    db.set_gitcoin_grant_metadata(
+        grant_id=1, name='foo', created_on=1,
+    )
+    result = db.get_gitcoin_grant_metadata(1)
+    assert result == {1: GitcoinGrantMetadata(grant_id=1, name='foo', created_on=1)}
+
+    # change existing grant metadata
+    db.set_gitcoin_grant_metadata(
+        grant_id=1, name='newfoo', created_on=2,
+    )
+    result = db.get_gitcoin_grant_metadata(1)
+    assert result == {1: GitcoinGrantMetadata(grant_id=1, name='newfoo', created_on=2)}
+
+    # add 2nd grant and check we can get both back
+    db.set_gitcoin_grant_metadata(
+        grant_id=2, name='boo', created_on=3,
+    )
+    result = db.get_gitcoin_grant_metadata(2)
+    assert result == {2: GitcoinGrantMetadata(grant_id=2, name='boo', created_on=3)}
+    assert db.get_gitcoin_grant_metadata() == {
+        1: GitcoinGrantMetadata(grant_id=1, name='newfoo', created_on=2),
+        2: GitcoinGrantMetadata(grant_id=2, name='boo', created_on=3),
+    }


### PR DESCRIPTION
Events will now return an object per grant and will contain metadata such as name and created_on for each grant.