### PR TITLE
Add e2e testing for blockchain account balances

### DIFF
--- a/frontend/app/src/components/accounts/AccountBalanceTable.vue
+++ b/frontend/app/src/components/accounts/AccountBalanceTable.vue
@@ -11,6 +11,7 @@
       :expanded.sync="expanded"
       sort-by="balance.usdValue"
       :custom-group="groupBy"
+      class="account-balances-list"
       :group-by="isBtc ? ['xpub', 'derivationPath'] : undefined"
       v-on="$listeners"
     >
@@ -26,6 +27,7 @@
       <template #item.accountSelection="{ item }">
         <v-simple-checkbox
           :ripple="false"
+          data-cy="account-balances-item-checkbox"
           color="primary"
           :value="selected.includes(item.address)"
           @input="selectionChanged(item.address, $event)"

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -25,6 +25,7 @@
             <template #activator="{ on, attrs }">
               <span v-bind="attrs" v-on="on">
                 <v-btn
+                  data-cy="account-balances__delete-button"
                   color="primary"
                   text
                   outlined
@@ -49,6 +50,7 @@
       </v-row>
       <account-balance-table
         ref="balances"
+        data-cy="blockchain-balances"
         :blockchain="blockchain"
         :balances="balances"
         :visible-tags="visibleTags"

--- a/frontend/app/src/components/accounts/AccountForm.vue
+++ b/frontend/app/src/components/accounts/AccountForm.vue
@@ -1,9 +1,15 @@
 <template>
-  <v-form ref="form" :value="value" @input="input">
+  <v-form
+    ref="form"
+    :value="value"
+    data-cy="blockchain-balance-form"
+    @input="input"
+  >
     <v-row no-gutters>
       <v-col cols="12">
         <v-select
           v-model="blockchain"
+          data-cy="account-blockchain-field"
           outlined
           class="account-form__chain pt-2"
           :items="items"
@@ -112,6 +118,7 @@
         <v-text-field
           v-if="!multiple"
           v-model="address"
+          data-cy="account-address-field"
           outlined
           class="account-form__address"
           :label="$t('account_form.labels.account')"
@@ -148,6 +155,7 @@
       <v-col cols="12">
         <v-text-field
           v-model="label"
+          data-cy="account-label-field"
           outlined
           class="account-form__label"
           :label="$t('account_form.labels.label')"
@@ -159,6 +167,7 @@
       <v-col cols="12">
         <tag-input
           v-model="tags"
+          data-cy="account-tag-field"
           outlined
           :disabled="accountOperation || loading"
         />

--- a/frontend/app/src/components/accounts/BlockchainBalances.vue
+++ b/frontend/app/src/components/accounts/BlockchainBalances.vue
@@ -7,6 +7,7 @@
       </template>
       <v-btn
         v-blur
+        data-cy="add-blockchain-balance"
         fixed
         fab
         bottom
@@ -34,6 +35,7 @@
         />
       </big-dialog>
       <asset-balances
+        data-cy="blockchain-asset-balances"
         :title="$t('blockchain_balances.per_asset.title')"
         :balances="blockchainAssets"
       />
@@ -51,6 +53,7 @@
       :title="$t('blockchain_balances.balances.eth')"
       blockchain="ETH"
       :balances="ethAccounts"
+      data-cy="blockchain-balances-ETH"
       @edit-account="editAccount($event)"
     />
 
@@ -66,6 +69,7 @@
       :title="$t('blockchain_balances.balances.btc')"
       blockchain="BTC"
       :balances="btcAccounts"
+      data-cy="blockchain-balances-BTC"
       @edit-account="editAccount($event)"
     />
 
@@ -81,6 +85,7 @@
       :title="$t('blockchain_balances.balances.ksm')"
       blockchain="KSM"
       :balances="kusamaBalances"
+      data-cy="blockchain-balances-KSM"
       @edit-account="editAccount($event)"
     />
 
@@ -96,6 +101,7 @@
       :title="$t('blockchain_balances.balances.dot')"
       blockchain="DOT"
       :balances="polkadotBalances"
+      data-cy="blockchain-balances-DOT"
       @edit-account="editAccount($event)"
     />
 
@@ -111,6 +117,7 @@
       :title="$t('blockchain_balances.balances.avax')"
       blockchain="AVAX"
       :balances="avaxAccounts"
+      data-cy="blockchain-balances-AVAX"
       @edit-account="editAccount($event)"
     />
   </div>

--- a/frontend/app/src/components/accounts/InputModeSelect.vue
+++ b/frontend/app/src/components/accounts/InputModeSelect.vue
@@ -6,7 +6,7 @@
       mandatory
       @change="input($event)"
     >
