### PR TITLE
Ignore yearn vaults when information couldn't be correctly queried

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Users connected to Alchemy as a node will be able to properly retrieve old ethereum transactions.
+* :bug:`-` Users that only deposited to Yearn's vaults won't see the deposit as a lost in the deposits section.
 
 
 * :release:`1.22.2 <2021-11-30>`

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -530,7 +530,7 @@ class Asset():
     name: str = field(init=False)
     symbol: str = field(init=False)
     asset_type: AssetType = field(init=False)
-    started: Timestamp = field(init=False)
+    started: Optional[Timestamp] = field(init=False)
     forked: Optional['Asset'] = field(init=False)
     swapped_for: Optional['Asset'] = field(init=False)
     # None means no special mapping. '' means not supported

--- a/rotkehlchen/chain/ethereum/modules/yearn/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaults.py
@@ -459,6 +459,10 @@ class YearnVaults(EthereumModule):
         """Process the events for a single vault and returns total profit/loss after all events"""
         total = Balance()
         profit_so_far = Balance()
+
+        if len(events) < 2:
+            return total
+
         for event in events:
             if event.event_type == 'deposit':
                 total -= event.from_value


### PR DESCRIPTION
When a user manually adds a Yearn v2 token the start date could be null and this would rise a calculation error for the ROI.
Also catched some potential remote errors.
