### PR TITLE
fix: include trades and asset movements from non connected exchanges in history

### DIFF
--- a/frontend/app/src/services/history/history-api.ts
+++ b/frontend/app/src/services/history/history-api.ts
@@ -54,6 +54,15 @@ export class HistoryApi {
     );
   }
 
+  async associatedLocations(): Promise<TradeLocation[]> {
+    return this.axios
+      .get<ActionResult<TradeLocation[]>>('/locations/associated', {
+        validateStatus: validStatus,
+        transformResponse: this.responseTransformer
+      })
+      .then(handleResponse);
+  }
+
   async trades(
     location?: TradeLocation,
     onlyCache?: boolean

--- a/frontend/app/src/views/history/DepositsWithdrawals.vue
+++ b/frontend/app/src/views/history/DepositsWithdrawals.vue
@@ -24,7 +24,6 @@ import ProgressScreen from '@/components/helper/ProgressScreen.vue';
 import StatusMixin from '@/mixins/status-mixin';
 import { Section } from '@/store/const';
 import {
-  FETCH_FROM_CACHE,
   FETCH_FROM_SOURCE,
   FETCH_REFRESH,
   HistoryActions
@@ -52,19 +51,19 @@ export default defineComponent({
     ])
   },
   async mounted() {
-    const { fetchMovements } = this as {
-      fetchMovements: (source: FetchSource) => Promise<void>;
-    };
-    await fetchMovements(FETCH_FROM_CACHE);
-    await fetchMovements(FETCH_FROM_SOURCE);
+    await this.fetch(FETCH_FROM_SOURCE);
   },
   methods: {
     ...mapActions('history', [HistoryActions.FETCH_MOVEMENTS]),
     async refresh() {
+      await this.fetch(FETCH_REFRESH);
+    },
+
+    async fetch(source: FetchSource) {
       const { fetchMovements } = this as {
         fetchMovements: (source: FetchSource) => Promise<void>;
       };
-      await fetchMovements(FETCH_REFRESH);
+      await fetchMovements(source);
     }
   }
 });

--- a/frontend/app/src/views/history/LedgerActions.vue
+++ b/frontend/app/src/views/history/LedgerActions.vue
@@ -58,7 +58,6 @@ import { deserializeApiErrorMessage } from '@/services/converters';
 import { TradeLocation } from '@/services/history/types';
 import { Section } from '@/store/const';
 import {
-  FETCH_FROM_CACHE,
   FETCH_FROM_SOURCE,
   FETCH_REFRESH,
   HistoryActions
@@ -160,12 +159,15 @@ export default class LedgerActions extends Mixins(StatusMixin) {
   }
 
   async refresh() {
-    await this[HistoryActions.FETCH_LEDGER_ACTIONS](FETCH_REFRESH);
+    await this.fetch(FETCH_REFRESH);
   }
 
   async mounted() {
-    await this[HistoryActions.FETCH_LEDGER_ACTIONS](FETCH_FROM_CACHE);
-    await this[HistoryActions.FETCH_LEDGER_ACTIONS](FETCH_FROM_SOURCE);
+    await this.fetch(FETCH_FROM_SOURCE);
+  }
+
+  async fetch(source: FetchSource) {
+    await this[HistoryActions.FETCH_LEDGER_ACTIONS](source);
   }
 
   async showForm(action: LedgerActionEntry | UnsavedAction = emptyAction()) {

--- a/frontend/app/src/views/history/TradeHistory.vue
+++ b/frontend/app/src/views/history/TradeHistory.vue
@@ -21,7 +21,6 @@ import StatusMixin from '@/mixins/status-mixin';
 import { TradeLocation } from '@/services/history/types';
 import { Section } from '@/store/const';
 import {
-  FETCH_FROM_CACHE,
   FETCH_FROM_SOURCE,
   FETCH_REFRESH,
   HistoryActions
@@ -89,18 +88,16 @@ export default class TradeHistory extends Mixins(StatusMixin) {
   }
 
   private async load() {
-    await Promise.all([
-      this.fetchTrades(FETCH_FROM_CACHE),
-      this.fetchUniswapTrades(false),
-      this.fetchBalancerTrades(false),
-      this.fetchSushiswapTrades(false)
-    ]);
-    await this.fetchTrades(FETCH_FROM_SOURCE);
+    await this.fetch(FETCH_FROM_SOURCE);
   }
 
   private async refresh() {
+    await this.fetch(FETCH_REFRESH);
+  }
+
+  private async fetch(source: FetchSource) {
     await Promise.all([
-      this.fetchTrades(FETCH_REFRESH),
+      this.fetchTrades(source),
       this.fetchUniswapTrades(true),
       this.fetchBalancerTrades(true),
       this.fetchSushiswapTrades(true)


### PR DESCRIPTION
Closes #1864

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

- [ ] Include trades and asset movements from non connected exchanges in history