### PR TITLE
fix: add manual balance only fetch that particular asset price

### DIFF
--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -281,6 +281,7 @@ const DashboardAssetTable = defineComponent({
     };
 
     const calculatePercentage = (value: BigNumber, divider: BigNumber) => {
+      if (divider.isZero()) return '0';
       return value.div(divider).multipliedBy(100).toFixed(2);
     };
 

--- a/frontend/app/src/components/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/NftBalanceTable.vue
@@ -186,6 +186,7 @@ export default defineComponent({
     );
 
     const calculatePercentage = (value: BigNumber, divider: BigNumber) => {
+      if (divider.isZero()) return '0';
       return value.div(divider).multipliedBy(100).toFixed(2);
     };
 

--- a/frontend/app/src/components/helper/PriceRefresh.vue
+++ b/frontend/app/src/components/helper/PriceRefresh.vue
@@ -4,7 +4,7 @@
     color="primary"
     :loading="refreshing"
     :disabled="refreshing || loadingData"
-    @click="refreshPrices(true)"
+    @click="refreshPrices({ ignoreCache: true })"
   >
     <v-icon left>mdi-refresh</v-icon>
     {{ $t('price_refresh.button') }}
@@ -15,6 +15,7 @@
 import { Component, Mixins } from 'vue-property-decorator';
 import { mapActions, mapGetters } from 'vuex';
 import StatusMixin from '@/mixins/status-mixin';
+import { FetchPricePayload } from '@/store/balances/types';
 import { Section } from '@/store/const';
 import { TaskType } from '@/types/task-type';
 
@@ -29,7 +30,7 @@ import { TaskType } from '@/types/task-type';
 export default class PriceRefresh extends Mixins(StatusMixin) {
   readonly section = Section.PRICES;
   isTaskRunning!: (type: TaskType) => boolean;
-  refreshPrices!: (ignoreCache: boolean) => Promise<void>;
+  refreshPrices!: (payload: FetchPricePayload) => Promise<void>;
 
   get loadingData(): boolean {
     return (

--- a/frontend/app/src/services/monitoring.ts
+++ b/frontend/app/src/services/monitoring.ts
@@ -28,7 +28,7 @@ class Monitoring {
     await dispatch('balances/fetchBlockchainBalances', { ignoreCache: true });
     await dispatch('balances/fetchLoopringBalances', true);
     await dispatch('balances/fetchConnectedExchangeBalances');
-    await dispatch('balances/refreshPrices', true);
+    await dispatch('balances/refreshPrices', { ignoreCache: true });
   }
 
   /**

--- a/frontend/app/src/store/balances/types.ts
+++ b/frontend/app/src/store/balances/types.ts
@@ -121,6 +121,11 @@ export interface AllBalancePayload {
   readonly ignoreErrors: boolean;
 }
 
+export interface FetchPricePayload {
+  readonly ignoreCache: boolean;
+  readonly selectedAsset?: string;
+}
+
 export interface AccountWithBalance extends GeneralAccount, HasBalance {}
 
 interface XpubAccount extends GeneralAccount, XpubPayload {}

--- a/frontend/app/src/store/session/actions.ts
+++ b/frontend/app/src/store/session/actions.ts
@@ -84,7 +84,7 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
     ];
 
     Promise.all(async).then(() =>
-      dispatch('balances/refreshPrices', false, options)
+      dispatch('balances/refreshPrices', { ignoreCache: false }, options)
     );
   },
 


### PR DESCRIPTION
Closes #2817

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- Add manual balance only fetch that particular asset price, instead fetch all assets prices