### PR TITLE
Set python and nginx version on the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY frontend/ .
 RUN npm install -g npm@7 && if ! npm ci --exit-code; then npm ci; fi
 RUN npm run docker:build
 
-FROM python:3.7 as backend-build-stage
+FROM python:3.7-buster as backend-build-stage
 
 ARG PYINSTALLER_VERSION=3.5
 RUN python3 -m venv /opt/venv
@@ -34,7 +34,7 @@ RUN pip install -e . && \
     python -c "import sys;from rotkehlchen.db.dbhandler import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)" && \
     pyinstaller --noconfirm --clean --distpath /tmp/dist rotkehlchen.spec
 
-FROM nginx:stable as runtime
+FROM nginx:1.21 as runtime
 
 LABEL maintainer="Rotki Solutions GmbH <info@rotki.com>"
 

--- a/packaging/docker-image.sh
+++ b/packaging/docker-image.sh
@@ -5,4 +5,4 @@ ROTKI_VERSION=$(cat .bumpversion.cfg | grep 'current_version = ' | sed -n -e 's/
 POSTFIX=$(if git describe --tags --exact-match "$REVISION" &>/dev/null; then echo ''; else echo '-dev'; fi)
 ROTKI_VERSION=${ROTKI_VERSION}${POSTFIX}
 
-docker build -t rotki . --build-arg REVISION="$REVISION" --build-arg ROTKI_VERSION="$ROTKI_VERSION"
+docker build --pull --no-cache -t rotki . --build-arg REVISION="$REVISION" --build-arg ROTKI_VERSION="$ROTKI_VERSION"


### PR DESCRIPTION
This PR fix this issue:

>In the 1.20.1 docker release I'm getting an error in the logs right after start up: [22] Error loading Python lib '/tmp/_MEIxdLJoV/libpython3.7m.so.1.0': dlopen: /lib/x86_64-linux-gnu/libm.so.6: version 'GLIBC_2.29' not found (required by /tmp/_MEIxdLJoV/libpython3.7m.so.1.0) seems to be blocking client connections

Previously, the Dockerfile used `python:3.7` (backend-build-stage) to compile, which has been updated to debian bulleyes (11.00), while the official version of `ngix:latest` (runtime) is still in buster (10.10) hence the glibc library isn't compatible.

To avoid this situation, it's highly recommended to use `python: 3.7-buster` in combination with `nginx:1.21` so they'll both be on the same page