### PR TITLE
Remove cryptocompare special histohour case of COMP

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` COMP price before 20/06/2020 will not be hardcoded to $239.13 if queried via cryptocompare.
 * :bug:`4381` Fixes a problem at the DB upgrade between v1.23.4 and 1.24.0 which affected a subset of some kraken users.
 
 * :release:`1.24.0 <2022-05-27>`

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -1,5 +1,4 @@
 import os
-import warnings as test_warnings
 from datetime import datetime
 from typing import List
 from unittest.mock import patch
@@ -19,15 +18,8 @@ from rotkehlchen.constants.assets import (
     A_ETH,
     A_EUR,
     A_USD,
-    A_USDT,
 )
-from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.externalapis.cryptocompare import (
-    A_COMP,
-    CRYPTOCOMPARE_HOURQUERYLIMIT,
-    CRYPTOCOMPARE_SPECIAL_HISTOHOUR_CASES,
-    Cryptocompare,
-)
+from rotkehlchen.externalapis.cryptocompare import CRYPTOCOMPARE_HOURQUERYLIMIT, Cryptocompare
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
@@ -314,65 +306,6 @@ def test_cryptocompare_query_compound_tokens(
         to_asset=A_USD,
     )
     assert price is not None
-
-
-@pytest.mark.parametrize('from_asset, to_asset, timestamp, expected_price', [
-    (A_ETH, A_USD, Timestamp(1592629200), Price(ZERO)),
-    (A_COMP, A_COMP, Timestamp(1592629200), Price(ZERO)),  # both assets COMP
-    (A_USD, A_USD, Timestamp(1592629200), Price(ZERO)),  # both assets USD
-    (A_COMP, A_USDT, Timestamp(1592629200), Price(ZERO)),  # to_asset USDT
-    (A_USDT, A_COMP, Timestamp(1592629200), Price(ZERO)),  # from_asset USDT
-    (A_COMP, A_USD, Timestamp(1592629200), Price(FVal('239.13'))),
-    (A_USD, A_COMP, Timestamp(1592629200), Price(FVal('0.004181825785137791159620290219'))),
-    (A_COMP, A_USD, Timestamp(1592629201), Price(ZERO)),  # timestamp gt
-    (A_USD, A_COMP, Timestamp(1592629201), Price(ZERO)),  # timestamp gt
-])
-def test_check_and_get_special_histohour_price(
-        cryptocompare,
-        from_asset,
-        to_asset,
-        timestamp,
-        expected_price,
-):
-    """
-    Test expected prices are returned for different combinations of
-    `from_asset`, `to_asset` and `timestamp`.
-    """
-    price = cryptocompare._check_and_get_special_histohour_price(
-        from_asset=from_asset,
-        to_asset=to_asset,
-        timestamp=timestamp,
-    )
-    assert price == expected_price
-
-
-def test_keep_special_histohour_cases_up_to_date(cryptocompare):
-    """Test CRYPTOCOMPARE_SPECIAL_HISTOHOUR_CASES assets timestamps are still
-    valid by checking that for a smaller timestamp the response contains
-    entries with all price attributes at zero.
-    """
-    def is_price_not_valid(hour_price_data):
-        return all(hour_price_data[attr] == 0 for attr in ('low', 'high', 'open', 'close'))
-
-    limit = 10
-    for asset, asset_data in CRYPTOCOMPARE_SPECIAL_HISTOHOUR_CASES.items():
-        # Call `query_endpoint_histohour()` for handling special assets
-        to_timestamp = Timestamp(asset_data.timestamp - 3600)
-        from_timestamp = Timestamp(to_timestamp - limit * 3600)
-        response = cryptocompare.query_endpoint_histohour(
-            from_asset=asset,
-            to_asset=A_USD,
-            limit=limit,
-            to_timestamp=to_timestamp,
-        )
-        if not any(is_price_not_valid(price_data) for price_data in response['Data']):
-            warning_msg = (
-                f'Cryptocompare histohour API has non-zero prices for asset '
-                f'{asset.identifier} from {from_timestamp} to {to_timestamp}. '
-                f' Please, update CRYPTOCOMPARE_SPECIAL_HISTOHOUR_CASES dict '
-                f'with a smaller timestamp.'
-            )
-            test_warnings.warn(UserWarning(warning_msg))
 
 
 @pytest.mark.parametrize('include_cryptocompare_key', [True])


### PR DESCRIPTION
COMP price before 20/06/2020 will not be hardcoded to $239.13 if queried via cryptocompare.

