### PR TITLE
fix bug where ethereum was missing in asset search

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -373,6 +373,9 @@ class GlobalDBHandler():
                     continue
 
                 substr_in_name = substr_in_symbol = None
+                # default to a value greater than the threshold to avoid false-positives
+                # and prevent raising `UnboundLocalError` when name/symbol is None.
+                lev_dist_name = lev_dist_symbol = 6
                 if entry[1] is not None:
                     name_casefold = entry[1].casefold()
                     lev_dist_name = levenshtein(substring_search, name_casefold)
@@ -389,27 +392,26 @@ class GlobalDBHandler():
                     if not substr_in_name and not substr_in_symbol:
                         continue
 
-                    if entry[0] not in (A_ETH.identifier, A_ETH2.identifier):
-                        entry_info = {
-                            'identifier': entry[0],
-                            'name': entry[1],
-                            'symbol': entry[2],
-                        }
-                        if entry[3] is not None:
-                            entry_info['chain'] = ChainID.deserialize_from_db(entry[3]).serialize()
-
-                        search_result.append(entry_info)
-                        levenshtein_distances.append(lev_dist_min)
+                    if treat_eth2_as_eth is True and entry[0] in (A_ETH.identifier, A_ETH2.identifier):  # noqa:E501
+                        if found_eth is False:
+                            search_result.append({
+                                'identifier': resolved_eth.identifier,
+                                'name': resolved_eth.name,
+                                'symbol': resolved_eth.symbol,
+                            })
+                            levenshtein_distances.append(lev_dist_min)
+                            found_eth = True
                         continue
 
-                    if treat_eth2_as_eth is True and found_eth is False:
-                        search_result.append({
-                            'identifier': resolved_eth.identifier,
-                            'name': resolved_eth.name,
-                            'symbol': resolved_eth.symbol,
-                        })
-                        levenshtein_distances.append(lev_dist_min)
-                        found_eth = True
+                    entry_info = {
+                        'identifier': entry[0],
+                        'name': entry[1],
+                        'symbol': entry[2],
+                    }
+                    if entry[3] is not None:
+                        entry_info['chain'] = ChainID.deserialize_from_db(entry[3]).serialize()
+                    search_result.append(entry_info)
+                    levenshtein_distances.append(lev_dist_min)
 
         search_result = [result for _, result in sorted(zip(levenshtein_distances, search_result), key=lambda item: item[0])]  # noqa: E501
         return search_result[:limit] if limit is not None else search_result


### PR DESCRIPTION
## Checklist

- [x] Ethereum now appears in asset searches when `treat_eth2_as_eth` setting is True