### PR TITLE
Implement backend API endpoint to query NFTs owned by all tracked addresses

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8753,3 +8753,70 @@ Gitcoin report
    :statuscode 400: Provided JSON or data is in some way malformed.
    :statuscode 409: User is not logged in.
    :statuscode 500: Internal rotki error
+
+
+Querying  NFTs
+============================
+
+.. http:get:: /api/(version)/nfts
+
+   .. note::
+      This endpoint also accepts parameters as query arguments.
+
+   .. note::
+      This endpoint can also be queried asynchronously by using ``"async_query": true``
+
+   Doing a GET on the NFTs endpoint will query all NFTs for all user tracked addresses.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      GET /api/1/nfts HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {"async_query": false}
+
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      { "result":
+            "addresses": {
+	        "0xeE3766e4F996DC0e0F8c929954EAAFef3441de87": [{
+	            "token_identifier": "8636",
+	            "name": "BASTARD GAN PUNK V2 #8636",
+	            "background_color": null,
+	            "image_url": "https://lh3.googleusercontent.com/kwF-39qZlluEalQnNv-yMxbntzNdc3g00pK2xALkpoir9ooWttVUO2hVFWOgPtOkJOHufYRajfn-nNFdjruRQ4YaMgOYHEB8E4CdjBk",
+	            "external_link": "https://www.bastardganpunks.club/v2/8636",
+	            "price_eth": "0.025",
+	            "price_usd": "250"
+		}]
+	    },
+            "entries_found": 95,
+            "entries_limit": 500,
+        "message": ""
+      }
+
+
+   :resjson object addresses: A mapping of ethereum addresses to list of owned NFTs.
+   :resjson int entries_found: The number of NFT entries found. If non-premium and the free limit has been hit this will be equal to the limit, since we stop searching after the limit.
+   :resjson int entries_limit: The free limit for NFTs.
+   :resjson string token_identifier: The identifier of the specific NFT token for the given contract type. This is not a unique id across all NFTs.
+   :resjson string background_color: [Optional]. A color for the background of the image of the NFT. Can be Null.
+   :resjson string image_url: [Optional]. Link to the image of the NFT. Can be Null.
+   :resjson string name: [ Optional] The name of the NFT. Can be Null.
+   :resjson string external_link: [Optional]. A link to the page of the creator of the NFT. Can be Null.
+   :resjson string permalink: [Optional]. A link to the NFT in opensea.
+   :resjson string price_eth: The last known price of the NFT in ETH. Can be zero.
+   :resjson string price_usd: The last known price of the NFT in USD. Can be zero.
+   :statuscode 200: NFTs succesfully queried
+   :statuscode 400: Provided JSON is in some way malformed
+   :statuscode 409: User is not logged in or some other error. Check error message for details.
+   :statuscode 500: Internal rotki error
+   :statuscode 502: An external service used in the query such as opensea could not be reached or returned unexpected response.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3411,3 +3411,27 @@ class RestAPI():
         # Success
         result_dict = _wrap_in_result(result, msg)
         return api_response(result_dict, status_code=status_code)
