### PR TITLE
Generalize and rename ethereum transactions related classes and functions

### DIFF
--- a/rotkehlchen/chain/ethereum/decoding/base.py
+++ b/rotkehlchen/chain/ethereum/decoding/base.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
-from rotkehlchen.types import EthereumTransaction, Location
+from rotkehlchen.types import EvmTransaction, Location
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int, ts_sec_to_ms
 
 from .constants import NAUGHTY_ERC721
@@ -102,7 +102,7 @@ class BaseDecoderTools():
             self,
             token: EvmToken,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
     ) -> Optional[HistoryBaseEntry]:
         """
         Caller should know this is a transfer of either an ERC20 or an ERC721 token.

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -28,13 +28,7 @@ from rotkehlchen.errors.serialization import ConversionError, DeserializationErr
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import (
-    ChecksumEvmAddress,
-    EthereumTransaction,
-    EVMTxHash,
-    Location,
-    TimestampMS,
-)
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction, EVMTxHash, Location, TimestampMS
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import (
     from_wei,
@@ -164,7 +158,7 @@ class EVMTransactionDecoder():
             self,
             token: Optional[EvmToken],
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],
             action_items: List[ActionItem],
     ) -> Optional[HistoryBaseEntry]:
@@ -178,7 +172,7 @@ class EVMTransactionDecoder():
     def decode_by_address_rules(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],
             all_logs: List[EthereumTxReceiptLog],
             action_items: List[ActionItem],
@@ -212,7 +206,7 @@ class EVMTransactionDecoder():
     def decode_transaction(
             self,
             write_cursor: 'DBCursor',
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             tx_receipt: EthereumTxReceipt,
     ) -> List[HistoryBaseEntry]:
         """Decodes an ethereum transaction and its receipt and saves result in the DB"""
@@ -295,7 +289,7 @@ class EVMTransactionDecoder():
     def get_or_decode_transaction_events(
             self,
             write_cursor: 'DBCursor',
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             tx_receipt: EthereumTxReceipt,
             ignore_cache: bool,
     ) -> List[HistoryBaseEntry]:
@@ -327,7 +321,7 @@ class EVMTransactionDecoder():
 
     def _maybe_decode_internal_transactions(
         self,
-        tx: EthereumTransaction,
+        tx: EvmTransaction,
         tx_receipt: EthereumTxReceipt,
         events: List[HistoryBaseEntry],
         ts_ms: TimestampMS,
@@ -370,7 +364,7 @@ class EVMTransactionDecoder():
 
     def _maybe_decode_simple_transactions(
             self,
-            tx: EthereumTransaction,
+            tx: EvmTransaction,
             tx_receipt: EthereumTxReceipt,
     ) -> List[HistoryBaseEntry]:
         """Decodes normal ETH transfers, internal transactions and gas cost payments"""
@@ -454,7 +448,7 @@ class EVMTransactionDecoder():
             self,
             token: Optional[EvmToken],
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> Optional[HistoryBaseEntry]:
@@ -500,7 +494,7 @@ class EVMTransactionDecoder():
             self,
             token: Optional[EvmToken],
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             action_items: List[ActionItem],
     ) -> Optional[HistoryBaseEntry]:
@@ -576,7 +570,7 @@ class EVMTransactionDecoder():
             self,
             token: Optional[EvmToken],  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> Optional[HistoryBaseEntry]:
@@ -611,7 +605,7 @@ class EVMTransactionDecoder():
             self,
             token: EvmToken,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             event: HistoryBaseEntry,
             action_items: List[ActionItem],
     ) -> None:
@@ -636,7 +630,7 @@ class EVMTransactionDecoder():
             self,
             token: Optional[EvmToken],  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> Optional[HistoryBaseEntry]:

--- a/rotkehlchen/chain/ethereum/defi/defisaver_proxy.py
+++ b/rotkehlchen/chain/ethereum/defi/defisaver_proxy.py
@@ -6,7 +6,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.interfaces import EthereumModule
@@ -60,7 +60,7 @@ class HasDSProxy(EthereumModule):
         result = DS_PROXY_REGISTRY.call(self.ethereum, 'proxies', arguments=[address])
         if int(result, 16) != 0:
             try:
-                return deserialize_ethereum_address(result)
+                return deserialize_evm_address(result)
             except DeserializationError as e:
                 msg = f'Failed to deserialize {result} DS proxy for address {address}'
                 log.error(msg)
@@ -94,7 +94,7 @@ class HasDSProxy(EthereumModule):
             )[0]
             if int(result, 16) != 0:
                 try:
-                    proxy_address = deserialize_ethereum_address(result)
+                    proxy_address = deserialize_evm_address(result)
                     mapping[address] = proxy_address
                 except DeserializationError as e:
                     msg = f'Failed to deserialize {result} DSproxy for address {address}. {str(e)}'

--- a/rotkehlchen/chain/ethereum/defi/zerionsdk.py
+++ b/rotkehlchen/chain/ethereum/defi/zerionsdk.py
@@ -23,7 +23,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer, get_underlying_asset_price
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, Price, SupportedBlockchain
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import get_chunks
@@ -358,7 +358,7 @@ class ZerionSDK():
         decimals = metadata[3]
         normalized_value = token_normalized_value_decimals(balance_value, decimals)
         token_symbol = metadata[2]
-        token_address = deserialize_ethereum_address(metadata[0])
+        token_address = deserialize_evm_address(metadata[0])
         token_name = metadata[1]
 
         special_handling = self.handle_protocols(
@@ -422,7 +422,7 @@ class ZerionSDK():
             return None
 
         return DefiBalance(
-            token_address=deserialize_ethereum_address(token_address),
+            token_address=deserialize_evm_address(token_address),
             token_name=token_name,
             token_symbol=token_symbol,
             balance=Balance(amount=normalized_balance, usd_value=normalized_balance * usd_price),

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
@@ -49,7 +49,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import (
     AssetAmount,
     ChecksumEvmAddress,
@@ -279,9 +279,9 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                 token1_ = event['pair']['token1']
 
                 try:
-                    token0_deserialized = deserialize_ethereum_address(token0_['id'])
-                    token1_deserialized = deserialize_ethereum_address(token1_['id'])
-                    pool_deserialized = deserialize_ethereum_address(event['pair']['id'])
+                    token0_deserialized = deserialize_evm_address(token0_['id'])
+                    token1_deserialized = deserialize_evm_address(token1_['id'])
+                    pool_deserialized = deserialize_evm_address(event['pair']['id'])
                     tx_hash_deserialized = deserialize_evm_tx_hash(event['transaction']['id'])
                 except DeserializationError as e:
                     msg = (
@@ -391,7 +391,7 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
 
             for tdd in result_data:
                 try:
-                    token_address = deserialize_ethereum_address(tdd['token']['id'])
+                    token_address = deserialize_evm_address(tdd['token']['id'])
                 except DeserializationError as e:
                     msg = (
                         f'Error deserializing address {tdd["token"]["id"]} '
@@ -487,8 +487,8 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                 lp_total_supply = FVal(lp_pair['totalSupply'])
                 user_lp_balance = FVal(lp['liquidityTokenBalance'])
                 try:
-                    user_address = deserialize_ethereum_address(lp['user']['id'])
-                    lp_address = deserialize_ethereum_address(lp_pair['id'])
+                    user_address = deserialize_evm_address(lp['user']['id'])
+                    lp_address = deserialize_evm_address(lp_pair['id'])
                 except DeserializationError as e:
                     msg = (
                         f'Failed to Deserialize address. Skipping {self.location} '
@@ -506,7 +506,7 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                 liquidity_pool_assets = []
                 for token in token0, token1:
                     try:
-                        deserialized_eth_address = deserialize_ethereum_address(token['id'])
+                        deserialized_eth_address = deserialize_evm_address(token['id'])
                     except DeserializationError as e:
                         msg = (
                             f'Failed to deserialize token address {token["id"]} '

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -66,8 +66,8 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_ethereum_address,
-    deserialize_ethereum_transaction,
+    deserialize_evm_address,
+    deserialize_evm_transaction,
     deserialize_int_from_hex,
 )
 from rotkehlchen.serialization.serialize import process_result
@@ -799,7 +799,7 @@ class EthereumManager():
             arguments.append(blockchain.ens_coin_type())
 
         try:
-            deserialized_resolver_addr = deserialize_ethereum_address(resolver_addr)
+            deserialized_resolver_addr = deserialize_evm_address(resolver_addr)
         except DeserializationError:
             log.error(
                 f'Error deserializing address {resolver_addr} while doing'
@@ -821,7 +821,7 @@ class EthereumManager():
         if blockchain != SupportedBlockchain.ETHEREUM:
             return HexStr(address.hex())
         try:
-            return deserialize_ethereum_address(address)
+            return deserialize_evm_address(address)
         except DeserializationError:
             log.error(f'Error deserializing address {address}')
             return None
@@ -927,7 +927,7 @@ class EthereumManager():
             tx_data = web3.eth.get_transaction(tx_hash)  # type: ignore
 
         try:
-            transaction = deserialize_ethereum_transaction(data=tx_data, internal=False, ethereum=self)  # noqa: E501
+            transaction = deserialize_evm_transaction(data=tx_data, internal=False, manager=self)  # noqa: E501
         except (DeserializationError, ValueError) as e:
             raise RemoteError(
                 f'Couldnt deserialize ethereum transaction data from {tx_data}. Error: {str(e)}',
@@ -1123,7 +1123,7 @@ class EthereumManager():
                             if same_event:
                                 events.pop()
 
-                        new_events[e_idx]['address'] = deserialize_ethereum_address(
+                        new_events[e_idx]['address'] = deserialize_evm_address(
                             event['address'],
                         )
                         new_events[e_idx]['blockNumber'] = block_number

--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -73,7 +73,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.serialization.serialize import process_result
 from rotkehlchen.types import (
     ChecksumEvmAddress,
-    EthereumTransaction,
+    EvmTransaction,
     EVMTxHash,
     SupportedBlockchain,
     Timestamp,
@@ -920,7 +920,7 @@ class EthereumManager():
             self,
             web3: Optional[Web3],
             tx_hash: EVMTxHash,
-    ) -> EthereumTransaction:
+    ) -> EvmTransaction:
         if web3 is None:
             tx_data = self.etherscan.get_transaction_by_hash(tx_hash=tx_hash)
         else:
@@ -939,7 +939,7 @@ class EthereumManager():
             self,
             tx_hash: EVMTxHash,
             call_order: Optional[Sequence[WeightedNode]] = None,
-    ) -> EthereumTransaction:
+    ) -> EvmTransaction:
         return self.query(
             method=self._get_transaction_by_hash,
             call_order=call_order if call_order is not None else self.default_call_order(),

--- a/rotkehlchen/chain/ethereum/modules/aave/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/graph.py
@@ -15,7 +15,7 @@ from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EVMTxHash, Timestamp, deserialize_evm_tx_hash
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now
@@ -317,7 +317,7 @@ def _parse_atoken_balance_history(
 
         try:
             address_s = '0x' + pairs[2]
-            reserve_address = deserialize_ethereum_address(address_s)
+            reserve_address = deserialize_evm_address(address_s)
         except DeserializationError:
             log.error(
                 f'Error deserializing reserve address {address_s}',
@@ -369,7 +369,7 @@ def _get_reserve_asset_and_decimals(
 ) -> Optional[Tuple[Asset, int]]:
     try:
         # The ID of reserve is the address of the asset and the address of the market's LendingPoolAddressProvider, in lower case  # noqa: E501
-        reserve_address = deserialize_ethereum_address(entry[reserve_key]['id'][:42])
+        reserve_address = deserialize_evm_address(entry[reserve_key]['id'][:42])
     except DeserializationError:
         log.error(f'Failed to Deserialize reserve address {entry[reserve_key]["id"]}')
         return None
@@ -447,7 +447,7 @@ class AaveGraphInquirer(AaveInquirer):
             try:
                 result.append(AaveUserReserve(
                     # The ID of reserve is the address of the asset and the address of the market's LendingPoolAddressProvider, in lower case  # noqa: E501
-                    address=deserialize_ethereum_address(reserve['id'][:42]),
+                    address=deserialize_evm_address(reserve['id'][:42]),
                     symbol=reserve['symbol'],
                 ))
             except DeserializationError:
@@ -481,7 +481,7 @@ class AaveGraphInquirer(AaveInquirer):
 
             try:
                 address_s = '0x' + pairs[2]
-                reserve_address = deserialize_ethereum_address(address_s)
+                reserve_address = deserialize_evm_address(address_s)
             except DeserializationError:
                 log.error(
                     f'Failed to deserialize reserve address {address_s} '

--- a/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.modules.aave.common import asset_to_atoken
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.constants.ethereum import AAVE_V1_LENDING_POOL
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 # from rotkehlchen.chain.ethereum.modules.aave.constants import CPT_AAVE_V1
@@ -25,7 +25,7 @@ class Aavev1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_pool_event(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -40,7 +40,7 @@ class Aavev1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_deposit_event(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -82,7 +82,7 @@ class Aavev1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_redeem_underlying_event(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/adex/adex.py
+++ b/rotkehlchen/chain/ethereum/modules/adex/adex.py
@@ -28,10 +28,7 @@ from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.serialization.deserialize import (
-    deserialize_ethereum_address,
-    deserialize_timestamp,
-)
+from rotkehlchen.serialization.deserialize import deserialize_evm_address, deserialize_timestamp
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp, deserialize_evm_tx_hash
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.interfaces import EthereumModule
@@ -268,10 +265,10 @@ class Adex(EthereumModule):
             ) from e
 
         try:
-            address = deserialize_ethereum_address(user_address)
+            address = deserialize_evm_address(user_address)
             identity_address = inverse_identity_address_map[address]
-            tx_address = deserialize_ethereum_address(tx_address)
-            token_address = deserialize_ethereum_address(token_address)
+            tx_address = deserialize_evm_address(tx_address)
+            token_address = deserialize_evm_address(token_address)
         except (KeyError, DeserializationError) as e:
             if isinstance(e, KeyError):
                 msg = f'Missing key in event: {str(e)}.'
@@ -340,7 +337,7 @@ class Adex(EthereumModule):
         - KeyError
         - DeserializationError
         """
