### PR TITLE
Fix potential liquity module errors

### DIFF
--- a/rotkehlchen/tests/api/test_adex.py
+++ b/rotkehlchen/tests/api/test_adex.py
@@ -11,7 +11,6 @@ from rotkehlchen.chain.ethereum.modules.adex.typing import Bond, ChannelWithdraw
 from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.constants.assets import A_ADX
 from rotkehlchen.fval import FVal
-from rotkehlchen.premium.premium import Premium
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
@@ -45,23 +44,12 @@ def test_get_balances_module_not_activated(
 @pytest.mark.parametrize('ethereum_modules', [['adex']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 def test_get_balances_premium(
-        rotkehlchen_api_server,
-        ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
+    rotkehlchen_api_server,
+    ethereum_accounts,  # pylint: disable=unused-argument
 ):
-    """Test get balances for premium users works as expected
-    """
+    """Test get balances for premium users works as expected"""
     async_query = random.choice([False, True])
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-
-    # Set module premium is required for calling `get_balances()`
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-
-    adex = rotki.chain_manager.get_module('adex')
-    adex.premium = premium
 
     setup = setup_balances(
         rotki,
@@ -100,22 +88,9 @@ def test_get_balances_premium(
 @pytest.mark.parametrize('ethereum_modules', [['adex']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('default_mock_price_value', [FVal(2)])
-def test_get_events(
-        rotkehlchen_api_server,
-        ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
-):
+def test_get_events(rotkehlchen_api_server, ethereum_accounts):  # pylint: disable=unused-argument
     async_query = random.choice([False, True])
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-
-    # Set module premium is required for calling `get_balances()`
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-
-    adex = rotki.chain_manager.get_module('adex')
-    adex.premium = premium
 
     setup = setup_balances(
         rotki,

--- a/rotkehlchen/tests/api/test_liquity.py
+++ b/rotkehlchen/tests/api/test_liquity.py
@@ -6,7 +6,6 @@ import requests
 from rotkehlchen.constants.assets import A_LUSD, A_ETH, A_LQTY
 from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.fval import FVal
-from rotkehlchen.premium.premium import Premium
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_ok_async_response,
@@ -42,21 +41,8 @@ liquity_mocked_historical_prices = {
 @pytest.mark.parametrize('ethereum_modules', [['liquity']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_trove_position(
-        rotkehlchen_api_server,
-        start_with_valid_premium,
-        rotki_premium_credentials,
-        inquirer,  # pylint: disable=unused-argument
-):
+def test_trove_position(rotkehlchen_api_server, inquirer):  # pylint: disable=unused-argument
     """Test that we can get the status of the trove and the staked lqty"""
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    # Set module premium is required
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-    liquity = rotki.chain_manager.get_module('liquity')
-    liquity.premium = premium
-
     async_query = random.choice([False, True])
     response = requests.get(api_url_for(
         rotkehlchen_api_server,
@@ -135,21 +121,8 @@ def test_trove_events(rotkehlchen_api_server):
 @pytest.mark.parametrize('ethereum_modules', [['liquity']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_account_without_info(
-        rotkehlchen_api_server,
-        start_with_valid_premium,
-        rotki_premium_credentials,
-        inquirer,  # pylint: disable=unused-argument
-):
+def test_account_without_info(rotkehlchen_api_server, inquirer):  # pylint: disable=unused-argument
     """Test that we can get the status of the trove and the staked lqty"""
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    # Set module premium is required
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-    liquity = rotki.chain_manager.get_module('liquity')
-    liquity.premium = premium
-
     async_query = random.choice([False, True])
     response = requests.get(api_url_for(
         rotkehlchen_api_server,

--- a/rotkehlchen/tests/api/test_sushiswap.py
+++ b/rotkehlchen/tests/api/test_sushiswap.py
@@ -17,7 +17,6 @@ from rotkehlchen.chain.ethereum.trades import AMMSwap, AMMTrade
 from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
-from rotkehlchen.premium.premium import Premium
 from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
@@ -60,7 +59,6 @@ def test_get_balances_module_not_activated(
 def test_get_balances(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,
         start_with_valid_premium,
 ):
     """Check querying the sushiswap balances endpoint works. Uses real data
@@ -69,16 +67,6 @@ def test_get_balances(
     onchain queries (without premium)
     """
     async_query = random.choice([False, True])
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-
-    # Set module premium attribute
-    sushiswap = rotki.chain_manager.get_module('sushiswap')
-    sushiswap.premium = premium
-
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'sushiswapbalancesresource'),
         json={'async_query': async_query},
@@ -365,8 +353,6 @@ def _query_and_assert_simple_sushiswap_trades(setup, api_server, async_query):
 def test_get_sushiswap_trades_history(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test that the last 11/23 sushiswap trades of the account since 1605437542
     are parsed and returned correctly
@@ -428,8 +414,6 @@ EXPECTED_EVENTS_BALANCES_1 = [
 def test_get_events_history_filtering_by_timestamp(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test the events balances from 1627401169 to 1627401170 (both included)."""
     # Call time range

--- a/rotkehlchen/tests/api/test_uniswap.py
+++ b/rotkehlchen/tests/api/test_uniswap.py
@@ -19,7 +19,6 @@ from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.constants.assets import A_ADAI_V1, A_DAI, A_LEND, A_USDC, A_WETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
-from rotkehlchen.premium.premium import Premium
 from rotkehlchen.tests.utils.aave import AAVE_TEST_ACC_1
 from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
@@ -81,7 +80,6 @@ SKIPPED_UNISWAP_TEST_OPTIONS = [UNISWAP_TEST_OPTIONS[-1]]
 def test_get_balances(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,
         start_with_valid_premium,
 ):
     """Check querying the uniswap balances endpoint works. Uses real data
@@ -92,16 +90,6 @@ def test_get_balances(
     THIS IS SUPER FREAKING SLOW. BE WARNED.
     """
     async_query = random.choice([False, True])
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-
-    # Set module premium attribute
-    uniswap = rotki.chain_manager.get_module('uniswap')
-    uniswap.premium = premium
-
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'uniswapbalancesresource'),
         json={'async_query': async_query},
@@ -461,8 +449,6 @@ def _query_and_assert_simple_uniswap_trades(setup, api_server, async_query):
 def test_get_uniswap_trades_history(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test that the last 11/23 uniswap trades of the account since 1605437542
     are parsed and returned correctly
@@ -673,8 +659,6 @@ def get_bothin_trades():
 def test_get_uniswap_exotic_history(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test a uniswap trading address with exotic token swaps (unicode symbol names)"""
     async_query = random.choice([False, True])
@@ -871,8 +855,6 @@ def get_expected_events_balances_2():
 def test_get_events_history_filtering_by_timestamp_case1(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test the events balances from 1604273256 to 1604283808 (both included).
 
@@ -950,8 +932,6 @@ def test_get_events_history_filtering_by_timestamp_case1(
 def test_get_events_history_filtering_by_timestamp_case2(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test the events balances from 1598270334 to 1599000975 (both included).
 
@@ -1037,21 +1017,11 @@ PNL_TEST_ACC = '0x1F9fbD2F6a8754Cd56D4F56ED35338A63C5Bfd1f'
 def test_events_pnl(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test the uniswap events history profit and loss calculation"""
     async_query = random.choice([False, True])
+
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-
-    # Set module premium is required for calling `get_balances()`
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-
-    uniswap = rotki.chain_manager.get_module('uniswap')
-    uniswap.premium = premium
-
     setup = setup_balances(
         rotki,
         ethereum_accounts=ethereum_accounts,
@@ -1104,21 +1074,11 @@ def test_events_pnl(
 def test_get_events_history_get_all_events_empty(
         rotkehlchen_api_server,
         ethereum_accounts,  # pylint: disable=unused-argument
-        rotki_premium_credentials,  # pylint: disable=unused-argument
-        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     """Test get all the events balances for an address without events.
     """
     async_query = random.choice([False, True])
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-
-    # Set module premium is required for calling `get_balances()`
-    premium = None
-    if start_with_valid_premium:
-        premium = Premium(rotki_premium_credentials)
-
-    uniswap = rotki.chain_manager.get_module('uniswap')
-    uniswap.premium = premium
 
     setup = setup_balances(
         rotki,

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -24,7 +24,7 @@ from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
 from rotkehlchen.tests.utils.history import maybe_mock_historical_price_queries
 from rotkehlchen.tests.utils.substrate import wait_until_all_substrate_nodes_connected
-from rotkehlchen.typing import Location
+from rotkehlchen.typing import AVAILABLE_MODULES_MAP, Location
 
 
 @pytest.fixture(name='max_tasks_num')
@@ -162,6 +162,11 @@ def initialize_mock_rotkehlchen_instance(
         rotki.premium = Premium(rotki_premium_credentials)
         rotki.premium_sync_manager.premium = rotki.premium
         rotki.chain_manager.premium = rotki.premium
+        # Add premium to all the modules
+        for module_name in AVAILABLE_MODULES_MAP:
+            module = rotki.chain_manager.get_module(module_name)
+            if module is not None:
+                module.premium = rotki.premium
 
     if legacy_messages_via_websockets is False:
         rotki.msg_aggregator.rotki_notifier = None


### PR DESCRIPTION
Avoid `KeyError` and `DivisionByZero` errors in liquity module