### PR TITLE
Add test for querying NFTs, ignoring cache, after adding new ETH acc

### DIFF
--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -359,7 +359,7 @@ def _add_blockchain_accounts_test_start(
         setup.enter_ethereum_patches(stack)
         response = requests.put(api_url_for(
             api_server,
-            "blockchainsaccountsresource",
+            'blockchainsaccountsresource',
             blockchain='ETH',
         ), json=data)
 


### PR DESCRIPTION
The bug report may have been invalid. This test shows the backend works fine. And when retried frontend test it worked this time. So perhaps it was something else.

Closes #3590