### PR TITLE
Allow detecting tokens for different blockchains using the API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2927,7 +2927,7 @@ Querying all supported assets
       }
 
    :resjson list result: A list of assets that match the query with their respective asset details.
-   :resjson string type: The type of asset. Valid values are ethereum token, own chain, omni token and more. For all valid values check `here <https://github.com/rotki/rotki/blob/8387c96eb77f9904b44a1ddd0eb2acbf3f8d03f6/rotkehlchen/assets/types.py#L10>`_. 
+   :resjson string type: The type of asset. Valid values are ethereum token, own chain, omni token and more. For all valid values check `here <https://github.com/rotki/rotki/blob/8387c96eb77f9904b44a1ddd0eb2acbf3f8d03f6/rotkehlchen/assets/types.py#L10>`_.
    :resjson integer started: An optional unix timestamp denoting when we know the asset started to have a price.
    :resjson string name: The long name of the asset. Does not need to be the same as the unique identifier.
    :resjson string forked: An optional attribute representing another asset out of which this asset forked from. For example ``ETC`` would have ``ETH`` here.
@@ -3173,12 +3173,12 @@ Querying owned assets
    :statuscode 409: No user is currently logged in.
    :statuscode 500: Internal rotki error
 
-Detecting owned ethereum tokens
-===============================
+Detecting owned tokens
+======================
 
-.. http:post:: /api/(version)/blockchains/ETH/tokens/detect
+.. http:post:: /api/(version)/blockchains/(blockchain)/tokens/detect
 
-   Doing POST on the detect tokens endpoint will detect ethereum tokens owned by the provided addresses. If no addresses provided, tokens for all user's ethereum addresses will be detected.
+   Doing POST on the detect tokens endpoint will detect tokens owned by the provided addresses on the specified blockchain. If no addresses provided, tokens for all user's addresses will be detected.
 
     .. note::
           This endpoint can also be queried asynchronously by using ``"async_query": true``

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -230,7 +230,6 @@ URLS_V1: URLS = [
     ('/blockchains/ETH/defi', DefiBalancesResource),
     ('/blockchains/ETH/airdrops', EthereumAirdropsResource),
     ('/blockchains/ETH/erc20details', ERC20TokenInfo),
-    ('/blockchains/ETH/tokens/detect', DetectTokensResource),
     ('/blockchains/ETH/modules/<string:module_name>/data', NamedEthereumModuleDataResource),
     ('/blockchains/ETH/modules/data', EthereumModuleDataResource),
     ('/blockchains/ETH/modules/data/counterparties', CounterpartiesResource),
@@ -265,6 +264,7 @@ URLS_V1: URLS = [
     ('/blockchains/ETH/modules/loopring/balances', LoopringBalancesResource),
     ('/blockchains/<string:blockchain>', BlockchainsAccountsResource),
     ('/blockchains/<string:blockchain>/nodes', Web3NodesResource),
+    ('/blockchains/<string:blockchain>/tokens/detect', DetectTokensResource),
     ('/blockchains/<string:blockchain>/xpub', BTCXpubResource),
     ('/blockchains/AVAX/transactions', AvalancheTransactionsResource),
     (

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -2648,17 +2648,19 @@ class DetectTokensResource(BaseMethodView):
     post_schema = DetectTokensSchema()
 
     @require_loggedin_user()
-    @use_kwargs(post_schema, location='json')
+    @use_kwargs(post_schema, location='json_and_view_args')
     def post(
             self,
+            blockchain: SupportedBlockchain,
             async_query: bool,
             only_cache: bool,
             addresses: Optional[List[ChecksumEvmAddress]],
     ) -> Response:
-        return self.rest_api.detect_ethereum_tokens(
+        return self.rest_api.detect_evm_tokens(
             async_query=async_query,
             only_cache=only_cache,
             addresses=addresses,
+            blockchain=blockchain,
         )
 
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2575,7 +2575,7 @@ class DetectTokensSchema(
     OnlyCacheQuerySchema,
     OptionalAddressesListSchema,
 ):
-    ...
+    blockchain = BlockchainField(required=True, exclude_types=(SupportedBlockchain.ETHEREUM_BEACONCHAIN,))  # noqa: E501
 
 
 class UserNotesPutSchema(Schema):

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.constants import ETHERSCAN_NODE
-from rotkehlchen.chain.ethereum.manager import EthereumManager
 from rotkehlchen.chain.ethereum.types import WeightedNode, string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
+from rotkehlchen.chain.evm.manager import EvmManager
 from rotkehlchen.constants.ethereum import ETH_SCAN
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.fval import FVal
@@ -97,7 +97,7 @@ def generate_multicall_chunks(
 
 
 class EvmTokens():
-    def __init__(self, database: DBHandler, manager: EthereumManager):
+    def __init__(self, database: DBHandler, manager: EvmManager):
         self.db = database
         self.manager = manager
 

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -260,8 +260,8 @@ def test_query_all_balances_ignore_cache(
     )
     tokens_query_patch = patch.object(
         rotki.chain_manager,
-        'query_ethereum_tokens',
-        wraps=rotki.chain_manager.query_ethereum_tokens,
+        'query_tokens',
+        wraps=rotki.chain_manager.query_tokens,
     )
     original_binance_query_dict = binance.api_query_dict
     binance_query_patch = patch.object(binance, 'api_query_dict', wraps=binance.api_query_dict)
@@ -821,11 +821,12 @@ def test_ethereum_tokens_detection(
 ):
     account = ethereum_accounts[0]
 
-    def query_detect_tokens() -> Dict[str, Any]:
+    def query_detect_eth_tokens() -> Dict[str, Any]:
         response = requests.post(
             api_url_for(
                 rotkehlchen_api_server,
                 'detecttokensresource',
+                blockchain='ETH',
             ), json={
                 'async_query': False,
                 'only_cache': True,
@@ -840,7 +841,7 @@ def test_ethereum_tokens_detection(
             'last_update_timestamp': None,
         },
     }
-    assert query_detect_tokens() == empty_tokens_result
+    assert query_detect_eth_tokens() == empty_tokens_result
 
     db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     with db.user_write() as write_cursor:
@@ -851,7 +852,7 @@ def test_ethereum_tokens_detection(
             tokens=[A_RDN, A_DAI],
         )
     cur_time = ts_now()
-    result = query_detect_tokens()
+    result = query_detect_eth_tokens()
     assert set(result[account]['tokens']) == {A_DAI.identifier, A_RDN.identifier}
     assert result[account]['last_update_timestamp'] >= cur_time
 

--- a/rotkehlchen/tests/api/test_blockchain.py
+++ b/rotkehlchen/tests/api/test_blockchain.py
@@ -253,8 +253,8 @@ def test_query_blockchain_balances_ignore_cache(
     )
     tokens_query = patch.object(
         rotki.chain_manager,
-        'query_ethereum_tokens',
-        wraps=rotki.chain_manager.query_ethereum_tokens,
+        'query_tokens',
+        wraps=rotki.chain_manager.query_tokens,
     )
 
     with ExitStack() as stack:


### PR DESCRIPTION
This is necessary in order to support other blockchains and L2s in rotki

Changes:

1. Generalized endpoint /api/(version)/blockchains/ETH/tokens/detect to /api/(version)/blockchains/(blockchain)/tokens/detect
2. Renamed and generalized methods such as detect_ethereum_tokens(), query_ethereum_tokens() and _add_protocol_balances() to allow other EVMs

Related: #4725

Requires: ~#4806~ ~#4807~ ~#4829~