### PR TITLE
Bump few backend packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gevent==21.12.0
 greenlet==1.1.2
 gevent-websocket==0.10.1
 wsaccel==0.6.3  # recommended for acceleration of gevent-websocket. But abandoned.
-web3==5.26.0
+web3==5.27.0
 pysqlcipher3==1.0.4
 requests==2.27.1
 urllib3==1.26.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pysqlcipher3==1.0.4
 requests==2.27.1
 urllib3==1.26.8
 coincurve==16.0.0
-typing-extensions==4.0.1
 base58check==1.0.2
 bech32==1.2.0
 gql==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pysqlcipher3==1.0.4
 requests==2.27.1
 urllib3==1.26.8
 coincurve==16.0.0
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
 base58check==1.0.2
 bech32==1.2.0
 gql==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,11 @@ typing-extensions==4.0.1
 base58check==1.0.2
 bech32==1.2.0
 gql==2.0.0
-scalecodec==1.0.28
+scalecodec==1.0.30
 py-sr25519-bindings==0.1.4
 py-ed25519-bindings==1.0.1
 py-bip39-bindings==0.1.8
-substrate-interface==1.1.7
+substrate-interface==1.1.8
 beautifulsoup4==4.10.0
 maxminddb==2.2.0
 miniupnpc==2.0.2; sys_platform != 'win32'

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -16,9 +16,9 @@ isort==5.10.1
 # type packages used by mypy
 # pinned here so that we can have reproducible mypy runs
 types-chardet==4.0.3
-types-cryptography==3.3.12
-types-enum34==1.1.2
-types-ipaddress==1.0.2
+types-cryptography==3.3.15
+types-enum34==1.1.8
+types-ipaddress==1.0.8
 types-pkg-resources==0.1.3
-types-requests==2.27.3
+types-requests==2.27.8
 types-toml==0.10.3

