### PR TITLE
Sqlcipher installation for ubuntu update v2

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -354,7 +354,7 @@ Get `sqlcipher <https://www.zetetic.net/sqlcipher/>`_ version 4:
 
 - If you are running Archlinux you can install the `package <https://www.archlinux.org/packages/community/x86_64/sqlcipher/>`_ with ``pacman``.
 
-- If you are running Ubuntu, at the time of writing of this article Ubuntu is still using sqlcipher v3 which is not supported by rotki. So you should build sqlcipher v4 by hand. We have a script for that which is also used by our CI. Check it out `here <https://github.com/rotki/rotki/blob/7573bcbd9bfc83e0ef352701ae2772a040b4ab5b/install_deps.sh>`__. Install libssl-dev and tclsh by running ``sudo apt-get install libssl-dev tclsh`` if not already installed.
+- If you are running Ubuntu, at the time of writing of this article Ubuntu is still using sqlcipher v3 which is not supported by rotki. So you should build sqlcipher v4 by hand. We have a script for that `here <https://github.com/rotki/rotki/blob/7203c09e9fc89e38950f89a5f452f57bf3d2542a/sqlcipher_ubuntu.sh>`__. Run this script inside venv and then run ``export $(cat sqlcipher.env)``. Install libssl-dev and tclsh by running ``sudo apt-get install libssl-dev tclsh`` if not already installed.
 
 - If you are running openSUSE Tumbleweed, you can install sqlcipher v4 as follows::
 

--- a/sqlcipher_ubuntu.sh
+++ b/sqlcipher_ubuntu.sh
@@ -48,10 +48,10 @@ git checkout v4.5.0
 CFLAGS="-DSQLITE_HAS_CODEC -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS" \
 LDFLAGS="-lcrypto" \
 prefix="$SQLCIPHER_DIR"
-  make
-  sudo make install
+make
+sudo make install
 
-  cd "$DIR" || exit 1
+cd "$DIR" || exit 1
 
 # We need to set LD_LIBRARY_PATH to use local version of sqlcipher
 echo "LD_LIBRARY_PATH=$SQLCIPHER_DIR/lib" > "$DIR/sqlcipher.env"

--- a/sqlcipher_ubuntu.sh
+++ b/sqlcipher_ubuntu.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# the directory of the script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# the temp directory used, within $DIR
+# omit the -p parameter to create a temporal directory in the default location
+WORK_DIR=$(mktemp -d -p "$DIR")
+SQLCIPHER_DIR="$DIR/.sqlcipher"
+
+# check if tmp dir was created
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+# deletes the temp directory
+function cleanup {
+  rm -rf "$WORK_DIR"
+  echo "Deleted temp working directory $WORK_DIR"
+}
+
+# register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+# check if SQLCIPHER_DIR exists
+[ -d "$SQLCIPHER_DIR" ] && SQLCIPHER_EXISTS=true || SQLCIPHER_EXISTS=false
+
+# Ask user what to do if directory exists
+if [[ $SQLCIPHER_EXISTS == true ]]; then
+    echo "Looks like you already have sqlcipher installed (in $SQLCIPHER_DIR directory). Would you like to reinstall it (yes/no)?"
+    read -r WANTS_TO_REINSTALL
+    if [[ $WANTS_TO_REINSTALL == "yes" ]]; then
+      sudo rm -r "$SQLCIPHER_DIR"
+    else
+      exit 1
+    fi
+fi
+
+echo "Downloading and compiling sqlcipher";
+# Go into the directory and build sqlcipher
+cd "$WORK_DIR" || exit 1
+git clone https://github.com/sqlcipher/sqlcipher
+cd sqlcipher || exit 1
+git checkout v4.5.0
+./configure \
+--enable-tempstore=yes \
+CFLAGS="-DSQLITE_HAS_CODEC -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS" \
+LDFLAGS="-lcrypto" \
+prefix="$SQLCIPHER_DIR"
+  make
+  sudo make install
+
+  cd "$DIR" || exit 1
+
+# We need to set LD_LIBRARY_PATH to use local version of sqlcipher
+echo "LD_LIBRARY_PATH=$SQLCIPHER_DIR/lib" > "$DIR/sqlcipher.env"


### PR DESCRIPTION
Closes #3129

## Checklist

- Created a new script based on install_deps.sh for manual sqlcipher installation
- The script installs sqlcipher locally and requires user to export a variable in order to use local sqlcipher (I haven't found a good way to do it automatically)
- Added this info to the documentation