-      <v-btn :value="MANUAL_ADD">
+      <v-btn :value="MANUAL_ADD" data-cy="input-mode-manual">
         <v-icon>mdi-pencil-plus</v-icon>
         <span class="hidden-sm-and-down ml-1">
           {{ $t('input_mode_select.manual_add.label') }}

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -137,7 +137,7 @@ import {
   setupExchangeRateGetter,
   setupManualBalances
 } from '@/composables/balances';
-import { currency, floatingPrecision, tags } from '@/composables/session';
+import { currency, tags } from '@/composables/session';
 import { aggregateTotal } from '@/filters';
 import i18n from '@/i18n';
 import { ManualBalance } from '@/services/balances/types';
@@ -233,8 +233,7 @@ const ManualBalanceTable = defineComponent({
       return aggregateTotal(
         visibleBalances.value,
         currency.value,
-        exchangeRate(currency.value) ?? new BigNumber(1),
-        floatingPrecision.value
+        exchangeRate(currency.value) ?? new BigNumber(1)
       );
     });
 

--- a/frontend/app/src/components/dashboard/BlockchainBalanceCardList.vue
+++ b/frontend/app/src/components/dashboard/BlockchainBalanceCardList.vue
@@ -2,6 +2,7 @@
   <fragment>
     <v-list-item
       :id="`${name}_box`"
+      data-cy="blockchain-balance-box__item"
       class="blockchain-balance-box__item"
       to="/accounts-balances/blockchain-balances"
     >

--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -128,7 +128,7 @@ import {
   setupAssetInfoRetrieval,
   setupExchangeRateGetter
 } from '@/composables/balances';
-import { currency, floatingPrecision } from '@/composables/session';
+import { currency } from '@/composables/session';
 import { totalNetWorthUsd } from '@/composables/statistics';
 import { aggregateTotal } from '@/filters';
 import i18n from '@/i18n';
@@ -194,8 +194,7 @@ const DashboardAssetTable = defineComponent({
       return aggregateTotal(
         balances.value,
         mainCurrency,
-        exchangeRate(mainCurrency) ?? new BigNumber(1),
-        floatingPrecision.value
+        exchangeRate(mainCurrency) ?? new BigNumber(1)
       );
     });
 
