### PR TITLE
Unsupported cex assets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :bug:`3714` Airdrops section will now work again for Windows users.
 * :bug:`-` Uniswap trades will be queried correctly now.
 * :bug:`3724` Users should see their per asset liabilities properly aggregated on dashboard.
+* :bug:`3702` RMRK for Kucoin and BCH for Bitfinex should now be properly recognized by rotki again.
 
 * :release:`1.22.0 <2021-11-12>`
 * :feature:`1146` Bitpanda exchange is now supported. Bitpanda balances are now shown and rotki can query trades and deposit/withdrawals from the exchange.

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -523,7 +523,6 @@ UNSUPPORTED_BINANCE_ASSETS = (
 )
 
 UNSUPPORTED_BITFINEX_ASSETS = (
-    'BCHN',  # https://www.bitfinex.com/posts/566  no cryptocompare/coingecko data
     'B21X',  # no cryptocompare/coingecko data
     'GTX',  # no cryptocompare/coingecko data (GT, Gate.io token)
     'IQX',  # no cryptocompare/coingecko data (EOS token)
@@ -649,7 +648,6 @@ UNSUPPORTED_KUCOIN_ASSETS = (
     'NAKA',  # Nakamoto.games, no cryptocompare/coingecko data
     'NEAR3L',  # no cryptocompare/coingecko data
     'NEAR3S',  # no cryptocompare/coingecko data
-    'RMRK',  # no cryptocompare/coingecko data
     'SAND3L',  # no cryptocompare/coingecko data
     'SAND3S',  # no cryptocompare/coingecko data
     'SATT',  # delisted

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 
 import pytest
 
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import WORLD_TO_BINANCE, Asset
 from rotkehlchen.assets.converters import UNSUPPORTED_BINANCE_ASSETS, asset_from_binance
 from rotkehlchen.constants.assets import A_ADA, A_BNB, A_BTC, A_DOT, A_ETH, A_EUR, A_USDT, A_WBTC
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
@@ -178,6 +178,9 @@ def test_binance_assets_are_known(
         database,
         inquirer,  # pylint: disable=unused-argument
 ):
+    unsupported_assets = set(UNSUPPORTED_BINANCE_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_BINANCE.values()))
+    assert not common_items, f'Binance assets {common_items} should not be unsupported'
     # use a real binance instance so that we always get the latest data
     binance = Binance(
         name='binance1',

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import WORLD_TO_BITFINEX
 from rotkehlchen.assets.converters import (
     BITFINEX_EXCHANGE_TEST_ASSETS,
     UNSUPPORTED_BITFINEX_ASSETS,
@@ -38,6 +39,9 @@ def test_name():
 def test_assets_are_known(mock_bitfinex):
     """This tests only exchange (trades) assets (not margin, nor futures ones).
     """
+    unsupported_assets = set(UNSUPPORTED_BITFINEX_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_BITFINEX.values()))
+    assert not common_items, f'Bitfinex assets {common_items} should not be unsupported'
     currencies_response = mock_bitfinex._query_currencies()
     if currencies_response.success is False:
         response = currencies_response.response

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -1,7 +1,7 @@
 import warnings as test_warnings
 from unittest.mock import patch
 
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import WORLD_TO_BITTREX, Asset
 from rotkehlchen.assets.converters import UNSUPPORTED_BITTREX_ASSETS, asset_from_bittrex
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_LTC
 from rotkehlchen.constants.misc import ZERO
@@ -34,6 +34,9 @@ def test_name():
 
 
 def test_bittrex_assets_are_known(bittrex):
+    unsupported_assets = set(UNSUPPORTED_BITTREX_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_BITTREX.values()))
+    assert not common_items, f'Bittrex assets {common_items} should not be unsupported'
     currencies = bittrex.get_currencies()
     for bittrex_asset in currencies:
         symbol = bittrex_asset['symbol']

--- a/rotkehlchen/tests/exchanges/test_ftx.py
+++ b/rotkehlchen/tests/exchanges/test_ftx.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import WORLD_TO_FTX, Asset
 from rotkehlchen.assets.converters import UNSUPPORTED_FTX_ASSETS, asset_from_ftx
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_1INCH, A_ETH, A_USD, A_USDC
@@ -28,6 +28,8 @@ def test_ftx_exchange_assets_are_known(mock_ftx: Ftx):
 
     unknown_assets: Set[str] = set()
     unsupported_assets = set(UNSUPPORTED_FTX_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_FTX.values()))
