### PR TITLE
Fix miniupnpc packaging for windows

### DIFF
--- a/package.ps1
+++ b/package.ps1
@@ -188,9 +188,35 @@ if ((-not ($env:VIRTUAL_ENV)) -and (-not ($Env:CI))) {
     ExitOnFailure("Failed to activate rotki VirtualEnv")
 }
 
-cd $PROJECT_DIR
-$NPM_VERSION = (npm --version) | Out-String
+if ($Env:CI) {
+    echo "::group::Fetch Miniupnpc"
+}
 
+
+echo "Fetching miniupnpc for windows"
+cd $PROJECT_DIR
+$PYTHON_LOCATION = (python -c "import os, sys; print(os.path.dirname(sys.executable))") | Out-String
+echo "Python location is $PYTHON_LOCATION"
+curl.exe -L -O "https://github.com/mrx23dot/miniupnp/releases/download/miniupnpd_2_2_24/miniupnpc_64bit_py37-2.2.24.zip"
+ExitOnFailure("Failed to download miniupnpc")
+echo "Downloaded miniupnpc.zip"
+Get-ChildItem -Path $PWD
+#Expand-Archive -Force -Path ".\miniupnpc_64bit_py37-2.2.24.zip" -DestinationPath "$PYTHON_LOCATION\Scripts"
+# For some reason we get Illegal characters in path. if we use $PYTHON_LOCATION\Scripts
+Expand-Archive -Force -Path ".\miniupnpc_64bit_py37-2.2.24.zip" -DestinationPath "C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts"
+ExitOnFailure("Failed to unzip miniupnpc")
+echo "Unzipped miniupnpc to $PYTHON_LOCATION\Scripts"
+#Get-ChildItem -Path $PYTHON_LOCATION\Scripts
+Get-ChildItem -Path C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts
+# For some reason we get Illegal characters in path. if we use $PYTHON_LOCATION\Scripts
+echo "Done with miniupnpc"
+
+if ($Env:CI) {
+    echo "::endgroup::"
+}
+
+
+$NPM_VERSION = (npm --version) | Out-String
 if ([version]$NPM_VERSION -lt [version]$MINIMUM_NPM_VERSION) {
     echo "Please make sure you have npm version $MINIMUM_NPM_VERSION or newer installed"
     exit 1;

--- a/package.ps1
+++ b/package.ps1
@@ -194,27 +194,40 @@ if ($Env:CI) {
 
 
 echo "Fetching miniupnpc for windows"
-cd $PROJECT_DIR
-$PYTHON_LOCATION = (python -c "import os, sys; print(os.path.dirname(sys.executable))") | Out-String
-echo "Python location is $PYTHON_LOCATION"
-curl.exe -L -O "https://github.com/mrx23dot/miniupnp/releases/download/miniupnpd_2_2_24/miniupnpc_64bit_py37-2.2.24.zip"
-ExitOnFailure("Failed to download miniupnpc")
-echo "Downloaded miniupnpc.zip"
-Get-ChildItem -Path $PWD
-#Expand-Archive -Force -Path ".\miniupnpc_64bit_py37-2.2.24.zip" -DestinationPath "$PYTHON_LOCATION\Scripts"
-# For some reason we get Illegal characters in path. if we use $PYTHON_LOCATION\Scripts
-Expand-Archive -Force -Path ".\miniupnpc_64bit_py37-2.2.24.zip" -DestinationPath "C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts"
-ExitOnFailure("Failed to unzip miniupnpc")
-echo "Unzipped miniupnpc to $PYTHON_LOCATION\Scripts"
-#Get-ChildItem -Path $PYTHON_LOCATION\Scripts
-Get-ChildItem -Path C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts
-# For some reason we get Illegal characters in path. if we use $PYTHON_LOCATION\Scripts
-echo "Done with miniupnpc"
+$PYTHON_LOCATION = ((python -c "import os, sys; print(os.path.dirname(sys.executable))") | Out-String).trim()
+$PYTHON_DIRECTORY = Split-Path -Path $PYTHON_LOCATION -Leaf
+
+if (-not ($PYTHON_DIRECTORY -match 'Scripts')) {
+    $PYTHON_LOCATION = (Join-Path $PYTHON_LOCATION "Scripts")
+}
+
+$DLL_PATH = (Join-Path $PYTHON_LOCATION "miniupnpc.dll")
+$MINIUPNPC_ZIP = "miniupnpc_64bit_py37-2.2.24.zip"
+$ZIP_PATH = (Join-Path $BUILD_DEPS_DIR $MINIUPNPC_ZIP)
+
+if (-not ((Test-Path $ZIP_PATH -PathType Leaf) -and (Test-Path $DLL_PATH -PathType Leaf))) {
+    echo "miniupnpc.dll will be installled in $PYTHON_LOCATION"
+
+    cd $BUILD_DEPS_DIR
+    curl.exe -L -O "https://github.com/mrx23dot/miniupnp/releases/download/miniupnpd_2_2_24/$MINIUPNPC_ZIP"
+    ExitOnFailure("Failed to download miniupnpc")
+
+    echo "Downloaded miniupnpc.zip"
+
+    Expand-Archive -Force -Path ".\$MINIUPNPC_ZIP" -DestinationPath $PYTHON_LOCATION
+
+    ExitOnFailure("Failed to unzip miniupnpc")
+    echo "Unzipped miniupnpc to $PYTHON_LOCATION"
+    echo "Done with miniupnpc"    
+} else {
+    echo "miniupnpc.dll already installled in $PYTHON_LOCATION. skipping"
+}
 
 if ($Env:CI) {
     echo "::endgroup::"
 }
 
+cd $PROJECT_DIR
 
 $NPM_VERSION = (npm --version) | Out-String
 if ([version]$NPM_VERSION -lt [version]$MINIMUM_NPM_VERSION) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ py-bip39-bindings==0.1.8
 substrate-interface==1.1.6
 beautifulsoup4==4.10.0
 maxminddb==2.2.0
-miniupnpc==2.0.2
+miniupnpc==2.0.2; sys_platform != 'win32'
+miniupnpc==2.2.3; sys_platform == 'win32'
 
 # For the rest api
 flask-cors==3.0.10


### PR DESCRIPTION
Essentially use release 2.2.3 that is only for windows (lol)
and which contains pre-built wheels for some python versions.

To use them we need to download the binaries from pypi to the python
scripts directory
