### PR TITLE
Fix some coinbase/pro mappings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 =========
 Changelog
 =========
+* :bug:`-` Fix coinbase/pro detection for GTC, TRU and FARM.
 * :bug:`3896` Fix dashboard balance search that does not show ethereum tokens.
 * :bug:`3895` Popup for successful forced sync operation should shows correct icon.
 * :bug:`3899` Crypto.com users will now be able to import supercharger events and recurring buy orders.

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -460,6 +460,8 @@ WORLD_TO_COINBASE_PRO = {
     strethaddress_to_identifier('0x0391D2021f89DC339F60Fff84546EA23E337750f'): 'BOND',
     strethaddress_to_identifier('0x2565ae0385659badCada1031DB704442E1b69982'): 'ASM',
     strethaddress_to_identifier('0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF'): 'IMX',
+    strethaddress_to_identifier('0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784'): 'TRU',
+    strethaddress_to_identifier('0xa0246c9032bC3A600820415aE600c6388619A14D'): 'FARM',
 }
 
 WORLD_TO_COINBASE = {
@@ -467,6 +469,9 @@ WORLD_TO_COINBASE = {
     strethaddress_to_identifier('0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b'): 'AXS',
     strethaddress_to_identifier('0x32353A6C91143bfd6C7d363B546e62a9A2489A20'): 'AGLD',
     strethaddress_to_identifier('0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85'): 'FET',
+    strethaddress_to_identifier('0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F'): 'GTC',
+    strethaddress_to_identifier('0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784'): 'TRU',
+    strethaddress_to_identifier('0xa0246c9032bC3A600820415aE600c6388619A14D'): 'FARM',
 }
 
 WORLD_TO_UPHOLD = {


### PR DESCRIPTION
Tokens GTC, TRU and FARM were ambiguous in coinbase/pro so mappings
are added

@yabirgb I am starting to get confused about those 2 exchanges. Do they have the same assets? Their mappings start to converge. If one is a superset perhaps we can use only one?