### PR TITLE
Handle BlockNotFound raised by web3.eth.get_block()

### DIFF
--- a/rotkehlchen/chain/avalanche/manager.py
+++ b/rotkehlchen/chain/avalanche/manager.py
@@ -90,6 +90,8 @@ class AvalancheManager():
         May raise:
         - RemoteError if an external service such as Covalent is queried and
         there is a problem with its query.
+        - BlockNotFound if number used to lookup the block can't be found. Raised
+        by web3.eth.get_block().
         """
         block_data: MutableAttributeDict = MutableAttributeDict(self.w3.eth.get_block(num))  # type: ignore # pylint: disable=no-member  # noqa: E501
         block_data['hash'] = hex_or_bytes_to_str(block_data['hash'])

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -18,7 +18,12 @@ from web3._utils.abi import get_abi_output_types
 from web3._utils.contracts import find_matching_event_abi
 from web3._utils.filters import construct_event_filter_params
 from web3.datastructures import MutableAttributeDict
-from web3.exceptions import BadFunctionCallOutput, BadResponseFormat, TransactionNotFound
+from web3.exceptions import (
+    BadFunctionCallOutput,
+    BadResponseFormat,
+    BlockNotFound,
+    TransactionNotFound,
+)
 from web3.middleware.exception_retry_request import http_retry_request_middleware
 from web3.types import FilterParams
 
@@ -412,6 +417,7 @@ class EthereumManager():
                     requests.exceptions.RequestException,
                     BlockchainQueryError,
                     TransactionNotFound,
+                    BlockNotFound,
                     KeyError,  # saw this happen inside web3.py if resulting json contains unexpected key. Probably fixed as written below, but no risking it. # noqa: E501
                     BadResponseFormat,  # should replace the above KeyError after https://github.com/ethereum/web3.py/pull/2188  # noqa: E501
             ) as e:
@@ -565,6 +571,8 @@ class EthereumManager():
         May raise:
         - RemoteError if an external service such as Etherscan is queried and
         there is a problem with its query.
+        - BlockNotFound if number used to lookup the block can't be found. Raised
+        by web3.eth.get_block().
         """
         if web3 is None:
             return self.etherscan.get_block_by_number(num)


### PR DESCRIPTION
This is a fix for something I spotted in production. Can happen if somehow the node used errors for get block by number.


```
[02/02/2022 13:24:19 CET] DEBUG web3.RequestManager Making request. Method: eth_getBlockByNumber
[02/02/2022 13:24:19 CET] DEBUG web3.providers.HTTPProvider Making request HTTP. URI: https://mainnet.eth.cloud.ava.do/, Method: eth_getBlockByNumber
[02/02/2022 13:24:20 CET] DEBUG rotkehlchen.api.rest Greenlet-3: Request successful response={"result": {"pending": [6], "completed": []}, "message": ""}, status_code=200
[02/02/2022 13:24:20 CET] INFO rotkehlchen.api.server.pywsgi 127.0.0.1 - - "GET /api/1/tasks/ HTTP/1.1" 200 248 0.001011
[02/02/2022 13:24:20 CET] DEBUG web3.providers.HTTPProvider Getting response HTTP. URI: https://mainnet.eth.cloud.ava.do/, Method: eth_getBlockByNumber, Response: {'jsonrpc': '2.0', 'id': 13, 'result': None}
[02/02/2022 13:24:20 CET] ERROR rotkehlchen.api.rest Greenlet with id 139697124194640: Greenlet for task 6 dies with exception: Block with id: '0xd16f10' not found..
Exception Name: <class 'web3.exceptions.BlockNotFound'>
Exception Info: Block with id: '0xd16f10' not found.
Traceback:
   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 306, in _do_query_async
    result = getattr(self, command)(**kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 3008, in _get_ethereum_transactions
    has_premium=self.rotkehlchen.premium is not None,
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/utils/mixins/lockable.py", line 46, in wrapper
    result = f(wrappingobj, *args, **kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/transactions.py", line 201, in query
    end_ts=to_ts,
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/transactions.py", line 154, in single_address_query_transactions
    transaction = self.ethereum.get_transaction_by_hash(tx_hash)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 835, in get_transaction_by_hash
    tx_hash=tx_hash,
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 409, in query
    result = method(web3, **kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 819, in _get_transaction_by_hash
    transaction = deserialize_ethereum_transaction(data=tx_data, internal=False, ethereum=self)  # noqa: E501
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/serialization/deserialize.py", line 544, in deserialize_ethereum_transaction
    block_data = ethereum.get_block_by_number(block_number)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 559, in get_block_by_number
    num=num,
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 409, in query
    result = method(web3, **kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/ethereum/manager.py", line 572, in _get_block_by_number
    block_data: MutableAttributeDict = MutableAttributeDict(web3.eth.get_block(num))  # type: ignore # pylint: disable=no-member  # noqa: E501
  File "/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/web3/eth.py", line 642, in get_block
    return self._get_block(block_identifier, full_transactions)
  File "/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/web3/module.py", line 60, in caller
    null_result_formatters)
  File "/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/web3/manager.py", line 201, in request_blocking
    null_result_formatters)
  File "/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/web3/manager.py", line 177, in formatted_response
    apply_null_result_formatters(null_result_formatters, response, params)
  File "/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/web3/manager.py", line 82, in apply_null_result_formatters
    formatted_resp = pipe(params, null_result_formatters)
  File "cytoolz/functoolz.pyx", line 667, in cytoolz.functoolz.pipe
  File "cytoolz/functoolz.pyx", line 642, in cytoolz.functoolz.c_pipe
  File "/home/lefteris/.virtualenvs/rotkipy37/lib/python3.7/site-packages/web3/_utils/method_formatters.py", line 630, in raise_block_not_found
    raise BlockNotFound(message)
```