### PR TITLE
Use load_default instead of missing in marshmallow

### DIFF
--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -808,41 +808,41 @@ class HistoricalPriceOracleField(fields.Field):
 
 class AsyncQueryArgumentSchema(Schema):
     """A schema for getters that only have one argument enabling async query"""
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
 
 
 class AsyncHistoricalQuerySchema(AsyncQueryArgumentSchema):
     """A schema for getters that have 2 arguments.
     One to enable async querying and another to force reset DB data by querying everytying again"""
-    reset_db_data = fields.Boolean(missing=False)
-    from_timestamp = TimestampField(missing=Timestamp(0))
-    to_timestamp = TimestampField(missing=ts_now)
+    reset_db_data = fields.Boolean(load_default=False)
+    from_timestamp = TimestampField(load_default=Timestamp(0))
+    to_timestamp = TimestampField(load_default=ts_now)
 
 
 class AsyncTasksQuerySchema(Schema):
-    task_id = fields.Integer(strict=True, missing=None)
+    task_id = fields.Integer(strict=True, load_default=None)
 
 
 class EthereumTransactionQuerySchema(Schema):
-    async_query = fields.Boolean(missing=False)
-    address = EthereumAddressField(missing=None)
-    from_timestamp = TimestampField(missing=Timestamp(0))
-    to_timestamp = TimestampField(missing=ts_now)
-    only_cache = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
+    address = EthereumAddressField(load_default=None)
+    from_timestamp = TimestampField(load_default=Timestamp(0))
+    to_timestamp = TimestampField(load_default=ts_now)
+    only_cache = fields.Boolean(load_default=False)
 
 
 class TimerangeQuerySchema(Schema):
-    from_timestamp = TimestampField(missing=Timestamp(0))
-    to_timestamp = TimestampField(missing=ts_now)
-    async_query = fields.Boolean(missing=False)
+    from_timestamp = TimestampField(load_default=Timestamp(0))
+    to_timestamp = TimestampField(load_default=ts_now)
+    async_query = fields.Boolean(load_default=False)
 
 
 class TimerangeLocationQuerySchema(TimerangeQuerySchema):
-    location = LocationField(missing=None)
+    location = LocationField(load_default=None)
 
 
 class TimerangeLocationCacheQuerySchema(TimerangeLocationQuerySchema):
-    only_cache = fields.Boolean(missing=False)
+    only_cache = fields.Boolean(load_default=False)
 
 
 class GitcoinReportSchema(TimerangeQuerySchema):
@@ -852,12 +852,12 @@ class GitcoinReportSchema(TimerangeQuerySchema):
             min=1,
             error='Gitcoin grant id must be a positive integer',
         ),
-        missing=None,
+        load_default=None,
     )
 
 
 class GitcoinEventsQuerySchema(GitcoinReportSchema):
-    only_cache = fields.Boolean(missing=False)
+    only_cache = fields.Boolean(load_default=False)
 
 
 class GitcoinEventsDeleteSchema(Schema):
@@ -867,7 +867,7 @@ class GitcoinEventsDeleteSchema(Schema):
             min=1,
             error='Gitcoin grant id must be a positive integer',
         ),
-        missing=None,
+        load_default=None,
     )
 
 
@@ -879,10 +879,10 @@ class TradeSchema(Schema):
     trade_type = TradeTypeField(required=True)
     amount = PositiveAmountField(required=True)
     rate = PriceField(required=True)
-    fee = FeeField(missing=None)
-    fee_currency = AssetField(missing=None)
-    link = fields.String(missing=None)
-    notes = fields.String(missing=None)
+    fee = FeeField(load_default=None)
+    fee_currency = AssetField(load_default=None)
+    link = fields.String(load_default=None)
+    notes = fields.String(load_default=None)
 
 
 class LedgerActionSchema(Schema):
@@ -891,10 +891,10 @@ class LedgerActionSchema(Schema):
     location = LocationField(required=True)
     amount = AmountField(required=True)
     asset = AssetField(required=True)
