### PR TITLE
upgrade: bump package coincurve=16.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.27.1
 urllib3==1.26.8
 pycryptodome==3.11.0
 pycryptodomex==3.11.0
-coincurve==13.0.0
+coincurve==16.0.0
 typing-extensions==3.10.0.2
 base58check==1.0.2
 bech32==1.2.0


### PR DESCRIPTION
### Description

While trying to setup rotki to run locally on mac !
`pip3 install -r requirements_dev.txt` was failing while trying to install `coincurve==13.0.0`
After checking the changelog and bumping the version to `16.0.0` I was able to get the app running locally.


### Testing 

-  [Sucessfully installs](https://user-images.githubusercontent.com/5358146/150539128-baa0a3a3-9599-433e-bf20-cd8af94867a3.png)
- App boots locally




