### PR TITLE
Fix bug in task manager transactions querying

### DIFF
--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -208,8 +208,6 @@ class TaskManager():
             address=address,
             start_ts=0,
             end_ts=now,
-            with_limit=False,
-            only_cache=False,
         )
         self.last_eth_tx_query_ts[address] = now
 

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -64,12 +64,10 @@ def test_maybe_query_ethereum_transactions(task_manager, ethereum_accounts):
     task_manager.potential_tasks = [task_manager._maybe_query_ethereum_transactions]
     now = ts_now()
 
-    def tx_query_mock(address, start_ts, end_ts, with_limit, only_cache):
+    def tx_query_mock(address, start_ts, end_ts):
         assert address in ethereum_accounts
         assert start_ts == 0
         assert end_ts >= now
-        assert with_limit is False
-        assert only_cache is False
 
     tx_query_patch = patch.object(
         task_manager.chain_manager.ethereum.transactions,


### PR DESCRIPTION
After the changes done at the DB transaction querying these arguments
were removed but since here it's called dynamically no tests detected it.