### PR TITLE
Do not add any NFT asset in global DB

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -10,6 +10,7 @@ from rotkehlchen.assets.asset import Asset, EthereumToken, UnderlyingToken
 from rotkehlchen.assets.typing import AssetData, AssetType
 from rotkehlchen.chain.ethereum.typing import string_to_ethereum_address
 from rotkehlchen.constants.assets import CONSTANT_ASSETS
+from rotkehlchen.constants.misc import NFT_DIRECTIVE
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors import DeserializationError, InputError, UnknownAsset
 from rotkehlchen.globaldb.upgrades.v1_v2 import upgrade_ethereum_asset_ids
@@ -869,7 +870,7 @@ class GlobalDBHandler():
         try:
             cursor.executemany(
                 'INSERT OR IGNORE INTO user_owned_assets(asset_id) VALUES(?)',
-                [(x.identifier,) for x in assets],
+                [(x.identifier,) for x in assets if not x.identifier.startswith(NFT_DIRECTIVE)],
             )
         except sqlite3.IntegrityError as e:
             log.error(


### PR DESCRIPTION
We noticed that some users were having foreign key errors due to nfts
being attempted to be added to their global db. This was a logic
error. NFTs should never be attempted to go at the global DB in their
current state. It was happening when adding the user owned assets.

This fixes it and adds a test for it.