### PR TITLE
Properly show 0 amount for assets in graphs when no balance existed 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`2613` Graphs of assets that used to miss all 0 balance data points between two time point will now properly show a 0 amount in the asset graph for the time period.
+
 * :release:`1.21.0 <2021-09-30>`
 * :feature:`3251` Users will now be able to easily access the asset edit page from the asset details page.
 * :feature:`3020` Users will now be able to copy their ETH1 addresses when visiting the ETH2 staking page.

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -574,11 +574,13 @@ def test_query_timed_balances(data_dir, username):
     assert result[0].amount == '500'
     assert result[0].usd_value == '500'
 
-    result = data.db.query_timed_balances(
+    all_data = data.db.query_timed_balances(
         from_ts=1451606300,
         to_ts=1485907000,
         asset=A_ETH,
     )
+    assert len(all_data) == 158
+    result = [x for x in all_data if x.amount != '0']
     assert len(result) == 2
     assert result[0].time == 1451606401
     assert result[0].category == BalanceType.ASSET
@@ -589,7 +591,9 @@ def test_query_timed_balances(data_dir, username):
     assert result[1].amount == '10'
     assert result[1].usd_value == '123'
 
-    result = data.db.query_timed_balances(A_ETH)
+    all_data = data.db.query_timed_balances(A_ETH)
+    assert len(all_data) == 399
+    result = [x for x in all_data if x.amount != '0']
     assert len(result) == 4
     result = data.db.query_timed_balances(A_ETH, balance_type=BalanceType.LIABILITY)
     assert len(result) == 1


### PR DESCRIPTION
Fix #2613

If no balance snapshot was taken for an asset in between a time range
the graphs used to show no data points and as such they looked wrong.

Now we create virtual data points to fix this.


Before:

![2021-10-01_11-44](https://user-images.githubusercontent.com/1658405/135600714-a022de76-b4fe-4fa1-bdab-28bb3f054c46.png)

After:

![2021-10-01_11-41](https://user-images.githubusercontent.com/1658405/135600738-cb7cb3eb-cd4a-46e4-a2a9-4e4d1b502468.png)
