### PR TITLE
fix: eth staking bug

### DIFF
--- a/frontend/app/src/components/helper/DataTable.vue
+++ b/frontend/app/src/components/helper/DataTable.vue
@@ -67,6 +67,8 @@ export default defineComponent({
     const tableRef = ref<any>(null);
 
     const onItemsPerPageChange = async (newValue: number) => {
+      if (get(itemsPerPage) === newValue) return;
+
       await updateSetting({
         [ITEMS_PER_PAGE]: newValue
       });

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -140,7 +140,7 @@ export default defineComponent({
       }
 
       const defaultSetting: ExplorerUrls = explorerUrls[get(chain)];
-      let formattedBaseUrl: string;
+      let formattedBaseUrl: string = '';
       if (get(chain) === 'zksync') {
         formattedBaseUrl = get(tx)
           ? defaultSetting.transaction
@@ -148,10 +148,15 @@ export default defineComponent({
       } else {
         const explorersSetting =
           get(explorers)[get(chain) as Exclude<Chains, 'zksync'>];
-        formattedBaseUrl = get(tx)
-          ? explorersSetting?.transaction ?? defaultSetting.transaction
-          : explorersSetting?.address ?? defaultSetting.address;
+
+        if (explorersSetting || defaultSetting) {
+          formattedBaseUrl = get(tx)
+            ? explorersSetting?.transaction ?? defaultSetting.transaction
+            : explorersSetting?.address ?? defaultSetting.address;
+        }
       }
+
+      if (!formattedBaseUrl) return '';
 
       return formattedBaseUrl.endsWith('/')
         ? formattedBaseUrl

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1823,7 +1823,7 @@
         "address": "Address",
         "name": "Name"
       },
-      "subtitle": "Add, edit, remove name for ETH addresses. Changes in the names will be reflected across all your accounts.",
+      "subtitle": "Add, edit, remove name for ETH addresses. Changes in the names will be reflected across the app.",
       "title": "Address Book"
     },
     "title": "Eth Address Book Management"

--- a/frontend/app/src/store/balances/getters.ts
+++ b/frontend/app/src/store/balances/getters.ts
@@ -690,7 +690,9 @@ export const getters: Getters<
       });
     }
 
-    return totals.sort((a, b) => sortDesc(a.usdValue, b.usdValue));
+    return totals
+      .filter(item => item.usdValue.gt(0))
+      .sort((a, b) => sortDesc(a.usdValue, b.usdValue));
   },
 
   accountAssets: (state: BalanceState) => (account: string) => {

--- a/frontend/app/src/store/balances/index.ts
+++ b/frontend/app/src/store/balances/index.ts
@@ -19,6 +19,7 @@ import { TaskMeta } from '@/types/task';
 import { TaskType } from '@/types/task-type';
 import { uniqueStrings } from '@/utils/data';
 import { logger } from '@/utils/logging';
+import { isValidEthAddress } from '@/utils/text';
 import { actions } from './actions';
 import { getters } from './getters';
 import { mutations } from './mutations';
@@ -45,9 +46,10 @@ export const useEthNamesStore = defineStore('ethNames', () => {
   const { notify } = useNotifications();
 
   const updateEnsAddresses = (newAddresses: string[]): boolean => {
-    const newEnsAddresses = [...get(ensAddresses), ...newAddresses].filter(
-      uniqueStrings
-    );
+    const newEnsAddresses = [...get(ensAddresses), ...newAddresses]
+      .filter(uniqueStrings)
+      .filter(address => isValidEthAddress(address));
+
     const currentEnsAddresses = [...get(ensAddresses)];
 
     const changed = !isEqual(newEnsAddresses, currentEnsAddresses);

--- a/frontend/app/src/store/history/index.ts
+++ b/frontend/app/src/store/history/index.ts
@@ -513,7 +513,7 @@ export const useAssetMovements = defineStore('history/assetMovements', () => {
         }
       });
 
-      fetchEnsNames(addresses, true);
+      fetchEnsNames(addresses, false);
 
       return mapped;
     };

--- a/frontend/app/src/views/staking/Eth2Page.vue
+++ b/frontend/app/src/views/staking/Eth2Page.vue
@@ -17,6 +17,7 @@
       :eth2-details="details"
       :eth2-deposits="deposits"
       :eth2-stats="stats"
+      :eth2-stats-loading="eth2StatsLoading"
       :ownership="ownership"
       @refresh="refresh"
       @update:stats-pagination="updatePagination"
@@ -71,7 +72,7 @@ import Eth2ValidatorFilter from '@/components/helper/filter/Eth2ValidatorFilter.
 import ProgressScreen from '@/components/helper/ProgressScreen.vue';
 import NoPremiumPlaceholder from '@/components/premium/NoPremiumPlaceholder.vue';
 import { setupBlockchainAccounts } from '@/composables/balances';
-import { setupStatusChecking } from '@/composables/common';
+import { isSectionLoading, setupStatusChecking } from '@/composables/common';
 import { getPremium, setupModuleEnabled } from '@/composables/session';
 import { Eth2Staking } from '@/premium/premium';
 import { Section } from '@/store/const';
@@ -114,6 +115,7 @@ const Eth2Page = defineComponent({
     const secondaryRefreshing = isSectionRefreshing(
       Section.STAKING_ETH2_DEPOSITS
     );
+    const eth2StatsLoading = isSectionLoading(Section.STAKING_ETH2_STATS);
 
     const { eth2Validators } = setupBlockchainAccounts();
     watch(filterType, () => set(selection, []));
@@ -137,6 +139,7 @@ const Eth2Page = defineComponent({
       loading,
       primaryRefreshing,
       secondaryRefreshing,
+      eth2StatsLoading,
       enabled,
       filterType,
       eth2Validators,


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [x] filter still be able to be done during the task.
- [x] add loading indicator.
- [x] fix wording "across all accounts" in eth address book
- [x] hide zero balances in blockchain summary detail in dashboard.
- [x] validate eth address when calling ens names.
- [x] Remove Error in render: "TypeError: Cannot read properties of undefined (reading 'address')"