### PR TITLE
Add "npm start" for simpler developer onboarding experience

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -341,7 +341,7 @@ Since the electron application is located in a different directory you also need
 Before starting the application you need to build the common package. To do this you can go to ``frontend`` and
 run ``npm run build -w @rotki/common``.
 
-After that you can start the application from the ``frontend`` directory and typing ``npm run electron:serve -w rotki``.
+After that you can start the application from the ``frontend`` directory and typing ``npm start``.
 
 OSX
 =====
@@ -590,7 +590,7 @@ Installing Electron and Running rotki
 
 3. At this point, your terminal's cwd should be ``<rotki development directory>\frontend\`` and the rotki virtualenv should be activated. You should now be able to start rotki in development mode by executing::
 
-    npm run electron:serve -w rotki
+    npm start
 
 After the app is built, if everything went well you should see the below text in your terminal and a new electron window that has opened with the rotki app running. ::
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "check": "npm run lint && npm run build && npm run test:unit --workspace=rotki",
     "check:all": "npm run lint && npm run build && npm run test:unit --workspace=rotki && npm run test:integration-ci --workspace=rotki",
     "clean:modules": "rimraf node_modules app/node_modules common/node_modules",
-    "dev": "node start-dev.js"
+    "dev": "node start-dev.js",
+    "start": "npm run electron:serve -w rotki"
   },
   "devDependencies": {
     "dotenv": "10.0.0",

--- a/frontend/start-dev.js
+++ b/frontend/start-dev.js
@@ -40,7 +40,7 @@ const commonProcesses = spawn("npm run watch -w @rotki/common", {
   stdio: [process.stdin, process.stdout, process.stderr]
 });
 process.stdout.write("Starting rotki dev mode \n");
-const devRotkiProcess = spawn("sleep 20 && npm run electron:serve -w rotki", {
+const devRotkiProcess = spawn("sleep 20 && npm start", {
   shell: true,
   stdio: [process.stdin, process.stdout, process.stderr]
 });


### PR DESCRIPTION
`npm run electron:serve -w rotki` is hard to remember, and not very friendly for new contributors.  Anything which can simplify the onboarding experience for new developers should help increase contributions to Rotki.  So make `npm start` do the same thing, and update the docs accordingly.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.