### PR TITLE
Add spam tokens as assets to globaldb

### DIFF
--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -58,7 +58,7 @@ def query_token_spam_list(db: 'DBHandler') -> Set[EthereumToken]:
     This function tries to add as assets to the globaldb the tokens listed in
     KNOWN_ETH_SPAM_TOKENS and not the ones coming from cryptoscamdb. The reason is that until the
     v2 of the API the response contains both spam addresses and tokens and there is no way to know
-    if the address is for a contract or not. Checking if the address is a contract takes to much
+    if the address is for a contract or not. Checking if the address is a contract takes too much
     time. When V2 gets released this can be fixed.
     May raise:
     - RemoteError
@@ -109,6 +109,7 @@ def query_token_spam_list(db: 'DBHandler') -> Set[EthereumToken]:
                 userdb=db,
                 ethereum_address=token_address,
                 protocol=SPAM_PROTOCOL,
+                form_with_incomplete_data=True,
             )
         except (RemoteError, NotERC20Conformant) as e:
             log.debug(f'Skipping {checksumed_address} due to {str(e)}')

--- a/rotkehlchen/data_migrations/migrations/migration_3.py
+++ b/rotkehlchen/data_migrations/migrations/migration_3.py
@@ -17,6 +17,6 @@ def data_migration_3(rotki: 'Rotkehlchen') -> None:
     Update the list of ignored assets with tokens from cryptoscamdb
     """
     try:
-        update_spam_assets(rotki.data.db)
+        update_spam_assets(db=rotki.data.db)
     except RemoteError as e:
         log.error(f'Failed to update the list of ignored assets during db migration. {str(e)}')

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -99,11 +99,11 @@ def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
         ), json={'assets': ignored_assets},
     )
     result = assert_proper_response_with_result(response)
-    expected_ignored_assets = set(ignored_assets + [KICK_TOKEN])
-    assert set(result) == expected_ignored_assets
+    expected_ignored_assets = set(ignored_assets + [KICK_TOKEN.identifier])
+    assert expected_ignored_assets <= set(result)
 
     # check they are there
-    assert set(rotki.data.db.get_ignored_assets()) == expected_ignored_assets
+    assert set(rotki.data.db.get_ignored_assets()) >= expected_ignored_assets
     # Query for ignored assets and check that the response returns them
     response = requests.get(
         api_url_for(
@@ -112,21 +112,21 @@ def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert set(result) == expected_ignored_assets
+    assert expected_ignored_assets <= set(result)
 
-    # remove two assets from ignored assets
+    # remove thre assets from ignored assets
     response = requests.delete(
         api_url_for(
             rotkehlchen_api_server_with_exchanges,
             'ignoredassetsresource',
         ), json={'assets': [A_GNO.identifier, 'XMR', kick_token_id]},
     )
-    assets_after_deletion = [A_RDN.identifier]
+    assets_after_deletion = {A_RDN.identifier}
     result = assert_proper_response_with_result(response)
-    assert result == assets_after_deletion
+    assert assets_after_deletion <= set(result)
 
     # check that the changes are reflected
-    assert rotki.data.db.get_ignored_assets() == assets_after_deletion
+    assert set(rotki.data.db.get_ignored_assets()) >= assets_after_deletion
     # Query for ignored assets and check that the response returns them
     response = requests.get(
         api_url_for(
@@ -135,7 +135,7 @@ def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert result == assets_after_deletion
+    assert assets_after_deletion <= set(result)
 
     # Fetch remote assets to be ignored
     response = requests.post(

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -114,7 +114,7 @@ def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
     result = assert_proper_response_with_result(response)
     assert expected_ignored_assets <= set(result)
 
-    # remove thre assets from ignored assets
+    # remove 3 assets from ignored assets
     response = requests.delete(
         api_url_for(
             rotkehlchen_api_server_with_exchanges,
@@ -236,7 +236,7 @@ def test_ignored_assets_endpoint_errors(rotkehlchen_api_server_with_exchanges, m
         ignored_assets +
         [KICK_TOKEN],
     )
-    assert set(rotki.data.db.get_ignored_assets()) == expected_tokens
+    assert set(rotki.data.db.get_ignored_assets()) >= expected_tokens
 
     # Test the adding an already existing asset or removing a non-existing asset is an error
     if method == 'put':
@@ -257,4 +257,4 @@ def test_ignored_assets_endpoint_errors(rotkehlchen_api_server_with_exchanges, m
         status_code=HTTPStatus.CONFLICT,
     )
     # Check that assets did not get modified
-    assert set(rotki.data.db.get_ignored_assets()) == expected_tokens
+    assert set(rotki.data.db.get_ignored_assets()) >= expected_tokens

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -303,7 +303,7 @@ def test_writing_fetching_data(data_dir, username):
     result, _ = data.add_ignored_assets([A_DOGE])
     assert result
     result, _ = data.add_ignored_assets([A_DOGE])
-    assert not result
+    assert result is None
 
     ignored_assets = data.db.get_ignored_assets()
     assert all(isinstance(asset, Asset) for asset in ignored_assets)
@@ -311,7 +311,7 @@ def test_writing_fetching_data(data_dir, username):
     # Test removing asset that is not in the list
     result, msg = data.remove_ignored_assets([A_RDN])
     assert 'not in ignored assets' in msg
-    assert not result
+    assert result is None
     result, _ = data.remove_ignored_assets([A_DOGE])
     assert result
     assert data.db.get_ignored_assets() == [A_DAO]

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -81,6 +81,7 @@ YEARN_VAULTS_V2_PROTOCOL = 'yearn_vaults_v2'
 CURVE_POOL_PROTOCOL = 'curve_pool'
 PICKLE_JAR_PROTOCOL = 'pickle_jar'
 COMPOUND_PROTOCOL = 'compound'
+SPAM_PROTOCOL = 'spam'
 
 
 KnownProtocolsAssets = (


### PR DESCRIPTION
The reason behind this is to add the assets so accounts with fresh global dbs
will have those assets and will properly ignore them.
