### PR TITLE
Fix processed + total actions count in the PnL report

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4313,8 +4313,8 @@ Query saved PnL Reports
    :resjson str total_profit_loss: An optional stringified amount of the total PnL gerated by the PnL report. Can be missing if the report did not finish.
    :resjson str total_taxable_profit_loss: An optional stringified amount of the total taxable PnL gerated by the PnL report. Can be missing if the report did not finish.
    :resjson int last_processed_timestamp: The timestamp of the last processed action. This helps us figure out when was the last action the backend processed and if it was before the start of the PnL period to warn the user WHY the PnL is empty.
-   :resjson int processed_actions: The number of actions processed by the PnL report. This is not the same as the events shown within the report as some of them may be before the time period of the report started. This may be smaller than "total_actions" in case of a non-premium user.
-   :resjson int total_actions: The total number of actions to be processed  by the PnL report. This is not the same as the events shown within the report as some of them they may be before the time period of the report started.
+   :resjson int processed_actions: The number of actions processed by the PnL report. This is not the same as the events shown within the report as some of them may be before the time period of the report started. This may be smaller than "total_actions".
+   :resjson int total_actions: The total number of actions to be processed  by the PnL report. This is not the same as the events shown within the report as some of them they may be before or after the time period of the report.
    :resjson str profit_currency: The identifier of the asset used as profit currency in the PnL report.
    :resjson integer taxfree_after_period: An optional integer for the value of taxfree_after_period setting. Can be either null or an integer.
    :resjson bool include_crypto2crypto: The value of the setting used in the PnL report.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`3943` Users will now be able to properly add multiple accounts on Avalance even if they exist on Ethereum.
 * :bug:`-` Kraken's KFEE will use the price of 0.01 USD when it is needed.
+* :bug:`-` If a PnL report is ran for a specific period and there is more events after the period a warning for missing events and prompt to upgrade to premium won't show mistakenly anymore.
 
 * :release:`1.23.1 <2022-01-14>`
 * :bug:`3929` Prevent users from using invalid character for thousands and decimal separator.

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -360,6 +360,7 @@ class Accountant():
 
         prev_time = Timestamp(0)
         count = 0
+        actions_length = len(actions)
         last_event_ts = Timestamp(0)
         ignored_actionids_mapping = self.db.get_ignored_action_ids(action_type=None)
         for action in actions:
@@ -418,11 +419,11 @@ class Accountant():
                 count += 1
                 continue
 
-            last_event_ts = action_get_timestamp(action)
             if not should_continue:
-                count += 1
-                break
+                actions_length = count
+                break  # we reached the period end
 
+            last_event_ts = action_get_timestamp(action)
             if count % 500 == 0:
                 # This loop can take a very long time depending on the amount of actions
                 # to process. We need to yield to other greenlets or else calls to the
@@ -479,7 +480,7 @@ class Accountant():
             report_id=report_id,
             last_processed_timestamp=last_event_ts,
             processed_actions=count,
-            total_actions=len(actions),
+            total_actions=actions_length,
             **profit_loss_overview,
         )
 


### PR DESCRIPTION
1. This fixes last_processed timestamp to be correct and not last processed + 1
2. If we stop processing due to reaching the end of the period, explicitly make actions total == actions processed.
3. Fix an off by one error at processed actions. We were counting an extra action if there were more actions left outside the processing period



For the frontend @kelsos one change would be nice: In the error message use the range: from first_processed_timestamp to last_processed_timestamp. At the moment the message only shows until last_processed_timestamp. But we also need to show first_processed_timestamp since it's the first timestamp of all actions we process. Can be before the start of the range. Say we got events since 2019 and we want to process 2021. First processed timestamp will be somewhere in 2019. And last_processed_timestamp will be last event processed. 
