### PR TITLE
Force the exchange trade query to always return ascending time order

### DIFF
--- a/rotkehlchen/tests/exchanges/test_bitcoinde.py
+++ b/rotkehlchen/tests/exchanges/test_bitcoinde.py
@@ -62,25 +62,25 @@ def test_query_trade_history(function_scope_bitcoinde):
         )
 
     assert len(trades) == 2
-    assert trades[0].timestamp == 1512531092
+    assert trades[0].timestamp == 1502439199
     assert trades[0].location == Location.BITCOINDE
     assert trades[0].base_asset == A_BTC
     assert trades[0].quote_asset == A_EUR
     assert trades[0].trade_type == TradeType.BUY
-    assert trades[0].amount == FVal('10')
-    assert trades[0].rate.is_close(FVal('234.121'))
-    assert trades[0].fee.is_close(FVal('1.5214'))
+    assert trades[0].amount == FVal('241.214')
+    assert trades[0].rate.is_close(FVal('17.09736582453754757186564627'))
+    assert trades[0].fee.is_close(FVal('0.93452135'))
     assert isinstance(trades[0].fee_currency, Asset)
     assert trades[0].fee_currency == A_EUR
 
-    assert trades[1].timestamp == 1502439199
+    assert trades[1].timestamp == 1512531092
     assert trades[1].location == Location.BITCOINDE
     assert trades[1].base_asset == A_BTC
     assert trades[1].quote_asset == A_EUR
     assert trades[1].trade_type == TradeType.BUY
-    assert trades[1].amount == FVal('241.214')
-    assert trades[1].rate.is_close(FVal('17.09736582453754757186564627'))
-    assert trades[1].fee.is_close(FVal('0.93452135'))
+    assert trades[1].amount == FVal('10')
+    assert trades[1].rate.is_close(FVal('234.121'))
+    assert trades[1].fee.is_close(FVal('1.5214'))
     assert isinstance(trades[1].fee_currency, Asset)
     assert trades[1].fee_currency == A_EUR
 

--- a/rotkehlchen/tests/exchanges/test_bitpanda.py
+++ b/rotkehlchen/tests/exchanges/test_bitpanda.py
@@ -200,17 +200,6 @@ def test_trades(mock_bitpanda):
     assert len(errors) == 0
 
     expected_trades = [Trade(
-        timestamp=1634963958,
-        location=Location.BITPANDA,
-        base_asset=A_LTC,
-        quote_asset=A_EUR,
-        trade_type=TradeType.BUY,
-        amount=FVal('0.00917887'),
-        rate=FVal('180.85'),
-        fee=FVal('1.71800028'),
-        fee_currency=A_BEST,
-        link='tradeid1',
-    ), Trade(
         timestamp=1629440767,
         location=Location.BITPANDA,
         base_asset=A_ADA,
@@ -221,6 +210,17 @@ def test_trades(mock_bitpanda):
         fee=ZERO,
         fee_currency=A_BEST,
         link='tradeid2',
+    ), Trade(
+        timestamp=1634963958,
+        location=Location.BITPANDA,
+        base_asset=A_LTC,
+        quote_asset=A_EUR,
+        trade_type=TradeType.BUY,
+        amount=FVal('0.00917887'),
+        rate=FVal('180.85'),
+        fee=FVal('1.71800028'),
+        fee_currency=A_BEST,
+        link='tradeid1',
     )]
     assert expected_trades == trades
 

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -213,17 +213,6 @@ def test_coinbase_query_trade_history(function_scope_coinbase):
     assert len(errors) == 0
     assert len(trades) == 2
     expected_trades = [Trade(
-        timestamp=1500705839,
-        location=Location.COINBASE,
-        base_asset=A_BTC,
-        quote_asset=A_USD,
-        trade_type=TradeType.BUY,
-        amount=FVal("486.34313725"),
-        rate=FVal("9.997920454875299055122012005"),
-        fee=FVal("1.01"),
-        fee_currency=A_USD,
-        link='9e14d574-30fa-5d85-b02c-6be0d851d61d',
-    ), Trade(
         timestamp=1459024920,
         location=Location.COINBASE,
         base_asset=A_ETH,
@@ -234,6 +223,17 @@ def test_coinbase_query_trade_history(function_scope_coinbase):
         fee=FVal("10.1"),
         fee_currency=A_USD,
         link='1e14d574-30fa-5d85-b02c-6be0d851d61d',
+    ), Trade(
+        timestamp=1500705839,
+        location=Location.COINBASE,
+        base_asset=A_BTC,
+        quote_asset=A_USD,
+        trade_type=TradeType.BUY,
+        amount=FVal("486.34313725"),
+        rate=FVal("9.997920454875299055122012005"),
+        fee=FVal("1.01"),
+        fee_currency=A_USD,
+        link='9e14d574-30fa-5d85-b02c-6be0d851d61d',
     )]
     assert trades == expected_trades
 

