### PR TITLE
Exposes statistics to components via api

### DIFF
--- a/frontend/app/src/premium/setup-interface.ts
+++ b/frontend/app/src/premium/setup-interface.ts
@@ -21,6 +21,7 @@ import Vuex from 'vuex';
 import { displayDateFormatter } from '@/data/date_formatter';
 import { DARK_COLORS, LIGHT_COLORS } from '@/plugins/theme';
 import { registerComponents } from '@/premium/register-components';
+import { statisticsApi } from '@/premium/statistics-api';
 import { api } from '@/services/rotkehlchen-api';
 import { HistoryActions } from '@/store/history/consts';
 import { FrontendSettingsPayload } from '@/store/settings/types';
@@ -73,7 +74,8 @@ const data: DataUtilities = {
         payload
       );
     }
-  }
+  },
+  statistics: statisticsApi
 };
 
 const settings: SettingsApi = {

--- a/frontend/app/src/premium/statistics-api.ts
+++ b/frontend/app/src/premium/statistics-api.ts
@@ -1,0 +1,32 @@
+import { StatisticsApi } from '@rotki/common/lib/premium';
+import {
+  LocationData,
+  OwnedAssets,
+  TimedAssetBalances,
+  TimedBalances
+} from '@rotki/common/lib/statistics';
+import { axiosCamelCaseTransformer } from '@/services/axios-tranformers';
+import { api } from '@/services/rotkehlchen-api';
+
+export const statisticsApi: StatisticsApi = {
+  async assetValueDistribution(): Promise<TimedAssetBalances> {
+    const data = await api.queryLatestAssetValueDistribution();
+    return TimedAssetBalances.parse(axiosCamelCaseTransformer(data));
+  },
+  async locationValueDistribution(): Promise<LocationData> {
+    const data = await api.queryLatestLocationValueDistribution();
+    return LocationData.parse(axiosCamelCaseTransformer(data));
+  },
+  async ownedAssets(): Promise<OwnedAssets> {
+    const ownedAssets = await api.assets.queryOwnedAssets();
+    return OwnedAssets.parse(ownedAssets);
+  },
+  async timedBalances(
+    asset: string,
+    start: number,
+    end: number
+  ): Promise<TimedBalances> {
+    const balances = await api.queryTimedBalancesData(asset, start, end);
+    return TimedBalances.parse(axiosCamelCaseTransformer(balances));
+  }
+};

--- a/frontend/common/src/premium/index.ts
+++ b/frontend/common/src/premium/index.ts
@@ -1,6 +1,7 @@
 import { ActionResult, SupportedAsset } from "../data";
 import { GitcoinGrantEventsPayload, GitcoinGrantReport, GitcoinGrants, GitcoinReportPayload } from "../gitcoin";
 import { DebugSettings, FrontendSettingsPayload, Themes, TimeUnit } from "../settings";
+import { LocationData, OwnedAssets, TimedAssetBalances, TimedBalances } from "../statistics";
 
 export interface RotkiPremiumInterface {
   readonly useHostComponents: boolean;
@@ -17,6 +18,17 @@ export interface GitCoinApi {
   generateReport(payload: GitcoinReportPayload): Promise<GitcoinGrantReport>;
 }
 
+export interface StatisticsApi {
+  assetValueDistribution(): Promise<TimedAssetBalances>
+  locationValueDistribution(): Promise<LocationData>
+  ownedAssets(): Promise<OwnedAssets>
+  timedBalances(
+    asset: string,
+    start: number,
+    end: number
+  ): Promise<TimedBalances>;
+}
+
 export interface DateUtilities {
   epoch(): number;
   format(date: string, oldFormat: string, newFormat: string): string;
@@ -31,6 +43,7 @@ export interface DataUtilities {
   assetInfo(identifier: string): SupportedAsset | undefined;
   getIdentifierForSymbol(symbol: string): string | undefined;
   readonly gitcoin: GitCoinApi;
+  readonly statistics: StatisticsApi;
 }
 
 export interface SettingsApi {

--- a/frontend/common/src/statistics/index.ts
+++ b/frontend/common/src/statistics/index.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { AssetBalance, Balance, NumericString } from "../index";
+
+const TimedEntry = z.object({ time: z.number().positive() });
+
+const TimedBalance = Balance.merge(TimedEntry);
+
+export type TimedBalance = z.infer<typeof TimedBalance>
+
+export const TimedBalances = z.array(TimedBalance);
+
+export type TimedBalances = z.infer<typeof TimedBalances>
+
+export const OwnedAssets = z.array(z.string())
+
+export type OwnedAssets = z.infer<typeof OwnedAssets>
+
+const LocationDataItem = z.object({
+  time: z.number().positive(),
+  location: z.string().nonempty(),
+  usdValue: NumericString
+})
+
+export const LocationData = z.array(LocationDataItem)
+
+export type LocationData = z.infer<typeof LocationData>
+
+const TimedAssetBalance = AssetBalance.merge(TimedEntry)
+
+export const TimedAssetBalances = z.array(TimedAssetBalance)
+
+export type TimedAssetBalances = z.infer<typeof TimedAssetBalances>


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- [x] Adds proper typing for statistics api
- [x] Adds API that will replace passing the whole API object

It can be easily tested via console:

```javascript
await rotki.utils.data.statistics.assetValueDistribution()
await rotki.utils.data.statistics.ownedAssets()
await rotki.utils.data.statistics.locationValueDistribution()
await rotki.utils.data.statistics.timedBalances('ETH',0,Math.floor(new Date().getTime()/1000))
```