### PR TITLE
Task scheduling should never occur after/during logout

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -317,7 +317,7 @@ class Rotkehlchen():
         self.user_is_logged_in = True
         log.debug('User unlocking complete')
 
-    def logout(self) -> None:
+    def _logout(self) -> None:
         if not self.user_is_logged_in:
             return
         user = self.data.username
@@ -349,6 +349,13 @@ class Rotkehlchen():
             'User successfully logged out',
             user=user,
         )
+
+    def logout(self) -> None:
+        if self.task_manager is None:  # no user logged in?
+            return
+
+        with self.task_manager.schedule_lock:
+            self._logout()
 
     def set_premium_credentials(self, credentials: PremiumCredentials) -> None:
         """


### PR DESCRIPTION
Again close #1889. It was kind of fixed before, but now with this lock
introduction the scheduling code should never run after or during a
logout has started.

This is to make sure this exception does not happen at the edge case of shutting down rotki while a premium DB upload is being scheduled.

```
2021-09-13T21:44:19.300Z: Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/rotkehlchen.py", line 427, in main_loop
  File "rotkehlchen/tasks/manager.py", line 268, in schedule
  File "rotkehlchen/premium/sync.py", line 209, in maybe_upload_data_to_server
AttributeError: 'DataHandler' object has no attribute 'db'
2021-09-13T21:44:19Z <Greenlet "Greenlet-1" at 0x7fcc2f7deef0: <bound method Rotkehlchen.main_loop of <rotkehlchen.rotkehlchen.Rotkehlchen object at 0x7fcc2f67bd10>>> failed with AttributeError
```