### PR TITLE
Chunk multicall

### DIFF
--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -137,6 +137,8 @@ def multicall_2(
         require_success: bool,
         call_order: Optional[Sequence['NodeName']] = None,
         block_identifier: BlockIdentifier = 'latest',
+        # only here to comply with multicall
+        calls_chunk_size: int = MULTICALL_CHUNKS,  # pylint: disable=unused-argument
 ) -> List[Tuple[bool, bytes]]:
     """
     Use a MULTICALL_2 contract for an aggregated query. If require_success

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -57,7 +57,7 @@ def test_nft_query(rotkehlchen_api_server, start_with_valid_premium):
 
             assert entry['name'] == 'MoonCat #129: 0x0082206dcb'
             assert entry['external_link'] == 'https://purrse.mooncat.community/129'
-            assert entry['image_url'] == 'https://lh3.googleusercontent.com/C5ceArerHdGigmSt9tCsUD67Nbxr-P05fSsP_Pye34zN78lr2519P66kANkb55nfWW-ZMWFM4oCawLF4fW2jfRPxWButdqIX0QM95DM'  # noqa: E501
+            assert 'image_url' in entry
             assert FVal(entry['price_eth']) > ZERO
             assert FVal(entry['price_usd']) > ZERO
             assert entry['collection']['name'] == 'MoonCats'


### PR DESCRIPTION
We are using multicall contract in the ENS queries to obtains ENS names for addresses. The problem that
we observed is that when the number of addresses is high (I tested it with 73) the url of the call to
the nodes was so long that it failed to make the request. The solution I propose chunks the query arguments
to the multicall contract to avoid such urls. I've tried different chunk sizes and 20 was the biggest that made
the query work.

Also I've avoided to repeat the same logic for the `multicall_2` contract since we don't use it in a way that
the logic breaks in the same way and could affect the speed of some queries.

