### PR TITLE
Minor tweaks in test_tokens.py

### DIFF
--- a/rotkehlchen/tests/unit/test_nfts.py
+++ b/rotkehlchen/tests/unit/test_nfts.py
@@ -14,6 +14,7 @@ def test_addresses_queried_for_nfts(blockchain):
     nft_module = blockchain.get_module('nfts')
     balances = nft_module.get_balances(
         addresses=[TEST_ACC1, TEST_ACC2],
+        uniswap_nfts=None,
         return_zero_values=False,
         ignore_cache=True,
     )


### PR DESCRIPTION
- Mark the test that queries etherscan as flaky
- Inquirer is needed by the ethtokens fixture. Not each test inidividually