### PR TITLE
Kraken fix instant trades rate

### DIFF
--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -838,8 +838,11 @@ class Kraken(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 is_spend_receive = True
                 receive_part = trade_part
             elif trade_part.event_type == HistoryEventType.SPEND:
-                is_spend_receive = True
-                spend_part = trade_part
+                if trade_part.event_subtype == HistoryEventSubType.FEE:
+                    fee_part = trade_part
+                else:
+                    is_spend_receive = True
+                    spend_part = trade_part
             elif trade_part.event_type == HistoryEventType.TRADE:
                 if trade_part.event_subtype == HistoryEventSubType.FEE:
                     fee_part = trade_part

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -43,7 +43,7 @@ from rotkehlchen.tests.utils.constants import (
 )
 from rotkehlchen.tests.utils.history import TEST_END_TS
 from rotkehlchen.tests.utils.mock import MockResponse
-from rotkehlchen.typing import AssetMovementCategory, Location, Timestamp
+from rotkehlchen.typing import AssetMovementCategory, Location, Timestamp, TradeType
 from rotkehlchen.utils.misc import ts_now
 
 
@@ -338,7 +338,7 @@ def test_kraken_trade_with_spend_receive(function_scope_kraken):
                 "amount": "1",
                 "fee": "0.0000000000",
                 "balance": "1001"
-                },
+            },
             "L1": {
                 "refid": "1",
                 "time": 1636406000.8654,
@@ -362,6 +362,13 @@ def test_kraken_trade_with_spend_receive(function_scope_kraken):
         )
 
     assert len(trades) == 1
+    trade = trades[0]
+    assert trade.amount == FVal(1)
+    assert trade.trade_type == TradeType.BUY
+    assert trade.rate == FVal(100)
+    assert trade.base_asset == A_ETH
+    assert trade.quote_asset == A_EUR
+    assert trade.fee == FVal(0.45)
     errors = kraken.msg_aggregator.consume_errors()
     warnings = kraken.msg_aggregator.consume_warnings()
     assert len(errors) == 0


### PR DESCRIPTION
The issue was that when searching for the fee part the subtype was not being check and fees have `historyeventtype == SPEND`