### PR TITLE
Add a flaky pytest plugin and mark some initial tests flaky

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,4 @@ coverage==6.3.2
 psutil==5.9.0
 pytest-freezegun==0.4.2
 freezegun==1.2.1
+flaky==3.7.0

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import gevent
 import pytest
 import requests
+from flaky import flaky
 
 from rotkehlchen.accounting.structures.balance import BalanceType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
@@ -684,6 +685,7 @@ def test_balances_caching_mixup(
         assert result_btc['totals']['liabilities'] == {}
 
 
+@flaky(max_runs=3, min_passes=1)  # Kusama open nodes some times time out
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('kusama_manager_connect_at_start', [KUSAMA_TEST_NODES])
 @pytest.mark.parametrize('ksm_accounts', [[SUBSTRATE_ACC1_KSM_ADDR, SUBSTRATE_ACC2_KSM_ADDR]])

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -3,6 +3,7 @@ import warnings as test_warnings
 
 import pytest
 import requests
+from flaky import flaky
 
 from rotkehlchen.chain.ethereum.modules.nfts import FREE_NFT_LIMIT
 from rotkehlchen.constants.misc import ZERO
@@ -19,6 +20,7 @@ TEST_ACC2 = '0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF'
 TEST_ACC3 = '0xC21A5ee89D306353e065a6dd5779470DE395DBaC'
 
 
+@flaky(max_runs=3, min_passes=1)  # all opensea calls have become quite flaky
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ACC1]])
 @pytest.mark.parametrize('start_with_valid_premium', [bool(random.getrandbits(1))])
 @pytest.mark.parametrize('ethereum_modules', [['nfts']])
@@ -69,6 +71,7 @@ def test_nft_query(rotkehlchen_api_server, start_with_valid_premium):
     assert nft_found, 'Could not find and verify the test NFT'
 
 
+@flaky(max_runs=3, min_passes=1)  # all opensea calls have become quite flaky
 @pytest.mark.parametrize('ethereum_accounts', [[]])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('ethereum_modules', [['nfts']])
@@ -111,6 +114,7 @@ def test_nft_query_after_account_add(rotkehlchen_api_server):
     assert TEST_ACC2 in result['addresses']
 
 
+@flaky(max_runs=3, min_passes=1)  # all opensea calls have become quite flaky
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ACC2, TEST_ACC3]])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('ethereum_modules', [['nfts']])

--- a/rotkehlchen/tests/api/test_substrate_manager.py
+++ b/rotkehlchen/tests/api/test_substrate_manager.py
@@ -1,11 +1,13 @@
 import pytest
 import requests
+from flaky import flaky
 
 from rotkehlchen.chain.substrate.types import KusamaNodeName
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
 from rotkehlchen.tests.utils.substrate import KUSAMA_TEST_NODES, SUBSTRATE_ACC1_KSM_ADDR
 
 
+@flaky(max_runs=3, min_passes=1)  # Kusama open nodes some times time out
 def test_set_own_rpc_endpoint(rotkehlchen_api_server):
     """Test that successfully setting an own node (via `ksm_rpc_endpoint` setting)
     updates the `available_node_attributes_map`, sorts `available_nodes_call_order`,


### PR DESCRIPTION
- I hope this will streamline our backend tests and eventually remove flaky test failures
- Help us keep a list of which tests are flaky and make us keep in mind ways to change the test (if possible). 