### PR TITLE
Fixes on eth2 validator ownership

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2.py
@@ -153,7 +153,13 @@ class Eth2(EthereumModule):
 
         for x in dbeth2.get_validators():
             if x.public_key not in pubkeys:
-                all_validators.append(ValidatorID(index=x.index, public_key=x.public_key))  # noqa: E501
+                all_validators.append(
+                    ValidatorID(
+                        index=x.index,
+                        public_key=x.public_key,
+                        ownership_proportion=x.ownership_proportion,
+                    ),
+                )
 
         return all_validators
 
@@ -190,8 +196,7 @@ class Eth2(EthereumModule):
             if validator.index is not None:
                 index_to_pubkey[validator.index] = validator.public_key
                 pubkeys.append(validator.public_key)
-            if isinstance(validator, Eth2Validator):
-                index_to_ownership[validator.index] = validator.ownership_proportion
+            index_to_ownership[validator.index] = validator.ownership_proportion
 
         # Get current balance of all validators. This may miss some balance if it's
         # in the deposit queue but it's too much work to get it right and should be

--- a/rotkehlchen/chain/ethereum/typing.py
+++ b/rotkehlchen/chain/ethereum/typing.py
@@ -85,6 +85,7 @@ class ValidatorID(NamedTuple):
     # not using index due to : https://github.com/python/mypy/issues/9043
     index: Optional[int]  # type: ignore  # may be null if the index is not yet determined
     public_key: Eth2PubKey
+    ownership_proportion: FVal
 
     def __hash__(self) -> int:
         return hash(self.public_key)

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -1736,6 +1736,9 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
             validator_index=validator_index,
             ownership_proportion=ownership_proportion,
         )
+        self.flush_cache('query_ethereum_beaconchain_balances')
+        self.flush_cache('query_balances')
+        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN)
 
     def add_eth2_validator(
             self,

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -233,6 +233,7 @@ class DBEth2():
                 f'Tried to edit validator with index {validator_index} '
                 f'that is not in the database',
             )
+        self.db.update_last_write()
 
     def delete_validator(self, validator_index: Optional[int], public_key: Optional[str]) -> None:
         """Deletes the given validator from the DB. Due to marshmallow here at least one

--- a/rotkehlchen/externalapis/beaconchain.py
+++ b/rotkehlchen/externalapis/beaconchain.py
@@ -10,6 +10,7 @@ from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.chain.ethereum.eth2_utils import ValidatorBalance
 from rotkehlchen.chain.ethereum.typing import Eth2Deposit, ValidatorID, ValidatorPerformance
 from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.constants.misc import ONE
 from rotkehlchen.constants.timing import DEFAULT_CONNECT_TIMEOUT, QUERY_RETRY_TIMES
 from rotkehlchen.errors import DeserializationError, RemoteError
 from rotkehlchen.externalapis.interface import ExternalServiceWithApiKey
@@ -259,7 +260,7 @@ class BeaconChain(ExternalServiceWithApiKey):
                 )
         except KeyError as e:
             raise RemoteError(
-                f'Beaconchai.in performance response processing error. Missing key entry {str(e)}',
+                f'Beaconcha.in performance response processing error. Missing key entry {str(e)}',
             ) from e
 
         return performance
@@ -287,11 +288,12 @@ class BeaconChain(ExternalServiceWithApiKey):
                 ValidatorID(
                     index=x['validatorindex'],
                     public_key=x['publickey'],
+                    ownership_proportion=ONE,
                 ) for x in data
             ]
         except KeyError as e:
             raise RemoteError(
-                f'Beaconchai.in eth1 response processing error. Missing key entry {str(e)}',
+                f'Beaconcha.in eth1 response processing error. Missing key entry {str(e)}',
             ) from e
         return validators
 


### PR DESCRIPTION
- Flush cache when editing eth2 validator % 
- Add the ownership_proportion field to validatorID
- Updates the last database write after editing an eth2 validator

