### PR TITLE
Fixes install popup not displaying after update download

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Users will now be properly prompted to restart the application after the auto-updater downloads the update.
 * :bug:`3943` Users will now be able to properly add multiple accounts on Avalance even if they exist on Ethereum.
 * :bug:`-` Kraken's KFEE will use the price of 0.01 USD when it is needed.
 

--- a/frontend/app/src/components/status/update/AppUpdatePopup.vue
+++ b/frontend/app/src/components/status/update/AppUpdatePopup.vue
@@ -143,6 +143,7 @@ export default class AppUpdatePopup extends Vue {
     });
     this.downloading = false;
     if (downloaded) {
+      this.downloadReady = true;
       this.openUpdatePopup();
     } else {
       this.error = this.$t('update_popup.download_failed.message').toString();


### PR DESCRIPTION
Closes #(issue_number)

This resolves a small part of #3944 where the restart prompt doesn't appear after the download is completed.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