+
+    def _get_nfts(self) -> Dict[str, Any]:
+        result: Optional[Dict[str, Any]]
+        try:
+            result = self.rotkehlchen.chain_manager.get_all_nfts()
+            msg = ''
+            status_code = HTTPStatus.OK
+        except RemoteError as e:
+            result = None
+            msg = str(e)
+            status_code = HTTPStatus.BAD_GATEWAY
+
+        return {'result': result, 'message': msg, 'status_code': status_code}
+
+    @require_loggedin_user()
+    def get_nfts(self, async_query: bool) -> Response:
+        if async_query:
+            return self._query_async(command='_get_nfts')
+
+        response = self._get_nfts()
+        return api_response(
+            result={'result': response['result'], 'message': response['message']},
+            status_code=response['status_code'],
+        )

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -29,6 +29,7 @@ from rotkehlchen.api.v1.resources import (
     AssetsTypesResource,
     AssetUpdatesResource,
     AsyncTasksResource,
+    AvalancheTransactionsResource,
     BalancerBalancesResource,
     BalancerEventsHistoryResource,
     BalancerTradesHistoryResource,
@@ -43,6 +44,7 @@ from rotkehlchen.api.v1.resources import (
     DataImportResource,
     DefiBalancesResource,
     ERC20TokenInfo,
+    ERC20TokenInfoAVAX,
     Eth2StakeDepositsResource,
     Eth2StakeDetailsResource,
     EthereumAirdropsResource,
@@ -75,19 +77,20 @@ from rotkehlchen.api.v1.resources import (
     MessagesResource,
     NamedEthereumModuleDataResource,
     NamedOracleCacheResource,
+    NFTSResource,
     OraclesResource,
     OwnedAssetsResource,
     PeriodicDataResource,
     PingResource,
     QueriedAddressesResource,
     SettingsResource,
-    SushiswapBalancesResource,
-    SushiswapEventsHistoryResource,
-    SushiswapTradesHistoryResource,
     StatisticsAssetBalanceResource,
     StatisticsNetvalueResource,
     StatisticsRendererResource,
     StatisticsValueDistributionResource,
+    SushiswapBalancesResource,
+    SushiswapEventsHistoryResource,
+    SushiswapTradesHistoryResource,
     TagsResource,
     TradesResource,
     UniswapBalancesResource,
@@ -104,8 +107,6 @@ from rotkehlchen.api.v1.resources import (
     YearnVaultsV2BalancesResource,
     YearnVaultsV2HistoryResource,
     create_blueprint,
-    AvalancheTransactionsResource,
-    ERC20TokenInfoAVAX,
 )
 from rotkehlchen.api.websockets.notifier import RotkiNotifier, RotkiWSApp
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -229,6 +230,7 @@ URLS_V1: URLS = [
     ('/import', DataImportResource),
     ('/gitcoin/events', GitcoinEventsResource),
     ('/gitcoin/report', GitcoinReportResource),
+    ('/nfts', NFTSResource),
 ]
 
 logger = logging.getLogger(__name__)

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -25,6 +25,7 @@ from rotkehlchen.api.v1.encoding import (
     AsyncHistoricalQuerySchema,
     AsyncQueryArgumentSchema,
     AsyncTasksQuerySchema,
+    AvalancheTransactionQuerySchema,
     BaseXpubSchema,
     BinanceMarketsUserSchema,
     BlockchainAccountsDeleteSchema,
@@ -90,7 +91,6 @@ from rotkehlchen.api.v1.encoding import (
     WatchersEditSchema,
     XpubAddSchema,
     XpubPatchSchema,
-    AvalancheTransactionQuerySchema,
 )
 from rotkehlchen.api.v1.parser import resource_parser
 from rotkehlchen.assets.asset import Asset, EthereumToken
@@ -1818,3 +1818,11 @@ class ERC20TokenInfoAVAX(BaseResource):
     @use_kwargs(get_schema, location='json_and_query')
     def get(self, address: ChecksumEthAddress, async_query: bool) -> Response:
         return self.rest_api.get_avax_token_information(address, async_query)
+
+
+class NFTSResource(BaseResource):
+    get_schema = AsyncQueryArgumentSchema()
+
+    @use_kwargs(get_schema, location='json_and_query')
+    def get(self, async_query: bool) -> Response:
+        return self.rest_api.get_nfts(async_query)

--- a/rotkehlchen/chain/ethereum/nft.py
+++ b/rotkehlchen/chain/ethereum/nft.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, List, NamedTuple
+
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.externalapis.opensea import NFT, Opensea
+from rotkehlchen.typing import ChecksumEthAddress
+from rotkehlchen.user_messages import MessagesAggregator
+
+FREE_NFT_LIMIT = 5
+
+
+class NFTResult(NamedTuple):
+    addresses: Dict[ChecksumEthAddress, List[NFT]]
+    entries_found: int
+    entries_limit: int
+
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            'addresses': {address: [x.serialize() for x in nfts] for address, nfts in self.addresses.items()},  # noqa: E501
+            'entries_found': self.entries_found,
+            'entries_limit': self.entries_limit,
+        }
+
+
+class NFTManager():
+
+    def __init__(
+            self,
+            database: DBHandler,
+            msg_aggregator: MessagesAggregator,
+    ) -> None:
+        self.opensea = Opensea(database=database, msg_aggregator=msg_aggregator)
+
+    def get_all_nfts(
+            self,
+            addresses: List[ChecksumEthAddress],
+            has_premium: bool,
+    ) -> NFTResult:
+        """Gets all NFTs of the given addresses
+
+        Returns a tuple with:
+        - Mapping of addresses to list of NFTs
+        - Total NFTs found - integer
+        - Limit for free NFTs - integer
+
+        May raise:
+        - RemoteError
+        """
+
+        result = {}
+        total_nfts_num = 0
+        for address in addresses:
+            nfts = self.opensea.get_account_nfts(address)
+            nfts_num = len(nfts)
+            if nfts_num != 0:
+                if has_premium is False:
+                    if nfts_num + total_nfts_num > FREE_NFT_LIMIT:
+                        remaining_size = FREE_NFT_LIMIT - total_nfts_num
+                    else:
+                        remaining_size = nfts_num
+                    if remaining_size != 0:
+                        result[address] = nfts[:remaining_size]
+                        total_nfts_num += remaining_size
+
+                    break  # we hit the nft limit
+
+                result[address] = nfts
+                total_nfts_num += nfts_num
+
+        return NFTResult(
+            addresses=result,
+            entries_found=total_nfts_num,
+            entries_limit=FREE_NFT_LIMIT,
+        )

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -49,6 +49,7 @@ from rotkehlchen.chain.ethereum.modules import (
     YearnVaults,
     YearnVaultsV2,
 )
+from rotkehlchen.chain.ethereum.nft import NFTManager
 from rotkehlchen.chain.ethereum.tokens import EthTokens
 from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.chain.substrate.manager import wait_until_a_node_is_available
@@ -335,6 +336,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
             ethereum_manager=self.ethereum,
             msg_aggregator=self.msg_aggregator,
         )
+        self.nft_manager = NFTManager(database=self.database, msg_aggregator=self.msg_aggregator)
 
     def __del__(self) -> None:
         del self.ethereum
@@ -498,6 +500,13 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
             raise InputError(
                 f'Blockchain account/s {",".join(existing_accounts)} already exist',
             )
+
+    def get_all_nfts(self) -> Dict[str, Any]:
+        result = self.nft_manager.get_all_nfts(
+            addresses=self.accounts.eth,
+            has_premium=self.premium is not None,
+        )
+        return result.serialize()
 
     @protect_with_lock(arguments_matter=True)
     @cache_response_timewise()

--- a/rotkehlchen/externalapis/covalent.py
+++ b/rotkehlchen/externalapis/covalent.py
@@ -4,15 +4,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from rotkehlchen.constants.timing import (
-    DEFAULT_TIMEOUT_TUPLE,
-)
+from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
 from rotkehlchen.errors import DeserializationError, RemoteError
+from rotkehlchen.externalapis.utils import read_integer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, CovalentTransaction, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
-from rotkehlchen.utils.misc import ts_now, create_timestamp
-from rotkehlchen.externalapis.utils import read_integer
+from rotkehlchen.utils.misc import create_timestamp, ts_now
 
 COVALENT_QUERY_LIMIT = 1000
 CONST_RETRY = 1
@@ -69,9 +67,11 @@ def convert_transaction_from_covalent(
 
 
 class Covalent():
-    def __init__(self,
-                 msg_aggregator: MessagesAggregator,
-                 chain_id: int) -> None:
+    def __init__(
+            self,
+            msg_aggregator: MessagesAggregator,
+            chain_id: int,
+    ) -> None:
         self.session = requests.session()
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
         self.msg_aggregator = msg_aggregator

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -1,0 +1,190 @@
+import json
+import logging
+from json.decoder import JSONDecodeError
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+
+import gevent
+import requests
+from eth_utils import to_checksum_address
+
+from rotkehlchen.assets.asset import EthereumToken
+from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset
+from rotkehlchen.externalapis.interface import ExternalServiceWithApiKey
+from rotkehlchen.fval import FVal
+from rotkehlchen.typing import ChecksumEthAddress, ExternalService
+from rotkehlchen.user_messages import MessagesAggregator
+
+MAX_LIMIT = 50  # according to opensea docs
+
+logger = logging.getLogger(__name__)
+
+
+class NFT(NamedTuple):
+    token_identifier: str
+    background_color: Optional[str]
+    image_url: Optional[str]
+    name: Optional[str]
+    external_link: Optional[str]
+    permalink: Optional[str]
+    price_eth: FVal
+    price_usd: FVal
+
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            'token_identifier': self.token_identifier,
+            'background_color': self.background_color,
+            'image_url': self.image_url if self.image_url not in (None, '') else None,
+            'name': self.name,
+            'external_link': self.external_link,
+            'permalink': self.permalink,
+            'price_eth': str(self.price_eth),
+            'price_usd': str(self.price_usd),
+        }
+
+    @staticmethod
+    def deserialize(entry: Dict[str, Any]) -> 'NFT':
+        """May raise:
+
+        - DeserializationError if the given dict can't be deserialized
+        - UnknownAsset if the given payment token isn't known
+        """
+        if not isinstance(entry, dict):
+            raise DeserializationError(
+                f'Failed to deserialize NFT value from non dict value: {entry}',
+            )
+
+        try:
+            last_sale = entry.get('last_sale')
+            if last_sale:
+                if last_sale['payment_token']['symbol'] == 'ETH':
+                    payment_token = A_ETH
+                else:
+                    payment_token = EthereumToken(
+                        to_checksum_address(last_sale['payment_token']['symbol']),
+                    )
+
+                amount = asset_normalized_value(int(last_sale['total_price']), payment_token)
+                usd_price = FVal(last_sale['payment_token']['usd_price'])
+                eth_price = FVal(last_sale['payment_token']['eth_price'])
+                price_in_eth = amount * eth_price
+                price_in_usd = amount * usd_price
+            else:
+                price_in_eth = ZERO
+                price_in_usd = ZERO
+
+            return NFT(
+                token_identifier=entry['token_id'],
+                background_color=entry['background_color'],
+                image_url=entry['image_url'],
+                name=entry['name'],
+                external_link=entry['external_link'],
+                permalink=entry['permalink'],
+                price_eth=price_in_eth,
+                price_usd=price_in_usd,
+            )
+        except KeyError as e:
+            raise DeserializationError(f'Could not find key {str(e)} when processing Opensea NFT data') from e  # noqa: E501
+
+
+class Opensea(ExternalServiceWithApiKey):
+    """https://docs.opensea.io/reference/api-overview"""
+    def __init__(self, database: DBHandler, msg_aggregator: MessagesAggregator) -> None:
+        super().__init__(database=database, service_name=ExternalService.OPENSEA)
+        self.msg_aggregator = msg_aggregator
+        self.session = requests.session()
+        self.session.headers.update({'User-Agent': 'rotkehlchen'})
+
+    def _query(
+            self,
+            endpoint: str,
+            options: Optional[Dict[str, Any]] = None,
+            timeout: Optional[Tuple[int, int]] = None,
+    ) -> Dict[str, Any]:
+        """May raise RemoteError"""
+        query_str = f'https://api.opensea.io/api/v1/{endpoint}'
+
+        backoff = 1
+        backoff_limit = 33
+        while backoff < backoff_limit:
+            logger.debug(f'Querying opensea: {query_str}')
+            try:
+                response = self.session.get(
+                    query_str,
+                    params=options,
+                    timeout=timeout if timeout else DEFAULT_TIMEOUT_TUPLE,
+                )
+            except requests.exceptions.RequestException as e:
+                raise RemoteError(
+                    f'Opensea API request {response.url} failed due to {str(e)}'
+                    f'with HTTP status code {response.status_code} and text '
+                    f'{response.text}',
+                ) from e
+
+            if response.status_code == 429:
+                logger.debug(
+                    f'Got 429 from opensea. Will backoff for {backoff} seconds',
+                )
+                gevent.sleep(backoff)
+                backoff = backoff * 2
+                if backoff >= backoff_limit:
+                    raise RemoteError(
+                        f'Reached opensea backoff limit after we incrementally backed off '
+                        f'for {response.url}',
+                    )
+                continue
+
+            break  # else we found response so let's break off the loop
+
+        if response.status_code != 200:
+            raise RemoteError(
+                f'Opensea API request {response.url} failed '
+                f'with HTTP status code {response.status_code} and text '
+                f'{response.text}',
+            )
+
+        try:
+            json_ret = json.loads(response.text)
+        except JSONDecodeError as e:
+            raise RemoteError(
+                f'Opensea API request {response.url} returned invalid '
+                f'JSON response: {response.text}',
+            ) from e
+
+        return json_ret
+
+    def get_account_nfts(self, account: ChecksumEthAddress) -> List[NFT]:
+        """May raise RemoteError"""
+        offset = 0
+        options = {'order_direction': 'desc', 'offset': offset, 'limit': MAX_LIMIT, 'owner': account}  # noqa: E501
+
+        raw_result = []
+        while True:
+            result = self._query(endpoint='assets', options=options)
+            raw_result.extend(result['assets'])
+            if len(result['assets']) != MAX_LIMIT:
+                break
+
+            # else continue by paginating
+            offset += MAX_LIMIT
+            options['offset'] = offset
+
+        nfts = []
+        for entry in raw_result:
+            try:
+                nfts.append(NFT.deserialize(entry))
+            except (UnknownAsset, DeserializationError) as e:
+                self.msg_aggregator.add_warning(
+                    f'Skipping detected NFT for {account} due to {str(e)}. '
+                    f'Check out logs for more details',
+                )
+                logger.warning(
+                    f'Skipping detected NFT for {account} due to {str(e)}. '
+                    f'Problematic entry: {entry} ',
+                )
+
+        return nfts

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -1,0 +1,57 @@
+import random
+import warnings as test_warnings
+
+import pytest
+import requests
+
+from rotkehlchen.chain.ethereum.nft import FREE_NFT_LIMIT
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.api import (
+    api_url_for,
+    assert_ok_async_response,
+    assert_proper_response_with_result,
+    wait_for_async_task,
+)
+
+TEST_ACC1 = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ACC1]])
+@pytest.mark.parametrize('start_with_valid_premium', [bool(random.getrandbits(1))])
+def test_nft_query(rotkehlchen_api_server, start_with_valid_premium):
+    async_query = bool(random.getrandbits(1))
+    response = requests.get(api_url_for(
+        rotkehlchen_api_server,
+        'nftsresource',
+    ), json={'async_query': async_query})
+    if async_query:
+        task_id = assert_ok_async_response(response)
+        outcome = wait_for_async_task(rotkehlchen_api_server, task_id, timeout=60)
+        assert outcome['message'] == ''
+        result = outcome['result']
+    else:
+        result = assert_proper_response_with_result(response)
+
+    if len(result['addresses']) == 0:
+        test_warnings.warn(UserWarning(f'Test account {TEST_ACC1} has no NFTs'))
+        return
+
+    if start_with_valid_premium is False:
+        assert result['entries_found'] == result['entries_limit']
+    else:
+        assert result['entries_found'] > result['entries_limit']
+    assert result['entries_limit'] == FREE_NFT_LIMIT
+    assert result['entries_found'] == len(result['addresses'][TEST_ACC1])
+
+    # find the one known nft in the nfts list
+    nfts = result['addresses'][TEST_ACC1]
+    for entry in nfts:
+        if entry['token_identifier'] == '8636':
+            assert entry['name'] == 'BASTARD GAN PUNK V2 #8636'
+            assert entry['permalink'] == 'https://opensea.io/assets/0x31385d3520bced94f77aae104b406994d8f2168c/8636'  # noqa: E501
+            assert entry['external_link'] == 'https://www.bastardganpunks.club/v2/8636'
+            assert entry['image_url'] == 'https://lh3.googleusercontent.com/kwF-39qZlluEalQnNv-yMxbntzNdc3g00pK2xALkpoir9ooWttVUO2hVFWOgPtOkJOHufYRajfn-nNFdjruRQ4YaMgOYHEB8E4CdjBk'  # noqa: E501
+            assert FVal(entry['price_eth']) > ZERO
+            assert FVal(entry['price_usd']) > ZERO
+            break

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -161,6 +161,7 @@ def initialize_mock_rotkehlchen_instance(
     if start_with_valid_premium:
         rotki.premium = Premium(rotki_premium_credentials)
         rotki.premium_sync_manager.premium = rotki.premium
+        rotki.chain_manager.premium = rotki.premium
 
     if legacy_messages_via_websockets is False:
         rotki.msg_aggregator.rotki_notifier = None

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -90,6 +90,7 @@ class ExternalService(Enum):
     CRYPTOCOMPARE = 1
     BEACONCHAIN = 2
     LOOPRING = 3
+    OPENSEA = 4
 
     @staticmethod
     def serialize(name: str) -> Optional['ExternalService']:
@@ -101,6 +102,8 @@ class ExternalService(Enum):
             return ExternalService.BEACONCHAIN
         if name == 'loopring':
             return ExternalService.LOOPRING
+        if name == 'opensea':
+            return ExternalService.OPENSEA
         # else
         return None
 


### PR DESCRIPTION
Initial backend work for #1097 

- Create API endpoint that queries Opensea to get data for all NFTs owned by all the tracked addresses
- Add an API test for this
- Add docs for this new API endpoint

Remaining work for later

- Allow user to insert an API key for Opensea
- Frontend @kelsos 
- Figure out if there is a better way to get a price estimate than last opensea sale
- Figure out if these should be part of the dashboard and have their price estimates (last price in opensea) included in user's net value