### PR TITLE
Change how the response from the movementes endpoint is handled for bistamp

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 * :feature:`44` Add option to change cost basis method (FIFO and LIFO order).
 * :bug:`-` Now no missing acquisitions should appear for fiat assets during accounting.
 * :bug:`4459` Transactions that happened in genesis block are now queried and stored properly.
+* :bug:`4530` Movements from Bitstamp should now be correctly read if the asset is known.
 * :bug:`-` The electron application will now terminate properly if the backend fails to start.
 * :bug:`-` Now querying ens names for an empty list of addresses won't be causing an error.
 * :bug:`4456` Now NFTs query should not raise any unhandled error during the process of adding new ethereum addresses.

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -101,6 +101,7 @@ a = Entrypoint(
         ('rotkehlchen/data/uniswapv2_lp_tokens.meta', 'rotkehlchen/data'),
         ('rotkehlchen/data/global.db', 'rotkehlchen/data'),
         ('rotkehlchen/data/curve_pools.json', 'rotkehlchen/data'),
+        ('rotkehlchen/data/nodes.json', 'rotkehlchen/data'),
         # TODO
         # We probably should have a better way to specify some data should be loaded
         # by a module in pyinstaller. Should be loaded dynamically by rotki and not

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -546,7 +546,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             if raw_movement_key in KNOWN_NON_ASSET_KEYS_FOR_MOVEMENTS:
                 continue
             try:
-                candicate_fee_asset = asset_from_bitstamp(raw_movement_key)
+                candidate_fee_asset = asset_from_bitstamp(raw_movement_key)
             except (UnknownAsset, DeserializationError):
                 continue
             try:
@@ -554,7 +554,7 @@ class Bitstamp(ExchangeInterface):  # lgtm[py/missing-call-to-init]
             except DeserializationError:
                 continue
             if amount != ZERO:
-                fee_asset = candicate_fee_asset
+                fee_asset = candidate_fee_asset
                 break
 
         if amount == ZERO:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
             'data/uniswapv2_lp_tokens.meta',
             'data/global.db',
             'data/curve_pools.json',
+            'data/nodes.json',
             'chain/ethereum/modules/dxdaomesa/data/contracts.json',
         ],
     },


### PR DESCRIPTION
Before we had a set of keys to iterate and we had to keep it up with the list of assets
provided by the exchange. Now we iterate all the keys trying to check if is an asset or not
and if the value for the fee is not ZERO.

Closes https://github.com/rotki/rotki/issues/4530

Also fixes a minor issue where the file with the new nodes was not being included in the packaged version