### PR TITLE
Catch possible errors querying rpc node version

### DIFF
--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -409,7 +409,15 @@ class EthereumManager():
             msg = ''
             try:
                 if mainnet_check:
-                    network_id = int(web3.net.version)
+                    try:
+                        network_id = int(web3.net.version)
+                    except requests.exceptions.RequestException as e:
+                        msg = (
+                            f'Connected to node {node} at endpoint {ethrpc_endpoint} but'
+                            f'failed to request node version due to {str(e)}'
+                        )
+                        log.warning(msg)
+                        return False, msg
 
                     if network_id != 1:
                         message = (


### PR DESCRIPTION
When requesting the node version a external request is created and this can fail

```
Exception Name: <class 'requests.exceptions.HTTPError'>
Exception Info: 403 Client Error: Forbidden for url: https://api.mycryptoapi.com/eth
Traceback:
   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/yabirgb/work/rotki/rotkehlchen/chain/ethereum/manager.py", line 412, in attempt_connect
    network_id = int(web3.net.version)
```