### PR TITLE
Fixes order of version with v prefix and without

### DIFF
--- a/.github/workflows/rotki_packaging.yaml
+++ b/.github/workflows/rotki_packaging.yaml
@@ -48,14 +48,14 @@ jobs:
               - [AppImage](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x86_64-${{ env.RELEASE_VERSION }}.AppImage)
               - [Tar with executable](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x64-${{ env.RELEASE_VERSION }}.tar.xz)
               - [deb package](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_amd64-${{ env.RELEASE_VERSION }}.deb)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ steps.change_log.outputs.version }}/rotkehlchen-${{ env.RELEASE_VERSION }}-linux)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotkehlchen-${{ steps.change_log.outputs.version }}-linux)
             - **OSX**
               - [DMG](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin_x64-${{ env.RELEASE_VERSION }}.dmg)
               - [ZIP](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin_x64-${{ env.RELEASE_VERSION }}.zip)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ steps.change_log.outputs.version }}/rotkehlchen-backend-${{ env.RELEASE_VERSION }}-macos.zip)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotkehlchen-backend-${{ steps.change_log.outputs.version }}-macos.zip)
             - **Windows**
               - [Windows executable](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-win32_x64-${{ env.RELEASE_VERSION }}.exe)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ steps.change_log.outputs.version }}/rotkehlchen-${{ env.RELEASE_VERSION }}-windows.exe)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotkehlchen-${{ steps.change_log.outputs.version }}-windows.exe)
             
             Optionally, you can also [verify the integrity](https://rotki.readthedocs.io/en/latest/installation_guide.html#verifying-integrity) of the aforementioned binaries using the following checksums:
             
@@ -63,14 +63,14 @@ jobs:
               - [AppImage checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x86_64-${{ env.RELEASE_VERSION }}.AppImage.sha512)
               - [Tar with executable checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x64-${{ env.RELEASE_VERSION }}.tar.xz.sha512)
               - [deb package](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_amd64-${{ env.RELEASE_VERSION }}.deb.sha512)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ steps.change_log.outputs.version }}/rotkehlchen-${{ env.RELEASE_VERSION }}-linux.sha512)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotkehlchen-${{ steps.change_log.outputs.version }}-linux.sha512)
             - **OSX**
               - [DMG checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin_x64-${{ env.RELEASE_VERSION }}.dmg.sha512)
               - [ZIP checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin_x64-${{ env.RELEASE_VERSION }}.zip.sha512)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ steps.change_log.outputs.version }}/rotkehlchen-backend-${{ env.RELEASE_VERSION }}-macos.zip.sha512)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotkehlchen-backend-${{ steps.change_log.outputs.version }}-macos.zip.sha512)
             - **Windows**
               - [Windows executable checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-win32_x64-${{ env.RELEASE_VERSION }}.exe.sha512)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ steps.change_log.outputs.version }}/rotkehlchen-${{ env.RELEASE_VERSION }}-windows.exe.sha512)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotkehlchen-${{ steps.change_log.outputs.version }}-windows.exe.sha512)
 
             # Release Highlights
             ----


### PR DESCRIPTION
They were in the wrong order

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
