### PR TITLE
Fix globaldb tests

### DIFF
--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -642,6 +642,7 @@ def test_query_yearn_vault_v2_balances(rotkehlchen_api_server, ethereum_accounts
         assert FVal(vault['underlying_value']['usd_value']) > ZERO
 
 
+@pytest.mark.skip('subgraph is dead. Fix via https://github.com/rotki/rotki/issues/4891')
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_V2_ACC2]])
 @pytest.mark.parametrize('ethereum_modules', [['yearn_vaults_v2']])
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -154,6 +154,7 @@ def _init_database(
 
 @pytest.fixture
 def database(
+        globaldb,  # pylint: disable=unused-argument  # needed for init_database
         user_data_dir,
         function_scope_messages_aggregator,
         db_password,
@@ -196,6 +197,7 @@ def database(
 
 @pytest.fixture(scope='session')
 def session_database(
+        session_globaldb,  # pylint: disable=unused-argument  # needed for init_database
         session_user_data_dir,
         messages_aggregator,
         session_db_password,

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -56,15 +56,14 @@ def create_globaldb(
     return handler
 
 
-@pytest.fixture(name='globaldb')
-def fixture_globaldb(
+def _initialize_fixture_globaldb(
         globaldb_version,
         tmpdir_factory,
-        sql_vm_instructions_cb,
+        sql_vm_instructions_cb: int,
         reload_user_assets,
         target_globaldb_version,
         globaldb_upgrades,
-):
+) -> GlobalDBHandler:
     # clean the previous resolver memory cache, as it
     # may have cached results from a discarded database
     AssetResolver().clean_memory_cache()
@@ -84,6 +83,40 @@ def fixture_globaldb(
         ):
             return create_globaldb(new_data_dir, sql_vm_instructions_cb)
     return create_globaldb(new_data_dir, sql_vm_instructions_cb)
+
+
+@pytest.fixture(scope='session', name='session_globaldb')
+def fixture_session_globaldb(
+        tmpdir_factory,
+        session_sql_vm_instructions_cb,
+):
+    return _initialize_fixture_globaldb(
+        globaldb_version=None,
+        tmpdir_factory=tmpdir_factory,
+        sql_vm_instructions_cb=session_sql_vm_instructions_cb,
+        reload_user_assets=True,
+        target_globaldb_version=GLOBAL_DB_VERSION,
+        globaldb_upgrades=[],
+    )
+
+
+@pytest.fixture(name='globaldb')
+def fixture_globaldb(
+        globaldb_version,
+        tmpdir_factory,
+        sql_vm_instructions_cb,
+        reload_user_assets,
+        target_globaldb_version,
+        globaldb_upgrades,
+):
+    return _initialize_fixture_globaldb(
+        globaldb_version=globaldb_version,
+        tmpdir_factory=tmpdir_factory,
+        sql_vm_instructions_cb=sql_vm_instructions_cb,
+        reload_user_assets=reload_user_assets,
+        target_globaldb_version=target_globaldb_version,
+        globaldb_upgrades=globaldb_upgrades,
+    )
 
 
 @pytest.fixture(name='globaldb_version')


### PR DESCRIPTION
- Adds a session scope globaldb fixture
- Skips yearn vaults v2 test failing due to subgraph