### PR TITLE
Use better random seed in `faker.py`

### DIFF
--- a/tools/data_faker/data_faker/faker.py
+++ b/tools/data_faker/data_faker/faker.py
@@ -23,7 +23,7 @@ class DataFaker():
         args.logfile = 'data_faker.log'
         self.rotki = Rotkehlchen(args)
 
-        random_seed = datetime.datetime.now()
+        random_seed = datetime.datetime.now().timestamp()
         logger.info(f'Random seed used: {random_seed}')
         random.seed(random_seed)
 


### PR DESCRIPTION
While working on https://github.com/python/typeshed/pull/6924 our CI identified that you are using a deprecated API of `random.seed`, it is deprecated since 3.9 and will be removed in 3.11

Instead, it is possible to use `float` as the seed value. It is possible to get `float` from `datetime` with `.timestamp()`: https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp

That's exactly what I did 🙂 