### PR TITLE
Replace the old trades queries for kucoin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`4378` Ask for users permission to access keychain only when `Remember Me` option at login screen is enabled.
 * :bug:`4384` Price caches filter should now be working again.
 * :bug:`-` Acquisitions for which no price can be found will still appear and not count as missing acquisitions.
+* :bug:`4122` Kucoin users should be able to retrieve information for old trades again.
 * :bug:`-` COMP price before 20/06/2020 will not be hardcoded to $239.13 if queried via cryptocompare.
 * :bug:`-` Prevent error while importing CSVs from cointracking when one trade row had a 0 amount bought.
 * :bug:`4381` Fixes a problem at the DB upgrade between v1.23.4 and 1.24.0 which affected a subset of some kraken users.

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -117,11 +117,6 @@ class KucoinCase(Enum):
 PAGINATED_CASES = (KucoinCase.OLD_TRADES, KucoinCase.TRADES, KucoinCase.DEPOSITS, KucoinCase.WITHDRAWALS)  # noqa: E501
 
 
-def _serialize_ts(time: Timestamp) -> Timestamp:
-    """Transform time from seconds to miliseconds"""
-    return Timestamp(time * 1000)
-
-
 def _deserialize_ts(case: KucoinCase, time: int) -> Timestamp:
     if case == KucoinCase.OLD_TRADES:
         return Timestamp(time)
@@ -365,11 +360,11 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             raise AssertionError(f'Unexpected case: {case}')
 
         call_options = options.copy()
-        call_options['startAt'] = _serialize_ts(max(start_ts, KUCOIN_LAUNCH_TS))
+        call_options['startAt'] = Timestamp(max(start_ts, KUCOIN_LAUNCH_TS) * 1000)
         while True:
             current_query_ts = _deserialize_ts(case, call_options['startAt'])
