### PR TITLE
Liquity module won't add addresses to the list of eth addresses.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :bug:`-` Kraken margin trades are not yet supported, so they won't show up or be taken into account in kraken trade history.
 * :bug:`3744` Freshly created users who don't open the app again before an upgrade will now be able to update to new DB versions again.
 * :bug:`3749` Users using multiple instances of the same exchange should now correctly see all their trades.
+* :bug:`-` Liquity users won't make extra balances queries when using DSProxies.
 
 * :release:`1.22.1 <2021-11-19>`
 * :bug:`3726` Manual liabilities should not count as assets and should be deducted from total net value when taking a snapshot. Also multiple liabilities of same asset should now be properly summed.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2725,7 +2725,7 @@ class RestAPI():
             module_name='liquity',
             method='get_positions',
             query_specific_balances_before=None,
-            addresses=self.rotkehlchen.chain_manager.queried_addresses_for_module('liquity'),
+            addresses_list=self.rotkehlchen.chain_manager.queried_addresses_for_module('liquity'),
         )
 
     @require_premium_user(active_check=False)

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -207,14 +207,15 @@ class Liquity(HasDSProxy):
 
     def get_positions(
         self,
-        addresses: List[ChecksumEthAddress],
+        addresses_list: List[ChecksumEthAddress],
     ) -> Dict[ChecksumEthAddress, Trove]:
         contract = EthereumContract(
             address=LIQUITY_TROVE_MANAGER.address,
             abi=LIQUITY_TROVE_MANAGER.abi,
             deployed_block=LIQUITY_TROVE_MANAGER.deployed_block,
         )
-
+        # make a copy of the list to avoid modifications in the list that is passed as argument
+        addresses = list(addresses_list)
         proxied_addresses = self._get_accounts_having_proxy()
         proxies_to_address = {v: k for k, v in proxied_addresses.items()}
         addresses += proxied_addresses.values()

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -1456,7 +1456,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
         if liquity_module is not None:
             # Get trove information
             liquity_balances = liquity_module.get_positions(
-                addresses=self.queried_addresses_for_module('liquity'),
+                addresses_list=self.queried_addresses_for_module('liquity'),
             )
             for address, deposits in liquity_balances.items():
                 collateral = deposits.collateral.balance

--- a/rotkehlchen/tests/api/test_liquity.py
+++ b/rotkehlchen/tests/api/test_liquity.py
@@ -210,3 +210,6 @@ def test_account_with_proxy(rotkehlchen_api_server, inquirer):  # pylint: disabl
     assert LQTY_PROXY in result
     assert ADDR_WITHOUT_TROVE not in result
     assert LQTY_ADDR in result
+    # test that the list of addresses was not mutated
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    assert len(rotki.chain_manager.accounts.eth) == 3


### PR DESCRIPTION
The get_positions method was overwritting the list of addresses passed
as argument and this made the list of addresses increase on length each time
the module was queried. This resulted in extra calls to check for balances in
the dsproxy contracts.

