### PR TITLE
Properly display revoking approvals in ethereum transactions

### DIFF
--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -469,7 +469,8 @@ class EVMTransactionDecoder():
 
         amount_raw = hex_or_bytes_to_int(tx_log.data)
         amount = token_normalized_value(token_amount=amount_raw, token=token)
-        notes = f'Approve {amount} {token.symbol} of {owner_address} for spending by {spender_address}'  # noqa: E501
+        prefix = f'Revoke {token.symbol} approval' if amount == ZERO else f'Approve {amount} {token.symbol}'  # noqa: E501
+        notes = f'{prefix} of {owner_address} for spending by {spender_address}'
         return HistoryBaseEntry(
             event_identifier=transaction.tx_hash.hex(),
             sequence_index=self.base.get_sequence_index(tx_log),

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -91,7 +91,7 @@ def test_1inchv1_swap(database, ethereum_manager, function_scope_messages_aggreg
             asset=A_CHI,
             balance=Balance(),
             location_label=ADDY,
-            notes=f'Approve 0 CHI of {ADDY} for spending by {chispender_addy}',
+            notes=f'Revoke CHI approval of {ADDY} for spending by {chispender_addy}',
             counterparty=chispender_addy,
         ),
     ]


### PR DESCRIPTION
I was planning to put other fixes for kelsos' issue here but at least for now I can't reproduce it, so just pushing this commit to not lose it.