### PR TITLE
Temporarily remove transaction event filtering from the backend

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`4383` Removing an address while running a PnL report should now work.
+* :bug:`4379` For many ethereum transactions the entire app should no longer hang. This is a temporary fix until a proper one is implemented. With this fix we temporarily remove the ability to filter in the ethereum transactions view.
 * :bug:`4398` Fix asset type selection that cannot be enabled for new asset addition.
 * :feature:`4401` The options for remember username and password are now separated.
 * :bug:`4386` Blockfi import for transactions now supports 'Crypto Transfer'

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -308,13 +308,14 @@ class ETHTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
             order_by_rules: Optional[List[Tuple[str, bool]]] = None,
             limit: Optional[int] = None,
             offset: Optional[int] = None,
-            addresses: Optional[List[ChecksumEthAddress]] = None,
+            # temporary unused argument here and below. Remove warning later.
+            addresses: Optional[List[ChecksumEthAddress]] = None,  # pylint: disable=unused-argument  # noqa: E501
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
             tx_hash: Optional[EVMTxHash] = None,
-            protocols: Optional[List[str]] = None,  # Events data
-            asset: Optional[Asset] = None,  # Events data
-            exclude_ignored_assets: bool = False,  # Events data
+            protocols: Optional[List[str]] = None,  # pylint: disable=unused-argument
+            asset: Optional[Asset] = None,  # pylint: disable=unused-argument
+            exclude_ignored_assets: bool = False,  # pylint: disable=unused-argument
     ) -> 'ETHTransactionsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -330,20 +331,21 @@ class ETHTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
         if tx_hash is not None:  # tx_hash means single result so make it as single filter
             filters.append(DBETHTransactionHashFilter(and_op=False, tx_hash=tx_hash))
         else:
-            should_join_events = asset is not None or protocols is not None or exclude_ignored_assets is True  # noqa: E501
-            if addresses is not None or should_join_events is True:
-                filter_query.join_clause = DBETHTransactionJoinsFilter(
-                    and_op=False,
-                    addresses=addresses,
-                    should_join_events=should_join_events,
-                )
+            # temporary to remove filtering https://github.com/rotki/rotki/issues/4379
+            # should_join_events = asset is not None or protocols is not None or exclude_ignored_assets is True  # noqa: E501
+            # if addresses is not None or should_join_events is True:
+            #     filter_query.join_clause = DBETHTransactionJoinsFilter(
+            #         and_op=False,
+            #         addresses=addresses,
+            #         should_join_events=should_join_events,
+            #     )
 
