### PR TITLE
Stop double counting stkAave 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`4077` stkAave balance should no longer be double counted. Also unclaimed stkAave will appear in the balance (as Aave).
 * :bug:`4059` Nexo importer won't consider `LockingTermDeposit` as another deposit. 
 
 * :release:`1.23.3 <2022-02-04>`

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -128,6 +128,8 @@ class EthTokens():
             # since the SDK entry might return other tokens from sushi and we don't
             # fully support sushi now.
             string_to_ethereum_address('0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272'),
+            # Ignore stkAave since it's queried by defi SDK.
+            string_to_ethereum_address('0x4da27a545c0c5B758a6BA100e3a049001de870f5'),
             # Ignore the following tokens. They are old tokens of upgraded contracts which
             # duplicated the balances at upgrade instead of doing a token swap.
             # e.g.: https://github.com/rotki/rotki/issues/3548


### PR DESCRIPTION
Fix https://github.com/rotki/rotki/issues/4077

Use defi sdk's balance for Aave which now also includes the unclaimed
stkAave and ignore the stkAave token query.