### PR TITLE
Update backend typing and sphinx docs dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ urllib3==1.26.6
 pycryptodome==3.6.6
 pycryptodomex==3.6.6
 coincurve==13.0.0
-typing-extensions==3.10.0.1
+typing-extensions==3.10.0.2
 base58check==1.0.2
 bech32==1.2.0
 gql==2.0.0

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
-sphinx==4.1.2
+sphinx==4.2.0
 sphinx-autobuild==2021.3.14
-sphinx_rtd_theme==0.5.2
+sphinx_rtd_theme==1.0.0
 sphinxcontrib-httpdomain==1.7.0
 # This is our fork of sphinxcontrib-httpexample in order to handle https://github.com/rotki/rotki/issues/2612
 sphinxcontrib-httpexample-rotki==0.1.2

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -15,10 +15,10 @@ isort==5.9.3
 
 # type packages used by mypy
 # pinned here so that we can have reproducible mypy runs
-types-chardet==0.1.5
+types-chardet==4.0.0
 types-cryptography==3.3.5
 types-enum34==1.1.0
 types-ipaddress==1.0.0
 types-pkg-resources==0.1.3
-types-requests==2.25.6
-types-toml==0.1.5
+types-requests==2.25.7
+types-toml==0.10.0

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -56,7 +56,7 @@ def test_nft_query(rotkehlchen_api_server, start_with_valid_premium):
             assert FVal(entry['price_eth']) > ZERO
             assert FVal(entry['price_usd']) > ZERO
             assert entry['collection']['name'] == 'BASTARD GAN PUNKS V2'
-            assert entry['collection']['banner_image'] == 'https://lh3.googleusercontent.com/InX38GA4YmuR2ukDhN0hjf8-Qj2U3Tdw3wD24IsbjuXNtrTZXNwWiIeWR9bJ_-rEUOnQgkpLbj71TDKrzNzHLHkOSRdLo8Yd2tE3_jg=s2500'  # noqa: E501
-            assert entry['collection']['description'] == "VERSION 2 OF BASTARD GAN PUNKS ARE COOLER, BETTER AND GOOFIER THAN BOTH BOOMER CRYPTOPUNKS & VERSION 1 BASTARD GAN PUNKS. THIS TIME, ALL CRYPTOPUNK ATTRIBUTES ARE EXTRACTED AND A NEW DATASET OF ALL COMBINATIONS OF THEM ARE TRAINED WITH GAN TO GIVE BIRTH TO EVEN MORE BADASS ONES. ALSO EACH ONE HAS A UNIQUE STORY GENERATED FROM MORE THAN 10K PUNK & EMO SONG LYRICS VIA GPT-2 LANGUAGE PROCESSING ALGORITHM. \r\n\r\nBASTARDS ARE SLOWLY DEGENERATING THE WORLD. ADOPT ONE TO KICK EVERYONE'S ASSES!\r\n\r\nDISCLAIMER: THIS PROJECT IS NOT AFFILIATED WITH LARVA LABS"  # noqa: E501
-            assert entry['collection']['large_image'] == 'https://lh3.googleusercontent.com/vF8johTucYy6yycIOJTM94LH-wcDQIPTn9-eKLMbxajrm7GZfJJWqxdX6uX59pA4n4n0QNEn3bh1RXcAFLeLzJmq79aZmIXVoazmVw=s300'  # noqa: E501
+            assert entry['collection']['banner_image'].startswith('https://')
+            assert isinstance(entry['collection']['description'], str)
+            assert entry['collection']['large_image'].startswith('https://')
             break


### PR DESCRIPTION
We also get a ton of errors like this when building the docs:

`WARNING: Problem in http domain: field is supposed to use role 'obj', but that role is not in the domain`

But they can be ignored for now. It's already fixed upstream here:
sphinx-contrib/httpdomain#53 and we are
waiting for a release
