### PR TITLE
Add the greenlet id to every log call via a log adapter

### DIFF
--- a/rotkehlchen/__main__.py
+++ b/rotkehlchen/__main__.py
@@ -5,12 +5,14 @@ import sys
 import traceback
 
 from rotkehlchen.errors import SystemPermissionError
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.server import RotkehlchenServer
 
 # monkey patch web3's non-thread safe lru cache with our own version
 from rotkehlchen.chain.ethereum import patch_web3  # isort:skip # pylint: disable=unused-import # lgtm[py/unused-import] # noqa
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def main() -> None:

--- a/rotkehlchen/accounting/cost_basis.py
+++ b/rotkehlchen/accounting/cost_basis.py
@@ -263,7 +263,7 @@ class CostBasisCalculator():
         )
         asset_events = self.get_events(asset)
         asset_events.acquisitions.append(event)
-        logger.debug(event)
+        log.debug(event)
 
     def spend_asset(
             self,
@@ -286,7 +286,7 @@ class CostBasisCalculator():
         )
         asset_events = self.get_events(asset)
         asset_events.spends.append(event)
-        logger.debug(event)
+        log.debug(event)
 
     def calculate_spend_cost_basis(
             self,

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -274,7 +274,7 @@ class TaxableEvents():
 
         sold_amount = trade_rate * bought_amount
         if sold_amount == ZERO:
-            logger.error(
+            log.error(
                 f'Not adding a virtual sell event. Could not calculate it from '
                 f'trade_rate * bought_amount = {trade_rate} * {bought_amount}',
             )
@@ -341,7 +341,7 @@ class TaxableEvents():
         if skip_trade:
             return
 
-        logger.debug(
+        log.debug(
             f'Processing buy trade of {bought_asset.identifier} with '
             f'{paid_with_asset.identifier} at {timestamp}',
         )
@@ -504,7 +504,7 @@ class TaxableEvents():
             return
 
         if selling_amount == ZERO:
-            logger.error(
+            log.error(
                 f'Skipping sell trade of {selling_asset.identifier} for '
                 f'{receiving_asset.identifier if receiving_asset else "nothing"} at {timestamp}'
                 f' since the selling amount is 0',
@@ -513,14 +513,14 @@ class TaxableEvents():
 
         if selling_asset.is_fiat():
             # Should be handled by a virtual buy
-            logger.debug(
+            log.debug(
                 f'Skipping sell trade of {selling_asset.identifier} for '
                 f'{receiving_asset.identifier if receiving_asset else "nothing"} at {timestamp} '
                 f'since selling of FIAT of something will just be treated as a buy.',
             )
             return
 
-        logger.debug(
+        log.debug(
             f'Processing sell trade of {selling_asset.identifier} for '
             f'{receiving_asset.identifier if receiving_asset else "nothing"} at {timestamp}',
         )

--- a/rotkehlchen/accounting/ledger_actions.py
+++ b/rotkehlchen/accounting/ledger_actions.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, NamedTuple, Optional
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.errors import DeserializationError
 from rotkehlchen.history.deserialization import deserialize_price
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
     deserialize_optional,
@@ -14,7 +15,8 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.typing import AssetAmount, Location, Price, Timestamp, Tuple
 from rotkehlchen.utils.mixins.dbenum import DBEnumMixIn
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class LedgerActionType(Enum):

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -115,6 +115,9 @@ if TYPE_CHECKING:
     from rotkehlchen.exchanges.kraken import KrakenAccountType
 
 
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
 OK_RESULT = {'result': True, 'message': ''}
 
 
@@ -210,10 +213,6 @@ def require_premium_user(active_check: bool) -> Callable:
     return _require_premium_user
 
 
-logger = logging.getLogger(__name__)
-log = RotkehlchenLogsAdapter(logger)
-
-
 class RestAPI():
     """ The Object holding the logic that runs inside all the API calls"""
     def __init__(self, rotkehlchen: Rotkehlchen) -> None:
@@ -271,12 +270,12 @@ class RestAPI():
             self._write_task_result(task_id, result)
 
     def _do_query_async(self, command: str, task_id: int, **kwargs: Any) -> None:
+        log.debug(f'Async task with task id {task_id} started')
         result = getattr(self, command)(**kwargs)
         self._write_task_result(task_id, result)
 
     def _query_async(self, command: str, **kwargs: Any) -> Response:
         task_id = self._new_task_id()
-
         greenlet = gevent.spawn(
             self._do_query_async,
             command,
@@ -2884,7 +2883,7 @@ class RestAPI():
                     timestamp=timestamp,
                 )
             except (RemoteError, NoPriceForGivenTimestamp) as e:
-                logger.error(
+                log.error(
                     f'Could not query the historical {target_asset.identifier} price for '
                     f'{asset.identifier} at time {timestamp} due to: {str(e)}. Using zero price',
                 )

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -61,6 +61,7 @@ from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.typing import HistoricalPriceOracle
 from rotkehlchen.icons import ALLOWED_ICON_EXTENSIONS
 from rotkehlchen.inquirer import CurrentPriceOracle
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_action_type,
     deserialize_asset_amount,
@@ -92,7 +93,8 @@ if TYPE_CHECKING:
     from rotkehlchen.externalapis.coingecko import Coingecko
     from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class DelimitedOrNormalList(webargs.fields.DelimitedList):

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -7,11 +7,13 @@ from geventwebsocket.exceptions import WebSocketError
 from geventwebsocket.websocket import WebSocket
 
 from rotkehlchen.greenlets import GreenletManager
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
     from rotkehlchen.api.websockets.typedefs import WSMessageType
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def _ws_send_impl(
@@ -25,7 +27,7 @@ def _ws_send_impl(
     try:
         websocket.send(to_send_msg)
     except WebSocketError as e:
-        logger.error(f'Websocket send with message {to_send_msg} failed due to {str(e)}')
+        log.error(f'Websocket send with message {to_send_msg} failed due to {str(e)}')
 
         if failure_callback:
             failure_callback_args = {} if failure_callback_args is None else failure_callback_args  # noqa: E501
@@ -47,13 +49,13 @@ class RotkiNotifier():
         self.subscribers: List[WebSocket] = []
 
     def subscribe(self, websocket: WebSocket) -> None:
-        logger.info(f'Websocket with hash id {hash(websocket)} subscribed to rotki notifier')
+        log.info(f'Websocket with hash id {hash(websocket)} subscribed to rotki notifier')
         self.subscribers.append(websocket)
 
     def unsubscribe(self, websocket: WebSocket) -> None:
         try:
             self.subscribers.remove(websocket)
-            logger.info(f'Websocket with hash id {hash(websocket)} unsubscribed from rotki notifier')  # noqa: E501
+            log.info(f'Websocket with hash id {hash(websocket)} unsubscribed from rotki notifier')  # noqa: E501
         except ValueError:
             pass
 
@@ -110,7 +112,7 @@ class RotkiWSApp(WebSocketApplication):
         try:
             self.ws.send(message, **kwargs)
         except WebSocketError as e:
-            logger.warning(
+            log.warning(
                 f'Got WebSocketError {str(e)} for sending message {message} to a websocket',
             )
 

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -11,11 +11,13 @@ from rotkehlchen.constants.resolver import (
 )
 from rotkehlchen.errors import DeserializationError, UnknownAsset, UnsupportedAsset
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 
 from .typing import AssetType
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 UnderlyingTokenDBTuple = Tuple[str, str]
 

--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -1,12 +1,9 @@
-import logging
 from typing import Dict, Optional
 
 from rotkehlchen.errors import UnknownAsset
 from rotkehlchen.globaldb import GlobalDBHandler
 
 from .typing import AssetData
-
-log = logging.getLogger(__name__)
 
 
 class AssetResolver():

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Optional
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.errors import DeserializationError, UnknownAsset
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress
 
 from .asset import Asset, EthereumToken, UnderlyingToken
@@ -12,7 +13,8 @@ from .typing import AssetType
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def add_ethereum_token_to_db(token_data: EthereumToken) -> EthereumToken:

--- a/rotkehlchen/chain/bitcoin/xpub.py
+++ b/rotkehlchen/chain/bitcoin/xpub.py
@@ -8,13 +8,15 @@ from rotkehlchen.chain.bitcoin.hdkey import HDKey
 from rotkehlchen.db.utils import insert_tag_mappings
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import BlockchainAccountData, BTCAddress, SupportedBlockchain
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.manager import BlockchainBalancesUpdate, ChainManager
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class XpubData(NamedTuple):

--- a/rotkehlchen/chain/ethereum/defi/zerionsdk.py
+++ b/rotkehlchen/chain/ethereum/defi/zerionsdk.py
@@ -19,6 +19,7 @@ from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset, UnsupportedAsset
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer, get_underlying_asset_price
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
 from rotkehlchen.typing import ChecksumEthAddress, Price
 from rotkehlchen.user_messages import MessagesAggregator
@@ -27,7 +28,8 @@ from rotkehlchen.utils.misc import get_chunks
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 PROTOCOLS_QUERY_NUM = 40  # number of protocols to query in a single call

--- a/rotkehlchen/chain/ethereum/eth2_utils.py
+++ b/rotkehlchen/chain/ethereum/eth2_utils.py
@@ -13,11 +13,13 @@ from rotkehlchen.constants.timing import DAY_IN_SECONDS
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import create_timestamp
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class ValidatorBalance(NamedTuple):

--- a/rotkehlchen/chain/ethereum/gitcoin/api.py
+++ b/rotkehlchen/chain/ethereum/gitcoin/api.py
@@ -21,6 +21,7 @@ from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.db.ranges import DBQueryRanges
 from rotkehlchen.errors import DeserializationError, InputError, RemoteError, UnknownAsset
 from rotkehlchen.history.deserialization import deserialize_price
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_int_from_str,
     deserialize_timestamp_from_date,
@@ -34,6 +35,7 @@ NO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class ZeroGitcoinAmount(Exception):
@@ -144,12 +146,12 @@ class GitcoinAPI():
         backoff = 1
         backoff_limit = 33
         while backoff < backoff_limit:
-            logger.debug(f'Querying gitcoin: {query_str}')
+            log.debug(f'Querying gitcoin: {query_str}')
             try:
                 response = self.session.get(query_str, timeout=DEFAULT_TIMEOUT_TUPLE)
             except requests.exceptions.RequestException as e:
                 if 'Max retries exceeded with url' in str(e):
-                    logger.debug(
+                    log.debug(
                         f'Got max retries exceeded from gitcoin. Will '
                         f'backoff for {backoff} seconds.',
                     )
@@ -301,7 +303,7 @@ class GitcoinAPI():
                 msg = str(e)
                 if isinstance(e, KeyError):
                     msg = f'Missing key entry for {msg}.'
-                logger.error(
+                log.error(
                     f'Unexpected data encountered during deserialization of gitcoin api '
                     f'query: {result}. Error was: {msg}',
                 )
@@ -345,7 +347,7 @@ class GitcoinAPI():
                     'Unexpected data encountered during deserialization of a gitcoin '
                     'api query. Check logs for details.',
                 )
-                logger.error(
+                log.error(
                     f'Unexpected data encountered during deserialization of gitcoin api '
                     f'query: {transaction}. Error was: {msg}',
                 )
@@ -357,7 +359,7 @@ class GitcoinAPI():
                 )
                 continue
             except ZeroGitcoinAmount:
-                logger.warning(f'Found gitcoin event with 0 amount for grant {grant_id}. Ignoring')
+                log.warning(f'Found gitcoin event with 0 amount for grant {grant_id}. Ignoring')
                 continue
 
             actions.append(action)

--- a/rotkehlchen/chain/ethereum/gitcoin/importer.py
+++ b/rotkehlchen/chain/ethereum/gitcoin/importer.py
@@ -13,6 +13,7 @@ from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.errors import DeserializationError, UnknownAsset
 from rotkehlchen.history.price import query_usd_price_zero_if_error
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
     deserialize_timestamp_from_date,
@@ -20,6 +21,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.typing import Location, Price
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class GitcoinDataImporter():
@@ -124,7 +126,7 @@ class GitcoinDataImporter():
                         'Unexpected data encountered during deserialization of a gitcoin CSV '
                         'entry. Check logs for details and open a bug report.',
                     )
-                    logger.error(
+                    log.error(
                         f'Unexpected data encountered during deserialization of a gitcoin '
                         f'CSV entry: {row} . Error was: {msg}',
                     )

--- a/rotkehlchen/chain/ethereum/gitcoin/processor.py
+++ b/rotkehlchen/chain/ethereum/gitcoin/processor.py
@@ -12,9 +12,11 @@ from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.errors import NoPriceForGivenTimestamp
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import PriceHistorian
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import Timestamp
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 @dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=False)
@@ -58,7 +60,7 @@ class GitcoinProcessor():
         for entry in actions:
             balance = Balance(amount=entry.amount)
             if entry.rate_asset is None or entry.rate is None:
-                logger.error(
+                log.error(
                     f'Found gitcoin ledger action for {entry.amount} {entry.asset} '
                     f'without a rate asset. Should not happen. Entry was '
                     f'possibly edited by hand. Skipping.',

--- a/rotkehlchen/chain/ethereum/graph.py
+++ b/rotkehlchen/chain/ethereum/graph.py
@@ -11,9 +11,11 @@ from typing_extensions import Literal
 
 from rotkehlchen.constants.timing import QUERY_RETRY_TIMES
 from rotkehlchen.errors import RemoteError
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 GRAPH_QUERY_LIMIT = 1000

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/typing.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/typing.py
@@ -11,6 +11,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.errors import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
     deserialize_ethereum_token_from_db,
@@ -18,7 +19,8 @@ from rotkehlchen.serialization.deserialize import (
 )
 from rotkehlchen.typing import AssetAmount, ChecksumEthAddress, Price, Timestamp
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 # Get balances

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/utils.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/utils.py
@@ -6,6 +6,7 @@ from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.assets.utils import get_or_create_ethereum_token
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress
 
 from .typing import LiquidityPool, LiquidityPoolAsset
@@ -14,7 +15,8 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 SUBGRAPH_REMOTE_ERROR_MSG = (

--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -19,6 +19,7 @@ from rotkehlchen.constants.ethereum import AAVE_V1_LENDING_POOL, AAVE_V2_LENDING
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import RemoteError, UnknownAsset
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
@@ -34,11 +35,13 @@ from .common import (
 )
 from .graph import AaveGraphInquirer
 
-log = logging.getLogger(__name__)
-
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
+
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class ReserveData(NamedTuple):

--- a/rotkehlchen/chain/ethereum/modules/aave/blockchain.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/blockchain.py
@@ -17,6 +17,7 @@ from rotkehlchen.constants.ethereum import (
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
@@ -29,7 +30,9 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class AaveBlockchainInquirer(AaveInquirer):

--- a/rotkehlchen/chain/ethereum/modules/aave/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/graph.py
@@ -21,6 +21,7 @@ from rotkehlchen.errors import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
@@ -41,7 +42,8 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 AAVE_GRAPH_RECENT_SECS = 600  # 10 mins
 

--- a/rotkehlchen/chain/ethereum/modules/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound.py
@@ -23,6 +23,7 @@ from rotkehlchen.errors import BlockchainQueryError, RemoteError, UnknownAsset
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
@@ -66,7 +67,8 @@ BORROW_EVENTS_QUERY_PREFIX = """{graph_event_name}
 }}}}"""
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class CompoundBalance(NamedTuple):

--- a/rotkehlchen/chain/ethereum/modules/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import gevent
 
-log = logging.getLogger(__name__)
 from rotkehlchen.accounting.structures import AssetBalance, Balance
 from rotkehlchen.chain.ethereum.eth2_utils import scrape_validator_daily_stats
 from rotkehlchen.chain.ethereum.typing import (
@@ -22,6 +21,7 @@ from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.externalapis.beaconchain import BeaconChain
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 ETH2_DEPOSIT = EthereumConstants().contract('ETH2_DEPOSIT')
 ETH2_DEPLOYED_TS = Timestamp(1602667372)

--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -124,6 +124,7 @@ from rotkehlchen.db.loopring import DBLoopring
 from rotkehlchen.errors import DeserializationError, RemoteError
 from rotkehlchen.externalapis.interface import ExternalServiceWithApiKey
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_int_from_str
 from rotkehlchen.typing import ChecksumEthAddress, ExternalService
 from rotkehlchen.user_messages import MessagesAggregator
@@ -138,6 +139,7 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 # Taken from https://github.com/Loopring/protocols/blob/master/packages/loopring_v3/deployment_mainnet_v3.6.md  # noqa: E501
@@ -337,7 +339,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
         if options is not None:
             querystr += '?' + urlencode(options)
 
-        logger.debug(f'Querying loopring {querystr}')
+        log.debug(f'Querying loopring {querystr}')
         try:
             response = self.session.get(querystr, timeout=DEFAULT_TIMEOUT_TUPLE)
         except requests.exceptions.RequestException as e:
@@ -483,7 +485,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
         May raise RemoteError in case of any problems
         """
         if not self.got_api_key():
-            logger.debug('Queried loopring balances without an API key. No balances returned')
+            log.debug('Queried loopring balances without an API key. No balances returned')
             return {}
 
         result = {}
@@ -491,7 +493,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
             try:
                 account_id = self.ethereum_account_to_loopring_id(l1_address=address)
             except LoopringUserNotFound:
-                logger.debug(
+                log.debug(
                     f'Skipping loopring query of address {address} '
                     f'because is not registered at loopring',
                 )
@@ -500,7 +502,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
                 self.msg_aggregator.add_warning('The Loopring API key is not a valid key.')
                 continue
             except RemoteError as e:
-                logger.debug(f'Skipping loopring query of address {address} due to {str(e)}')
+                log.debug(f'Skipping loopring query of address {address} due to {str(e)}')
                 continue
 
             try:

--- a/rotkehlchen/chain/ethereum/modules/makerdao/dsr.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/dsr.py
@@ -13,6 +13,7 @@ from rotkehlchen.errors import ConversionError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_or_use_default
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.typing import ChecksumEthAddress, Price, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
@@ -25,7 +26,8 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)

--- a/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
@@ -73,6 +73,7 @@ from rotkehlchen.errors import DeserializationError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_or_use_default
 from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
@@ -86,7 +87,8 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 GEMJOIN_MAPPING = {

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
@@ -16,12 +16,9 @@ from rotkehlchen.chain.ethereum.interfaces.ammswap.typing import (
 from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import SUBGRAPH_REMOTE_ERROR_MSG
 from rotkehlchen.chain.ethereum.trades import AMMTrade
 from rotkehlchen.errors import ModuleInitializationFailure, RemoteError
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.typing import (
-    ChecksumEthAddress,
-    Location,
-    Timestamp,
-)
+from rotkehlchen.typing import ChecksumEthAddress, Location, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.interfaces import EthereumModule
 
@@ -30,7 +27,8 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 SUSHISWAP_EVENTS_PREFIX = 'sushiswap_events'
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List, Optional, Set
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.assets.utils import get_or_create_ethereum_token
 from rotkehlchen.chain.ethereum.graph import GRAPH_QUERY_LIMIT, Graph, format_query_indentation
+from rotkehlchen.chain.ethereum.interfaces.ammswap import UNISWAP_TRADES_PREFIX
 from rotkehlchen.chain.ethereum.interfaces.ammswap.ammswap import AMMSwapPlatform
 from rotkehlchen.chain.ethereum.interfaces.ammswap.typing import (
     AddressEvents,
@@ -17,22 +18,17 @@ from rotkehlchen.chain.ethereum.interfaces.ammswap.typing import (
     ProtocolBalance,
 )
 from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import SUBGRAPH_REMOTE_ERROR_MSG
-from rotkehlchen.chain.ethereum.interfaces.ammswap import UNISWAP_TRADES_PREFIX
 from rotkehlchen.chain.ethereum.trades import AMMSwap, AMMTrade
 from rotkehlchen.constants import ZERO
 from rotkehlchen.errors import DeserializationError, ModuleInitializationFailure, RemoteError
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount_force_positive,
     deserialize_ethereum_address,
 )
-from rotkehlchen.typing import (
-    AssetAmount,
-    ChecksumEthAddress,
-    Location,
-    Timestamp,
-)
+from rotkehlchen.typing import AssetAmount, ChecksumEthAddress, Location, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.interfaces import EthereumModule
 
@@ -44,7 +40,8 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 UNISWAP_EVENTS_PREFIX = 'uniswap_events'
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -8,20 +8,21 @@ import requests
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.chain.ethereum.contracts import EthereumContract
 from rotkehlchen.chain.ethereum.defi.zerionsdk import ZERION_ADAPTER_ADDRESS
+from rotkehlchen.chain.ethereum.interfaces.ammswap.typing import LiquidityPool
 from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import _decode_result
 from rotkehlchen.chain.ethereum.typing import NodeName
 from rotkehlchen.constants.ethereum import ZERION_ABI
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress
 from rotkehlchen.utils.misc import get_chunks
-
-from rotkehlchen.chain.ethereum.interfaces.ammswap.typing import LiquidityPool
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def uniswap_lp_token_balances(

--- a/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
@@ -22,6 +22,7 @@ from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import ModuleInitializationFailure, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.typing import YEARN_VAULTS_V2_PROTOCOL, ChecksumEthAddress, EthAddress, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
@@ -34,7 +35,8 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 BLOCKS_PER_YEAR = 2425846
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 SUBGRAPH_REMOTE_ERROR_MSG = (
     "Failed to request the Yearn Finance vaults v2 subgraph due to {error_msg}. "
     "All the deposits and withdrawals history queries are not functioning until this is fixed. "  # noqa: E501

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -383,7 +383,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
         if module:
             return module  # already activated
 
-        logger.debug(f'Activating {module_name} module')
+        log.debug(f'Activating {module_name} module')
         kwargs = {}
         if module_name == 'eth2':
             kwargs['beaconchain'] = self.beaconchain
@@ -398,7 +398,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
                 **kwargs,
             )
         except ModuleInitializationFailure as e:
-            logger.error(f'Failed to activate {module_name} due to: {str(e)}')
+            log.error(f'Failed to activate {module_name} due to: {str(e)}')
             return None
 
         self.eth_modules[module_name] = instance
@@ -417,7 +417,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
         if instance is None:
             return  # nothing to do
 
-        logger.debug(f'Deactivating {module_name} module')
+        log.debug(f'Deactivating {module_name} module')
         instance.deactivate()
         del instance
         return

--- a/rotkehlchen/config.py
+++ b/rotkehlchen/config.py
@@ -4,7 +4,10 @@ import platform
 import shutil
 from pathlib import Path
 
-log = logging.getLogger(__name__)
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def get_xdg_data_home() -> Path:

--- a/rotkehlchen/data/importer.py
+++ b/rotkehlchen/data/importer.py
@@ -17,6 +17,7 @@ from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.errors import DeserializationError, UnknownAsset
 from rotkehlchen.exchanges.data_structures import AssetMovement, AssetMovementCategory, Trade
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
     deserialize_asset_amount_force_positive,
@@ -26,7 +27,8 @@ from rotkehlchen.serialization.deserialize import (
 )
 from rotkehlchen.typing import AssetAmount, Fee, Location, Price, Timestamp, TradeType
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def remap_header(fieldnames: List[str]) -> List[str]:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -21,8 +21,12 @@ from rotkehlchen.chain.bitcoin.xpub import (
     XpubDerivedAddressData,
     deserialize_derivation_path_for_db,
 )
-from rotkehlchen.chain.ethereum.modules.aave.constants import ATOKENV1_TO_ASSET
+from rotkehlchen.chain.ethereum.interfaces.ammswap import (
+    SUSHISWAP_TRADES_PREFIX,
+    UNISWAP_TRADES_PREFIX,
+)
 from rotkehlchen.chain.ethereum.interfaces.ammswap.typing import EventType, LiquidityPoolEvent
+from rotkehlchen.chain.ethereum.modules.aave.constants import ATOKENV1_TO_ASSET
 from rotkehlchen.chain.ethereum.modules.adex import (
     ADEX_EVENTS_PREFIX,
     AdexEventType,
@@ -39,10 +43,6 @@ from rotkehlchen.chain.ethereum.modules.balancer import (
 )
 from rotkehlchen.chain.ethereum.modules.sushiswap import SUSHISWAP_EVENTS_PREFIX
 from rotkehlchen.chain.ethereum.modules.uniswap import UNISWAP_EVENTS_PREFIX
-from rotkehlchen.chain.ethereum.interfaces.ammswap import (
-    UNISWAP_TRADES_PREFIX,
-    SUSHISWAP_TRADES_PREFIX,
-)
 from rotkehlchen.chain.ethereum.structures import (
     AaveEvent,
     YearnVault,
@@ -1177,7 +1177,7 @@ class DBHandler:
             self.delete_loopring_data()
             self.delete_eth2_deposits()
             self.delete_eth2_daily_stats()
-            logger.debug('Purged all module data from the DB')
+            log.debug('Purged all module data from the DB')
             return
 
         if module_name == 'uniswap':
@@ -1203,10 +1203,10 @@ class DBHandler:
             self.delete_eth2_deposits()
             self.delete_eth2_daily_stats()
         else:
-            logger.debug(f'Requested to purge {module_name} data from the DB but nothing to do')
+            log.debug(f'Requested to purge {module_name} data from the DB but nothing to do')
             return
 
-        logger.debug(f'Purged {module_name} data from the DB')
+        log.debug(f'Purged {module_name} data from the DB')
 
     def delete_uniswap_trades_data(self) -> None:
         """Delete all historical Uniswap trades data"""
@@ -2247,14 +2247,14 @@ class DBHandler:
                         # Also if we have transactions of one account sending to the
                         # other and both accounts are being tracked.
                         string_repr = db_tuple_to_str(entry, tuple_type)
-                        logger.debug(
+                        log.debug(
                             f'Did not add "{string_repr}" to the DB due to "{str(e)}".'
                             f'Either it already exists or some constraint was hit.',
                         )
                         continue
 
                     string_repr = db_tuple_to_str(entry, tuple_type)
-                    logger.warning(
+                    log.warning(
                         f'Did not add "{string_repr}" to the DB due to "{str(e)}".'
                         f'It either already exists or some other constraint was hit.',
                     )
@@ -2967,7 +2967,7 @@ class DBHandler:
             try:
                 asset1, asset2 = [Asset(x) for x in entry]
             except UnknownAsset as e:
-                logger.warning(
+                log.warning(
                     f'At processing owned assets from base/quote could not deserialize '
                     f'asset due to {str(e)}',
                 )
@@ -3510,7 +3510,7 @@ class DBHandler:
                 updates.append((actual_id, db_id))
 
         if len(updates) != 0:
-            logger.debug(
+            log.debug(
                 f'Found {len(updates)} identifier discrepancies in the DB '
                 f'for {table_name}. Correcting...',
             )
@@ -3524,9 +3524,9 @@ class DBHandler:
         changing and no longer corresponding to the calculated id.
         """
         start_time = ts_now()
-        logger.debug('Starting DB data integrity check')
+        log.debug('Starting DB data integrity check')
         self._ensure_data_integrity('trades', Trade)
         self._ensure_data_integrity('asset_movements', AssetMovement)
         self._ensure_data_integrity('margin_positions', MarginPosition)
         self.conn.commit()
-        logger.debug(f'DB data integrity check finished after {ts_now() - start_time} seconds')
+        log.debug(f'DB data integrity check finished after {ts_now() - start_time} seconds')

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -5,6 +5,7 @@ from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.chain.ethereum.typing import Eth2Deposit, ValidatorDailyStats
 from rotkehlchen.db.utils import form_query_to_filter_timestamps
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 
 if TYPE_CHECKING:
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 ETH2_DEPOSITS_PREFIX = 'eth2_deposits'
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class DBEth2():
@@ -114,7 +116,7 @@ class DBEth2():
                     entry.to_db_tuple(),
                 )
             except sqlcipher.IntegrityError:  # pylint: disable=no-member
-                logger.debug(
+                log.debug(
                     f'Eth2 staking detail entry {str(entry)} already existed in the DB. Skipping.',
                 )
 

--- a/rotkehlchen/db/ledger_actions.py
+++ b/rotkehlchen/db/ledger_actions.py
@@ -8,10 +8,12 @@ from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.chain.ethereum.gitcoin.constants import GITCOIN_GRANTS_PREFIX
 from rotkehlchen.db.utils import form_query_to_filter_timestamps
 from rotkehlchen.errors import DeserializationError, UnknownAsset
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import Location, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -280,7 +280,7 @@ class Coingecko():
         if subpath:
             url += subpath
 
-        logger.debug(f'Querying coingecko: {url}?{urlencode(options)}')
+        log.debug(f'Querying coingecko: {url}?{urlencode(options)}')
         tries = COINGECKO_QUERY_RETRY_TIMES
         while tries >= 0:
             try:

--- a/rotkehlchen/externalapis/covalent.py
+++ b/rotkehlchen/externalapis/covalent.py
@@ -4,15 +4,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from rotkehlchen.constants.timing import (
-    DEFAULT_TIMEOUT_TUPLE,
-)
+from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
 from rotkehlchen.errors import DeserializationError, RemoteError
+from rotkehlchen.externalapis.utils import read_integer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, CovalentTransaction, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
-from rotkehlchen.utils.misc import ts_now, create_timestamp
-from rotkehlchen.externalapis.utils import read_integer
+from rotkehlchen.utils.misc import create_timestamp, ts_now
 
 COVALENT_QUERY_LIMIT = 1000
 CONST_RETRY = 1
@@ -104,7 +102,7 @@ class Covalent():
 
         retry = 0
         while retry <= CONST_RETRY:
-            logger.debug(f'Querying covalent: {query_str}')  # noqa: E501 lgtm [py/clear-text-logging-sensitive-data]
+            log.debug(f'Querying covalent: {query_str}')  # noqa: E501 lgtm [py/clear-text-logging-sensitive-data]
             try:
                 response = self.session.get(query_str, timeout=timeout if timeout else DEFAULT_TIMEOUT_TUPLE)  # noqa: E501
             except requests.exceptions.RequestException as e:

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -242,7 +242,7 @@ class Cryptocompare(ExternalServiceWithApiKey):
         got_cached_data = data_range is not None and data_range[0] <= timestamp <= data_range[1]
         rate_limited = self.rate_limited_in_last(seconds)
         can_query = got_cached_data or not rate_limited
-        logger.debug(
+        log.debug(
             f'{"Will" if can_query else "Will not"} query '
             f'Cryptocompare history for {from_asset.identifier} -> '
             f'{to_asset.identifier} @ {timestamp}. Cached data: {got_cached_data}'

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -155,7 +155,7 @@ class Etherscan(ExternalServiceWithApiKey):
         backoff = 1
         backoff_limit = 33
         while backoff < backoff_limit:
-            logger.debug(f'Querying etherscan: {query_str}')
+            log.debug(f'Querying etherscan: {query_str}')
             try:
                 response = self.session.get(query_str, timeout=timeout if timeout else DEFAULT_TIMEOUT_TUPLE)  # noqa: E501
             except requests.exceptions.RequestException as e:

--- a/rotkehlchen/externalapis/xratescom.py
+++ b/rotkehlchen/externalapis/xratescom.py
@@ -8,10 +8,12 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
 from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset
 from rotkehlchen.history.deserialization import deserialize_price
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import Price, Timestamp
 from rotkehlchen.utils.misc import timestamp_to_date
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def _scrape_xratescom_exchange_rates(url: str) -> Dict[Asset, Price]:

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -14,11 +14,13 @@ from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import DeserializationError, InputError, UnknownAsset
 from rotkehlchen.globaldb.upgrades.v1_v2 import upgrade_ethereum_asset_ids
 from rotkehlchen.history.typing import HistoricalPrice, HistoricalPriceOracle
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 
 from .schema import DB_SCRIPT_CREATE_TABLES
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 GLOBAL_DB_VERSION = 2
 

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -14,13 +14,15 @@ from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.typing import AssetData, AssetType
 from rotkehlchen.errors import DeserializationError, RemoteError, UnknownAsset
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
 from rotkehlchen.typing import ChecksumEthAddress, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 
 from .handler import GlobalDBHandler, initialize_globaldb
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 ASSETS_VERSION_KEY = 'assets_version'
 

--- a/rotkehlchen/globaldb/upgrades/v1_v2.py
+++ b/rotkehlchen/globaldb/upgrades/v1_v2.py
@@ -3,8 +3,10 @@ import sqlite3
 from collections import defaultdict
 
 from rotkehlchen.constants.resolver import ETHEREUM_DIRECTIVE
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def upgrade_ethereum_asset_ids(connection: sqlite3.Connection) -> None:

--- a/rotkehlchen/greenlets.py
+++ b/rotkehlchen/greenlets.py
@@ -4,9 +4,11 @@ from typing import Any, Callable, List, Optional
 
 import gevent
 
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.user_messages import MessagesAggregator
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class GreenletManager():

--- a/rotkehlchen/icons.py
+++ b/rotkehlchen/icons.py
@@ -13,9 +13,11 @@ from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
 from rotkehlchen.errors import RemoteError, UnsupportedAsset
 from rotkehlchen.externalapis.coingecko import DELISTED_ASSETS, Coingecko
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.hashing import file_md5
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 ALLOWED_ICON_EXTENSIONS = ('.png', '.svg', '.jpeg', '.jpg', '.webp')
 

--- a/rotkehlchen/logging.py
+++ b/rotkehlchen/logging.py
@@ -17,7 +17,7 @@ class RotkehlchenLogsAdapter(logging.LoggerAdapter):
     def __init__(self, logger: logging.Logger):
         super().__init__(logger, extra={})
 
-    def process(self, msg: str, kwargs: MutableMapping[str, Any]) -> Tuple[str, Dict]:
+    def process(self, given_msg: Any, kwargs: MutableMapping[str, Any]) -> Tuple[str, Dict]:
         """
         This is the main post-processing function for rotki logs
 
@@ -25,6 +25,7 @@ class RotkehlchenLogsAdapter(logging.LoggerAdapter):
         - appends all kwargs to the final message
         - appends the greenlet id in the log message
         """
+        msg = str(given_msg)
         greenlet = gevent.getcurrent()
         if greenlet.parent is None:
             greenlet_name = 'Main Greenlet'

--- a/rotkehlchen/logging.py
+++ b/rotkehlchen/logging.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, MutableMapping, Tuple
 
-from gevent import getcurrent
+import gevent
 
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now
 
@@ -25,11 +25,15 @@ class RotkehlchenLogsAdapter(logging.LoggerAdapter):
         - appends all kwargs to the final message
         - appends the greenlet id in the log message
         """
-        greenlet = getcurrent()
+        greenlet = gevent.getcurrent()
         if greenlet.parent is None:
             greenlet_name = 'Main Greenlet'
         else:
-            greenlet_name = greenlet.name
+            try:
+                greenlet_name = greenlet.name
+            except AttributeError:  # means it's a raw greenlet
+                greenlet_name = f'Greenlet with id {id(greenlet)}'
+
         msg = greenlet_name + ': ' + msg + ','.join(' {}={}'.format(a[0], a[1]) for a in kwargs.items())  # noqa: E501
         return msg, {}
 

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -20,10 +20,12 @@ from rotkehlchen.errors import (
     PremiumAuthenticationError,
     RemoteError,
 )
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.typing import B64EncodedBytes, Timestamp
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 HANDLABLE_STATUS_CODES = [
     HTTPStatus.OK,
@@ -224,7 +226,7 @@ class Premium():
             )
         except requests.exceptions.RequestException as e:
             msg = f'Could not connect to rotki server due to {str(e)}'
-            logger.error(msg)
+            log.error(msg)
             raise RemoteError(msg) from e
 
         return _process_dict_response(response)
@@ -250,7 +252,7 @@ class Premium():
             )
         except requests.exceptions.RequestException as e:
             msg = f'Could not connect to rotki server due to {str(e)}'
-            logger.error(msg)
+            log.error(msg)
             raise RemoteError(msg) from e
 
         return _process_dict_response(response)
@@ -275,7 +277,7 @@ class Premium():
             )
         except requests.exceptions.RequestException as e:
             msg = f'Could not connect to rotki server due to {str(e)}'
-            logger.error(msg)
+            log.error(msg)
             raise RemoteError(msg) from e
 
         result = _process_dict_response(response)
@@ -306,7 +308,7 @@ class Premium():
             )
         except requests.exceptions.RequestException as e:
             msg = f'Could not connect to rotki server due to {str(e)}'
-            logger.error(msg)
+            log.error(msg)
             raise RemoteError(msg) from e
 
         result = _process_dict_response(response)
@@ -334,7 +336,7 @@ class Premium():
             )
         except requests.exceptions.RequestException as e:
             msg = f'Could not connect to rotki server due to {str(e)}'
-            logger.error(msg)
+            log.error(msg)
             raise RemoteError(msg) from e
 
         return _decode_premium_json(response)

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -761,7 +761,7 @@ class Rotkehlchen():
             # should only be an exchange
             exchanges_list = self.exchange_manager.connected_exchanges.get(location)
             if exchanges_list is None:
-                logger.warning(
+                log.warning(
                     f'Tried to query trades from {str(location)} which is either not an '
                     f'exchange or not an exchange the user has connected to',
                 )
@@ -994,7 +994,7 @@ class Rotkehlchen():
             else:
                 exchanges_list = self.exchange_manager.connected_exchanges.get(location)
                 if exchanges_list is None:
-                    logger.warning(
+                    log.warning(
                         f'Tried to query deposits/withdrawals from {str(location)} which is '
                         f'either not an exchange or not an exchange the user has connected to',
                     )

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from typing import Any, Dict, List, Optional, Union
 from unittest.mock import patch
 
@@ -21,8 +20,6 @@ from rotkehlchen.tests.utils.eth_tokens import CONTRACT_ADDRESS_TO_TOKEN
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.typing import BTCAddress, ChecksumEthAddress
 from rotkehlchen.utils.misc import from_wei, satoshis_to_btc
-
-logger = logging.getLogger(__name__)
 
 
 def assert_btc_balances_result(

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -5,10 +5,12 @@ from typing import List, Tuple
 import gevent
 
 from rotkehlchen.chain.ethereum.manager import NodeName
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 NODE_CONNECTION_TIMEOUT = 10
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 INFURA_TEST = 'https://mainnet.infura.io/v3/66302b8fb9874614905a3cbe903a0dbb'
 

--- a/rotkehlchen/tests/utils/substrate.py
+++ b/rotkehlchen/tests/utils/substrate.py
@@ -17,10 +17,12 @@ from rotkehlchen.chain.substrate.typing import (
 )
 from rotkehlchen.constants.assets import A_KSM
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 NODE_CONNECTION_TIMEOUT = 15
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 # Accounts

--- a/rotkehlchen/usage_analytics.py
+++ b/rotkehlchen/usage_analytics.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, NamedTuple, Optional
 
 import requests
 
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import get_system_spec
 from rotkehlchen.utils.serialization import jsonloads_dict
 
@@ -15,7 +16,8 @@ from rotkehlchen.utils.serialization import jsonloads_dict
 LOCATION_DATA_QUERY_TIMEOUT = 5
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class GeolocationData(NamedTuple):

--- a/rotkehlchen/user_messages.py
+++ b/rotkehlchen/user_messages.py
@@ -3,12 +3,14 @@ from collections import deque
 from typing import TYPE_CHECKING, Deque, List, Optional
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
     from rotkehlchen.api.websockets.notifier import RotkiNotifier
 
 
 logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class MessagesAggregator():
@@ -25,7 +27,7 @@ class MessagesAggregator():
         self.warnings.appendleft(msg)
 
     def add_warning(self, msg: str) -> None:
-        logger.warning(msg)
+        log.warning(msg)
         if self.rotki_notifier is not None:
             data = {'verbosity': 'warning', 'value': msg}
             self.rotki_notifier.broadcast(
@@ -48,7 +50,7 @@ class MessagesAggregator():
         self.errors.appendleft(msg)
 
     def add_error(self, msg: str) -> None:
-        logger.error(msg)
+        log.error(msg)
         if self.rotki_notifier is not None:
             data = {'verbosity': 'error', 'value': msg}
             self.rotki_notifier.broadcast(

--- a/rotkehlchen/utils/network.py
+++ b/rotkehlchen/utils/network.py
@@ -6,11 +6,13 @@ from typing import Any, Callable, Dict, List, Union
 import gevent
 import requests
 
-logger = logging.getLogger(__name__)
-
 from rotkehlchen.constants import GLOBAL_REQUESTS_TIMEOUT
 from rotkehlchen.constants.timing import QUERY_RETRY_TIMES
 from rotkehlchen.errors import RemoteError, UnableToDecryptRemoteData
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def request_get(
@@ -24,7 +26,7 @@ def request_get(
     - UnableToDecryptRemoteData from request_get
     - Remote error if the get request fails
     """
-    logger.debug(f'Querying {url}')
+    log.debug(f'Querying {url}')
     # TODO make this a bit more smart. Perhaps conditional on the type of request.
     # Not all requests would need repeated attempts
     response = retry_calls(
@@ -93,7 +95,7 @@ def retry_calls(
                         f"{location} query for {method_name} failed after {times} tries",
                     )
 
-                logger.debug(
+                log.debug(
                     f'In retry_call for {location}-{method_name}. Got 429. Backing off for '
                     f'{backoff_in_seconds} seconds',
                 )
@@ -105,7 +107,7 @@ def retry_calls(
 
         except requests.exceptions.RequestException as e:
             tries -= 1
-            logger.debug(
+            log.debug(
                 f'In retry_call for {location}-{method_name}. Got error {str(e)} '
                 f'Trying again ... with {tries} tries left',
             )


### PR DESCRIPTION
Fix #3337

All log entries should now also have their greenlet id at the start.
Greenlet ids can also be associated with task ids via this log entry:

`Async task with task id XX started`