### PR TITLE
Modify icon retrieval resource to use get instead of post

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3556,20 +3556,17 @@ Querying asset icons
 
 .. http:post:: /api/(version)/assets/icon
 
-   Doing a POST on the asset icon endpoint will return the icon of the given asset. If we have no icon for an asset a 404 is returned
+   Doing a GET on the asset icon endpoint will return the icon of the given asset. If we have no icon for an asset a 404 is returned
 
 
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests
 
-      POST /api/1/assets/icon HTTP/1.1
+      GET /api/1/assets/icon?asset=eip155:1/erc20:3A0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e HTTP/1.1
       Host: localhost:5042
-      Content-Type: application/json;charset=UTF-8
 
-      {"asset": "eip155:1/erc20:3A0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"}
-
-   :reqjson string asset: Identifier of the asset to be queried.
+   :reqquery string asset: Identifier of the asset to be queried.
 
    **Example Response**:
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -2147,10 +2147,10 @@ class WatchersResource(BaseMethodView):
 
 class AssetIconFileResource(BaseMethodView):
 
-    post_schema = SingleAssetIdentifierSchema()
+    get_schema = SingleAssetIdentifierSchema()
 
-    @use_kwargs(post_schema, location='json')
-    def post(self, asset: Asset) -> Response:
+    @use_kwargs(get_schema, location='query')
+    def get(self, asset: Asset) -> Response:
         # Process the if-match and if-none-match headers so that comparison with etag can be done
         match_header = flask_request.headers.get('If-Match', None)
         if not match_header:

--- a/rotkehlchen/tests/api/test_icons.py
+++ b/rotkehlchen/tests/api/test_icons.py
@@ -55,9 +55,9 @@ def test_upload_custom_icon(rotkehlchen_api_server, file_upload, data_dir):
     assert filecmp.cmp(uploaded_icon, filepath)
 
     # query the file using the endpoint
-    response = requests.post(
+    response = requests.get(
         api_url_for(rotkehlchen_api_server, 'asseticonfileresource'),
-        json={'asset': A_GNO.identifier},
+        params={'asset': A_GNO.identifier},
     )
     assert response.status_code == HTTPStatus.OK
     response.headers.pop('Date')


### PR DESCRIPTION
This endpoint returns an image and the common way to use this kind of endpoints for images is using a src tag in
the html that triggers a get in the browser. Using post instead of get is possible but complicated and a bad pattern
as it has been explained by @lukicenturi.

The reason to keep it in two resources is for consistency since the other verbs use json and this
one uses the query args (can't use other thing since is get and there is this bug with the view
args)

