### PR TITLE
Remove lock from single tx_receipt query and augment logs

### DIFF
--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -16,7 +16,6 @@ from ens.utils import (
     normalize_name,
 )
 from eth_typing import BlockNumber, HexStr
-from gevent.lock import Semaphore
 from web3 import HTTPProvider, Web3
 from web3._utils.abi import get_abi_output_types
 from web3._utils.contracts import find_matching_event_abi
@@ -269,8 +268,6 @@ class EthereumManager():
         )
         # A cache for the erc20 contract info to not requery same one
         self.contract_info_cache: Dict[ChecksumEthAddress, Dict[str, Any]] = {}
-        # Locks to be used by this and other objects utilizing it such as EthTransactions
-        self.receipts_query_lock = Semaphore()
 
     def connected_to_any_web3(self) -> bool:
         return (


### PR DESCRIPTION
This is some initial changes I needed to do to transactions query.

Need to also find out the reason for some very weird logs I noticed where timestamp is going backwards.