### PR TITLE
Selectively choose the fee asset in coinbase conversions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 * :bug:`-` If binance returns a delisted market as active and rotki queries it, the entire binance trade history query will not fail.
 * :bug:`4010` Crypto.com users won't see errors for rows containing zeros.
 * :bug:`-` All Liquity events will now always be correctly queried.
+* :bug:`3947` Coinbase conversions will now choose in a better way the asset to nominate the fees.
 * :feature:`-` Support for LUNA and card top ups has been added to the crypto.com importer.
 
 * :release:`1.23.2 <2022-01-21>`

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -133,13 +133,33 @@ def trade_from_conversion(trade_a: Dict[str, Any], trade_b: Dict[str, Any]) -> O
     # amount_after_fee + amount_before_fee is a negative amount and the fee needs to be positive
     conversion_native_fee_amount = abs(amount_after_fee + amount_before_fee)
     if ZERO not in (tx_amount, conversion_native_fee_amount, amount_before_fee):
-        # We have the fee amount in the native currency. To get it in the
-        # converted asset we have to get the rate
-        asset_native_rate = tx_amount / abs(amount_before_fee)
-        fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
+        # To get the asset in wich the fee is nominated we pay attention to the creation
+        # date of each event. As per hour hypothesis the fee is nominated in the asset
+        # for wich the first transaction part was intialized
+        time_created_a = deserialize_timestamp_from_date(
+            date=trade_a['created_at'],
+            formatstr='iso8601',
+            location='coinbase',
+        )
+        time_created_b = deserialize_timestamp_from_date(
+            date=trade_b['created_at'],
+            formatstr='iso8601',
+            location='coinbase',
+        )
+        if time_created_a < time_created_b:
+            # We have the fee amount in the native currency. To get it in the
+            # converted asset we have to get the rate
+            asset_native_rate = tx_amount / abs(amount_before_fee)
+            fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
+            fee_asset = asset_from_coinbase(trade_a['amount']['currency'], time=timestamp)
+        else:
+            trade_b_amount = abs(deserialize_asset_amount(trade_b['amount']['amount']))
+            asset_native_rate = trade_b_amount / abs(amount_after_fee)
+            fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
+            fee_asset = asset_from_coinbase(trade_b['amount']['currency'], time=timestamp)
     else:
         fee_amount = Fee(ZERO)
-    fee_asset = asset_from_coinbase(trade_a['amount']['currency'], time=timestamp)
+        fee_asset = asset_from_coinbase(trade_a['amount']['currency'], time=timestamp)
 
     return Trade(
         timestamp=timestamp,

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -132,10 +132,10 @@ def trade_from_conversion(trade_a: Dict[str, Any], trade_b: Dict[str, Any]) -> O
     amount_before_fee = deserialize_asset_amount(trade_a['native_amount']['amount'])
     # amount_after_fee + amount_before_fee is a negative amount and the fee needs to be positive
     conversion_native_fee_amount = abs(amount_after_fee + amount_before_fee)
-    if ZERO not in (tx_amount, conversion_native_fee_amount, amount_before_fee):
+    if ZERO not in (tx_amount, conversion_native_fee_amount, amount_before_fee, amount_after_fee):
         # To get the asset in wich the fee is nominated we pay attention to the creation
-        # date of each event. As per hour hypothesis the fee is nominated in the asset
-        # for wich the first transaction part was intialized
+        # date of each event. As per our hypothesis the fee is nominated in the asset
+        # for which the first transaction part was initialized
         time_created_a = deserialize_timestamp_from_date(
             date=trade_a['created_at'],
             formatstr='iso8601',

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -1088,7 +1088,7 @@ def test_asset_conversion():
             "currency": "USD",
         },
         "description": None,
-        "created_at": "2020-06-08T02:32:16Z",
+        "created_at": "2020-06-08T02:32:15Z",
         "updated_at": "2021-06-08T02:32:16Z",
         "resource": "transaction",
         "resource_path": "/v2/accounts/sd5af/transactions/77c5ad72-764e-414b-8bdb-b5aed20fb4b1",
@@ -1170,7 +1170,7 @@ def test_asset_conversion_not_stable_coin():
             "currency": "USD",
         },
         "description": None,
