### PR TITLE
Makes the asset name nullable and adds checks

### DIFF
--- a/frontend/app/src/components/asset-manager/AssetForm.vue
+++ b/frontend/app/src/components/asset-manager/AssetForm.vue
@@ -389,7 +389,7 @@ export default class AssetForm extends Vue {
       return;
     }
 
-    this.name = token.name;
+    this.name = token.name ?? '';
     this.symbol = token.symbol;
     this.identifier = token.identifier ?? '';
     this.swappedFor = token.swappedFor ?? '';

--- a/frontend/app/src/components/asset-manager/AssetTable.vue
+++ b/frontend/app/src/components/asset-manager/AssetTable.vue
@@ -181,7 +181,7 @@ export default class AssetTable extends Vue {
       return true;
     }
     const keyword = search?.toLocaleLowerCase()?.trim() ?? '';
-    const name = item.name.toLocaleLowerCase().trim();
+    const name = item.name?.toLocaleLowerCase().trim() ?? '';
     const symbol = item.symbol.toLocaleLowerCase().trim();
     return symbol.indexOf(keyword) >= 0 || name.indexOf(keyword) >= 0;
   }

--- a/frontend/app/src/components/helper/AssetDetailsBase.vue
+++ b/frontend/app/src/components/helper/AssetDetailsBase.vue
@@ -67,7 +67,7 @@ export default class AssetDetailsBase extends Vue {
   }
 
   get fullName(): string {
-    return this.asset.name;
+    return this.asset.name ?? '';
   }
 
   get name(): string {

--- a/frontend/app/src/utils/assets.ts
+++ b/frontend/app/src/utils/assets.ts
@@ -40,7 +40,7 @@ function levenshtein(a: string, b: string) {
 
 function score(keyword: string, { name, symbol }: ManagedAsset): number {
   const symbolScore = levenshtein(keyword, symbol.toLocaleLowerCase());
-  const nameScore = levenshtein(keyword, name.toLocaleLowerCase());
+  const nameScore = name ? levenshtein(keyword, name.toLocaleLowerCase()) : 0;
   return Math.min(symbolScore, nameScore);
 }
 

--- a/frontend/common/src/data/index.ts
+++ b/frontend/common/src/data/index.ts
@@ -10,7 +10,7 @@ export interface BaseAsset {
   readonly coingecko?: Nullable<string>;
   readonly cryptocompare?: string;
   readonly started?: Nullable<number>;
-  readonly name: string;
+  readonly name: Nullable<string>;
   readonly symbol: string;
   readonly swappedFor?: Nullable<string>;
 }


### PR DESCRIPTION
It should fix an issue where the Balancer pools would break the asset search due to null name