### PR TITLE
Fixes docker publishing and adds manual publish docs

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -244,43 +244,19 @@ jobs:
           } | ConvertTo-Json
           Invoke-RestMethod -Method Post -Uri $uri -ContentType "application/json" -Body $body
 
-  docker-matrix:
-    name: Prepare docker platform matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: 'Check if scheduled'
-        id: set-matrix
-        run: |
-          X86_64="{\"name\":\"x86_64\",\"platform\":\"linux/amd64\"}"
-          ARM64="{\"name\":\"arm64\",\"platform\":\"linux/arm64\"}"
-          if [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
-            MATRIX="[$X86_64,$ARM64]"
-          else
-            MATRIX="[$X86_64]"
-          fi
-          echo "::set-output name=matrix::$MATRIX"
-
   build-docker:
-    name: Build docker image (${{ matrix.arch.name }})
+    name: Build docker images
     runs-on: ubuntu-18.04
-    needs: docker-matrix
     environment: docker
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ${{ fromJSON(needs.docker-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        if: startsWith(matrix.arch.name, 'arm64')
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: ${{ matrix.arch.name }}
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
@@ -298,10 +274,11 @@ jobs:
       - name: Build Information
         id: build_information
         run: |
-          PLATFORMS='${{ matrix.arch.platform }}'
           if [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
+            PLATFORMS='linux/amd64,linux/arm64'
             TAG=nightly
           else
+            PLATFORMS=linux/amd64
             TAG=dev
           fi
           echo "::set-output name=tag::$TAG"

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -313,24 +313,16 @@ jobs:
             dist/rotki-core-*-windows.exe
 
   docker:
-    name: Build docker image (${{ matrix.arch.name }})
+    name: 'Build docker images'
     runs-on: ubuntu-18.04
     environment: docker
-    strategy:
-      matrix:
-        arch:
-          - name: x86_64
-            platform: linux/amd64
-          - name: arm64
-            platform: linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up QEMU
-        if: startsWith(matrix.arch.name, 'arm64')
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: ${{ matrix.arch.name }}
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
@@ -347,7 +339,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ matrix.arch.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |            
             ${{ github.repository }}:${{ steps.rotki_version.outputs.version }}

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -376,3 +376,24 @@ Finally open the svg with any compatible viewer and explore the flamegraph. It w
 .. image:: images/flamegraph_example.svg
    :alt: A flamegraph profiling example
    :align: center
+
+Docker publishing (manual)
+*****************
+
+If a need exists to publish on hub.docker.com then the following steps need to be followed.
+
+.. note::
+
+    Make sure that you are logged with an account that has access to publish to docker.
+
+This installs the qemu binaries required to build the arm64 binary and uses buildx to build the images.
+Please replace the the ``REVISION`` with the git sha of the tag and the ``ROTKI_VERSION`` with the
+tag name.
+
+.. code-block::
+
+    docker pull tonistiigi/binfmt:latest
+    docker run --rm --privileged tonistiigi/binfmt:latest --install arm64
+    docker buildx create --name imgbldr --use
+    docker buildx inspect --bootstrap --builder imgbldr
+    docker buildx build --build-arg REVISION='git sha' --build-arg ROTKI_VERSION=vx.x.x --file ./Dockerfile --platform linux/amd64 --platform linux/arm64 --tag rotki/rotki:vx.x.x --tag rotki/rotki:latest --push .


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Note
So this is what I realized during Droidcon, if you push a single architecture it doesn't update 
the existing tag but it replaces it.

It would be nice if we can also get that merged to develop