### PR TITLE
Improve Assets Endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2988,13 +2988,17 @@ Get asset identifiers mappings
               },
               "eip155:1/erc20:0xcC4eF9EEAF656aC1a2Ab886743E98e97E090ed38": {
                   "name": "DigitalDevelopersFund",
-                  "symbol": "DDF"
+                  "symbol": "DDF",
+                  "chain": "ethereum"
               }
           },
           "message": ""
       }
 
-   :resjson object result: A mapping of identifiers to names and symbols.
+   :resjson object result: A mapping of identifiers to their name, symbol & chain(if available).
+   :resjson string name: Name of the asset.
+   :resjson string symbol: Symbol of the asset.
+   :resjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: One of the identifiers is not valid. Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.
@@ -3029,6 +3033,7 @@ Search for assets
    :reqjson string value: A string to be used search the assets. Required.
    :reqjson string search_column: A column on the assets table to perform the search on. One of ``"name"`` or ``"symbol"``. Required.
    :reqjson bool return_exact_matches: A flag that specifies whether the result returned should match the search keyword. Defaults to ``"false"``.
+   :reqjson string[optional] chain: A string representing the name of a supported EVM chain used to filter the result. e.g "ethereum", "optimism", "binance", etc.
 
 
    **Example Response**:
@@ -3056,10 +3061,10 @@ Search for assets
       }
 
    :resjson object result: A list of objects that contain the asset details which match the search keyword.
-   :reqjson string identifier: Identifier of the asset.
-   :reqjson string name: Name of the asset.
-   :reqjson string symbol: Symbol of the asset.
-   :reqjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
+   :resjson string identifier: Identifier of the asset.
+   :resjson string name: Name of the asset.
+   :resjson string symbol: Symbol of the asset.
+   :resjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.
@@ -3089,6 +3094,7 @@ Search for assets(Levenshtein)
    :reqjson list[string] order_by_attributes: This is the list of attributes of the asset by which to order the results. By default we sort using ``name``.
    :reqjson list[bool] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
    :reqjson string value: A string to be used to search the assets. Required.
+   :reqjson string[optional] chain: A string representing the name of a supported EVM chain used to filter the result. e.g "ethereum", "optimism", "binance", etc.
 
    **Example Response**:
 
@@ -3110,10 +3116,10 @@ Search for assets(Levenshtein)
       }
 
    :resjson object result: A list of objects that contain the asset details which match the search keyword ordered by distance to search keyword.
-   :reqjson string identifier: Identifier of the asset.
-   :reqjson string name: Name of the asset.
-   :reqjson string symbol: Symbol of the asset.
-   :reqjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
+   :resjson string identifier: Identifier of the asset.
+   :resjson string name: Name of the asset.
+   :resjson string symbol: Symbol of the asset.
+   :resjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2989,7 +2989,7 @@ Get asset identifiers mappings
               "eip155:1/erc20:0xcC4eF9EEAF656aC1a2Ab886743E98e97E090ed38": {
                   "name": "DigitalDevelopersFund",
                   "symbol": "DDF",
-                  "chain": "ethereum"
+                  "evm_chain": "ethereum"
               }
           },
           "message": ""
@@ -2998,7 +2998,7 @@ Get asset identifiers mappings
    :resjson object result: A mapping of identifiers to their name, symbol & chain(if available).
    :resjson string name: Name of the asset.
    :resjson string symbol: Symbol of the asset.
-   :resjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
+   :resjson string evm_chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: One of the identifiers is not valid. Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.
@@ -3033,7 +3033,7 @@ Search for assets
    :reqjson string value: A string to be used search the assets. Required.
    :reqjson string search_column: A column on the assets table to perform the search on. One of ``"name"`` or ``"symbol"``. Required.
    :reqjson bool return_exact_matches: A flag that specifies whether the result returned should match the search keyword. Defaults to ``"false"``.
-   :reqjson string[optional] chain: A string representing the name of a supported EVM chain used to filter the result. e.g "ethereum", "optimism", "binance", etc.
+   :reqjson string[optional] evm_chain: A string representing the name of a supported EVM chain used to filter the result. e.g "ethereum", "optimism", "binance", etc.
 
 
    **Example Response**:
