### PR TITLE
Adds cypress support for setting an etherscan key

### DIFF
--- a/frontend/app/tests/e2e/pages/rotki-app.ts
+++ b/frontend/app/tests/e2e/pages/rotki-app.ts
@@ -1,4 +1,14 @@
 export class RotkiApp {
+  private loadEnv(): void {
+    const apiKey = Cypress.env('ETHERSCAN_API_KEY');
+    if (apiKey) {
+      cy.log('Using CYPRESS_ETHERSCAN_API_KEY env variable');
+      cy.addEtherscanKey(apiKey);
+    } else {
+      cy.log('CYPRESS_ETHERSCAN_API_KEY not set');
+    }
+  }
+
   visit() {
     cy.visit('/?skip_update=1');
   }
@@ -23,10 +33,12 @@ export class RotkiApp {
     cy.get('.create-account__analytics__button__confirm').click();
     cy.get('[data-cy=account-management__loading]').should('not.exist');
     cy.updateAssets();
+    this.loadEnv();
   }
 
   fasterLogin(username: string, password: string = '1234') {
     cy.createAccount(username, password);
+    this.loadEnv();
     this.visit();
     this.login(username, password);
     this.closePremiumOverlay();

--- a/frontend/app/tests/e2e/support/commands.ts
+++ b/frontend/app/tests/e2e/support/commands.ts
@@ -147,9 +147,25 @@ const addLedgerAction = (action: ExternalLedgerAction) => {
     .its('body');
 };
 
+const addEtherscanKey = (key: string) => {
+  return cy
+    .request({
+      url: 'http://localhost:22221/api/1/external_services/',
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      },
+      body: {
+        services: [{ name: 'etherscan', api_key: key }]
+      }
+    })
+    .its('status');
+};
+
 Cypress.Commands.add('logout', logout);
 Cypress.Commands.add('updateAssets', updateAssets);
 Cypress.Commands.add('disableModules', disableModules);
 Cypress.Commands.add('createAccount', createAccount);
 Cypress.Commands.add('addExternalTrade', addExternalTrade);
 Cypress.Commands.add('addLedgerAction', addLedgerAction);
+Cypress.Commands.add('addEtherscanKey', addEtherscanKey);

--- a/frontend/app/tests/e2e/support/types.d.ts
+++ b/frontend/app/tests/e2e/support/types.d.ts
@@ -38,6 +38,7 @@ declare global {
       createAccount: (username: string, password?: string) => Chainable;
       addExternalTrade: (trade: ExternalTrade) => Chainable;
       addLedgerAction: (action: ExternalLedgerAction) => Chainable;
+      addEtherscanKey: (key: string) => Chainable;
     }
   }
 }


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

This can be used by setting `CYPRESS_ETHERSCAN_API_KEY`.
We can see for CI but it will hopefully help with local running.