### PR TITLE
More stuff before v1.23.0

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9713,7 +9713,7 @@ Gitcoin report
 
       {
           "result": {
-	      "profit_currencty": "EUR",
+	      "profit_currency": "EUR",
 	      "reports": {
 		  "149": {
 		      "per_asset": {

--- a/rotkehlchen/chain/ethereum/modules/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2.py
@@ -125,7 +125,7 @@ class Eth2(EthereumModule):
         result_deposits.sort(key=lambda deposit: (deposit.timestamp, deposit.tx_index))
         return result_deposits
 
-    def _fetch_eth1_validator_data(
+    def fetch_eth1_validator_data(
             self,
             addresses: List[ChecksumEthAddress],
     ) -> List[ValidatorID]:
@@ -189,7 +189,7 @@ class Eth2(EthereumModule):
         balance_mapping: Dict[Eth2PubKey, Balance] = defaultdict(Balance)
         validators: Union[List[ValidatorID], List[Eth2Validator]]
         if fetch_validators_for_eth1:
-            validators = self._fetch_eth1_validator_data(addresses)
+            validators = self.fetch_eth1_validator_data(addresses)
         else:
             validators = dbeth2.get_validators()
 

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, NamedTuple, Optional
 
 from rotkehlchen.data_migrations.migrations.migration_1 import data_migration_1
+from rotkehlchen.data_migrations.migrations.migration_2 import data_migration_2
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
@@ -19,6 +20,7 @@ class MigrationRecord(NamedTuple):
 
 MIGRATION_LIST = [
     MigrationRecord(version=1, function=data_migration_1),
+    MigrationRecord(version=2, function=data_migration_2),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migration_2.py
+++ b/rotkehlchen/data_migrations/migrations/migration_2.py
@@ -1,0 +1,45 @@
+import logging
+from typing import TYPE_CHECKING
+
+import gevent
+
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.utils.mixins.common import function_sig_key
+
+if TYPE_CHECKING:
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+def _do_query_validator_data(rotki: 'Rotkehlchen') -> None:
+    """Queries validator data if needed. Also captures the lock of beacon chain
+    balance queries so that they do not start unless this is finished"""
+    eth2 = rotki.chain_manager.get_module('eth2')
+    if eth2 is None:
+        return
+
+    lock_key = function_sig_key('query_ethereum_beaconchain_balances', arguments_matter=False, skip_ignore_cache=False)  # noqa: E501
+    lock = rotki.chain_manager.query_locks_map[lock_key]
+
+    with lock:
+        addresses = rotki.chain_manager.queried_addresses_for_module('eth2')
+        eth2.fetch_eth1_validator_data(addresses)
+
+
+def data_migration_2(rotki: 'Rotkehlchen') -> None:
+    """
+    At v1.23.0 we added a new eth2 validators table and all validators are detected
+    from there. But for already existing addresses there is no validators detected
+    and they can only be detected if balances are force queried without cache (which
+    for ETH2 also detects validator deposits for all addresses)
+
+    This migration does the same thing so that users can still see their eth2 validators
+    when downloading v1.23.0 without having to do anything special
+
+    Since this function happens at user unlock we spawn a greenlet to do the work
+    asynchronously to not slow down unlock too much.
+    """
+    gevent.spawn(_do_query_validator_data, rotki)

--- a/rotkehlchen/data_migrations/migrations/migration_2.py
+++ b/rotkehlchen/data_migrations/migrations/migration_2.py
@@ -1,17 +1,11 @@
-import logging
 from typing import TYPE_CHECKING
 
 import gevent
 
-from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.mixins.common import function_sig_key
 
 if TYPE_CHECKING:
     from rotkehlchen.rotkehlchen import Rotkehlchen
-
-
-logger = logging.getLogger(__name__)
-log = RotkehlchenLogsAdapter(logger)
 
 
 def _do_query_validator_data(rotki: 'Rotkehlchen') -> None:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2061,11 +2061,14 @@ class DBHandler:
         )
         extras = {}
         for entry in result:
-            if entry[0] != 'kraken_account_type':
+            if entry[0] not in ('kraken_account_type', 'PAIRS'):
                 log.error(
                     f'Unknown credential setting {entry[0]} found in the DB. Skipping.',
                 )
                 continue
+
+            if entry[0] == 'PAIRS':
+                continue  # TODO: https://github.com/rotki/rotki/issues/3886
 
             try:
                 extras['kraken_account_type'] = KrakenAccountType.deserialize(entry[1])

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -188,7 +188,6 @@ class Rotkehlchen():
         self.premium_sync_manager = PremiumSyncManager(data=self.data, password=password)
         # set the DB in the external services instances that need it
         self.cryptocompare.set_database(self.data.db)
-        DataMigrationManager(self).maybe_migrate_data()
 
         # Anything that was set above here has to be cleaned in case of failure in the next step
         # by reset_after_failed_account_creation_or_login()
@@ -316,6 +315,7 @@ class Rotkehlchen():
             chain_manager=self.chain_manager,
             exchange_manager=self.exchange_manager,
         )
+        DataMigrationManager(self).maybe_migrate_data()
         self.greenlet_manager.spawn_and_track(
             after_seconds=5,
             task_name='periodically_query_icons_until_all_cached',


### PR DESCRIPTION
- Data migration to refetch eth2 validators for eth1 addies at 1.23.0
- Temporarily ignore PAIRS in get_exchange_credentials_extras