### PR TITLE
marshmallow missing -> load_default

### DIFF
--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -2011,7 +2011,7 @@ class AssetUpdatesRequestSchema(Schema):
 
 class AssetResetRequestSchema(Schema):
     reset = fields.String(required=True)
-    ignore_warnings = fields.Boolean(missing=False)
+    ignore_warnings = fields.Boolean(load_default=False)
 
 
 class NamedEthereumModuleDataSchema(Schema):


### PR DESCRIPTION
The astroid warnings are from inside astroid and seem to be like a reminder for them. They should remove them, themselves.