### PR TITLE
Fix: reduce failing when empty in rotkehlchen/chain/ethereum/modules/liquity/trove.py:630

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -627,7 +627,9 @@ class Liquity(EthereumModule):
             changes = self._process_trove_events(trove['changes'], from_timestamp, to_timestamp)
             result.append(changes)
         # Flatten the result (list of lists to list)
-        return reduce(add, result)
+        if result:
+            return reduce(add, result)
+        return []
 
     # -- Methods following the EthereumModule interface -- #
     def on_startup(self) -> None:


### PR DESCRIPTION
Closes (see below)

When trying to generate a PnL Report, i get following error in `rotki.log`

```
[10/09/2021 14:57:03 CEST] ERROR rotkehlchen.api.rest Greenlet with id 139858799794896: Greenlet for task 59 dies with exception: reduce() of empty sequence with no initial value.
Exception Name: <class 'TypeError'>
Exception Info: reduce() of empty sequence with no initial value
Traceback:
   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/api/rest.py", line 276, in _do_query_async
  File "rotkehlchen/api/rest.py", line 1581, in _process_history
  File "rotkehlchen/rotkehlchen.py", line 594, in process_history
  File "rotkehlchen/history/events.py", line 343, in get_history
  File "rotkehlchen/chain/ethereum/modules/liquity/trove.py", line 630, in get_history_events
```


## Checklist

- [ ] ~~The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.~~

> No Frontend related changes