### PR TITLE
Some pnl changes

### DIFF
--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -128,6 +128,9 @@ class AccountingPot(CustomizableDateMixin):
 
         If a custom price for the asset should be used it can be passed here via
         given_price. Price is always in profit currency during accounting."""
+        if amount == ZERO:  # do nothing for zero acquisitions
+            return
+
         if given_price is not None:
             price = given_price
         else:
@@ -201,6 +204,9 @@ class AccountingPot(CustomizableDateMixin):
 
         Returns (free, taxable) amounts.
         """
+        if amount == ZERO:  # do nothing for zero spends
+            return ZERO, ZERO
+
         if asset.is_fiat() and event_type != AccountingEventType.FEE:
             taxable = False
 

--- a/rotkehlchen/globaldb/manual_price_oracle.py
+++ b/rotkehlchen/globaldb/manual_price_oracle.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.constants import ZERO
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPriceOracle
@@ -38,7 +37,7 @@ class ManualPriceOracle:
             max_seconds_distance=3600,
             source=HistoricalPriceOracle.MANUAL,
         )
-        if price_entry and price_entry.price != Price(ZERO):
+        if price_entry is not None:
             log.debug('Got historical manual price', from_asset=from_asset, to_asset=to_asset, timestamp=timestamp)  # noqa: E501
             return price_entry.price
 

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -242,15 +242,14 @@ class PriceHistorian():
             except (PriceQueryUnsupportedAsset, NoPriceForGivenTimestamp, RemoteError):
                 continue
 
-            if price != Price(ZERO):
-                log.debug(
-                    f'Historical price oracle {oracle} got price',
-                    price=price,
-                    from_asset=from_asset,
-                    to_asset=to_asset,
-                    timestamp=timestamp,
-                )
-                return price
+            log.debug(
+                f'Historical price oracle {oracle} got price',
+                price=price,
+                from_asset=from_asset,
+                to_asset=to_asset,
+                timestamp=timestamp,
+            )
+            return price
 
         raise NoPriceForGivenTimestamp(
             from_asset=from_asset,

--- a/rotkehlchen/interfaces.py
+++ b/rotkehlchen/interfaces.py
@@ -49,4 +49,11 @@ class HistoricalPriceOracleInterface(CurrentPriceOracleInterface):
             to_asset: Asset,
             timestamp: Timestamp,
     ) -> Price:
+        """An oracle implements this to return a historical price from_asset to to_asset at time.
+
+        If no price can be found may raise:
+        - PriceQueryUnsupportedAsset
+        - NoPriceForGivenTimestamp
+        - RemoteError
+        """
         ...

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rotkehlchen.constants.assets import A_BTC, A_USD
-from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp, PriceQueryUnsupportedAsset
 from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
@@ -118,7 +117,7 @@ def test_token_to_fiat_no_price_found_exception(fake_price_historian):
 
     for oracle_instance in price_historian._oracle_instances:
         if not isinstance(oracle_instance, ManualPriceOracle):
-            oracle_instance.query_historical_price.return_value = Price(ZERO)
+            oracle_instance.query_historical_price.side_effect = NoPriceForGivenTimestamp(from_asset=A_BTC, to_asset=A_USD, time=0)  # noqa: E501  # make sure they all fail
 
     with pytest.raises(NoPriceForGivenTimestamp):
         price_historian.query_historical_price(


### PR DESCRIPTION
- PNL: Do not log zero spends, or zero acquisitions
- Price oracles: Zero price should be a valid oracle result if the oracle supports it. For example for a non-tradable token given zero price when we acquired it for the manual oracle. For the oracles where zero means error, the oracle itself should handle it and raise exceptions (cryptocompare).