+    assert not common_items, f'FTX assets {common_items} should not be unsupported'
 
     def process_currency(currency: Optional[str]):
         """Check if a currency is known for the FTX exchange"""

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 import requests
 
+from rotkehlchen.assets.asset import WORLD_TO_GEMINI
 from rotkehlchen.assets.converters import UNSUPPORTED_GEMINI_ASSETS
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_ETH, A_LINK, A_LTC, A_USD
 from rotkehlchen.constants.misc import ZERO
@@ -63,6 +64,9 @@ def test_gemini_all_symbols_are_known(sandbox_gemini):
 
     Use the real gemini API
     """
+    unsupported_assets = set(UNSUPPORTED_GEMINI_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_GEMINI.values()))
+    assert not common_items, f'Gemini assets {common_items} should not be unsupported'
     symbols = sandbox_gemini._public_api_query('symbols')
     for symbol in symbols:
         try:

--- a/rotkehlchen/tests/exchanges/test_iconomi.py
+++ b/rotkehlchen/tests/exchanges/test_iconomi.py
@@ -1,8 +1,8 @@
 import warnings as test_warnings
 from unittest.mock import patch
 
-from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.converters import asset_from_iconomi
+from rotkehlchen.assets.asset import WORLD_TO_ICONOMI, Asset
+from rotkehlchen.assets.converters import UNSUPPORTED_ICONOMI_ASSETS, asset_from_iconomi
 from rotkehlchen.constants.assets import A_ETH, A_EUR, A_REP
 from rotkehlchen.errors import UnknownAsset
 from rotkehlchen.exchanges.iconomi import Iconomi
@@ -96,6 +96,9 @@ def test_iconomi_assets_are_known(
         database,
         inquirer,  # pylint: disable=unused-argument
 ):
+    unsupported_assets = set(UNSUPPORTED_ICONOMI_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_ICONOMI.values()))
+    assert not common_items, f'Iconomi assets {common_items} should not be unsupported'
     # use a real Iconomi instance so that we always get the latest data
     iconomi = Iconomi(
         name='iconomi1',

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from rotkehlchen.accounting.structures import Balance
+from rotkehlchen.assets.asset import WORLD_TO_KUCOIN
 from rotkehlchen.assets.converters import UNSUPPORTED_KUCOIN_ASSETS, asset_from_kucoin
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_LINK, A_USDT
 from rotkehlchen.errors import RemoteError, UnknownAsset, UnsupportedAsset
@@ -54,6 +55,8 @@ def test_kucoin_exchange_assets_are_known(mock_kucoin):
 
     # Extract the unique symbols from the exchange pairs
     unsupported_assets = set(UNSUPPORTED_KUCOIN_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_KUCOIN.values()))
+    assert not common_items, f'Kucoin assets {common_items} should not be unsupported'
     for entry in response_dict['data']:
         symbol = entry['currency']
         try:

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.asset import WORLD_TO_POLONIEX, Asset
 from rotkehlchen.assets.converters import UNSUPPORTED_POLONIEX_ASSETS, asset_from_poloniex
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_ETH
 from rotkehlchen.errors import DeserializationError, UnknownAsset, UnsupportedAsset
@@ -344,6 +344,9 @@ def test_query_trade_history_unexpected_data(function_scope_poloniex):
 
 
 def test_poloniex_assets_are_known(poloniex):
+    unsupported_assets = set(UNSUPPORTED_POLONIEX_ASSETS)
+    common_items = unsupported_assets.intersection(set(WORLD_TO_POLONIEX.values()))
+    assert not common_items, f'Poloniex assets {common_items} should not be unsupported'
     currencies = poloniex.return_currencies()
     for poloniex_asset in currencies.keys():
         try:


### PR DESCRIPTION
Closes #3702  (again)

## Add tests for all cexes comparing unsupported assets to mapping 

This is so that we don't add a mapping to a specific asset thinking we
have fixed the mapping but have also forgotten it in the unsupported
assets list like we did in this issue:

## RMRK for Kucoin and BCH for Bitfinex should now work properly again