### PR TITLE
Fix no_op callback for exchanges

### DIFF
--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -48,7 +48,7 @@ TX_RECEIPTS_QUERY_LIMIT = 500
 TX_DECODING_LIMIT = 500
 
 
-def noop_exchange_succes_cb(trades, margin, asset_movements, ledger_actions, exchange_specific_data) -> None:  # type: ignore # noqa: E501
+def noop_exchange_success_cb(trades, margin, asset_movements, exchange_specific_data) -> None:  # type: ignore # noqa: E501
     pass
 
 
@@ -298,7 +298,7 @@ class TaskManager():
             method=exchange.query_history_with_callbacks,
             start_ts=0,
             end_ts=now,
-            success_callback=noop_exchange_succes_cb,
+            success_callback=noop_exchange_success_cb,
             fail_callback=exchange_fail_cb,
         )
         self.last_exchange_query_ts[exchange.location_id()] = now


### PR DESCRIPTION
In https://github.com/rotki/rotki/commit/19652d3823449cecc4d9acb7e6449e909b54efdd#diff-d199ac968fb3b62a46339f896a59a3d9a07403a0df6c0168356a99f7e1c59a17L499
the ledger actions were removed from the list of returned events. The no_op callback was taking 5 arguments and this was causing a error for invalid number of arguments raising a error to the frontend

