### PR TITLE
Fixes aave id read from subgraph

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/aave/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/graph.py
@@ -269,16 +269,23 @@ def _parse_common_event_data(
         # Since for the user data we can't query per timestamp, filter timestamps here
         return None
 
-    pair = entry['id'].split(':')
-    if len(pair) != 2:
+    event_id_parts = entry['id'].split(':')
+    if len(event_id_parts) == 5:
+        # aave v2 has 5 elements in the ids as can be checked in their code
+        # https://github.com/aave/protocol-subgraphs/commit/40e09d0e0d3196e5624ca113fc346a1d65c4f4fb#diff-835762719eeb8a927a81e727fcd8ecdb8f5b2ea4d56f39478a17ade85588acf2R4-R14  # noqa: E501
+        tx_hash = event_id_parts[2]
+        index = int(event_id_parts[3])
+    elif len(event_id_parts) == 2:
+        # aave v1 uses only tx_hash and index in their ids
+        tx_hash = event_id_parts[0]
+        index = int(event_id_parts[1])
+    else:
         log.error(
             f'Could not parse the id entry for an aave liquidation as '
             f'returned by graph: {entry["id"]}.  Skipping entry ...',
         )
         return None
 
-    tx_hash = pair[0]
-    index = int(pair[1])  # not really log index
     return timestamp, tx_hash, index
 
 

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -111,7 +111,6 @@ def test_query_aave_balances(rotkehlchen_api_server, ethereum_accounts):
 @pytest.mark.parametrize('mocked_price_queries', [aave_mocked_historical_prices])
 @pytest.mark.parametrize('mocked_current_prices', [aave_mocked_current_prices])
 @pytest.mark.parametrize('default_mock_price_value', [FVal(1)])
-@pytest.mark.skip('https://github.com/rotki/rotki/issues/4161')
 def test_query_aave_history_with_borrowing_v2(rotkehlchen_api_server, ethereum_accounts):  # pylint: disable=unused-argument  # noqa: E501
     """Check querying the aave histoy endpoint works. Uses real data."""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen

--- a/rotkehlchen/tests/utils/aave.py
+++ b/rotkehlchen/tests/utils/aave.py
@@ -470,7 +470,7 @@ expected_aave_v2_events = [
         block_number=0,
         timestamp=Timestamp(1615333105),
         tx_hash='0x75444c0ae48700f388d05ec8380b3922c4daf1e8eef2476001437b68d36f56a1',
-        log_index=1,
+        log_index=216,
     ), AaveBorrowEvent(
         event_type='borrow',
         asset=A_USDT,
@@ -481,7 +481,7 @@ expected_aave_v2_events = [
         block_number=0,
         timestamp=Timestamp(1615333284),
         tx_hash='0x74e8781fd86e81a87a4ba93bc7755d4a94901765cd72399f0372d36e7a26a03a',
-        log_index=2,
+        log_index=352,
         borrow_rate_mode='stable',
         borrow_rate=FVal('0.088712770921360153608109216'),
         accrued_borrow_interest=ZERO,
@@ -496,7 +496,7 @@ expected_aave_v2_events = [
         block_number=0,
         timestamp=Timestamp(1615587042),
         tx_hash='0x164e3eafef02ac1a956ba3c7d027506d47de36b34daee1e05ca0d178413911c1',
-        log_index=4,
+        log_index=29,
     ), AaveInterestEvent(
         event_type='interest',
         asset=A_ALINK_V2,
@@ -507,7 +507,7 @@ expected_aave_v2_events = [
         block_number=0,
         timestamp=Timestamp(1615669328),
         tx_hash='0xfeee61357d43e79a2beae9edab860c30db9765964be26eff82c6834d4e2c2db7',
-        log_index=4,
+        log_index=133,
     ), AaveDepositWithdrawalEvent(
         event_type='withdrawal',
         asset=A_LINK,
@@ -519,6 +519,6 @@ expected_aave_v2_events = [
         block_number=0,
         timestamp=Timestamp(1615669328),
         tx_hash='0xfeee61357d43e79a2beae9edab860c30db9765964be26eff82c6834d4e2c2db7',
-        log_index=3,
+        log_index=132,
     ),
 ]


### PR DESCRIPTION
After the upgrade of the schema to prepare aave v3 in the aave subgraph
the function that generates the id of the event has changed as described in this
commit https://github.com/aave/protocol-subgraphs/commit/40e09d0e0d3196e5624ca113fc346a1d65c4f4fb#diff-835762719eeb8a927a81e727fcd8ecdb8f5b2ea4d56f39478a17ade85588acf2R4-R14

Also it was needed to update the log index in the tests since now it seems to be actually using the log index of the transaction.

Closes #4161