--- a/rotkehlchen/tests/exchanges/test_independentreserve.py
+++ b/rotkehlchen/tests/exchanges/test_independentreserve.py
@@ -220,7 +220,7 @@ def test_query_trade_history(function_scope_independentreserve):
             fee_currency=A_ETH,
             link='foo1',
         )]
-    assert trades == expected_trades[::-1]
+    assert trades == expected_trades
 
 
 # TODO: Make a test for asset movements.

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -239,27 +239,27 @@ def test_query_trade_history(function_scope_poloniex):
         )
 
     assert len(trades) == 2
-    assert trades[0].timestamp == 1539713117
+    assert trades[0].timestamp == 1539709423
     assert trades[0].location == Location.POLONIEX
-    assert trades[0].base_asset == A_BCH
+    assert trades[0].base_asset == A_ETH
     assert trades[0].quote_asset == A_BTC
-    assert trades[0].trade_type == TradeType.SELL
-    assert trades[0].amount == FVal('1.40308443')
-    assert trades[0].rate == FVal('0.06935244')
-    assert trades[0].fee.is_close(FVal('0.00009730732'))
+    assert trades[0].trade_type == TradeType.BUY
+    assert trades[0].amount == FVal('3600.53748129')
+    assert trades[0].rate == FVal('0.00003432')
+    assert trades[0].fee.is_close(FVal('7.20107496258'))
     assert isinstance(trades[0].fee_currency, Asset)
-    assert trades[0].fee_currency == A_BTC
+    assert trades[0].fee_currency == A_ETH
 
-    assert trades[1].timestamp == 1539709423
+    assert trades[1].timestamp == 1539713117
     assert trades[1].location == Location.POLONIEX
-    assert trades[1].base_asset == A_ETH
+    assert trades[1].base_asset == A_BCH
     assert trades[1].quote_asset == A_BTC
-    assert trades[1].trade_type == TradeType.BUY
-    assert trades[1].amount == FVal('3600.53748129')
-    assert trades[1].rate == FVal('0.00003432')
-    assert trades[1].fee.is_close(FVal('7.20107496258'))
+    assert trades[1].trade_type == TradeType.SELL
+    assert trades[1].amount == FVal('1.40308443')
+    assert trades[1].rate == FVal('0.06935244')
+    assert trades[1].fee.is_close(FVal('0.00009730732'))
     assert isinstance(trades[1].fee_currency, Asset)
-    assert trades[1].fee_currency == A_ETH
+    assert trades[1].fee_currency == A_BTC
 
 
 def test_query_trade_history_unexpected_data(function_scope_poloniex):


### PR DESCRIPTION
And do it by making a simple change.

1. If not only cache, query the exchange and save it in the DB.
2. At the end just always query the DB for the entire range

This will also fix the gemini failing test which resulted due to them reversing the order their endpoint returns trades in: https://twitter.com/rotkiapp/status/1547150014367023104