### PR TITLE
Make queries for avax balances more reliable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :bug:`-` The application will now notify the user and exit if multiple backend binaries exist due to a failed update.
 * :bug:`-` Kraken's KFEE will use the price of 0.01 USD when it is needed.
 * :bug:`-` If a PnL report is ran for a specific period and there is more events after the period a warning for missing events and prompt to upgrade to premium won't show mistakenly anymore.
+* :bug:`-` Query for AVAX balances will be more reliable now.
 * :feature:`3952` Maker's WBTC-B, WBTC-C and MATIC-A vaults are now supported.
 
 * :release:`1.23.1 <2022-01-14>`

--- a/rotkehlchen/chain/avalanche/manager.py
+++ b/rotkehlchen/chain/avalanche/manager.py
@@ -62,9 +62,11 @@ class AvalancheManager():
         else:
             balance = ZERO
             for entry in result:
-                if entry.get('contract_address') in (AVAX_ADDRESS, COVALENT_AVAX_ADDRESS):
+                if entry.get('contract_ticker_symbol') == 'AVAX':
                     balance = from_wei(FVal(entry.get('balance', 0)))
                     break
+            if balance == ZERO:
+                balance = from_wei(FVal(self.w3.eth.get_balance(account)))
         return FVal(balance)
 
     def get_multiavax_balance(


### PR DESCRIPTION
- Query avax balance filtering by symbol instead of address
- If balance is not found force a query using the RPC node