### PR TITLE
Add mapping for Barnbridge in coinbasepro

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 * :bug:`3418` Users will now be able to finish import from crypto.com's CSV files when there is a time mismatch between rows.
 * :bug:`3056` Users will now be better notified when an error occurred while importing information from crypto.com on credit/debit events with special cases.
 * :bug:`3493` Users of Bitstamp will see correctly imported assets movements with fees in any coin.
+* :bug:`3491` Coinbasepro users who own Barnbridge governance token (BOND) will now be able to properly see it in balances, trades and deposits/withdrawals.
 
 * :release:`1.20.1 <2021-08-27>`
 * :bug:`3349` Defi swaps trade now shows in trade history.

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -401,6 +401,7 @@ WORLD_TO_COINBASE_PRO = {
     strethaddress_to_identifier('0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85'): 'FET',
     strethaddress_to_identifier('0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9'): 'WLUNA',
     strethaddress_to_identifier('0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b'): 'AXS',
+    strethaddress_to_identifier('0x0391D2021f89DC339F60Fff84546EA23E337750f'): 'BOND',
 }
 
 WORLD_TO_COINBASE = {


### PR DESCRIPTION
Fix #3491

This is needed since BOND is ambiguous as a symbol:

```
sqlite> SELECT * from assets where symbol="BOND";
_ceth_0x0391D2021f89DC339F60Fff84546EA23E337750f|C|BarnBridge|BOND|1599494104||barnbridge||0x0391D2021f89DC339F60Fff84546EA23E337750f
_ceth_0x5Dc02Ea99285E17656b8350722694c35154DB1E8|C|BOND|BOND|||||0x5Dc02Ea99285E17656b8350722694c35154DB1E8
sqlite>
```