@@ -234,7 +233,6 @@ const DashboardAssetTable = defineComponent({
       total,
       tableHeaders: tableHeaders(totalNetWorthUsd),
       currencySymbol,
-      floatingPrecision: floatingPrecision,
       sortItems: getSortItems(getAssetInfo),
       assetFilter,
       percentage

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -3,6 +3,7 @@
     <v-tooltip top open-delay="400" :disabled="!truncated">
       <template #activator="{ on }">
         <span
+          data-cy="labeled-address-display"
           class="labeled-address-display__address"
           :class="
             $vuetify.breakpoint.xsOnly

--- a/frontend/app/src/components/helper/RowActions.vue
+++ b/frontend/app/src/components/helper/RowActions.vue
@@ -7,7 +7,7 @@
           v-bind="attrs"
           icon
           :disabled="disabled"
-          class="mx-1"
+          class="mx-1 account-balances-list__actions__edit"
           data-cy="row-edit"
           v-on="on"
           @click="editClick"
@@ -24,7 +24,7 @@
           v-bind="attrs"
           icon
           :disabled="disabled || deleteDisabled"
-          class="mx-1"
+          class="mx-1 account-balances-list__actions__delete"
           data-cy="row-delete"
           v-on="on"
           @click="deleteClick"

--- a/frontend/app/src/filters.ts
+++ b/frontend/app/src/filters.ts
@@ -51,17 +51,12 @@ export function balanceSum(value: BigNumber[]): BigNumber {
 export function aggregateTotal(
   balances: any[],
   mainCurrency: string,
-  exchangeRate: BigNumber,
-  precision: number
+  exchangeRate: BigNumber
 ): BigNumber {
   return balances.reduce((previousValue, currentValue) => {
     if (currentValue.asset === mainCurrency) {
-      return previousValue
-        .plus(currentValue.amount)
-        .dp(precision, BigNumber.ROUND_DOWN);
+      return previousValue.plus(currentValue.amount);
     }
-    return previousValue
-      .plus(currentValue.usdValue.multipliedBy(exchangeRate))
-      .dp(precision, BigNumber.ROUND_DOWN);
+    return previousValue.plus(currentValue.usdValue.multipliedBy(exchangeRate));
   }, Zero);
 }

--- a/frontend/app/src/store/statistics/getters.ts
+++ b/frontend/app/src/store/statistics/getters.ts
@@ -78,7 +78,6 @@ export const getters: Getters<
       'balances/liabilities': liabilities,
       'balances/nfBalances': nfBalances,
       'balances/exchangeRate': exchangeRate,
-      'session/floatingPrecision': floatingPrecision,
       'session/currencySymbol': mainCurrency
     }
   ) => {
@@ -90,23 +89,19 @@ export const getters: Getters<
 
     if (_rootState.settings?.nftsInNetValue) {
       nftTotal = nfbs.reduce((sum, balance) => {
-        return sum
-          .plus(balance.usdPrice.multipliedBy(rate))
-          .dp(floatingPrecision, BigNumber.ROUND_DOWN);
+        return sum.plus(balance.usdPrice.multipliedBy(rate));
       }, Zero);
     }
 
     const assetSum = aggregateTotal(
       balances,
       mainCurrency,
-      exchangeRate(mainCurrency),
-      floatingPrecision
+      exchangeRate(mainCurrency)
     ).plus(nftTotal);
     const liabilitySum = aggregateTotal(
       totalLiabilities,
       mainCurrency,
-      exchangeRate(mainCurrency),
-      floatingPrecision
+      exchangeRate(mainCurrency)
     );
     return assetSum.minus(liabilitySum);
   },

--- a/frontend/app/src/views/Dashboard.vue
+++ b/frontend/app/src/views/Dashboard.vue
@@ -112,7 +112,7 @@
       :loading="anyIsLoading"
       :balances="liabilities"
     />
-    <nft-balance-table class="mt-8" />
+    <nft-balance-table data-cy="nft-balance-table" class="mt-8" />
   </v-container>
 </template>
 

--- a/frontend/app/tests/e2e/fixtures/blockchain-balances.json
+++ b/frontend/app/tests/e2e/fixtures/blockchain-balances.json
@@ -1,0 +1,14 @@
+[
+  {
+    "blockchain": "ETH",
+    "inputMode": "manual_add",
+    "label": "ETH 1",
+    "tags": ["public"]
+  },
+  {
+    "blockchain": "BTC",
+    "inputMode": "manual_add",
+    "label": "BTC 1",
+    "tags": []
+  }
+]

--- a/frontend/app/tests/e2e/pages/account-balances-page/blockchain-balances-page.ts
+++ b/frontend/app/tests/e2e/pages/account-balances-page/blockchain-balances-page.ts
@@ -1,0 +1,166 @@
+import { Blockchain } from '@rotki/common/lib/blockchain';
+import { bigNumberify, Zero } from '@/utils/bignumbers';
+import { AccountBalancesPage } from './index';
+
+export interface FixtureBlockchainBalance {
+  readonly blockchain: Blockchain;
+  readonly inputMode: string;
+  readonly address: string;
+  readonly label: string;
+  readonly tags: string[];
+}
+
+export class BlockchainBalancesPage extends AccountBalancesPage {
+  visit() {
+    cy.get('.accounts-balances__blockchain-balances')
+      .scrollIntoView()
+      .should('be.visible')
+      .click({
+        force: true
+      });
+  }
+
+  isGroupped(balance: FixtureBlockchainBalance) {
+    return balance.blockchain === Blockchain.ETH;
+  }
+
+  addBalance(balance: FixtureBlockchainBalance) {
+    cy.get('.big-dialog').should('be.visible');
+    cy.get('[data-cy="blockchain-balance-form"]').should('be.visible');
+    cy.get('[data-cy="account-blockchain-field"]').parent().click();
+    cy.get('.v-menu__content').contains(balance.blockchain).click();
+    cy.get('[data-cy="input-mode-manual"]').click();
+    cy.get('[data-cy="account-address-field"]').type(balance.address);
+    cy.get('[data-cy="account-label-field"]').type(balance.label);
+
+    for (const tag of balance.tags) {
+      cy.get('[data-cy="account-tag-field"]').type(tag).type('{enter}');
+    }
+
+    cy.get('.big-dialog__buttons__confirm').click();
+    cy.get('.big-dialog', { timeout: 45000 }).should('not.be.visible');
+  }
+
+  isEntryVisible(position: number, balance: FixtureBlockchainBalance) {
+    // account balances card section for particular blockchain type should be showed
+    // sometime the table need long time to be loaded
+    cy.get(`[data-cy="blockchain-balances-${balance.blockchain}"]`, {
+      timeout: 300000
+    }).as('blockchain-section');
+
+    cy.get('@blockchain-section').should('exist');
+
+    cy.get('@blockchain-section')
+      .find('[data-cy="blockchain-balances"] tbody')
+      .find('tr')
+      .eq(position + (this.isGroupped(balance) ? 0 : 1))
+      .as('row');
+
+    cy.get('@row')
+      .find('[data-cy="labeled-address-display"]')
+      .scrollIntoView()
+      .trigger('mouseenter');
+
+    cy.get('.v-tooltip__content.menuable__content__active').as(
+      'address-tooltip'
+    );
+
+    cy.get('@address-tooltip')
+      .find('span:nth-child(1)')
+      .contains(balance.label);
+    cy.get('@address-tooltip')
+      .find('span:nth-child(2)')
+      .contains(balance.address);
+
+    cy.get('@row')
+      .find('[data-cy="labeled-address-display"]')
+      .scrollIntoView()
+      .trigger('mouseleave');
+  }
+
+  getBlockchainBalances() {
+    const blockchainBalances = [
+      { blockchain: Blockchain.ETH, renderedValue: Zero },
+      { blockchain: Blockchain.BTC, renderedValue: Zero }
+    ];
+
+    blockchainBalances.forEach(blockchainBalance => {
+      cy.get(
+        `[data-cy="blockchain-balances-${blockchainBalance.blockchain}"] tr`
+      ).then($rows => {
+        if ($rows.text().includes(blockchainBalance.blockchain)) {
+          cy.get(
+            `[data-cy="blockchain-balances-${blockchainBalance.blockchain}"] tbody tr:contains(${blockchainBalance.blockchain})`
+          ).each($row => {
+            // loops over all blockchain asset balances rows and adds up the total per blockchain type
+            cy.wrap($row)
+              .find(
+                ':nth-child(4) > .amount-display > .v-skeleton-loader .amount-display__value'
+              )
+              .then($amount => {
+                if (blockchainBalance.renderedValue === Zero) {
+                  blockchainBalance.renderedValue = bigNumberify(
+                    this.getSanitizedAmountString($amount.text())
+                  );
+                } else {
+                  blockchainBalance.renderedValue =
+                    blockchainBalance.renderedValue.plus(
+                      bigNumberify(
+                        this.getSanitizedAmountString($amount.text())
+                      )
+                    );
+                }
+              });
+          });
+        }
+      });
+    });
+
+    return cy.wrap(blockchainBalances);
+  }
+
+  editBalance(
+    balance: FixtureBlockchainBalance,
+    position: number,
+    label: string
+  ) {
+    cy.get(`[data-cy="blockchain-balances-${balance.blockchain}"] tbody`)
+      .find('tr')
+      .eq(position + (this.isGroupped(balance) ? 0 : 1))
+      .find('button.account-balances-list__actions__edit')
+      .click();
+
+    cy.get('[data-cy="blockchain-balance-form"]').as('edit-form');
+    cy.get('@edit-form')
+      .find('[data-cy="account-label-field"]')
+      .click()
+      .clear()
+      .type(label);
+    cy.get('.big-dialog__buttons__confirm').click();
+  }
+
+  deleteBalance(balance: FixtureBlockchainBalance, position: number) {
+    cy.get(`[data-cy="blockchain-balances-${balance.blockchain}"] tbody`)
+      .find('tr')
+      .eq(position + (this.isGroupped(balance) ? 0 : 1))
+      .find('[data-cy="account-balances-item-checkbox"]')
+      .click();
+
+    cy.get(`[data-cy="blockchain-balances-${balance.blockchain}"]`)
+      .find('[data-cy="account-balances__delete-button"]')
+      .click();
+
+    this.confirmDelete();
+
+    cy.get(`[data-cy="blockchain-balances-${balance.blockchain}"]`).should(
+      'not.be.exist'
+    );
+  }
+
+  confirmDelete() {
+    cy.get('[data-cy=confirm-dialog]')
+      .find('[data-cy=dialog-title]')
+      .should('contain', 'Account delete');
+    cy.get('[data-cy=confirm-dialog]').find('[data-cy=button-confirm]').click();
+  }
+}

--- a/frontend/app/tests/e2e/pages/account-balances-page/index.ts
+++ b/frontend/app/tests/e2e/pages/account-balances-page/index.ts
@@ -1,0 +1,18 @@
+import { bigNumberify } from '@/utils/bignumbers';
+
+export class AccountBalancesPage {
+  getSanitizedAmountString(amount: string) {
+    // TODO: extract the `replace(/,/g, '')` as to use user settings (when implemented)
+    return amount.replace(/,/g, '');
+  }
+
+  formatAmount(amount: string) {
+    return bigNumberify(amount).toFormat(2);
+  }
+
+  visit() {
+    cy.get('.v-app-bar__nav-icon').click();
+    cy.get('.navigation__accounts-balances').click();
+    cy.get('[data-cy=accounts-balances]').should('be.visible');
+  }
+}


### PR DESCRIPTION
Closes #1062 
Closes #3571 (obsolete)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide]

Create e2e testing for blockchain account balances `tests/e2e/specs/accounts-balances.spec.ts`: 
- [ ] Add an ETH account
- [ ] Verify that the account is added
- [ ] Add a BTC account
- [ ] Verify that the account is added
- [ ] Balance showed on dashboard

I also remove some `rounding` on several balance, to increase accurability (rounding should be done when we want to show the amount of balance, not on calculation) 

![image](https://user-images.githubusercontent.com/26648140/143058621-a6c7dcac-f401-4093-8408-ae9225cb93f7.png)
