### PR TITLE
Add 1D Timeframe

### DIFF
--- a/frontend/app/src/components/dashboard/NetworthChart.vue
+++ b/frontend/app/src/components/dashboard/NetworthChart.vue
@@ -186,7 +186,7 @@ export default class NetWorthChart extends Vue {
       month: labelFormat(TimeFramePeriod.ALL),
       week: labelFormat(TimeFramePeriod.MONTH),
       day: labelFormat(TimeFramePeriod.WEEK),
-      hour: labelFormat(TimeFramePeriod.WEEK)
+      hour: labelFormat(TimeFramePeriod.DAY)
     };
 
     const time: TimeScale = {

--- a/frontend/app/src/store/settings/utils.ts
+++ b/frontend/app/src/store/settings/utils.ts
@@ -32,6 +32,8 @@ export function loadFrontendSettings(commit: Commit, value: string) {
 
 export function isPeriodAllowed(period: TimeFrameSetting): boolean {
   return (
-    period === TimeFramePeriod.WEEK || period === TimeFramePeriod.TWO_WEEKS
+    period === TimeFramePeriod.WEEK ||
+    period === TimeFramePeriod.TWO_WEEKS ||
+    period === TimeFramePeriod.DAY
   );
 }

--- a/frontend/common/src/settings/graphs.ts
+++ b/frontend/common/src/settings/graphs.ts
@@ -6,7 +6,8 @@ export enum TimeFramePeriod  {
   THREE_MONTHS = '3M',
   MONTH = '1M',
   TWO_WEEKS = '2W',
-  WEEK = '1W'
+  WEEK = '1W',
+  DAY = '1D'
 }
 
 export enum TimeFramePersist {
@@ -53,6 +54,12 @@ function unitDefaults(timeUnit: TimeUnit): TimeframeDefaults {
       xAxisLabelDisplayFormat: 'MMMM YYYY',
       tooltipTimeFormat: 'MMMM D, YYYY'
     };
+  } else if (timeUnit === TimeUnit.HOUR) {
+    return {
+      xAxisTimeUnit: timeUnit,
+      xAxisLabelDisplayFormat: 'HH:mm',
+      tooltipTimeFormat: 'D, HH:mm'
+    };
   }
   throw new Error(`Invalid time unit selected: ${timeUnit}`);
 }
@@ -74,6 +81,8 @@ function createTimeframe(
       startUnit = TimeUnit.MONTH;
     } else if ([TimeFramePeriod.WEEK, TimeFramePeriod.TWO_WEEKS].includes(frame)) {
       startUnit = TimeUnit.WEEK;
+    } else if ([TimeFramePeriod.DAY].includes(frame)) {
+      startUnit = TimeUnit.HOUR;
     } else {
       throw new Error(`unsupported timeframe: ${frame}`);
     }
@@ -101,7 +110,8 @@ export const timeframes: (startingDate: StartingDateCalculator) => Timeframes = 
     ),
     [TimeFramePeriod.MONTH]: createTimeframe(startingDate, TimeFramePeriod.MONTH, TimeUnit.WEEK),
     [TimeFramePeriod.TWO_WEEKS]: createTimeframe(startingDate, TimeFramePeriod.TWO_WEEKS, TimeUnit.DAY, 2),
-    [TimeFramePeriod.WEEK]: createTimeframe(startingDate, TimeFramePeriod.WEEK, TimeUnit.DAY)
+    [TimeFramePeriod.WEEK]: createTimeframe(startingDate, TimeFramePeriod.WEEK, TimeUnit.DAY),
+    [TimeFramePeriod.DAY]: createTimeframe(startingDate, TimeFramePeriod.DAY, TimeUnit.HOUR)
   }
 };
 

--- a/frontend/common/src/settings/index.ts
+++ b/frontend/common/src/settings/index.ts
@@ -15,7 +15,8 @@ export enum TimeUnit {
   YEAR = 'year',
   MONTH = 'month',
   WEEK = 'week',
-  DAY = 'day'
+  DAY = 'day',
+  HOUR = 'hour'
 }
 
 export const DARK_MODE_ENABLED = 'darkModeEnabled' as const;


### PR DESCRIPTION
Adds 1D (1 Day) as selectable Timeframe to the dashboard net worth graph

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

> Could provide updated screenshots if needed (is it enough to just create a new test user and add some manual assets?, because one of the screenshots with the graph visible has loopring in its name, guess its about the coin in that one?)
