### PR TITLE
enable generic data import for rotki

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10450,9 +10450,9 @@ Data imports
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"source": "cointracking.info", "filepath": "/path/to/data/file", "timestamp_format": "%d/%m/%Y %H:%M:%S"}
+      {"source": "cointracking", "filepath": "/path/to/data/file", "timestamp_format": "%d/%m/%Y %H:%M:%S"}
 
-   :reqjson str source: The source of the data to import. Valid values are ``"cointracking"``, ``"cryptocom"``, ``"blockfi_transactions"``, ``"blockfi_trades"``, ``"nexo"``,  ``"shapeshift_trades"``, ``"uphold_transactions"``, ``"bisq_trades"``, ``"binance"``.
+   :reqjson str source: The source of the data to import. Valid values are ``"cointracking"``, ``"cryptocom"``, ``"blockfi_transactions"``, ``"blockfi_trades"``, ``"nexo"``,  ``"shapeshift_trades"``, ``"uphold_transactions"``, ``"bisq_trades"``, ``"binance"``, ``"rotki_events"``, ``"rotki_trades"``.
    :reqjson str filepath: The filepath to the data for importing
    :reqjson str timestamp_format: Optional. Custom format to use for dates in the CSV file. Should follow rules at `Datetime docs <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes>`__.
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -89,7 +89,7 @@ from rotkehlchen.types import (
     UserNote,
 )
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
-from rotkehlchen.utils.misc import create_order_by_rules_list, is_valid_ethereum_tx_hash, ts_now
+from rotkehlchen.utils.misc import create_order_by_rules_list, ts_now
 
 from .fields import (
     AmountField,
@@ -487,10 +487,7 @@ class HistoryBaseEntrySchema(Schema):
         if self.identifier_required is True and data['identifier'] is None:
             raise ValidationError('History event identifier should be given')
         try:
-            if is_valid_ethereum_tx_hash(data['event_identifier']):
-                data['event_identifier'] = HistoryBaseEntry.deserialize_event_identifier(data['event_identifier'])  # noqa: 501
-            else:
-                data['event_identifier'] = HistoryBaseEntry.deserialize_event_identifier_from_kraken(data['event_identifier'])  # noqa: 501
+            data['event_identifier'] = HistoryBaseEntry.deserialize_event_identifier(data['event_identifier'])  # noqa: E501
         except DeserializationError as e:
             raise ValidationError(str(e)) from e
 

--- a/rotkehlchen/data_import/importers/rotki_events.py
+++ b/rotkehlchen/data_import/importers/rotki_events.py
@@ -1,0 +1,114 @@
+import csv
+from pathlib import Path
+from typing import Any, Dict, List
+from uuid import uuid4
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.base import HistoryBaseEntry
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.assets.utils import symbol_to_asset_or_token
+from rotkehlchen.constants import ZERO
+from rotkehlchen.data_import.utils import BaseExchangeImporter, UnsupportedCSVEntry
+from rotkehlchen.db.drivers.gevent import DBCursor
+from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.misc import InputError
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.serialization.deserialize import deserialize_asset_amount, deserialize_timestamp
+from rotkehlchen.types import Fee, Location, TimestampMS
+
+GENERIC_TYPE_TO_HISTORY_EVENT_TYPE_MAPPINGS = {
+    'Deposit': (HistoryEventType.DEPOSIT, HistoryEventSubType.SPEND),
+    'Withdrawal': (HistoryEventType.WITHDRAWAL, HistoryEventSubType.RECEIVE),
+    'Income': (HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE),
+    'Loss': (HistoryEventType.SPEND, HistoryEventSubType.NONE),
+    'Staking': (HistoryEventType.STAKING, HistoryEventSubType.REWARD),
+}
+
+
+class RotkiGenericEventsImporter(BaseExchangeImporter):
+    def _consume_rotki_event(
+            self,
+            cursor: DBCursor,
+            csv_row: Dict[str, Any],
+            sequence_index: int,
+    ) -> None:
+        """Consume rotki generic events import CSV file.
+        May raise:
+        - UnsupportedCSVEntry if an unknown type is encountered.
+        - DeserializationError
+        - UnknownAsset
+        - KeyError
+        """
+        identifier = f'rotki_events_{uuid4().hex}'
+        try:
+            event_type, event_subtype = GENERIC_TYPE_TO_HISTORY_EVENT_TYPE_MAPPINGS[csv_row['Type']]  # noqa: E501
+        except KeyError as e:
+            raise UnsupportedCSVEntry(f'Unsupported entry {csv_row["Type"]}. Data: {csv_row}') from e  # noqa: E501
+        events: List[HistoryBaseEntry] = []
+        location = Location.deserialize(csv_row['Location'])
+        timestamp = TimestampMS(deserialize_timestamp(csv_row['Timestamp']))
+        fee = Fee(deserialize_asset_amount(csv_row['Fee'])) if csv_row['Fee'] else Fee(ZERO)  # noqa: E501
+        fee_currency = (
+            symbol_to_asset_or_token(csv_row['Fee Currency'])
+            if csv_row['Fee Currency'] and fee is not None else None
+        )
+        history_event = HistoryBaseEntry(
+            event_identifier=HistoryBaseEntry.deserialize_event_identifier(identifier),
+            sequence_index=sequence_index,
+            timestamp=timestamp,
+            location=location,
+            event_type=event_type,
+            event_subtype=event_subtype,
+            asset=symbol_to_asset_or_token(csv_row['Currency']),
+            balance=Balance(
+                amount=deserialize_asset_amount(csv_row['Amount']),
+                usd_value=ZERO,
+            ),
+            notes=csv_row['Description'],
+        )
+        events.append(history_event)
+        if fee != ZERO and fee_currency is not None:
+            fee_event = HistoryBaseEntry(
+                event_identifier=HistoryBaseEntry.deserialize_event_identifier(identifier),
+                sequence_index=sequence_index + 1,
+                timestamp=timestamp,
+                location=location,
+                event_type=event_type,
+                event_subtype=HistoryEventSubType.FEE,
+                asset=fee_currency,
+                balance=Balance(
+                    amount=fee,
+                    usd_value=ZERO,
+                ),
+                notes=csv_row['Description'],
+            )
+            events.append(fee_event)
+        self.add_history_events(cursor, events)
+
+    def _import_csv(self, cursor: DBCursor, filepath: Path, **kwargs: Any) -> None:
+        """May raise:
+        - InputError if one of the rows is malformed
+        """
+        with open(filepath, 'r', encoding='utf-8-sig') as csvfile:
+            data = csv.DictReader(csvfile)
+            for idx, row in enumerate(data):
+                try:
+                    kwargs['sequence_index'] = idx
+                    self._consume_rotki_event(cursor, row, **kwargs)
+                except UnknownAsset as e:
+                    self.db.msg_aggregator.add_warning(
+                        f'During rotki generic events CSV import, found action with unknown '
+                        f'asset {e.asset_name}. Ignoring entry',
+                    )
+                    continue
+                except DeserializationError as e:
+                    self.db.msg_aggregator.add_warning(
+                        f'Deserialization error during rotki generic events CSV import. '
+                        f'{str(e)}. Ignoring entry',
+                    )
+                    continue
+                except UnsupportedCSVEntry as e:
+                    self.db.msg_aggregator.add_warning(str(e))
+                    continue
+                except KeyError as e:
+                    raise InputError(f'Could not find key {str(e)} in csv row {str(row)}') from e

--- a/rotkehlchen/data_import/importers/rotki_trades.py
+++ b/rotkehlchen/data_import/importers/rotki_trades.py
@@ -1,0 +1,93 @@
+import csv
+import logging
+from decimal import DivisionByZero
+from pathlib import Path
+from typing import Any, Dict
+
+from rotkehlchen.assets.utils import symbol_to_asset_or_token
+from rotkehlchen.data_import.utils import BaseExchangeImporter
+from rotkehlchen.db.drivers.gevent import DBCursor
+from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.misc import InputError
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.exchanges.data_structures import Trade
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.serialization.deserialize import (
+    deserialize_asset_amount,
+    deserialize_timestamp_from_date,
+)
+from rotkehlchen.types import Fee, Location, Price, TradeType
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class RotkiGenericTradesImporter(BaseExchangeImporter):
+    def _consume_rotki_trades(
+            self,
+            cursor: DBCursor,
+            csv_row: Dict[str, Any],
+            timestamp_format: str = '%Y-%m-%d %H:%M:%S',
+    ) -> None:
+        """Consume rotki generic trades import CSV file.
+        May raise:
+        - DeserializationError
+        - UnknownAsset
+        - KeyError
+        - DivisionByZero if `amount_bought` is ZERO
+        """
+        fee = Fee(deserialize_asset_amount(csv_row['Fee'])) if csv_row['Fee'] else None  # noqa: E501
+        fee_currency = (
+            symbol_to_asset_or_token(csv_row['Fee Currency'])
+            if csv_row['Fee Currency'] and fee is not None else None
+        )
+        amount_sold = deserialize_asset_amount(csv_row['Sell Amount'])
+        amount_bought = deserialize_asset_amount(csv_row['Buy Amount'])
+        location = Location.deserialize(csv_row['Location'])
+        trade = Trade(
+            timestamp=deserialize_timestamp_from_date(
+                date=csv_row['Timestamp'],
+                formatstr=timestamp_format,
+                location='Rotki generic trades importer',
+            ),
+            location=location,
+            fee=fee,
+            fee_currency=fee_currency,
+            rate=Price(amount_sold / amount_bought),
+            base_asset=symbol_to_asset_or_token(csv_row['Base Currency']),
+            quote_asset=symbol_to_asset_or_token(csv_row['Quote Currency']),
+            trade_type=TradeType.SELL if csv_row['Type'] == 'Sell' else TradeType.BUY,
+            amount=amount_bought,
+            notes=csv_row['Description'],
+        )
+        self.add_trade(cursor, trade)
+
+    def _import_csv(self, cursor: DBCursor, filepath: Path, **kwargs: Any) -> None:
+        """May raise:
+        - InputError if one of the rows is malformed
+        """
+        with open(filepath, 'r', encoding='utf-8-sig') as csvfile:
+            data = csv.DictReader(csvfile)
+            for row in data:
+                try:
+                    self._consume_rotki_trades(cursor, row, **kwargs)
+                except UnknownAsset as e:
+                    self.db.msg_aggregator.add_warning(
+                        f'During rotki generic trades CSV import, found action with unknown '
+                        f'asset {e.asset_name}. Ignoring entry',
+                    )
+                    continue
+                except DeserializationError as e:
+                    self.db.msg_aggregator.add_warning(
+                        f'Deserialization error during rotki generic trades CSV import. '
+                        f'{str(e)}. Ignoring entry',
+                    )
+                    continue
+                except DivisionByZero:
+                    self.db.msg_aggregator.add_warning(
+                        f'During rotki generic trades import, csv row {str(row)} has zero '
+                        f'amount bought. Ignoring entry',
+                    )
+                    continue
+                except KeyError as e:
+                    raise InputError(f'Could not find key {str(e)} in csv row {str(row)}') from e

--- a/rotkehlchen/data_import/manager.py
+++ b/rotkehlchen/data_import/manager.py
@@ -8,6 +8,8 @@ from rotkehlchen.data_import.importers.blockfi_transactions import BlockfiTransa
 from rotkehlchen.data_import.importers.cointracking import CointrackingImporter
 from rotkehlchen.data_import.importers.cryptocom import CryptocomImporter
 from rotkehlchen.data_import.importers.nexo import NexoImporter
+from rotkehlchen.data_import.importers.rotki_events import RotkiGenericEventsImporter
+from rotkehlchen.data_import.importers.rotki_trades import RotkiGenericTradesImporter
 from rotkehlchen.data_import.importers.shapeshift_trades import ShapeshiftTradesImporter
 from rotkehlchen.data_import.importers.uphold_transactions import UpholdTransactionsImporter
 from rotkehlchen.data_import.utils import BaseExchangeImporter
@@ -25,6 +27,8 @@ class DataImportSource(SerializableEnumMixin):
     UPHOLD_TRANSACTIONS = 7
     BISQ_TRADES = 8
     BINANCE = 9
+    ROTKI_TRADES = 10
+    ROTKI_EVENTS = 11
 
     def get_importer_type(self) -> Type[BaseExchangeImporter]:
         if self == DataImportSource.COINTRACKING:
@@ -45,6 +49,10 @@ class DataImportSource(SerializableEnumMixin):
             return BisqTradesImporter
         if self == DataImportSource.BINANCE:
             return BinanceImporter
+        if self == DataImportSource.ROTKI_TRADES:
+            return RotkiGenericTradesImporter
+        if self == DataImportSource.ROTKI_EVENTS:
+            return RotkiGenericEventsImporter
         raise AssertionError(f'Unknown DataImportSource value {self}')
 
 

--- a/rotkehlchen/data_import/utils.py
+++ b/rotkehlchen/data_import/utils.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from typing import Any, List, Tuple
 
 from rotkehlchen.accounting.ledger_actions import LedgerAction
+from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.drivers.gevent import DBCursor
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
@@ -17,9 +19,11 @@ class BaseExchangeImporter(metaclass=ABCMeta):
     def __init__(self, db: DBHandler) -> None:
         self.db = db
         self.db_ledger = DBLedgerActions(self.db, self.db.msg_aggregator)
+        self.history_db = DBHistoryEvents(self.db)
         self._trades: List[Trade] = []
         self._asset_movements: List[AssetMovement] = []
         self._ledger_actions: List[LedgerAction] = []
+        self._history_events: List[HistoryBaseEntry] = []
 
     def import_csv(self, filepath: Path, **kwargs: Any) -> Tuple[bool, str]:
         try:
@@ -50,17 +54,23 @@ class BaseExchangeImporter(metaclass=ABCMeta):
         self._ledger_actions.append(ledger_action)
         self.maybe_flush_all(cursor)
 
+    def add_history_events(self, cursor: DBCursor, history_events: List[HistoryBaseEntry]) -> None:
+        self._history_events.extend(history_events)
+        self.maybe_flush_all(cursor)
+
     def maybe_flush_all(self, cursor: DBCursor) -> None:
-        if len(self._trades) + len(self._asset_movements) + len(self._ledger_actions) >= ITEMS_PER_DB_WRITE:  # noqa: E501
+        if len(self._trades) + len(self._asset_movements) + len(self._ledger_actions) + len(self._history_events) >= ITEMS_PER_DB_WRITE:  # noqa: E501
             self._flush_all(cursor)
 
     def _flush_all(self, cursor: DBCursor) -> None:
         self.db.add_trades(cursor, trades=self._trades)
         self.db.add_asset_movements(cursor, asset_movements=self._asset_movements)
         self.db_ledger.add_ledger_actions(cursor, actions=self._ledger_actions)
+        self.history_db.add_history_events(cursor, history=self._history_events)
         self._trades = []
         self._asset_movements = []
         self._ledger_actions = []
+        self._history_events = []
 
 
 class UnsupportedCSVEntry(Exception):

--- a/rotkehlchen/db/upgrades/v32_v33.py
+++ b/rotkehlchen/db/upgrades/v32_v33.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.types import deserialize_evm_tx_hash
-from rotkehlchen.utils.misc import is_valid_ethereum_tx_hash
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -455,10 +454,7 @@ def _force_bytes_for_tx_hashes(cursor: 'DBCursor') -> None:
     for history_event in history_events:
         history_event = list(history_event)
         try:
-            if is_valid_ethereum_tx_hash(history_event[1]):
-                history_event[1] = HistoryBaseEntry.deserialize_event_identifier(history_event[1])
-            else:
-                history_event[1] = HistoryBaseEntry.deserialize_event_identifier_from_kraken(history_event[1])  # noqa: 501
+            history_event[1] = HistoryBaseEntry.deserialize_event_identifier(history_event[1])
         except DeserializationError:
             continue
         new_history_events.append(tuple(history_event))

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -213,7 +213,7 @@ def history_event_from_kraken(
             # Make sure to not generate an event for KFEES that is not of type FEE
             if asset != A_KFEE:
                 group_events.append(HistoryBaseEntry(
-                    event_identifier=HistoryBaseEntry.deserialize_event_identifier_from_kraken(identifier),  # noqa: 501
+                    event_identifier=HistoryBaseEntry.deserialize_event_identifier(identifier),
                     sequence_index=idx,
                     timestamp=timestamp,
                     location=Location.KRAKEN,
@@ -229,7 +229,7 @@ def history_event_from_kraken(
                 ))
             if fee_amount != ZERO:
                 group_events.append(HistoryBaseEntry(
-                    event_identifier=HistoryBaseEntry.deserialize_event_identifier_from_kraken(identifier),  # noqa: 501
+                    event_identifier=HistoryBaseEntry.deserialize_event_identifier(identifier),
                     sequence_index=current_fee_index,
                     timestamp=timestamp,
                     location=Location.KRAKEN,

--- a/rotkehlchen/tests/api/test_data_import.py
+++ b/rotkehlchen/tests/api/test_data_import.py
@@ -29,6 +29,8 @@ from rotkehlchen.tests.utils.dataimport import (
     assert_cryptocom_special_events_import_results,
     assert_custom_cointracking,
     assert_nexo_results,
+    assert_rotki_generic_events_import_results,
+    assert_rotki_generic_trades_import_results,
     assert_shapeshift_trades_import_results,
     assert_uphold_transactions_import_results,
 )
@@ -451,6 +453,40 @@ def test_data_import_binance_history(rotkehlchen_api_server):
     result = assert_proper_response_with_result(response)
     assert result is True
     assert_binance_import_results(rotki)
+
+
+def test_data_import_rotki_generic_trades(rotkehlchen_api_server):
+    """Test that data import works for Rotki generic trades import csv file."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dir_path = Path(__file__).resolve().parent.parent
+    filepath = dir_path / 'data' / 'rotki_generic_trades.csv'
+
+    json_data = {'source': 'rotki_trades', 'file': str(filepath)}
+    response = requests.put(
+        api_url_for(
+            rotkehlchen_api_server,
+            'dataimportresource',
+        ), json=json_data,
+    )
+    assert assert_proper_response_with_result(response) is True
+    assert_rotki_generic_trades_import_results(rotki)
+
+
+def test_data_import_rotki_generic_events(rotkehlchen_api_server):
+    """Test that data import works for Rotki generic events import csv file."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dir_path = Path(__file__).resolve().parent.parent
+    filepath = dir_path / 'data' / 'rotki_generic_events.csv'
+
+    json_data = {'source': 'rotki_events', 'file': str(filepath)}
+    response = requests.put(
+        api_url_for(
+            rotkehlchen_api_server,
+            'dataimportresource',
+        ), json=json_data,
+    )
+    assert assert_proper_response_with_result(response) is True
+    assert_rotki_generic_events_import_results(rotki)
 
 
 def test_docker_async_import(rotkehlchen_api_server):

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -32,7 +32,7 @@ def entry_to_input_dict(entry: HistoryBaseEntry, include_identifier: bool) -> Di
 
 def _add_entries(server) -> List[HistoryBaseEntry]:
     entries = [HistoryBaseEntry(
-        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0x64f1982504ab714037467fdd45d3ecf5a6356361403fc97dd325101d8c038c4e'),  # noqa: 501
+        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0x64f1982504ab714037467fdd45d3ecf5a6356361403fc97dd325101d8c038c4e'),  # noqa: E501
         sequence_index=162,
         timestamp=TimestampMS(1569924574000),
         location=Location.BLOCKCHAIN,
@@ -44,7 +44,7 @@ def _add_entries(server) -> List[HistoryBaseEntry]:
         event_subtype=HistoryEventSubType.APPROVE,
         counterparty='0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
     ), HistoryBaseEntry(
-        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0x64f1982504ab714037467fdd45d3ecf5a6356361403fc97dd325101d8c038c4e'),  # noqa: 501
+        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0x64f1982504ab714037467fdd45d3ecf5a6356361403fc97dd325101d8c038c4e'),  # noqa: E501
         sequence_index=163,
         timestamp=TimestampMS(1569924574000),
         location=Location.BLOCKCHAIN,
@@ -56,7 +56,7 @@ def _add_entries(server) -> List[HistoryBaseEntry]:
         event_subtype=HistoryEventSubType.APPROVE,
         counterparty='0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
     ), HistoryBaseEntry(
-        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0xf32e81dbaae8a763cad17bc96b77c7d9e8c59cc31ed4378b8109ce4b301adbbc'),  # noqa: 501
+        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0xf32e81dbaae8a763cad17bc96b77c7d9e8c59cc31ed4378b8109ce4b301adbbc'),  # noqa: E501
         sequence_index=2,
         timestamp=TimestampMS(1619924574000),
         location=Location.BLOCKCHAIN,
@@ -68,7 +68,7 @@ def _add_entries(server) -> List[HistoryBaseEntry]:
         event_subtype=HistoryEventSubType.FEE,
         counterparty=CPT_GAS,
     ), HistoryBaseEntry(
-        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0xf32e81dbaae8a763cad17bc96b77c7d9e8c59cc31ed4378b8109ce4b301adbbc'),  # noqa: 501
+        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0xf32e81dbaae8a763cad17bc96b77c7d9e8c59cc31ed4378b8109ce4b301adbbc'),  # noqa: E501
         sequence_index=3,
         timestamp=TimestampMS(1619924574000),
         location=Location.BLOCKCHAIN,
@@ -80,7 +80,7 @@ def _add_entries(server) -> List[HistoryBaseEntry]:
         event_subtype=HistoryEventSubType.NONE,
         counterparty='somewhere',
     ), HistoryBaseEntry(
-        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0x4b5489ed325483db3a8c4831da1d5ac08fb9ab0fd8c570aa3657e0c267a7d023'),  # noqa: 501
+        event_identifier=HistoryBaseEntry.deserialize_event_identifier('0x4b5489ed325483db3a8c4831da1d5ac08fb9ab0fd8c570aa3657e0c267a7d023'),  # noqa: E501
         sequence_index=55,
         timestamp=TimestampMS(1629924574000),
         location=Location.BLOCKCHAIN,

--- a/rotkehlchen/tests/data/rotki_generic_events.csv
+++ b/rotkehlchen/tests/data/rotki_generic_events.csv
@@ -1,0 +1,8 @@
+Type,Location,Currency,Amount,Fee,Fee Currency,Description,Timestamp
+Deposit,kucoin,EUR,1000.00,,,Deposit EUR to Kucoin,1658912400000
+Withdrawal,binance,USDT,99.00,1.00,USDT,,1658998800000
+Withdrawal,kraken,BNB,1.01,,,,1659085200000
+Staking,luno,ETH,0.0513,,,ETH Staking reward from QRS,1659340800000
+Loss,coinbase,BTC,0.0910,,,,1659430800000
+Income,cex,DAI,1000.00,,,,1659513600000
+Invalid,bisq,BCH,0.3456,,,,1659686400000

--- a/rotkehlchen/tests/data/rotki_generic_trades.csv
+++ b/rotkehlchen/tests/data/rotki_generic_trades.csv
@@ -1,0 +1,6 @@
+Location,Base Currency,Quote Currency,Type,Buy Amount,Sell Amount,Fee,Fee Currency,Description,Timestamp
+binance,USDC,ETH,Sell,1.0000,1875.64,,,Trade USDC for ETH,2022-07-29 09:00:00
+kraken,BTC,LTC,Buy,4.3241,392.8870,,,Trade LTC for BTC,2022-07-30 09:00:00
+kucoin,UNI,DAI,Sell,880.0000,20.0000,0.1040,USD,Trade UNI for DAI,2022-08-01 09:00:00
+luno,BCH,ADA,Buy,16.3444,4576.6400,5.1345,USD,Trade ADA for BCH,2022-08-02 09:00:00
+bisq,DAI,USDT,Buy,0,4576.6400,5.1345,USD,Trade USDT for DAI,2022-08-03 09:00:00

--- a/rotkehlchen/tests/unit/accounting/test_transactions.py
+++ b/rotkehlchen/tests/unit/accounting/test_transactions.py
@@ -25,7 +25,7 @@ def test_receiving_value_from_tx(accountant, google_service):
     Test that receiving a transaction that provides value works fine
     """
     addr2 = make_ethereum_address()
-    tx_hash = HistoryBaseEntry.deserialize_event_identifier('0x5cc0e6e62753551313412492296d5e57bea0a9d1ce507cc96aa4aa076c5bde7a')  # noqa: 501
+    tx_hash = HistoryBaseEntry.deserialize_event_identifier('0x5cc0e6e62753551313412492296d5e57bea0a9d1ce507cc96aa4aa076c5bde7a')  # noqa: E501
     history = [
         HistoryBaseEntry(
             event_identifier=tx_hash,
@@ -59,7 +59,7 @@ def test_gas_fees_after_year(accountant, google_service):
     Test that for an expense like gas fees after year the "selling" part is tax free
     PnL, and the expense part is taxable pnl.
     """
-    tx_hash = HistoryBaseEntry.deserialize_event_identifier('0x5cc0e6e62753551313412492296d5e57bea0a9d1ce507cc96aa4aa076c5bde7a')  # noqa: 501
+    tx_hash = HistoryBaseEntry.deserialize_event_identifier('0x5cc0e6e62753551313412492296d5e57bea0a9d1ce507cc96aa4aa076c5bde7a')  # noqa: E501
     history = [
         LedgerAction(
             identifier=0,

--- a/rotkehlchen/tests/unit/test_history.py
+++ b/rotkehlchen/tests/unit/test_history.py
@@ -117,7 +117,7 @@ def test_pnl_processing_with_eth2_staking_setting(accountant, db_settings):
             end_amount=FVal('32.045'),
             pnl=FVal('-0.005'),  # -0.005 * 469.82 + 0.005 * 469.82 - 0.005*449.68 = -2.2484
         ), HistoryBaseEntry(
-            event_identifier=HistoryBaseEntry.deserialize_event_identifier_from_kraken('XXX'),
+            event_identifier=HistoryBaseEntry.deserialize_event_identifier('XXX'),  # noqa: E501
             sequence_index=0,
             timestamp=1625001464000,  # ETH price: 1837.31 ETH/EUR
             location=Location.KRAKEN,
@@ -131,7 +131,7 @@ def test_pnl_processing_with_eth2_staking_setting(accountant, db_settings):
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,  # 0.0000541090 * 1837.31 = 0.09941500679
         ), HistoryBaseEntry(
-            event_identifier=HistoryBaseEntry.deserialize_event_identifier_from_kraken('XXX'),
+            event_identifier=HistoryBaseEntry.deserialize_event_identifier('XXX'),  # noqa: E501
             sequence_index=0,
             timestamp=1640493374000,  # ETH price: 4072.51 ETH/EUR
             location=Location.KRAKEN,

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -1,9 +1,13 @@
 from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.base import HistoryBaseEntry
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_binance, asset_from_cryptocom
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
 from rotkehlchen.constants.assets import (
     A_BAT,
+    A_BNB,
     A_BTC,
     A_DAI,
     A_DOGE,
@@ -24,9 +28,11 @@ from rotkehlchen.constants.assets import (
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.db.filtering import (
     AssetMovementsFilterQuery,
+    HistoryEventFilterQuery,
     LedgerActionsFilterQuery,
     TradesFilterQuery,
 )
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.ledger_actions import DBLedgerActions
 from rotkehlchen.exchanges.data_structures import AssetMovement, Trade
 from rotkehlchen.fval import FVal
@@ -39,6 +45,7 @@ from rotkehlchen.types import (
     Location,
     Price,
     Timestamp,
+    TimestampMS,
     TradeType,
 )
 
@@ -1450,3 +1457,160 @@ def assert_binance_import_results(rotki: Rotkehlchen):
         'Skipped 4 rows during processing binance csv file. Check logs for details',
     ]
     assert warnings == expected_warnings
+
+
+def assert_rotki_generic_trades_import_results(rotki: Rotkehlchen):
+    expected_trades = [
+        Trade(
+            timestamp=Timestamp(1659085200),
+            location=Location.BINANCE,
+            base_asset=A_USDC,
+            quote_asset=A_ETH,
+            trade_type=TradeType.SELL,
+            amount=AssetAmount(FVal('1.0000')),
+            rate=Price(FVal('1875.64')),
+            fee=None,
+            fee_currency=None,
+            notes='Trade USDC for ETH',
+        ), Trade(
+            timestamp=Timestamp(1659171600),
+            location=Location.KRAKEN,
+            base_asset=A_BTC,
+            quote_asset=A_LTC,
+            trade_type=TradeType.BUY,
+            amount=AssetAmount(FVal('4.3241')),
+            rate=Price(FVal('90.85983210379038412617654541')),
+            fee=None,
+            fee_currency=None,
+            notes='Trade LTC for BTC',
+        ), Trade(
+            timestamp=Timestamp(1659344400),
+            location=Location.KUCOIN,
+            base_asset=A_UNI,
+            quote_asset=A_DAI,
+            trade_type=TradeType.SELL,
+            amount=AssetAmount(FVal('880.0000')),
+            rate=Price(FVal('0.02272727272727272727272727273')),
+            fee=Fee(FVal('0.1040')),
+            fee_currency=A_USD,
+            notes='Trade UNI for DAI',
+        ),
+    ]
+    with rotki.data.db.conn.read_ctx() as cursor:
+        trades = rotki.data.db.get_trades(cursor, filter_query=TradesFilterQuery.make(), has_premium=True)  # noqa: E501
+        warnings = rotki.msg_aggregator.consume_warnings()
+
+    expected_warnings = [
+        'Deserialization error during rotki generic trades CSV import. Failed to deserialize Location value luno. Ignoring entry',  # noqa: E501
+        'During rotki generic trades import, csv row {\'Location\': \'bisq\', \'Base Currency\': \'DAI\', \'Quote Currency\': \'USDT\', \'Type\': \'Buy\', \'Buy Amount\': \'0\', \'Sell Amount\': \'4576.6400\', \'Fee\': \'5.1345\', \'Fee Currency\': \'USD\', \'Description\': \'Trade USDT for DAI\', \'Timestamp\': \'2022-08-03 09:00:00\'} has zero amount bought. Ignoring entry',  # noqa: E501
+    ]
+    assert trades == expected_trades
+    assert warnings == expected_warnings
+
+
+def assert_rotki_generic_events_import_results(rotki: Rotkehlchen):
+    expected_history_events = [
+        HistoryBaseEntry(
+            identifier=1,
+            event_identifier=b'1xyz',  # placeholder as this field is randomnly generated on import
+            sequence_index=0,
+            timestamp=TimestampMS(1658912400000),
+            location=Location.KUCOIN,
+            asset=A_EUR,
+            event_type=HistoryEventType.DEPOSIT,
+            event_subtype=HistoryEventSubType.SPEND,
+            balance=Balance(
+                amount=FVal('1000.00'),
+                usd_value=ZERO,
+            ),
+            notes='Deposit EUR to Kucoin',
+        ), HistoryBaseEntry(
+            identifier=2,
+            event_identifier=b'2xyz',  # placeholder as this field is randomnly generated on import
+            sequence_index=1,
+            timestamp=TimestampMS(1658998800000),
+            location=Location.BINANCE,
+            asset=A_USDT,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            balance=Balance(
+                amount=FVal('99.00'),
+                usd_value=ZERO,
+            ),
+            notes='',
+        ), HistoryBaseEntry(
+            identifier=3,
+            event_identifier=b'2xyz',  # placeholder as this field is randomnly generated on import
+            sequence_index=2,
+            timestamp=TimestampMS(1658998800000),
+            location=Location.BINANCE,
+            asset=A_USDT,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.FEE,
+            balance=Balance(
+                amount=FVal('1.00'),
+                usd_value=ZERO,
+            ),
+            notes='',
+        ), HistoryBaseEntry(
+            identifier=4,
+            event_identifier=b'3xyz',  # placeholder as this field is randomnly generated on import
+            sequence_index=2,
+            timestamp=TimestampMS(1659085200000),
+            location=Location.KRAKEN,
+            asset=A_BNB,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            balance=Balance(
+                amount=FVal('1.01'),
+                usd_value=ZERO,
+            ),
+            notes='',
+        ), HistoryBaseEntry(
+            identifier=5,
+            event_identifier=b'5xyz',  # placeholder as this field is randomnly generated on import
+            sequence_index=4,
+            timestamp=TimestampMS(1659430800000),
+            location=Location.COINBASE,
+            asset=A_BTC,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.NONE,
+            balance=Balance(
+                amount=FVal('0.0910'),
+                usd_value=ZERO,
+            ),
+            notes='',
+        ),
+    ]
+    with rotki.data.db.conn.read_ctx() as cursor:
+        history_db = DBHistoryEvents(rotki.data.db)
+        history_events = history_db.get_history_events(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(),
+            has_premium=True,
+        )
+        warnings = rotki.msg_aggregator.consume_warnings()
+    expected_warnings = [
+        'Deserialization error during rotki generic events CSV import. Failed to deserialize Location value luno. Ignoring entry',  # noqa: E501
+        'Deserialization error during rotki generic events CSV import. Failed to deserialize Location value cex. Ignoring entry',  # noqa: E501
+        'Unsupported entry Invalid. Data: {\'Type\': \'Invalid\', \'Location\': \'bisq\', \'Currency\': \'BCH\', \'Amount\': \'0.3456\', \'Fee\': \'\', \'Fee Currency\': \'\', \'Description\': \'\', \'Timestamp\': \'1659686400000\'}',  # noqa: E501
+    ]
+    assert len(history_events) == 5
+    assert len(expected_history_events) == 5
+    assert len(warnings) == 3
+    assert warnings == expected_warnings
+    for actual, expected in zip(history_events, expected_history_events):
+        assert_is_equal_history_event(actual=actual, expected=expected)
+
+
+def assert_is_equal_history_event(
+        actual: HistoryBaseEntry,
+        expected: HistoryBaseEntry,
+) -> None:
+    """Compares two `HistoryBaseEntry` objects omitting the `event_identifier` as its
+    generated randomly upon import."""
+    actual_dict = actual.serialize()
+    actual_dict.pop('event_identifier')
+    expected_dict = expected.serialize()
+    expected_dict.pop('event_identifier')
+    assert actual_dict == expected_dict


### PR DESCRIPTION
Resolves backend aspect of #2270 

Currently, the import format chosen is...
`Transaction ID, Base Asset, Quote Asset, Type, Amount, Rate, Fee, Fee Currency, Description, Time`.

- `Amount` can be turned into `Buy Amount` & `Sell Amount` to improve ease of use for users. Thereby ruling out the need for a `Rate` column in the CSV template.
- `Transaction ID` can also be `ID`

This is a draft to know if the present approach is a step in the right direction.