### PR TITLE
Allow flag to sync database if premium

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -106,6 +106,7 @@ Handling user creation, sign-in, log-out and querying
             "password": "supersecurepassword",
             "premium_api_key": "dasdsda",
             "premium_api_secret": "adsadasd",
+            "sync_database": true,
             "initial_settings": {
                 "submit_usage_analytics": false
             }
@@ -115,6 +116,7 @@ Handling user creation, sign-in, log-out and querying
    :reqjson string password: The password with which to encrypt the database for the new user
    :reqjson string[optional] premium_api_key: An optional api key if the user has a rotki premium account.
    :reqjson string[optional] premium_api_secret: An optional api secret if the user has a rotki premium account.
+   :reqjson bool[optional] sync_database: If set to true rotki will try to download a remote database for premium users if there is any.
    :reqjson object[optional] initial_settings: Optionally provide DB settings to set when creating the new user. If not provided, default settings are used.
 
    **Example Response**:

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1130,6 +1130,7 @@ class RestAPI():
             password: str,
             premium_api_key: str,
             premium_api_secret: str,
+            sync_database: bool,
             initial_settings: Optional[ModifiableDBSettings],
     ) -> Response:
         result_dict: Dict[str, Any] = {'result': None, 'message': ''}
@@ -1170,6 +1171,7 @@ class RestAPI():
                 sync_approval='yes',
                 premium_credentials=premium_credentials,
                 initial_settings=initial_settings,
+                sync_database=sync_database,
             )
         # not catching RotkehlchenPermissionError here as for new account with premium
         # syncing there is no way that permission needs to be asked by the user

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -1274,6 +1274,7 @@ class UserPremiumSyncSchema(AsyncQueryArgumentSchema):
 class NewUserSchema(BaseUserSchema):
     premium_api_key = fields.String(load_default='')
     premium_api_secret = fields.String(load_default='')
+    sync_database = fields.Boolean(load_default=True)
     initial_settings = fields.Nested(ModifiableSettingsSchema, load_default=None)
 
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -801,6 +801,7 @@ class UsersResource(BaseResource):
             password: str,
             premium_api_key: str,
             premium_api_secret: str,
+            sync_database: bool,
             initial_settings: Optional[ModifiableDBSettings],
     ) -> Response:
         return self.rest_api.create_new_user(
@@ -808,6 +809,7 @@ class UsersResource(BaseResource):
             password=password,
             premium_api_key=premium_api_key,
             premium_api_secret=premium_api_secret,
+            sync_database=sync_database,
             initial_settings=initial_settings,
         )
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -158,6 +158,7 @@ class Rotkehlchen():
             sync_approval: Literal['yes', 'no', 'unknown'],
             premium_credentials: Optional[PremiumCredentials],
             initial_settings: Optional[ModifiableDBSettings] = None,
+            sync_database: bool = True,
     ) -> None:
         """Unlocks an existing user or creates a new one if `create_new` is True
 
@@ -174,6 +175,7 @@ class Rotkehlchen():
             user=user,
             create_new=create_new,
             sync_approval=sync_approval,
+            sync_database=sync_database,
             initial_settings=initial_settings,
         )
 
@@ -194,6 +196,7 @@ class Rotkehlchen():
                 username=user,
                 create_new=create_new,
                 sync_approval=sync_approval,
+                sync_database=sync_database,
             )
         except PremiumAuthenticationError:
             # Reraise it only if this is during the creation of a new account where

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -18,6 +18,7 @@ from rotkehlchen.tests.utils.premium import (
     VALID_PREMIUM_KEY,
     VALID_PREMIUM_SECRET,
     assert_db_got_replaced,
+    asset_database_wasnt_replaced,
     create_patched_requests_get_for_premium,
     get_different_hash,
     setup_starting_environment,
@@ -176,6 +177,28 @@ def test_try_premium_at_start_new_account_can_pull_data(
         db_can_sync_setting=False,
     )
     assert_db_got_replaced(rotkehlchen_instance=rotkehlchen_instance, username=username)
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_try_premium_at_start_new_account_rejects_data(
+        rotkehlchen_instance,
+        username,
+        db_password,
+        rotki_premium_credentials,
+):
+    # Test that even with can_sync False, at start of new account we attempt data pull
+    setup_starting_environment(
+        rotkehlchen_instance=rotkehlchen_instance,
+        username=username,
+        db_password=db_password,
+        premium_credentials=rotki_premium_credentials,
+        first_time=True,
+        same_hash_with_remote=False,
+        newer_remote_db=True,
+        db_can_sync_setting=False,
+        sync_database=False,
+    )
+    asset_database_wasnt_replaced(rotkehlchen_instance=rotkehlchen_instance)
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -18,7 +18,6 @@ from rotkehlchen.tests.utils.premium import (
     VALID_PREMIUM_KEY,
     VALID_PREMIUM_SECRET,
     assert_db_got_replaced,
-    asset_database_wasnt_replaced,
     create_patched_requests_get_for_premium,
     get_different_hash,
     setup_starting_environment,
@@ -198,7 +197,9 @@ def test_try_premium_at_start_new_account_rejects_data(
         db_can_sync_setting=False,
         sync_database=False,
     )
-    asset_database_wasnt_replaced(rotkehlchen_instance=rotkehlchen_instance)
+    msg = 'Test default main currency should be different from the restored currency'
+    assert DEFAULT_TESTS_MAIN_CURRENCY != A_GBP, msg
+    assert rotkehlchen_instance.data.db.get_main_currency() == DEFAULT_TESTS_MAIN_CURRENCY
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -224,9 +224,3 @@ def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
 
     assert main_db_exists
     assert backup_db_exists
-
-
-def asset_database_wasnt_replaced(rotkehlchen_instance: Rotkehlchen):
-    msg = 'Test default main currency should be different from the restored currency'
-    assert DEFAULT_TESTS_MAIN_CURRENCY != A_GBP, msg
-    assert rotkehlchen_instance.data.db.get_main_currency() == DEFAULT_TESTS_MAIN_CURRENCY

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -144,6 +144,7 @@ def setup_starting_environment(
         premium_credentials: PremiumCredentials,
         remote_data: bytes = REMOTE_DATA,
         sync_approval: Literal['yes', 'no', 'unknown'] = 'yes',
+        sync_database: bool = True,
 ):
     """
     Sets up the starting environment for premium testing when the user
@@ -192,6 +193,7 @@ def setup_starting_environment(
             username=username,
             create_new=create_new,
             sync_approval=sync_approval,
+            sync_database=sync_database,
         )
 
 
@@ -222,3 +224,9 @@ def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
 
     assert main_db_exists
     assert backup_db_exists
+
+
+def asset_database_wasnt_replaced(rotkehlchen_instance: Rotkehlchen):
+    msg = 'Test default main currency should be different from the restored currency'
+    assert DEFAULT_TESTS_MAIN_CURRENCY != A_GBP, msg
+    assert rotkehlchen_instance.data.db.get_main_currency() == DEFAULT_TESTS_MAIN_CURRENCY


### PR DESCRIPTION
This PR adds a new parameter to the endpoints for user creation and user login `sync_database` of type bool. If set to true and the user is premium rotki will try to download a remote database. If set to false it will skip completely the check.