### PR TITLE
Generalize EthTransactions (EvmTransactions)

### DIFF
--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def add_ethereum_token_to_db(token_data: EvmToken) -> EvmToken:
-    """Adds an ethereum token to the DB and returns it
+def add_evm_token_to_db(token_data: EvmToken) -> EvmToken:
+    """Adds an EVM token to the DB and returns it
 
     May raise:
     - InputError if token already exists in the DB
@@ -48,13 +48,13 @@ def get_or_create_evm_token(
         protocol: Optional[str] = None,
         underlying_tokens: Optional[List[UnderlyingToken]] = None,
         form_with_incomplete_data: bool = False,
-        ethereum_manager: 'EthereumManager' = None,
+        manager: 'EthereumManager' = None,
 ) -> EvmToken:
     """Given a token address return the <EvmToken>
 
     If the token exists in the GlobalDB it's returned. If not it's created and added.
 
-    If an ethereum_manager instance is passed then in the case that the token is not
+    If an manager instance is passed then in the case that the token is not
     in the global DB it will be added and an attempt to get metadata will be made.
 
     Note: if the token already exists but the other arguments don't match the
@@ -70,14 +70,14 @@ def get_or_create_evm_token(
         token_type=token_kind,
     )
     try:
-        ethereum_token = EvmToken(identifier, form_with_incomplete_data)
+        evm_token = EvmToken(identifier, form_with_incomplete_data)
     except (UnknownAsset, DeserializationError):
         log.info(
             f'Encountered unknown asset with address '
             f'{evm_address}. Adding it to the global DB',
         )
-        if ethereum_manager is not None:
-            info = ethereum_manager.get_basic_contract_info(evm_address)
+        if manager is not None:
+            info = manager.get_basic_contract_info(evm_address)
             decimals = info['decimals'] if decimals is None else decimals
             symbol = info['symbol'] if symbol is None else symbol
             name = info['name'] if name is None else name
@@ -96,11 +96,11 @@ def get_or_create_evm_token(
             underlying_tokens=underlying_tokens,
         )
         # This can but should not raise InputError since it should not already exist
-        ethereum_token = add_ethereum_token_to_db(token_data)
+        evm_token = add_evm_token_to_db(token_data)
         with userdb.user_write() as cursor:
-            userdb.add_asset_identifiers(cursor, [ethereum_token.identifier])
+            userdb.add_asset_identifiers(cursor, [evm_token.identifier])
 
-    return ethereum_token
+    return evm_token
 
 
 def get_asset_by_symbol(

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -8,7 +8,7 @@ from gevent.lock import Semaphore
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken, UnderlyingToken
-from rotkehlchen.assets.utils import add_ethereum_token_to_db
+from rotkehlchen.assets.utils import add_evm_token_to_db
 from rotkehlchen.chain.ethereum.graph import (
     GRAPH_QUERY_LIMIT,
     GRAPH_QUERY_SKIP_LIMIT,
@@ -665,7 +665,7 @@ class Balancer(EthereumModule):
                         underlying_tokens=underlying_tokens,
                         protocol='balancer',
                     )
-                    balancer_pool = add_ethereum_token_to_db(token_data)
+                    balancer_pool = add_evm_token_to_db(token_data)
                     balancer_pools.append(balancer_pool)
 
                 # Aggregate the <BalancerInvestEvent> token amounts related with the

--- a/rotkehlchen/chain/ethereum/modules/curve/pools_cache.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/pools_cache.py
@@ -79,7 +79,7 @@ def ensure_curve_tokens_existence(
             userdb=ethereum_manager.database,
             evm_address=lp_token_address,
             chain=ChainID.ETHEREUM,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             protocol=CURVE_POOL_PROTOCOL,
         )
 
@@ -96,7 +96,7 @@ def ensure_curve_tokens_existence(
                     userdb=ethereum_manager.database,
                     evm_address=token_address,
                     chain=ChainID.ETHEREUM,
-                    ethereum_manager=ethereum_manager,
+                    manager=ethereum_manager,
                 )
         else:
             # Otherwise, coins and underlying coins lists represent a
@@ -109,14 +109,14 @@ def ensure_curve_tokens_existence(
                     userdb=ethereum_manager.database,
                     evm_address=underlying_token_address,
                     chain=ChainID.ETHEREUM,
-                    ethereum_manager=ethereum_manager,
+                    manager=ethereum_manager,
                 )
                 # and ensure token exists
                 get_or_create_evm_token(
                     userdb=ethereum_manager.database,
                     evm_address=token_address,
                     chain=ChainID.ETHEREUM,
-                    ethereum_manager=ethereum_manager,
+                    manager=ethereum_manager,
                     underlying_tokens=[UnderlyingToken(
                         address=underlying_token_address,
                         token_kind=EvmTokenKind.ERC20,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
@@ -45,7 +45,7 @@ def decode_uniswap_v2_like_swap(
         evm_address=tx_log.address,
         chain=ChainID.ETHEREUM,
         token_kind=EvmTokenKind.ERC20,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
     )
 
     if pool_token.symbol in exclude_amms.values():

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -42,7 +42,7 @@ from rotkehlchen.chain.ethereum.modules.curve.pools_cache import (
 )
 from rotkehlchen.chain.ethereum.oracles.saddle import SaddleOracle
 from rotkehlchen.chain.ethereum.oracles.uniswap import UniswapV2Oracle, UniswapV3Oracle
-from rotkehlchen.chain.ethereum.transactions import EthTransactions
+from rotkehlchen.chain.ethereum.transactions import EvmTransactions
 from rotkehlchen.chain.manager import ChainManager
 from rotkehlchen.chain.substrate.manager import SubstrateManager
 from rotkehlchen.chain.substrate.types import SubstrateChain
@@ -294,7 +294,7 @@ class Rotkehlchen():
             connect_on_startup=len(blockchain_accounts.dot) != 0,
             own_rpc_endpoint=settings.dot_rpc_endpoint,
         )
-        self.eth_transactions = EthTransactions(ethereum=ethereum_manager, database=self.data.db)
+        self.eth_transactions = EvmTransactions(manager=ethereum_manager, database=self.data.db)
         self.covalent_avalanche = Covalent(
             database=self.data.db,
             msg_aggregator=self.msg_aggregator,
@@ -334,7 +334,7 @@ class Rotkehlchen():
         )
         self.eth_tx_decoder = EVMTransactionDecoder(
             database=self.data.db,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=self.eth_transactions,
             msg_aggregator=self.msg_aggregator,
         )

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -127,7 +127,7 @@ class TaskManager():
             self._maybe_schedule_exchange_history_query,
             self._maybe_schedule_ethereum_txreceipts,
             self._maybe_query_missing_prices,
-            self._maybe_decode_evm_transactions,
+            self._maybe_decode_ethereum_transactions,
             self._maybe_check_premium_status,
             self._maybe_update_snapshot_balances,
             self._maybe_update_curve_pools,
@@ -402,8 +402,8 @@ class TaskManager():
         with self.database.user_write() as cursor:
             cursor.executemany(query, updates)
 
-    def _maybe_decode_evm_transactions(self) -> None:
-        """Schedules the evm transaction decoding task
+    def _maybe_decode_ethereum_transactions(self) -> None:
+        """Schedules the ethereum transaction decoding task
 
         The DB check happens first here to see if scheduling would even be needed.
         But the DB query will happen again inside the query task while having the

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -160,7 +160,7 @@ def assert_force_redecode_txns_works(api_server: APIServer, hashes: Optional[Lis
         'get_or_decode_transaction_events',
         wraps=rotki.eth_tx_decoder.get_or_decode_transaction_events,
     )
-    get_or_query_txn_receipt_patch = patch('rotkehlchen.chain.ethereum.transactions.EthTransactions.get_or_query_transaction_receipt')  # noqa: 501
+    get_or_query_txn_receipt_patch = patch('rotkehlchen.chain.ethereum.transactions.EvmTransactions.get_or_query_transaction_receipt')  # noqa: 501
     with ExitStack() as stack:
         function_call_counters = []
         function_call_counters.append(stack.enter_context(get_or_decode_txn_events_patch))

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -5,7 +5,7 @@ import pytest
 from rotkehlchen.chain.avalanche.manager import AvalancheManager
 from rotkehlchen.chain.ethereum.decoding import EVMTransactionDecoder
 from rotkehlchen.chain.ethereum.manager import EthereumManager, NodeName
-from rotkehlchen.chain.ethereum.transactions import EthTransactions
+from rotkehlchen.chain.ethereum.transactions import EvmTransactions
 from rotkehlchen.chain.manager import ChainManager
 from rotkehlchen.chain.substrate.manager import SubstrateChainProperties, SubstrateManager
 from rotkehlchen.chain.substrate.types import KusamaAddress, PolkadotAddress, SubstrateChain
@@ -145,7 +145,7 @@ def fixture_evm_transaction_decoder(
 ):
     return EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=function_scope_messages_aggregator,
     )
@@ -156,8 +156,8 @@ def fixture_eth_transactions(
         database,
         ethereum_manager,
 ):  # noqa: E501
-    return EthTransactions(
-        ethereum=ethereum_manager,
+    return EvmTransactions(
+        manager=ethereum_manager,
         database=database,
     )
 

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -24,7 +24,7 @@ def test_1inchv1_swap(database, ethereum_manager, function_scope_messages_aggreg
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x8b8652c502e80ce7c5441cdedc9184ea8f07a9c13b4c3446a47ae08c6c1d6efa')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,
@@ -107,7 +107,7 @@ def test_1inchv2_swap_for_eth(database, ethereum_manager, function_scope_message
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x5edc23d5a05e347afc60e64a4d5831ed2551985c21dceb85d267926ca2e2c13e')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_aave.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave.py
@@ -23,7 +23,7 @@ def test_aave_deposit_v1(database, ethereum_manager, function_scope_messages_agg
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,
@@ -91,7 +91,7 @@ def test_aave_withdraw_v1(database, ethereum_manager, function_scope_messages_ag
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,
@@ -160,7 +160,7 @@ def test_aave_eth_withdraw_v1(database, ethereum_manager, function_scope_message
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0xbd333bdd5784c10630aac5683e63f703e660a78d06f95b2ff2a8788a8dade787')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_compound.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound.py
@@ -23,7 +23,7 @@ def test_compound_ether_deposit(database, ethereum_manager, function_scope_messa
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x06a8b9f758b0471886186c2a48dea189b3044916c7f94ee7f559026fefd91c39')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,
@@ -77,7 +77,7 @@ def test_compound_ether_withdraw(database, ethereum_manager, function_scope_mess
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x024bd402420c3ba2f95b875f55ce2a762338d2a14dac4887b78174254c9ab807')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,
@@ -135,7 +135,7 @@ def test_compound_deposit_with_comp_claim(
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0xfdbfe6e9ce822bd988054945c86f2dff1fac6a12b4acb0b68c8805b5aa3b30ba')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -138,7 +138,7 @@ def test_booster_deposit(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -241,7 +241,7 @@ def test_booster_withdraw(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -376,7 +376,7 @@ def test_cvxcrv_get_reward(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -505,7 +505,7 @@ def test_cvxcrv_withdraw(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -607,7 +607,7 @@ def test_cvxcrv_stake(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -723,7 +723,7 @@ def test_cvx_stake(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -869,7 +869,7 @@ def test_cvx_get_reward(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -961,7 +961,7 @@ def test_cvx_withdraw(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -1044,7 +1044,7 @@ def test_claimzap_abracadabras(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
@@ -1137,7 +1137,7 @@ def test_claimzap_cvx_locker(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )

--- a/rotkehlchen/tests/unit/decoders/test_element_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_element_finance.py
@@ -21,7 +21,7 @@ def test_claim_aidrop(database, ethereum_manager, function_scope_messages_aggreg
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_enriched.py
+++ b/rotkehlchen/tests/unit/decoders/test_enriched.py
@@ -72,7 +72,7 @@ def test_1inch_claim(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -183,7 +183,7 @@ def test_gnosis_chain_bridge(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -280,7 +280,7 @@ def test_gitcoin_claim(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin.py
@@ -22,7 +22,7 @@ def test_gitcoin_old_donation(database, ethereum_manager, function_scope_message
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0x811ba23a10c76111289133ec6f90d3c33a604baa50053739210e870687a456d9')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_hop.py
+++ b/rotkehlchen/tests/unit/decoders/test_hop.py
@@ -21,7 +21,7 @@ def test_hop_l2_deposit(database, ethereum_manager, function_scope_messages_aggr
     # TODO: For faster tests hard-code the transaction and the logs here so no remote query needed
     tx_hash = deserialize_evm_tx_hash('0xd46640417a686b399b2f2a920b0c58a35095759365cbe7b795bddec34b8c5eee')  # noqa: E501
     events = get_decoded_events_of_transaction(
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         database=database,
         msg_aggregator=function_scope_messages_aggregator,
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -86,7 +86,7 @@ def test_kyber_legacy_old_contract(database, ethereum_manager, eth_transactions)
         dbethtx.add_ethereum_internal_transactions(cursor, [internal_tx], relevant_address='0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b')  # noqa: E501
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -213,7 +213,7 @@ def test_kyber_legacy_new_contract(database, ethereum_manager, eth_transactions)
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -97,7 +97,7 @@ def test_liquity_trove_adjust(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -213,7 +213,7 @@ def test_liquity_trove_deposit_lusd(database, ethereum_manager, eth_transactions
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -326,7 +326,7 @@ def test_liquity_trove_remove_eth(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_internal_transactions(cursor, [internal_tx], relevant_address=user_address)  # noqa: E501
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )

--- a/rotkehlchen/tests/unit/decoders/test_pickle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pickle.py
@@ -73,7 +73,7 @@ def test_pickle_deposit(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -186,7 +186,7 @@ def test_pickle_withdraw(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -84,7 +84,7 @@ def test_sushiswap_single_swap(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -130,7 +130,7 @@ def test_uniswap_v2_swap(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -254,7 +254,7 @@ def test_uniswap_v2_swap_eth_returned(database, ethereum_manager, eth_transactio
     dbethtx = DBEthTx(database)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -99,7 +99,7 @@ def test_uniswap_v3_swap(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
@@ -229,7 +229,7 @@ def test_uniswap_v3_swap_received_token2(database, ethereum_manager, eth_transac
         dbethtx.add_ethereum_internal_transactions(cursor, [internal_tx], relevant_address='0xeB312F4921aEbbE99faCaCFE92f22b942Cbd7599')  # noqa: E501
         decoder = EVMTransactionDecoder(
             database=database,
-            ethereum_manager=ethereum_manager,
+            manager=ethereum_manager,
             transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )

--- a/rotkehlchen/tests/unit/decoders/test_votium.py
+++ b/rotkehlchen/tests/unit/decoders/test_votium.py
@@ -74,7 +74,7 @@ def test_votium_claim(database, ethereum_manager, eth_transactions):
         dbethtx.add_ethereum_transactions(cursor, [transaction], relevant_address=None)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=ethereum_manager,
         transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.ethereum.constants import ETHERSCAN_NODE
 from rotkehlchen.chain.ethereum.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.chain.ethereum.manager import EthereumManager, NodeName
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceipt, EthereumTxReceiptLog
-from rotkehlchen.chain.ethereum.transactions import EthTransactions
+from rotkehlchen.chain.ethereum.transactions import EvmTransactions
 from rotkehlchen.chain.ethereum.types import WeightedNode, string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.db.dbhandler import DBHandler
@@ -289,18 +289,18 @@ def setup_ethereum_transactions_test(
 
 
 def get_decoded_events_of_transaction(
-        ethereum_manager: EthereumManager,
+        manager: EthereumManager,
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
         tx_hash: EVMTxHash,
 ) -> List[HistoryBaseEntry]:
     """A convenience function to ask get transaction, receipt and decoded event for a tx_hash"""
-    transactions = EthTransactions(ethereum=ethereum_manager, database=database)
+    transactions = EvmTransactions(manager=manager, database=database)
     with database.user_write() as cursor:
         transactions.get_or_query_transaction_receipt(cursor, tx_hash=tx_hash)
     decoder = EVMTransactionDecoder(
         database=database,
-        ethereum_manager=ethereum_manager,
+        manager=manager,
         transactions=transactions,
         msg_aggregator=msg_aggregator,
     )


### PR DESCRIPTION
* Rename `EthTransactions` to `EvmTransactions`
* Rename `add_ethereum_token_to_db` to `add_evm_token_to_db` and `ethereum_manager` parameter
* Rename parameters in `EVMTransactionDecoder`

Related #4725

Still TODO:

- Database migration adding blockchain column to the `ethereum_transactions` table (will be renamed to `evm_transactions`)
    - Remove blockchain column from evm_tx_mappings?
- https://github.com/rotki/rotki/pull/4829#issuecomment-1246829041

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