-            if asset is not None:
-                filters.append(DBAssetFilter(and_op=True, asset=asset, asset_key='asset'))
-            if protocols is not None:
-                filters.append(DBProtocolsFilter(and_op=True, protocols=protocols))
-            if exclude_ignored_assets is True:
-                filters.append(DBIgnoredAssetsFilter(and_op=True, asset_key='asset'))
+            # if asset is not None:
+            #     filters.append(DBAssetFilter(and_op=True, asset=asset, asset_key='asset'))
+            # if protocols is not None:
+            #     filters.append(DBProtocolsFilter(and_op=True, protocols=protocols))
+            # if exclude_ignored_assets is True:
+            #     filters.append(DBIgnoredAssetsFilter(and_op=True, asset_key='asset'))
 
             filter_query.timestamp_filter = DBTimestampFilter(
                 and_op=True,

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -592,9 +592,13 @@ def test_query_transactions_over_limit(
                 queried_ranges=[(start_ts, end_ts)],
             )
 
-    free_expected_entries_total = [FREE_ETH_TX_LIMIT - 35, 35]
-    free_expected_entries_found = [FREE_ETH_TX_LIMIT - 10, 60]
-    premium_expected_entries = [FREE_ETH_TX_LIMIT - 10, 60]
+    # TODO: Restore the commented out checks when filtering is back
+    # free_expected_entries_total = [FREE_ETH_TX_LIMIT - 35, 35]
+    free_expected_entries_total = [FREE_ETH_TX_LIMIT, FREE_ETH_TX_LIMIT]
+    # free_expected_entries_found = [FREE_ETH_TX_LIMIT - 10, 60]
+    free_expected_entries_found = [all_transactions_num, all_transactions_num]
+    # premium_expected_entries = [FREE_ETH_TX_LIMIT - 10, 60]
+    premium_expected_entries = [all_transactions_num, all_transactions_num]
 
     # Check that we get all transactions correctly even if we query two times
     for _ in range(2):
@@ -680,25 +684,26 @@ def test_query_transactions_from_to_address(
                 queried_ranges=[(start_ts, end_ts)],
             )
 
-    expected_entries = {ethereum_accounts[0]: 3, ethereum_accounts[1]: 1}
-    # Check that we get all transactions correctly even if we query two times
-    for _ in range(2):
-        for address in ethereum_accounts:
-            response = requests.get(
-                api_url_for(
-                    rotkehlchen_api_server,
-                    'ethereumtransactionsresource',
-                ), json={
-                    'from_timestamp': start_ts,
-                    'to_timestamp': end_ts,
-                    'address': address,
-                },
-            )
-            result = assert_proper_response_with_result(response)
-            assert len(result['entries']) == expected_entries[address]
-            assert result['entries_limit'] == FREE_ETH_TX_LIMIT
-            assert result['entries_found'] == expected_entries[address]
-            assert result['entries_total'] == 3
+    # TODO: Restore commented out check once filtering is back
+    # expected_entries = {ethereum_accounts[0]: 3, ethereum_accounts[1]: 1}
+    # # Check that we get all transactions correctly even if we query two times
+    # for _ in range(2):
+    #     for address in ethereum_accounts:
+    #         response = requests.get(
+    #             api_url_for(
+    #                 rotkehlchen_api_server,
+    #                 'ethereumtransactionsresource',
+    #             ), json={
+    #                 'from_timestamp': start_ts,
+    #                 'to_timestamp': end_ts,
+    #                 'address': address,
+    #             },
+    #         )
+    #         result = assert_proper_response_with_result(response)
+    #         assert len(result['entries']) == expected_entries[address]
+    #         assert result['entries_limit'] == FREE_ETH_TX_LIMIT
+    #         assert result['entries_found'] == expected_entries[address]
+    #         assert result['entries_total'] == 3
 
 
 @pytest.mark.parametrize('number_of_eth_accounts', [2])
@@ -868,28 +873,29 @@ def test_transaction_same_hash_same_nonce_two_tracked_accounts(
         assert result['entries_found'] == 2
         assert result['entries_total'] == 2
 
-        response = requests.get(
-            api_url_for(
-                rotkehlchen_api_server,
-                'per_address_ethereum_transactions_resource',
-                address=ethereum_accounts[0],
-            ),
-        )
-        result = assert_proper_response_with_result(response)
-        assert len(result['entries']) == 1
-        assert result['entries_found'] == 1
-        assert result['entries_total'] == 2
-        response = requests.get(
-            api_url_for(
-                rotkehlchen_api_server,
-                'per_address_ethereum_transactions_resource',
-                address=ethereum_accounts[1],
-            ),
-        )
-        result = assert_proper_response_with_result(response)
-        assert len(result['entries']) == 2
-        assert result['entries_found'] == 2
-        assert result['entries_total'] == 2
+        # TODO: Restore those checks once filtering is back
+        # response = requests.get(
+        #     api_url_for(
+        #         rotkehlchen_api_server,
+        #         'per_address_ethereum_transactions_resource',
+        #         address=ethereum_accounts[0],
+        #     ),
+        # )
+        # result = assert_proper_response_with_result(response)
+        # assert len(result['entries']) == 1
+        # assert result['entries_found'] == 1
+        # assert result['entries_total'] == 2
+        # response = requests.get(
+        #     api_url_for(
+        #         rotkehlchen_api_server,
+        #         'per_address_ethereum_transactions_resource',
+        #         address=ethereum_accounts[1],
+        #     ),
+        # )
+        # result = assert_proper_response_with_result(response)
+        # assert len(result['entries']) == 2
+        # assert result['entries_found'] == 2
+        # assert result['entries_total'] == 2
 
 
 @pytest.mark.parametrize('ethereum_accounts', [['0x6e15887E2CEC81434C16D587709f64603b39b545']])
@@ -1107,6 +1113,7 @@ def test_query_transactions_check_decoded_events(
     assert dbevents.get_history_events(HistoryEventFilterQuery.make(), True) == []
 
 
+@pytest.mark.skip('Temporarily skip until filtering is restored')
 def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
     """Tests filtering by transaction's events' properties
     Test cases:
@@ -1210,6 +1217,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
     assert result['entries'] == expected
 
 
+@pytest.mark.skip('Temporarily skip until filtering is restored')
 def test_ignored_assets(rotkehlchen_api_server, ethereum_accounts):
     """This test tests that transactions with ignored assets are excluded when needed"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen

--- a/rotkehlchen/tests/db/test_db_filters.py
+++ b/rotkehlchen/tests/db/test_db_filters.py
@@ -13,6 +13,7 @@ from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import Location, Timestamp
 
 
+@pytest.mark.skip('Temporarily skip until filtering is restored')
 def test_ethereum_transaction_filter():
     addresses = [make_ethereum_address()]
     filter_query = ETHTransactionsFilterQuery.make(

--- a/rotkehlchen/tests/db/test_ethtx.py
+++ b/rotkehlchen/tests/db/test_ethtx.py
@@ -109,9 +109,10 @@ def test_add_get_ethereum_transactions(data_dir, username):
     result = dbethtx.get_ethereum_transactions(ETHTransactionsFilterQuery.make(tx_hash=b'dsadsad'), has_premium=True)  # noqa: E501
     assert result == []
 
+    # TODO: Uncomment this when filtering is restored
     # Now try transaction by relevant addresses
-    result = dbethtx.get_ethereum_transactions(ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS1, make_ethereum_address()]), has_premium=True)  # noqa: E501
-    assert result == [tx1, tx3]
+    # result = dbethtx.get_ethereum_transactions(ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS1, make_ethereum_address()]), has_premium=True)  # noqa: E501
+    # assert result == [tx1, tx3]
 
 
 def test_query_also_internal_ethereum_transactions(data_dir, username):
@@ -247,30 +248,31 @@ def test_query_also_internal_ethereum_transactions(data_dir, username):
     assert len(errors) == 0
     assert len(warnings) == 0
 
-    result, total_filter_count = dbethtx.get_ethereum_transactions_and_limit_info(
-        ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS3]),
-        has_premium=True,
-    )
-    assert {x.tx_hash for x in result} == {b'1', b'3', b'4'}
-    assert total_filter_count == 3
+    # TODO: Uncomment these when filtering is restored
+    # result, total_filter_count = dbethtx.get_ethereum_transactions_and_limit_info(
+    #     ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS3]),
+    #     has_premium=True,
+    # )
+    # assert {x.tx_hash for x in result} == {b'1', b'3', b'4'}
+    # assert total_filter_count == 3
 
