### PR TITLE
Prevent from adding future dates to ledger actions

### DIFF
--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -40,6 +40,7 @@ from rotkehlchen.types import (
     Timestamp,
     make_evm_tx_hash,
 )
+from rotkehlchen.utils.misc import ts_now
 from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,22 @@ class TimestampField(fields.Field):
             timestamp = deserialize_timestamp(value)
         except DeserializationError as e:
             raise ValidationError(str(e)) from e
+
+        return Timestamp(timestamp * self.ts_multiplier)
+
+
+class TimestampUntilNowField(TimestampField):
+
+    def _deserialize(
+            self,
+            value: str,
+            attr: Optional[str],
+            data: Optional[Mapping[str, Any]],
+            **kwargs: Any,
+    ) -> Timestamp:
+        timestamp = super()._deserialize(value, attr, data, **kwargs)
+        if timestamp > ts_now():
+            raise ValidationError('Given date cannot be in the future')
 
         return Timestamp(timestamp * self.ts_multiplier)
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -99,6 +99,7 @@ from .fields import (
     SerializableEnumField,
     TaxFreeAfterPeriodField,
     TimestampField,
+    TimestampUntilNowField,
     XpubField,
 )
 
@@ -505,7 +506,7 @@ class TimerangeQuerySchema(Schema):
 
 
 class TradeSchema(Schema):
-    timestamp = TimestampField(required=True)
+    timestamp = TimestampUntilNowField(required=True)
     location = LocationField(required=True)
     base_asset = AssetField(required=True)
     quote_asset = AssetField(required=True)
@@ -520,7 +521,7 @@ class TradeSchema(Schema):
 
 class LedgerActionSchema(Schema):
     identifier = fields.Integer(load_default=None, required=False)
-    timestamp = TimestampField(required=True)
+    timestamp = TimestampUntilNowField(required=True)
     action_type = SerializableEnumField(enum_class=LedgerActionType, required=True)
     location = LocationField(required=True)
     amount = AmountField(required=True)


### PR DESCRIPTION
I evaluated the possibility of having the `earlist_valid_date` and `latest_valid_date` as metadata for the timestamp field but that would require to pass functions as parameters since if not once the TimestampField is initializated the value will be static and this is not desired when using `ts_now`