### PR TITLE
Experiment with uniswap pool liquidity limits

### DIFF
--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -10,9 +10,10 @@ from web3.types import BlockIdentifier
 from rotkehlchen.assets.asset import Asset, EthereumToken
 from rotkehlchen.chain.ethereum.constants import ZERO_ADDRESS
 from rotkehlchen.chain.ethereum.contracts import EthereumContract
-from rotkehlchen.chain.ethereum.utils import multicall, multicall_specific
+from rotkehlchen.chain.ethereum.utils import multicall, multicall_specific, token_normalized_value
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_USD, A_USDC, A_USDT, A_WETH
 from rotkehlchen.constants.ethereum import (
+    SINGLE_SIDE_USD_POOL_LIMIT,
     UNISWAP_V2_FACTORY,
     UNISWAP_V2_LP_ABI,
     UNISWAP_V3_FACTORY,
@@ -22,6 +23,7 @@ from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.errors.defi import DefiPoolError
 from rotkehlchen.errors.price import PriceQueryUnsupportedAsset
 from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.interfaces import CurrentPriceOracleInterface
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEthAddress, Price
@@ -191,6 +193,7 @@ class UniswapOracle(CurrentPriceOracleInterface, CacheableMixIn):
 
         Can raise:
         - PriceQueryUnsupportedAsset
+        - DefiPoolError
         - RemoteError
         """
         log.debug(
@@ -330,6 +333,9 @@ class UniswapV3Oracle(UniswapOracle):
     ) -> PoolPrice:
         """
         Returns the units of token1 that one token0 can buy
+
+        May raise:
+        - DefiPoolError
         """
         pool_contract = EthereumContract(
             address=pool_addr,
@@ -360,6 +366,7 @@ class UniswapV3Oracle(UniswapOracle):
         token_1 = EthereumToken(
             to_checksum_address(pool_contract.decode(output[2], 'token1')[0]),  # noqa: E501 pylint:disable=unsubscriptable-object
         )
+
         sqrt_price_x96, _, _, _, _, _, _ = pool_contract.decode(output[0], 'slot0')
         if token_0.decimals is None:
             raise DefiPoolError(f'Token {token_0} has None as decimals')
@@ -403,6 +410,9 @@ class UniswapV2Oracle(UniswapOracle):
     ) -> PoolPrice:
         """
         Returns the units of token1 that one token0 can buy
+
+        May raise:
+        - DefiPoolError
         """
         pool_contract = EthereumContract(
             address=pool_addr,
@@ -433,6 +443,7 @@ class UniswapV2Oracle(UniswapOracle):
         token_1 = EthereumToken(
             to_checksum_address(pool_contract.decode(output[2], 'token1')[0]),  # noqa: E501 pylint:disable=unsubscriptable-object
         )
+
         if token_0.decimals is None:
             raise DefiPoolError(f'Token {token_0} has None as decimals')
         if token_1.decimals is None:
@@ -442,6 +453,15 @@ class UniswapV2Oracle(UniswapOracle):
 
         if ZERO in (reserve_0, reserve_1):
             raise DefiPoolError(f'Uniswap pool for {token_0}/{token_1} has asset with no reserves')
+
+        # Ignore pools with too low single side-liquidity. Imperfect approach to avoid spam
+        # pylint: disable=unexpected-keyword-arg  # no idea why pylint sees this here
+        price_0 = Inquirer().find_usd_price(token_0, skip_onchain=True)
+        price_1 = Inquirer().find_usd_price(token_1, skip_onchain=True)
+        if price_0 != ZERO and price_0 * token_normalized_value(token_amount=reserve_0, token=token_0) < SINGLE_SIDE_USD_POOL_LIMIT:  # noqa: E501
+            raise DefiPoolError(f'Uniswap pool for {token_0}/{token_1} has too low reserves')
+        if price_1 != ZERO and price_1 * token_normalized_value(token_amount=reserve_1, token=token_1) < SINGLE_SIDE_USD_POOL_LIMIT:  # noqa: E501
+            raise DefiPoolError(f'Uniswap pool for {token_0}/{token_1} has too low reserves')
 
         price = FVal((reserve_1 / reserve_0) * decimals_constant)
         return PoolPrice(price=price, token_0=token_0, token_1=token_1)

--- a/rotkehlchen/constants/ethereum.py
+++ b/rotkehlchen/constants/ethereum.py
@@ -185,3 +185,5 @@ UNISWAP_V3_NFT_MANAGER = EthereumConstants.contract('UNISWAP_V3_NFT_POSITIONS_MA
 SADDLE_ALETH_POOL = EthereumConstants().contract('SADDLE_ALETH_POOL')
 
 RAY_DIGITS = 27
+# If an on-chain pool single-side asset liquidity is less than this, ignore the pool
+SINGLE_SIDE_USD_POOL_LIMIT = 5000

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -338,14 +338,24 @@ class Inquirer():
     def _query_oracle_instances(
             from_asset: Asset,
             to_asset: Asset,
+            skip_onchain: bool = False,
     ) -> Price:
         instance = Inquirer()
         cache_key = (from_asset, to_asset)
-        oracles = instance._oracles
-        oracle_instances = instance._oracle_instances
-        assert isinstance(oracles, list) and isinstance(oracle_instances, list), (
+        assert isinstance(instance._oracles, list) and isinstance(instance._oracle_instances, list), (  # noqa: E501
             'Inquirer should never be called before the setting the oracles'
         )
+        oracles = instance._oracles
+        oracle_instances = instance._oracle_instances
+
+        if skip_onchain:
+            oracles = []
+            oracle_instances = []
+            for oracle, oracle_instance in zip(instance._oracles, instance._oracle_instances):
+                if oracle not in (CurrentPriceOracle.UNISWAPV2, CurrentPriceOracle.UNISWAPV3, CurrentPriceOracle.SADDLE):  # noqa: E501
+                    oracles.append(oracle)
+                    oracle_instances.append(oracle_instance)
+
         price = Price(ZERO)
         for oracle, oracle_instance in zip(oracles, oracle_instances):
             if (
@@ -383,6 +393,7 @@ class Inquirer():
             from_asset: Asset,
             to_asset: Asset,
             ignore_cache: bool = False,
+            skip_onchain: bool = False,
     ) -> Price:
         """Returns the current price of 'from_asset' in 'to_asset' valuation.
         NB: prices for special symbols in any currency but USD are not supported.
@@ -401,13 +412,14 @@ class Inquirer():
             if cache is not None:
                 return cache.price
 
-        oracle_price = instance._query_oracle_instances(from_asset=from_asset, to_asset=to_asset)
+        oracle_price = instance._query_oracle_instances(from_asset=from_asset, to_asset=to_asset, skip_onchain=skip_onchain)  # noqa: E501
         return oracle_price
 
     @staticmethod
     def find_usd_price(
             asset: Asset,
             ignore_cache: bool = False,
+            skip_onchain: bool = False,
     ) -> Price:
         """Returns the current USD price of the asset
 
@@ -500,7 +512,7 @@ class Inquirer():
             # KFEE is a kraken special asset where 1000 KFEE = 10 USD
             return Price(FVal(0.01))
 
-        return instance._query_oracle_instances(from_asset=asset, to_asset=A_USD)
+        return instance._query_oracle_instances(from_asset=asset, to_asset=A_USD, skip_onchain=skip_onchain)  # noqa: E501
 
     def find_uniswap_v2_lp_price(
             self,


### PR DESCRIPTION
Experimenting with handling spam asset tokens.

Essentially the problem of having an airdrop of a scam token (non-transferrable, all-approval-baiting, advertising/phishing) to the user with liquidity in a uniswap pool.

This way they appear to have a lot of money in a token that's not real. The current solution is to ask the user to ignore the token. But it would be nice to try and auto-detect situations like this.

With this approach we try to mitigate it by ignoring any pool with liquidity lower than $5k on any single side.

Caveats: 

1. This is temporary and not a good solution.
2. This is only for uniswap v2. @yabirgb I had a quick look at the get pool price of v3 but did not immediately see a way to get reserves there. How do you do it? But I think also all spam assets I saw are in v2.