### PR TITLE
Fix query balance for avax chain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 * :bug:`3896` Fix dashboard balance search that does not show ethereum tokens.
 * :bug:`3895` Popup for successful forced sync operation should shows correct icon.
 * :bug:`-` Restores arm64 docker images.
+* :bug:`-` AVAX balances should now be always correctly queried.
 * :bug:`3903` The application should now run on macOS 10.14 (Mojave) without errors.
 * :bug:`3901` Coinbase accounts with intenal subaccount movements will now display the Coinbase withdrawals properly.
 

--- a/rotkehlchen/chain/avalanche/manager.py
+++ b/rotkehlchen/chain/avalanche/manager.py
@@ -60,16 +60,11 @@ class AvalancheManager():
         if result is None:
             balance = from_wei(FVal(self.w3.eth.get_balance(account)))
         else:
-            def filter_avax(value: Dict) -> bool:
-                if 'contract_address' in value:
-                    return value['contract_address'] in (AVAX_ADDRESS, COVALENT_AVAX_ADDRESS)
-                return False
-
-            avax_coin = list(filter(filter_avax, result))
-            if len(avax_coin) != 0:
-                balance = from_wei(FVal(avax_coin[0]['balance']))
-            else:
-                return ZERO
+            balance = ZERO
+            for entry in result:
+                if entry.get('contract_address') in (AVAX_ADDRESS, COVALENT_AVAX_ADDRESS):
+                    balance = from_wei(FVal(entry.get('balance', 0)))
+                    break
         return FVal(balance)
 
     def get_multiavax_balance(

--- a/rotkehlchen/chain/avalanche/manager.py
+++ b/rotkehlchen/chain/avalanche/manager.py
@@ -7,6 +7,7 @@ from web3.exceptions import BadFunctionCallOutput
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
 from rotkehlchen.chain.ethereum.graph import Graph
+from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors import BlockchainQueryError, DeserializationError, RemoteError
 from rotkehlchen.externalapis.covalent import Covalent
 from rotkehlchen.fval import FVal
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 AVAX_ADDRESS = '0x9debca6ea3af87bf422cea9ac955618ceb56efb4'
+COVALENT_AVAX_ADDRESS = '0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 WEB3_LOGQUERY_BLOCK_RANGE = 250000
 
 
@@ -60,11 +62,14 @@ class AvalancheManager():
         else:
             def filter_avax(value: Dict) -> bool:
                 if 'contract_address' in value:
-                    return value['contract_address'] == AVAX_ADDRESS
+                    return value['contract_address'] in (AVAX_ADDRESS, COVALENT_AVAX_ADDRESS)
                 return False
 
             avax_coin = list(filter(filter_avax, result))
-            balance = from_wei(FVal(avax_coin[0]['balance']))
+            if len(avax_coin) != 0:
+                balance = from_wei(FVal(avax_coin[0]['balance']))
+            else:
+                return ZERO
         return FVal(balance)
 
     def get_multiavax_balance(


### PR DESCRIPTION
Seems that the response for covalent has changed and now the avax address is represented
as `0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`. Example response from the API

```
{
      "contract_decimals":18,
      "contract_name":"Avalanche Coin",
      "contract_ticker_symbol":"AVAX",
      "contract_address":"0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
      "supports_erc":null,
      "logo_url":"https://logos.covalenthq.com/tokens/43114/0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.png",
      "last_transferred_at":null,
      "type":"cryptocurrency",
      "balance":"568277566196774216",
      "balance_24h":null,
      "quote_rate":95.84449,
      "quote_rate_24h":null,
      "quote":54.466274,
      "quote_24h":null,
      "nft_data":null
}
```

What I've done is include this address in the search and also prevent any possible
error if the account has 0 AVAX. Also I 've changed the logic to exit early. The test went from 12 secs to 3
