### PR TITLE
Fix bad segfault happening at complex async DB read/write access

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -111,8 +111,8 @@ class GlobalDBHandler():
         if GlobalDBHandler.__instance is not None:
             return GlobalDBHandler.__instance
 
-        assert data_dir, 'First instantiation of GlobalDBHandler should have a data_dir'
-        assert sql_vm_instructions_cb, 'First instantiation of GlobalDBHandler should have a sql_vm_instructions_cb'  # noqa: E501
+        assert data_dir is not None, 'First instantiation of GlobalDBHandler should have a data_dir'  # noqa: E501
+        assert sql_vm_instructions_cb is not None, 'First instantiation of GlobalDBHandler should have a sql_vm_instructions_cb'  # noqa: E501
         GlobalDBHandler.__instance = object.__new__(cls)
         GlobalDBHandler.__instance._data_directory = data_dir
         GlobalDBHandler.__instance.conn = _initialize_global_db_directory(data_dir, sql_vm_instructions_cb)  # noqa: E501

--- a/rotkehlchen/tests/db/test_async.py
+++ b/rotkehlchen/tests/db/test_async.py
@@ -1,6 +1,7 @@
 from random import randint, uniform
 
 import gevent
+import pytest
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType
 from rotkehlchen.constants.assets import A_ETH
@@ -35,6 +36,30 @@ def write_actions(database, num):
         cursor.executemany(query, [x.serialize_for_db() for x in actions])
 
 
+def write_single_action(database, action):
+    query = """
+    INSERT INTO ledger_actions(
+    timestamp, type, location, amount, asset, rate, rate_asset, link, notes
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"""
+    with database.user_write() as write_cursor:
+        write_cursor.execute(query, action.serialize_for_db())
+
+
+def write_single_action_frequently(database, num, sleep_between_writes):
+    for _ in range(num):
+        write_single_action(database, make_ledger_action())
+        gevent.sleep(sleep_between_writes)
+
+
+def read_single_action_frequently(database, msg_aggregator, num, limit, sleep_between_reads):
+    dbla = DBLedgerActions(database, msg_aggregator)
+    for _ in range(num):
+        with database.conn.read_ctx() as cursor:
+            dbla.get_ledger_actions(cursor, LedgerActionsFilterQuery.make(limit=limit), has_premium=True)  # noqa: E501
+        gevent.sleep(sleep_between_reads)
+
+
 def read_actions(database, limit, msg_aggregator):
     dbla = DBLedgerActions(database, msg_aggregator)
     with database.conn.read_ctx() as cursor:
@@ -45,8 +70,10 @@ def read_actions(database, limit, msg_aggregator):
         )
 
 
-def test_async_segfault(database, function_scope_messages_aggregator):
+@pytest.mark.parametrize('sql_vm_instructions_cb', [100])
+def test_callback_segfault_simple(database, function_scope_messages_aggregator):
     """Test that the async and sqlite progress handler segfault yielding bug does not hit us
+    This one is protected against by having the lock inside the callback.
 
     The bug can be summed up as following:
     1. Get in the progress callback
@@ -70,3 +97,56 @@ def test_async_segfault(database, function_scope_messages_aggregator):
     b = gevent.spawn(write_actions, database=database, num=200)
     c = gevent.spawn(write_actions, database=database, num=200)
     gevent.joinall([a, b, c])
+
+
+@pytest.mark.parametrize('sql_vm_instructions_cb', [100])
+def test_callback_segfault_complex(database, function_scope_messages_aggregator):
+    """Test that we protect against the yielding segfault bug that happens when lots
+    of complicated actions happen at the same time.
+
+    The bug can be summed up as following:
+    1. Get in the progress callback but before the in_callback lock is acquired.
+    2. Wait for the lock acquisition and context switch out
+    3.A lot of things happen and the callback gets entered by a lot of other sections
+    and has the lock acquired. Some of those places do connection.commit
+    and modify the connection. As per the docs that's a no no.
+    https://www.sqlite.org/c3ref/progress_handler.html
+    4. We context switch back to the original callback acquire the lock and then release it
+    and the callback is exited. Since the connection has been modified KABOOM SEGFAULT.
+    """
+    # first write some data in the DB to have enough data to read.
+    write_actions(database, 500)
+
+    # Then have lots of stuff happen at the same time so that the situation described
+    # in the docstring occurs
+    a = gevent.spawn(
+        read_actions,
+        database=database,
+        limit=50,
+        msg_aggregator=function_scope_messages_aggregator,
+    )
+    b = gevent.spawn(
+        write_actions,
+        database=database,
+        num=100,
+    )
+    c = gevent.spawn(
+        write_single_action_frequently,
+        database=database,
+        num=10,
+        sleep_between_writes=0.5,
+    )
+    d = gevent.spawn(
+        read_single_action_frequently,
+        database=database,
+        msg_aggregator=function_scope_messages_aggregator,
+        num=10,
+        limit=1,
+        sleep_between_reads=0.5,
+    )
+    e = gevent.spawn(
+        write_actions,
+        database=database,
+        num=100,
+    )
+    gevent.joinall([a, b, c, d, e])

--- a/rotkehlchen/tests/db/test_async.py
+++ b/rotkehlchen/tests/db/test_async.py
@@ -150,3 +150,12 @@ def test_callback_segfault_complex(database, function_scope_messages_aggregator)
         num=100,
     )
     gevent.joinall([a, b, c, d, e])
+
+
+@pytest.mark.parametrize('sql_vm_instructions_cb', [0])
+def test_can_disable_callback(database):  # pylint: disable=unused-argument
+    """Simply test that setting sql_vm_instructions_cb to 0 works
+
+    This is a regression test since setting to 0 was hitting an assertion before
+    """
+    assert True  # no need to do anything. Test would fail at fixture setup


### PR DESCRIPTION
What was happening is the following:

1. Get in the progress callback but before the `in_callback` lock is acquired.
2. Wait for the lock acquisition and context switch out to other greenlets. .A lot of things happen and the callback gets entered by a lot of other sections and has the lock acquired. Some of those places do `connection.commit()` and modify the connection. As per the docs that's a no no: https://www.sqlite.org/c3ref/progress_handler.html
4. We context switch back to the original callback acquire the lock
and then release it and the callback is exited. Since the connection has been modified **KABOOM SEGFAULT**.

The way around this is:

1.To also acquire the callback lock before connection
modifications. So before commit and rollback.
2. If we get in the callback and see that the lock is acquired we do
not wait for it. Instead we exit the callback immediately. This
guarantees that in the case this happens we will not context switch
and exit the callback with the connection having been modified. We
just exit immediately so no modifications can ever happen so long as
we are in the callback.

This PR also adds a test that fails with the segfault if the fix is not committed and also adds a small bug fix for allowing setting the `sql_vm_instructions_cb` to 0