### PR TITLE
Update sphincontrib-httpdomain

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,7 +1,7 @@
 sphinx==4.2.0
 sphinx-autobuild==2021.3.14
 sphinx_rtd_theme==1.0.0
-sphinxcontrib-httpdomain==1.7.0
+sphinxcontrib-httpdomain==1.8.0
 # This is our fork of sphinxcontrib-httpexample in order to handle https://github.com/rotki/rotki/issues/2612
 sphinxcontrib-httpexample-rotki==0.1.2
 # This is our fork of releases in order to handle https://github.com/rotki/rotki/issues/704


### PR DESCRIPTION
They made a new release which fixes https://github.com/sphinx-contrib/httpdomain/issues/53 and makes the docs build have no errors again.
