### PR TITLE
Fix transaction receipt parsing for nodes that do not return type field

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 * :bug:`3667` Users should be able to upload asset icons to docker instances when using a remote connection via the application.
 * :bug:`3664` Binance US users will no longer see errors regarding the fiat payments and orders endpoints.
 * :bug:`3666` An ethereum token's address will be properly filled when navigating to the asset edit from the asset overview page.
+* :bug:`-` Transaction receipts will now be processed properly even for nodes(such as open ethereum) that do not return the type field for non EIP1559 transactions.
 
 * :release:`1.21.3 <2021-10-28>`
 * :bug:`2178` Premium DB sync popup should no longer popup if you only use one instance of rotki in one system.

--- a/rotkehlchen/db/ethtx.py
+++ b/rotkehlchen/db/ethtx.py
@@ -142,7 +142,8 @@ class DBEthTx():
           or if the receipt already exists in the DB. TODO: Differentiate?
         """
         tx_hash_b = hexstring_to_bytes(data['transactionHash'])
-        tx_type = hexstr_to_int(data['type'])
+        # some nodes miss the type field for older non EIP1559 transactions. So assume legacy (0)
+        tx_type = hexstr_to_int(data.get('type', '0x0'))
         cursor = self.db.conn.cursor()
         status = data.get('status', 1)  # status may be missing for older txs. Assume 1.
         contract_address = deserialize_ethereum_address(data['contractAddress']) if data['contractAddress'] else None  # noqa: E501

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -27,8 +27,19 @@ INFURA_TEST = random.choice([
     'https://mainnet.infura.io/v3/edeb337c7f41425e933ec619f3c5b940',
     'https://mainnet.infura.io/v3/66302b8fb9874614905a3cbe903a0dbb',
 ])
+ALCHEMY_TEST = 'https://eth-mainnet.alchemyapi.io/v2/ga1GtB7R26UgzjextaVpbaWZ49nSi2zt'
 
 ETHERSCAN_AND_INFURA_PARAMS: Tuple[str, List[Tuple]] = ('ethrpc_endpoint,ethereum_manager_connect_at_start, call_order', [  # noqa: E501
+    ('', (), (NodeName.ETHERSCAN,)),
+    (
+        INFURA_TEST,
+        (NodeName.OWN,),
+        (NodeName.OWN,),
+    ),
+])
+
+
+ETHERSCAN_AND_INFURA_AND_ALCHEMY: Tuple[str, List[Tuple]] = ('ethrpc_endpoint,ethereum_manager_connect_at_start, call_order', [  # noqa: E501
     # Query etherscan only
     ('', (), (NodeName.ETHERSCAN,)),
     # For "our own" node querying use infura
@@ -37,8 +48,15 @@ ETHERSCAN_AND_INFURA_PARAMS: Tuple[str, List[Tuple]] = ('ethrpc_endpoint,ethereu
         (NodeName.OWN,),
         (NodeName.OWN,),
     ),
+    (
+        ALCHEMY_TEST,
+        (NodeName.OWN,),
+        (NodeName.OWN,),
+    ),
 ])
 
+
+# Test with etherscan and infura
 ETHEREUM_TEST_PARAMETERS: Tuple[str, List[Tuple]]
 if 'GITHUB_WORKFLOW' in os.environ:
     # For Github actions don't use infura. It seems that connecting to it
@@ -50,6 +68,20 @@ if 'GITHUB_WORKFLOW' in os.environ:
 else:
     # For Travis and local tests also use Infura, works fine
     ETHEREUM_TEST_PARAMETERS = ETHERSCAN_AND_INFURA_PARAMS
+
+
+# Test with multipe node types and etherscan
+ETHEREUM_FULL_TEST_PARAMETERS: Tuple[str, List[Tuple]]
+if 'GITHUB_WORKFLOW' in os.environ:
+    # For Github actions don't use infura. It seems that connecting to it
+    # from Github actions hangs and times out
+    ETHEREUM_FULL_TEST_PARAMETERS = ('ethrpc_endpoint,ethereum_manager_connect_at_start, call_order', [  # noqa: E501
+        # Query etherscan only
+        ('', (), (NodeName.ETHERSCAN,)),
+    ])
+else:
+    # For Travis and local tests also use Infura, works fine
+    ETHEREUM_FULL_TEST_PARAMETERS = ETHERSCAN_AND_INFURA_AND_ALCHEMY
 
 
 def wait_until_all_nodes_connected(


### PR DESCRIPTION
Transaction receipts will now be processed properly even for nodes(such as open ethereum) that do not return the type field for non EIP1559 transactions.