### PR TITLE
Fix binance symbols_to_pairs usage

### DIFF
--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -254,6 +254,7 @@ class Binance(ExchangeInterface):  # lgtm[py/missing-call-to-init]
 
     @property
     def symbols_to_pair(self) -> Dict[str, BinancePair]:
+        """Returns binance symbols to pair if in memory otherwise queries binance"""
         self.first_connection()
         return self._symbols_to_pair
 

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from importlib import import_module
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, cast
 
 from rotkehlchen.exchanges.binance import BINANCE_BASE_URL, BINANCEUS_BASE_URL
 from rotkehlchen.exchanges.exchange import ExchangeInterface
@@ -18,6 +18,7 @@ from rotkehlchen.user_messages import MessagesAggregator
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.exchanges.binance import Binance
     from rotkehlchen.exchanges.kraken import KrakenAccountType
 
 logger = logging.getLogger(__name__)
@@ -292,11 +293,11 @@ class ExchangeManager():
 
     def get_all_binance_pairs(self) -> List[str]:
         if Location.BINANCE in self.connected_exchanges:
-            binance = self.connected_exchanges[Location.BINANCE][0]
-            return binance._symbols_to_pair.keys()  # type: ignore
+            binance = cast('Binance', self.connected_exchanges[Location.BINANCE][0])
+            return list(binance.symbols_to_pair.keys())
         if Location.BINANCEUS in self.connected_exchanges:
-            binance = self.connected_exchanges[Location.BINANCEUS][0]
-            return binance._symbols_to_pair.keys()  # type: ignore
+            binance = cast('Binance', self.connected_exchanges[Location.BINANCEUS][0])
+            return list(binance.symbols_to_pair.keys())
         return []
 
     def get_user_binance_pairs(self, name: str, location: Location) -> List[str]:


### PR DESCRIPTION
Fixes a bug where some times binance pairs endpoint was called before
the first binance call established a connection and initialized the
mapping. Used to manifest with this exception:

```
[14/10/2021 17:40:57 GMT Daylight Time] ERROR rotkehlchen.api.server Exception on /api/1/exchanges/binance/pairs [GET]
Traceback (most recent call last):
  File "site-packages\flask\app.py", line 1513, in full_dispatch_request
  File "site-packages\flask\app.py", line 1499, in dispatch_request
  File "site-packages\flask_restful\__init__.py", line 467, in wrapper
  File "site-packages\flask\views.py", line 83, in view
  File "site-packages\flask_restful\__init__.py", line 582, in dispatch_request
  File "rotkehlchen\api\v1\resources.py", line 1834, in get
  File "rotkehlchen\api\rest.py", line 3240, in get_all_binance_pairs
  File "rotkehlchen\exchanges\manager.py", line 296, in get_all_binance_pairs
AttributeError: 'Binance' object has no attribute '_symbols_to_pair'
```