### PR TITLE
HistoryEvent sequence_index + event_identifier are Unique

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -224,8 +224,8 @@ def db_tuple_to_str(
         )
     if tuple_type == 'history_event':
         return (
-            f'History event with event identifier {data[1]} from '
-            f'{Location.deserialize_from_db(data[4])}.'
+            f'History event with event identifier {data[0]} from '
+            f'{Location.deserialize_from_db(data[3])}.'
         )
 
     raise AssertionError('db_tuple_to_str() called with invalid tuple_type {tuple_type}')

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -617,7 +617,8 @@ CREATE TABLE IF NOT EXISTS history_events (
     notes TEXT,
     type TEXT NOT NULL,
     subtype TEXT,
-    counterparty TEXT
+    counterparty TEXT,
+    UNIQUE(event_identifier, sequence_index)
 );
 """
 

--- a/rotkehlchen/db/upgrades/v31_v32.py
+++ b/rotkehlchen/db/upgrades/v31_v32.py
@@ -21,7 +21,8 @@ def _upgrade_history_events(cursor: 'Cursor') -> None:
         notes TEXT,
         type TEXT NOT NULL,
         subtype TEXT,
-        counterparty TEXT
+        counterparty TEXT,
+        UNIQUE(event_identifier, sequence_index)
     );""")
     cursor.execute("""
     INSERT INTO history_events_copy (event_identifier, sequence_index, timestamp, location,

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1,7 +1,6 @@
 import os
 import random
 from contextlib import ExitStack
-from copy import deepcopy
 from http import HTTPStatus
 from unittest.mock import patch
 
@@ -970,7 +969,6 @@ def test_query_transactions_check_decoded_events(rotkehlchen_api_server, ethereu
     assert entries[3]['decoded_events'] == tx4_events
 
     # Now let's edit 1 event and add another one
-    tx2_event_before_edit = deepcopy(tx2_events[1])
     event = tx2_events[1]['entry']
     event['asset'] = A_DAI.identifier
     event['balance'] = {'amount': '2500', 'usd_value': '2501.1'}
@@ -1032,12 +1030,9 @@ def test_query_transactions_check_decoded_events(rotkehlchen_api_server, ethereu
     assert customized_events[1].serialize() == tx2_events[1]['entry']
 
     # requery all transactions and events and assert they are the same (different event id though)
-    tx2_events.insert(0, deepcopy(tx2_events[1]))
-    tx2_events[2] = tx2_event_before_edit
     result = query_transactions(rotki, tx_module)
     entries = result['entries']
     assert len(entries) == 4
-    # assert_serialized_dicts_equal(entries[0]['decoded_events'], tx1_events, ignore_keys='identifier')  # noqa: E501
 
     assert_serialized_lists_equal(entries[0]['decoded_events'], tx1_events, ignore_keys='identifier')  # noqa: E501
     assert_serialized_lists_equal(entries[1]['decoded_events'], tx2_events, ignore_keys='identifier')  # noqa: E501


### PR DESCRIPTION
This now means that if when decoding all transactions a sequence index
+ event identifier has been customized it won't be re-decoded and have
a duplicate event made.