### PR TITLE
Fix broken mkvirtualenv install link for ubuntu

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -364,7 +364,7 @@ Install electron and any other npm dependencies by::
     cd frontend
     npm ci
 
-Create a new `virtual environment <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_ with python 3.9 to install all the python dependencies. If you don't have ``mkvirtualenv`` then check how to get it depending on your distribution. `Here <http://exponential.io/blog/2015/02/10/install-virtualenv-and-virtualenvwrapper-on-ubuntu/>`__ is a guide for Ubuntu and `here <https://wiki.archlinux.org/index.php/Python/Virtual_environment>`__ is one for ArchLinux::
+Create a new `virtual environment <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_ with python 3.9 to install all the python dependencies. If you don't have ``mkvirtualenv`` then check how to get it depending on your distribution. `Here <https://virtualenvwrapper.readthedocs.io/en/latest/install.html#basic-installation>`__ is a guide for Ubuntu and `here <https://wiki.archlinux.org/index.php/Python/Virtual_environment>`__ is one for ArchLinux::
 
     mkvirtualenv rotki -p /usr/bin/python3.9
 


### PR DESCRIPTION
Changes a broken link in the docs to installation guides for `mkvirtualenv` on Ubuntu