### PR TITLE
Take balance snapshots despite NFT query failures

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -16,10 +16,10 @@ isort==5.10.1
 # type packages used by mypy
 # pinned here so that we can have reproducible mypy runs
 types-chardet==4.0.3
-types-cryptography==3.3.18
+types-cryptography==3.3.19
 types-enum34==1.1.8
 types-ipaddress==1.0.8
 types-pkg-resources==0.1.3
-types-requests==2.27.12
+types-requests==2.27.16
 types-urllib3==1.26.11
 types-toml==0.10.4

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -694,10 +694,9 @@ class Rotkehlchen():
                     ignore_cache=False,
                 )
             except RemoteError as e:
-                problem_free = False
-                self.msg_aggregator.add_message(
-                    message_type=WSMessageType.BALANCE_SNAPSHOT_ERROR,
-                    data={'location': 'nfts', 'error': str(e)},
+                log.error(
+                    f'At balance snapshot NFT balances query failed due to {str(e)}. Error '
+                    f'is ignored and balance snapshot will still be saved.',
                 )
             else:
                 if len(nft_mapping) != 0:


### PR DESCRIPTION
Opensea has started failing so often and being so unreliable that it
has caused most user snapshots to not be taken unless force-saved.

To mitigate that we are making the errors in the NFT query not affect
whether or not the balance is saved.