### PR TITLE
Add traling / to url to frontend query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :bug:`3546` Coinbase users with trades/deposits/withdrawals/balances of FET (Fetch.ai) should have it properly detected.
 * :bug:`2613` Graphs of assets that used to miss all 0 balance data points between two time point will now properly show a 0 amount in the asset graph for the time period.
 * :bug:`3552` Users with semi-fungible tokens in different ethereum wallets will see them correctly in the NFT gallery.
+* :bug:`-` Docker users will be able to retrieve automatic information for tokens when adding new ethereum assets.
 
 * :release:`1.21.0 <2021-09-30>`
 * :feature:`3251` Users will now be able to easily access the asset edit page from the asset details page.

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -994,7 +994,7 @@ export class RotkehlchenApi {
 
   async erc20details(address: string): Promise<PendingTask> {
     return this.axios
-      .get<ActionResult<PendingTask>>('/blockchains/ETH/erc20details', {
+      .get<ActionResult<PendingTask>>('/blockchains/ETH/erc20details/', {
         params: axiosSnakeCaseTransformer({
           asyncQuery: true,
           address


### PR DESCRIPTION
Add traling / to url so docker instances correctly query backend for erc-20 token information

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
