### PR TITLE
Properly handle decoding of special token case information

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`4401` The options for remember username and password are now separated.
 * :bug:`4386` Blockfi import for transactions now supports 'Crypto Transfer'
+* :bug:`4420` Transactions with the old WETH contract and other contracts that don't have decimals, symbol and name should now be decoded properly.
 * :bug:`4378` Ask for users permission to access keychain only when `Remember Me` option at login screen is enabled.
 * :bug:`4384` Price caches filter should now be working again.
 * :bug:`-` Acquisitions for which no price can be found will still appear and not count as missing acquisitions.

--- a/frontend/app/tests/e2e/specs/settings.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings.spec.ts
@@ -143,7 +143,7 @@ describe('settings', () => {
           '.accounting-settings__asset-to-ignore',
           '1CR'
         );
-        pageAccounting.ignoredAssetCount('20');
+        pageAccounting.ignoredAssetCount('21');
       });
       it('remove an ignored asset, validate UI message, and confirm count is 3', () => {
         pageAccounting.remIgnoredAsset('1SG');
@@ -151,7 +151,7 @@ describe('settings', () => {
           '.accounting-settings__ignored-assets',
           '1SG'
         );
-        pageAccounting.ignoredAssetCount('19');
+        pageAccounting.ignoredAssetCount('20');
       });
     });
   });
@@ -192,7 +192,7 @@ describe('settings', () => {
         '.accounting-settings__taxfree-period',
         'false'
       );
-      pageAccounting.ignoredAssetCount('19');
+      pageAccounting.ignoredAssetCount('20');
     });
   });
 });

--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -125,6 +125,11 @@ KNOWN_ETH_SPAM_TOKENS: Dict[ChecksumEthAddress, Dict[str, Any]] = {
         'symbol': 'Luna Token',
         'decimals': 18,
     },
+    string_to_ethereum_address('0x3baB61Ad5D103Bb5b203C9092Eb3a5e11677a5D0'): {
+        'name': 'ETH2Dao.net',
+        'symbol': 'ETH2DAO.net',
+        'decimals': 18,
+    },
 }
 
 


### PR DESCRIPTION
For some contracts like the old WETH contract that are missing name,
symbol and decimals we now properly handle the raised exception.

What's more since the decoded token is wrong, we can pre-populate the
token info cache with the special case of the old WETH contract as
many users presumably may hit this, with the proper values.

Fix https://github.com/rotki/rotki/issues/4420