@@ -3064,7 +3064,7 @@ Search for assets
    :resjson string identifier: Identifier of the asset.
    :resjson string name: Name of the asset.
    :resjson string symbol: Symbol of the asset.
-   :resjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
+   :resjson string evm_chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.
@@ -3094,7 +3094,7 @@ Search for assets(Levenshtein)
    :reqjson list[string] order_by_attributes: This is the list of attributes of the asset by which to order the results. By default we sort using ``name``.
    :reqjson list[bool] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
    :reqjson string value: A string to be used to search the assets. Required.
-   :reqjson string[optional] chain: A string representing the name of a supported EVM chain used to filter the result. e.g "ethereum", "optimism", "binance", etc.
+   :reqjson string[optional] evm_chain: A string representing the name of a supported EVM chain used to filter the result. e.g "ethereum", "optimism", "binance", etc.
 
    **Example Response**:
 
@@ -3109,7 +3109,7 @@ Search for assets(Levenshtein)
                   "identifier": "eip155:1/erc20:0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
                   "name": "0xBitcoin",
                   "symbol": "0xBTC"
-                  "chain": "ethereum",
+                  "evm_chain": "ethereum",
               }
           ],
           "message": ""
@@ -3119,7 +3119,7 @@ Search for assets(Levenshtein)
    :resjson string identifier: Identifier of the asset.
    :resjson string name: Name of the asset.
    :resjson string symbol: Symbol of the asset.
-   :resjson string chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
+   :resjson string evm_chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1821,6 +1821,7 @@ class AssetsSearchSchema(DBOrderBySchema, DBPaginationSchema):
         validate=webargs.validate.OneOf(choices=('name', 'symbol')),
     )
     return_exact_matches = fields.Boolean(load_default=False)
+    chain = SerializableEnumField(enum_class=ChainID, load_default=None)
 
     @validates_schema
     def validate_schema(  # pylint: disable=no-self-use
@@ -1849,6 +1850,7 @@ class AssetsSearchSchema(DBOrderBySchema, DBPaginationSchema):
             substring_search=data['value'].strip(),
             search_column=data['search_column'],
             return_exact_matches=data['return_exact_matches'],
+            chain=data['chain'],
         )
         return {'filter_query': filter_query}
 
@@ -1866,6 +1868,7 @@ class AssetsSearchLevenshteinSchema(AssetsSearchSchema):
         filter_query = AssetsFilterQuery.make(
             and_op=True,
             order_by_rules=create_order_by_rules_list(data=data, default_order_by_field='name'),
+            chain=data['chain'],
         )
         return {
             'filter_query': filter_query,

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1821,7 +1821,7 @@ class AssetsSearchSchema(DBOrderBySchema, DBPaginationSchema):
         validate=webargs.validate.OneOf(choices=('name', 'symbol')),
     )
     return_exact_matches = fields.Boolean(load_default=False)
-    chain = SerializableEnumField(enum_class=ChainID, load_default=None)
+    evm_chain = SerializableEnumField(enum_class=ChainID, load_default=None)
 
     @validates_schema
     def validate_schema(  # pylint: disable=no-self-use
@@ -1850,7 +1850,7 @@ class AssetsSearchSchema(DBOrderBySchema, DBPaginationSchema):
             substring_search=data['value'].strip(),
             search_column=data['search_column'],
             return_exact_matches=data['return_exact_matches'],
-            chain=data['chain'],
+            evm_chain=data['evm_chain'],
         )
         return {'filter_query': filter_query}
 
@@ -1868,7 +1868,7 @@ class AssetsSearchLevenshteinSchema(AssetsSearchSchema):
         filter_query = AssetsFilterQuery.make(
             and_op=True,
             order_by_rules=create_order_by_rules_list(data=data, default_order_by_field='name'),
-            chain=data['chain'],
+            evm_chain=data['evm_chain'],
         )
         return {
             'filter_query': filter_query,

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -932,7 +932,7 @@ class AssetsFilterQuery(DBFilterQuery):
             ignored_assets_identifiers: Optional[List[str]] = None,
             user_owned_assets_identifiers: Optional[List[str]] = None,
             return_exact_matches: bool = False,
-            chain: Optional[ChainID] = None,
+            evm_chain: Optional[ChainID] = None,
     ) -> 'AssetsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('name', True)]
