### PR TITLE
Limit separator length to one character and prevent numeric character

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 =========
 Changelog
 =========
+* :bug:`3929` Prevent user from using invalid character for thousand and decimal separator.
 * :bug:`3913` NFT Balances table at dashboard should be updated when users remove an ethereum account.
 * :bug:`3916` Users with ethereum transactions that deploy contracts will now be able to load the transactions view properly.
 * :bug:`-` Fix coinbase/pro detection for GTC, TRU and FARM.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1461,7 +1461,8 @@
     "decimal_separator": {
       "validation": {
         "empty": "The decimal separator cannot be empty",
-        "cannot_be_the_same": "The decimal separator cannot be the same as thousand separator"
+        "cannot_be_the_same": "The decimal separator cannot be the same as the thousand separator",
+        "cannot_be_numeric_character": "The decimal separator cannot be numeric character"
       }
     },
     "version_update_check_hint": "How often (in hours) your app version will be checked for update",
@@ -1485,7 +1486,8 @@
     "thousand_separator": {
       "validation": {
         "empty": "The thousand separator cannot be empty",
-        "cannot_be_the_same": "The thousand separator cannot be the same as decimal separator"
+        "cannot_be_the_same": "The thousand separator cannot be the same as the decimal separator",
+        "cannot_be_numeric_character": "The thousand separator cannot be numeric character"
       }
     },
     "validation": {

--- a/frontend/app/src/views/settings/GeneralSettings.vue
+++ b/frontend/app/src/views/settings/GeneralSettings.vue
@@ -200,6 +200,7 @@
           <v-text-field
             v-model="thousandSeparator"
             outlined
+            maxlength="1"
             class="general-settings__fields__thousand-separator"
             :label="$t('general_settings.amount.label.thousand_separator')"
             type="text"
@@ -212,6 +213,7 @@
           <v-text-field
             v-model="decimalSeparator"
             outlined
+            maxlength="1"
             class="general-settings__fields__decimal-separator"
             :label="$t('general_settings.amount.label.decimal_separator')"
             type="text"
@@ -594,13 +596,21 @@ export default class General extends Mixins<SettingsMixin<SettingsEntries>>(
             'general_settings.thousand_separator.validation.cannot_be_the_same'
           ).toString();
         }
+        if (/[0-9]/.test(v)) {
+          return this.$t(
+            'general_settings.thousand_separator.validation.cannot_be_numeric_character'
+          ).toString();
+        }
         return true;
       }
     ];
   }
 
   async onThousandSeparatorChange(thousandSeparator: string) {
-    if (thousandSeparator === this.decimalSeparator) {
+    if (
+      thousandSeparator === this.decimalSeparator ||
+      /[0-9]/.test(thousandSeparator)
+    ) {
       const state = this.$store.state;
       this.thousandSeparator = state.settings![THOUSAND_SEPARATOR];
       return;
@@ -633,13 +643,21 @@ export default class General extends Mixins<SettingsMixin<SettingsEntries>>(
             'general_settings.decimal_separator.validation.cannot_be_the_same'
           ).toString();
         }
+        if (/[0-9]/.test(v)) {
+          return this.$t(
+            'general_settings.decimal_separator.validation.cannot_be_numeric_character'
+          ).toString();
+        }
         return true;
       }
     ];
   }
 
   async onDecimalSeparatorChange(decimalSeparator: string) {
-    if (decimalSeparator === this.thousandSeparator) {
+    if (
+      decimalSeparator === this.thousandSeparator ||
+      /[0-9]/.test(decimalSeparator)
+    ) {
       const state = this.$store.state;
       this.decimalSeparator = state.settings![DECIMAL_SEPARATOR];
       return;


### PR DESCRIPTION
Closes #3929

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- [ ]  Limit separator length to one character and prevent numeric character.