### PR TITLE
Profile tests execution duration (ci)

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -195,7 +195,8 @@ jobs:
       - name: Run tests
         run: |
           COVERAGE_ARGS='--cov=./'
-          python pytestgeventwrapper.py $COVERAGE_ARGS rotkehlchen/tests
+          PYTEST_ARGS='--durations=150'
+          python pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS rotkehlchen/tests
       - name: Upload coverage
         run: ./.github/.codecov -F backend
 
@@ -227,13 +228,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/Cypress  
+            ~/.cache/Cypress
             frontend/app/components.d.ts
           key: ${{ runner.os }}-e2e-js-${{ hashFiles('frontend/package-lock.json') }}
       - name: Store test data
         uses: actions/cache@v3
         with:
-          path: |          
+          path: |
             ~/rotki-e2e/icons
             ~/rotki-e2e/global_data
           key: ${{ runner.os }}-e2e-data-${{ hashFiles('rotkehlchen/data/global.db') }}


### PR DESCRIPTION
This change will allow us to see each test execution duration and a ranking of the slowest ones.

[New output](https://pipelines.actions.githubusercontent.com/serviceHosts/e167a0bc-6c19-47c8-9fc3-e0791a800685/_apis/pipelines/1/runs/9328/signedlogcontent/35?urlExpires=2022-09-20T14%3A19%3A58.6682172Z&urlSigningMethod=HMACV1&urlSignature=k2y%2F2mG%2F8TAJ6gRQwS6VjhhzIJB1TJUJExsOdoeqxw8%3D):

```
2022-09-20T14:18:40.9189024Z ============================ slowest 150 durations =============================
2022-09-20T14:18:40.9189504Z 211.19s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_query_vaults_details_liquidation[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-3]
2022-09-20T14:18:40.9189979Z 129.60s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_two_vaults_same_account_same_collateral[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-1]
2022-09-20T14:18:40.9190401Z 80.38s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_query_vaults_usdc[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-1]
2022-09-20T14:18:40.9190899Z 75.21s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_query_only_details_and_not_vaults[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-1]
2022-09-20T14:18:40.9191315Z 64.86s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_query_vaults_wbtc[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-1]
2022-09-20T14:18:40.9191715Z 63.19s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_query_vaults[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-1]
2022-09-20T14:18:40.9191926Z 42.80s call     rotkehlchen/tests/api/test_ethereum_transactions.py::test_events_filter_params
2022-09-20T14:18:40.9192420Z 40.49s call     rotkehlchen/tests/api/test_compound.py::test_query_compound_history[default_mock_price_value0-mocked_current_prices0-mocked_price_queries0-True-ethereum_modules0-ethereum_accounts0]
2022-09-20T14:18:40.9192624Z 36.73s call     rotkehlchen/tests/api/test_bitcoin.py::test_add_delete_xpub_multiple_chains[0]
2022-09-20T14:18:40.9192806Z 36.35s call     rotkehlchen/tests/api/test_exchanges.py::test_setup_exchange[0]
2022-09-20T14:18:40.9193095Z 25.63s call     rotkehlchen/tests/unit/test_ethereum_airdrops.py::test_check_airdrops[True-2]
2022-09-20T14:18:40.9193296Z 18.35s call     rotkehlchen/tests/unit/test_assets.py::test_coingecko_identifiers_are_reachable
2022-09-20T14:18:40.9193682Z 16.31s call     rotkehlchen/tests/api/test_makerdao_dsr.py::test_dsr_for_account_with_proxy_but_no_dsr[True-ethereum_modules0-ethereum_accounts0]
2022-09-20T14:18:40.9193901Z 16.11s call     rotkehlchen/tests/unit/test_tokens.py::test_detect_tokens_for_addresses[ignored_assets0]
2022-09-20T14:18:40.9194096Z 16.10s call     rotkehlchen/tests/api/test_bitcoin.py::test_add_xpub_with_conversion_works[0]
2022-09-20T14:18:40.9194450Z 15.97s setup    rotkehlchen/tests/api/test_blockchain.py::test_add_ksm_blockchain_account[kusama_manager_connect_at_start0-0]
2022-09-20T14:18:40.9194823Z 15.96s setup    rotkehlchen/tests/api/test_blockchain.py::test_add_ksm_blockchain_account_ens_domain[kusama_manager_connect_at_start0-0]
2022-09-20T14:18:40.9195176Z 15.53s call     rotkehlchen/tests/api/test_nfts.py::test_nft_query_after_account_add[ethereum_modules0-True-ethereum_accounts0]
2022-09-20T14:18:40.9195414Z 10.97s call     rotkehlchen/tests/integration/test_blockchain.py::test_multiple_concurrent_ethereum_blockchain_queries[0]
2022-09-20T14:18:40.9195601Z 10.36s call     rotkehlchen/tests/unit/test_ethereum_manager.py::test_use_open_nodes
2022-09-20T14:18:40.9195931Z 10.04s call     rotkehlchen/tests/api/test_aave.py::test_query_aave_balances[ethereum_modules0-ethereum_accounts0]
2022-09-20T14:18:40.9196180Z 9.53s call     rotkehlchen/tests/exchanges/test_gemini.py::test_gemini_query_all_trades_pagination
2022-09-20T14:18:40.9196521Z 9.25s call     rotkehlchen/tests/api/test_nfts.py::test_nft_ids_are_unique[ethereum_modules0-True-ethereum_accounts0]
...
2022-09-20T14:18:40.9250805Z ========= 1024 passed, 22 skipped, 5906 warnings in 2210.00s (0:36:49) =========
```
## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