-            call_options['endAt'] = _serialize_ts(
-                time=min(Timestamp(current_query_ts + time_step), end_ts),
+            call_options['endAt'] = Timestamp(
+                min(Timestamp(current_query_ts + time_step), end_ts) * 1000,
             )
             logger.debug(
                 f'Querying kucoin {case} from {current_query_ts} to {call_options["endAt"]}',
@@ -458,7 +453,7 @@ class Kucoin(ExchangeInterface):  # lgtm[py/missing-call-to-init]
                 call_options['currentPage'] = current_page + 1
             else:
                 call_options['currentPage'] = 1
-            call_options['startAt'] = _serialize_ts(current_query_ts)
+            call_options['startAt'] = Timestamp(current_query_ts * 1000)
 
         return results
 

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -412,8 +412,8 @@ def test_deserialize_asset_movement_withdrawal(mock_kucoin):
 
 @pytest.mark.skip('Fails with status code: 404 and text: KC-API-KEY not exists')
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_query_balances_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unused-argument
-    assets_balance, msg = sandbox_kuckoin.query_balances()
+def test_query_balances_sandbox(sandbox_kucoin, inquirer):  # pylint: disable=unused-argument
+    assets_balance, msg = sandbox_kucoin.query_balances()
     assert assets_balance == {
         A_BTC: Balance(
             amount=FVal('2.61018067'),
@@ -437,7 +437,7 @@ def test_query_balances_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=u
 
 @pytest.mark.skip('Fails with status code: 404 and text: KC-API-KEY not exists')
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_query_trades_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unused-argument
+def test_query_trades_sandbox(sandbox_kucoin, inquirer):  # pylint: disable=unused-argument
     """The sandbox account has 6 trades. Below a list of the trades and their
     timestamps in ascending mode.
     - trade 1: 1612556651 -> skipped
@@ -504,7 +504,7 @@ def test_query_trades_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unu
             notes='',
         ),
     ]
-    trades, _ = sandbox_kuckoin.query_online_trade_history(
+    trades, _ = sandbox_kucoin.query_online_trade_history(
         start_ts=Timestamp(1612556693),
         end_ts=Timestamp(1612556765),
     )
@@ -513,7 +513,7 @@ def test_query_trades_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unu
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
 def test_query_asset_movements_sandbox(
-        sandbox_kuckoin,
+        sandbox_kucoin,
         inquirer,  # pylint: disable=unused-argument
 ):
     """Unfortunately the sandbox environment does not support deposits and
@@ -751,14 +751,14 @@ def test_query_asset_movements_sandbox(
         new=2,
     )
     api_query_patch = patch.object(
-        target=sandbox_kuckoin,
+        target=sandbox_kucoin,
         attribute='_api_query',
         side_effect=mock_api_query_response,
     )
     with ExitStack() as stack:
         stack.enter_context(months_in_seconds_patch)
         stack.enter_context(api_query_patch)
-        asset_movements = sandbox_kuckoin.query_online_deposits_withdrawals(
+        asset_movements = sandbox_kucoin.query_online_deposits_withdrawals(
             start_ts=Timestamp(1612556651),
             end_ts=Timestamp(1612556654),
         )
@@ -767,20 +767,20 @@ def test_query_asset_movements_sandbox(
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_query_old_trades_sandbox(sandbox_kuckoin, inquirer):  # pylint: disable=unused-argument
+def test_query_old_trades_sandbox(sandbox_kucoin, inquirer):  # pylint: disable=unused-argument
     """Test that the endpoint for old trades returns valid results from the api
     in very old timestamps
     """
-    trades, _ = sandbox_kuckoin.query_online_trade_history(
+    trades, _ = sandbox_kucoin.query_online_trade_history(
         start_ts=Timestamp(KUCOIN_LAUNCH_TS),
         end_ts=Timestamp(KUCOIN_LAUNCH_TS + WEEK_IN_SECONDS * 4),
     )
-    msg_aggregator = sandbox_kuckoin.msg_aggregator
+    msg_aggregator = sandbox_kucoin.msg_aggregator
     assert len(msg_aggregator.consume_errors()) == 0
     assert len(msg_aggregator.consume_warnings()) == 0
     assert trades == []
 
-    last_trades, _ = sandbox_kuckoin.query_online_trade_history(
+    last_trades, _ = sandbox_kucoin.query_online_trade_history(
         start_ts=Timestamp(1651425348),
         end_ts=Timestamp(1654110961),
     )

--- a/rotkehlchen/tests/fixtures/exchanges/kucoin.py
+++ b/rotkehlchen/tests/fixtures/exchanges/kucoin.py
@@ -45,19 +45,19 @@ def mock_kucoin(
 @pytest.fixture(name='kucoin_sandbox_api_key')
 def fixture_kucoin_sandbox_api_key():
     # General permission (aka read-only)
-    return '6023e471a2644e00063aa8bb'
+    return '6296162429c69200011e6d6f'
 
 
 @pytest.fixture(name='kucoin_sandbox_api_secret')
 def fixture_kucoin_sandbox_api_secret():
     # General permission (aka read-only)
-    return b'3a817593-eceb-47f3-90d4-26de79de588a'
+    return b'59df08af-5a6e-4893-9a8c-81e0d0a5b655'
 
 
 @pytest.fixture(name='kucoin_sandbox_passphrase')
 def fixture_kucoin_sandbox_passphrase():
     # General permission (aka read-only)
-    return 'rotkidev'
+    return 'rotkiapi'
 
 
 @pytest.fixture(name='kucoin_sandbox_base_uri')

--- a/rotkehlchen/tests/fixtures/exchanges/kucoin.py
+++ b/rotkehlchen/tests/fixtures/exchanges/kucoin.py
@@ -66,7 +66,7 @@ def fixture_kucoin_sandbox_base_uri():
 
 
 @pytest.fixture
-def sandbox_kuckoin(
+def sandbox_kucoin(
         database,
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,


### PR DESCRIPTION
the endpoint we were using got deprecated and we had to research an
alternative way of querying old trades from the exchange

Closes #4122 
