### PR TITLE
Change to our sphinxcontrib-httpexample fork

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -2,6 +2,7 @@ sphinx==4.0.2
 sphinx-autobuild==2021.3.14
 sphinx_rtd_theme==0.5.2
 sphinxcontrib-httpdomain==1.7.0
-sphinxcontrib-httpexample==0.11.0
+# This is our fork of sphinxcontrib-httpexample in order to handle https://github.com/rotki/rotki/issues/2612
+sphinxcontrib-httpexample-rotki==0.1.2
 # This is our fork of releases in order to handle https://github.com/rotki/rotki/issues/704
 rotki-releases


### PR DESCRIPTION
This is in order to fix https://github.com/rotki/rotki/issues/2612 by
allowing curl calls with a GET endpoint and JSON payload to generate a
proper command