-        identity_address = deserialize_ethereum_address(raw_event['owner'])
+        identity_address = deserialize_evm_address(raw_event['owner'])
         address = identity_address_map[identity_address]
         event_id = raw_event['id']
         if not isinstance(event_id, str):
@@ -357,7 +354,7 @@ class Adex(EthereumModule):
             raise DeserializationError(f'Unexpected format in {case} event id: {event_id}') from e
 
         if case in ('unbond', 'unbond_request'):
-            tx_address = deserialize_ethereum_address(tx_address)
+            tx_address = deserialize_evm_address(tx_address)
 
             if address != tx_address:
                 raise DeserializationError(

--- a/rotkehlchen/chain/ethereum/modules/adex/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/adex/utils.py
@@ -7,7 +7,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
-    deserialize_ethereum_address,
+    deserialize_evm_address,
     deserialize_timestamp,
 )
 from rotkehlchen.types import make_evm_tx_hash
@@ -68,8 +68,8 @@ def deserialize_adex_event_from_db(
         )
 
     tx_hash = make_evm_tx_hash(event_tuple[0])
-    address = deserialize_ethereum_address(event_tuple[1])
-    identity_address = deserialize_ethereum_address(event_tuple[2])
+    address = deserialize_evm_address(event_tuple[1])
+    identity_address = deserialize_evm_address(event_tuple[2])
     timestamp = deserialize_timestamp(event_tuple[3])
     pool_id = event_tuple[5]
     amount = deserialize_asset_amount(event_tuple[6])

