### PR TITLE
feat: enable running single frontend integration test

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -20,8 +20,8 @@
     "lint:style": "stylelint 'src/**/*.{vue,scss}'",
     "lint:style:fix": "stylelint --fix 'src/**/*.{vue,scss}'",
     "test:e2e-ci": "nyc vue-cli-service test:e2e --mode e2e --headless",
-    "test:integration": "start-server-and-test serve:backend http://localhost:22221/api/1/ping test:e2e",
-    "test:integration-ci": "start-server-and-test serve:backend http://localhost:22221/api/1/ping test:e2e-ci"
+    "test:integration": "cross-env-shell 'start-server-and-test serve:backend http://localhost:22221/api/1/ping \"npm run test:e2e -- $ARGS\"'",
+    "test:integration-ci": "cross-env-shell 'start-server-and-test serve:backend http://localhost:22221/api/1/ping \"npm run test:e2e-ci -- $ARGS\"'"
   },
   "main": "background.js",
   "dependencies": {
@@ -29,13 +29,13 @@
     "@vue/composition-api": "1.4.6",
     "@vueuse/core": "7.5.5",
     "axios": "0.25.0",
-    "ethereum-blockies-base64": "1.0.2",
     "chart.js": "2.9.4",
     "cleave.js": "1.6.0",
     "core-js": "3.20.3",
     "dayjs": "1.10.7",
     "electron-updater": "4.6.5",
     "electron-window-state": "5.0.3",
+    "ethereum-blockies-base64": "1.0.2",
     "lodash": "4.17.21",
     "loglevel": "1.8.0",
     "pinia": "2.0.9",
@@ -88,6 +88,7 @@
     "babel-eslint": "10.1.0",
     "babel-jest": "27.4.6",
     "babel-plugin-istanbul": "6.1.1",
+    "cross-env": "7.0.3",
     "dotenv": "14.3.0",
     "electron": "18.0.1",
     "electron-builder": "22.14.13",

--- a/frontend/app/src/components/display/AmountDisplay.vue
+++ b/frontend/app/src/components/display/AmountDisplay.vue
@@ -266,7 +266,7 @@ export default defineComponent({
       if (hiddenDecimals && get(rounding) === BigNumber.ROUND_UP) {
         return `< ${formattedValue}`;
       } else if (
-        price.lt(1) &&
+        price.abs().lt(1) &&
         hiddenDecimals &&
         get(rounding) === BigNumber.ROUND_DOWN
       ) {
@@ -305,7 +305,7 @@ export default defineComponent({
     });
 
     const rounding = computed<RoundingMode | undefined>(() => {
-      const isValue = get(fiatCurrency) === get(currencySymbol);
+      const isValue = get(fiatCurrency);
       let rounding: RoundingMode | undefined = undefined;
       if (isValue) {
         rounding = get(valueRoundingMode);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -94,6 +94,7 @@
         "babel-eslint": "10.1.0",
         "babel-jest": "27.4.6",
         "babel-plugin-istanbul": "6.1.1",
+        "cross-env": "7.0.3",
         "dotenv": "14.3.0",
         "electron": "18.0.1",
         "electron-builder": "22.14.13",
@@ -13128,6 +13129,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -47786,6 +47805,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -61275,6 +61303,7 @@
         "chart.js": "2.9.4",
         "cleave.js": "1.6.0",
         "core-js": "3.20.3",
+        "cross-env": "7.0.3",
         "cypress": "8.3.1",
         "dayjs": "1.10.7",
         "dmg-license": "1.0.10",


### PR DESCRIPTION
Closes #4183

How to run:
`ARGS="-s tests/e2e/specs/account-creation.spec.ts" npm run test:integration-ci`