### PR TITLE
Fix issue with packaged rotki 

### DIFF
--- a/rotkehlchen/assets/contracts.py
+++ b/rotkehlchen/assets/contracts.py
@@ -1,5 +1,7 @@
 from rotkehlchen.chain.ethereum.types import string_to_ethereum_address
 
+# Pickle contracts
+# TODO @yabirgb: Since those are ERC20 tokens move them to the globaldb
 PICKLE_LOOKS = string_to_ethereum_address('0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69')
 PICKLE_RBN_ETH = string_to_ethereum_address('0x506748d736b77f51c5b490e4aC6c26B8c3975b14')
 PICKLE_SCRV = string_to_ethereum_address('0x68d14d66B2B0d6E157c06Dc8Fefa3D8ba0e66a89')

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.accounting.structures import (
 from rotkehlchen.assets.asset import EthereumToken
 from rotkehlchen.assets.utils import get_or_create_ethereum_token
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
-from rotkehlchen.chain.ethereum.decoding.pickle.decoder import maybe_enrich_pickle_transfers
+from rotkehlchen.chain.ethereum.decoding.enrichers.pickle import maybe_enrich_pickle_transfers
 from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceipt, EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.transactions import EthTransactions
@@ -110,7 +110,7 @@ class EVMTransactionDecoder():
         rules_results = []
         for _, name, is_pkg in pkgutil.walk_packages(package.__path__):
             full_name = package.__name__ + '.' + name
-            if full_name == __name__:
+            if full_name == __name__ or 'enrichers' in full_name:
                 continue  # skip -- this is this source file
 
             if is_pkg:

--- a/rotkehlchen/chain/ethereum/decoding/enrichers/pickle.py
+++ b/rotkehlchen/chain/ethereum/decoding/enrichers/pickle.py
@@ -6,7 +6,7 @@ from rotkehlchen.accounting.structures import (
     HistoryEventType,
 )
 from rotkehlchen.assets.asset import EthereumToken
-from rotkehlchen.chain.ethereum.decoding.pickle.constants import PICKLE_CONTRACTS
+from rotkehlchen.assets.contracts import PICKLE_CONTRACTS
 from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value


### PR DESCRIPTION
The pickle decoder was instead of conventional decoder a enricher for transfers.
For how this part of the code is designed it was not automatically imported but
instead imported as normal function and loaded in the logic of the transaction decoders.

The code worked fine but when packaged there was an error dinamically importing the decoder modules.
This error appears in a combination for how pyinstaller creates the package and how walk_packages
works + the fact that the module was pre loaded at the moment of importing the transaction enricher.

The approach took was to refactor the file structures moving the transfer enrichers to a different folder
and ignoring it when loading the decoder modules.

Additionally as discused in the previous pickle PR the jars contracts will be moved to the globaldb once
the PR with the assets gets merged.