### PR TITLE
Fix missing fiat acquisitions bug

### DIFF
--- a/rotkehlchen/accounting/cost_basis/base.py
+++ b/rotkehlchen/accounting/cost_basis/base.py
@@ -249,9 +249,7 @@ class CostBasisCalculator(CustomizableDateMixin):
         """Searches all acquisition events for asset and reduces them by amount.
 
         Returns True if enough acquisition events to reduce the asset by amount were
-        found and False otherwise.
-
-        In the case of insufficient acquisition amounts a critical error is logged.
+        found and False otherwise. Adds missing acquisition only if asset is not fiat.
 
         This function does the same as calculate_spend_cost_basis as far as consuming
         acquisitions is concerned but does not calculate bought cost.
@@ -284,14 +282,15 @@ class CostBasisCalculator(CustomizableDateMixin):
         if remaining_amount_from_last_buy != FVal('-1'):
             asset_events.acquisitions[0].remaining_amount = remaining_amount_from_last_buy
         elif remaining_amount != ZERO:
-            self.missing_acquisitions.append(
-                MissingAcquisition(
-                    asset=asset,
-                    time=timestamp,
-                    found_amount=amount - remaining_amount,
-                    missing_amount=remaining_amount,
-                ),
-            )
+            if not asset.is_fiat():
+                self.missing_acquisitions.append(
+                    MissingAcquisition(
+                        asset=asset,
+                        time=timestamp,
+                        found_amount=amount - remaining_amount,
+                        missing_amount=remaining_amount,
+                    ),
+                )
             return False
 
         return True


### PR DESCRIPTION
Fix missing fiat acquisitions bug
Now `reduce_asset_amount` doesn't add a missing acquisition if asset is fiat.