### PR TITLE
Remove some modules by default

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :bug:`3847` Remove whitespace when inputting address in new asset form.
+
+* :feature:`-` If active modules have not been set then the default active modules is now not all, but all except for: MakerDAO DSR, Adex, Yearn vaults v1.
 * :feature:`3842` Users will now be taken directly to create account when downloading the application for the first time.
 * :feature:`-` Any ethereum transactions that were ignored for accounting will now need to be re-ignored.
 * :feature:`1242` Users will be asked first whether to activate premium feature, and enable database sync when create new account.
@@ -39,6 +40,7 @@ Changelog
 * :bug:`-` Users connected to Alchemy as a node will be able to properly retrieve old ethereum transactions.
 * :bug:`-` Users whose only interaction with a yearn vault was a deposit will no longer see the entire deposit as loss in the PnL.
 * :bug:`3804` Bitpanda users should now be able to see their crypto deposits and withdrawals.
+* :bug:`3847` Inputting an address in the asset form with extra whitespace will now work properly thanks to trimming.
 
 * :release:`1.22.2 <2021-11-30>`
 * :feature:`-` rotki will now detect locked SRM balances in FTX.

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -335,7 +335,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
             data_directory: Path,
             beaconchain: 'BeaconChain',
             btc_derivation_gap_limit: int,
-            eth_modules: Optional[List[ModuleName]] = None,
+            eth_modules: List[ModuleName],
     ):
         log.debug('Initializing ChainManager')
         super().__init__()
@@ -369,9 +369,8 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
         self.greenlet_manager = greenlet_manager
         # TODO: Turn this mapping into a typed dict once we upgrade to python 3.8
         self.eth_modules: Dict[ModuleName, Union[EthereumModule]] = {}
-        if eth_modules:
-            for given_module in eth_modules:
-                self.activate_module(given_module)
+        for given_module in eth_modules:
+            self.activate_module(given_module)
 
         self.defichad = DefiChad(
             ethereum_manager=self.ethereum,

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -12,7 +12,7 @@ from rotkehlchen.history.typing import (
     HistoricalPriceOracle,
 )
 from rotkehlchen.inquirer import DEFAULT_CURRENT_PRICE_ORACLES_ORDER, CurrentPriceOracle
-from rotkehlchen.typing import AVAILABLE_MODULES_MAP, ModuleName, Timestamp
+from rotkehlchen.typing import AVAILABLE_MODULES_MAP, DEFAULT_OFF_MODULES, ModuleName, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 
 ROTKEHLCHEN_DB_VERSION = 31
@@ -26,7 +26,7 @@ DEFAULT_BALANCE_SAVE_FREQUENCY = 24
 DEFAULT_MAIN_CURRENCY = A_USD
 DEFAULT_DATE_DISPLAY_FORMAT = '%d/%m/%Y %H:%M:%S %Z'
 DEFAULT_SUBMIT_USAGE_ANALYTICS = True
-DEFAULT_ACTIVE_MODULES = list(AVAILABLE_MODULES_MAP.keys())
+DEFAULT_ACTIVE_MODULES = list(set(AVAILABLE_MODULES_MAP.keys()) - DEFAULT_OFF_MODULES)
 DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS = True
 DEFAULT_BTC_DERIVATION_GAP_LIMIT = 20
 DEFAULT_CALCULATE_PAST_COST_BASIS = True

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -48,6 +48,7 @@ AVAILABLE_MODULES_MAP = {
     'pickle_finance': 'Pickle Finance',
     'nfts': 'NFTs',
 }
+DEFAULT_OFF_MODULES = {'makerdao_dsr', 'yearn_vaults', 'adex'}
 
 
 IMPORTABLE_LOCATIONS = Literal[


### PR DESCRIPTION
MakerDAO DSR, Yearn Vaults V1 and ADEX take a long time for queries,
most people have not used them so having them off by default makes sense.
