### PR TITLE
Add websocket messages for status querying ethereum transactions

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -747,7 +747,7 @@
     },
     "ethereum_transactions": {
       "title": "Transactions query update",
-      "message": "Querying information for {address}, {address_index} of {total_addresses}"
+      "message": "Querying ethereum transactions information for {address} between {start} and {end}"
     }
   },
   "pagination": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -744,6 +744,10 @@
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",
       "title": "Balance Snapshot failed"
+    },
+    "ethereum_transactions": {
+      "title": "Transactions query update",
+      "message": "Querying information for {address}, {address_index} of {total_addresses}"
     }
   },
   "pagination": {

--- a/frontend/app/src/services/websocket/message-handling.ts
+++ b/frontend/app/src/services/websocket/message-handling.ts
@@ -2,6 +2,8 @@ import { Severity } from '@rotki/common/lib/messages';
 import i18n from '@/i18n';
 import {
   BalanceSnapshotError,
+  EthereumTransactionQueryData,
+  EthereumTransactionsQueryStatus,
   SocketMessageType,
   WebsocketMessage
 } from '@/services/websocket/messages';
@@ -19,6 +21,30 @@ export async function handleSnapshotError(
       .toString(),
     display: true
   });
+}
+
+export async function handleEthereumTransactionStatus(
+  message: WebsocketMessage<SocketMessageType>
+) {
+  const data = EthereumTransactionQueryData.parse(message.data);
+  const { notify } = useNotifications();
+  if (data.status === EthereumTransactionsQueryStatus.ACCOUNT_CHANGE) {
+    const messageData = {
+      address: data.address,
+      address_index: data.period[0],
+      total_addresses: data.period[1]
+    };
+    notify({
+      title: i18n
+        .t('notification_messages.ethereum_transactions.title')
+        .toString(),
+      message: i18n
+        .t('notification_messages.ethereum_transactions.message', messageData)
+        .toString(),
+      display: true,
+      severity: Severity.INFO
+    });
+  }
 }
 
 export async function handleLegacyMessage(message: string, isWarning: boolean) {

--- a/frontend/app/src/services/websocket/message-handling.ts
+++ b/frontend/app/src/services/websocket/message-handling.ts
@@ -31,8 +31,8 @@ export async function handleEthereumTransactionStatus(
   if (data.status === EthereumTransactionsQueryStatus.ACCOUNT_CHANGE) {
     const messageData = {
       address: data.address,
-      address_index: data.period[0],
-      total_addresses: data.period[1]
+      start: data.period[0],
+      end: data.period[1]
     };
     notify({
       title: i18n

--- a/frontend/app/src/services/websocket/messages.ts
+++ b/frontend/app/src/services/websocket/messages.ts
@@ -17,16 +17,34 @@ export const BalanceSnapshotError = z.object({
   error: z.string()
 });
 
+export enum EthereumTransactionsQueryStatus {
+  ACCOUNT_CHANGE = 'account_change',
+  QUERYING_TRANSACTIONS = 'querying_transactions',
+  QUERYING_INTERNAL_TRANSACTIONS = 'querying_internal_transactions',
+  QUERYING_ETHEREUM_TOKENS_TRANSACTIONS = 'querying_ethereum_tokens_transactions'
+}
+
+export const EthereumTransactionQueryData = z.object({
+  status: z.nativeEnum(EthereumTransactionsQueryStatus),
+  address: z.string(),
+  period: z.array(z.number())
+});
+
 export type BalanceSnapshotError = z.infer<typeof BalanceSnapshotError>;
+export type EthereumTransactionQueryData = z.infer<
+  typeof EthereumTransactionQueryData
+>;
 
 export enum SocketMessageType {
   LEGACY = 'legacy',
-  BALANCES_SNAPSHOT_ERROR = 'balance_snapshot_error'
+  BALANCES_SNAPSHOT_ERROR = 'balance_snapshot_error',
+  ETHEREUM_TRANSACTION_STATUS = 'ethereum_transaction_status'
 }
 
 type MessageData = {
   [SocketMessageType.LEGACY]: LegacyMessageData;
   [SocketMessageType.BALANCES_SNAPSHOT_ERROR]: BalanceSnapshotError;
+  [SocketMessageType.ETHEREUM_TRANSACTION_STATUS]: EthereumTransactionQueryData;
 };
 
 export interface WebsocketMessage<T extends SocketMessageType> {

--- a/frontend/app/src/services/websocket/websocket-service.ts
+++ b/frontend/app/src/services/websocket/websocket-service.ts
@@ -1,5 +1,6 @@
 import * as logger from 'loglevel';
 import {
+  handleEthereumTransactionStatus,
   handleLegacyMessage,
   handleSnapshotError
 } from '@/services/websocket/message-handling';
@@ -54,6 +55,10 @@ class WebsocketService {
             data.value,
             data.verbosity === MESSAGE_WARNING
           );
+        } else if (
+          message.type === SocketMessageType.ETHEREUM_TRANSACTION_STATUS
+        ) {
+          await handleEthereumTransactionStatus(message);
         } else {
           logger.warn(`Unsupported socket message received: ${message}`);
         }

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -18,7 +18,7 @@ class WSMessageType(Enum):
 
 
 class TransactionStatusStep(Enum):
-    ACCOUNT_CHANGE = auto()
+    QUERYING_TRANSACTIONS_STARTED = auto()
     QUERYING_TRANSACTIONS = auto()
     QUERYING_INTERNAL_TRANSACTIONS = auto()
     QUERYING_ETHEREUM_TOKENS_TRANSACTIONS = auto()

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -22,6 +22,7 @@ class TransactionStatusStep(Enum):
     QUERYING_TRANSACTIONS = auto()
     QUERYING_INTERNAL_TRANSACTIONS = auto()
     QUERYING_ETHEREUM_TOKENS_TRANSACTIONS = auto()
+    QUERYING_TRANSACTIONS_FINISHED = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -5,12 +5,23 @@ https://github.com/python/mypy/issues/10722
 https://github.com/python/mypy/issues/1876#issuecomment-782458452
 """
 
-from enum import Enum
+from enum import Enum, auto
 
 
 class WSMessageType(Enum):
-    LEGACY = 0
-    BALANCE_SNAPSHOT_ERROR = 1
+    LEGACY = auto()
+    BALANCE_SNAPSHOT_ERROR = auto()
+    ETHEREUM_TRANSACTION_STATUS = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()  # pylint: disable=no-member
+
+
+class TransactionStatusStep(Enum):
+    ACCOUNT_CHANGE = auto()
+    QUERYING_TRANSACTIONS = auto()
+    QUERYING_INTERNAL_TRANSACTIONS = auto()
+    QUERYING_ETHEREUM_TOKENS_TRANSACTIONS = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -79,6 +79,14 @@ class EthTransactions:
         """
         lock = self.address_tx_locks[address]
         with lock:
+            self.msg_aggregator.add_message(
+                message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
+                data={
+                    'address': address,
+                    'period': [start_ts, end_ts],
+                    'status': str(TransactionStatusStep.QUERYING_TRANSACTIONS_STARTED),
+                },
+            )
             self._get_transactions_for_range(address=address, start_ts=start_ts, end_ts=end_ts)
             self._get_internal_transactions_for_ranges(
                 address=address,

--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -90,6 +90,14 @@ class EthTransactions:
                 start_ts=start_ts,
                 end_ts=end_ts,
             )
+        self.msg_aggregator.add_message(
+            message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
+            data={
+                'address': address,
+                'period': [start_ts, end_ts],
+                'status': str(TransactionStatusStep.QUERYING_TRANSACTIONS_FINISHED),
+            },
+        )
 
     def query(
             self,
@@ -120,14 +128,6 @@ class EthTransactions:
             from_ts = Timestamp(0) if f_from_ts is None else f_from_ts
             to_ts = ts_now() if f_to_ts is None else f_to_ts
             for address in accounts:
-                self.msg_aggregator.add_message(
-                    message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
-                    data={
-                        'address': address,
-                        'period': [from_ts, to_ts],
-                        'status': str(TransactionStatusStep.ACCOUNT_CHANGE),
-                    },
-                )
                 self.single_address_query_transactions(
                     address=address,
                     start_ts=from_ts,

--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -160,14 +160,6 @@ class EthTransactions:
         dbethtx = DBEthTx(self.database)
         for query_start_ts, query_end_ts in ranges_to_query:
             log.debug(f'Querying Transactions for {address} -> {query_start_ts} - {query_end_ts}')
-            self.msg_aggregator.add_message(
-                message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
-                data={
-                    'address': address,
-                    'period': [query_start_ts, query_end_ts],
-                    'status': str(TransactionStatusStep.QUERYING_TRANSACTIONS),
-                },
-            )
             try:
                 for new_transactions in self.ethereum.etherscan.get_transactions(
                     account=address,
@@ -184,6 +176,14 @@ class EthTransactions:
                         ranges.update_used_query_range(  # update last queried time for the address
                             location_string=location_string,
                             queried_ranges=[(query_start_ts, new_transactions[-1].timestamp)],
+                        )
+                        self.msg_aggregator.add_message(
+                            message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
+                            data={
+                                'address': address,
+                                'period': [query_start_ts, new_transactions[-1].timestamp],
+                                'status': str(TransactionStatusStep.QUERYING_TRANSACTIONS),
+                            },
                         )
 
             except RemoteError as e:
@@ -223,14 +223,6 @@ class EthTransactions:
         new_internal_txs = []
         for query_start_ts, query_end_ts in ranges_to_query:
             log.debug(f'Querying Internal Transactions for {address} -> {query_start_ts} - {query_end_ts}')  # noqa: E501
-            self.msg_aggregator.add_message(
-                message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
-                data={
-                    'address': address,
-                    'period': [query_start_ts, query_end_ts],
-                    'status': str(TransactionStatusStep.QUERYING_INTERNAL_TRANSACTIONS),
-                },
-            )
             try:
                 for new_internal_txs in self.ethereum.etherscan.get_transactions(
                     account=address,
@@ -263,6 +255,14 @@ class EthTransactions:
                             ranges.update_used_query_range(  # update last queried time for address
                                 location_string=location_string,
                                 queried_ranges=[(query_start_ts, timestamp)],
+                            )
+                            self.msg_aggregator.add_message(
+                                message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
+                                data={
+                                    'address': address,
+                                    'period': [query_start_ts, timestamp],
+                                    'status': str(TransactionStatusStep.QUERYING_INTERNAL_TRANSACTIONS),  # noqa: E501
+                                },
                             )
 
             except RemoteError as e:
@@ -301,14 +301,6 @@ class EthTransactions:
         )
         for query_start_ts, query_end_ts in ranges_to_query:
             log.debug(f'Querying ERC20 Transfers for {address} -> {query_start_ts} - {query_end_ts}')  # noqa: E501
-            self.msg_aggregator.add_message(
-                message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
-                data={
-                    'address': address,
-                    'period': [query_start_ts, query_end_ts],
-                    'status': str(TransactionStatusStep.QUERYING_ETHEREUM_TOKENS_TRANSACTIONS),
-                },
-            )
             try:
                 for erc20_tx_hashes in self.ethereum.etherscan.get_token_transaction_hashes(
                     account=address,
@@ -335,6 +327,14 @@ class EthTransactions:
                         ranges.update_used_query_range(  # update last queried time for the address
                             location_string=location_string,
                             queried_ranges=[(query_start_ts, timestamp)],
+                        )
+                        self.msg_aggregator.add_message(
+                            message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
+                            data={
+                                'address': address,
+                                'period': [query_start_ts, timestamp],
+                                'status': str(TransactionStatusStep.QUERYING_ETHEREUM_TOKENS_TRANSACTIONS),  # noqa: E501
+                            },
                         )
             except RemoteError as e:
                 self.ethereum.msg_aggregator.add_error(

--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -119,12 +119,12 @@ class EthTransactions:
             f_to_ts = filter_query.to_ts
             from_ts = Timestamp(0) if f_from_ts is None else f_from_ts
             to_ts = ts_now() if f_to_ts is None else f_to_ts
-            for i, address in enumerate(accounts):
+            for address in accounts:
                 self.msg_aggregator.add_message(
                     message_type=WSMessageType.ETHEREUM_TRANSACTION_STATUS,
                     data={
                         'address': address,
-                        'period': [i + 1, len(accounts)],
+                        'period': [from_ts, to_ts],
                         'status': str(TransactionStatusStep.ACCOUNT_CHANGE),
                     },
                 )
@@ -180,10 +180,6 @@ class EthTransactions:
                         dbethtx.add_ethereum_transactions(
                             ethereum_transactions=new_transactions,
                             relevant_address=address,
-                        )
-                        log.debug(
-                            f'Transactions update range {query_start_ts} - '
-                            f'{new_transactions[-1].timestamp}',
                         )
                         ranges.update_used_query_range(  # update last queried time for the address
                             location_string=location_string,


### PR DESCRIPTION
Adds websockets notifications to informt the user what is the current progress querying ethereum transactions.

At the moment a notification is displayed when the address that is being queried changes but more information is sent to the frontend via the websockets connection: 

 - `QUERYING_TRANSACTIONS`
 - `QUERYING_INTERNAL_TRANSACTIONS`
 - `QUERYING_ETHEREUM_TOKENS_TRANSACTIONS`

@lukicenturi We were discussing about adding this information to the ethereum transactions panel instead of showing notifications since they could blink and pile up if you have many accounts. What do you think of adding the information here when the websockets receives the change in step?

![image](https://user-images.githubusercontent.com/5068010/169521295-e61b3b2f-b63c-4fd3-8dbc-bcc7e3974a0a.png)


