### PR TITLE
Fix async db yielding

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1382,7 +1382,8 @@ class RestAPI():
                 # Before deleting, also make sure we have up to date global DB owned data
                 self.rotkehlchen.data.db.update_owned_assets_in_globaldb(cursor)
                 self.rotkehlchen.data.db.delete_asset_identifier(cursor, identifier)
-                GlobalDBHandler().delete_custom_asset(identifier)
+                with GlobalDBHandler().conn.write_ctx() as cursor:
+                    GlobalDBHandler().delete_custom_asset(cursor, identifier)
         except InputError as e:
             return api_response(wrap_in_fail_result(str(e)), status_code=HTTPStatus.CONFLICT)
 
@@ -1463,7 +1464,8 @@ class RestAPI():
                 # Before deleting, also make sure we have up to date global DB owned data
                 self.rotkehlchen.data.db.update_owned_assets_in_globaldb(cursor)
                 self.rotkehlchen.data.db.delete_asset_identifier(cursor, ethaddress_to_identifier(address))  # noqa: E501
-                identifier = GlobalDBHandler().delete_ethereum_token(address=address)
+                with GlobalDBHandler().conn.write_ctx() as gcursor:
+                    identifier = GlobalDBHandler().delete_ethereum_token(write_cursor=gcursor, address=address)  # noqa: E501
         except InputError as e:
             return api_response(wrap_in_fail_result(str(e)), status_code=HTTPStatus.CONFLICT)
 

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -947,7 +947,8 @@ class HasEthereumToken(Asset):
         object.__setattr__(self, 'decimals', data.decimals)
         object.__setattr__(self, 'protocol', data.protocol)
 
-        underlying_tokens = GlobalDBHandler().fetch_underlying_tokens(data.ethereum_address)
+        with GlobalDBHandler().conn.read_ctx() as cursor:
+            underlying_tokens = GlobalDBHandler().fetch_underlying_tokens(cursor, data.ethereum_address)  # noqa: E501
         object.__setattr__(self, 'underlying_tokens', underlying_tokens)
 
     def serialize_all_info(self) -> Dict[str, Any]:

--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -4,9 +4,11 @@ but heavily modified"""
 
 import sqlite3
 from contextlib import contextmanager
+from enum import Enum, auto
 from pathlib import Path
+from random import randint
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Generator, List, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Sequence, Type, Union
 
 import gevent
 from pysqlcipher3 import dbapi2 as sqlcipher
@@ -44,10 +46,8 @@ class DBCursor:
         """  # noqa: E501
         if __debug__:
             logger.trace(f'Get next item for cursor {self._cursor}')
-        self.connection.enter_critical_section()
         result = next(self._cursor, None)
         if result is None:
-            self.connection.exit_critical_section()
             raise StopIteration()
 
         if __debug__:
@@ -131,39 +131,88 @@ class DBCursor:
         self._cursor.close()
 
 
-def progress_callback() -> int:
-    if __debug__:
-        logger.trace('Got in the progress callback')
-    gevent.sleep(0)
-    if __debug__:
-        logger.trace('Going out of the progress callback')
-    return 0
+class DBConnectionType(Enum):
+    USER = auto()
+    TRANSIENT = auto()
+    GLOBAL = auto()
+
+
+# This is a global connection map to be able to get the connection from inside the
+# progress handler. Having a global mapping and 3 different progress callbacks is
+# a sort of ugly hack. If anybody knows of a better way to make it work let's improve it.
+# With this approach we have named connections and a different progress callback per connection.
+CONNECTION_MAP: Dict[DBConnectionType, 'DBConnection'] = {}
+
+
+def _progress_callback(connection: Optional['DBConnection']) -> int:
+    """Needs to be a static function. Cannot be a connection class method
+    or sqlite breaks in funny ways. Raises random Operational errors.
+    """
+    if connection is None:
+        return 0
+
+    with connection.in_callback:
+        if __debug__:
+            logger.trace('Got in the progress callback')
+        gevent.sleep(0)
+        if __debug__:
+            logger.trace('Going out of the progress callback')
+        return 0
+
+
+def user_callback() -> int:
+    connection = CONNECTION_MAP.get(DBConnectionType.USER)
+    return _progress_callback(connection)
+
+
+def transient_callback() -> int:
+    connection = CONNECTION_MAP.get(DBConnectionType.TRANSIENT)
+    return _progress_callback(connection)
+
+
+def global_callback() -> int:
+    connection = CONNECTION_MAP.get(DBConnectionType.GLOBAL)
+    return _progress_callback(connection)
+
+
+CALLBACK_MAP = {
+    DBConnectionType.USER: user_callback,
+    DBConnectionType.TRANSIENT: transient_callback,
+    DBConnectionType.GLOBAL: global_callback,
+}
 
 
 class DBConnection:
 
