### PR TITLE
Temporary fix for ignored assets exclusion at tx events

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -168,7 +168,7 @@ class EthereumTransactionQuerySchema(
     to_timestamp = TimestampField(load_default=ts_now)
     protocols = fields.List(fields.String(), load_default=None)
     asset = AssetField(load_default=None)
-    exclude_ignored_assets = fields.Boolean(load_default=True)
+    exclude_ignored_assets = fields.Boolean(load_default=False)
 
     @validates_schema
     def validate_ethtx_query_schema(  # pylint: disable=no-self-use


### PR DESCRIPTION
Setting it temporarily to False. But we need to find a way to properly
ignore them. Basically exlude ignored assets to only work if there is events for that transaction in the DB, otherwise filter nothing.

cc @nebolax 