### PR TITLE
Allow to sort by multiple fields in the API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2138,8 +2138,8 @@ Querying ethereum transactions
 
    :reqjson int limit: This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: This is the attribute of the transaction by which to order the results.
-   :reqjson bool ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
+   :reqjson list[string] order_by_attributes: This is the list of attributes of the transaction by which to order the results.
+   :reqjson list[bool] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
    :reqjson int from_timestamp: The timestamp after which to return transactions. If not given zero is considered as the start.
    :reqjson int to_timestamp: The timestamp until which to return transactions. If not given all transactions from ``from_timestamp`` until now are returned.
    :reqjson bool only_cache: If true then only the ethereum transactions in the DB are queried.
@@ -3899,8 +3899,8 @@ Dealing with trades
 
    :reqjson int limit: Optional. This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: Optional. This is the attribute of the trade table by which to order the results. If none is given 'time' is assumed. Valid values are: ['time', 'location', 'type', 'amount', 'rate', 'fee'].
-   :reqjson bool ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
+   :reqjson list[string] order_by_attributes: Optional. This is the list of attributes of the trade table by which to order the results. If none is given 'time' is assumed. Valid values are: ['time', 'location', 'type', 'amount', 'rate', 'fee'].
+   :reqjson list[bool] ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson string location: Optionally filter trades by location. A valid location name has to be provided. If missing location filtering does not happen.
@@ -4161,8 +4161,8 @@ Querying asset movements
 
    :reqjson int limit: Optional. This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: Optional. This is the attribute of the asset movements table by which to order the results. If none is given 'time' is assumed. Valid values are: ['time', 'location', 'category', 'amount', 'fee'].
-   :reqjson bool ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
+   :reqjson list[string] order_by_attributes: Optional. This is the list of attributes of the asset movements table by which to order the results. If none is given 'time' is assumed. Valid values are: ['time', 'location', 'category', 'amount', 'fee'].
+   :reqjson list[bool] ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson string location: Optionally filter asset movements by location. A valid location name has to be provided. Valid locations are for now only exchanges for deposits/withdrawals.
@@ -4249,8 +4249,8 @@ Dealing with ledger actions
 
    :reqjson int limit: Optional. This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: Optional. This is the attribute of the ledger actions table by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'location', 'type', 'amount', 'rate'].
-   :reqjson bool ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
+   :reqjson list[string] order_by_attributes: Optional. This is the list of attributes of the ledger actions table by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'location', 'type', 'amount', 'rate'].
+   :reqjson list[bool] ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson string asset: Optionally filter by action asset. A valid asset has to be provided. If missing asset filtering does not happen.
@@ -5218,8 +5218,8 @@ Get saved events of a PnL Report
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson str from_timestamp: Optional. A filter for the from_timestamp of the range of events to query.
    :reqjson str to_timestamp: Optional. A filter for the to_timestamp of the range of events to query.
-   :reqjson str order_by_attribute: Optional. Default is "timestamp". The name of the attribute to order results by.
-   :reqjson bool ascending: Optional. Default is false. The order in which to return results depending on the order by attribute.
+   :reqjson list[string] order_by_attributes: Optional. Default is ["timestamp"]. The list of the attributes to order results by.
+   :reqjson list[bool] ascending: Optional. Default is [false]. The order in which to return results depending on the order by attribute.
    :reqjson str event_type: Optional. Not used yet. In the future will be a filter for the type of event to query.
 
    **Example Response**:
@@ -8481,8 +8481,8 @@ Getting Eth2 Staking daily stats
    :reqjson bool only_cache: If true then only the daily stats in the DB are queried.
    :reqjson int limit: Optional. This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: Optional. This is the attribute of the eth2_daily_staking_details table by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'validator_index', 'start_usd_price', 'end_usd_price', 'pnl', 'start_amount', 'end_amount', 'missed_attestations', 'orphaned_attestations', 'proposed_blocks', 'missed_blocks', 'orphaned_blocks', 'included_attester_slashings', 'proposer_attester_slashings', 'deposits_number', 'amount_deposited'].
-   :reqjson bool ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
+   :reqjson list[string] order_by_attributes: Optional. This is the list of attributes of the eth2_daily_staking_details table by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'validator_index', 'start_usd_price', 'end_usd_price', 'pnl', 'start_amount', 'end_amount', 'missed_attestations', 'orphaned_attestations', 'proposed_blocks', 'missed_blocks', 'orphaned_blocks', 'included_attester_slashings', 'proposer_attester_slashings', 'deposits_number', 'amount_deposited'].
+   :reqjson list[bool] ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson list(string) validators: Optionally filter entries validator indices. If missing data for all validators are returned.
@@ -10918,8 +10918,8 @@ Staking events
 
    :reqjson int limit: Optional. This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: Optional. This is the attribute of the history by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'location', 'amount'].
