### PR TITLE
Allow to query associated locations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,10 +4,12 @@ Changelog
 
 * :feature:`3716` Users can now see if any of their addresses have PSP available to claim from the PSP airdrop.
 * :feature:`824` Users will now be able to import their trade history from bisq.
+* :feature:`1864` Users will now be able to see trades, deposits and withdrawals imported in CSV from exchanges not connected using API keys.
 * :feature:`3685` Users will now be able to correctly read more transaction types in CSV files imported from crypto.com.
 * :feature:`3497` Users will now be able to add ETH2 validators via index or public key.
 * :feature:`3725` Users can now see if any of their addresses have SDL available to claim from the SDL airdrop.
 * :feature:`3549` Users will now be able to select whether to include or not NFT total value in total net worth and graphs.
+* :feature:`3712` Users will now be able to choose a custom date format while importing CSV files.
 * :bug:`-` Deposits and withdrawals in files from cointracking will now be correctly registered.
 
 * :release:`1.22.2 <2021-11-30>`


### PR DESCRIPTION
The api needed adjustment to query locations of exchanges when no keys are provided for them but trades exists. This PR addresses this issue.

To test the implementation an environment with two exchanges and several trades from different locations has been set up. Then is checked that all expected locations are included in the trades returned by the API