### PR TITLE
Fix missing imports (mypy)

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -86,7 +86,7 @@ from .utils import (
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
-    from rotkehlchen.db.driver.gevent import DBCursor
+    from rotkehlchen.db.drivers.gevent import DBCursor
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -17,7 +17,7 @@ from rotkehlchen.types import ChainID, ChecksumEvmAddress, Price, SupportedBlock
 from rotkehlchen.utils.misc import combine_dicts, get_chunks
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.drivers.gevent import DBCursor
+    from rotkehlchen.db.drivers.gevent import DBCursor
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -23,8 +23,8 @@ from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import timestamp_to_date
 
 if TYPE_CHECKING:
-    from rotkehlchen.accounting.event.mixins import AccountingEventMixin
     from rotkehlchen.accounting.ledger_actions import LedgerAction
+    from rotkehlchen.accounting.mixins.event import AccountingEventMixin
     from rotkehlchen.chain.ethereum.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.ethereum.transactions import EthTransactions
     from rotkehlchen.chain.manager import ChainManager

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.oracles.uniswap import UniswapV2Oracle, UniswapV3Oracle
     from rotkehlchen.externalapis.coingecko import Coingecko
     from rotkehlchen.externalapis.cryptocompare import Cryptocompare
-    from rotkehlchen.externalapis.manual_current_price import ManualCurrentOracle
+    from rotkehlchen.globaldb.manual_price_oracles import ManualCurrentOracle
 
 
 logger = logging.getLogger(__name__)

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -39,7 +39,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import convert_to_int, create_timestamp, iso8601ts_to_timestamp
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.manager import EvmManager
+    from rotkehlchen.chain.ethereum.manager import EthereumManager
 
 
 logger = logging.getLogger(__name__)
@@ -497,7 +497,7 @@ def deserialize_optional(input_val: Optional[X], fn: Callable[[X], Y]) -> Option
 def deserialize_evm_transaction(
         data: Dict[str, Any],
         internal: Literal[True],
-        manager: Optional['EvmManager'] = None,
+        manager: Optional['EthereumManager'] = None,
 ) -> EvmInternalTransaction:
     ...
 
@@ -506,7 +506,7 @@ def deserialize_evm_transaction(
 def deserialize_evm_transaction(
         data: Dict[str, Any],
         internal: Literal[False],
-        manager: Optional['EvmManager'] = None,
+        manager: Optional['EthereumManager'] = None,
 ) -> EvmTransaction:
     ...
 
@@ -514,7 +514,7 @@ def deserialize_evm_transaction(
 def deserialize_evm_transaction(
         data: Dict[str, Any],
         internal: bool,
-        manager: Optional['EvmManager'] = None,
+        manager: Optional['EthereumManager'] = None,
 ) -> Union[EvmTransaction, EvmInternalTransaction]:
     """Reads dict data of a transaction and deserializes it.
     If the transaction is not from etherscan then it's missing some data

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ disallow_untyped_decorators = True
 disallow_untyped_calls = True
 mypy_path=./stubs/
 
+[mypy-rotkehlchen.*]
+ignore_missing_imports = False
+
 # -- These modules still need to have proper type definitions given --
 [mypy-rotkehlchen.tests.*]
 check_untyped_defs = False


### PR DESCRIPTION
EvmManager class does not exist yet and it was not caught by mypy because rotki deliberately ignores missing imports (`--ignore-missing-imports`). This PR adds a new section to setup.cfg in order to unignore our packages (rotkehchen/).

I have traced back when this flag was introduced and I reached 3cdff0ba8058e20c8223c78a32a4c54d7137588f where rotki started to use mypy.

UPDATE (obsolete):

After some investigation the flag is there because otherwise mypy outputs lots of errors related to other packages:

![image](https://user-images.githubusercontent.com/73274/191007880-a183dac8-f4f7-4ba3-8690-4b7f91aa571f.png)

In this PR I'm fixing only those related to rotkehlchen (4) and leave the flag set.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