@@ -948,16 +948,16 @@ class AssetsFilterQuery(DBFilterQuery):
 
         filters: List[DBFilter] = []
         if name is not None:
-            filters.append(DBEqualsFilter(
+            filters.append(DBSubStringFilter(
                 and_op=True,
-                column='name',
-                value=name,
+                field='name',
+                search_string=name,
             ))
         if symbol is not None:
-            filters.append(DBEqualsFilter(
+            filters.append(DBSubStringFilter(
                 and_op=True,
-                column='symbol',
-                value=symbol,
+                field='symbol',
+                search_string=symbol,
             ))
         if asset_type is not None:
             filters.append(DBEqualsFilter(
@@ -991,11 +991,11 @@ class AssetsFilterQuery(DBFilterQuery):
                 operator='NOT IN',
                 values=ignored_assets_identifiers,
             ))
-        if chain is not None:
+        if evm_chain is not None:
             filters.append(DBEqualsFilter(
                 and_op=True,
                 column='chain',
-                value=chain.serialize_for_db(),
+                value=evm_chain.serialize_for_db(),
             ))
         filter_query.filters = filters
         return filter_query

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -12,6 +12,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import (
     AssetMovementCategory,
+    ChainID,
     ChecksumEvmAddress,
     EVMTxHash,
     Location,
@@ -429,7 +430,7 @@ class DBTypeFilter(DBFilter):
 class DBEqualsFilter(DBFilter):
     """Filter a column by comparing its column to its value for equality."""
     column: str
-    value: Union[str, bytes]
+    value: Union[str, bytes, int]
     alias: Optional[str] = None
 
     def prepare(self) -> Tuple[List[str], List[Any]]:
@@ -931,6 +932,7 @@ class AssetsFilterQuery(DBFilterQuery):
             ignored_assets_identifiers: Optional[List[str]] = None,
             user_owned_assets_identifiers: Optional[List[str]] = None,
             return_exact_matches: bool = False,
+            chain: Optional[ChainID] = None,
     ) -> 'AssetsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('name', True)]
@@ -988,6 +990,12 @@ class AssetsFilterQuery(DBFilterQuery):
                 column='identifier',
                 operator='NOT IN',
                 values=ignored_assets_identifiers,
+            ))
+        if chain is not None:
+            filters.append(DBEqualsFilter(
+                and_op=True,
+                column='chain',
+                value=chain.serialize_for_db(),
             ))
         filter_query.filters = filters
         return filter_query

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -314,7 +314,7 @@ class GlobalDBHandler():
             for entry in cursor:
                 result[entry[0]] = {'name': entry[1], 'symbol': entry[2]}
                 if entry[3] is not None:
-                    result[entry[0]].update({'chain': ChainID.deserialize_from_db(entry[3]).serialize()})  # noqa: E501
+                    result[entry[0]].update({'evm_chain': ChainID.deserialize_from_db(entry[3]).serialize()})  # noqa: E501
             if len(result) != len(identifiers):
                 raise InputError('One or more of the given identifiers could not be found in the database')  # noqa: E501
         return result
@@ -349,7 +349,7 @@ class GlobalDBHandler():
                     'symbol': entry[2],
                 }
                 if entry[3] is not None:
-                    entry_info['chain'] = ChainID.deserialize_from_db(entry[3]).serialize()
+                    entry_info['evm_chain'] = ChainID.deserialize_from_db(entry[3]).serialize()
 
                 search_result.append(entry_info)
         return search_result
@@ -412,7 +412,7 @@ class GlobalDBHandler():
                         'symbol': entry[2],
                     }
                     if entry[3] is not None:
-                        entry_info['chain'] = ChainID.deserialize_from_db(entry[3]).serialize()
+                        entry_info['evm_chain'] = ChainID.deserialize_from_db(entry[3]).serialize()
                     search_result.append(entry_info)
                     levenshtein_distances.append(lev_dist_min)
 


### PR DESCRIPTION
## Checklist

- [x] assets mappings endpoint`/assets/mappings` now includes a "chain" detail if available.
- [x] assets search (`/assets/search` & `/assets/search/levenshtein`) endpoints now allow filtering by chain.
- [x] closes #4899  
