### PR TITLE
Allow custom date format while uploading CSV files

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8984,11 +8984,11 @@ Data imports
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"source": "cointracking.info", "filepath": "/path/to/data/file", "timestamp_format": "%d/%m/%Y %H:%M"}
+      {"source": "cointracking.info", "filepath": "/path/to/data/file", "timestamp_format": "%d/%m/%Y %H:%M:%S"}
 
    :reqjson str source: The source of the data to import. Valid values are ``"cointracking.info"``, ``"cryptocom"``, ``"blockfi-transactions"``, ``"blockfi-trades"``, ``"nexo"``, ``"gitcoin"``, ``"shapeshift-trades"``, ``"uphold"``.
    :reqjson str filepath: The filepath to the data for importing
-   :reqjson str timestamp_format: Optional. Custom format to use for dates in the CSV file
+   :reqjson str timestamp_format: Optional. Custom format to use for dates in the CSV file. Should follow rules at `Datetime docs <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes>`__.
 
    **Example Response**:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8984,10 +8984,11 @@ Data imports
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"source": "cointracking.info", "filepath": "/path/to/data/file"}
+      {"source": "cointracking.info", "filepath": "/path/to/data/file", "timestamp_format": "%d/%m/%Y %H:%M"}
 
    :reqjson str source: The source of the data to import. Valid values are ``"cointracking.info"``, ``"cryptocom"``, ``"blockfi-transactions"``, ``"blockfi-trades"``, ``"nexo"``, ``"gitcoin"``, ``"shapeshift-trades"``, ``"uphold"``.
    :reqjson str filepath: The filepath to the data for importing
+   :reqjson str timestamp_format: Optional. Custom format to use for dates in the CSV file
 
    **Example Response**:
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2091,16 +2091,12 @@ class RestAPI():
             self,
             source: IMPORTABLE_LOCATIONS,
             filepath: Path,
-            timestamp_format: str,
+            timestamp_format: Optional[str],
     ) -> Response:
-        extra_parameters = {}
-        if timestamp_format is not None:
-            extra_parameters['timestamp_format'] = timestamp_format
-
         if source == 'cointracking.info':
             success, msg = self.rotkehlchen.data_importer.import_cointracking_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
@@ -2108,7 +2104,7 @@ class RestAPI():
         elif source == 'cryptocom':
             success, msg = self.rotkehlchen.data_importer.import_cryptocom_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
@@ -2116,7 +2112,7 @@ class RestAPI():
         elif source == 'blockfi-transactions':
             success, msg = self.rotkehlchen.data_importer.import_blockfi_transactions_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
@@ -2124,7 +2120,7 @@ class RestAPI():
         elif source == 'blockfi-trades':
             success, msg = self.rotkehlchen.data_importer.import_blockfi_trades_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
@@ -2132,7 +2128,7 @@ class RestAPI():
         elif source == 'nexo':
             success, msg = self.rotkehlchen.data_importer.import_nexo_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
@@ -2149,7 +2145,7 @@ class RestAPI():
         elif source == 'shapeshift-trades':
             success, msg = self.rotkehlchen.data_importer.import_shapeshift_trades_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
@@ -2157,7 +2153,7 @@ class RestAPI():
         elif source == 'uphold':
             success, msg = self.rotkehlchen.data_importer.import_uphold_transactions_csv(
                 filepath=filepath,
-                extra_parameters=extra_parameters,
+                timestamp_format=timestamp_format,
             )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2091,29 +2091,49 @@ class RestAPI():
             self,
             source: IMPORTABLE_LOCATIONS,
             filepath: Path,
+            timestamp_format: str,
     ) -> Response:
+        extra_parameters = {}
+        if timestamp_format is not None:
+            extra_parameters['timestamp_format'] = timestamp_format
+
         if source == 'cointracking.info':