-    # Now try transaction query by relevant addresses and see we get more due to the
-    # internal tx mappings
-    result, total_filter_count = dbethtx.get_ethereum_transactions_and_limit_info(
-        ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS1]),
-        has_premium=True,
-    )
-    assert result == [tx1, tx3, tx4, tx5]
-    assert total_filter_count == 4
+    # # Now try transaction query by relevant addresses and see we get more due to the
+    # # internal tx mappings
+    # result, total_filter_count = dbethtx.get_ethereum_transactions_and_limit_info(
+    #     ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS1]),
+    #     has_premium=True,
+    # )
+    # assert result == [tx1, tx3, tx4, tx5]
+    # assert total_filter_count == 4
 
-    result = dbethtx.get_ethereum_transactions(
-        ETHTransactionsFilterQuery.make(addresses=[address_4]),
-        has_premium=True,
-    )
-    assert result == [tx3]
+    # result = dbethtx.get_ethereum_transactions(
+    #     ETHTransactionsFilterQuery.make(addresses=[address_4]),
+    #     has_premium=True,
+    # )
+    # assert result == [tx3]
 
-    result = dbethtx.get_ethereum_transactions(
-        ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS3]),
-        has_premium=True,
-    )
-    assert result == [tx1, tx3, tx4]
+    # result = dbethtx.get_ethereum_transactions(
+    #     ETHTransactionsFilterQuery.make(addresses=[ETH_ADDRESS3]),
+    #     has_premium=True,
+    # )
+    # assert result == [tx1, tx3, tx4]


### PR DESCRIPTION
The filtering query uses a really bad DB query that kills the entire
app

```
SELECT DISTINCT ethereum_transactions.tx_hash, timestamp,
block_number, from_address, to_address, value, gas, gas_price,
gas_used, input_data, nonce FROM  ethereum_transactions  LEFT
JOIN (SELECT event_identifier, counterparty, asset FROM
history_events) ON
lower(hex(ethereum_transactions.tx_hash))=lower(substr(event_identifier,
3)) WHERE 1  AND ((asset IS NULL OR asset NOT IN (SELECT value FROM
multisettings WHERE name="ignored_asset")) AND (timestamp >= 0 AND
timestamp <= 1654249739)) ORDER BY timestamp DESC LIMIT 20 OFFSET 0;
```

We need to optimize and fix the DB schema for this, but until then for
the patch release we will simply remove filtering.

Fix https://github.com/rotki/rotki/issues/4379