-   :reqjson bool ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
+   :reqjson list[string] order_by_attributes: Optional. This is the list of attributes of the history by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'location', 'amount'].
+   :reqjson list[bool] ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
    :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson bool only_cache: Optional.If this is true then the equivalent exchange/location is not queried, but only what is already in the DB is returned.
@@ -11611,8 +11611,8 @@ Handling user notes
 
    :reqjson int limit: This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
-   :reqjson string order_by_attribute: This is the attribute of the note by which to order the results. By default we sort using ``last_update_timestamp``.
-   :reqjson bool ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
+   :reqjson list[string] order_by_attributes: This is the list of attributes of the note by which to order the results. By default we sort using ``last_update_timestamp``.
+   :reqjson list[bool] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
    :reqjson int from_timestamp: The timestamp after which to return transactions. If not given zero is considered as the start.
    :reqjson int to_timestamp: The timestamp until which to return transactions. If not given all transactions from ``from_timestamp`` until now are returned.
    :reqjson string title_substring: The substring to use as filter for the title of the notes.

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -539,11 +539,11 @@ def test_query_transactions_errors(rotkehlchen_api_server):
             rotkehlchen_api_server,
             'per_address_ethereum_transactions_resource',
             address='0xaFB7ed3beBE50E0b62Fa862FAba93e7A46e59cA7',