-        "created_at": "2020-06-08T02:32:16Z",
+        "created_at": "2020-06-08T02:32:15Z",
         "updated_at": "2021-06-08T02:32:16Z",
         "resource": "transaction",
         "resource_path": "/v2/accounts/sd5af/transactions/77c5ad72-764e-414b-8bdb-b5aed20fb4b1",
@@ -1239,7 +1239,6 @@ def test_asset_conversion_not_stable_coin():
 
 def test_asset_conversion_zero_fee():
     """Test a conversion with 0 fee"""
-
     trade_a = {
         "id": "77c5ad72-764e-414b-8bdb-b5aed20fb4b1",
         "type": "trade",
@@ -1316,5 +1315,92 @@ def test_asset_conversion_zero_fee():
         fee=FVal(ZERO),
         fee_currency=A_1INCH,
         link='5dceef97-ef34-41e6-9171-3e60cd01639e',
+    )
+    assert trade == expected_trade
+
+
+def test_asset_conversion_choosing_fee_asset():
+    """Test that the fee asset is correctly choosen when the received asset transaction
+    is created before the giving transaction.
+    """
+
+    trade_a = {
+        "id": "REDACTED",
+        "type": "trade",
+        "status": "completed",
+        "amount": {
+            "amount": "-37734.034561",
+            "currency": "ETH",
+        },
+        "native_amount": {
+            "amount": "-79362.22",
+            "currency": "USD",
+        },
+        "description": None,
+        "created_at": "2021-10-12T13:23:56Z",
+        "updated_at": "2021-10-12T13:23:56Z",
+        "resource": "transaction",
+        "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+        "instant_exchange": False,
+        "trade": {
+            "id": "id_of_trade",
+            "resource": "trade",
+            "resource_path": "/v2/accounts/REDACTED/trades/id_of_trade",
+        },
+        "details": {
+            "title": "Converted from ETH",
+            "subtitle": "Using ETH Wallet",
+            "header": "Converted 37,734.034561 ETH ($79,362.22)",
+            "health": "positive",
+            "payment_method_name": "ETH Wallet",
+        },
+        "hide_native_amount": False,
+    }
+
+    trade_b = {
+        "id": "REDACTED",
+        "type": "trade",
+        "status": "completed",
+        "amount": {
+            "amount": "552.315885836",
+            "currency": "BTC",
+        },
+        "native_amount": {
+            "amount": "77827.94",
+            "currency": "USD",
+        },
+        "description": None,
+        "created_at": "2021-10-12T13:23:55Z",
+        "updated_at": "2021-10-12T13:23:57Z",
+        "resource": "transaction",
+        "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+        "instant_exchange": False,
+        "trade": {
+            "id": "id_of_trade",
+            "resource": "trade",
+            "resource_path": "/v2/accounts/REDACTED/trades/id_of_trade",
+        },
+        "details": {
+            "title": "Converted to BTC",
+            "subtitle": "Using ETH Wallet",
+            "header": "Converted 552.31588584 BTC ($77,827.94)",
+            "health": "positive",
+            "payment_method_name": "ETH Wallet",
+        },
+        "hide_native_amount": False,
+    }
+
+    trade = trade_from_conversion(trade_a, trade_b)
+    expected_trade = Trade(
+        timestamp=1634045036,
+        location=Location.COINBASE,
+        base_asset=A_ETH,
+        quote_asset=A_BTC,
+        trade_type=TradeType.SELL,
+        amount=FVal('37734.034561'),
+        rate=FVal('0.01463707478571204566189616471'),
+        fee=FVal('10.88821337581925051594581586'),
+        fee_currency=A_BTC,
+        link='id_of_trade',
     )
     assert trade == expected_trade


### PR DESCRIPTION
This PR modfifies how trades are generated from coinbase transactions

logic assumed that the fee was paid in the converted asset but as how it was noted
by the user at #3947 if all the owned asset is sold this could lead to incorrect calculations
in the profit and loss report since we were making a wrong calculation of the fee costs.

Now the fee is nominated in the asset for wich the first transaction (of the two) is created.
The hyphotesis is that the fee is nominated in this asset as per what I saw in the data.

Closes #3947
