### PR TITLE
Splits exchanges state to their own pinia store

### DIFF
--- a/frontend/app/src/components/GlobalSearch.vue
+++ b/frontend/app/src/components/GlobalSearch.vue
@@ -121,7 +121,6 @@ import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import LocationIcon from '@/components/history/LocationIcon.vue';
 import { TradeLocationData } from '@/components/history/type';
 import {
-  setupExchanges,
   setupGeneralBalances,
   setupLocationInfo
 } from '@/composables/balances';
@@ -130,6 +129,7 @@ import { interop } from '@/electron-interop';
 import i18n from '@/i18n';
 import { routesRef } from '@/router/routes';
 import { useAssetInfoRetrieval } from '@/store/assets';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { Exchange } from '@/types/exchanges';
 
@@ -169,7 +169,7 @@ export default defineComponent({
 
     const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
     const { assetSymbol } = useAssetInfoRetrieval();
-    const { connectedExchanges } = setupExchanges();
+    const { connectedExchanges } = storeToRefs(useExchangeBalancesStore());
     const { aggregatedBalances, balancesByLocation } = setupGeneralBalances();
     const { getLocation } = setupLocationInfo();
     const { dark } = useTheme();

--- a/frontend/app/src/components/settings/api-keys/ExchangeKeysForm.vue
+++ b/frontend/app/src/components/settings/api-keys/ExchangeKeysForm.vue
@@ -162,8 +162,8 @@ import ExchangeDisplay from '@/components/display/ExchangeDisplay.vue';
 import BinancePairsSelector from '@/components/helper/BinancePairsSelector.vue';
 import { tradeLocations } from '@/components/history/consts';
 import RevealableInput from '@/components/inputs/RevealableInput.vue';
-import { setupGeneralBalances } from '@/composables/balances';
 import i18n from '@/i18n';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { ExchangePayload } from '@/store/balances/types';
 import {
   KrakenAccountType,
@@ -186,7 +186,7 @@ export default defineComponent({
     const editKeys = ref(false);
     const form = ref();
 
-    const { exchangeNonce } = setupGeneralBalances();
+    const { getExchangeNonce } = useExchangeBalancesStore();
 
     const requiresPassphrase = computed(() => {
       const { location } = get(exchange);
@@ -228,7 +228,8 @@ export default defineComponent({
       const location = tradeLocations.find(
         ({ identifier }) => identifier === exchange
       );
-      return location ? `${location.name} ${exchangeNonce(exchange)}` : '';
+      const nonce = get(getExchangeNonce(exchange));
+      return location ? `${location.name} ${nonce}` : '';
     };
 
     const toggleEdit = () => {

--- a/frontend/app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/frontend/app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -91,9 +91,9 @@ import ConfirmDialog from '@/components/dialogs/ConfirmDialog.vue';
 import RowActions from '@/components/helper/RowActions.vue';
 import { exchangeName } from '@/components/history/consts';
 import ExchangeKeysForm from '@/components/settings/api-keys/ExchangeKeysForm.vue';
-import { setupExchanges } from '@/composables/balances';
 import { useRouter } from '@/composables/common';
 import i18nFn from '@/i18n';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { ExchangePayload } from '@/store/balances/types';
 import { useNotifications } from '@/store/notifications';
 import { useSettingsStore } from '@/store/settings';
@@ -118,7 +118,9 @@ const nonSyncingExchanges = ref<Exchange[]>([]);
 const pendingRemoval = ref<Nullable<Exchange>>(null);
 const confirmation = ref<boolean>(false);
 
-const { connectedExchanges, setupExchange, removeExchange } = setupExchanges();
+const store = useExchangeBalancesStore();
+const { setupExchange, removeExchange } = store;
+const { connectedExchanges } = storeToRefs(store);
 
 const exchange = ref<ExchangePayload>(placeholder());
 

--- a/frontend/app/src/composables/balances.ts
+++ b/frontend/app/src/composables/balances.ts
@@ -19,9 +19,7 @@ import {
   BlockchainAccountWithBalance,
   BlockchainBalancePayload,
   BlockchainTotal,
-  ExchangeBalancePayload,
   ExchangeRateGetter,
-  ExchangeSetupPayload,
   FetchPricePayload,
   HistoricPricePayload,
   LocationBalance,
@@ -32,7 +30,6 @@ import {
 import { ActionStatus } from '@/store/types';
 import { useStore } from '@/store/utils';
 import { Eth2Validator } from '@/types/balances';
-import { Exchange, ExchangeInfo, SupportedExchange } from '@/types/exchanges';
 import { PriceOracle } from '@/types/user';
 import { assert } from '@/utils/assertions';
 
@@ -63,10 +60,6 @@ export const setupGeneralBalances = () => {
   const blockchainTotals = computed<BlockchainTotal[]>(() => {
     return store.getters['balances/blockchainTotals'];
   });
-
-  const exchangeNonce = (exchange: SupportedExchange): number => {
-    return store.getters['balances/exchangeNonce'](exchange);
-  };
 
   const hasDetails = (account: string) =>
     computed<boolean>(() => {
@@ -156,7 +149,6 @@ export const setupGeneralBalances = () => {
     liabilities,
     blockchainTotals,
     nfBalances,
-    exchangeNonce,
     nfTotalValue,
     hasDetails,
     accountAssets,
@@ -402,53 +394,5 @@ export const usePrices = () => {
     createOracleCache,
     getPriceCache,
     deletePriceCache
-  };
-};
-
-export const setupExchanges = () => {
-  const store = useStore();
-
-  const exchanges = computed<ExchangeInfo[]>(() => {
-    return store.getters['balances/exchanges'];
-  });
-
-  const connectedExchanges = computed<Exchange[]>(() => {
-    return store.state.balances!!.connectedExchanges;
-  });
-
-  const exchangeBalances = (exchange: string) =>
-    computed<AssetBalanceWithPrice[]>(() =>
-      store.getters['balances/exchangeBalances'](exchange)
-    );
-
-  const fetchExchangeBalances: (
-    payload: ExchangeBalancePayload
-  ) => Promise<void> = async payload => {
-    return await store.dispatch('balances/fetchExchangeBalances', payload);
-  };
-
-  const fetchConnectedExchangeBalances = async (refresh: boolean = false) => {
-    return await store.dispatch(
-      'balances/fetchConnectedExchangeBalances',
-      refresh
-    );
-  };
-
-  const setupExchange = async (payload: ExchangeSetupPayload) => {
-    return await store.dispatch('balances/setupExchange', payload);
-  };
-
-  const removeExchange = async (exchange: Exchange) => {
-    return await store.dispatch('balances/removeExchange', exchange);
-  };
-
-  return {
-    exchanges,
-    exchangeBalances,
-    connectedExchanges,
-    fetchExchangeBalances,
-    fetchConnectedExchangeBalances,
-    setupExchange,
-    removeExchange
   };
 };

--- a/frontend/app/src/services/monitoring.ts
+++ b/frontend/app/src/services/monitoring.ts
@@ -1,7 +1,8 @@
 import { get } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
-import { setupExchanges, setupGeneralBalances } from '@/composables/balances';
+import { setupGeneralBalances } from '@/composables/balances';
 import { websocket } from '@/services/websocket/websocket-service';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { useNotifications } from '@/store/notifications';
 import { useSessionStore } from '@/store/session';
 import { useWatchersStore } from '@/store/session/watchers';
@@ -35,7 +36,7 @@ class Monitoring {
       fetchLoopringBalances,
       refreshPrices
     } = setupGeneralBalances();
-    const { fetchConnectedExchangeBalances } = setupExchanges();
+    const { fetchConnectedExchangeBalances } = useExchangeBalancesStore();
 
     await fetchManualBalances();
     await fetchBlockchainBalances({ ignoreCache: true });

--- a/frontend/app/src/store/balances/exchanges.ts
+++ b/frontend/app/src/store/balances/exchanges.ts
@@ -1,0 +1,330 @@
+import { AssetBalanceWithPrice, Balance } from '@rotki/common';
+import { computed, ComputedRef, Ref, ref } from '@vue/composition-api';
+import { get, set } from '@vueuse/core';
+import { forEach } from 'lodash';
+import { acceptHMRUpdate, defineStore } from 'pinia';
+import i18n from '@/i18n';
+import { balanceKeys } from '@/services/consts';
+import { api } from '@/services/rotkehlchen-api';
+import { useAssetInfoRetrieval, useIgnoredAssetsStore } from '@/store/assets';
+import {
+  AssetBalances,
+  EditExchange,
+  ExchangeBalancePayload,
+  ExchangeSetupPayload
+} from '@/store/balances/types';
+import { Section, Status } from '@/store/const';
+import { useHistory } from '@/store/history';
+import { useNotifications } from '@/store/notifications';
+import store from '@/store/store';
+import { useTasks } from '@/store/tasks';
+import { getStatus, setStatus, showError } from '@/store/utils';
+import {
+  Exchange,
+  ExchangeData,
+  ExchangeInfo,
+  SupportedExchange
+} from '@/types/exchanges';
+import { ExchangeMeta } from '@/types/task';
+import { TaskType } from '@/types/task-type';
+import { assert } from '@/utils/assertions';
+import { NoPrice, sortDesc } from '@/utils/bignumbers';
+import { assetSum, balanceSum } from '@/utils/calculation';
+
+export const useExchangeBalancesStore = defineStore(
+  'balances/exchanges',
+  () => {
+    const connectedExchanges: Ref<Exchange[]> = ref([]);
+    const exchangeBalances: Ref<ExchangeData> = ref({});
+
+    const { awaitTask, isTaskRunning, metadata } = useTasks();
+    const { notify } = useNotifications();
+    const { purgeHistoryLocation } = useHistory();
+    const { getAssociatedAssetIdentifier } = useAssetInfoRetrieval();
+    const { isAssetIgnored } = useIgnoredAssetsStore();
+
+    const exchanges: ComputedRef<ExchangeInfo[]> = computed(() => {
+      const balances = get(exchangeBalances);
+      return Object.keys(balances)
+        .map(value => ({
+          location: value,
+          balances: balances[value],
+          total: assetSum(balances[value])
+        }))
+        .sort((a, b) => sortDesc(a.total, b.total));
+    });
+
+    const getExchangeNonce = (exchange: SupportedExchange) =>
+      computed(() => {
+        return (
+          get(connectedExchanges).filter(
+            ({ location }) => location === exchange
+          ).length + 1
+        );
+      });
+
+    const getBalances = (
+      exchange: SupportedExchange
+    ): ComputedRef<AssetBalanceWithPrice[]> =>
+      computed(() => {
+        const ownedAssets: Record<string, Balance> = {};
+        const balances = get(exchangeBalances);
+
+        forEach(balances[exchange], (value: Balance, asset: string) => {
+          const associatedAsset: string = get(
+            getAssociatedAssetIdentifier(asset)
+          );
+
+          const ownedAsset = ownedAssets[associatedAsset];
+
+          ownedAssets[associatedAsset] = !ownedAsset
+            ? {
+                ...value
+              }
+            : {
+                ...balanceSum(ownedAsset, value)
+              };
+        });
+
+        const prices = store.state.balances!.prices;
+        return Object.keys(ownedAssets)
+          .filter(asset => !get(isAssetIgnored(asset)))
+          .map(asset => ({
+            asset,
+            amount: ownedAssets[asset].amount,
+            usdValue: ownedAssets[asset].usdValue,
+            usdPrice: prices[asset] ?? NoPrice
+          }));
+      });
+
+    const addExchange = (exchange: Exchange) => {
+      set(connectedExchanges, [...get(connectedExchanges), exchange]);
+    };
+
+    const editExchange = ({
+      exchange: { location, name: oldName, krakenAccountType, ftxSubaccount },
+      newName
+    }: EditExchange) => {
+      const exchanges = [...get(connectedExchanges)];
+      const name = newName ?? oldName;
+      const index = exchanges.findIndex(
+        value => value.name === oldName && value.location === location
+      );
+      exchanges[index] = {
+        ...exchanges[index],
+        name,
+        location,
+        krakenAccountType,
+        ftxSubaccount
+      };
+      set(connectedExchanges, exchanges);
+    };
+
+    const removeExchange = async (exchange: Exchange): Promise<boolean> => {
+      try {
+        const success = await api.removeExchange(exchange);
+        const connected = get(connectedExchanges);
+        if (success) {
+          const exchangeIndex = connected.findIndex(
+            ({ location, name }) =>
+              name === exchange.name && location === exchange.location
+          );
+          assert(
+            exchangeIndex >= 0,
+            `${exchange} not found in ${connected
+              .map(exchange => `${exchange.name} on ${exchange.location}`)
+              .join(', ')}`
+          );
+
+          const exchanges = [...connected];
+          const balances = { ...get(exchangeBalances) };
+          const index = exchanges.findIndex(
+            ({ location, name }) =>
+              name === exchange.name && location === exchange.location
+          );
+          // can't modify in place or else the vue reactivity does not work
+          exchanges.splice(index, 1);
+          delete balances[exchange.location];
+          set(connectedExchanges, exchanges);
+          set(exchangeBalances, balances);
+
+          if (exchanges.length > 0) {
+            await fetchExchangeBalances({
+              location: exchange.location,
+              ignoreCache: false
+            });
+          }
+        }
+
+        await purgeHistoryLocation(exchange.location);
+
+        return success;
+      } catch (e: any) {
+        showError(
+          i18n.tc('actions.balances.exchange_removal.description', 0, {
+            exchange,
+            error: e.message
+          }),
+          i18n.tc('actions.balances.exchange_removal.title')
+        );
+        return false;
+      }
+    };
+
+    const setExchanges = async (exchanges: Exchange[]): Promise<void> => {
+      set(connectedExchanges, exchanges);
+      await fetchConnectedExchangeBalances(false);
+    };
+
+    const fetchExchangeBalances = async (
+      payload: ExchangeBalancePayload
+    ): Promise<void> => {
+      const { location, ignoreCache } = payload;
+      const taskType = TaskType.QUERY_EXCHANGE_BALANCES;
+      const meta = metadata<ExchangeMeta>(taskType);
+
+      if (get(isTaskRunning(taskType)) && meta?.location === location) {
+        return;
+      }
+
+      const currentStatus: Status = getStatus(Section.EXCHANGES);
+      const section = Section.EXCHANGES;
+      const newStatus =
+        currentStatus === Status.LOADED ? Status.REFRESHING : Status.LOADING;
+      setStatus(newStatus, section);
+
+      try {
+        const { taskId } = await api.queryExchangeBalances(
+          location,
+          ignoreCache
+        );
+        const meta: ExchangeMeta = {
+          location,
+          title: i18n
+            .t('actions.balances.exchange_balances.task.title', {
+              location
+            })
+            .toString(),
+          numericKeys: balanceKeys
+        };
+
+        const { result } = await awaitTask<AssetBalances, ExchangeMeta>(
+          taskId,
+          taskType,
+          meta,
+          true
+        );
+
+        set(exchangeBalances, {
+          ...get(exchangeBalances),
+          [location]: result
+        });
+      } catch (e: any) {
+        const message = i18n
+          .t('actions.balances.exchange_balances.error.message', {
+            location,
+            error: e.message
+          })
+          .toString();
+        const title = i18n
+          .t('actions.balances.exchange_balances.error.title', {
+            location
+          })
+          .toString();
+
+        notify({
+          title,
+          message,
+          display: true
+        });
+      } finally {
+        setStatus(Status.LOADED, section);
+      }
+    };
+
+    const fetchConnectedExchangeBalances = async (
+      refresh: boolean = false
+    ): Promise<void> => {
+      const exchanges = get(connectedExchanges);
+      for (const exchange of exchanges) {
+        await fetchExchangeBalances({
+          location: exchange.location,
+          ignoreCache: refresh
+        } as ExchangeBalancePayload);
+      }
+    };
+
+    const setupExchange = async ({
+      exchange,
+      edit
+    }: ExchangeSetupPayload): Promise<boolean> => {
+      try {
+        const success = await api.setupExchange(exchange, edit);
+        const exchangeEntry: Exchange = {
+          name: exchange.name,
+          location: exchange.location,
+          krakenAccountType: exchange.krakenAccountType ?? undefined,
+          ftxSubaccount: exchange.ftxSubaccount ?? undefined
+        };
+
+        if (!edit) {
+          addExchange(exchangeEntry);
+        } else {
+          editExchange({
+            exchange: exchangeEntry,
+            newName: exchange.newName
+          });
+        }
+
+        fetchExchangeBalances({
+          location: exchange.location,
+          ignoreCache: false
+        }).then(() =>
+          store.dispatch('balances/refreshPrices', { ignoreCache: false })
+        );
+
+        purgeHistoryLocation(exchange.location);
+
+        return success;
+      } catch (e: any) {
+        showError(
+          i18n
+            .t('actions.balances.exchange_setup.description', {
+              exchange: exchange.location,
+              error: e.message
+            })
+            .toString(),
+          i18n.t('actions.balances.exchange_setup.title').toString()
+        );
+        return false;
+      }
+    };
+
+    const reset = () => {
+      set(connectedExchanges, []);
+      set(exchangeBalances, {});
+    };
+
+    return {
+      exchanges,
+      connectedExchanges,
+      exchangeBalances,
+      setExchanges,
+      setupExchange,
+      addExchange,
+      editExchange,
+      removeExchange,
+      getBalances,
+      getExchangeNonce,
+      fetchExchangeBalances,
+      fetchConnectedExchangeBalances,
+      reset
+    };
+  }
+);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useExchangeBalancesStore, import.meta.hot)
+  );
+}

--- a/frontend/app/src/store/balances/mutations.ts
+++ b/frontend/app/src/store/balances/mutations.ts
@@ -14,10 +14,8 @@ import {
   AccountAssetBalances,
   AssetPrices,
   BalanceState,
-  EditExchange,
   NonFungibleBalances
 } from '@/store/balances/types';
-import { Exchange, ExchangeData, ExchangeInfo } from '@/types/exchanges';
 import { ExchangeRates } from '@/types/user';
 
 export const mutations: MutationTree<BalanceState> = {
@@ -65,53 +63,6 @@ export const mutations: MutationTree<BalanceState> = {
     usdToFiatExchangeRates: ExchangeRates
   ) {
     state.usdToFiatExchangeRates = usdToFiatExchangeRates;
-  },
-  connectedExchanges(state: BalanceState, connectedExchanges: Exchange[]) {
-    state.connectedExchanges = connectedExchanges;
-  },
-  addExchange(state: BalanceState, exchange: Exchange) {
-    state.connectedExchanges.push(exchange);
-  },
-  editExchange(
-    state: BalanceState,
-    {
-      exchange: { location, name: oldName, krakenAccountType, ftxSubaccount },
-      newName
-    }: EditExchange
-  ) {
-    const exchanges = [...state.connectedExchanges];
-    const name = newName ?? oldName;
-    const index = exchanges.findIndex(
-      value => value.name === oldName && value.location === location
-    );
-    exchanges[index] = Object.assign(exchanges[index], {
-      name,
-      location,
-      krakenAccountType,
-      ftxSubaccount
-    });
-    state.connectedExchanges = exchanges;
-  },
-  removeExchange(state: BalanceState, exchange: Exchange) {
-    const exchanges = [...state.connectedExchanges];
-    const balances = { ...state.exchangeBalances };
-    const index = exchanges.findIndex(
-      ({ location, name }) =>
-        name === exchange.name && location === exchange.location
-    );
-    // can't modify in place or else the vue reactivity does not work
-    exchanges.splice(index, 1);
-    delete balances[exchange.location];
-    state.connectedExchanges = exchanges;
-    state.exchangeBalances = balances;
-  },
-  updateExchangeBalances(state: BalanceState, data: ExchangeData) {
-    state.exchangeBalances = data;
-  },
-  addExchangeBalances(state: BalanceState, data: ExchangeInfo) {
-    const update: ExchangeData = {};
-    update[data.location] = data.balances;
-    state.exchangeBalances = { ...state.exchangeBalances, ...update };
   },
   ethAccounts(state: BalanceState, accounts: GeneralAccountData[]) {
     state.ethAccounts = accounts;

--- a/frontend/app/src/store/balances/state.ts
+++ b/frontend/app/src/store/balances/state.ts
@@ -17,8 +17,6 @@ export const defaultState = (): BalanceState => ({
   totals: {},
   liabilities: {},
   usdToFiatExchangeRates: {},
-  connectedExchanges: [],
-  exchangeBalances: {},
   ethAccounts: [],
   ksmAccounts: [],
   dotAccounts: [],

--- a/frontend/app/src/store/balances/types.ts
+++ b/frontend/app/src/store/balances/types.ts
@@ -15,7 +15,6 @@ import { Section } from '@/store/const';
 import { Nullable } from '@/types';
 import {
   Exchange,
-  ExchangeData,
   KrakenAccountType,
   SupportedExchange
 } from '@/types/exchanges';
@@ -53,8 +52,6 @@ export interface BalanceState {
   totals: AssetBalances;
   liabilities: AssetBalances;
   usdToFiatExchangeRates: ExchangeRates;
-  connectedExchanges: Exchange[];
-  exchangeBalances: ExchangeData;
   ethAccounts: GeneralAccountData[];
   btcAccounts: BtcAccountData;
   bchAccounts: BtcAccountData;

--- a/frontend/app/src/views/Dashboard.vue
+++ b/frontend/app/src/views/Dashboard.vue
@@ -155,7 +155,9 @@ import {
   defineComponent
 } from '@vue/composition-api';
 import { get } from '@vueuse/core';
-import { setupExchanges, setupGeneralBalances } from '@/composables/balances';
+import { storeToRefs } from 'pinia';
+import { setupGeneralBalances } from '@/composables/balances';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { useUniswapStore } from '@/store/defi/uniswap';
 import { useTasks } from '@/store/tasks';
 import { TaskType } from '@/types/task-type';
@@ -200,7 +202,8 @@ export default defineComponent({
       fetchManualBalances
     } = setupGeneralBalances();
 
-    const { exchanges, fetchExchangeBalances } = setupExchanges();
+    const exchangeStore = useExchangeBalancesStore();
+    const { exchanges } = storeToRefs(exchangeStore);
 
     const isQueryingBlockchain = isTaskRunning(
       TaskType.QUERY_BLOCKCHAIN_BALANCES
@@ -241,12 +244,7 @@ export default defineComponent({
         const { fetchV3Balances } = useUniswapStore();
         fetchV3Balances();
       } else if (balanceSource === 'exchange') {
-        for (const exchange of get(exchanges)) {
-          fetchExchangeBalances({
-            location: exchange.location,
-            ignoreCache: true
-          });
-        }
+        exchangeStore.fetchConnectedExchangeBalances(true);
       }
     };
 

--- a/frontend/app/src/views/staking/KrakenPage.vue
+++ b/frontend/app/src/views/staking/KrakenPage.vue
@@ -60,11 +60,12 @@ import {
   watch
 } from '@vue/composition-api';
 import { get } from '@vueuse/core';
+import { storeToRefs } from 'pinia';
 import FullSizeContent from '@/components/common/FullSizeContent.vue';
 import ProgressScreen from '@/components/helper/ProgressScreen.vue';
 import KrakenStaking from '@/components/staking/kraken/KrakenStaking.vue';
-import { setupExchanges } from '@/composables/balances';
 import { setupStatusChecking } from '@/composables/common';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { Section } from '@/store/const';
 import { useKrakenStakingStore } from '@/store/staking/kraken';
 import { SupportedExchange } from '@/types/exchanges';
@@ -76,7 +77,7 @@ export default defineComponent({
     const { shouldShowLoadingScreen } = setupStatusChecking();
     const { load } = useKrakenStakingStore();
 
-    const { connectedExchanges } = setupExchanges();
+    const { connectedExchanges } = storeToRefs(useExchangeBalancesStore());
     const isKrakenConnected = computed(() => {
       const exchanges = get(connectedExchanges);
       return !!exchanges.find(

--- a/frontend/app/tests/unit/store/balances/getters.spec.ts
+++ b/frontend/app/tests/unit/store/balances/getters.spec.ts
@@ -1,9 +1,11 @@
-import { AssetBalance, AssetBalanceWithPrice } from '@rotki/common';
+import { AssetBalanceWithPrice } from '@rotki/common';
+import { set } from '@vueuse/core';
 import sortBy from 'lodash/sortBy';
-import { createPinia, setActivePinia } from 'pinia';
+import { createPinia, setActivePinia, storeToRefs } from 'pinia';
 import { TRADE_LOCATION_BANKS } from '@/data/defaults';
 import { BalanceType, BtcBalances } from '@/services/balances/types';
 import { BtcAccountData } from '@/services/types-api';
+import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { BalanceGetters, getters } from '@/store/balances/getters';
 import { BalanceState } from '@/store/balances/types';
 import store from '@/store/store';
@@ -14,36 +16,42 @@ import { stub } from '../../../common/utils';
 
 describe('balances:getters', () => {
   beforeEach(() => {
-    const pinia = createPinia();
-    setActivePinia(pinia);
+    setActivePinia(createPinia());
   });
 
   test('aggregatedBalances', () => {
+    const { connectedExchanges, exchangeBalances } = storeToRefs(
+      useExchangeBalancesStore()
+    );
+    set(connectedExchanges, [
+      {
+        location: SupportedExchange.KRAKEN,
+        name: 'Bitrex Acc'
+      }
+    ]);
+
+    set(exchangeBalances, {
+      [SupportedExchange.KRAKEN]: {
+        DAI: {
+          amount: bigNumberify(50),
+          usdValue: bigNumberify(50)
+        },
+        BTC: {
+          amount: bigNumberify(50),
+          usdValue: bigNumberify(50)
+        },
+        ETH: {
+          amount: bigNumberify(50),
+          usdValue: bigNumberify(50)
+        },
+        EUR: {
+          amount: bigNumberify(50),
+          usdValue: bigNumberify(50)
+        }
+      }
+    });
+
     const mockGetters = {
-      exchangeBalances: function (): AssetBalance[] {
-        return [
-          {
-            asset: 'DAI',
-            amount: bigNumberify(50),
-            usdValue: bigNumberify(50)
-          },
-          {
-            asset: 'BTC',
-            amount: bigNumberify(50),
-            usdValue: bigNumberify(50)
-          },
-          {
-            asset: 'ETH',
-            amount: bigNumberify(50),
-            usdValue: bigNumberify(50)
-          },
-          {
-            asset: 'EUR',
-            amount: bigNumberify(50),
-            usdValue: bigNumberify(50)
-          }
-        ];
-      },
       totals: [
         {
           asset: 'DAI',
@@ -88,13 +96,7 @@ describe('balances:getters', () => {
         SAI: bigNumberify(1),
         ETH: bigNumberify(3000),
         BTC: bigNumberify(40000)
-      },
-      connectedExchanges: [
-        {
-          location: SupportedExchange.BITTREX,
-          name: 'Bitrex Acc'
-        }
-      ]
+      }
     });
 
     const actualResult = sortBy(


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

@lukicenturi I think it makes sense to do the last part in smaller chunks to make it easier

I think further down we can start splitting the state to smaller pinia stores:
- balances/prices
- balances/manual
- balances/blockchain (we can see if it makes sense to split it further down
- balances (has the totals/liabilities + the aggregation of the values from different submodules)

What do you think about this approach?