### PR TITLE
Add default value for name and decimals in spam tokens

### DIFF
--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -110,6 +110,8 @@ def query_token_spam_list(db: 'DBHandler') -> Set[EthereumToken]:
                 ethereum_address=token_address,
                 protocol=SPAM_PROTOCOL,
                 form_with_incomplete_data=True,
+                decimals=18,
+                name='Autodetected spam token',
             )
         except (RemoteError, NotERC20Conformant) as e:
             log.debug(f'Skipping {checksumed_address} due to {str(e)}')

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -178,7 +178,7 @@ def test_binance_assets_are_known(inquirer):  # pylint: disable=unused-argument
     common_items = unsupported_assets.intersection(set(WORLD_TO_BINANCE.values()))
     assert not common_items, f'Binance assets {common_items} should not be unsupported'
 
-    exchange_data = requests.get('https://binance.com/api/v3/exchangeInfo').json()
+    exchange_data = requests.get('https://api3.binance.com/api/v3/exchangeInfo').json()
     binance_assets = set()
     for pair_symbol in exchange_data['symbols']:
         binance_assets.add(pair_symbol['baseAsset'])


### PR DESCRIPTION
For spam tokens we don't waste time trying to query on chain info about the properties of the tokens.
Before the decimals and name were not populated but this is incorrect since leads to a inconsistent state.
This PR sets a default value for those fields that can be later modified

