### PR TITLE
Add filters for transactions and their events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1894,7 +1894,7 @@ Querying ethereum transactions
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a GET on the transactions endpoint for ETH will query all ethereum transactions for all the tracked user addresses. Caller can also specify an address to further filter the query as a from address. Also they can limit the queried transactions by timestamps. If the user is not premium and has more than 500 transaction then the returned transaction will be limited to that number. Any filtering will also be limited to those first 500 transaction. Transactions are returned most recent first.
+   Doing a GET on the transactions endpoint for ETH will query all ethereum transactions for all the tracked user addresses. Caller can also specify an address to further filter the query as a from address. Also they can limit the queried transactions by timestamps and can filter transactions by related event's properties (asset and protocol). If the user is not premium and has more than 500 transaction then the returned transaction will be limited to that number. Any filtering will also be limited to those first 500 transaction. Transactions are returned most recent first.
 
    **Example Request**:
 
@@ -1913,6 +1913,8 @@ Querying ethereum transactions
    :reqjson int from_timestamp: The timestamp after which to return transactions. If not given zero is considered as the start.
    :reqjson int to_timestamp: The timestamp until which to return transactions. If not given all transactions from ``from_timestamp`` until now are returned.
    :reqjson bool only_cache: If true then only the ethereum transactions in the DB are queried.
+   :reqjson string asset: Optional. Serialized asset to filter by.
+   :reqjson string protocol: Optional. Protocol (counterparty) to filter by.
 
 
    **Example Response**:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1894,7 +1894,7 @@ Querying ethereum transactions
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a GET on the transactions endpoint for ETH will query all ethereum transactions for all the tracked user addresses. Caller can also specify an address to further filter the query as a from address. Also they can limit the queried transactions by timestamps and can filter transactions by related event's properties (asset and protocol). If the user is not premium and has more than 500 transaction then the returned transaction will be limited to that number. Any filtering will also be limited to those first 500 transaction. Transactions are returned most recent first.
+   Doing a GET on the transactions endpoint for ETH will query all ethereum transactions for all the tracked user addresses. Caller can also specify an address to further filter the query as a from address. Also they can limit the queried transactions by timestamps and can filter transactions by related event's properties (asset and protocol). If the user is not premium and has more than the transaction limit then the returned transaction will be limited to that number. Any filtering will also be limited. Transactions are returned most recent first.
 
    **Example Request**:
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3040,7 +3040,6 @@ class RestAPI():
                 filter_query=filter_query,
                 has_premium=self.rotkehlchen.premium is not None,
             )
-            transactions = list(set(transactions))
             status_code = HTTPStatus.OK
             message = ''
         except RemoteError as e:
@@ -3065,7 +3064,7 @@ class RestAPI():
                     filter_query=HistoryEventFilterQuery.make(
                         event_identifier=entry.tx_hash.hex(),
                         asset=event_params['asset'],
-                        counterparty=event_params['protocol'],
+                        protocols=event_params['protocols'],
                     ),
                     has_premium=True,  # for this function we don't limit. We only limit txs.
                 )

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -132,7 +132,6 @@ from rotkehlchen.types import (
     ChecksumEthAddress,
     EnsMapping,
     Eth2PubKey,
-    EthereumTransaction,
     EVMTxHash,
     ExternalService,
     ExternalServiceApiCredentials,
@@ -3029,18 +3028,19 @@ class RestAPI():
             self,
             only_cache: bool,
             filter_query: ETHTransactionsFilterQuery,
+            event_params: Dict[str, Any],
     ) -> Dict[str, Any]:
         tx_module = EthTransactions(
             ethereum=self.rotkehlchen.chain_manager.ethereum,
             database=self.rotkehlchen.data.db,
         )
-        transactions: Optional[List[EthereumTransaction]]
         try:
             transactions, total_filter_count = tx_module.query(
                 only_cache=only_cache,
                 filter_query=filter_query,
                 has_premium=self.rotkehlchen.premium is not None,
             )
+            transactions = list(set(transactions))
             status_code = HTTPStatus.OK
             message = ''
         except RemoteError as e:
@@ -3064,6 +3064,8 @@ class RestAPI():
                 events = dbevents.get_history_events(
                     filter_query=HistoryEventFilterQuery.make(
                         event_identifier=entry.tx_hash.hex(),
+                        asset=event_params['asset'],
+                        counterparty=event_params['protocol'],
                     ),
                     has_premium=True,  # for this function we don't limit. We only limit txs.
                 )
@@ -3099,17 +3101,20 @@ class RestAPI():
             async_query: bool,
             only_cache: bool,
             filter_query: ETHTransactionsFilterQuery,