--- a/rotkehlchen/accounting/structures.py
+++ b/rotkehlchen/accounting/structures.py
@@ -2,9 +2,7 @@ import operator
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple
-
-from typing_extensions import Literal
+from typing import Any, Callable, DefaultDict, Dict, List, Literal, Optional, Tuple
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -14,6 +14,7 @@ from typing import (
     DefaultDict,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -26,7 +27,6 @@ from flask import Response, make_response, send_file
 from gevent.event import Event
 from gevent.lock import Semaphore
 from pysqlcipher3 import dbapi2 as sqlcipher
-from typing_extensions import Literal
 from web3.exceptions import BadFunctionCallOutput
 
 from rotkehlchen.accounting.constants import FREE_PNL_EVENTS_LIMIT, FREE_REPORTS_LOOKUP_LIMIT

--- a/rotkehlchen/api/v1/encoding.py
+++ b/rotkehlchen/api/v1/encoding.py
@@ -6,6 +6,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -18,7 +19,6 @@ import webargs
 from eth_utils import to_checksum_address
 from marshmallow import Schema, fields, post_load, validates_schema
 from marshmallow.exceptions import ValidationError
-from typing_extensions import Literal
 from werkzeug.datastructures import FileStorage
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 from flask import Blueprint, Request, Response, request as flask_request
 from flask_restful import Resource
 from marshmallow import Schema
 from marshmallow.utils import missing
-from typing_extensions import Literal
 from webargs.flaskparser import parser, use_kwargs
 from webargs.multidictproxy import MultiDictProxy
 from werkzeug.datastructures import FileStorage

--- a/rotkehlchen/chain/ethereum/contracts.py
+++ b/rotkehlchen/chain/ethereum/contracts.py
@@ -1,7 +1,17 @@
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from eth_typing.abi import Decodable
-from typing_extensions import Literal
 from web3 import Web3
 from web3._utils.abi import get_abi_output_types
 

--- a/rotkehlchen/chain/ethereum/defi/structures.py
+++ b/rotkehlchen/chain/ethereum/defi/structures.py
@@ -1,6 +1,4 @@
-from typing import Callable, Dict, List, NamedTuple, Union
-
-from typing_extensions import Literal
+from typing import Callable, Dict, List, Literal, NamedTuple, Union
 
 from rotkehlchen.accounting.structures import Balance, BalanceSheet
 from rotkehlchen.typing import ChecksumEthAddress

--- a/rotkehlchen/chain/ethereum/gitcoin/utils.py
+++ b/rotkehlchen/chain/ethereum/gitcoin/utils.py
@@ -1,6 +1,4 @@
-from typing import Any, Dict, Tuple
-
-from typing_extensions import Literal
+from typing import Any, Dict, Literal, Tuple
 
 from rotkehlchen.accounting.ledger_actions import GitcoinEventTxType
 

--- a/rotkehlchen/chain/ethereum/graph.py
+++ b/rotkehlchen/chain/ethereum/graph.py
@@ -1,13 +1,12 @@
 import json
 import logging
 import re
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Literal, Optional, Tuple
 
 import gevent
 import requests
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
-from typing_extensions import Literal
 
 from rotkehlchen.constants.timing import QUERY_RETRY_TIMES
 from rotkehlchen.errors import RemoteError

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -2,7 +2,7 @@ import json
 import logging
 import random
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, overload
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union, overload
 from urllib.parse import urlparse
 
 import requests
@@ -12,7 +12,6 @@ from ens.exceptions import InvalidName
 from ens.main import ENS_MAINNET_ADDR
 from ens.utils import is_none_or_zero_address, normal_name_to_hash, normalize_name
 from eth_typing import BlockNumber, HexStr
-from typing_extensions import Literal
 from web3 import HTTPProvider, Web3
 from web3._utils.abi import get_abi_output_types
 from web3._utils.contracts import find_matching_event_abi

--- a/rotkehlchen/chain/ethereum/modules/adex/adex.py
+++ b/rotkehlchen/chain/ethereum/modules/adex/adex.py
@@ -1,10 +1,9 @@
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Union, cast, overload
 
 import requests
 from eth_typing import ChecksumAddress
-from typing_extensions import Literal
 from web3 import Web3
 
 from rotkehlchen.accounting.structures import AssetBalance, Balance, DefiEvent, DefiEventType

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -2,10 +2,9 @@ import datetime
 import logging
 from collections import defaultdict
 from operator import add, sub
-from typing import TYPE_CHECKING, DefaultDict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, DefaultDict, List, Literal, Optional, Set, Tuple
 
 from gevent.lock import Semaphore
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken, UnderlyingToken

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -1,7 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Tuple
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken, UnderlyingToken

--- a/rotkehlchen/chain/ethereum/modules/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound.py
@@ -1,8 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Union
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, NamedTuple, Optional, Tuple, Union
 
 from rotkehlchen.accounting.structures import (
     AssetBalance,

--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -2,11 +2,10 @@ import json
 import logging
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, overload
 from urllib.parse import urlencode
 
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import Asset

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -3,11 +3,10 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import reduce
 from operator import add
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, NamedTuple, Optional
 
 from eth_utils import to_checksum_address
 from gevent.lock import Semaphore
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import AssetBalance, Balance, DefiEvent, DefiEventType
 from rotkehlchen.assets.asset import Asset

--- a/rotkehlchen/chain/ethereum/modules/makerdao/dsr.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/dsr.py
@@ -1,9 +1,8 @@
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, NamedTuple, Optional, Union
 
 from gevent.lock import Semaphore
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import AssetBalance, Balance, DefiEvent, DefiEventType
 from rotkehlchen.chain.ethereum.defi.defisaver_proxy import HasDSProxy

--- a/rotkehlchen/chain/ethereum/modules/yearn/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/graph.py
@@ -1,8 +1,7 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from eth_utils import to_checksum_address
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import EthereumToken

--- a/rotkehlchen/chain/ethereum/structures.py
+++ b/rotkehlchen/chain/ethereum/structures.py
@@ -1,9 +1,7 @@
 """Ethereum/defi protocol structures that need to be accessed from multiple places"""
 
 import dataclasses
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
-
-from typing_extensions import Literal
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Tuple
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.assets.asset import Asset, EthereumToken

--- a/rotkehlchen/chain/ethereum/trades.py
+++ b/rotkehlchen/chain/ethereum/trades.py
@@ -1,6 +1,4 @@
-from typing import Any, Dict, List, NamedTuple, Tuple
-
-from typing_extensions import Literal
+from typing import Any, Dict, List, Literal, NamedTuple, Tuple
 
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.constants.assets import A_DAI

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -13,6 +13,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     Optional,
     Tuple,
     TypeVar,
@@ -21,7 +22,6 @@ from typing import (
 )
 
 from gevent.lock import Semaphore
-from typing_extensions import Literal
 from web3.exceptions import BadFunctionCallOutput
 
 from rotkehlchen.accounting.structures import (

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -2,7 +2,19 @@ import logging
 from functools import wraps
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 from urllib.parse import urlparse
 
 import gevent
@@ -10,7 +22,6 @@ import requests
 from requests.adapters import Response
 from substrateinterface import SubstrateInterface
 from substrateinterface.exceptions import BlockNotFound, SubstrateRequestException
-from typing_extensions import Literal
 from websocket import WebSocketException
 
 from rotkehlchen.assets.asset import Asset

--- a/rotkehlchen/chain/substrate/utils.py
+++ b/rotkehlchen/chain/substrate/utils.py
@@ -1,8 +1,7 @@
-from typing import Union, overload
+from typing import Literal, Union, overload
 
 from substrateinterface import Keypair
 from substrateinterface.utils.ss58 import is_valid_ss58_address
-from typing_extensions import Literal
 
 from .typing import (
     KusamaAddress,

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -6,10 +6,9 @@ import shutil
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Type, Union, cast
 
 from pysqlcipher3 import dbapi2 as sqlcipher
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import ActionType, BalanceType
 from rotkehlchen.assets.asset import Asset, EthereumToken

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -1,8 +1,7 @@
 import logging
-from typing import TYPE_CHECKING, List, Optional, Sequence
+from typing import TYPE_CHECKING, List, Literal, Optional, Sequence
 
 from pysqlcipher3 import dbapi2 as sqlcipher
-from typing_extensions import Literal
 
 from rotkehlchen.chain.ethereum.structures import Eth2Validator
 from rotkehlchen.chain.ethereum.typing import Eth2Deposit, ValidatorDailyStats

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -1,8 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, List, NamedTuple, Optional, Tuple, Union, cast
-
-from typing_extensions import Literal
+from typing import Any, List, Literal, NamedTuple, Optional, Tuple, Union, cast
 
 from rotkehlchen.accounting.ledger_actions import LedgerActionType
 from rotkehlchen.accounting.structures import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/db/reports.py
+++ b/rotkehlchen/db/reports.py
@@ -1,9 +1,8 @@
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from pysqlcipher3 import dbapi2 as sqlcipher
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.constants import FREE_PNL_EVENTS_LIMIT, FREE_REPORTS_LOOKUP_LIMIT
 from rotkehlchen.accounting.typing import NamedJson

--- a/rotkehlchen/db/utils.py
+++ b/rotkehlchen/db/utils.py
@@ -1,8 +1,7 @@
 from sqlite3 import Cursor
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, NamedTuple, Optional, Tuple, Union
 
 from eth_utils import is_checksum_address
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import BalanceType
 from rotkehlchen.assets.asset import Asset

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -4,12 +4,22 @@ import json
 import logging
 from collections import defaultdict
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    DefaultDict,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 from urllib.parse import urlencode
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -4,11 +4,10 @@ import json
 import logging
 import time
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import urlencode
 
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -13,6 +13,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Set,
@@ -27,7 +28,6 @@ import gevent
 import requests
 from gevent.lock import Semaphore
 from requests.adapters import Response
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -2,12 +2,22 @@ import json
 import logging
 from collections import defaultdict
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    DefaultDict,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 from urllib.parse import urlencode
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Tuple,
@@ -20,7 +21,6 @@ from urllib.parse import urlencode
 
 import requests
 from requests.adapters import Response
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -4,12 +4,11 @@ import json
 import logging
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -8,12 +8,22 @@ from base64 import b64decode, b64encode
 from collections import defaultdict
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, Iterator, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    DefaultDict,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 from urllib.parse import urlencode
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/ftx.py
+++ b/rotkehlchen/exchanges/ftx.py
@@ -4,12 +4,22 @@ import time
 from collections import defaultdict
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    DefaultDict,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 from urllib.parse import quote, urlencode
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -13,6 +13,7 @@ from typing import (
     DefaultDict,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -21,7 +22,6 @@ from typing import (
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -5,11 +5,10 @@ import json
 import logging
 import time
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import urlencode
 
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -5,11 +5,10 @@ import logging  # lgtm [py/import-and-import-from]  # https://github.com/github/
 import time
 from collections import OrderedDict
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -14,6 +14,7 @@ from typing import (
     DefaultDict,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -24,7 +25,6 @@ from urllib.parse import urlencode
 import gevent
 import requests
 from requests.adapters import Response
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
 from rotkehlchen.accounting.structures import Balance

--- a/rotkehlchen/externalapis/beaconchain.py
+++ b/rotkehlchen/externalapis/beaconchain.py
@@ -1,10 +1,9 @@
 import logging
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.structures import Balance
 from rotkehlchen.chain.ethereum.eth2_utils import ValidatorBalance

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -1,11 +1,10 @@
 import json
 import logging
-from typing import Any, Dict, List, NamedTuple, Optional, Union, overload
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Union, overload
 from urllib.parse import urlencode
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -3,11 +3,10 @@ import os
 from collections import deque
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Deque, Dict, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Deque, Dict, List, Literal, NamedTuple, Optional
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -1,10 +1,9 @@
 import logging
 from json.decoder import JSONDecodeError
-from typing import Any, Dict, List, Optional, Tuple, Union, overload
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
 
 import gevent
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.constants.timing import (
     DEFAULT_CONNECT_TIMEOUT,

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -1,13 +1,23 @@
 import dataclasses
 import logging
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 import gevent
 import requests
 from cryptography.fernet import Fernet
 from eth_utils import to_checksum_address
-from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -2,9 +2,19 @@ import logging
 import shutil
 import sqlite3
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union, cast, overload
-
-from typing_extensions import Literal
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 from rotkehlchen.assets.asset import Asset, EthereumToken, UnderlyingToken
 from rotkehlchen.assets.typing import AssetData, AssetType

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -5,10 +5,9 @@ import sqlite3
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Tuple, Union
 
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.assets.resolver import AssetResolver

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -7,11 +7,10 @@ from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
 from enum import Enum
 from http import HTTPStatus
-from typing import Any, Dict, NamedTuple, Optional, Tuple
+from typing import Any, Dict, Literal, NamedTuple, Optional, Tuple
 from urllib.parse import urlencode
 
 import requests
-from typing_extensions import Literal
 
 from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
 from rotkehlchen.errors import (

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -2,9 +2,7 @@ import base64
 import logging
 import shutil
 from enum import Enum
-from typing import Any, Dict, NamedTuple, Optional, Tuple
-
-from typing_extensions import Literal
+from typing import Any, Dict, Literal, NamedTuple, Optional, Tuple
 
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.errors import (

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -6,10 +6,9 @@ import os
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Literal, Optional, Tuple, Union
 
 import gevent
-from typing_extensions import Literal
 
 from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.structures import Balance, BalanceType

--- a/rotkehlchen/tests/exchanges/test_coinbasepro.py
+++ b/rotkehlchen/tests/exchanges/test_coinbasepro.py
@@ -10,9 +10,8 @@ TODO: Make some mock tests at some point
 
 import warnings as test_warnings
 from enum import Enum
+from typing import Literal
 from unittest.mock import patch
-
-from typing_extensions import Literal
 
 from rotkehlchen.constants.assets import A_BAT, A_ETH
 from rotkehlchen.errors import UnknownAsset

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -2,10 +2,8 @@ import base64
 import json
 import os
 from http import HTTPStatus
-from typing import Optional
+from typing import Literal, Optional
 from unittest.mock import patch
-
-from typing_extensions import Literal
 
 from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
 from rotkehlchen.premium.premium import Premium, PremiumCredentials

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -1,8 +1,19 @@
 from enum import Enum
-from typing import Any, Callable, Dict, List, NamedTuple, NewType, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    NamedTuple,
+    NewType,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from eth_typing import ChecksumAddress
-from typing_extensions import Literal
 
 from rotkehlchen.errors import DeserializationError  # lgtm [py/unsafe-cyclic-import]  # noqa: E501
 from rotkehlchen.fval import FVal


### PR DESCRIPTION
web3, substrate, typing stuf. Also remove typing extensions since we only use it for Literal and it's in main typing library since 3.8.

We may need to use typing extensions at some other point in the future if a useful typing construct/tool is not in our support python version: https://github.com/python/typing/tree/master/typing_extensions