### PR TITLE
Add max date constraint for trade and ledger action form

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`4072` Prevent users from inputting future date on trade and ledger action form.
 * :bug:`4077` stkAave balance should no longer be double counted. Also unclaimed stkAave will appear in the balance (as Aave).
 * :bug:`4059` Nexo importer won't consider `LockingTermDeposit` as another deposit.
 * :bug:`-` BlockFi import for trades will use the correct rate.

--- a/frontend/app/src/components/ExternalTradeForm.vue
+++ b/frontend/app/src/components/ExternalTradeForm.vue
@@ -15,6 +15,7 @@
               outlined
               class="pt-1"
               seconds
+              limit-now
               data-cy="date"
               :label="$t('external_trade_form.date.label')"
               persistent-hint

--- a/frontend/app/src/components/history/LedgerActionForm.vue
+++ b/frontend/app/src/components/history/LedgerActionForm.vue
@@ -24,6 +24,7 @@
       persistent-hint
       required
       seconds
+      limit-now
       data-cy="datetime"
       :hint="$t('ledger_action_form.date.hint')"
       :error-messages="errorMessages['timestamp']"


### PR DESCRIPTION
Closes #4072

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
- [ ] Prevent users from inputting future date on trade and ledger action form.