### PR TITLE
Don't allow the user to add NFTs as custom assets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :bug:`4077` stkAave balance should no longer be double counted. Also unclaimed stkAave will appear in the balance (as Aave).
 * :bug:`4059` Nexo importer won't consider `LockingTermDeposit` as another deposit.
 * :bug:`-` BlockFi import for trades will use the correct rate.
+* :bug:`3661` NFT won't be displayed as option while adding custom assets since the logic there is not compatible with NFTs.
 * :bug:`-` If an owned NFT has no image URL, NFTs will still be properly queried and shown in the frontend.
 
 * :release:`1.23.3 <2022-02-04>`

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -56,7 +56,7 @@ from rotkehlchen.constants.limits import (
     FREE_LEDGER_ACTIONS_LIMIT,
     FREE_TRADES_LIMIT,
 )
-from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.constants.misc import ASSET_TYPES_EXCLUDED_FOR_USERS, ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.db.cache_handler import DBAccountingReports
 from rotkehlchen.db.ethtx import DBEthTx
@@ -1333,7 +1333,7 @@ class RestAPI():
 
     @staticmethod
     def get_asset_types() -> Response:
-        types = [str(x) for x in AssetType]
+        types = [str(x) for x in AssetType if x not in ASSET_TYPES_EXCLUDED_FOR_USERS]
         return api_response(_wrap_in_ok_result(types), status_code=HTTPStatus.OK)
 
     @require_loggedin_user()

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -1,3 +1,4 @@
+from rotkehlchen.assets.typing import AssetType
 from rotkehlchen.fval import FVal
 from rotkehlchen.typing import EventType
 
@@ -24,3 +25,5 @@ KRAKEN_API_VERSION = '0'
 # KRAKEN_BASE_URL = 'http://localhost:5001/kraken'
 # KRAKEN_API_VERSION = 'mock'
 # BINANCE_BASE_URL = 'http://localhost:5001/binance/api/'
+
+ASSET_TYPES_EXCLUDED_FOR_USERS = {AssetType.NFT}

--- a/rotkehlchen/tests/api/test_custom_assets.py
+++ b/rotkehlchen/tests/api/test_custom_assets.py
@@ -9,6 +9,7 @@ from rotkehlchen.accounting.structures import BalanceType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.typing import AssetType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
+from rotkehlchen.constants.misc import ASSET_TYPES_EXCLUDED_FOR_USERS
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
@@ -527,7 +528,7 @@ def test_query_asset_types(rotkehlchen_api_server):
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert result == [str(x) for x in AssetType]
+    assert result == [str(x) for x in AssetType if x not in ASSET_TYPES_EXCLUDED_FOR_USERS]
     assert all(isinstance(AssetType.deserialize(x), AssetType) for x in result)
 
 


### PR DESCRIPTION
This will prevent users to add NFTs as asset type since it won't be handled correctly by our logic until we add the needed changes

Closes #3661

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
