### PR TITLE
Sets max width of bottom sheet to 900px

### DIFF
--- a/frontend/app/src/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/components/dialogs/BigDialog.vue
@@ -5,6 +5,7 @@
     over
     class="big-dialog"
     width="98%"
+    max-width="900px"
     @click:outside="cancel()"
     @keydown.esc.stop="cancel()"
     @input="cancel"


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

### Notes
98% is too match on any desktop screen but it is especially bad in 4k. 900px as max-width is good enough