### PR TITLE
Makes sure that brew uninstall doesn't fail

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -98,7 +98,7 @@ jobs:
         run: brew install autoconf automake libtool pkg-config
       - name: Build universal libbfi (required by coincurve)
         run: |
-          brew uninstall --ignore-dependencies libffi
+          brew uninstall --ignore-dependencies libffi || true
           echo "::group::Autogen"
           ./autogen.sh
           echo "::endgroup::"

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -179,7 +179,7 @@ jobs:
         run: brew install autoconf automake libtool pkg-config
       - name: Build universal libbfi (required by coincurve)
         run: |
-          brew uninstall --ignore-dependencies libffi
+          brew uninstall --ignore-dependencies libffi || true
           echo "::group::Autogen"
           ./autogen.sh
           echo "::endgroup::"


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

They seem to have removed libffi from the pre-installed kegs.
Keeping the command there but making it to not exit on failure in case they re-introduce it.