### PR TITLE
Add arm64 support for docker builds

### DIFF
--- a/.github/workflows/rotki_nightly_builds.yml
+++ b/.github/workflows/rotki_nightly_builds.yml
@@ -224,8 +224,6 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/rotki_nightly_builds.yml
+++ b/.github/workflows/rotki_nightly_builds.yml
@@ -220,8 +220,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -249,6 +253,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: rotki/rotki:${{ steps.docker_tag.outputs.tag }}
           build-args: |

--- a/.github/workflows/rotki_packaging.yaml
+++ b/.github/workflows/rotki_packaging.yaml
@@ -364,8 +364,6 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/rotki_packaging.yaml
+++ b/.github/workflows/rotki_packaging.yaml
@@ -360,8 +360,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -376,6 +380,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             rotki/rotki:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 # build stage
-FROM node:lts-alpine as frontend-build-stage
+FROM node:14-buster as frontend-build-stage
 
 WORKDIR /app
 COPY frontend/ .
-RUN apk add python3 make g++
-RUN npm install -g npm@7 && if ! npm ci --exit-code; then npm ci; fi
+RUN apt-get update && apt-get install -y build-essential python3
+RUN npm install -g npm
+RUN npm ci
 RUN npm run docker:build
 
-FROM python:3.7 as backend-build-stage
+FROM python:3.7-buster as backend-build-stage
 
-ARG PYINSTALLER_VERSION=3.5
+ARG PYINSTALLER_VERSION=v3.5
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
+
+RUN apt-get update && apt-get install -y build-essential zlib1g-dev
 
 RUN git clone https://github.com/sqlcipher/sqlcipher && \
     cd sqlcipher && \
@@ -38,8 +41,14 @@ RUN pip install -r requirements.txt
 
 COPY . /app
 
+RUN git clone https://github.com/pyinstaller/pyinstaller.git && cd pyinstaller && \
+    git checkout ${PYINSTALLER_VERSION} && \
+    cd bootloader && \
+    ./waf all && \
+    cd .. && \
+    python setup.py install
+
 RUN pip install -e . && \
-    pip install pyinstaller==$PYINSTALLER_VERSION && \
     python -c "import sys;from rotkehlchen.db.dbhandler import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)" && \
     pyinstaller --noconfirm --clean --distpath /tmp/dist rotkehlchen.spec
 


### PR DESCRIPTION
Hello !

This PR is a proposed fix for docker builds on ARM64. I also updated the corresponding GitHub actions for automatically building images for both platforms.

I tried to deploy Rotki on my Homelab running Kubernetes on Raspberry pi. I noticed a few errors when building the docker image for ARM64. Most notable changes includes: 

- Using a common Debian base -sharing the same glic version- in the frontend and backend build stages
- Installing Pyinstaller manually and not through pip (bootloader compilation fails on ARM64)

This patch has been tested locally on ARM64 and AMD64.

Have a great day!

Fix #3336