### PR TITLE
Fix the guide to build dev-proxy

### DIFF
--- a/frontend/dev-proxy/README.md
+++ b/frontend/dev-proxy/README.md
@@ -71,7 +71,8 @@ In order to build the bundle you need to go to the premium components directory 
 run the following.
 
 ```bash
-yarn build:bundle
+npm ci
+npm run build
 ```
 
 ## Mocking async queries


### PR DESCRIPTION
Hey @kelsos I think this was outdated, right? Is my change correct? If yes we also need the same in the readme in dev proxy repo itself.