### PR TITLE
Fix links not working on docker & adding an environment variable for python packaging version

### DIFF
--- a/frontend/app/src/electron-interop.ts
+++ b/frontend/app/src/electron-interop.ts
@@ -46,7 +46,7 @@ export class ElectronInterop {
   }
 
   openUrl(url: string) {
-    window.interop?.openUrl(url);
+    this.isPackaged ? window.interop?.openUrl(url) : window.open(url, '_blank');
   }
 
   openPath(path: string) {

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires='>=3.9',
     install_requires=requirements,
     use_scm_version={
-        'fallback_version': environ.get('PACKAGE_FALLBACK_VERSION'),
+        'fallback_version': environ.get('PACKAGE_FALLBACK_VERSION') or version,
     },
     setup_requires=['setuptools_scm'],
     long_description=directory.joinpath('README.md').read_text(),

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pathlib
+from os import environ
 
 from pkg_resources import parse_requirements
 from setuptools import find_packages, setup
@@ -30,7 +31,9 @@ setup(
     },
     python_requires='>=3.9',
     install_requires=requirements,
-    use_scm_version=True,
+    use_scm_version={
+        'fallback_version': environ.get('PACKAGE_FALLBACK_VERSION'),
+    },
     setup_requires=['setuptools_scm'],
     long_description=directory.joinpath('README.md').read_text(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Fix issue with links not opening on docker.
- Allow python packaging to fallback to a particular version.