### PR TITLE
Fix loopring get balances by initializing LockableQueryMixing in loopring's ctor

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -295,6 +295,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
             premium: Optional['Premium'],  # pylint: disable=unused-argument
     ) -> None:
         super().__init__(database=database, service_name=ExternalService.LOOPRING)
+        LockableQueryMixIn.__init__(self)
         api_key = self._get_api_key()
         self.msg_aggregator = msg_aggregator
         self.session = requests.session()

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -519,6 +519,7 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
     )
 
 
+@flaky(max_runs=3, min_passes=1)  # some makerdao vault tests take long time and may time out
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/unit/test_loopring.py
+++ b/rotkehlchen/tests/unit/test_loopring.py
@@ -56,7 +56,7 @@ def test_loopring_accountid_mapping(database):
     assert db.get_accountid_mapping(addr1) is None
 
 
-def test_query_balances(temp_loopring, inquirer):  # pylint: disable=W0613
+def test_get_account_balances(temp_loopring, inquirer):  # pylint: disable=W0613
     """Test the get account balances and check that all the conversions
     are done correctly.
     """
@@ -68,3 +68,12 @@ def test_query_balances(temp_loopring, inquirer):  # pylint: disable=W0613
         assert result[A_ETH].amount == FVal(8.4270061497)
         assert result[A_LRC].amount == FVal(435.974889)
         assert result[A_DPI].amount == FVal(2.82924992)
+
+
+def test_get_balances(temp_loopring, inquirer):  # pylint: disable=W0613
+    """Test that loopring's get_balances can be called"""
+    loopring = temp_loopring
+    patched_loopring = patch_loopring(loopring)
+
+    with patched_loopring:
+        loopring.get_balances(addresses=[])


### PR DESCRIPTION
Fix and test for an error at initialization of loopring module

```
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 314, in _do_query_async
rotki     result = getattr(self, command)(**kwargs)
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 2501, in _eth_module_query
rotki     result = getattr(module_obj, method)(**kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/utils/mixins/lockable.py", line 43, in wrapper
rotki     with wrappingobj.query_locks_map_lock:
rotki AttributeError: 'Loopring' object has no attribute 'query_locks_map_lock'
rotki 2022-04-23T13:25:14Z <Greenlet "Greenlet-11" at 0x7f6e19764480: <bound method RestAPI._do_query_async of <rotkehlchen.api.rest.RestAPI object at 0x7f6e1aaaad60>>('_eth_module_query', 2, module_name='loopring', method='get_balances', query_specific_balances_before=None, addresses=['0x4066643f04859fa538Ba8EAa906C197c57e4e3e0'])> failed with AttributeError
rotki Traceback (most recent call last):
rotki   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 314, in _do_query_async
rotki     result = getattr(self, command)(**kwargs)
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 466, in _query_all_balances
    result = self.rotkehlchen.query_balances(
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/rotkehlchen.py", line 681, in query_balances
rotki     loopring_balances = self.chain_manager.get_loopring_balances()
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/utils/mixins/cacheable.py", line 97, in wrapper
rotki     result = f(wrappingobj, *args, **kwargs)
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/manager.py", line 1765, in get_loopring_balances
    balances = loopring_module.get_balances(addresses=addresses)
rotki   File "/home/lefteris/w/rotkehlchen/rotkehlchen/utils/mixins/lockable.py", line 43, in wrapper
    with wrappingobj.query_locks_map_lock:
rotki AttributeError: 'Loopring' object has no attribute
'query_locks_map_lock'