### PR TITLE
Go back to the stable vue tools

### DIFF
--- a/frontend/app/src/background.ts
+++ b/frontend/app/src/background.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { app, BrowserWindow, Menu, MenuItem, protocol } from 'electron';
-import installExtension, { VUEJS3_DEVTOOLS } from 'electron-devtools-installer';
+import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
 import windowStateKeeper from 'electron-window-state';
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib';
 import { ipcSetup } from '@/electron-main/ipc-setup';
@@ -32,7 +32,7 @@ const onReady = async () => {
   if (isDevelopment && !process.env.IS_TEST) {
     // Install Vue Devtools
     try {
-      await installExtension(VUEJS3_DEVTOOLS);
+      await installExtension(VUEJS_DEVTOOLS);
     } catch (e: any) {
       console.error('Vue Devtools failed to install:', e.toString());
     }


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

The vue3 dev tools beta used is really outdated.

@rotki/rotki-devs This might requires some manual intervention because at least in my case it didn't auto-update to the latest stable and I had to delete the extensions under `~/.config/rotki/extensions/`