### PR TITLE
fix: change popup successful forced sync operations icon

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3895` Popup for successful forced sync operation should shows correct icon.
 * :bug:`-` Restores arm64 docker images.
 * :bug:`3903` The application should now run on macOS 10.14 (Mojave) without errors.
 * :bug:`3901` Coinbase accounts with intenal subaccount movements will now display the Coinbase withdrawals properly.

--- a/frontend/app/src/store/session/actions.ts
+++ b/frontend/app/src/store/session/actions.ts
@@ -25,6 +25,7 @@ import { Section, Status } from '@/store/const';
 import { ACTION_PURGE_PROTOCOL } from '@/store/defi/const';
 import { HistoryActions } from '@/store/history/consts';
 import { useNotifications } from '@/store/notifications';
+import { Severity } from '@/store/notifications/consts';
 import { useReports } from '@/store/reports';
 import {
   ACTION_PURGE_CACHED_DATA,
@@ -631,6 +632,7 @@ export const actions: ActionTree<SessionState, RotkehlchenState> = {
       notify({
         title,
         message,
+        severity: Severity.INFO,
         display: true
       });
 


### PR DESCRIPTION
Closes #3895 

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- [ ] Fix: change popup successful forced sync operations icon

![image](https://user-images.githubusercontent.com/26648140/148060537-aa2461a3-9dbc-4f7b-b1bf-4779e0a0f2d0.png)
