### PR TITLE
Fix query pagination in ammswap

### DIFF
--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/graph.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/graph.py
@@ -8,8 +8,10 @@ MINTS_QUERY = (
             to: $address,
             timestamp_gte: $start_ts,
             timestamp_lte: $end_ts,
+            id_gt: $id,
         }}
     ) {{
+        id
         transaction {{
             id
         }}
@@ -49,8 +51,10 @@ BURNS_QUERY = (
             sender: $address,
             timestamp_gte: $start_ts,
             timestamp_lte: $end_ts,
+            id_gt: $id,
         }}
     ) {{
+        id
         transaction {{
             id
         }}
@@ -90,8 +94,10 @@ SWAPS_QUERY = (
             from: $address,
             timestamp_gte: $start_ts,
             timestamp_lte: $end_ts,
+            id_gt: $id,
         }}
     ) {{
+        id
         transaction {{
             swaps {{
                 id
@@ -133,8 +139,10 @@ SUSHISWAP_SWAPS_QUERY = (
             to: $address,
             timestamp_gte: $start_ts,
             timestamp_lte: $end_ts,
+            id_gt: $id,
         }}
     ) {{
+        id
         transaction {{
             swaps {{
                 id
@@ -195,6 +203,7 @@ LIQUIDITY_POSITIONS_QUERY = (
         where: {{
             user_in: $addresses,
             liquidityTokenBalance_gt: $balance,
+            id_gt: $id,
         }}
     ) {{
         id


### PR DESCRIPTION
## Post mortem

The pagination in the ammswap was being done increasing the offset limit but not moving the start point.

## Solution

Fetch id of all objects and compare to a bigger id when making queries to the graph

## How I verified this PR

I tested it with the big account and either we exhaust the time or get the correct result. Also added a `set` to the code to verify that we were not getting duplicate entries (and then removed it)