### PR TITLE
fix: update scrollbar color on dark mode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`4078` Adjust scrollbar color in dark mode for better visibility.
 * :feature:`4071` Add option to reduce the animations effect.
 * :feature:`3669` Users can export and import their custom assets.
 * :feature:`4068` Introduces location overview page.

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -335,14 +335,10 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .v-navigation-drawer {
   &--is-mobile {
     padding-top: 60px !important;
   }
-
-  @extend .themed-scrollbar;
 }
 
 ::v-deep {
@@ -457,8 +453,6 @@ export default defineComponent({
       left: 300px;
       width: calc(100vw - 300px);
     }
-
-    @extend .themed-scrollbar;
   }
 }
 </style>

--- a/frontend/app/src/components/AccountManagement.vue
+++ b/frontend/app/src/components/AccountManagement.vue
@@ -336,8 +336,6 @@ export default defineComponent({
 </script>
 
 <style module lang="scss">
-@import '~@/scss/scroll';
-
 @keyframes scrollLarge {
   0% {
     transform: rotate(-13deg) translateY(0px);
@@ -390,8 +388,6 @@ export default defineComponent({
   z-index: 5;
   max-height: calc(100vh - 140px);
   overflow: auto;
-
-  @extend .themed-scrollbar;
 }
 
 .icon {

--- a/frontend/app/src/components/CurrencyDropDown.vue
+++ b/frontend/app/src/components/CurrencyDropDown.vue
@@ -123,8 +123,6 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 ::v-deep {
   .currency-dropdown {
     font-size: 1.6em !important;
@@ -133,8 +131,6 @@ export default defineComponent({
     &__list {
       max-height: 400px;
       overflow-y: scroll;
-
-      @extend .themed-scrollbar;
     }
   }
 }

--- a/frontend/app/src/components/asset-manager/UnderlyingTokenManager.vue
+++ b/frontend/app/src/components/asset-manager/UnderlyingTokenManager.vue
@@ -156,16 +156,12 @@ export default class UnderlyingTokenManager extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .underlying-tokens {
   ::v-deep {
     tbody {
       height: 200px;
       overflow-y: scroll;
       overflow-x: hidden;
-
-      @extend .themed-scrollbar;
     }
 
     thead,

--- a/frontend/app/src/components/defi/Overview.vue
+++ b/frontend/app/src/components/defi/Overview.vue
@@ -157,8 +157,6 @@ export default defineComponent({
 </script>
 
 <style module lang="scss">
-@import '~@/scss/scroll';
-
 .overview {
   min-height: 250px !important;
   min-width: 300px;
@@ -166,7 +164,5 @@ export default defineComponent({
 
 .details {
   height: 300px;
-
-  @extend .themed-scrollbar;
 }
 </style>

--- a/frontend/app/src/components/defi/QueriedAddressDialog.vue
+++ b/frontend/app/src/components/defi/QueriedAddressDialog.vue
@@ -186,8 +186,6 @@ export default class QueriedAddressDialog extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .queried-address-dialog {
   &__list {
     overflow-y: scroll;
@@ -195,8 +193,6 @@ export default class QueriedAddressDialog extends Vue {
     width: 99%;
     padding: 8px;
     height: 250px;
-
-    @extend .themed-scrollbar;
   }
 
   &__empty {

--- a/frontend/app/src/components/defi/wizard/ModuleAddressSelector.vue
+++ b/frontend/app/src/components/defi/wizard/ModuleAddressSelector.vue
@@ -129,8 +129,6 @@ export default class ModuleAddressSelector extends Vue {
 
 <!--suppress Stylelint -->
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .module-address-selector {
   border: none !important;
   box-shadow: none !important;
@@ -148,8 +146,6 @@ export default class ModuleAddressSelector extends Vue {
         hr {
           display: none;
         }
-
-        @extend .themed-scrollbar;
       }
 
       &__step {

--- a/frontend/app/src/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/components/dialogs/BigDialog.vue
@@ -89,8 +89,6 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .big-dialog {
   height: calc(100vh - 80px);
 
@@ -101,7 +99,6 @@ export default defineComponent({
   &__content {
     height: calc(100% - 85px);
     overflow-y: scroll;
-    @extend .themed-scrollbar;
   }
 }
 

--- a/frontend/app/src/components/helper/Card.vue
+++ b/frontend/app/src/components/helper/Card.vue
@@ -114,8 +114,6 @@ export default Card;
 </script>
 
 <style module lang="scss">
-@import '~@/scss/scroll';
-
 .title {
   margin-top: -22px;
 }
@@ -131,8 +129,6 @@ export default Card;
 .contained {
   max-height: calc(100vh - 206px);
   overflow-y: scroll;
-
-  @extend .themed-scrollbar;
 }
 
 .no-radius-bottom {

--- a/frontend/app/src/components/history/TransactionsDetails.vue
+++ b/frontend/app/src/components/history/TransactionsDetails.vue
@@ -76,8 +76,6 @@ export default class TransactionDetails extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .transaction-details {
   &__data {
     background-color: var(--v-rotki-light-grey-lighten1);
@@ -88,7 +86,6 @@ export default class TransactionDetails extends Vue {
     height: 80px;
     padding: 16px;
     font-size: 14px;
-    @extend .themed-scrollbar;
   }
 }
 </style>

--- a/frontend/app/src/components/staking/kraken/KrakenStakingReceived.vue
+++ b/frontend/app/src/components/staking/kraken/KrakenStakingReceived.vue
@@ -89,14 +89,10 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-@import '~@/scss/scroll';
-
 .received {
   max-height: 155px;
   overflow-y: scroll;
   overflow-x: hidden;
-
-  @extend .themed-scrollbar;
 }
 
 .amount {

--- a/frontend/app/src/components/tags/TagManager.vue
+++ b/frontend/app/src/components/tags/TagManager.vue
@@ -178,20 +178,6 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
-::v-deep {
-  .v-dialog {
-    &__content {
-      .v-dialog {
-        &--active {
-          @extend .themed-scrollbar;
-        }
-      }
-    }
-  }
-}
-
 .tag-manager {
   overflow: auto;
   height: 100%;

--- a/frontend/app/src/main.scss
+++ b/frontend/app/src/main.scss
@@ -1,3 +1,5 @@
+@import '~@/scss/scroll';
+
 html {
   overflow-y: hidden !important;
   max-height: 100vh;

--- a/frontend/app/src/scss/scroll.scss
+++ b/frontend/app/src/scss/scroll.scss
@@ -1,47 +1,51 @@
-::-webkit-scrollbar {
-  width: 14px;
-  height: 18px;
+/* stylelint-disable no-descending-specificity */
 
-  &-thumb {
-    height: 6px;
-    border: 4px solid rgba(0, 0, 0, 0);
-    background-clip: padding-box;
-    border-radius: 7px;
-    background-color: rgba(0, 0, 0, 0.15);
-    box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05),
-      inset 1px 1px 0px rgba(0, 0, 0, 0.05);
+* {
+  scrollbar-color: rgba(0, 0, 0, 0.15) !important;
+  scrollbar-width: medium;
 
-    &:hover {
-      background-color: rgba(0, 0, 0, 0.3);
-    }
-
-    &:active {
-      background-color: rgba(0, 0, 0, 0.5);
-    }
-  }
-}
-
-.themed-scrollbar {
-  ::-webkit-scrollbar {
+  &::-webkit-scrollbar {
     width: 14px;
     height: 18px;
-  
+
     &-thumb {
       height: 6px;
       border: 4px solid rgba(0, 0, 0, 0);
       background-clip: padding-box;
       border-radius: 7px;
-      background-color: rgba(0, 0, 0, 0.15);
-      box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05),
-        inset 1px 1px 0px rgba(0, 0, 0, 0.05);
-  
+      background-color: rgba(0, 0, 0, 0.15) !important;
+
       &:hover {
-        background-color: rgba(0, 0, 0, 0.3);
+        background-color: rgba(0, 0, 0, 0.3) !important;
       }
-  
+
       &:active {
-        background-color: rgba(0, 0, 0, 0.5);
+        background-color: rgba(0, 0, 0, 0.5) !important;
       }
     }
   }
 }
+
+.theme {
+  &--dark {
+    * {
+      scrollbar-color: rgba(255, 255, 255, 0.3) !important;
+      scrollbar-width: medium;
+
+      &::-webkit-scrollbar {
+        &-thumb {
+          background-color: rgba(255, 255, 255, 0.3) !important;
+
+          &:hover {
+            background-color: rgba(255, 255, 255, 0.4) !important;
+          }
+
+          &:active {
+            background-color: rgba(255, 255, 255, 0.5) !important;
+          }
+        }
+      }
+    }
+  }
+}
+/* stylelint-enable no-descending-specificity */

--- a/frontend/app/src/views/settings/DateFormatHelp.vue
+++ b/frontend/app/src/views/settings/DateFormatHelp.vue
@@ -98,14 +98,10 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-@import '~@/scss/scroll';
-
 .date-format-help {
   &__content {
     max-height: 300px;
     overflow-y: scroll;
-
-    @extend .themed-scrollbar;
   }
 
   &__directive {


### PR DESCRIPTION
Closes #4078

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- Update scrollbar color on dark mode

<img width="309" alt="image" src="https://user-images.githubusercontent.com/26648140/155343121-27375781-b535-4ddd-83b9-176169272084.png">

<img width="306" alt="image" src="https://user-images.githubusercontent.com/26648140/155343221-f6b1758b-9cbc-4ea0-979a-c2a67b6341df.png">
