### PR TITLE
Change subgraphs for Uniswap and Compound

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`3714` Airdrops section will now work again for Windows users.
+* :bug:`-` Uniswap trades will be queried correctly now.
 
 * :release:`1.22.0 <2021-11-12>`
 * :feature:`1146` Bitpanda exchange is now supported. Bitpanda balances are now shown and rotki can query trades and deposit/withdrawals from the exchange.

--- a/rotkehlchen/chain/ethereum/modules/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound.py
@@ -156,7 +156,7 @@ class Compound(EthereumModule):
         self.msg_aggregator = msg_aggregator
         try:
             self.graph: Optional[Graph] = Graph(
-                'https://api.thegraph.com/subgraphs/name/juanmardefago/compound-v2',
+                'https://api.thegraph.com/subgraphs/name/graphprotocol/compound-v2',
             )
         except RemoteError as e:
             self.graph = None

--- a/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
@@ -65,7 +65,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
                 'https://api.thegraph.com/subgraphs/name/benesjan/uniswap-v2',
             )
             self.graph_v3 = Graph(
-                'https://api.thegraph.com/subgraphs/name/benesjan/uniswap-v3-subgraph',
+                'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
             )
         except RemoteError as e:
             self.msg_aggregator.add_error(


### PR DESCRIPTION
The uniswap subgraph that we were using was a fork since the official
one was missing a field to correctly filter by the address executing the
transaction.

Now the official subgraph has been fixed and includes this field.
Also we update the compound subgraph address since the issue has been fixed
in the official one.