+            event_params: Dict[str, Any],
     ) -> Response:
         if async_query:
             return self._query_async(
                 command='_get_ethereum_transactions',
                 only_cache=only_cache,
                 filter_query=filter_query,
+                event_params=event_params,
             )
 
         response = self._get_ethereum_transactions(
             only_cache=only_cache,
             filter_query=filter_query,
+            event_params=event_params,
         )
         result = response['result']
         msg = response['message']

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -357,11 +357,13 @@ class EthereumTransactionsResource(BaseResource):
             async_query: bool,
             only_cache: bool,
             filter_query: ETHTransactionsFilterQuery,
+            event_params: Dict[str, Any],
     ) -> Response:
         return self.rest_api.get_ethereum_transactions(
             async_query=async_query,
             only_cache=only_cache,
             filter_query=filter_query,
+            event_params=event_params,
         )
 
     @use_kwargs(post_schema, location='json_and_query')

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -181,6 +181,12 @@ class EthereumTransactionQuerySchema(
                 message=f'order_by_attribute for transactions can not be {value}',
                 field_name='order_by_attribute',
             )
+        protocols = data['protocols']
+        if protocols is not None and len(protocols) == 0:
+            raise ValidationError(
+                message='protocols have to be either not passed or contain at least one item',
+                field_name='protocols',
+            )
 
     @post_load
     def make_ethereum_transaction_query(  # pylint: disable=no-self-use
@@ -191,8 +197,6 @@ class EthereumTransactionQuerySchema(
         address = data.get('address')
         order_by_attribute = data['order_by_attribute'] if data['order_by_attribute'] is not None else 'timestamp'  # noqa: E501
         protocols, asset = data['protocols'], data['asset']
-        if not protocols:  # If protocols == []
-            protocols = None
         filter_query = ETHTransactionsFilterQuery.make(
             order_by_rules=[(order_by_attribute, data['ascending'])],
             limit=data['limit'],

--- a/rotkehlchen/db/ethtx.py
+++ b/rotkehlchen/db/ethtx.py
@@ -156,10 +156,10 @@ class DBEthTx():
         cursor = self.db.conn.cursor()
         query, bindings = filter_.prepare()
         if has_premium:
-            query = 'SELECT * FROM ethereum_transactions ' + query
+            query = 'SELECT DISTINCT ethereum_transactions.tx_hash, timestamp, block_number, from_address, to_address, value, gas, gas_price, gas_used, input_data, nonce FROM ethereum_transactions ' + query  # noqa: E501
             results = cursor.execute(query, bindings)
         else:
-            query = 'SELECT * FROM (SELECT * from ethereum_transactions ORDER BY timestamp DESC LIMIT ?) ' + query  # noqa: E501
+            query = 'SELECT DISTINCT ethereum_transactions.tx_hash, timestamp, block_number, from_address, to_address, value, gas, gas_price, gas_used, input_data, nonce FROM (SELECT * from ethereum_transactions ORDER BY timestamp DESC LIMIT ?) ethereum_transactions ' + query  # noqa: E501
             results = cursor.execute(query, [FREE_ETH_TX_LIMIT] + bindings)
 
         ethereum_transactions = []

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1,16 +1,26 @@
+import logging
 import os
 import random
 from contextlib import ExitStack
 from http import HTTPStatus
+from typing import List, Optional, Tuple
 from unittest.mock import patch
 
 import gevent
 import pytest
 import requests
 
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.base import (
+    HistoryBaseEntry,
+    HistoryEventSubType,
+    HistoryEventType,
+)
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceipt
 from rotkehlchen.chain.ethereum.transactions import EthTransactions
-from rotkehlchen.constants.assets import A_DAI, A_USDT
+from rotkehlchen.constants import ONE
+from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_USDT
 from rotkehlchen.constants.limits import FREE_ETH_TX_LIMIT
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
@@ -29,7 +39,13 @@ from rotkehlchen.tests.utils.checks import assert_serialized_lists_equal
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
-from rotkehlchen.types import EthereumTransaction, Timestamp, make_evm_tx_hash
+from rotkehlchen.types import (
+    EthereumTransaction,
+    Location,
+    Timestamp,
+    TimestampMS,
+    make_evm_tx_hash,
+)
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 
 EXPECTED_AFB7_TXS = [{
@@ -1051,3 +1067,143 @@ def test_query_transactions_check_decoded_events(rotkehlchen_api_server, ethereu
     ):
         assert cursor.execute(f'SELECT COUNT(*) from {name}').fetchone()[0] == 0
     assert dbevents.get_history_events(HistoryEventFilterQuery.make(), True) == []
+
+
+def create_tx(tx_hash: bytes) -> EthereumTransaction:
+    # Helper function to reduce lines of code in tests
+    return EthereumTransaction(
+        tx_hash=make_evm_tx_hash(tx_hash),
+        timestamp=Timestamp(0),
+        block_number=0,
+        from_address=make_ethereum_address(),
+        to_address=make_ethereum_address(),
+        value=1,
+        gas=1,
+        gas_price=1,
+        gas_used=1,
+        input_data=b'',
+        nonce=0,
+    )
+
+
+def create_tx_event(
+    tx_hash: bytes,
+    index: int,
+    asset: Asset,
+    counterparty: Optional[str] = None,
+) -> HistoryBaseEntry:
+    # Helper function to reduce lines of code in tests
+    return HistoryBaseEntry(
+        event_identifier=make_evm_tx_hash(tx_hash).hex(),  # pylint: disable=no-member
+        sequence_index=index,
+        identifier=index,
+        timestamp=TimestampMS(0),
+        location=Location.KRAKEN,
+        event_type=HistoryEventType.UNKNOWN,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=asset,
+        balance=Balance(amount=ONE, usd_value=ONE),
+        counterparty=counterparty,
+    )
+
+
+def generate_tx_entries_response(
+    data: List[Tuple[EthereumTransaction, List[HistoryBaseEntry]]],
+) -> List:
+    # Helper function to reduce lines of code in tests
+    result = []
+    for tx, events in data:
+        decoded_events = []
+        for event in events:
+            decoded_events.append({
+                'entry': event.serialize(),
+                'customized': False,
+            })
+        result.append({
+            'entry': tx.serialize(),
+            'decoded_events': decoded_events,
+            'ignored_in_accounting': False,
+        })
+    return result
+
+
+def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
+    """Tests filtering by transaction's events' properties
+    Test cases:
+        - Filtering by asset
+        - Filtering by protocol (counterparty)
+        - Filtering by both asset and a protocol
+        - Transaction has multiple related events
+        - Transaction has no related events
+        - Multiple transactions are queried
+    """
+    logging.getLogger('rotkehlchen.externalapis.etherscan').disabled = True
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    db = rotki.data.db
+    tx1 = create_tx(tx_hash=b'1')
+    tx2 = create_tx(tx_hash=b'2')
+    tx3 = create_tx(tx_hash=b'3')
+    event1 = create_tx_event(tx_hash=b'1', index=1, asset=A_ETH)
+    event2 = create_tx_event(tx_hash=b'1', index=2, asset=A_ETH, counterparty='EXAMPLE_PROTOCOL')
+    event3 = create_tx_event(tx_hash=b'1', index=3, asset=A_BTC, counterparty='EXAMPLE_PROTOCOL')
+    event4 = create_tx_event(tx_hash=b'2', index=4, asset=A_BTC)
+    dbethtx = DBEthTx(db)
+    dbethtx.add_ethereum_transactions([tx1, tx2, tx3], relevant_address=ethereum_accounts[0])
+    dbevents = DBHistoryEvents(db)
+    dbevents.add_history_events([event1, event2, event3, event4])
+
+    response = requests.get(
+        api_url_for(
+            rotkehlchen_api_server,
+            'ethereumtransactionsresource',
+        ),
+        json={
+            'asset': A_ETH.serialize(),
+        },
+    )
+    result = assert_proper_response_with_result(response)
+    expected = generate_tx_entries_response([(tx1, [event1, event2])])
+    assert result['entries'] == expected
+
+    response = requests.get(
+        api_url_for(
+            rotkehlchen_api_server,
+            'ethereumtransactionsresource',
+        ),
+        json={
+            'asset': A_BTC.serialize(),
+        },
+    )
+    result = assert_proper_response_with_result(response)
+    expected = generate_tx_entries_response([(tx1, [event3]), (tx2, [event4])])
+    # For some reason data this data can be reversed,
+    # and we avoid failing with a help of this ugly check.
+    # Dicts are not hashable, so it's not possible to use better and simpler way
+    assert result['entries'] == expected or result['entries'] == list(reversed(expected))
+
+    response = requests.get(
+        api_url_for(
+            rotkehlchen_api_server,
+            'ethereumtransactionsresource',
+        ),
+        json={
+            'protocol': 'EXAMPLE_PROTOCOL',
+        },
+    )
+    result = assert_proper_response_with_result(response)
+    expected = generate_tx_entries_response([(tx1, [event2, event3])])
+    assert result['entries'] == expected
+
+    response = requests.get(
+        api_url_for(
+            rotkehlchen_api_server,
+            'ethereumtransactionsresource',
+        ),
+        json={
+            'asset': A_BTC.serialize(),
+            'protocol': 'EXAMPLE_PROTOCOL',
+        },
+    )
+    result = assert_proper_response_with_result(response)
+    expected = generate_tx_entries_response([(tx1, [event3])])
+    assert result['entries'] == expected


### PR DESCRIPTION
Part of #4220

Added ability to filter transactions by related events on endpoint `/blockchains/ETH/transactions` with `GET` method.

No changelog since this feature also requires frontend implementation.