### PR TITLE
Move detect_sqlcipher_version to db/utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN if [ "$TARGETARCH" != "amd64" ]; then \
     fi
 
 RUN pip install -e . && \
-    python -c "import sys;from rotkehlchen.db.dbhandler import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)" && \
+    python -c "import sys;from rotkehlchen.db.misc import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)" && \
     PYTHONOPTIMIZE=2 pyinstaller --noconfirm --clean --exclude-module debugimporter --distpath /tmp/dist rotkehlchen.spec
 
 FROM nginx:1.21 as runtime

--- a/package.py
+++ b/package.py
@@ -811,7 +811,7 @@ class BackendBuilder:
     def __sanity_check(self) -> None:
         os.chdir(self.__storage.working_directory)
         ret_code = subprocess.call(
-            'python -c "import sys;from rotkehlchen.db.dbhandler import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)"',  # noqa: E501
+            'python -c "import sys;from rotkehlchen.db.misc import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)"',  # noqa: E501
             shell=True,
         )
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -73,6 +73,7 @@ from rotkehlchen.db.eth2 import ETH2_DEPOSITS_PREFIX
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.db.filtering import AssetMovementsFilterQuery, TradesFilterQuery
 from rotkehlchen.db.loopring import DBLoopring
+from rotkehlchen.db.misc import detect_sqlcipher_version
 from rotkehlchen.db.schema import DB_SCRIPT_CREATE_TABLES
 from rotkehlchen.db.schema_transient import DB_SCRIPT_CREATE_TRANSIENT_TABLES
 from rotkehlchen.db.settings import (
@@ -188,21 +189,6 @@ def _protect_password_sqlcipher(password: str) -> str:
     source: https://stackoverflow.com/a/603579/110395
 """
     return password.replace(r'"', r'""')
-
-
-def detect_sqlcipher_version() -> int:
-    """Returns the major part of the version of the system's sqlcipher package"""
-    conn = DBConnection(path=':memory:', use_sqlcipher=True)
-    query = conn.execute('PRAGMA cipher_version;')
-    version = query.fetchall()[0][0]
-
-    match = re.search(r'(\d+).(\d+).(\d+)', version)
-    if not match:
-        raise ValueError(f'Could not process the version returned by sqlcipher: {version}')
-
-    sqlcipher_version = int(match.group(1))
-    conn.close()
-    return sqlcipher_version
 
 
 def db_tuple_to_str(

--- a/rotkehlchen/db/misc.py
+++ b/rotkehlchen/db/misc.py
@@ -1,0 +1,22 @@
+"""A module with miscellaneous functions that do not depend on db/drivers/gevent.py
+due. Needed in packaging since that code has log.trace and should only be
+imported if trace level has been setup"""
+
+import re
+
+from pysqlcipher3 import dbapi2 as sqlcipher
+
+
+def detect_sqlcipher_version() -> int:
+    """Returns the major part of the version of the system's sqlcipher package"""
+    conn = sqlcipher.connect(':memory:')  # pylint: disable=no-member
+    query = conn.execute('PRAGMA cipher_version;')
+    version = query.fetchall()[0][0]
+
+    match = re.search(r'(\d+).(\d+).(\d+)', version)
+    if not match:
+        raise ValueError(f'Could not process the version returned by sqlcipher: {version}')
+
+    sqlcipher_version = int(match.group(1))
+    conn.close()
+    return sqlcipher_version

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -15,8 +15,9 @@ from rotkehlchen.constants import ONE, YEAR_IN_SECONDS
 from rotkehlchen.constants.assets import A_1INCH, A_BTC, A_DAI, A_ETH, A_ETH2, A_USD
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.data_handler import DataHandler
-from rotkehlchen.db.dbhandler import DBHandler, detect_sqlcipher_version
+from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.filtering import AssetMovementsFilterQuery, TradesFilterQuery
+from rotkehlchen.db.misc import detect_sqlcipher_version
 from rotkehlchen.db.queried_addresses import QueriedAddresses
 from rotkehlchen.db.settings import (
     DEFAULT_ACCOUNT_FOR_ASSETS_MOVEMENTS,


### PR DESCRIPTION
This way we avoid importing anything that logs at trace. So the sanity
check of packaging (also in Dockerfile) does not hit an attribute
error for log.trace.