### PR TITLE
Fix custom import ui

### DIFF
--- a/frontend/app/src/components/import/ImportSource.vue
+++ b/frontend/app/src/components/import/ImportSource.vue
@@ -14,7 +14,7 @@
           @update:uploaded="uploaded = $event"
         />
         <v-switch
-          v-if="source.startsWith('rotki_') === false"
+          v-if="!isRotkiCustomImport"
           :value="dateInputFormat !== null"
           @change="changeShouldCustomDateFormat"
         >
@@ -197,6 +197,10 @@ const changeShouldCustomDateFormat = () => {
     set(dateInputFormat, null);
   }
 };
+
+const isRotkiCustomImport = computed(() => {
+  return get(source).startsWith('rotki_');
+});
 </script>
 
 <style module lang="scss">

--- a/frontend/app/src/components/import/ImportSource.vue
+++ b/frontend/app/src/components/import/ImportSource.vue
@@ -14,6 +14,7 @@
           @update:uploaded="uploaded = $event"
         />
         <v-switch
+          v-if="source.startsWith('rotki_') === false"
           :value="dateInputFormat !== null"
           @change="changeShouldCustomDateFormat"
         >

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1993,7 +1993,7 @@
     "date_input_format": {
       "hint": "Use this if date format in your file is: {format}",
       "placeholder": "Input custom date format",
-      "switch_label": "Use custom date format to parsing your file"
+      "switch_label": "Use custom date format to parse your file"
     },
     "drop_area": "Drop the file or",
     "import_complete": "Import was completed successfully.",


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [x] Removes `Use custom date format to parsing your file` from custom import as it's not used
- [x] Change `Use custom date format to parsing your file` -> `Use custom date format to parse your file`
