### PR TITLE
Fix the rotki cover image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # rotki
-
-<img src="https://raw.githubusercontent.com/rotkehlchenio/rotkehlchen/develop/frontend/app/src/assets/images/rotkehlchen_no_text.png" width="250">
+<img src="https://raw.githubusercontent.com/rotki/rotki/develop/frontend/app/public/assets/images/rotkehlchen_no_text.png" width="250">
 
 rotki is an open source portfolio tracking, analytics, accounting and tax reporting tool that respects your privacy.  The mission of rotki is to bring transparency into the crypto and financial sectors through the use of open source. Most importantly unlike virtually every other competing service which consists of closed source SaaS onto which you are forced to hand over all your financial data, with rotki your data is stored encrypted locally in your computer. It enables you to take ownership of your financial data!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rotki
+
 <img src="https://raw.githubusercontent.com/rotki/rotki/develop/frontend/app/public/assets/images/rotkehlchen_no_text.png" width="250">
 
 rotki is an open source portfolio tracking, analytics, accounting and tax reporting tool that respects your privacy.  The mission of rotki is to bring transparency into the crypto and financial sectors through the use of open source. Most importantly unlike virtually every other competing service which consists of closed source SaaS onto which you are forced to hand over all your financial data, with rotki your data is stored encrypted locally in your computer. It enables you to take ownership of your financial data!


### PR DESCRIPTION
Closes #(issue_number)

The cover image links to personal URL (@rotkehlchenio) instead of the public url

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
