### PR TITLE
Adjust recursion handling in inquirer

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -159,7 +159,8 @@ class Rotkehlchen():
             data_dir=self.data_dir,
             cryptocompare=self.cryptocompare,
             coingecko=self.coingecko,
-            manualcurrent=ManualCurrentOracle(msg_aggregator=self.msg_aggregator),
+            manualcurrent=ManualCurrentOracle(),
+            msg_aggregator=self.msg_aggregator,
         )
         self.task_manager: Optional[TaskManager] = None
         self.shutdown_event = gevent.event.Event()

--- a/rotkehlchen/tests/api/test_current_assets_price.py
+++ b/rotkehlchen/tests/api/test_current_assets_price.py
@@ -283,11 +283,9 @@ def test_manual_current_prices_loop(inquirer):
     )
     price = inquirer.find_price(from_asset=A_ETH, to_asset=A_EUR)
     assert price > 100  # should be real ETH price
-    warnings = inquirer._manualcurrent.msg_aggregator.consume_warnings()
-    assert len(warnings) == 3
-    assert 'from BTC(Bitcoin) to EUR(Euro) since your manual current' in warnings[0]
-    assert 'from USD(United States Dollar) to EUR(Euro) since your manual current' in warnings[1]
-    assert 'from ETH(Ethereum) to EUR(Euro) since your manual current' in warnings[2]
+    warnings = inquirer._msg_aggregator.consume_warnings()
+    assert len(warnings) == 1
+    assert 'from ETH(Ethereum) to EUR(Euro) since your manual latest' in warnings[0]
 
 
 @pytest.mark.parametrize('ignore_mocked_prices_for', ['ETH'])


### PR DESCRIPTION
Scenario of the problem that this PR fixes:

1. We run into a recursion error (say, we are at recursion level 1000)
2. We catch the error at the latest manual current price query and get to the level 999
3. We try to query other oracle, but immediately run into a recursion error again
4. We catch this error and get to the level 998
5. And this happens until we get enough recursion room to query coingecko, cryptocompare, etc. which results in a lot of warnings thrown

With this PR we now catch the recursion error only at the very top.