### PR TITLE
Allow to edit title on user notes

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3446,8 +3446,14 @@ class DBHandler:
         """
         with self.user_write() as write_cursor:
             write_cursor.execute(
-                'UPDATE user_notes SET content=?, last_update_timestamp=?, is_pinned=? WHERE identifier=?',  # noqa: E501
-                (user_note.content, ts_now(), user_note.is_pinned, user_note.identifier),
+                'UPDATE user_notes SET title=?, content=?, last_update_timestamp=?, is_pinned=? WHERE identifier=?',  # noqa: E501
+                (
+                    user_note.title,
+                    user_note.content,
+                    ts_now(),
+                    user_note.is_pinned,
+                    user_note.identifier,
+                ),
             )
             if write_cursor.rowcount == 0:
                 raise InputError(f'User note with identifier {user_note.identifier} does not exist')  # noqa: E501

--- a/rotkehlchen/tests/api/test_user_notes.py
+++ b/rotkehlchen/tests/api/test_user_notes.py
@@ -98,9 +98,9 @@ def test_edit_user_notes(rotkehlchen_api_server):
             'usernotesresource',
         ), json={
             'identifier': 1,
-            'title': 'TODO List',
+            'title': 'My TODO List',
             'content': 'Dont sleep, wake up!!!!!',
-            'location': 'manual balances',
+            'location': 'ledger actions',
             'last_update_timestamp': 12345678,
             'is_pinned': True,
         },
@@ -111,8 +111,10 @@ def test_edit_user_notes(rotkehlchen_api_server):
     user_notes = rotkehlchen_api_server.rest_api.rotkehlchen.data.db.get_user_notes(filter_query=filter_query)  # noqa: E501
     for note in user_notes:
         if note.identifier == 1:
+            assert note.title == 'My TODO List'
             assert note.content == 'Dont sleep, wake up!!!!!'
             assert note.is_pinned is True
+            assert note.last_update_timestamp > 12345678
 
     # check that editing a user note with an invalid identifier fails
     response = requests.patch(


### PR DESCRIPTION
@lukicenturi detected that the title was not being edited. The reason was that the title was not passed in the set of fields that were being changed

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