-            success, msg = self.rotkehlchen.data_importer.import_cointracking_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_cointracking_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         elif source == 'cryptocom':
-            success, msg = self.rotkehlchen.data_importer.import_cryptocom_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_cryptocom_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         elif source == 'blockfi-transactions':
-            success, msg = self.rotkehlchen.data_importer.import_blockfi_transactions_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_blockfi_transactions_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         elif source == 'blockfi-trades':
-            success, msg = self.rotkehlchen.data_importer.import_blockfi_trades_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_blockfi_trades_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         elif source == 'nexo':
-            success, msg = self.rotkehlchen.data_importer.import_nexo_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_nexo_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
@@ -2127,12 +2147,18 @@ class RestAPI():
             gitcoin_importer = GitcoinDataImporter(db=self.rotkehlchen.data.db)
             gitcoin_importer.import_gitcoin_csv(filepath)
         elif source == 'shapeshift-trades':
-            success, msg = self.rotkehlchen.data_importer.import_shapeshift_trades_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_shapeshift_trades_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)
         elif source == 'uphold':
-            success, msg = self.rotkehlchen.data_importer.import_uphold_transactions_csv(filepath)
+            success, msg = self.rotkehlchen.data_importer.import_uphold_transactions_csv(
+                filepath=filepath,
+                extra_parameters=extra_parameters,
+            )
             if not success:
                 result = wrap_in_fail_result(f'Invalid CSV format, missing required field: {msg}')
                 return api_response(result, status_code=HTTPStatus.BAD_REQUEST)

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -1984,6 +1984,7 @@ class DataImportSchema(Schema):
         ),
     )
     file = FileField(required=True, allowed_extensions=('.csv',))
+    timestamp_format = fields.String(load_default=None)
 
 
 class AssetIconUploadSchema(Schema):

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1176,20 +1176,30 @@ class DataImportResource(BaseResource):
         self,
         source: IMPORTABLE_LOCATIONS,
         file: Path,
+        timestamp_format: str,
     ) -> Response:
-        return self.rest_api.import_data(source=source, filepath=file)
+        return self.rest_api.import_data(
+            source=source,
+            filepath=file,
+            timestamp_format=timestamp_format,
+        )
 
     @use_kwargs(upload_schema, location='form_and_file')
     def post(
             self,
             source: IMPORTABLE_LOCATIONS,
             file: FileStorage,
+            timestamp_format: str,
     ) -> Response:
         with TemporaryDirectory() as temp_directory:
             filename = file.filename if file.filename else f'{source}.csv'
             filepath = Path(temp_directory) / filename
             file.save(str(filepath))
-            response = self.rest_api.import_data(source=source, filepath=filepath)
+            response = self.rest_api.import_data(
+                source=source,
+                filepath=filepath,
+                timestamp_format=timestamp_format,
+            )
 
         return response
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1176,7 +1176,7 @@ class DataImportResource(BaseResource):
         self,
         source: IMPORTABLE_LOCATIONS,
         file: Path,
-        timestamp_format: str,
+        timestamp_format: Optional[str],
     ) -> Response:
         return self.rest_api.import_data(
             source=source,
@@ -1189,7 +1189,7 @@ class DataImportResource(BaseResource):
             self,
             source: IMPORTABLE_LOCATIONS,
             file: FileStorage,
-            timestamp_format: str,
+            timestamp_format: Optional[str],
     ) -> Response:
         with TemporaryDirectory() as temp_directory:
             filename = file.filename if file.filename else f'{source}.csv'

--- a/rotkehlchen/data/importer.py
+++ b/rotkehlchen/data/importer.py
@@ -96,11 +96,7 @@ class DataImporter():
         self.db = db
         self.db_ledger = DBLedgerActions(self.db, self.db.msg_aggregator)
 
