### PR TITLE
fix issue with pytest import causing `tests/test_no_missing_init.py` to fail on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ sqlcipher.dll
 libcrypto-1_1-x64.dll
 /.run/
 frontend/logs
+.venv

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -39,7 +39,7 @@ if sys.platform == 'darwin':
     @pytest.fixture(scope='session', autouse=True)
     def _tmpdir_short(request):
         """Shorten tmpdir paths"""
-        from _pytest.tmpdir import TempdirFactory  # pylint: disable=import-outside-toplevel
+        from pytest import TempdirFactory  # pylint: disable=import-outside-toplevel
 
         def getbasetemp(self):
             """ return base temporary directory. """


### PR DESCRIPTION
- I also added `.venv` to `.gitignore` because my virtual environment was created in-project.
