### PR TITLE
Change uniswap v3 subgraph

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/uniswap/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/graph.py
@@ -8,7 +8,7 @@ V3_SWAPS_QUERY = (
         first: $limit,
         skip: $offset,
         where: {{
-            recipient: $address,
+            origin: $address,
             timestamp_gte: $start_ts,
             timestamp_lte: $end_ts,
         }}

--- a/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
@@ -51,7 +51,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
 
     * Uniswap subgraph:
     https://github.com/Uniswap/uniswap-v2-subgraph
-    https://github.com/Uniswap/uniswap-v3-subgraph
+    https://github.com/croco-finance/uniswap-v3-subgraph
     """
     def __init__(
             self,
@@ -65,7 +65,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
                 'https://api.thegraph.com/subgraphs/name/benesjan/uniswap-v2',
             )
             self.graph_v3 = Graph(
-                'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
+                'https://api.thegraph.com/subgraphs/name/benesjan/uniswap-v3-subgraph',
             )
         except RemoteError as e:
             self.msg_aggregator.add_error(


### PR DESCRIPTION
There is an issue with how the uniswap offical subgraph maps
swaps where for certain trades the person receiving the
transaction is not properly detected.
We had a similar issue with uniswap v2 #2648 and the people
at croco-finance offered a similar solution.

Closes #3638

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