-        ), json={'order_by_attribute': 'tim3'},
+        ), json={'order_by_attributes': ['tim3'], 'ascending': [False]},
     )
     assert_error_response(
         response=response,
-        contained_in_msg='order_by_attribute for transactions can not be tim3',
+        contained_in_msg='order_by_attributes for transactions can not be tim3',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -747,7 +747,7 @@ def test_query_asset_movements(rotkehlchen_api_server_with_exchanges, start_with
 
     def assert_order_by(order_by: str):
         """A helper to keep things DRY in the test"""
-        data = {'order_by_attribute': order_by, 'ascending': False, 'only_cache': True}
+        data = {'order_by_attributes': [order_by], 'ascending': [False], 'only_cache': True}
         response = requests.get(
             api_url_for(
                 rotkehlchen_api_server_with_exchanges,
@@ -760,7 +760,7 @@ def test_query_asset_movements(rotkehlchen_api_server_with_exchanges, start_with
         assert result['entries_found'] == 10
         desc_result = result['entries']
         assert len(desc_result) == 10
-        data = {'order_by_attribute': order_by, 'ascending': True, 'only_cache': True}
+        data = {'order_by_attributes': [order_by], 'ascending': [True], 'only_cache': True}
         response = requests.get(
             api_url_for(
                 rotkehlchen_api_server_with_exchanges,

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -279,7 +279,8 @@ def test_query_pnl_report_events_pagination_filtering(
             json={
                 'offset': offset,
                 'limit': 10,
-                'ascending': ascending_timestamp,
+                'order_by_attributes': ['timestamp'],
+                'ascending': [ascending_timestamp],
             },
         )
         events_result = assert_proper_response_with_result(response)

--- a/rotkehlchen/tests/api/test_ledger_actions.py
+++ b/rotkehlchen/tests/api/test_ledger_actions.py
@@ -177,7 +177,7 @@ def test_add_and_query_ledger_actions(rotkehlchen_api_server, start_with_valid_p
         api_url_for(
             rotkehlchen_api_server,
             'ledgeractionsresource',
-        ), json={'asset': 'EUR', 'ascending': True},
+        ), json={'asset': 'EUR', 'order_by_attributes': ['timestamp'], 'ascending': [True]},
     )
     result = assert_proper_response_with_result(response)
     result = [x['entry'] for x in result['entries']]
@@ -211,7 +211,7 @@ def test_add_and_query_ledger_actions(rotkehlchen_api_server, start_with_valid_p
 
     def assert_order_by(order_by: str):
         """A helper to keep things DRY in the test"""
-        data = {'order_by_attribute': order_by, 'ascending': False, 'only_cache': True}
+        data = {'order_by_attributes': [order_by], 'ascending': [False], 'only_cache': True}
         response = requests.get(
             api_url_for(
                 rotkehlchen_api_server,
@@ -224,7 +224,7 @@ def test_add_and_query_ledger_actions(rotkehlchen_api_server, start_with_valid_p
         assert result['entries_found'] == 4
         desc_result = result['entries']
         assert len(desc_result) == 4
-        data = {'order_by_attribute': order_by, 'ascending': True, 'only_cache': True}
+        data = {'order_by_attributes': [order_by], 'ascending': [True], 'only_cache': True}
         response = requests.get(
             api_url_for(
                 rotkehlchen_api_server,

--- a/rotkehlchen/tests/api/test_trades.py
+++ b/rotkehlchen/tests/api/test_trades.py
@@ -150,7 +150,7 @@ def test_query_trades(rotkehlchen_api_server_with_exchanges, start_with_valid_pr
 
     def assert_order_by(order_by: str):
         """A helper to keep things DRY in the test"""
-        data = {'order_by_attribute': order_by, 'ascending': False, 'only_cache': True}
+        data = {'order_by_attributes': [order_by], 'ascending': [False], 'only_cache': True}
         response = requests.get(
             api_url_for(
                 rotkehlchen_api_server_with_exchanges,
@@ -163,7 +163,7 @@ def test_query_trades(rotkehlchen_api_server_with_exchanges, start_with_valid_pr
         assert result['entries_found'] == 5
         desc_result = result['entries']
         assert len(desc_result) == 5
-        data = {'order_by_attribute': order_by, 'ascending': True, 'only_cache': True}
+        data = {'order_by_attributes': [order_by], 'ascending': [True], 'only_cache': True}
         response = requests.get(
             api_url_for(
                 rotkehlchen_api_server_with_exchanges,

--- a/rotkehlchen/tests/api/test_user_notes.py
+++ b/rotkehlchen/tests/api/test_user_notes.py
@@ -23,7 +23,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
             'title': '#1',
             'content': 'Romero Uno',
             'location': 'manual balances',
-            'is_pinned': False,
+            'is_pinned': True,
         },
     )
     result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
@@ -79,6 +79,23 @@ def test_add_get_user_notes(rotkehlchen_api_server):
     )
     result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
     assert len(result) == 1
+
+    # test sorting by multiple fields
+    response = requests.get(
+        api_url_for(
+            rotkehlchen_api_server,
+            'usernotesresource',
+        ),
+        json={
+            'order_by_attributes': ['is_pinned', 'last_update_timestamp'],
+            'ascending': [False, True],
+        },
+    )
+    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    assert len(result) == 3
+    assert result[0]['title'] == '#1'
+    assert result[1]['title'] == '#3'
+    assert result[2]['title'] == '#2'
 
 
 def test_edit_user_notes(rotkehlchen_api_server):

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -866,12 +866,12 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'stakingresource',
         ),
         json={
-            "ascending": False,
+            "ascending": [False],
             "async_query": False,
             "limit": 10,
             "offset": 0,
             "only_cache": True,
-            "order_by_attribute": "random_column",
+            "order_by_attributes": ["random_column"],
         },
     )
     assert_error_response(
@@ -887,12 +887,12 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'stakingresource',
         ),
         json={
-            "ascending": False,
+            "ascending": [False],
             "async_query": False,
             "limit": 10,
             "offset": 0,
             "only_cache": True,
-            "order_by_attribute": "event_type",
+            "order_by_attributes": ["event_type"],
         },
     )
     assert_proper_response_with_result(response)

--- a/rotkehlchen/tests/utils/pnl_report.py
+++ b/rotkehlchen/tests/utils/pnl_report.py
@@ -59,7 +59,8 @@ def query_api_create_and_get_report(
         json={
             'offset': events_offset,
             'limit': events_limit,
-            'ascending': events_ascending_timestamp,
+            'order_by_attributes': ['timestamp'],
+            'ascending': [events_ascending_timestamp],
         },
     )
     events_result = assert_proper_response_with_result(response)

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -16,6 +16,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Tuple,
     TypeVar,
     Union,
     overload,
@@ -370,3 +371,16 @@ def shift_num_right_by(num: int, digits: int) -> int:
 def is_valid_ethereum_tx_hash(val: str) -> bool:
     """Validates an Ethereum transaction hash."""
     return len(val) == 66 and is_hexstr(val) is True
+
+
+def create_order_by_rules_list(
+        data: Dict[str, Any],
+        timestamp_field: str = 'timestamp',
+) -> List[Tuple[str, bool]]:
+    """Create a list of attributes and sorting order taking values from DBOrderBySchema
+    to be used by the filters that allow sorting. By default the attribute used for sorting is
+    timestamp and the ascending value for this field is False.
+    """
+    order_by_attribute = data['order_by_attributes'] if data['order_by_attributes'] is not None else [timestamp_field]  # noqa: E501
+    ascending = data['ascending'] if data['ascending'] is not None else [False]
+    return list(zip(order_by_attribute, ascending))


### PR DESCRIPTION
This PR removes a TODO from the code that was needed by @lukicenturi and allows to sort using multiple fields. Now the `order_by_attribute` and `ascending` take a list of arguments and pass it to the different filters used in the API

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