-    def __init__(self, path: Union[str, Path], use_sqlcipher: bool) -> None:
-        self._conn: UnderlyingConnection
-        if use_sqlcipher is True:
-            self._conn = sqlcipher.connect(path, check_same_thread=False)  # pylint: disable=no-member  # noqa: E501
-        else:
-            self._conn = sqlite3.connect(path, check_same_thread=False)
+    def _set_progress_handler(self) -> None:
+        callback = CALLBACK_MAP.get(self.connection_type)
+        # https://github.com/python/typeshed/issues/8105
+        self._conn.set_progress_handler(callback, SQL_VM_INSTRUCTIONS_CB)  # type: ignore
 
+    def __init__(self, path: Union[str, Path], connection_type: DBConnectionType) -> None:
+        self._conn: UnderlyingConnection
         self._in_critical_section = False
-        self._conn.set_progress_handler(progress_callback, SQL_VM_INSTRUCTIONS_CB)
+        self.in_callback = gevent.lock.Semaphore()
+        self.connection_type = connection_type
+        if connection_type == DBConnectionType.GLOBAL:
+            self._conn = sqlite3.connect(path, check_same_thread=False)
+        else:
+            self._conn = sqlcipher.connect(path, check_same_thread=False)  # pylint: disable=no-member  # noqa: E501
+        self._set_progress_handler()
+        CONNECTION_MAP[connection_type] = self
 
     def enter_critical_section(self) -> None:
-        if __debug__:
-            logger.trace('entering critical section')
-        self._in_critical_section = True
-        self._conn.set_progress_handler(None, 0)
+        with self.in_callback:
+            if __debug__:
+                logger.trace('entering critical section')
+            self._in_critical_section = True
+            self._conn.set_progress_handler(None, 0)
 
     def exit_critical_section(self) -> None:
         if __debug__:
             logger.trace('exiting critical section')
         self._in_critical_section = False
-        # https://github.com/python/typeshed/issues/8105
-        self._conn.set_progress_handler(progress_callback, SQL_VM_INSTRUCTIONS_CB)  # type: ignore
+        self._set_progress_handler()
 
     def execute(self, statement: str, *bindings: Sequence) -> DBCursor:
         if __debug__:
@@ -217,6 +266,7 @@ class DBConnection:
 
     def close(self) -> None:
         self._conn.close()
+        del CONNECTION_MAP[self.connection_type]
 
     @contextmanager
     def read_ctx(self) -> Generator['DBCursor', None, None]:

--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -6,7 +6,6 @@ import sqlite3
 from contextlib import contextmanager
 from enum import Enum, auto
 from pathlib import Path
-from random import randint
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Sequence, Type, Union
 
@@ -279,6 +278,7 @@ class DBConnection:
     @contextmanager
     def write_ctx(self) -> Generator['DBCursor', None, None]:
         cursor = self.cursor()
+        self.enter_critical_section()
         try:
             yield cursor
         except Exception:
@@ -288,6 +288,7 @@ class DBConnection:
             self._conn.commit()
         finally:
             cursor.close()  # lgtm [py/should-use-with]
+            self.exit_critical_section()
 
     @property
     def total_changes(self) -> int:

--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -265,7 +265,7 @@ class DBConnection:
 
     def close(self) -> None:
         self._conn.close()
-        del CONNECTION_MAP[self.connection_type]
+        CONNECTION_MAP.pop(self.connection_type, None)
 
     @contextmanager
     def read_ctx(self) -> Generator['DBCursor', None, None]:

--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -22,7 +22,7 @@ UnderlyingConnection = Union[sqlite3.Connection, sqlcipher.Connection]  # pylint
 import logging
 
 logger: 'RotkehlchenLogger' = logging.getLogger(__name__)  # type: ignore
-SQL_VM_INSTRUCTIONS_CB = 100
+SQL_VM_INSTRUCTIONS_CB = 1000
 
 
 class DBCursor:

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -22,7 +22,7 @@ from rotkehlchen.chain.ethereum.types import string_to_ethereum_address
 from rotkehlchen.constants.assets import CONSTANT_ASSETS
 from rotkehlchen.constants.misc import NFT_DIRECTIVE
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
-from rotkehlchen.db.drivers.gevent import DBConnection, DBCursor
+from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType, DBCursor
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -55,7 +55,7 @@ def _get_setting_value(cursor: DBCursor, name: str, default_value: int) -> int:
 
 
 def initialize_globaldb(dbpath: Path) -> DBConnection:
-    connection = DBConnection(path=dbpath, use_sqlcipher=False)
+    connection = DBConnection(path=dbpath, connection_type=DBConnectionType.GLOBAL)
     connection.executescript(DB_SCRIPT_CREATE_TABLES)
     cursor = connection.cursor()
     db_version = _get_setting_value(cursor, 'version', GLOBAL_DB_VERSION)

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -635,7 +635,9 @@ class Inquirer():
         """
         assert self._ethereum is not None, 'Inquirer ethereum manager should have been initialized'  # noqa: E501
 
-        maybe_underlying_token = GlobalDBHandler().fetch_underlying_tokens(token.ethereum_address)
+        globaldb = GlobalDBHandler()
+        with globaldb.conn.read_ctx() as cursor:
+            maybe_underlying_token = globaldb.fetch_underlying_tokens(cursor, token.ethereum_address)  # noqa: E501
         if maybe_underlying_token is None or len(maybe_underlying_token) != 1:
             log.error(f'Yearn vault token {token} without an underlying asset')
             return None

--- a/rotkehlchen/tests/db/test_async.py
+++ b/rotkehlchen/tests/db/test_async.py
@@ -1,0 +1,72 @@
+from random import randint, uniform
+
+import gevent
+
+from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType
+from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.db.filtering import LedgerActionsFilterQuery
+from rotkehlchen.db.ledger_actions import DBLedgerActions
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import Location
+
+
+def make_ledger_action():
+    return LedgerAction(
+        identifier=1,
+        timestamp=randint(1, 16433333),
+        asset=A_ETH,
+        action_type=LedgerActionType.INCOME,
+        location=Location.BLOCKCHAIN,
+        amount=FVal(randint(1, 1642323)),
+        rate=FVal(uniform(0.00001, 5)),
+        link='dasd',
+        notes='asdsad',
+    )
+
+
+def write_actions(database, num):
+    actions = [make_ledger_action() for _ in range(1, num)]
+    query = """
+    INSERT INTO ledger_actions(
+    timestamp, type, location, amount, asset, rate, rate_asset, link, notes
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"""
+    with database.user_write() as cursor:
+        cursor.executemany(query, [x.serialize_for_db() for x in actions])
+
+
+def read_actions(database, limit, msg_aggregator):
+    dbla = DBLedgerActions(database, msg_aggregator)
+    with database.conn.read_ctx() as cursor:
+        dbla.get_ledger_actions(
+            cursor,
+            LedgerActionsFilterQuery.make(limit=limit),
+            has_premium=True,
+        )
+
+
+def test_async_segfault(database, function_scope_messages_aggregator):
+    """Test that the async and sqlite progress handler segfault yielding bug does not hit us
+
+    The bug can be summed up as following:
+    1. Get in the progress callback
+    2. Context switch out of the callback with sleep(0)
+    3. Enter critical section, which essentially disables the callback
+    4. Write/read more data in the DB
+    5. Exit critical section, re-enabling the callback
+    6. Context switch back to the progress callback of (1) and exit it.
+    7. Segmentation fault.
+    """
+    # first write some data in the DB to have enough data to read.
+    write_actions(database, 1000)
+
+    # Then start reading from one greenlet and writing from others to create the problem
+    a = gevent.spawn(
+        read_actions,
+        database=database,
+        limit=100,
+        msg_aggregator=function_scope_messages_aggregator,
+    )
+    b = gevent.spawn(write_actions, database=database, num=200)
+    c = gevent.spawn(write_actions, database=database, num=200)
+    gevent.joinall([a, b, c])

--- a/rotkehlchen/tests/unit/test_globaldb.py
+++ b/rotkehlchen/tests/unit/test_globaldb.py
@@ -58,8 +58,9 @@ bidr_asset_data = AssetData(
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('custom_ethereum_tokens', [INITIAL_TOKENS])
 def test_get_ethereum_token_identifier(globaldb):
-    assert globaldb.get_ethereum_token_identifier('0xnotexistingaddress') is None
-    token_0_id = globaldb.get_ethereum_token_identifier(INITIAL_TOKENS[0].ethereum_address)
+    with globaldb.conn.read_ctx() as cursor:
+        assert globaldb.get_ethereum_token_identifier(cursor, '0xnotexistingaddress') is None
+        token_0_id = globaldb.get_ethereum_token_identifier(cursor, INITIAL_TOKENS[0].ethereum_address)  # noqa: E501
     assert token_0_id == ethaddress_to_identifier(INITIAL_TOKENS[0].ethereum_address)
 
 

--- a/rotkehlchen/tests/unit/test_globaldb.py
+++ b/rotkehlchen/tests/unit/test_globaldb.py
@@ -108,7 +108,8 @@ def test_add_edit_token_with_wrong_swapped_for(globaldb):
         data=token_to_delete,
     )
     asset_to_delete = Asset(token_to_delete_id)
-    assert globaldb.delete_ethereum_token(address_to_delete) == token_to_delete_id
+    with globaldb.conn.write_ctx() as cursor:
+        assert globaldb.delete_ethereum_token(cursor, address_to_delete) == token_to_delete_id
 
     # now try to add a new token with swapped_for pointing to a non existing token in the DB
     with pytest.raises(InputError):


### PR DESCRIPTION
The bug can be summed up as following:
1. Get in the progress callback
2. Context switch out of the callback with sleep(0)
3. Enter critical section, which essentially disables the callback
4. Write/read more data in the DB
5. Exit critical section, re-enabling the callback
6. Context switch back to the progress callback of (1) and exit it.
7. Segmentation fault.

What we now do is to guard the yielding with a semaphore. And
whenever the critical section is entered we wait for that
semaphore. And going into a write cursor is essentially entering the
critical section.