### PR TITLE
Add context switching for ethercan and transaction querying

### DIFF
--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
+import gevent
 from gevent.lock import Semaphore
 
 from rotkehlchen.api.websockets.typedefs import TransactionStatusStep, WSMessageType
@@ -241,12 +242,14 @@ class EthTransactions:
                     if len(new_internal_txs) != 0:
                         for internal_tx in new_internal_txs:
                             # make sure all internal transaction parent transactions are in the DB
+                            gevent.sleep(0)
                             result = dbethtx.get_ethereum_transactions(
                                 ETHTransactionsFilterQuery.make(tx_hash=internal_tx.parent_tx_hash),  # noqa: E501
                                 has_premium=True,  # ignore limiting here
                             )
                             if len(result) == 0:  # parent transaction is not in the DB. Get it
                                 transaction = self.ethereum.get_transaction_by_hash(internal_tx.parent_tx_hash)  # noqa: E501
+                                gevent.sleep(0)
                                 dbethtx.add_ethereum_transactions(
                                     ethereum_transactions=[transaction],
                                     relevant_address=address,
@@ -322,6 +325,7 @@ class EthTransactions:
                             has_premium=True,  # ignore limiting here
                         )
                         if len(result) == 0:  # if transaction is not there add it
+                            gevent.sleep(0)
                             transaction = self.ethereum.get_transaction_by_hash(tx_hash_bytes)
                             dbethtx.add_ethereum_transactions(
                                 [transaction],

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -45,7 +45,7 @@ from rotkehlchen.utils.misc import hex_or_bytes_to_int
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 ETHERSCAN_TX_QUERY_LIMIT = 10000
-TRANSACTIONS_BATCH_NUM = 20
+TRANSACTIONS_BATCH_NUM = 10
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -283,6 +283,7 @@ class Etherscan(ExternalServiceWithApiKey):
             result = self._query(module='account', action=action, options=options)
             last_ts = deserialize_timestamp(result[0]['timeStamp']) if len(result) != 0 else None  # noqa: E501 pylint: disable=unsubscriptable-object
             for entry in result:
+                gevent.sleep(0)
                 try:
                     tx = deserialize_ethereum_transaction(  # type: ignore
                         data=entry,
@@ -329,6 +330,7 @@ class Etherscan(ExternalServiceWithApiKey):
             result = self._query(module='account', action='tokentx', options=options)
             last_ts = deserialize_timestamp(result[0]['timeStamp']) if len(result) != 0 else None  # noqa: E501 pylint: disable=unsubscriptable-object
             for entry in result:
+                gevent.sleep(0)
                 timestamp = deserialize_timestamp(entry['timeStamp'])
                 if timestamp > last_ts and len(hashes) >= TRANSACTIONS_BATCH_NUM:  # type: ignore
                     yield _hashes_tuple_to_list(hashes)


### PR DESCRIPTION
Adding context switching for gevent during etherscan queries, and
general transaction querying.

This is an imperfect solution to the problem of observing timeouts in
the app with many addresses with lots of transactions.

The reason for this is that something is starving the app, and at some
point with too many long running tasks limits are being hit.