### PR TITLE
Add missing db.conn.commit after snapshot deletion

### DIFF
--- a/frontend/app/src/data/currencies.ts
+++ b/frontend/app/src/data/currencies.ts
@@ -74,7 +74,7 @@ export const currencies: Currency[] = [
   new Currency(i18n.t('currencies.nok').toString(), CURRENCY_NOK, 'kr'),
   new Currency(i18n.t('currencies.inr').toString(), CURRENCY_INR, '₹'),
   new Currency(i18n.t('currencies.dkk').toString(), CURRENCY_DKK, 'kr'),
-  new Currency(i18n.t('currencies.pln').toString(), CURRENCY_DKK, 'zł'),
+  new Currency(i18n.t('currencies.pln').toString(), CURRENCY_PLN, 'zł'),
   new Currency('Bitcoin', CURRENCY_BTC, '₿'),
   new Currency('Ether', CURRENCY_ETH, 'Ξ')
 ];

--- a/rotkehlchen/db/snapshots.py
+++ b/rotkehlchen/db/snapshots.py
@@ -314,4 +314,5 @@ class DBSnapshot:
         if cursor.rowcount == 0:
             self.db.conn.rollback()
             return False, 'No snapshot found for the specified timestamp'
+        self.db.update_last_write()
         return True, ''


### PR DESCRIPTION
If no other DB event happens the snapshot deletion did not persist
after restart
