### PR TITLE
Allow reverse ens api endpoint async query and more changes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10531,7 +10531,10 @@ Get ENS names
 
    Doing a POST on the ENS reverse endpoint will return the ENS names for
    the given ethereum addresses from cache if found and from blockchain otherwise.
-   If force_update is true, the entire cache will be updated
+   If ignore_cache is true, then the entire cache will be recreated
+
+   .. note::
+      This endpoint can also be queried asynchronously by using ``"async_query": true``.
 
    **Example Request**:
 
@@ -10553,11 +10556,11 @@ Get ENS names
 
           {
               "ethereum_addresses": ["0x1", "0x2"],
-              "force_update": true
+              "ignore_cache": true
           }
 
    :reqjson list ethereum_addresses: A list of ethereum addresses to get names for.
-   :reqjson bool force_update: If true, the entire cache will be updated.
+   :reqjson bool ignore_cache: If true, the entire cache will be updated.
 
    **Example Response**:
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -2155,6 +2155,15 @@ class DBSnapshotDeletingResource(BaseResource):
 class ReverseEnsResource(BaseResource):
     reverse_ens_schema = ReverseEnsSchema
 
-    @use_kwargs(reverse_ens_schema, location='json_and_query')
-    def post(self, ethereum_addresses: List[ChecksumEthAddress], force_update: bool) -> Response:
-        return self.rest_api.get_ens_mappings(addresses=ethereum_addresses, force_update=force_update)  # noqa: E501
+    @use_kwargs(reverse_ens_schema, location='json')
+    def post(
+            self,
+            ethereum_addresses: List[ChecksumEthAddress],
+            ignore_cache: bool,
+            async_query: bool,
+    ) -> Response:
+        return self.rest_api.get_ens_mappings(
+            addresses=ethereum_addresses,
+            ignore_cache=ignore_cache,
+            async_query=async_query,
+        )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1993,9 +1993,8 @@ class AssetsImportingFromFormSchema(Schema):
     file = FileField(allowed_extensions=['.zip', '.json'], required=True)
 
 
-class ReverseEnsSchema(Schema):
+class ReverseEnsSchema(AsyncIgnoreCacheQueryArgumentSchema):
     ethereum_addresses = fields.List(EthereumAddressField(), required=True)
-    force_update = fields.Boolean(required=False, load_default=False)
 
 
 class SnapshotImportingSchema(Schema):

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -79,7 +79,6 @@ def fixture_cli_args(data_dir, ethrpc_endpoint):
     args = namedtuple('args', [
         'sleep_secs',
         'data_dir',
-        'zerorpc_port',
         'ethrpc_endpoint',
         'logfile',
         'logtarget',


### PR DESCRIPTION
1. Reverse ENS query can now be done asynchronously. This should be
called as an async task by the frontend as it can block the entire app when
called for multiple addresses and transactions
2. Rename `force_update` argument to `ignore_cache` so that the
endpoint is in line with the rest of the API
3. Endpoint only accepts json and not query args
4. Cleaned the tests a bit by using the proper api test helper functions