--- a/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.constants.assets import A_1INCH, A_BADGER, A_CVX, A_ELFI, A_FOX, A_FPIS, A_UNI
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction, Location
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction, Location
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int, ts_sec_to_ms
 
 from .constants import (
@@ -68,7 +68,7 @@ class AirdropsDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_uniswap_claim(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -93,7 +93,7 @@ class AirdropsDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_fox_claim(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -118,7 +118,7 @@ class AirdropsDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_badger_claim(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -143,7 +143,7 @@ class AirdropsDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_oneinch_claim(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -168,7 +168,7 @@ class AirdropsDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_fpis_claim(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -201,7 +201,7 @@ class AirdropsDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_elfi_claim(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -12,7 +12,7 @@ from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
-    deserialize_ethereum_address,
+    deserialize_evm_address,
     deserialize_timestamp,
 )
 from rotkehlchen.types import (
@@ -67,8 +67,8 @@ def deserialize_bpt_event(
     if total_weight == ZERO:
         raise DeserializationError('Pool weight is zero.')
 
-    user_address = deserialize_ethereum_address(raw_user_address)
-    pool_address = deserialize_ethereum_address(raw_pool_address)
+    user_address = deserialize_evm_address(raw_user_address)
+    pool_address = deserialize_evm_address(raw_pool_address)
 
     underlying_tokens = []
     for raw_token in raw_pool_tokens:
@@ -81,7 +81,7 @@ def deserialize_bpt_event(
         except KeyError as e:
             raise DeserializationError(f'Missing key: {str(e)}.') from e
 
-        token_address = deserialize_ethereum_address(raw_token_address)
+        token_address = deserialize_evm_address(raw_token_address)
 
         token = get_or_create_evm_token(
             userdb=userdb,
@@ -144,15 +144,15 @@ def deserialize_invest_event(
     except KeyError as e:
         raise DeserializationError(f'Missing key: {str(e)}.') from e
 
-    user_address = deserialize_ethereum_address(raw_user_address)
-    pool_address = deserialize_ethereum_address(raw_pool_address)
+    user_address = deserialize_evm_address(raw_user_address)
+    pool_address = deserialize_evm_address(raw_pool_address)
     try:
         pool_address_token = EvmToken(ethaddress_to_identifier(pool_address))
     except UnknownAsset as e:
         raise DeserializationError(
             f'Balancer pool token with address {pool_address} should have been in the DB',
         ) from e
-    token_address = deserialize_ethereum_address(raw_token_address)
+    token_address = deserialize_evm_address(raw_token_address)
 
     invest_event = BalancerInvestEvent(
         tx_hash=tx_hash,
@@ -186,8 +186,8 @@ def deserialize_pool_share(
     if total_weight == ZERO:
         raise DeserializationError('Pool weight is zero.')
 
-    user_address = deserialize_ethereum_address(raw_user_address)
-    pool_address = deserialize_ethereum_address(raw_address)
+    user_address = deserialize_evm_address(raw_user_address)
+    pool_address = deserialize_evm_address(raw_address)
 
     pool_tokens = []
     pool_token_balances = []
@@ -202,7 +202,7 @@ def deserialize_pool_share(
         except KeyError as e:
             raise DeserializationError(f'Missing key: {str(e)}.') from e
 
-        token_address = deserialize_ethereum_address(raw_token_address)
+        token_address = deserialize_evm_address(raw_token_address)
 
         token = get_or_create_evm_token(
             userdb=userdb,
@@ -278,7 +278,7 @@ def deserialize_token_price(
     except KeyError as e:
         raise DeserializationError(f'Missing key: {str(e)}.') from e
 
-    token_address = deserialize_ethereum_address(token_address)
+    token_address = deserialize_evm_address(token_address)
 
     return token_address, usd_price
 
@@ -293,6 +293,6 @@ def deserialize_token_day_data(
     except KeyError as e:
         raise DeserializationError(f'Missing key: {str(e)}.') from e
 
-    token_address = deserialize_ethereum_address(token_address)
+    token_address = deserialize_evm_address(token_address)
 
     return token_address, usd_price

--- a/rotkehlchen/chain/ethereum/modules/compound/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_norma
 from rotkehlchen.constants.assets import A_COMP
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import COMPTROLLER_PROXY, CPT_COMPOUND
@@ -42,7 +42,7 @@ class CompoundDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
 
     def _decode_mint(
             self,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             tx_log: EthereumTxReceiptLog,
             decoded_events: List[HistoryBaseEntry],
             compound_token: EvmToken,
@@ -123,7 +123,7 @@ class CompoundDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def decode_compound_token_movement(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument
@@ -141,7 +141,7 @@ class CompoundDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def decode_comp_claim(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -25,7 +25,7 @@ from rotkehlchen.chain.ethereum.modules.convex.constants import (
 )
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 
@@ -33,7 +33,7 @@ class ConvexDecoder(DecoderInterface):
     @staticmethod
     def _decode_convex_events(
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -90,7 +90,7 @@ class ConvexDecoder(DecoderInterface):
     def _maybe_enrich_convex_transfers(
             token: EvmToken,  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             event: HistoryBaseEntry,
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> bool:

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address
 
 from .constants import CPT_CURVE
@@ -49,7 +49,7 @@ class CurveDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_curve_remove_events(
         self,
         tx_log: EthereumTxReceiptLog,
-        transaction: EthereumTransaction,
+        transaction: EvmTransaction,
         decoded_events: List[HistoryBaseEntry],
         user_address: ChecksumEvmAddress,
     ) -> Tuple[Optional[HistoryBaseEntry], Optional[ActionItem]]:
@@ -154,7 +154,7 @@ class CurveDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_curve_events(  # pylint: disable=no-self-use
         self,
         tx_log: EthereumTxReceiptLog,
-        transaction: EthereumTransaction,
+        transaction: EvmTransaction,
         decoded_events: List[HistoryBaseEntry],
         all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
         action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument
@@ -191,7 +191,7 @@ class CurveDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             self,
             token: EvmToken,  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             event: HistoryBaseEntry,
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> bool:

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.contracts import EvmContract
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction, Location
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 from .constants import CPT_DXDAO_MESA
@@ -50,7 +50,7 @@ class DxdaomesaDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_events(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -69,7 +69,7 @@ class DxdaomesaDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_deposit(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -98,7 +98,7 @@ class DxdaomesaDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_withdraw(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -127,7 +127,7 @@ class DxdaomesaDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_withdraw_request(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -165,7 +165,7 @@ class DxdaomesaDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_order_placement(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import from_wei
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
@@ -45,7 +45,7 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):  # lgtm[py/missing-ca
     def _decode_name_renewed(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import EthereumTransaction
+from rotkehlchen.types import EvmTransaction
 
 from .constants import CPT_GITCOIN
 
@@ -35,7 +35,7 @@ class GitcoinDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             self,
             token: EvmToken,  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             event: HistoryBaseEntry,
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> bool:

--- a/rotkehlchen/chain/ethereum/modules/hop/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hop/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import from_wei, hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import CPT_HOP
@@ -35,7 +35,7 @@ class HopDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_send_eth(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
@@ -88,7 +88,7 @@ class KyberDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_legacy_trade(  # pylint: disable=no-self-use
         self,
         tx_log: EthereumTxReceiptLog,
-        transaction: EthereumTransaction,  # pylint: disable=unused-argument
+        transaction: EvmTransaction,  # pylint: disable=unused-argument
         decoded_events: List[HistoryBaseEntry],
         all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
         action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument
@@ -118,7 +118,7 @@ class KyberDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_legacy_upgraded_trade(  # pylint: disable=no-self-use
         self,
         tx_log: EthereumTxReceiptLog,
-        transaction: EthereumTransaction,  # pylint: disable=unused-argument
+        transaction: EvmTransaction,  # pylint: disable=unused-argument
         decoded_events: List[HistoryBaseEntry],
         all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
         action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_LUSD
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 
 from .constants import CPT_LIQUITY
 
@@ -20,7 +20,7 @@ class LiquityDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     @staticmethod
     def _decode_trove_operations(
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -68,7 +68,7 @@ from rotkehlchen.constants.ethereum import (
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction, Location
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction, Location
 from rotkehlchen.utils.misc import (
     hex_or_bytes_to_address,
     hex_or_bytes_to_int,
@@ -163,7 +163,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def decode_makerdao_vault_action(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -209,7 +209,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def decode_makerdao_debt_payback(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -242,7 +242,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def decode_pot_for_dsr(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             all_logs: List[EthereumTxReceiptLog],
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -329,7 +329,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def decode_proxy_creation(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -362,7 +362,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def _decode_vault_creation(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
     ) -> Tuple[Optional[HistoryBaseEntry], Optional[ActionItem]]:
@@ -394,7 +394,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def _decode_vault_debt_generation(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
     ) -> Tuple[Optional[HistoryBaseEntry], Optional[ActionItem]]:
@@ -434,7 +434,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def _decode_vault_change(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -493,7 +493,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def decode_cdp_manager_events(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -510,7 +510,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
     def decode_saidai_migration(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -67,7 +67,7 @@ from rotkehlchen.constants.ethereum import (
     RAY_DIGITS,
 )
 from rotkehlchen.errors.serialization import DeserializationError
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction, Location
 from rotkehlchen.utils.misc import (
     hex_or_bytes_to_address,
@@ -155,7 +155,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):  # lgtm[py/missing-call-to-
             if int(result, 16) == 0:
                 raise DeserializationError('Could not deserialize {result} as address}')
 
-            address = deserialize_ethereum_address(result)
+            address = deserialize_evm_address(result)
             mapping[method_name] = address
 
         return mapping['urns'], mapping['owns']

--- a/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
@@ -77,7 +77,7 @@ from rotkehlchen.history.price import query_usd_price_or_use_default
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EVMTxHash, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import address_to_bytes32, hexstr_to_int, shift_num_right_by, ts_now
@@ -651,7 +651,7 @@ class MakerdaoVaults(HasDSProxy):
         vaults = []
         for idx, identifier in enumerate(result[0]):
             try:
-                urn = deserialize_ethereum_address(result[1][idx])
+                urn = deserialize_evm_address(result[1][idx])
             except DeserializationError as e:
                 raise RemoteError(
                     f'Failed to deserialize address {result[1][idx]} '

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.modules.constants import AMM_POSSIBLE_COUNTERPAR
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction, Location
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction, Location
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int, ts_sec_to_ms
 
 from ..constants import CPT_ONEINCH_V1
@@ -36,7 +36,7 @@ class Oneinchv1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_history(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
     ) -> Tuple[Optional[HistoryBaseEntry], Optional[ActionItem]]:
@@ -90,7 +90,7 @@ class Oneinchv1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_swapped(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
     ) -> Tuple[Optional[HistoryBaseEntry], Optional[ActionItem]]:
@@ -138,7 +138,7 @@ class Oneinchv1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def decode_action(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from ..constants import CPT_ONEINCH_V2
@@ -33,7 +33,7 @@ class Oneinchv2Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_swapped(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
     ) -> Tuple[Optional[HistoryBaseEntry], Optional[ActionItem]]:
@@ -78,7 +78,7 @@ class Oneinchv2Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def decode_action(
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.types import PICKLE_JAR_PROTOCOL, EthereumTransaction
+from rotkehlchen.types import PICKLE_JAR_PROTOCOL, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import CPT_PICKLE
@@ -41,7 +41,7 @@ class PickleFinanceDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             self,
             token: EvmToken,  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,
+            transaction: EvmTransaction,
             event: HistoryBaseEntry,
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> bool:

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
-from rotkehlchen.types import EthereumTransaction
+from rotkehlchen.types import EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address
 
 from ..constants import CPT_UNISWAP_V1
@@ -24,7 +24,7 @@ class Uniswapv1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             self,
             token: Optional[EvmToken],  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> None:

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.types import EthereumTransaction
+from rotkehlchen.types import EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from ..constants import CPT_UNISWAP_V2
@@ -25,7 +25,7 @@ class Uniswapv2Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             self,
             token: Optional[EvmToken],  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> None:

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.types import EthereumTransaction
+from rotkehlchen.types import EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from ..constants import CPT_UNISWAP_V3
@@ -26,7 +26,7 @@ class Uniswapv3Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             self,
             token: Optional[EvmToken],  # pylint: disable=unused-argument
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> None:

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import CPT_VOTIUM
@@ -21,7 +21,7 @@ class VotiumDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_claim(  # pylint: disable=no-self-use
         self,
         tx_log: EthereumTxReceiptLog,
-        transaction: EthereumTransaction,  # pylint: disable=unused-argument
+        transaction: EvmTransaction,  # pylint: disable=unused-argument
         decoded_events: List[HistoryBaseEntry],
         all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
         action_items: Optional[List[ActionItem]],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_raw_value
-from rotkehlchen.types import ChecksumEvmAddress, EthereumTransaction
+from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import CPT_ZKSYNC
@@ -22,7 +22,7 @@ class ZksyncDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_event(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument
@@ -35,7 +35,7 @@ class ZksyncDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
     def _decode_deposit(  # pylint: disable=no-self-use
             self,
             tx_log: EthereumTxReceiptLog,
-            transaction: EthereumTransaction,  # pylint: disable=unused-argument
+            transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: List[HistoryBaseEntry],  # pylint: disable=unused-argument
             all_logs: List[EthereumTxReceiptLog],  # pylint: disable=unused-argument
             action_items: List[ActionItem],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -20,7 +20,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import (
     ChecksumEvmAddress,
-    EthereumTransaction,
+    EvmTransaction,
     EVMTxHash,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -115,7 +115,7 @@ class EthTransactions:
             filter_query: ETHTransactionsFilterQuery,
             has_premium: bool = False,
             only_cache: bool = False,
-    ) -> Tuple[List[EthereumTransaction], int]:
+    ) -> Tuple[List[EvmTransaction], int]:
         """Queries for all transactions of an ethereum address or of all addresses.
 
         Returns a list of all transactions filtered and sorted according to the parameters.

--- a/rotkehlchen/db/ethtx.py
+++ b/rotkehlchen/db/ethtx.py
@@ -19,7 +19,7 @@ from rotkehlchen.serialization.deserialize import deserialize_evm_address, deser
 from rotkehlchen.types import (
     ChecksumEvmAddress,
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     EVMTxHash,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -46,7 +46,7 @@ class DBEthTx():
     def add_ethereum_transactions(
             self,
             write_cursor: 'DBCursor',
-            ethereum_transactions: List[EthereumTransaction],
+            ethereum_transactions: List[EvmTransaction],
             relevant_address: Optional[ChecksumEvmAddress],
     ) -> None:
         """Adds ethereum transactions to the database"""
@@ -157,7 +157,7 @@ class DBEthTx():
             cursor: 'DBCursor',
             filter_: ETHTransactionsFilterQuery,
             has_premium: bool,
-    ) -> List[EthereumTransaction]:
+    ) -> List[EvmTransaction]:
         """Returns a list of ethereum transactions optionally filtered by
         the given filter query
 
@@ -176,7 +176,7 @@ class DBEthTx():
         ethereum_transactions = []
         for result in results:
             try:
-                tx = EthereumTransaction(
+                tx = EvmTransaction(
                     tx_hash=make_evm_tx_hash(result[0]),
                     timestamp=deserialize_timestamp(result[1]),
                     block_number=result[2],
@@ -205,7 +205,7 @@ class DBEthTx():
             cursor: 'DBCursor',
             filter_: ETHTransactionsFilterQuery,
             has_premium: bool,
-    ) -> Tuple[List[EthereumTransaction], int]:
+    ) -> Tuple[List[EvmTransaction], int]:
         """Gets all ethereum transactions for the query from the D.
 
         Also returns how many are the total found for the filter.
@@ -437,7 +437,7 @@ class DBEthTx():
     def get_or_create_genesis_transaction(
             self,
             account: ChecksumEvmAddress,
-    ) -> EthereumTransaction:
+    ) -> EvmTransaction:
         with self.db.conn.read_ctx() as cursor:
             tx_in_db = self.get_ethereum_transactions(
                 cursor=cursor,
@@ -447,7 +447,7 @@ class DBEthTx():
         if len(tx_in_db) == 1:
             tx = tx_in_db[0]
         else:
-            tx = EthereumTransaction(
+            tx = EvmTransaction(
                 timestamp=ETHEREUM_BEGIN,
                 block_number=0,
                 tx_hash=GENESIS_HASH,

--- a/rotkehlchen/db/ethtx.py
+++ b/rotkehlchen/db/ethtx.py
@@ -15,10 +15,7 @@ from rotkehlchen.db.filtering import ETHTransactionsFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import (
-    deserialize_ethereum_address,
-    deserialize_timestamp,
-)
+from rotkehlchen.serialization.deserialize import deserialize_evm_address, deserialize_timestamp
 from rotkehlchen.types import (
     ChecksumEvmAddress,
     EthereumInternalTransaction,
@@ -298,7 +295,7 @@ class DBEthTx():
         status = data.get('status', 1)  # status may be missing for older txs. Assume 1.
         if status is None:
             status = 1
-        contract_address = deserialize_ethereum_address(data['contractAddress']) if data['contractAddress'] else None  # noqa: E501
+        contract_address = deserialize_evm_address(data['contractAddress']) if data['contractAddress'] else None  # noqa: E501
         write_cursor.execute(
             'INSERT INTO ethtx_receipts (tx_hash, contract_address, status, type) '
             'VALUES(?, ?, ?, ?) ',
@@ -313,7 +310,7 @@ class DBEthTx():
                 tx_hash_b,
                 log_index,
                 hexstring_to_bytes(log_entry['data']),
-                deserialize_ethereum_address(log_entry['address']),
+                deserialize_evm_address(log_entry['address']),
                 int(log_entry['removed']),
             ))
 

--- a/rotkehlchen/db/ethtx.py
+++ b/rotkehlchen/db/ethtx.py
@@ -18,7 +18,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address, deserialize_timestamp
 from rotkehlchen.types import (
     ChecksumEvmAddress,
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     EVMTxHash,
     Timestamp,
@@ -92,7 +92,7 @@ class DBEthTx():
     def add_ethereum_internal_transactions(
             self,
             write_cursor: 'DBCursor',
-            transactions: List[EthereumInternalTransaction],
+            transactions: List[EvmInternalTransaction],
             relevant_address: ChecksumEvmAddress,
     ) -> None:
         """Adds ethereum transactions to the database"""
@@ -130,7 +130,7 @@ class DBEthTx():
     def get_ethereum_internal_transactions(
             self,
             parent_tx_hash: EVMTxHash,
-    ) -> List[EthereumInternalTransaction]:
+    ) -> List[EvmInternalTransaction]:
         """Get all internal transactions under a parent tx_hash"""
         cursor = self.db.conn.cursor()
         results = cursor.execute(
@@ -139,7 +139,7 @@ class DBEthTx():
         )
         transactions = []
         for result in results:
-            tx = EthereumInternalTransaction(
+            tx = EvmInternalTransaction(
                 parent_tx_hash=make_evm_tx_hash(result[0]),
                 trace_id=result[1],
                 timestamp=result[2],

--- a/rotkehlchen/externalapis/beaconchain.py
+++ b/rotkehlchen/externalapis/beaconchain.py
@@ -21,7 +21,7 @@ from rotkehlchen.externalapis.interface import ExternalServiceWithApiKey
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import (
     ChecksumEvmAddress,
     Eth2PubKey,
@@ -342,7 +342,7 @@ class BeaconChain(ExternalServiceWithApiKey):
                     msg_aggregator=self.msg_aggregator,
                 )
                 deposits.append(Eth2Deposit(
-                    from_address=deserialize_ethereum_address(entry['from_address']),
+                    from_address=deserialize_evm_address(entry['from_address']),
                     pubkey=entry['publickey'],
                     withdrawal_credentials=entry['withdrawal_credentials'],
                     value=Balance(

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -37,7 +37,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ChecksumEvmAddress,
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     EVMTxHash,
     ExternalService,
     Timestamp,
@@ -122,7 +122,7 @@ class Etherscan(ExternalServiceWithApiKey):
             action: str,
             options: Optional[Dict[str, Any]] = None,
             timeout: Optional[Tuple[int, int]] = None,
-    ) -> Union[List[Dict[str, Any]], str, List[EthereumTransaction], Dict[str, Any]]:
+    ) -> Union[List[Dict[str, Any]], str, List[EvmTransaction], Dict[str, Any]]:
         """Queries etherscan
 
         May raise:
@@ -255,7 +255,7 @@ class Etherscan(ExternalServiceWithApiKey):
             action: Literal['txlist'],
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
-    ) -> Iterator[List[EthereumTransaction]]:
+    ) -> Iterator[List[EvmTransaction]]:
         ...
 
     def get_transactions(
@@ -264,7 +264,7 @@ class Etherscan(ExternalServiceWithApiKey):
             action: Literal['txlist', 'txlistinternal'],
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
-    ) -> Union[Iterator[List[EthereumTransaction]], Iterator[List[EvmInternalTransaction]]]:
+    ) -> Union[Iterator[List[EvmTransaction]], Iterator[List[EvmInternalTransaction]]]:
         """Gets a list of transactions (either normal or internal) for account.
 
         May raise:
@@ -279,7 +279,7 @@ class Etherscan(ExternalServiceWithApiKey):
             to_block = self.get_blocknumber_by_time(to_ts)
             options['endBlock'] = str(to_block)
 
-        transactions: Union[Sequence[EthereumTransaction], Sequence[EvmInternalTransaction]] = []  # noqa: E501
+        transactions: Union[Sequence[EvmTransaction], Sequence[EvmInternalTransaction]] = []  # noqa: E501
         is_internal = action == 'txlistinternal'
         while True:
             result = self._query(module='account', action=action, options=options)

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -36,7 +36,7 @@ from rotkehlchen.serialization.deserialize import (
 )
 from rotkehlchen.types import (
     ChecksumEvmAddress,
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     EVMTxHash,
     ExternalService,
@@ -245,7 +245,7 @@ class Etherscan(ExternalServiceWithApiKey):
             action: Literal['txlistinternal'],
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
-    ) -> Iterator[List[EthereumInternalTransaction]]:
+    ) -> Iterator[List[EvmInternalTransaction]]:
         ...
 
     @overload
@@ -264,7 +264,7 @@ class Etherscan(ExternalServiceWithApiKey):
             action: Literal['txlist', 'txlistinternal'],
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
-    ) -> Union[Iterator[List[EthereumTransaction]], Iterator[List[EthereumInternalTransaction]]]:
+    ) -> Union[Iterator[List[EthereumTransaction]], Iterator[List[EvmInternalTransaction]]]:
         """Gets a list of transactions (either normal or internal) for account.
 
         May raise:
@@ -279,7 +279,7 @@ class Etherscan(ExternalServiceWithApiKey):
             to_block = self.get_blocknumber_by_time(to_ts)
             options['endBlock'] = str(to_block)
 
-        transactions: Union[Sequence[EthereumTransaction], Sequence[EthereumInternalTransaction]] = []  # noqa: E501
+        transactions: Union[Sequence[EthereumTransaction], Sequence[EvmInternalTransaction]] = []  # noqa: E501
         is_internal = action == 'txlistinternal'
         while True:
             result = self._query(module='account', action=action, options=options)

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -30,7 +30,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.interface import ExternalServiceWithApiKey
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_ethereum_transaction,
+    deserialize_evm_transaction,
     deserialize_int_from_str,
     deserialize_timestamp,
 )
@@ -289,10 +289,10 @@ class Etherscan(ExternalServiceWithApiKey):
                 try:
                     # Handle genesis block transactions
                     if entry['hash'].startswith('GENESIS') is False:
-                        tx = deserialize_ethereum_transaction(  # type: ignore
+                        tx = deserialize_evm_transaction(  # type: ignore
                             data=entry,
                             internal=is_internal,
-                            ethereum=None,
+                            manager=None,
                         )
                     else:
                         # Handling genesis transactions
@@ -302,10 +302,10 @@ class Etherscan(ExternalServiceWithApiKey):
                         entry['from'] = ZERO_ADDRESS
                         entry['hash'] = GENESIS_HASH
                         entry['traceId'] = trace_id
-                        internal_tx = deserialize_ethereum_transaction(
+                        internal_tx = deserialize_evm_transaction(
                             data=entry,
                             internal=True,
-                            ethereum=None,
+                            manager=None,
                         )
                         with self.db.user_write() as cursor:  # type: ignore  # db always here
                             dbtx.add_ethereum_internal_transactions(

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -19,7 +19,7 @@ from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 
@@ -261,7 +261,7 @@ class AssetsUpdater():
             token_kind = None
 
         return (
-            deserialize_ethereum_address(self._parse_str(match.group(4), 'address', insert_text)),
+            deserialize_evm_address(self._parse_str(match.group(4), 'address', insert_text)),
             self._parse_optional_int(match.group(5), 'decimals', insert_text),
             self._parse_optional_str(match.group(6), 'protocol', insert_text),
             chain,

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -27,7 +27,7 @@ from rotkehlchen.types import (
     AssetAmount,
     AssetMovementCategory,
     ChecksumEvmAddress,
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     Fee,
     HexColorCode,
@@ -39,7 +39,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import convert_to_int, create_timestamp, iso8601ts_to_timestamp
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.ethereum.manager import EthereumManager
+    from rotkehlchen.chain.evm.manager import EvmManager
 
 
 logger = logging.getLogger(__name__)
@@ -497,7 +497,8 @@ def deserialize_optional(input_val: Optional[X], fn: Callable[[X], Y]) -> Option
 def deserialize_evm_transaction(
         data: Dict[str, Any],
         internal: Literal[True],
-) -> EthereumInternalTransaction:
+        manager: Optional['EvmManager'] = None,
+) -> EvmInternalTransaction:
     ...
 
 
@@ -540,7 +541,7 @@ def deserialize_evm_transaction(
         value = read_integer(data, 'value', source)
 
         if internal:
-            return EthereumInternalTransaction(
+            return EvmInternalTransaction(
                 parent_tx_hash=tx_hash,
                 trace_id=int(data['traceId']),
                 timestamp=timestamp,

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -28,7 +28,7 @@ from rotkehlchen.types import (
     AssetMovementCategory,
     ChecksumEvmAddress,
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     Fee,
     HexColorCode,
     Optional,
@@ -507,7 +507,7 @@ def deserialize_evm_transaction(
         data: Dict[str, Any],
         internal: Literal[False],
         manager: Optional['EvmManager'] = None,
-) -> EthereumTransaction:
+) -> EvmTransaction:
     ...
 
 
@@ -515,7 +515,7 @@ def deserialize_evm_transaction(
         data: Dict[str, Any],
         internal: bool,
         manager: Optional['EvmManager'] = None,
-) -> Union[EthereumTransaction, EthereumInternalTransaction]:
+) -> Union[EvmTransaction, EvmInternalTransaction]:
     """Reads dict data of a transaction and deserializes it.
     If the transaction is not from etherscan then it's missing some data
     so evm manager is used to fetch it.
@@ -563,7 +563,7 @@ def deserialize_evm_transaction(
         else:
             gas_used = read_integer(data, 'gasUsed', source)
         nonce = read_integer(data, 'nonce', source)
-        return EthereumTransaction(
+        return EvmTransaction(
             timestamp=timestamp,
             block_number=block_number,
             tx_hash=tx_hash,

--- a/rotkehlchen/serialization/serialize.py
+++ b/rotkehlchen/serialization/serialize.py
@@ -71,8 +71,8 @@ from rotkehlchen.types import (
     AssetMovementCategory,
     BlockchainAccountData,
     CostBasisMethod,
-    EthereumTransaction,
     EvmTokenKind,
+    EvmTransaction,
     ExchangeLocationID,
     Location,
     TradeType,
@@ -131,7 +131,7 @@ def _process_entry(entry: Any) -> Union[str, List[Any], Dict[str, Any], Any]:
         return entry.serialize()
     if isinstance(entry, (
             Trade,
-            EthereumTransaction,
+            EvmTransaction,
             MakerdaoVault,
             DSRAccountReport,
             Balance,

--- a/rotkehlchen/tests/api/test_data_purging.py
+++ b/rotkehlchen/tests/api/test_data_purging.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.exchanges import (
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import (
     BlockchainAccountData,
-    EthereumTransaction,
+    EvmTransaction,
     Location,
     SupportedBlockchain,
     make_evm_tx_hash,
@@ -67,7 +67,7 @@ def test_purge_ethereum_transaction_data(rotkehlchen_api_server):
         )
         db.add_ethereum_transactions(
             cursor,
-            [EthereumTransaction(
+            [EvmTransaction(
                 tx_hash=make_evm_tx_hash(bytes()),
                 timestamp=1,
                 block_number=1,

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -44,7 +44,7 @@ from rotkehlchen.tests.utils.factories import (
 )
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
-from rotkehlchen.types import EthereumTransaction, EVMTxHash, Timestamp, make_evm_tx_hash
+from rotkehlchen.types import EvmTransaction, EVMTxHash, Timestamp, make_evm_tx_hash
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 
 EXPECTED_AFB7_TXS = [{
@@ -560,7 +560,7 @@ def test_query_transactions_over_limit(
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     db = rotki.data.db
     all_transactions_num = FREE_ETH_TX_LIMIT + 50
-    transactions = [EthereumTransaction(
+    transactions = [EvmTransaction(
         tx_hash=make_evm_tx_hash(x.to_bytes(2, byteorder='little')),
         timestamp=x,
         block_number=x,
@@ -573,7 +573,7 @@ def test_query_transactions_over_limit(
         input_data=x.to_bytes(2, byteorder='little'),
         nonce=x,
     ) for x in range(FREE_ETH_TX_LIMIT - 10)]
-    extra_transactions = [EthereumTransaction(
+    extra_transactions = [EvmTransaction(
         tx_hash=make_evm_tx_hash((x + 500).to_bytes(2, byteorder='little')),
         timestamp=x,
         block_number=x,
@@ -640,7 +640,7 @@ def test_query_transactions_from_to_address(
     end_ts = 1598453214
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     db = rotki.data.db
-    transactions = [EthereumTransaction(
+    transactions = [EvmTransaction(
         tx_hash=make_evm_tx_hash(b'1'),
         timestamp=0,
         block_number=0,
@@ -652,7 +652,7 @@ def test_query_transactions_from_to_address(
         gas_used=1,
         input_data=b'',
         nonce=0,
-    ), EthereumTransaction(
+    ), EvmTransaction(
         tx_hash=make_evm_tx_hash(b'2'),
         timestamp=0,
         block_number=0,
@@ -664,7 +664,7 @@ def test_query_transactions_from_to_address(
         gas_used=1,
         input_data=b'',
         nonce=1,
-    ), EthereumTransaction(
+    ), EvmTransaction(
         tx_hash=make_evm_tx_hash(b'3'),
         timestamp=0,
         block_number=0,
@@ -725,7 +725,7 @@ def test_query_transactions_removed_address(
     end_ts = 1598453214
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     db = rotki.data.db
-    transactions = [EthereumTransaction(
+    transactions = [EvmTransaction(
         tx_hash=make_evm_tx_hash(b'1'),
         timestamp=0,
         block_number=0,
@@ -737,7 +737,7 @@ def test_query_transactions_removed_address(
         gas_used=1,
         input_data=b'',
         nonce=0,
-    ), EthereumTransaction(
+    ), EvmTransaction(
         tx_hash=make_evm_tx_hash(b'2'),
         timestamp=0,
         block_number=0,
@@ -749,7 +749,7 @@ def test_query_transactions_removed_address(
         gas_used=1,
         input_data=b'',
         nonce=1,
-    ), EthereumTransaction(  # should remain after deleting account[0]
+    ), EvmTransaction(  # should remain after deleting account[0]
         tx_hash=make_evm_tx_hash(b'3'),
         timestamp=0,
         block_number=0,
@@ -761,7 +761,7 @@ def test_query_transactions_removed_address(
         gas_used=1,
         input_data=b'',
         nonce=55,
-    ), EthereumTransaction(  # should remain after deleting account[0]
+    ), EvmTransaction(  # should remain after deleting account[0]
         tx_hash=make_evm_tx_hash(b'4'),
         timestamp=0,
         block_number=0,
@@ -773,7 +773,7 @@ def test_query_transactions_removed_address(
         gas_used=1,
         input_data=b'',
         nonce=0,
-    ), EthereumTransaction(  # should remain after deleting account[0]
+    ), EvmTransaction(  # should remain after deleting account[0]
         tx_hash=make_evm_tx_hash(b'5'),
         timestamp=0,
         block_number=0,

--- a/rotkehlchen/tests/db/test_ethtx.py
+++ b/rotkehlchen/tests/db/test_ethtx.py
@@ -11,7 +11,7 @@ from rotkehlchen.tests.utils.constants import (
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import (
     BlockchainAccountData,
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     SupportedBlockchain,
     Timestamp,
@@ -203,7 +203,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         input_data=MOCK_INPUT_DATA,
         nonce=55,
     )
-    internal_tx1 = EthereumInternalTransaction(
+    internal_tx1 = EvmInternalTransaction(
         parent_tx_hash=make_evm_tx_hash(b'3'),
         trace_id=1,
         timestamp=Timestamp(1452806400),
@@ -212,7 +212,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         to_address=address_4,
         value=0,
     )
-    internal_tx2 = EthereumInternalTransaction(
+    internal_tx2 = EvmInternalTransaction(
         parent_tx_hash=make_evm_tx_hash(b'5'),
         trace_id=21,
         timestamp=Timestamp(1629064001),
@@ -221,7 +221,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         to_address=make_ethereum_address(),
         value=0,
     )
-    internal_tx3 = EthereumInternalTransaction(
+    internal_tx3 = EvmInternalTransaction(
         parent_tx_hash=make_evm_tx_hash(b'4'),
         trace_id=25,
         timestamp=Timestamp(1628064001),
@@ -230,7 +230,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         to_address=ETH_ADDRESS3,
         value=10,
     )
-    internal_tx4 = EthereumInternalTransaction(
+    internal_tx4 = EvmInternalTransaction(
         parent_tx_hash=make_evm_tx_hash(b'4'),
         trace_id=26,
         timestamp=Timestamp(1628064001),

--- a/rotkehlchen/tests/db/test_ethtx.py
+++ b/rotkehlchen/tests/db/test_ethtx.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import (
     BlockchainAccountData,
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     SupportedBlockchain,
     Timestamp,
     make_evm_tx_hash,
@@ -40,7 +40,7 @@ def test_add_get_ethereum_transactions(data_dir, username, sql_vm_instructions_c
             ],
         )
 
-    tx1 = EthereumTransaction(
+    tx1 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'1'),
         timestamp=Timestamp(1451606400),
         block_number=1,
@@ -53,7 +53,7 @@ def test_add_get_ethereum_transactions(data_dir, username, sql_vm_instructions_c
         input_data=MOCK_INPUT_DATA,
         nonce=1,
     )
-    tx2 = EthereumTransaction(
+    tx2 = EvmTransaction(
         tx_hash=tx2_hash,
         timestamp=Timestamp(1451706400),
         block_number=3,
@@ -66,7 +66,7 @@ def test_add_get_ethereum_transactions(data_dir, username, sql_vm_instructions_c
         input_data=MOCK_INPUT_DATA,
         nonce=1,
     )
-    tx3 = EthereumTransaction(
+    tx3 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'3'),
         timestamp=Timestamp(1452806400),
         block_number=5,
@@ -138,7 +138,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
             ],
         )
 
-    tx1 = EthereumTransaction(
+    tx1 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'1'),
         timestamp=Timestamp(1451606400),
         block_number=1,
@@ -151,7 +151,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         input_data=MOCK_INPUT_DATA,
         nonce=1,
     )
-    tx2 = EthereumTransaction(
+    tx2 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'2'),
         timestamp=Timestamp(1451706400),
         block_number=3,
@@ -164,7 +164,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         input_data=MOCK_INPUT_DATA,
         nonce=1,
     )
-    tx3 = EthereumTransaction(
+    tx3 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'3'),
         timestamp=Timestamp(1452806400),
         block_number=5,
@@ -177,7 +177,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         input_data=MOCK_INPUT_DATA,
         nonce=3,
     )
-    tx4 = EthereumTransaction(
+    tx4 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'4'),
         timestamp=Timestamp(1628064001),
         block_number=6,
@@ -190,7 +190,7 @@ def test_query_also_internal_ethereum_transactions(data_dir, username, sql_vm_in
         input_data=MOCK_INPUT_DATA,
         nonce=55,
     )
-    tx5 = EthereumTransaction(
+    tx5 = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'5'),
         timestamp=Timestamp(1629064001),
         block_number=7,

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -13,7 +13,7 @@ from rotkehlchen.serialization.deserialize import deserialize_evm_transaction
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import (
     BlockchainAccountData,
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     ExternalService,
     ExternalServiceApiCredentials,
@@ -156,7 +156,7 @@ def test_etherscan_get_transactions_genesis_block(eth_transactions):
     ]
 
     assert internal_tx_in_db == [
-        EthereumInternalTransaction(
+        EvmInternalTransaction(
             parent_tx_hash=GENESIS_HASH,
             trace_id=0,
             timestamp=ETHEREUM_BEGIN,

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -14,7 +14,7 @@ from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import (
     BlockchainAccountData,
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     ExternalService,
     ExternalServiceApiCredentials,
     SupportedBlockchain,
@@ -86,7 +86,7 @@ def test_deserialize_transaction_from_etherscan():
     # Make sure that a missing to address due to contract creation is handled
     data = {'blockNumber': 54092, 'timeStamp': 1439048640, 'hash': '0x9c81f44c29ff0226f835cd0a8a2f2a7eca6db52a711f8211b566fd15d3e0e8d4', 'nonce': 0, 'blockHash': '0xd3cabad6adab0b52ea632c386ea19403680571e682c62cb589b5abcd76de2159', 'transactionIndex': 0, 'from': '0x5153493bB1E1642A63A098A65dD3913daBB6AE24', 'to': '', 'value': 11901464239480000000000000, 'gas': 2000000, 'gasPrice': 10000000000000, 'isError': 0, 'txreceipt_status': '', 'input': '0x313233', 'contractAddress': '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', 'cumulativeGasUsed': 1436963, 'gasUsed': 1436963, 'confirmations': 8569454}  # noqa: E501
     transaction = deserialize_evm_transaction(data, internal=False, manager=None)
-    assert transaction == EthereumTransaction(
+    assert transaction == EvmTransaction(
         tx_hash=deserialize_evm_tx_hash(data['hash']),
         timestamp=1439048640,
         block_number=54092,
@@ -128,7 +128,7 @@ def test_etherscan_get_transactions_genesis_block(eth_transactions):
         internal_tx_in_db = dbtx.get_ethereum_internal_transactions(parent_tx_hash=GENESIS_HASH)
 
     assert regular_tx_in_db == [
-        EthereumTransaction(
+        EvmTransaction(
             tx_hash=GENESIS_HASH,
             timestamp=ETHEREUM_BEGIN,
             block_number=0,
@@ -140,7 +140,7 @@ def test_etherscan_get_transactions_genesis_block(eth_transactions):
             gas_used=0,
             input_data=b'',
             nonce=0,
-        ), EthereumTransaction(
+        ), EvmTransaction(
             tx_hash=deserialize_evm_tx_hash('0x352b93ac19dfbfd65d4d8385cded959d7a156c3f352a71a5a49560b088e1c8df'),  # noqa: E501
             timestamp=Timestamp(1443534531),
             block_number=307793,

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -9,7 +9,7 @@ from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.db.filtering import ETHTransactionsFilterQuery
 from rotkehlchen.externalapis.etherscan import Etherscan
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_transaction
+from rotkehlchen.serialization.deserialize import deserialize_evm_transaction
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import (
     BlockchainAccountData,
@@ -85,7 +85,7 @@ def test_maximum_rate_limit_reached(temp_etherscan, **kwargs):  # pylint: disabl
 def test_deserialize_transaction_from_etherscan():
     # Make sure that a missing to address due to contract creation is handled
     data = {'blockNumber': 54092, 'timeStamp': 1439048640, 'hash': '0x9c81f44c29ff0226f835cd0a8a2f2a7eca6db52a711f8211b566fd15d3e0e8d4', 'nonce': 0, 'blockHash': '0xd3cabad6adab0b52ea632c386ea19403680571e682c62cb589b5abcd76de2159', 'transactionIndex': 0, 'from': '0x5153493bB1E1642A63A098A65dD3913daBB6AE24', 'to': '', 'value': 11901464239480000000000000, 'gas': 2000000, 'gasPrice': 10000000000000, 'isError': 0, 'txreceipt_status': '', 'input': '0x313233', 'contractAddress': '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae', 'cumulativeGasUsed': 1436963, 'gasUsed': 1436963, 'confirmations': 8569454}  # noqa: E501
-    transaction = deserialize_ethereum_transaction(data, internal=False, ethereum=None)
+    transaction = deserialize_evm_transaction(data, internal=False, manager=None)
     assert transaction == EthereumTransaction(
         tx_hash=deserialize_evm_tx_hash(data['hash']),
         timestamp=1439048640,

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -22,7 +22,7 @@ from rotkehlchen.constants.assets import A_CRV, A_CVX, A_ETH
 from rotkehlchen.constants.ethereum import EthereumConstants
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import EthereumTransaction, Location, deserialize_evm_tx_hash
+from rotkehlchen.types import EvmTransaction, Location, deserialize_evm_tx_hash
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 from rotkehlchen.utils.misc import hex_or_bytes_to_address
 
@@ -91,7 +91,7 @@ def test_booster_deposit(database, ethereum_manager, eth_transactions):
     tx_hex = '0x8f643dc245ce64085197692ed98309a94fd176a1e7394e8967ae7bfa10ad1f8f'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0xC960338B529e0353F570f62093Fd362B8FB55f0B')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -184,7 +184,7 @@ def test_booster_withdraw(database, ethereum_manager, eth_transactions):
     tx_hex = '0x79fcbafa4367e0563d3e614f774c5e4257c4e41f124ae8288980a310e2b2b547'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0x53913A03a065f685097f8E8f40284D58016bB0F9')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -301,7 +301,7 @@ def test_cvxcrv_get_reward(database, ethereum_manager, eth_transactions):
     tx_hex = '0x5e62ce39159fcdf528905d044e5387c8f21a1eca015d08cebc652bfb9c183611'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0xFb305A40Dac406BdCF3b85F6311e5430770f44bA')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1655675488,
         block_number=14998088,
@@ -450,7 +450,7 @@ def test_cvxcrv_withdraw(database, ethereum_manager, eth_transactions):
     tx_hex = '0x0a804804cc62f615b72dff55e8c245d9b69aa8f8ed3de549101ae128a4ae432b'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0xe81FC42336c9314A9Be1EDB3F50eA9e275C93df3')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -551,7 +551,7 @@ def test_cvxcrv_stake(database, ethereum_manager, eth_transactions):
     tx_hex = '0x3cc0b25887e2f0dac7f86fabd81aaafb1e041e84dbe8167885073c443320ad5f'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0x2AcEcBF2Ee5BFc8eed599D58835EE9A7c45F3E2c')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -667,7 +667,7 @@ def test_cvx_stake(database, ethereum_manager, eth_transactions):
     tx_hex = '0xc33246acb86798b81fe650061061d32751c53879d46ece6991fb4a3eda808103'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0x5B186c93A50D3CB435fE2933427d36E6Dc688e4b')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -783,7 +783,7 @@ def test_cvx_get_reward(database, ethereum_manager, eth_transactions):
     tx_hex = '0xdaead2f96859462b5800584ecdcf30f2b83a1ca2c36c49a838b23e43c61d803f'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = '0x95c5582D781d507A084c9E5f885C77BabACf8EeA'
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -915,7 +915,7 @@ def test_cvx_withdraw(database, ethereum_manager, eth_transactions):
     tx_hex = '0xe725bd6e00b840f4fb8f73cd7286bfa18b04a24ca9278cac7249218ee9f420a8'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0x84BCE169c271e1c1777715bb0dd38Ad9e6381BAa')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -1007,7 +1007,7 @@ def test_claimzap_abracadabras(database, ethereum_manager, eth_transactions):
     tx_hex = '0xe03d27127fda879144ea4cc587470bd37040be9921ff6a90f48d4efd0cb4fe13'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0x999EcCEa3C4f9219B1B1B42b4830e62c26004B40')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,
@@ -1090,7 +1090,7 @@ def test_claimzap_cvx_locker(database, ethereum_manager, eth_transactions):
     tx_hex = '0x53e092e6f25e540d6323af851a1e889276096d58ec25495aef4500467ef2753c'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = string_to_evm_address('0x0C3Cc503EaE928Ed6B5b01B8a9EE8de2855d03Ac')
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=0,
         block_number=0,

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -16,7 +16,7 @@ from rotkehlchen.globaldb import GlobalDBHandler
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import (
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     GeneralCacheType,
     Location,
     Timestamp,
@@ -66,7 +66,7 @@ def test_curve_deposit(database, evm_transaction_decoder):
     tx_hex = '0x523b7df8e168315e97a836a3d516d639908814785d7df1ef1745de3e55501982'
     location_label = '0x57bF3B0f29E37619623994071C9e12091919675c'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1650276061,
         block_number=14608535,
@@ -204,7 +204,7 @@ def test_curve_deposit_eth(database, evm_transaction_decoder):
     tx_hex = '0x51c052c8fb60f092f98ffc3cab6340c7c5348ee3b339582feba1c17cbd97ea56'
     location_label = '0x767B35b9F06F6e28e5ed05eE7C27bDf992eba5d2'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1650276061,
         block_number=14608535,
@@ -353,7 +353,7 @@ def test_curve_remove_liquidity(database, evm_transaction_decoder):
     tx_hex = '0xd63dccdbebeede3a1f50b97c0a8592255203a0559880b80377daa39f915741b0'
     location_label = '0xDf9f0AE722A3919fE7f9cC8805773ef142007Ca6'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1650276061,
         block_number=14608535,
@@ -477,7 +477,7 @@ def test_curve_remove_liquidity_with_internal(database, evm_transaction_decoder)
     tx_hex = '0x30bb99f3e34fb1fbcf009320af7e290caf18b04b207319e15aa8ffbf645f4ad9'
     location_label = '0xa8005630caE7b7d2AFADD38FD3B3040d13cbE2BC'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1650276061,
         block_number=14647221,
@@ -591,7 +591,7 @@ def test_curve_remove_imbalanced(database, evm_transaction_decoder):
     tx_hex = '0xd8832abcf4773abe24d8cda5581fb53bfb3850c535c1956d1d120a72a4ebcbd8'
     location_label = '0x2fac74A3a04B031F240923621a578724C40678af'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1650276061,
         block_number=14647221,

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -15,7 +15,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb import GlobalDBHandler
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import (
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     GeneralCacheType,
     Location,
@@ -518,7 +518,7 @@ def test_curve_remove_liquidity_with_internal(database, evm_transaction_decoder)
             ),
         ],
     )
-    internal_tx = EthereumInternalTransaction(
+    internal_tx = EvmInternalTransaction(
         parent_tx_hash=evmhash,
         trace_id=27,
         timestamp=Timestamp(1591043988),

--- a/rotkehlchen/tests/unit/decoders/test_enriched.py
+++ b/rotkehlchen/tests/unit/decoders/test_enriched.py
@@ -13,7 +13,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import EthereumTransaction, Location, deserialize_evm_tx_hash
+from rotkehlchen.types import EvmTransaction, Location, deserialize_evm_tx_hash
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 
@@ -26,7 +26,7 @@ def test_1inch_claim(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x0582a0db79de3fa21d3b92a8658e0b1034c51ea54a8e06ea84fbb91d41b8fe17'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,
@@ -123,7 +123,7 @@ def test_gnosis_chain_bridge(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x52f853d559d83b5303faf044e00e9109bd5c6a05b6633f9df34939f8e7c6de02'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,
@@ -234,7 +234,7 @@ def test_gitcoin_claim(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x0e22cbdbac56c785f186bec44d715ab0834ceeadd96573c030f2fae1550b64fa'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -13,7 +13,7 @@ from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     Location,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -30,7 +30,7 @@ def test_kyber_legacy_old_contract(database, ethereum_manager, eth_transactions)
     msg_aggregator = MessagesAggregator()
     tx_hex = '0xe9cc9f27ef2a09fe23abc886a0a0f7ae19d9e2eb73663e1e41e07a3e0c011b87'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1591043988,
         block_number=10182160,
@@ -154,7 +154,7 @@ def test_kyber_legacy_new_contract(database, ethereum_manager, eth_transactions)
     msg_aggregator = MessagesAggregator()
     tx_hex = '0xe80928d5e21f9628c047af1f8b191cbffbb6b8b9945adb502cfb3af152552f22'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1644182638,
         block_number=14154915,

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -12,7 +12,7 @@ from rotkehlchen.constants.assets import A_CRV, A_ETH, A_USDC
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     Location,
     Timestamp,
@@ -71,7 +71,7 @@ def test_kyber_legacy_old_contract(database, ethereum_manager, eth_transactions)
             ),
         ],
     )
-    internal_tx = EthereumInternalTransaction(
+    internal_tx = EvmInternalTransaction(
         parent_tx_hash=evmhash,
         trace_id=27,
         timestamp=Timestamp(1591043988),

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -12,7 +12,7 @@ from rotkehlchen.constants.misc import EXP18, ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     Location,
     Timestamp,
@@ -310,7 +310,7 @@ def test_liquity_trove_remove_eth(database, ethereum_manager, eth_transactions):
             ),
         ],
     )
-    internal_tx = EthereumInternalTransaction(
+    internal_tx = EvmInternalTransaction(
         parent_tx_hash=evmhash,
         trace_id=19,
         timestamp=Timestamp(1646375440),

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -13,7 +13,7 @@ from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     Location,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -32,7 +32,7 @@ def test_liquity_trove_adjust(database, ethereum_manager, eth_transactions):
     tx_hex = '0xdb9a541a4af7d5d46d7ea5fe4a2a752dcb731d64d052f86f630e97362063602c'
     user_address = '0x9ba961989Dd6609Ed091f512bE947118c40F2291'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14318825,
@@ -158,7 +158,7 @@ def test_liquity_trove_deposit_lusd(database, ethereum_manager, eth_transactions
     tx_hex = '0x40bb08427a3b99fb9896cf14858d82d361a6e7a8fb7dd6d2000511ac3dca5707'
     user_address = '0x648E180e246741363639B1496762763dd25649db'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14318825,
@@ -261,7 +261,7 @@ def test_liquity_trove_remove_eth(database, ethereum_manager, eth_transactions):
     tx_hex = '0x6be5312c21855c3cc324b5b6ce9f9f65dbd488e270e84ac5e6fb96c74d83fe4e'
     user_address = '0x648E180e246741363639B1496762763dd25649db'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14318825,

--- a/rotkehlchen/tests/unit/decoders/test_pickle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pickle.py
@@ -12,7 +12,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import EthereumTransaction, Location, deserialize_evm_tx_hash
+from rotkehlchen.types import EvmTransaction, Location, deserialize_evm_tx_hash
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 
@@ -25,7 +25,7 @@ def test_pickle_deposit(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0xba9a52a144d4e79580a557160e9f8269d3e5373ce44bce00ebd609754034b7bd'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14318825,
@@ -138,7 +138,7 @@ def test_pickle_withdraw(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x91bc102e1cbb0e4542a10a7a13370b5e591d8d284989bdb0ca4ece4e54e61bab'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14355951,

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -14,8 +14,8 @@ from rotkehlchen.constants.misc import EXP18, ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
-    EthereumTransaction,
     EvmInternalTransaction,
+    EvmTransaction,
     Location,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -32,7 +32,7 @@ def test_uniswap_v2_swap(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x67cf6c4ce5078f9750a14afd2f5070c327caf8c5180bdee2be59644ac59974e1'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,
@@ -188,7 +188,7 @@ def test_uniswap_v2_swap_eth_returned(database, ethereum_manager, eth_transactio
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x20ecc226c438a8803a6195d8031ae7dd97a27351e6b7429621b36194121b9b76'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -14,8 +14,8 @@ from rotkehlchen.constants.misc import EXP18, ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
-    EthereumInternalTransaction,
     EthereumTransaction,
+    EvmInternalTransaction,
     Location,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -241,7 +241,7 @@ def test_uniswap_v2_swap_eth_returned(database, ethereum_manager, eth_transactio
         ],
     )
 
-    internal_tx = EthereumInternalTransaction(
+    internal_tx = EvmInternalTransaction(
         parent_tx_hash=evmhash,
         trace_id=27,
         timestamp=Timestamp(1646375440),

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -15,7 +15,7 @@ from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
     EvmInternalTransaction,
-    EthereumTransaction,
+    EvmTransaction,
     Location,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -32,7 +32,7 @@ def test_uniswap_v3_swap(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x1c50c336329a7ee41f722ce5d848ebd066b72bf44a1eaafcaa92e8c0282049d2'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,
@@ -160,7 +160,7 @@ def test_uniswap_v3_swap_received_token2(database, ethereum_manager, eth_transac
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x116b3a9c0b2a4857605e336438c8e4c91897a9ef2af23178f9dbceba85264bd9'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14351442,

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -14,7 +14,7 @@ from rotkehlchen.constants.misc import EXP18, ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
-    EthereumInternalTransaction,
+    EvmInternalTransaction,
     EthereumTransaction,
     Location,
     Timestamp,
@@ -213,7 +213,7 @@ def test_uniswap_v3_swap_received_token2(database, ethereum_manager, eth_transac
         ],
     )
 
-    internal_tx = EthereumInternalTransaction(
+    internal_tx = EvmInternalTransaction(
         parent_tx_hash=evmhash,
         trace_id=27,
         timestamp=Timestamp(1646375440),

--- a/rotkehlchen/tests/unit/decoders/test_votium.py
+++ b/rotkehlchen/tests/unit/decoders/test_votium.py
@@ -12,7 +12,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import EthereumTransaction, Location, deserialize_evm_tx_hash
+from rotkehlchen.types import EvmTransaction, Location, deserialize_evm_tx_hash
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 
@@ -25,7 +25,7 @@ def test_votium_claim(database, ethereum_manager, eth_transactions):
     msg_aggregator = MessagesAggregator()
     tx_hex = '0x75b81b2edd454a7b564cc55a6b676e2441e155401bde99a38d867028081d2c30'
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EthereumTransaction(
+    transaction = EvmTransaction(
         tx_hash=evmhash,
         timestamp=1646375440,
         block_number=14318825,

--- a/rotkehlchen/tests/unit/test_ethereum_manager.py
+++ b/rotkehlchen/tests/unit/test_ethereum_manager.py
@@ -16,7 +16,7 @@ from rotkehlchen.tests.utils.ethereum import (
 from rotkehlchen.tests.utils.factories import make_ethereum_address
 from rotkehlchen.types import (
     BlockchainAccountData,
-    EthereumTransaction,
+    EvmTransaction,
     SupportedBlockchain,
     deserialize_evm_tx_hash,
     make_evm_tx_hash,
@@ -77,7 +77,7 @@ def test_get_transaction_receipt(
         )
         db.add_ethereum_transactions(
             cursor,
-            [EthereumTransaction(  # need to add the tx first
+            [EvmTransaction(  # need to add the tx first
                 tx_hash=tx_hash,
                 timestamp=1,  # all other fields don't matter for this test
                 block_number=1,
@@ -133,7 +133,7 @@ def test_get_transaction_by_hash(ethereum_manager, call_order, ethereum_manager_
         hexstring_to_bytes('0x5b180e3dcc19cd29c918b98c876f19393e07b74c07fd728102eb6241db3c2d5c'),
         call_order=call_order,
     )
-    expected_tx = EthereumTransaction(
+    expected_tx = EvmTransaction(
         tx_hash=make_evm_tx_hash(b'[\x18\x0e=\xcc\x19\xcd)\xc9\x18\xb9\x8c\x87o\x199>\x07\xb7L\x07\xfdr\x81\x02\xebbA\xdb<-\\'),  # noqa: E501
         timestamp=1633128954,
         block_number=13336285,

--- a/rotkehlchen/tests/unit/test_serialization.py
+++ b/rotkehlchen/tests/unit/test_serialization.py
@@ -13,7 +13,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_int_from_hex_or_int,
 )
 from rotkehlchen.types import (
-    EthereumTransaction,
+    EvmTransaction,
     Location,
     Timestamp,
     TradeType,
@@ -131,7 +131,7 @@ def test_deserialize_deployment_ethereum_transaction():
         internal=False,
         manager=None,
     )
-    expected = EthereumTransaction(
+    expected = EvmTransaction(
         timestamp=Timestamp(0),
         block_number=1,
         tx_hash=deserialize_evm_tx_hash(data['hash']),

--- a/rotkehlchen/tests/unit/test_serialization.py
+++ b/rotkehlchen/tests/unit/test_serialization.py
@@ -8,8 +8,8 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.utils import read_hash
 from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import (
-    deserialize_ethereum_address,
-    deserialize_ethereum_transaction,
+    deserialize_evm_address,
+    deserialize_evm_transaction,
     deserialize_int_from_hex_or_int,
 )
 from rotkehlchen.types import (
@@ -126,16 +126,16 @@ def test_deserialize_deployment_ethereum_transaction():
         'input': '',
         'nonce': 1,
     }
-    tx = deserialize_ethereum_transaction(
+    tx = deserialize_evm_transaction(
         data=data,
         internal=False,
-        ethereum=None,
+        manager=None,
     )
     expected = EthereumTransaction(
         timestamp=Timestamp(0),
         block_number=1,
         tx_hash=deserialize_evm_tx_hash(data['hash']),
-        from_address=deserialize_ethereum_address(data['from']),
+        from_address=deserialize_evm_address(data['from']),
         to_address=None,
         value=data['value'],
         gas=data['gas'],

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -17,7 +17,7 @@ from rotkehlchen.externalapis.beaconchain import BeaconChain
 from rotkehlchen.externalapis.etherscan import Etherscan
 from rotkehlchen.fval import FVal
 from rotkehlchen.rotkehlchen import Rotkehlchen
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.tests.utils.eth_tokens import CONTRACT_ADDRESS_TO_TOKEN
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import BTCAddress, ChecksumEvmAddress
@@ -370,14 +370,14 @@ def mock_etherscan_query(
                     scan_output_types = get_abi_output_types(scan_fn_abi)
                     result_bytes = []
                     for call_entry in decoded_input[0]:  # pylint: disable=unsubscriptable-object
-                        call_contract_address = deserialize_ethereum_address(call_entry[0])
+                        call_contract_address = deserialize_evm_address(call_entry[0])
                         assert call_contract_address == contract.address, 'balances multicall should only contain calls to scan contract'  # noqa: E501
                         call_data = call_entry[1]
                         scan_decoded_input = web3.codec.decode_abi(scan_input_types, call_data[4:])
-                        account_address = deserialize_ethereum_address(scan_decoded_input[0])  # pylint: disable=unsubscriptable-object  # noqa: E501
+                        account_address = deserialize_evm_address(scan_decoded_input[0])  # pylint: disable=unsubscriptable-object  # noqa: E501
                         token_values = []
                         for token_addy_str in scan_decoded_input[1]:  # pylint: disable=unsubscriptable-object # noqa: E501
-                            token_address = deserialize_ethereum_address(token_addy_str)
+                            token_address = deserialize_evm_address(token_addy_str)
                             token = _get_token(token_address)
                             if token is None:
                                 value = 0  # if token is missing from mapping return 0 value
@@ -423,7 +423,7 @@ def mock_etherscan_query(
                 decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
                 args = []
                 for account_address in decoded_input[0]:  # pylint: disable=unsubscriptable-object  # noqa: E501
-                    account_address = deserialize_ethereum_address(account_address)
+                    account_address = deserialize_evm_address(account_address)
                     args.append(int(eth_map[account_address]['ETH']))
                 result = '0x' + web3.codec.encode_abi(output_types, [args]).hex()
                 response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
@@ -442,10 +442,10 @@ def mock_etherscan_query(
                 decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
                 args = []
                 for account_address in decoded_input[0]:  # pylint: disable=unsubscriptable-object  # noqa: E501
-                    account_address = deserialize_ethereum_address(account_address)
+                    account_address = deserialize_evm_address(account_address)
                     x = []
                     for token_address in decoded_input[1]:  # pylint: disable=unsubscriptable-object  # noqa: E501
-                        token_address = deserialize_ethereum_address(token_address)
+                        token_address = deserialize_evm_address(token_address)
                         value_to_add = 0
                         for given_asset, value in eth_map[account_address].items():
                             given_asset = _get_token(given_asset)
@@ -476,10 +476,10 @@ def mock_etherscan_query(
                 output_types = get_abi_output_types(fn_abi)
                 decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
                 args = []
-                account_address = deserialize_ethereum_address(decoded_input[0])  # pylint: disable=unsubscriptable-object  # noqa: E501
+                account_address = deserialize_evm_address(decoded_input[0])  # pylint: disable=unsubscriptable-object  # noqa: E501
                 x = []
                 for token_address in decoded_input[1]:  # pylint: disable=unsubscriptable-object  # noqa: E501
-                    token_address = deserialize_ethereum_address(token_address)
+                    token_address = deserialize_evm_address(token_address)
                     value_to_add = 0
                     for given_asset, value in eth_map[account_address].items():
                         given_asset = _get_token(given_asset)

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -19,7 +19,7 @@ from rotkehlchen.db.filtering import ETHTransactionsFilterQuery
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import (
     BlockchainAccountData,
-    EthereumTransaction,
+    EvmTransaction,
     EVMTxHash,
     SupportedBlockchain,
     Timestamp,
@@ -157,7 +157,7 @@ def setup_ethereum_transactions_test(
         database: DBHandler,
         transaction_already_queried: bool,
         one_receipt_in_db: bool = False,
-) -> Tuple[List[EthereumTransaction], List[EthereumTxReceipt]]:
+) -> Tuple[List[EvmTransaction], List[EthereumTxReceipt]]:
     dbethtx = DBEthTx(database)
     tx_hash1 = deserialize_evm_tx_hash('0x692f9a6083e905bdeca4f0293f3473d7a287260547f8cbccc38c5cb01591fcda')  # noqa: E501
     addr1 = string_to_evm_address('0x443E1f9b1c866E54e914822B7d3d7165EdB6e9Ea')
@@ -172,7 +172,7 @@ def setup_ethereum_transactions_test(
             ],
         )
 
-    transaction1 = EthereumTransaction(
+    transaction1 = EvmTransaction(
         tx_hash=tx_hash1,
         timestamp=Timestamp(1630532276),
         block_number=13142218,
@@ -186,7 +186,7 @@ def setup_ethereum_transactions_test(
         nonce=13,
     )
     tx_hash2 = deserialize_evm_tx_hash('0x6beab9409a8f3bd11f82081e99e856466a7daf5f04cca173192f79e78ed53a77')  # noqa: E501
-    transaction2 = EthereumTransaction(
+    transaction2 = EvmTransaction(
         tx_hash=tx_hash2,
         timestamp=Timestamp(1631013757),
         block_number=13178342,

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -18,7 +18,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     ChecksumEvmAddress,
-    EthereumTransaction,
+    EvmTransaction,
     Location,
     Timestamp,
     TimestampMS,
@@ -68,10 +68,10 @@ def make_ethereum_address() -> ChecksumEvmAddress:
     return to_checksum_address('0x' + make_random_bytes(20).hex())
 
 
-def make_ethereum_transaction(tx_hash: Optional[bytes] = None) -> EthereumTransaction:
+def make_ethereum_transaction(tx_hash: Optional[bytes] = None) -> EvmTransaction:
     if tx_hash is None:
         tx_hash = make_random_bytes(42)
-    return EthereumTransaction(
+    return EvmTransaction(
         tx_hash=make_evm_tx_hash(tx_hash),
         timestamp=Timestamp(0),
         block_number=0,
@@ -109,7 +109,7 @@ def make_ethereum_event(
 
 
 def generate_tx_entries_response(
-    data: List[Tuple[EthereumTransaction, List[HistoryBaseEntry]]],
+    data: List[Tuple[EvmTransaction, List[HistoryBaseEntry]]],
 ) -> List:
     result = []
     for tx, events in data:

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -194,8 +194,8 @@ T_TradeID = str
 TradeID = NewType('TradeID', T_TradeID)
 
 
-class EthereumTransaction(NamedTuple):
-    """Represent an Ethereum transaction"""
+class EvmTransaction(NamedTuple):
+    """Represent an EVM transaction"""
     tx_hash: EVMTxHash
     timestamp: Timestamp
     block_number: int
@@ -224,7 +224,7 @@ class EthereumTransaction(NamedTuple):
         return hash(self.identifier)
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, EthereumTransaction):
+        if not isinstance(other, EvmTransaction):
             return False
 
         return hash(self) == hash(other)

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -234,8 +234,8 @@ class EthereumTransaction(NamedTuple):
         return self.tx_hash.hex()
 
 
-class EthereumInternalTransaction(NamedTuple):
-    """Represent an internal Ethereum transaction"""
+class EvmInternalTransaction(NamedTuple):
+    """Represent an internal EVM transaction"""
     parent_tx_hash: EVMTxHash
     trace_id: int
     timestamp: Timestamp
@@ -254,7 +254,7 @@ class EthereumInternalTransaction(NamedTuple):
         return hash(self.identifier)
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, EthereumInternalTransaction):
+        if not isinstance(other, EvmInternalTransaction):
             return False
 
         return hash(self) == hash(other)

--- a/tools/uniswapv2/detect.py
+++ b/tools/uniswapv2/detect.py
@@ -14,7 +14,7 @@ from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.externalapis.etherscan import Etherscan
 from rotkehlchen.greenlets import GreenletManager
-from rotkehlchen.serialization.deserialize import deserialize_ethereum_address
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.types import SupportedBlockchain
 from rotkehlchen.user_messages import MessagesAggregator
@@ -65,7 +65,7 @@ def pairs_from_ethereum(ethereum: EthereumManager) -> Dict[str, Any]:
         print(f'Querying univ2 pairs chunk {idx + 1} / {len(chunks)}')
         result = ethereum.multicall_specific(univ2factory, 'allPairs', chunk)
         try:
-            pairs.extend([deserialize_ethereum_address(x[0]) for x in result])
+            pairs.extend([deserialize_evm_address(x[0]) for x in result])
         except DeserializationError:
             print('Error deserializing address while fetching uniswap v2 pool tokens')
             sys.exit(1)
@@ -105,9 +105,9 @@ def pairs_and_token_details_from_graph() -> Dict[str, Any]:
         result = graph.query(querystr, param_types=param_types, param_values=param_values)
         for entry in result['pairs']:
             try:
-                deserialized_entry = deserialize_ethereum_address(entry['id'])
-                deserialized_token_0 = deserialize_ethereum_address(entry['token0']['id'])
-                deserialized_token_1 = deserialize_ethereum_address(entry['token1']['id'])
+                deserialized_entry = deserialize_evm_address(entry['id'])
+                deserialized_token_0 = deserialize_evm_address(entry['token0']['id'])
+                deserialized_token_1 = deserialize_evm_address(entry['token1']['id'])
             except DeserializationError:
                 print('Error deserializing address while fetching uniswap v2 pool tokens')
                 sys.exit(1)


### PR DESCRIPTION
This is just a big rename (sorry about it! :sweat_smile:) split in 3 commits for easier review:

1. Rename deserialize_ethereum_address and generalize deserialize_ethereum_transaction
2. Rename EthereumInternalTransaction -> EvmInternalTransaction
3. Rename EthereumTransaction to EvmTransaction

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
