### PR TITLE
Fix : fix eth transactions that deploy a contract break transaction view

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 =========
 Changelog
 =========
+* :bug:`3916` Users with ethereum transactions that deploy contracts will now be able to load the transactions view properly.
 * :bug:`-` Fix coinbase/pro detection for GTC, TRU and FARM.
 * :bug:`3896` Fix dashboard balance search that does not show ethereum tokens.
 * :bug:`3895` Popup for successful forced sync operation should shows correct icon.

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -82,7 +82,7 @@ import { randomHex } from '@/utils/data';
   }
 })
 export default class HashLink extends Mixins(ScrambleMixin, ThemeMixin) {
-  @Prop({ required: true, type: String })
+  @Prop({ required: false, type: String, default: '' })
   text!: string;
   @Prop({ required: false, type: Boolean, default: false })
   fullAddress!: boolean;

--- a/frontend/app/src/services/history/types.ts
+++ b/frontend/app/src/services/history/types.ts
@@ -130,7 +130,7 @@ export const EthTransaction = z.object({
   timestamp: z.number(),
   blockNumber: z.number(),
   fromAddress: z.string(),
-  toAddress: z.string(),
+  toAddress: z.string().nullable().optional(),
   value: NumericString,
   gas: NumericString,
   gasPrice: NumericString,


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- [ ] Fix eth transactions that deploy a contract break transaction view