-    def _consume_cointracking_entry(
-        self,
-        csv_row: Dict[str, Any],
-        extra_parameters: Dict[str, Any],
-    ) -> None:
+    def _consume_cointracking_entry(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """Consumes a cointracking entry row from the CSV and adds it into the database
         Can raise:
             - DeserializationError if something is wrong with the format of the expected values
@@ -110,9 +106,10 @@ class DataImporter():
             - UnknownAsset if one of the assets founds in the entry are not supported
         """
         row_type = csv_row['Type']
+        formatstr = kwargs.get('timestamp_format')
         timestamp = deserialize_timestamp_from_date(
             date=csv_row['Date'],
-            formatstr=extra_parameters.get('timestamp_format', '%d.%m.%Y %H:%M:%S'),
+            formatstr=formatstr if formatstr is not None else '%d.%m.%Y %H:%M:%S',
             location='cointracking.info',
         )
         notes = csv_row['Comment']
@@ -185,14 +182,14 @@ class DataImporter():
     def import_cointracking_csv(
         self,
         filepath: Path,
-        extra_parameters: Dict[str, Any],
+        **kwargs: Any,
     ) -> Tuple[bool, str]:
         with open(filepath, 'r', encoding='utf-8-sig') as csvfile:
             data = csv.reader(csvfile, delimiter=',', quotechar='"')
             header = remap_header(next(data))
             for row in data:
                 try:
-                    self._consume_cointracking_entry(dict(zip(header, row)), extra_parameters)
+                    self._consume_cointracking_entry(dict(zip(header, row)), **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During cointracking CSV import found action with unknown '
@@ -219,11 +216,7 @@ class DataImporter():
 
         return True, ''
 
-    def _consume_cryptocom_entry(
-        self,
-        csv_row: Dict[str, Any],
-        extra_parameters: Dict[str, Any],
-    ) -> None:
+    def _consume_cryptocom_entry(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """Consumes a cryptocom entry row from the CSV and adds it into the database
         Can raise:
             - DeserializationError if something is wrong with the format of the expected values
@@ -233,9 +226,10 @@ class DataImporter():
             - sqlcipher.IntegrityError from db_ledger.add_ledger_action
         """
         row_type = csv_row['Transaction Kind']
+        formatstr = kwargs.get('timestamp_format')
         timestamp = deserialize_timestamp_from_date(
             date=csv_row['Timestamp (UTC)'],
-            formatstr=extra_parameters.get('timestamp_format', '%Y-%m-%d %H:%M:%S'),
+            formatstr=formatstr if formatstr is not None else '%Y-%m-%d %H:%M:%S',
             location='cryptocom',
         )
         description = csv_row['Transaction Description']
@@ -413,7 +407,7 @@ class DataImporter():
         self,
         data: Any,
         tx_kind: str,
-        extra_parameters: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         """Look for events that have associated entries and handle them as trades.
 
@@ -434,7 +428,8 @@ class DataImporter():
         credited_row = None
         expects_debited = False
         credited_timestamp = None
-        timestamp_format = extra_parameters.get('timestamp_format', '%Y-%m-%d %H:%M:%S')
+        formatstr = kwargs.get('timestamp_format')
+        timestamp_format = formatstr if formatstr is not None else '%Y-%m-%d %H:%M:%S'
         for row in data:
             # If we don't have the corresponding debited entry ignore them
             # and warn the user
@@ -620,11 +615,7 @@ class DataImporter():
                         )
                         self.db_ledger.add_ledger_action(action)
 
-    def import_cryptocom_csv(
-        self,
-        filepath: Path,
-        extra_parameters: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+    def import_cryptocom_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         with open(filepath, 'r', encoding='utf-8-sig') as csvfile:
             data = csv.DictReader(csvfile)
             try:
@@ -633,7 +624,7 @@ class DataImporter():
                 self._import_cryptocom_associated_entries(
                     data,
                     'dynamic_coin_swap',
-                    extra_parameters,
+                    **kwargs,
                 )
                 # reset the iterator
                 csvfile.seek(0)
@@ -643,16 +634,16 @@ class DataImporter():
                 self._import_cryptocom_associated_entries(
                     data,
                     'dust_conversion',
-                    extra_parameters,
+                    **kwargs,
                 )
                 csvfile.seek(0)
                 next(data)
 
-                self._import_cryptocom_associated_entries(data, 'interest_swap', extra_parameters)
+                self._import_cryptocom_associated_entries(data, 'interest_swap', **kwargs)
                 csvfile.seek(0)
                 next(data)
 
-                self._import_cryptocom_associated_entries(data, 'invest', extra_parameters)
+                self._import_cryptocom_associated_entries(data, 'invest', **kwargs)
                 csvfile.seek(0)
                 next(data)
             except KeyError as e:
@@ -669,7 +660,7 @@ class DataImporter():
 
             for row in data:
                 try:
-                    self._consume_cryptocom_entry(row, extra_parameters)
+                    self._consume_cryptocom_entry(row, **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During cryptocom CSV import found action with unknown '
@@ -697,11 +688,7 @@ class DataImporter():
                     return False, str(e)
         return True, ''
 
-    def _consume_blockfi_entry(
-        self,
-        csv_row: Dict[str, Any],
-        extra_parameters: Dict[str, Any],
-    ) -> None:
+    def _consume_blockfi_entry(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """
         Process entry for BlockFi transaction history. Trades for this file are ignored
         and istead should be extracted from the file containing only trades.
@@ -712,9 +699,10 @@ class DataImporter():
         - sqlcipher.IntegrityError from db_ledger.add_ledger_action
         """
         if len(csv_row['Confirmed At']) != 0:
+            formatstr = kwargs.get('timestamp_format')
             timestamp = deserialize_timestamp_from_date(
                 date=csv_row['Confirmed At'],
-                formatstr=extra_parameters.get('timestamp_format', '%Y-%m-%d %H:%M:%S'),
+                formatstr=formatstr if formatstr is not None else '%Y-%m-%d %H:%M:%S',
                 location='BlockFi',
             )
         else:
@@ -789,11 +777,7 @@ class DataImporter():
         else:
             raise UnsupportedCSVEntry(f'Unsuported entry {entry_type}. Data: {csv_row}')
 
-    def import_blockfi_transactions_csv(
-        self,
-        filepath: Path,
-        extra_parameters: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+    def import_blockfi_transactions_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         """
         Information for the values that the columns can have has been obtained from
         https://github.com/BittyTax/BittyTax/blob/06794f51223398759852d6853bc7112ffb96129a/bittytax/conv/parsers/blockfi.py#L67
@@ -802,7 +786,7 @@ class DataImporter():
             data = csv.DictReader(csvfile)
             for row in data:
                 try:
-                    self._consume_blockfi_entry(row, extra_parameters)
+                    self._consume_blockfi_entry(row, **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During BlockFi CSV import found action with unknown '
@@ -830,20 +814,17 @@ class DataImporter():
                     return False, str(e)
         return True, ''
 
-    def _consume_blockfi_trade(
-        self,
-        csv_row: Dict[str, Any],
-        extra_parameters: Dict[str, Any],
-    ) -> None:
+    def _consume_blockfi_trade(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """
         Consume the file containing only trades from BlockFi. As per my investigations
         (@yabirgb) this file can only contain confirmed trades.
         - UnknownAsset
         - DeserializationError
         """
+        formatstr = kwargs.get('timestamp_format')
         timestamp = deserialize_timestamp_from_date(
             date=csv_row['Date'],
-            formatstr=extra_parameters.get('timestamp_format', '%Y-%m-%d %H:%M:%S'),
+            formatstr=formatstr if formatstr is not None else '%Y-%m-%d %H:%M:%S',
             location='BlockFi',
         )
 
@@ -870,11 +851,7 @@ class DataImporter():
         )
         self.db.add_trades([trade])
 
-    def import_blockfi_trades_csv(
-        self,
-        filepath: Path,
-        extra_parameters: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+    def import_blockfi_trades_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         """
         Information for the values that the columns can have has been obtained from
         the issue in github #1674
@@ -883,7 +860,7 @@ class DataImporter():
             data = csv.DictReader(csvfile)
             for row in data:
                 try:
-                    self._consume_blockfi_trade(row, extra_parameters)
+                    self._consume_blockfi_trade(row, **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During BlockFi CSV import found action with unknown '
@@ -900,7 +877,7 @@ class DataImporter():
                     return False, str(e)
         return True, ''
 
-    def _consume_nexo(self, csv_row: Dict[str, Any], extra_parameters: Dict[str, Any]) -> None:
+    def _consume_nexo(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """
         Consume CSV file from NEXO.
         This method can raise:
@@ -919,9 +896,10 @@ class DataImporter():
         )
 
         if 'rejected' not in csv_row['Details']:
+            formatstr = kwargs.get('timestamp_format')
             timestamp = deserialize_timestamp_from_date(
                 date=csv_row['Date / Time'],
-                formatstr=extra_parameters.get('timestamp_format', '%Y-%m-%d %H:%M:%S'),
+                formatstr=formatstr if formatstr is not None else '%Y-%m-%d %H:%M:%S',
                 location='NEXO',
             )
         else:
@@ -1008,11 +986,7 @@ class DataImporter():
         else:
             raise UnsupportedCSVEntry(f'Unsuported entry {entry_type}. Data: {csv_row}')
 
-    def import_nexo_csv(
-        self,
-        filepath: Path,
-        extra_parameters: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+    def import_nexo_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         """
         Information for the values that the columns can have has been obtained from
         https://github.com/BittyTax/BittyTax/blob/06794f51223398759852d6853bc7112ffb96129a/bittytax/conv/parsers/nexo.py
@@ -1021,7 +995,7 @@ class DataImporter():
             data = csv.DictReader(csvfile)
             for row in data:
                 try:
-                    self._consume_nexo(row, extra_parameters)
+                    self._consume_nexo(row, **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During Nexo CSV import found action with unknown '
@@ -1049,17 +1023,14 @@ class DataImporter():
                     return False, str(e)
         return True, ''
 
-    def _consume_shapeshift_trade(
-        self,
-        csv_row: Dict[str, Any],
-        extra_parameters: Dict[str, Any],
-    ) -> None:
+    def _consume_shapeshift_trade(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """
         Consume the file containing only trades from ShapeShift.
         """
+        formatstr = kwargs.get('timestamp_format')
         timestamp = deserialize_timestamp_from_date(
             date=csv_row['timestamp'],
-            formatstr=extra_parameters.get('timestamp_format', 'iso8601'),
+            formatstr=formatstr if formatstr is not None else 'iso8601',
             location='ShapeShift',
         )
         buy_asset = symbol_to_asset_or_token(csv_row['outputCurrency'])
@@ -1110,11 +1081,7 @@ Trade from ShapeShift with ShapeShift Deposit Address:
         )
         self.db.add_trades([trade])
 
-    def import_shapeshift_trades_csv(
-        self,
-        filepath: Path,
-        extra_parameters: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+    def import_shapeshift_trades_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         """
         Information for the values that the columns can have has been obtained from sample CSVs
         """
@@ -1122,7 +1089,7 @@ Trade from ShapeShift with ShapeShift Deposit Address:
             data = csv.DictReader(csvfile)
             for row in data:
                 try:
-                    self._consume_shapeshift_trade(row, extra_parameters)
+                    self._consume_shapeshift_trade(row, **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During ShapeShift CSV import found action with unknown '
@@ -1139,11 +1106,7 @@ Trade from ShapeShift with ShapeShift Deposit Address:
                     return False, str(e)
         return True, ''
 
-    def _consume_uphold_transaction(
-        self,
-        csv_row: Dict[str, Any],
-        extra_parameters: Dict[str, Any],
-    ) -> None:
+    def _consume_uphold_transaction(self, csv_row: Dict[str, Any], **kwargs: Any) -> None:
         """
         Consume the file containing both trades and transactions from uphold.
         This method can raise:
@@ -1151,9 +1114,10 @@ Trade from ShapeShift with ShapeShift Deposit Address:
         - DeserializationError
         - KeyError
         """
+        formatstr = kwargs.get('timestamp_format')
         timestamp = deserialize_timestamp_from_date(
             date=csv_row['Date'],
-            formatstr=extra_parameters.get('timestamp_format', '%a %b %d %Y %H:%M:%S %Z%z'),
+            formatstr=formatstr if formatstr is not None else '%a %b %d %Y %H:%M:%S %Z%z',
             location='uphold',
         )
         destination = csv_row['Destination']
@@ -1287,11 +1251,7 @@ Activity from uphold with uphold transaction id:
                     else:
                         log.debug(f'Ignoring trade with Destination Amount: {destination_amount}.')
 
-    def import_uphold_transactions_csv(
-        self,
-        filepath: Path,
-        extra_parameters: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+    def import_uphold_transactions_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         """
         Information for the values that the columns can have has been obtained from sample CSVs
         """
@@ -1299,7 +1259,7 @@ Activity from uphold with uphold transaction id:
             data = csv.DictReader(csvfile)
             for row in data:
                 try:
-                    self._consume_uphold_transaction(row, extra_parameters)
+                    self._consume_uphold_transaction(row, **kwargs)
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During uphold CSV import found action with unknown '

--- a/rotkehlchen/tests/data/cointracking_custom_dates.csv
+++ b/rotkehlchen/tests/data/cointracking_custom_dates.csv
@@ -1,0 +1,3 @@
+﻿"Type","Buy","Cur.","Sell","Cur.","Fee","Cur.","Exchange","Group","Comment","Date"
+"Deposit","5.00000000","XMR","-","","","","Poloniex","","","5/9/2017 21:14"
+"Withdrawal","-","","0.05770427","ETH","0.0001","ETH","Coinbase","","","5/9/2017 21:14"

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -813,3 +813,40 @@ Activity from uphold with uphold transaction id:
     assert asset_movements == expected_movements
     assert len(ledger_actions) == 1
     assert ledger_actions == expected_ledger_actions
+
+
+def assert_custom_cointracking(rotki: Rotkehlchen):
+    """
+    A utility function to help assert on correctness of importing data from cointracking.info
+    when using custom formats for dates
+    """
+    asset_movements = rotki.data.db.get_asset_movements()
+    warnings = rotki.msg_aggregator.consume_warnings()
+    errors = rotki.msg_aggregator.consume_errors()
+    assert len(errors) == 0
+    assert len(warnings) == 0
+
+    expected_movements = [AssetMovement(
+        location=Location.POLONIEX,
+        category=AssetMovementCategory.DEPOSIT,
+        timestamp=Timestamp(1504646040),
+        address=None,
+        transaction_id=None,
+        asset=A_XMR,
+        amount=AssetAmount(FVal('5')),
+        fee_asset=A_USD,
+        fee=Fee(ZERO),
+        link='',
+    ), AssetMovement(
+        location=Location.COINBASE,
+        category=AssetMovementCategory.WITHDRAWAL,
+        address=None,
+        transaction_id=None,
+        timestamp=Timestamp(1504646040),
+        asset=A_ETH,
+        amount=AssetAmount(FVal('0.05770427')),
+        fee_asset=A_ETH,
+        fee=Fee(FVal("0.0001")),
+        link='',
+    )]
+    assert expected_movements == asset_movements


### PR DESCRIPTION
This is work that should help #3712 if not close it. A new **optional** field has been added to the endpoint, `timestamp_format`, and allows to set the desired format for this field.

Has been enabled in all CSV importers