### PR TITLE
More balancer related fixes

### DIFF
--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -712,7 +712,7 @@ class EthereumToken(HasEthereumToken):
     def from_asset(
             cls: Type[T],
             asset: Asset,
-            form_with_incomplete_data: bool = False,
+            form_with_incomplete_data: bool = True,
     ) -> Optional[T]:
         """Attempts to turn an asset into an EthereumToken. If it fails returns None"""
         return cls.from_identifier(
@@ -724,7 +724,7 @@ class EthereumToken(HasEthereumToken):
     def from_identifier(
             cls: Type[T],
             identifier: str,
-            form_with_incomplete_data: bool = False,
+            form_with_incomplete_data: bool = True,
     ) -> Optional[T]:
         """Attempts to turn an asset into an EthereumToken. If it fails returns None"""
         if not identifier.startswith(ETHEREUM_DIRECTIVE):

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -613,15 +613,19 @@ class Balancer(EthereumModule):
                 try:
                     amm_swap = deserialize_swap(self.database, raw_swap)
                 except DeserializationError as e:
+                    error = str(e)
+                    self.msg_aggregator.add_error(
+                        f'Failed to deserialize a balancer swap due to {error}. Check logs for more details',  # noqa: E501
+                    )
                     log.error(
                         'Failed to deserialize a balancer swap',
-                        error=str(e),
+                        error=error,
                         raw_swap=raw_swap,
                         start_ts=start_ts,
                         end_ts=end_ts,
                         param_values=param_values,
                     )
-                    raise RemoteError('Failed to deserialize balancer trades') from e
+                    continue
 
                 address_to_unique_swaps[amm_swap.address].add(amm_swap)
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -288,12 +288,21 @@ def deserialize_swap(userdb: 'DBHandler', raw_swap: Dict[str, Any]) -> AMMSwap:
     if len(raw_tokens) != 0:
         try:
             raw_address_tokens = {raw_token['address']: raw_token for raw_token in raw_tokens}
-            raw_token0 = raw_address_tokens[raw_token_in_address]
-            raw_token1 = raw_address_tokens[raw_token_out_address]
-            token0_name = raw_token0['name']
-            token0_decimals = raw_token0['decimals']
-            token1_name = raw_token1['name']
-            token1_decimals = raw_token1['decimals']
+            raw_token0 = raw_address_tokens.get(raw_token_in_address)
+            raw_token1 = raw_address_tokens.get(raw_token_out_address)
+            if raw_token0 is not None:
+                token0_name = raw_token0['name']
+                token0_decimals = raw_token0['decimals']
+            else:
+                token0_name = None
+                token0_decimals = None
+            if raw_token1 is not None:
+                token1_name = raw_token1['name']
+                token1_decimals = raw_token1['decimals']
+            else:
+                token1_name = None
+                token1_decimals = None
+
         except KeyError as e:
             raise DeserializationError(f'Missing key: {str(e)}.') from e
     else:

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -128,7 +128,10 @@ class EthTokens():
         for asset in ignored_assets:  # don't query for the ignored tokens
             if asset.is_eth_token():  # type ignore since we know asset is a token
                 exceptions.append(EthereumToken.from_asset(asset).ethereum_address)  # type: ignore
-        all_tokens = GlobalDBHandler().get_ethereum_tokens(exceptions=exceptions)
+        all_tokens = GlobalDBHandler().get_ethereum_tokens(
+            exceptions=exceptions,
+            except_protocols=['balancer'],
+        )
         # With etherscan with chunks > 120, we get request uri too large
         # so the limitation is not in the gas, but in the request uri length
         etherscan_chunks = list(get_chunks(all_tokens, n=ETHERSCAN_MAX_TOKEN_CHUNK_LENGTH))

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -533,7 +533,7 @@ class GlobalDBHandler():
 
             if except_protocols is not None:
                 questionmarks = '?' * len(except_protocols)
-                querystr_additions.append(f'B.protocol NOT IN ({",".join(questionmarks)}) ')
+                querystr_additions.append(f'(B.protocol NOT IN ({",".join(questionmarks)}) OR B.protocol IS NULL) ')  # noqa: E501
                 bindings_list.extend(except_protocols)
 
             querystr += 'WHERE ' + 'AND '.join(querystr_additions) + ';'
@@ -542,7 +542,6 @@ class GlobalDBHandler():
             querystr += ';'
             bindings = ()
 
-        log.debug(f'querystr: {querystr}, bindings: {bindings}')
         query = cursor.execute(querystr, bindings)
         tokens = []
         for entry in query:

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -340,6 +340,14 @@ class AssetsUpdater():
                 local_data = AssetResolver().get_asset_data(local_asset.identifier, False)
                 self.conflicts.append((local_data, remote_asset_data))
 
+        # special case upgrade that should be temporary, until we make non-asset specific
+        # update lines possible in our update mechanism:
+        # https://github.com/rotki/assets/pull/49
+        if version == 7:
+            cursor.execute(
+                'UPDATE ethereum_tokens SET decimals=18 WHERE protocol=="balancer";',
+            )
+
         # at the very end update the current version in the DB
         cursor.execute(
             'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',


### PR DESCRIPTION
- Ignore balancer protocol tokens from all tokens query
- Don't kill balancer trade query thread for a swap read error
- If a balancer pool misses a token just ignore its details
- Add test for balancer swap on pool with only 1 token