### PR TITLE
Temporarily disable arm64 build due to build errors

### DIFF
--- a/.github/workflows/rotki_packaging.yaml
+++ b/.github/workflows/rotki_packaging.yaml
@@ -379,7 +379,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             rotki/rotki:latest


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
