### PR TITLE
Fix packaging after webargs upgrade to 8.1.0

### DIFF
--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -59,7 +59,7 @@ def Entrypoint(dist, group, name, scripts=None, pathex=None, hiddenimports=None,
         hookspath=hookspath,
         excludes=excludes,
         runtime_hooks=runtime_hooks,
-        datas=datas
+        datas=datas,
     )
 
 
@@ -93,7 +93,7 @@ a = Entrypoint(
         ('rotkehlchen/data/global.db', 'rotkehlchen/data'),
         ('rotkehlchen/data/curve_pools.json', 'rotkehlchen/data'),
     ],
-    excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter', 'packaging'],
+    excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'],
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)


### PR DESCRIPTION
The "packaging" package was always added due to the way pyinstaller
works, but was never needed. So we excluded it from the final packaged
binary.

webargs and marshmallow started requiring it
https://github.com/marshmallow-code/webargs/commit/b1ad38c9fb2dbb652cd2facaeb7834086bf21272#diff-793dabaa3b46579cc6d0b805e13e64eceea09be09d8b069ac55dab3eb328dbe0
https://github.com/marshmallow-code/marshmallow/pull/1925/files

So we need to remove the exclude