### PR TITLE
Stops nft balance check when module is not active

### DIFF
--- a/frontend/app/src/store/balances/actions.ts
+++ b/frontend/app/src/store/balances/actions.ts
@@ -1306,9 +1306,13 @@ export const actions: ActionTree<BalanceState, RotkehlchenState> = {
   },
 
   async [BalanceActions.FETCH_NF_BALANCES](
-    { commit, rootGetters: { status } },
+    { commit, rootGetters: { status }, rootState: { session } },
     payload?: { ignoreCache: boolean }
   ): Promise<void> {
+    const { activeModules } = session!!.generalSettings;
+    if (!activeModules.includes(Module.NFTS)) {
+      return;
+    }
     const section = Section.NON_FUNGIBLE_BALANCES;
     try {
       setStatus(Status.LOADING, section, status, commit);


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

There was an error because frontend was querying the NFT balances with the module deactivated