### PR TITLE
Remove eth_transactions parameter from EventsHistorian and TaskManager constructors

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3183,7 +3183,7 @@ class RestAPI():
             tx_hashes: Optional[List[EVMTxHash]],
     ) -> Dict[str, Any]:
         try:
-            self.rotkehlchen.evm_tx_decoder.decode_transaction_hashes(ignore_cache=ignore_cache, tx_hashes=tx_hashes)  # noqa: E501
+            self.rotkehlchen.eth_tx_decoder.decode_transaction_hashes(ignore_cache=ignore_cache, tx_hashes=tx_hashes)  # noqa: E501
             return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
         except (RemoteError, DeserializationError) as e:
             status_code = HTTPStatus.BAD_GATEWAY
@@ -4347,7 +4347,7 @@ class RestAPI():
         return api_response(
             result={
                 # Converting to list since set is not json serializable
-                'result': list(self.rotkehlchen.evm_tx_decoder.all_counterparties),
+                'result': list(self.rotkehlchen.eth_tx_decoder.all_counterparties),
                 'message': '',
             },
         )

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -76,13 +76,13 @@ class EVMTransactionDecoder():
             self,
             database: 'DBHandler',
             ethereum_manager: 'EthereumManager',
-            eth_transactions: 'EthTransactions',
+            transactions: 'EthTransactions',
             msg_aggregator: MessagesAggregator,
     ):
         self.database = database
         self.all_counterparties: Set[str] = set()
         self.ethereum_manager = ethereum_manager
-        self.eth_transactions = eth_transactions
+        self.transactions = transactions
         self.msg_aggregator = msg_aggregator
         self.dbethtx = DBEthTx(self.database)
         self.dbevents = DBHistoryEvents(self.database)
@@ -273,7 +273,7 @@ class EVMTransactionDecoder():
         with self.database.user_write() as cursor:
             for tx_hash in tx_hashes:
                 try:
-                    receipt = self.eth_transactions.get_or_query_transaction_receipt(cursor, tx_hash)  # noqa: E501
+                    receipt = self.transactions.get_or_query_transaction_receipt(cursor, tx_hash)  # noqa: E501
                 except RemoteError as e:
                     raise InputError(f'Hash {tx_hash.hex()} does not correspond to a transaction') from e  # noqa: E501
 

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from rotkehlchen.accounting.event.mixins import AccountingEventMixin
     from rotkehlchen.accounting.ledger_actions import LedgerAction
     from rotkehlchen.chain.ethereum.decoding.decoder import EVMTransactionDecoder
-    from rotkehlchen.chain.ethereum.transactions import EthTransactions
     from rotkehlchen.chain.manager import ChainManager
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
@@ -55,8 +54,7 @@ class EventsHistorian:
             msg_aggregator: MessagesAggregator,
             exchange_manager: ExchangeManager,
             chain_manager: 'ChainManager',
-            eth_transactions: 'EthTransactions',
-            evm_tx_decoder: 'EVMTransactionDecoder',
+            eth_tx_decoder: 'EVMTransactionDecoder',
     ) -> None:
 
         self.msg_aggregator = msg_aggregator
@@ -64,8 +62,7 @@ class EventsHistorian:
         self.db = db
         self.exchange_manager = exchange_manager
         self.chain_manager = chain_manager
-        self.evm_tx_decoder = evm_tx_decoder
-        self.eth_transactions = eth_transactions
+        self.eth_tx_decoder = eth_tx_decoder
         self._reset_variables()
 
     def timestamp_to_date(self, timestamp: Timestamp) -> str:
@@ -346,7 +343,7 @@ class EventsHistorian:
             to_ts=end_ts,
         )
         try:
-            _, _ = self.eth_transactions.query(
+            _, _ = self.eth_tx_decoder.transactions.query(
                 filter_query=tx_filter_query,
                 has_premium=True,  # ignore limits here. Limit applied at processing
                 only_cache=False,
@@ -361,11 +358,11 @@ class EventsHistorian:
         step = self._increase_progress(step, total_steps)
 
         self.processing_state_name = 'Querying ethereum transaction receipts'
-        self.eth_transactions.get_receipts_for_transactions_missing_them()
+        self.eth_tx_decoder.transactions.get_receipts_for_transactions_missing_them()
         step = self._increase_progress(step, total_steps)
 
         self.processing_state_name = 'Decoding raw transactions'
-        self.evm_tx_decoder.get_and_decode_undecoded_transactions(limit=None)
+        self.eth_tx_decoder.get_and_decode_undecoded_transactions(limit=None)
         step = self._increase_progress(step, total_steps)
 
         # Include all external trades and trades from external exchanges

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -332,10 +332,10 @@ class Rotkehlchen():
             beaconchain=self.beaconchain,
             btc_derivation_gap_limit=settings.btc_derivation_gap_limit,
         )
-        self.evm_tx_decoder = EVMTransactionDecoder(
+        self.eth_tx_decoder = EVMTransactionDecoder(
             database=self.data.db,
             ethereum_manager=ethereum_manager,
-            eth_transactions=self.eth_transactions,
+            transactions=self.eth_transactions,
             msg_aggregator=self.msg_aggregator,
         )
         self.evm_accounting_aggregator = EVMAccountingAggregator(
@@ -354,8 +354,7 @@ class Rotkehlchen():
             msg_aggregator=self.msg_aggregator,
             exchange_manager=self.exchange_manager,
             chain_manager=self.chain_manager,
-            evm_tx_decoder=self.evm_tx_decoder,
-            eth_transactions=self.eth_transactions,
+            eth_tx_decoder=self.eth_tx_decoder,
         )
         self.task_manager = TaskManager(
             max_tasks_num=DEFAULT_MAX_TASKS_NUM,
@@ -366,8 +365,7 @@ class Rotkehlchen():
             premium_sync_manager=self.premium_sync_manager,
             chain_manager=self.chain_manager,
             exchange_manager=self.exchange_manager,
-            eth_transactions=self.eth_transactions,
-            evm_tx_decoder=self.evm_tx_decoder,
+            eth_tx_decoder=self.eth_tx_decoder,
             deactivate_premium=self.deactivate_premium_status,
             activate_premium=self.activate_premium_status,
             query_balances=self.query_balances,
@@ -619,7 +617,7 @@ class Rotkehlchen():
             if blockchain == SupportedBlockchain.ETHEREUM:
                 stack.enter_context(self.eth_transactions.wait_until_no_query_for(eth_addresses))
                 stack.enter_context(self.eth_transactions.missing_receipts_lock)
-                stack.enter_context(self.evm_tx_decoder.undecoded_tx_query_lock)
+                stack.enter_context(self.eth_tx_decoder.undecoded_tx_query_lock)
             self.data.db.remove_blockchain_accounts(cursor, blockchain, accounts)
 
     def get_history_query_status(self) -> Dict[str, str]:
@@ -995,11 +993,11 @@ class Rotkehlchen():
                 ethereum_manager=self.chain_manager.ethereum,
             )
             try:
-                curve_decoder = self.evm_tx_decoder.decoders['Curve']
+                curve_decoder = self.eth_tx_decoder.decoders['Curve']
             except KeyError as e:
                 raise InputError(
                     'Expected to find Curve decoder but it was not loaded. '
                     'Please open an issue on github.com/rotki/rotki/issues if you saw this.',
                 ) from e
             new_mappings = curve_decoder.reload()
-            self.evm_tx_decoder.address_mappings.update(new_mappings)
+            self.eth_tx_decoder.address_mappings.update(new_mappings)

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -42,7 +42,6 @@ from rotkehlchen.utils.misc import ts_now
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding import EVMTransactionDecoder
-    from rotkehlchen.chain.ethereum.transactions import EthTransactions
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -86,8 +85,7 @@ class TaskManager():
             premium_sync_manager: Optional[PremiumSyncManager],
             chain_manager: ChainManager,
             exchange_manager: ExchangeManager,
-            evm_tx_decoder: 'EVMTransactionDecoder',
-            eth_transactions: 'EthTransactions',
+            eth_tx_decoder: 'EVMTransactionDecoder',
             deactivate_premium: Callable[[], None],
             activate_premium: Callable[[Premium], None],
             query_balances: Callable,
@@ -100,8 +98,7 @@ class TaskManager():
         self.database = database
         self.cryptocompare = cryptocompare
         self.exchange_manager = exchange_manager
-        self.evm_tx_decoder = evm_tx_decoder
-        self.eth_transactions = eth_transactions
+        self.eth_tx_decoder = eth_tx_decoder
         self.cryptocompare_queries: Set[CCHistoQuery] = set()
         self.chain_manager = chain_manager
         self.last_xpub_derivation_ts = 0
@@ -273,7 +270,7 @@ class TaskManager():
             after_seconds=None,
             task_name=task_name,
             exception_is_error=True,
-            method=self.eth_transactions.single_address_query_transactions,
+            method=self.eth_tx_decoder.transactions.single_address_query_transactions,
             address=address,
             start_ts=0,
             end_ts=now,
@@ -298,7 +295,7 @@ class TaskManager():
             after_seconds=None,
             task_name=task_name,
             exception_is_error=True,
-            method=self.eth_transactions.get_receipts_for_transactions_missing_them,
+            method=self.eth_tx_decoder.transactions.get_receipts_for_transactions_missing_them,
             limit=TX_RECEIPTS_QUERY_LIMIT,
         )
 
@@ -422,7 +419,7 @@ class TaskManager():
                 after_seconds=None,
                 task_name=task_name,
                 exception_is_error=True,
-                method=self.evm_tx_decoder.get_and_decode_undecoded_transactions,
+                method=self.eth_tx_decoder.get_and_decode_undecoded_transactions,
                 limit=TX_DECODING_LIMIT,
             )
 

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -151,14 +151,14 @@ EXPECTED_4193_TXS = [{
 def assert_force_redecode_txns_works(api_server: APIServer, hashes: Optional[List[EVMTxHash]]):
     rotki = api_server.rest_api.rotkehlchen
     get_eth_txns_patch = patch.object(
-        rotki.evm_tx_decoder.dbethtx,
+        rotki.eth_tx_decoder.dbethtx,
         'get_ethereum_transactions',
-        wraps=rotki.evm_tx_decoder.dbethtx.get_ethereum_transactions,
+        wraps=rotki.eth_tx_decoder.dbethtx.get_ethereum_transactions,
     )
     get_or_decode_txn_events_patch = patch.object(
-        rotki.evm_tx_decoder,
+        rotki.eth_tx_decoder,
         'get_or_decode_transaction_events',
-        wraps=rotki.evm_tx_decoder.get_or_decode_transaction_events,
+        wraps=rotki.eth_tx_decoder.get_or_decode_transaction_events,
     )
     get_or_query_txn_receipt_patch = patch('rotkehlchen.chain.ethereum.transactions.EthTransactions.get_or_query_transaction_receipt')  # noqa: 501
     with ExitStack() as stack:

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -146,7 +146,7 @@ def fixture_evm_transaction_decoder(
     return EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=function_scope_messages_aggregator,
     )
 

--- a/rotkehlchen/tests/fixtures/history.py
+++ b/rotkehlchen/tests/fixtures/history.py
@@ -80,7 +80,6 @@ def events_historian(
         blockchain,
         evm_transaction_decoder,
         exchange_manager,
-        eth_transactions,
 ):
     historian = EventsHistorian(
         user_directory=data_dir,
@@ -88,7 +87,6 @@ def events_historian(
         msg_aggregator=function_scope_messages_aggregator,
         exchange_manager=exchange_manager,
         chain_manager=blockchain,
-        evm_tx_decoder=evm_transaction_decoder,
-        eth_transactions=eth_transactions,
+        eth_tx_decoder=evm_transaction_decoder,
     )
     return historian

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -139,7 +139,7 @@ def test_booster_deposit(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -242,7 +242,7 @@ def test_booster_withdraw(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -377,7 +377,7 @@ def test_cvxcrv_get_reward(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -506,7 +506,7 @@ def test_cvxcrv_withdraw(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -608,7 +608,7 @@ def test_cvxcrv_stake(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -724,7 +724,7 @@ def test_cvx_stake(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -870,7 +870,7 @@ def test_cvx_get_reward(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -962,7 +962,7 @@ def test_cvx_withdraw(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -1045,7 +1045,7 @@ def test_claimzap_abracadabras(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:
@@ -1138,7 +1138,7 @@ def test_claimzap_cvx_locker(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with dbethtx.db.user_write() as cursor:

--- a/rotkehlchen/tests/unit/decoders/test_enriched.py
+++ b/rotkehlchen/tests/unit/decoders/test_enriched.py
@@ -73,7 +73,7 @@ def test_1inch_claim(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -184,7 +184,7 @@ def test_gnosis_chain_bridge(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -281,7 +281,7 @@ def test_gitcoin_claim(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -87,7 +87,7 @@ def test_kyber_legacy_old_contract(database, ethereum_manager, eth_transactions)
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -214,7 +214,7 @@ def test_kyber_legacy_new_contract(database, ethereum_manager, eth_transactions)
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -98,7 +98,7 @@ def test_liquity_trove_adjust(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -214,7 +214,7 @@ def test_liquity_trove_deposit_lusd(database, ethereum_manager, eth_transactions
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -327,7 +327,7 @@ def test_liquity_trove_remove_eth(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)

--- a/rotkehlchen/tests/unit/decoders/test_pickle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pickle.py
@@ -74,7 +74,7 @@ def test_pickle_deposit(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -187,7 +187,7 @@ def test_pickle_withdraw(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -85,7 +85,7 @@ def test_sushiswap_single_swap(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -131,7 +131,7 @@ def test_uniswap_v2_swap(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -255,7 +255,7 @@ def test_uniswap_v2_swap_eth_returned(database, ethereum_manager, eth_transactio
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with database.user_write() as cursor:

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -100,7 +100,7 @@ def test_uniswap_v3_swap(database, ethereum_manager, eth_transactions):
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
@@ -230,7 +230,7 @@ def test_uniswap_v3_swap_received_token2(database, ethereum_manager, eth_transac
         decoder = EVMTransactionDecoder(
             database=database,
             ethereum_manager=ethereum_manager,
-            eth_transactions=eth_transactions,
+            transactions=eth_transactions,
             msg_aggregator=msg_aggregator,
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)

--- a/rotkehlchen/tests/unit/decoders/test_votium.py
+++ b/rotkehlchen/tests/unit/decoders/test_votium.py
@@ -75,7 +75,7 @@ def test_votium_claim(database, ethereum_manager, eth_transactions):
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=eth_transactions,
+        transactions=eth_transactions,
         msg_aggregator=msg_aggregator,
     )
     with database.user_write() as cursor:

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -46,7 +46,6 @@ def fixture_task_manager(
         cryptocompare,
         exchange_manager,
         evm_transaction_decoder,
-        eth_transactions,
         messages_aggregator,
 ) -> TaskManager:
     task_manager = TaskManager(
@@ -58,8 +57,7 @@ def fixture_task_manager(
         premium_sync_manager=MockPremiumSyncManager(),  # type: ignore
         chain_manager=blockchain,
         exchange_manager=exchange_manager,
-        evm_tx_decoder=evm_transaction_decoder,
-        eth_transactions=eth_transactions,
+        eth_tx_decoder=evm_transaction_decoder,
         deactivate_premium=lambda: None,
         query_balances=lambda: None,
         update_curve_pools_cache=lambda: None,
@@ -80,7 +78,7 @@ def test_maybe_query_ethereum_transactions(task_manager, ethereum_accounts):
         assert end_ts >= now
 
     tx_query_patch = patch.object(
-        task_manager.eth_transactions,
+        task_manager.eth_tx_decoder.transactions,
         'single_address_query_transactions',
         wraps=tx_query_mock,
     )

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -301,7 +301,7 @@ def get_decoded_events_of_transaction(
     decoder = EVMTransactionDecoder(
         database=database,
         ethereum_manager=ethereum_manager,
-        eth_transactions=transactions,
+        transactions=transactions,
         msg_aggregator=msg_aggregator,
     )
     return decoder.decode_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash])


### PR DESCRIPTION
Access it through the EVMTransactionDecoder.

Also improve parameters naming by renaming evm_tx_decoder to eth_tx_decoder when an EVMTransactionDecoder object with ethereum transactions is expected. And same for transactions and eth_transactions.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