-    rate = PriceField(missing=None)
-    rate_asset = AssetField(missing=None)
-    link = fields.String(missing=None)
-    notes = fields.String(missing=None)
+    rate = PriceField(load_default=None)
+    rate_asset = AssetField(load_default=None)
+    link = fields.String(load_default=None)
+    notes = fields.String(load_default=None)
 
 
 class LedgerActionWithIdentifierSchema(LedgerActionSchema):
@@ -926,7 +926,7 @@ class ManuallyTrackedBalanceSchema(Schema):
     label = fields.String(required=True)
     amount = PositiveAmountField(required=True)
     location = LocationField(required=True)
-    tags = fields.List(fields.String(), missing=None)
+    tags = fields.List(fields.String(), load_default=None)
 
     @post_load
     def make_manually_tracked_balances(  # pylint: disable=no-self-use
@@ -955,16 +955,16 @@ class TradeDeleteSchema(Schema):
 
 class TagSchema(Schema):
     name = fields.String(required=True)
-    description = fields.String(missing=None)
+    description = fields.String(load_default=None)
     background_color = ColorField(required=True)
     foreground_color = ColorField(required=True)
 
 
 class TagEditSchema(Schema):
     name = fields.String(required=True)
-    description = fields.String(missing=None)
-    background_color = ColorField(missing=None)
-    foreground_color = ColorField(missing=None)
+    description = fields.String(load_default=None)
+    background_color = ColorField(load_default=None)
+    foreground_color = ColorField(load_default=None)
 
 
 class TagDeleteSchema(Schema):
@@ -1007,9 +1007,9 @@ def _validate_historical_price_oracles(
 
 class ModifiableSettingsSchema(Schema):
     """This is the Schema for the settings that can be modified via the API"""
-    premium_should_sync = fields.Bool(missing=None)
-    include_crypto2crypto = fields.Bool(missing=None)
-    submit_usage_analytics = fields.Bool(missing=None)
+    premium_should_sync = fields.Bool(load_default=None)
+    include_crypto2crypto = fields.Bool(load_default=None)
+    submit_usage_analytics = fields.Bool(load_default=None)
     ui_floating_precision = fields.Integer(
         strict=True,
         validate=webargs.validate.Range(
@@ -1017,52 +1017,52 @@ class ModifiableSettingsSchema(Schema):
             max=8,
             error='Floating numbers precision in the UI must be between 0 and 8',
         ),
-        missing=None,
+        load_default=None,
     )
-    taxfree_after_period = TaxFreeAfterPeriodField(missing=None)
+    taxfree_after_period = TaxFreeAfterPeriodField(load_default=None)
     balance_save_frequency = fields.Integer(
         strict=True,
         validate=webargs.validate.Range(
             min=1,
             error='The number of hours after which balances should be saved should be >= 1',
         ),
-        missing=None,
+        load_default=None,
     )
-    include_gas_costs = fields.Bool(missing=None)
+    include_gas_costs = fields.Bool(load_default=None)
     # TODO: Add some validation to this field
     # even though it gets validated since we try to connect to it
-    eth_rpc_endpoint = fields.String(missing=None)
-    ksm_rpc_endpoint = fields.String(missing=None)
-    dot_rpc_endpoint = fields.String(missing=None)
-    main_currency = AssetField(missing=None)
+    eth_rpc_endpoint = fields.String(load_default=None)
+    ksm_rpc_endpoint = fields.String(load_default=None)
+    dot_rpc_endpoint = fields.String(load_default=None)
+    main_currency = AssetField(load_default=None)
     # TODO: Add some validation to this field
-    date_display_format = fields.String(missing=None)
-    active_modules = fields.List(fields.String(), missing=None)
-    frontend_settings = fields.String(missing=None)
-    account_for_assets_movements = fields.Bool(missing=None)
+    date_display_format = fields.String(load_default=None)
+    active_modules = fields.List(fields.String(), load_default=None)
+    frontend_settings = fields.String(load_default=None)
+    account_for_assets_movements = fields.Bool(load_default=None)
     btc_derivation_gap_limit = fields.Integer(
         strict=True,
         validate=webargs.validate.Range(
             min=1,
             error='The bitcoin address derivation gap limit should be >= 1',
         ),
-        missing=None,
+        load_default=None,
     )
-    calculate_past_cost_basis = fields.Bool(missing=None)
-    display_date_in_localtime = fields.Bool(missing=None)
+    calculate_past_cost_basis = fields.Bool(load_default=None)
+    display_date_in_localtime = fields.Bool(load_default=None)
     current_price_oracles = fields.List(
         CurrentPriceOracleField,
         validate=_validate_current_price_oracles,
-        missing=None,
+        load_default=None,
     )
     historical_price_oracles = fields.List(
         HistoricalPriceOracleField,
         validate=_validate_historical_price_oracles,
-        missing=None,
+        load_default=None,
     )
-    taxable_ledger_actions = fields.List(LedgerActionTypeField, missing=None)
-    pnl_csv_with_formulas = fields.Bool(missing=None)
-    pnl_csv_have_summary = fields.Bool(missing=None)
+    taxable_ledger_actions = fields.List(LedgerActionTypeField, load_default=None)
+    pnl_csv_with_formulas = fields.Bool(load_default=None)
+    pnl_csv_have_summary = fields.Bool(load_default=None)
 
     @validates_schema
     def validate_settings_schema(  # pylint: disable=no-self-use
@@ -1123,17 +1123,17 @@ class BaseUserSchema(Schema):
 class UserActionSchema(Schema):
     name = fields.String(required=True)
     # All the fields below are not needed for logout/modification so are not required=True
-    password = fields.String(missing=None)
+    password = fields.String(load_default=None)
     sync_approval = fields.String(
-        missing='unknown',
+        load_default='unknown',
         validate=webargs.validate.OneOf(choices=('unknown', 'yes', 'no')),
     )
     action = fields.String(
         validate=webargs.validate.OneOf(choices=('login', 'logout')),
-        missing=None,
+        load_default=None,
     )
-    premium_api_key = fields.String(missing='')
-    premium_api_secret = fields.String(missing='')
+    premium_api_key = fields.String(load_default='')
+    premium_api_secret = fields.String(load_default='')
 
     @validates_schema
     def validate_user_action_schema(  # pylint: disable=no-self-use
@@ -1165,15 +1165,15 @@ class UserPremiumSyncSchema(AsyncQueryArgumentSchema):
 
 
 class NewUserSchema(BaseUserSchema):
-    premium_api_key = fields.String(missing='')
-    premium_api_secret = fields.String(missing='')
-    initial_settings = fields.Nested(ModifiableSettingsSchema, missing=None)
+    premium_api_key = fields.String(load_default='')
+    premium_api_secret = fields.String(load_default='')
+    initial_settings = fields.Nested(ModifiableSettingsSchema, load_default=None)
 
 
 class AllBalancesQuerySchema(Schema):
-    async_query = fields.Boolean(missing=False)
-    save_data = fields.Boolean(missing=False)
-    ignore_cache = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
+    save_data = fields.Boolean(load_default=False)
+    ignore_cache = fields.Boolean(load_default=False)
 
 
 class ExternalServiceSchema(Schema):
@@ -1201,13 +1201,13 @@ class ExternalServicesResourceDeleteSchema(Schema):
 class ExchangesResourceEditSchema(Schema):
     name = fields.String(required=True)
     location = LocationField(limit_to=SUPPORTED_EXCHANGES, required=True)
-    new_name = fields.String(missing=None)
-    api_key = ApiKeyField(missing=None)
-    api_secret = ApiSecretField(missing=None)
-    passphrase = fields.String(missing=None)
-    kraken_account_type = KrakenAccountTypeField(missing=None)
-    binance_markets = fields.List(fields.String(), missing=None)
-    ftx_subaccount = fields.String(missing=None)
+    new_name = fields.String(load_default=None)
+    api_key = ApiKeyField(load_default=None)
+    api_secret = ApiSecretField(load_default=None)
+    passphrase = fields.String(load_default=None)
+    kraken_account_type = KrakenAccountTypeField(load_default=None)
+    binance_markets = fields.List(fields.String(), load_default=None)
+    ftx_subaccount = fields.String(load_default=None)
 
 
 class ExchangesResourceAddSchema(Schema):
@@ -1215,14 +1215,14 @@ class ExchangesResourceAddSchema(Schema):
     location = LocationField(limit_to=SUPPORTED_EXCHANGES, required=True)
     api_key = ApiKeyField(required=True)
     api_secret = ApiSecretField(required=True)
-    passphrase = fields.String(missing=None)
-    kraken_account_type = KrakenAccountTypeField(missing=None)
-    binance_markets = fields.List(fields.String(), missing=None)
-    ftx_subaccount = fields.String(missing=None)
+    passphrase = fields.String(load_default=None)
+    kraken_account_type = KrakenAccountTypeField(load_default=None)
+    binance_markets = fields.List(fields.String(), load_default=None)
+    ftx_subaccount = fields.String(load_default=None)
 
 
 class ExchangesDataResourceSchema(Schema):
-    location = LocationField(limit_to=ALL_SUPPORTED_EXCHANGES, missing=None)
+    location = LocationField(limit_to=ALL_SUPPORTED_EXCHANGES, load_default=None)
 
 
 class ExchangesResourceRemoveSchema(Schema):
@@ -1231,21 +1231,21 @@ class ExchangesResourceRemoveSchema(Schema):
 
 
 class ExchangeBalanceQuerySchema(Schema):
-    location = LocationField(limit_to=SUPPORTED_EXCHANGES, missing=None)
-    async_query = fields.Boolean(missing=False)
-    ignore_cache = fields.Boolean(missing=False)
+    location = LocationField(limit_to=SUPPORTED_EXCHANGES, load_default=None)
+    async_query = fields.Boolean(load_default=False)
+    ignore_cache = fields.Boolean(load_default=False)
 
 
 class BlockchainBalanceQuerySchema(Schema):
-    blockchain = BlockchainField(missing=None)
-    async_query = fields.Boolean(missing=False)
-    ignore_cache = fields.Boolean(missing=False)
+    blockchain = BlockchainField(load_default=None)
+    async_query = fields.Boolean(load_default=False)
+    ignore_cache = fields.Boolean(load_default=False)
 
 
 class StatisticsAssetBalanceSchema(Schema):
     asset = AssetField(required=True)
-    from_timestamp = TimestampField(missing=Timestamp(0))
-    to_timestamp = TimestampField(missing=ts_now)
+    from_timestamp = TimestampField(load_default=Timestamp(0))
+    to_timestamp = TimestampField(load_default=ts_now)
 
 
 class StatisticsValueDistributionSchema(Schema):
@@ -1256,9 +1256,9 @@ class StatisticsValueDistributionSchema(Schema):
 
 
 class HistoryProcessingSchema(Schema):
-    from_timestamp = TimestampField(missing=Timestamp(0))
-    to_timestamp = TimestampField(missing=ts_now)
-    async_query = fields.Boolean(missing=False)
+    from_timestamp = TimestampField(load_default=Timestamp(0))
+    to_timestamp = TimestampField(load_default=ts_now)
+    async_query = fields.Boolean(load_default=False)
 
 
 class HistoryExportingSchema(Schema):
@@ -1267,27 +1267,27 @@ class HistoryExportingSchema(Schema):
 
 class BlockchainAccountDataSchema(Schema):
     address = fields.String(required=True)
-    label = fields.String(missing=None)
-    tags = fields.List(fields.String(), missing=None)
+    label = fields.String(load_default=None)
+    tags = fields.List(fields.String(), load_default=None)
 
 
 class BaseXpubSchema(Schema):
     xpub = XpubField(required=True)
-    derivation_path = DerivationPathField(missing=None)
-    async_query = fields.Boolean(missing=False)
+    derivation_path = DerivationPathField(load_default=None)
+    async_query = fields.Boolean(load_default=False)
 
 
 class XpubAddSchema(Schema):
     xpub = fields.String(required=True)
-    derivation_path = DerivationPathField(missing=None)
-    async_query = fields.Boolean(missing=False)
-    label = fields.String(missing=None)
+    derivation_path = DerivationPathField(load_default=None)
+    async_query = fields.Boolean(load_default=False)
+    label = fields.String(load_default=None)
     xpub_type = fields.String(
         required=False,
-        missing=None,
+        load_default=None,
         validate=webargs.validate.OneOf(choices=('p2pkh', 'p2sh_p2wpkh', 'wpkh')),
     )
-    tags = fields.List(fields.String(), missing=None)
+    tags = fields.List(fields.String(), load_default=None)
 
     @post_load
     def transform_data(  # pylint: disable=no-self-use
@@ -1311,9 +1311,9 @@ class XpubAddSchema(Schema):
 
 class XpubPatchSchema(Schema):
     xpub = XpubField(required=True)
-    derivation_path = DerivationPathField(missing=None)
-    label = fields.String(missing=None)
-    tags = fields.List(fields.String(), missing=None)
+    derivation_path = DerivationPathField(load_default=None)
+    label = fields.String(load_default=None)
+    tags = fields.List(fields.String(), load_default=None)
 
 
 class BlockchainAccountsGetSchema(Schema):
@@ -1614,13 +1614,13 @@ class BlockchainAccountsPatchSchema(Schema):
 
 
 class BlockchainAccountsPutSchema(BlockchainAccountsPatchSchema):
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
 
 
 class BlockchainAccountsDeleteSchema(Schema):
     blockchain = BlockchainField(required=True)
     accounts = fields.List(fields.String(), required=True)
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
 
     def __init__(self, ethereum_manager: EthereumManager):
         super().__init__()
@@ -1666,7 +1666,7 @@ class IgnoredAssetsSchema(Schema):
 
 
 class IgnoredActionsGetSchema(Schema):
-    action_type = ActionTypeField(missing=None)
+    action_type = ActionTypeField(load_default=None)
 
 
 class IgnoredActionsModifySchema(Schema):
@@ -1675,7 +1675,7 @@ class IgnoredActionsModifySchema(Schema):
 
 
 class OptionalEthereumAddressSchema(Schema):
-    address = EthereumAddressField(required=False, missing=None)
+    address = EthereumAddressField(required=False, load_default=None)
 
 
 class RequiredEthereumAddressSchema(Schema):
@@ -1713,11 +1713,11 @@ class AssetSchema(Schema):
     asset_type = AssetTypeField(required=True, exclude_types=(AssetType.ETHEREUM_TOKEN,))
     name = fields.String(required=True)
     symbol = fields.String(required=True)
-    started = TimestampField(missing=None)
-    forked = AssetField(missing=None)
-    swapped_for = AssetField(missing=None)
-    coingecko = fields.String(missing=None)
-    cryptocompare = fields.String(missing=None)
+    started = TimestampField(load_default=None)
+    forked = AssetField(load_default=None)
+    swapped_for = AssetField(load_default=None)
+    coingecko = fields.String(load_default=None)
+    cryptocompare = fields.String(load_default=None)
 
     def __init__(self, coingecko: 'Coingecko', cryptocompare: 'Cryptocompare'):
         super().__init__()
@@ -1750,12 +1750,12 @@ class EthereumTokenSchema(Schema):
     )
     name = fields.String(required=True)
     symbol = fields.String(required=True)
-    started = TimestampField(missing=None)
-    swapped_for = AssetField(missing=None)
-    coingecko = fields.String(missing=None)
-    cryptocompare = fields.String(missing=None)
-    protocol = fields.String(missing=None)
-    underlying_tokens = fields.List(fields.Nested(UnderlyingTokenInfoSchema), missing=None)
+    started = TimestampField(load_default=None)
+    swapped_for = AssetField(load_default=None)
+    coingecko = fields.String(load_default=None)
+    cryptocompare = fields.String(load_default=None)
+    protocol = fields.String(load_default=None)
+    underlying_tokens = fields.List(fields.Nested(UnderlyingTokenInfoSchema), load_default=None)
 
     def __init__(
             self,
@@ -1882,7 +1882,7 @@ class AssetIconUploadSchema(Schema):
 
 
 class ExchangeRatesSchema(Schema):
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
     currencies = DelimitedOrNormalList(AssetField(), required=True)
 
 
@@ -1936,8 +1936,8 @@ class CurrentAssetsPriceSchema(Schema):
         validate=webargs.validate.Length(min=1),
     )
     target_asset = AssetField(required=True)
-    ignore_cache = fields.Boolean(missing=False)
-    async_query = fields.Boolean(missing=False)
+    ignore_cache = fields.Boolean(load_default=False)
+    async_query = fields.Boolean(load_default=False)
 
 
 class HistoricalAssetsPriceSchema(Schema):
@@ -1950,20 +1950,20 @@ class HistoricalAssetsPriceSchema(Schema):
         validate=webargs.validate.Length(min=1),
     )
     target_asset = AssetField(required=True)
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
 
 
 class AssetUpdatesRequestSchema(Schema):
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
     up_to_version = fields.Integer(
         strict=True,
         validate=webargs.validate.Range(
             min=0,
             error='Asset update target version should be >= 0',
         ),
-        missing=None,
+        load_default=None,
     )
-    conflicts = AssetConflictsField(missing=None)
+    conflicts = AssetConflictsField(load_default=None)
 
 
 class NamedEthereumModuleDataSchema(Schema):
@@ -1979,8 +1979,8 @@ class NamedOracleCacheSchema(Schema):
 
 
 class NamedOracleCacheCreateSchema(NamedOracleCacheSchema):
-    purge_old = fields.Boolean(missing=False)
-    async_query = fields.Boolean(missing=False)
+    purge_old = fields.Boolean(load_default=False)
+    async_query = fields.Boolean(load_default=False)
 
 
 class NamedOracleCacheGetSchema(AsyncQueryArgumentSchema):
@@ -1989,7 +1989,7 @@ class NamedOracleCacheGetSchema(AsyncQueryArgumentSchema):
 
 class ERC20InfoSchema(Schema):
     address = EthereumAddressField(required=True)
-    async_query = fields.Boolean(missing=False)
+    async_query = fields.Boolean(load_default=False)
 
 
 class BinanceMarketsUserSchema(Schema):
@@ -2005,8 +2005,8 @@ class ManualPriceSchema(Schema):
 
 
 class ManualPriceRegisteredSchema(Schema):
-    from_asset = AssetField(missing=None)
-    to_asset = AssetField(missing=None)
+    from_asset = AssetField(load_default=None)
+    to_asset = AssetField(load_default=None)
 
 
 class ManualPriceDeleteSchema(Schema):
@@ -2016,7 +2016,7 @@ class ManualPriceDeleteSchema(Schema):
 
 
 class AvalancheTransactionQuerySchema(Schema):
-    async_query = fields.Boolean(missing=False)
-    address = EthereumAddressField(missing=None)
-    from_timestamp = TimestampField(missing=Timestamp(0))
-    to_timestamp = TimestampField(missing=ts_now)
+    async_query = fields.Boolean(load_default=False)
+    address = EthereumAddressField(load_default=None)
+    from_timestamp = TimestampField(load_default=Timestamp(0))
+    to_timestamp = TimestampField(load_default=ts_now)


### PR DESCRIPTION
Gets rid of the deprecation warning for marshmallow 4

```
/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/marshmallow/fields.py:184: RemovedInMarshmallow4Warning: The 'missing' argument to fields is deprecated. Use 'load_default' instead.                                                                         
    RemovedInMarshmallow4Warning,                                                                                             
```