### PR TITLE
Allow deletion of multiple database backups with a single call

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`3987` Users will now be able to delete multiple database backups.
 * :bug:`-` If binance returns a delisted market as active and rotki queries it, the entire binance trade history query will not fail.
 * :bug:`-` All Liquity events will now always be correctly queried.
 

--- a/frontend/app/src/components/settings/data-security/backups/DatabaseBackups.vue
+++ b/frontend/app/src/components/settings/data-security/backups/DatabaseBackups.vue
@@ -1,10 +1,15 @@
 <template>
   <fragment>
     <data-table
+      :value="selected"
       :items="items"
       sort-by="time"
+      show-select
+      item-key="time"
+      :single-select="false"
       :headers="headers"
       :loading="loading"
+      @input="onSelectedChange"
     >
       <template #item.time="{ item }">
         <date-display :timestamp="item.time" />
@@ -47,7 +52,7 @@
       </template>
       <template #body.append="{ isMobile }">
         <tr>
-          <td :colspan="isMobile ? 1 : 2" class="font-weight-medium">
+          <td :colspan="isMobile ? 2 : 3" class="font-weight-medium">
             {{ $t('database_backups.row.total') }}
           </td>
           <td class="text-right">
@@ -107,6 +112,7 @@ export default defineComponent({
   components: { Fragment },
   props: {
     items: { required: true, type: Array as PropType<UserDbBackup[]> },
+    selected: { required: true, type: Array as PropType<UserDbBackup[]> },
     loading: { required: false, type: Boolean, default: false },
     directory: { required: true, type: String }
   },
@@ -148,9 +154,14 @@ export default defineComponent({
     const getLink = (db: UserDbBackup) =>
       api.backups.fileUrl(getFilepath(db, directory));
 
+    const onSelectedChange = (selected: UserDbBackup[]) => {
+      emit('change', selected);
+    };
+
     return {
       remove,
       getLink,
+      onSelectedChange,
       messageInfo,
       pendingDeletion,
       size,

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -188,6 +188,7 @@
   },
   "backup_manager": {
     "backup_button": "Create new Backup",
+    "delete_selected": "Delete selected Backups",
     "title": "User Database Backups"
   },
   "balancer": {
@@ -359,10 +360,12 @@
     },
     "confirm": {
       "message": "Are you sure you want to delete the {size} database backup from {date}?",
+      "mass_message": "Are you sure you want to delete these {length} database backup(s)?",
       "title": "Delete database backup"
     },
     "delete_error": {
       "message": "There was a problem deleting {file}: {message}",
+      "mass_message": "There was a problem while deleting the database backups: {message}",
       "title": "Backup delete failure"
     },
     "load_error": {


### PR DESCRIPTION
Closes #3692

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- [ ] Allow deletion of multiple database backups with a single call (frontend)