### PR TITLE
Upgrade pep8-naming and disable its exception naming warning

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -10,5 +10,5 @@ flake8-comprehensions==3.5.0
 flake8-debugger==4.0.0
 flake8-executable==2.1.1
 flake8-mutable==1.2.0
-pep8-naming==0.11.1
+pep8-naming==0.12.0
 isort==5.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 99
-ignore = E731, E402, W504
+ignore = E731, E402, W504, N818
 
 [isort]
 line_length=99


### PR DESCRIPTION
Disabling N818 suggestion. Really not required to have the "Error"
suffix on every single exception.

```
flake8 rotkehlchen/ tools/data_faker
rotkehlchen/errors.py:27:8: N818 exception name 'IncorrectApiKeyFormat' should be named with an Error suffix
rotkehlchen/errors.py:31:8: N818 exception name 'UnableToDecryptRemoteData' should be named with an Error suffix
rotkehlchen/errors.py:55:8: N818 exception name 'PriceQueryUnsupportedAsset' should be named with an Error suffix
rotkehlchen/errors.py:62:8: N818 exception name 'UnprocessableTradePair' should be named with an Error suffix
rotkehlchen/errors.py:68:8: N818 exception name 'UnknownAsset' should be named with an Error suffix
rotkehlchen/errors.py:74:8: N818 exception name 'UnsupportedAsset' should be named with an Error suffix
rotkehlchen/errors.py:88:8: N818 exception name 'NoPriceForGivenTimestamp' should be named with an Error suffix
rotkehlchen/errors.py:120:8: N818 exception name 'ModuleInitializationFailure' should be named with an Error suffix
rotkehlchen/errors.py:124:8: N818 exception name 'ModuleInactive' should be named with an Error suffix
rotkehlchen/chain/ethereum/modules/l2/loopring.py:278:8: N818 exception name 'LoopringInvalidApiKey' should be named with an Error suffix
rotkehlchen/chain/ethereum/modules/l2/loopring.py:282:8: N818 exception name 'LoopringUserNotFound' should be named with an Error suffix
rotkehlchen/chain/ethereum/gitcoin/api.py:39:8: N818 exception name 'ZeroGitcoinAmount' should be named with an Error suffix
rotkehlchen/data/importer.py:38:8: N818 exception name
'UnsupportedCSVEntry' should be named with an Error suffix
```