### PR TITLE
Some balancer related decimal fixes

### DIFF
--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -709,17 +709,31 @@ class EthereumToken(HasEthereumToken):
         return f'{self.symbol}({self.ethereum_address})'
 
     @classmethod
-    def from_asset(cls: Type[T], asset: Asset) -> Optional[T]:
+    def from_asset(
+            cls: Type[T],
+            asset: Asset,
+            form_with_incomplete_data: bool = False,
+    ) -> Optional[T]:
         """Attempts to turn an asset into an EthereumToken. If it fails returns None"""
-        return cls.from_identifier(asset.identifier)
+        return cls.from_identifier(
+            identifier=asset.identifier,
+            form_with_incomplete_data=form_with_incomplete_data,
+        )
 
     @classmethod
-    def from_identifier(cls: Type[T], identifier: str) -> Optional[T]:
+    def from_identifier(
+            cls: Type[T],
+            identifier: str,
+            form_with_incomplete_data: bool = False,
+    ) -> Optional[T]:
         """Attempts to turn an asset into an EthereumToken. If it fails returns None"""
         if not identifier.startswith(ETHEREUM_DIRECTIVE):
             return None
 
         try:
-            return cls(identifier[ETHEREUM_DIRECTIVE_LENGTH:])
+            return cls(
+                identifier[ETHEREUM_DIRECTIVE_LENGTH:],
+                form_with_incomplete_data=form_with_incomplete_data,
+            )
         except DeserializationError:
             return None

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -39,6 +39,7 @@ def get_or_create_ethereum_token(
         decimals: Optional[int] = None,
         protocol: Optional[str] = None,
         underlying_tokens: Optional[List[UnderlyingToken]] = None,
+        form_with_incomplete_data: bool = False
 ) -> EthereumToken:
     """Given a token symbol and address return the <EthereumToken>
 
@@ -47,7 +48,7 @@ def get_or_create_ethereum_token(
     existing token will still be silently returned
     """
     try:
-        ethereum_token = EthereumToken(ethereum_address)
+        ethereum_token = EthereumToken(ethereum_address, form_with_incomplete_data)
     except (UnknownAsset, DeserializationError):
         log.info(
             f'Encountered unknown asset {symbol} with address '

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -39,7 +39,7 @@ def get_or_create_ethereum_token(
         decimals: Optional[int] = None,
         protocol: Optional[str] = None,
         underlying_tokens: Optional[List[UnderlyingToken]] = None,
-        form_with_incomplete_data: bool = False
+        form_with_incomplete_data: bool = False,
 ) -> EthereumToken:
     """Given a token symbol and address return the <EthereumToken>
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -864,10 +864,11 @@ class Balancer(EthereumModule):
                             self.msg_aggregator.add_error(
                                 f"Failed to request the USD price of {token.identifier} at "
                                 f"timestamp {invest_event.timestamp}. The USD price of the "
-                                f"Balancer {event_type} for the pool {bpt_event.pool_address} "
+                                f"Balancer {event_type} for the pool {bpt_event.pool_address_token.ethereum_address} "  # noqa: E501
                                 f"at transaction {bpt_event.tx_hash} can't be calculated and "
                                 f"it will be set to zero.",
                             )
+
                 if is_missing_token_price is True:
                     lp_balance.usd_value = ZERO
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -101,7 +101,9 @@ def deserialize_bpt_event(
         ethereum_address=pool_address,
         symbol='BPT',
         protocol='balancer',
+        decimals=18,  # all BPT tokens have 18 decimals
         underlying_tokens=underlying_tokens,
+        form_with_incomplete_data=True,  # since some may not have decimals input correctly
     )
     bpt_event = BalancerBPTEvent(
         tx_hash=tx_hash,
@@ -228,7 +230,9 @@ def deserialize_pool_share(
         symbol='BPT',
         ethereum_address=pool_address,
         protocol='balancer',
+        decimals=18,  # All BPT tokens have 18 decimals
         underlying_tokens=pool_tokens,
+        form_with_incomplete_data=True,  # since some may not have had decimals input correctly
     )
     pool = BalancerPoolBalance(
         pool_token=balancer_pool_token,

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -46,7 +46,10 @@ ENS_RESOLVER_ABI_MULTICHAIN_ADDRESS = [
 ]
 
 
-def token_normalized_value_decimals(token_amount: int, token_decimals: int) -> FVal:
+def token_normalized_value_decimals(token_amount: int, token_decimals: Optional[int]) -> FVal:
+    if token_decimals is None:  # if somehow no info on decimals ends up here assume 18
+        token_decimals = 18
+
     return token_amount / (FVal(10) ** FVal(token_decimals))
 
 

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -39,7 +39,7 @@ def query_usd_price_or_use_default(
         )
     except (RemoteError, NoPriceForGivenTimestamp):
         log.error(
-            f'Could not query usd price for {asset.identifier} and time {time}'
+            f'Could not query usd price for {asset.identifier} and time {time} '
             f'when processing {location}. Assuming price of ${str(default_value)}',
         )
         usd_price = Price(default_value)


### PR DESCRIPTION
- If a token somehow ended up with null decimals count it as 18
- Always instantiate BPT tokens with 18 decimals. They always have 18.
- Consider BPT tokens from the DB as existing even with incomplete
  data (possibly due to the decimals)