### PR TITLE
#1345: Fix import source not matching valid value.

### DIFF
--- a/frontend/app/src/components/import/UpholdImport.vue
+++ b/frontend/app/src/components/import/UpholdImport.vue
@@ -1,5 +1,5 @@
 <template>
-  <import-source source="uphold-trades">
+  <import-source source="uphold">
     <template #image>
       <uphold-horizontal />
     </template>


### PR DESCRIPTION
Closes #1345

## Checklist

- [x] The PR modified the frontend and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

The import source had the wrong value in the new `UpholdImport.vue` component.  This slip-up caused uphold transaction import UI to fail with an improper import source validation error in the frontend.