### PR TITLE
dockerfile fix for aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:lts-alpine as frontend-build-stage
 
 WORKDIR /app
 COPY frontend/ .
+RUN apk add python3 make g++
 RUN npm install -g npm@7 && if ! npm ci --exit-code; then npm ci; fi
 RUN npm run docker:build
 
@@ -23,8 +24,16 @@ RUN git clone https://github.com/sqlcipher/sqlcipher && \
     make install && \
     ldconfig
 
+RUN python3 -m pip install --upgrade pip
 COPY ./requirements.txt /app/requirements.txt
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup default nightly-2021-03-24 
+
 WORKDIR /app
+
+RUN pip install maturin==0.11.2 py-sr25519-bindings==0.1.2 wheel
 RUN pip install -r requirements.txt
 
 COPY . /app


### PR DESCRIPTION
Closes #2280

## Checklist
This PR modified Dockerfile to allow a docker image to be produced on aarch64/armv8/arm64. It maintains compatibility with amd64. Specifically, the following changes were made:
- adds the gcc toolchain in the frontend builder-image allowing the installation of npm dependencies
- adds the correct rust toolchain to the backend builder-image allowing to compile python packages for aarch64

## Some notes about this PR:
- It works on a rpi4 aarch64/arm64 as well as on amd64. Hasn't been tested on armv7.
- The following line of code may be redundant as the libraries are resolved through dependencies in requirements.txt.
`RUN pip install maturin==0.11.2 py-sr25519-bindings==0.1.2 wheel`
I've kept it as installing py-sr25519-bindings==0.1.2 from source does not work on the newest nightly rust toolchain due to the following error: 
```
Step 21/41 : RUN pip install py-sr25519-bindings==0.1.2 maturin==0.11
 ---> Running in 4d825f0c0e5c
Collecting py-sr25519-bindings==0.1.2
  Downloading py_sr25519_bindings-0.1.2.tar.gz (12 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: still running...
    Preparing wheel metadata: finished with status 'done'
Collecting maturin==0.11
  Downloading maturin-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (4.9 MB)
Building wheels for collected packages: py-sr25519-bindings
  Building wheel for py-sr25519-bindings (PEP 517): started
  Building wheel for py-sr25519-bindings (PEP 517): still running...
  Building wheel for py-sr25519-bindings (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /opt/venv/bin/python3 /opt/venv/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmp7bc3s775
       cwd: /tmp/pip-install-v_iy5spp/py-sr25519-bindings_df2dbe500b5e4470bd76b2cfc4b438d3
  Complete output (58 lines):
  Running `maturin pep517 build-wheel -i /opt/venv/bin/python3`
  ⚠  Warning: Please use maturin in pyproject.toml with a version constraint, e.g. `requires = ["maturin>=0.11,<0.12"]`. This will become an error.
     Compiling proc-macro2 v1.0.28
     Compiling unicode-xid v0.2.2
     Compiling syn v1.0.74
     Compiling libc v0.2.98
     Compiling typenum v1.13.0
     Compiling getrandom v0.1.16
     Compiling cfg-if v1.0.0
     Compiling proc-macro-hack v0.5.19
     Compiling serde_derive v1.0.126
     Compiling ryu v1.0.5
     Compiling serde v1.0.126
     Compiling serde_json v1.0.66
     Compiling byteorder v1.4.3
     Compiling regex-syntax v0.6.25
     Compiling byte-tools v0.3.1
     Compiling autocfg v1.0.1
     Compiling itoa v0.4.7
     Compiling inventory v0.1.10
     Compiling unindent v0.1.7
     Compiling scopeguard v1.1.0
     Compiling smallvec v1.6.1
     Compiling cfg-if v0.1.10
     Compiling ppv-lite86 v0.2.10
     Compiling version_check v0.9.3
     Compiling subtle v2.4.1
     Compiling keccak v0.1.0
     Compiling fake-simd v0.1.2
     Compiling opaque-debug v0.2.3
     Compiling arrayvec v0.5.2
     Compiling arrayref v0.3.6
     Compiling block-padding v0.1.5
     Compiling lock_api v0.3.4
     Compiling num-traits v0.2.14
  error: could not compile `lock_api` due to 2 previous errors
  warning: build failed, waiting for other jobs to finish...
  error: build failed
  💥 maturin failed
    Caused by: Failed to build a native library through cargo
    Caused by: Cargo build finished with "exit status: 101": `cargo rustc --message-format json --manifest-path Cargo.toml --release --lib --`
  🔗 Found pyo3 bindings
  🐍 Found CPython 3.7m at /opt/venv/bin/python3
  error[E0557]: feature has been removed
    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.3.4/src/lib.rs:91:42
     |
  91 | #![cfg_attr(feature = "nightly", feature(const_fn))]
     |                                          ^^^^^^^^ feature has been removed
     |
     = note: split into finer-grained feature gates


  error: aborting due to previous error


  For more information about this error, try `rustc --explain E0557`.

  Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/opt/venv/bin/python3'] returned non-zero exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for py-sr25519-bindings
Failed to build py-sr25519-bindings
```