### PR TITLE
Fix xrates query

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 gevent==21.12.0
+asyncio-gevent==0.2.1  # to be able to use asyncio packages
 greenlet==1.1.3
 gevent-websocket==0.10.1
 wsaccel==0.6.3  # recommended for acceleration of gevent-websocket. But abandoned.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ wsaccel==0.6.3  # recommended for acceleration of gevent-websocket. But abandone
 web3==5.31.0
 rotki-pysqlcipher3==2022.8.1
 requests==2.28.1
+requests_html==0.10.0  # needed for scraping after javascript
 urllib3==1.26.12
 coincurve==17.0.0
 base58check==1.0.2

--- a/rotkehlchen/externalapis/session.py
+++ b/rotkehlchen/externalapis/session.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from requests_html import HTMLSession
+
+
+class GlobalRequestsHTML():
+    """A global wrapper around requests_html HTMLSession
+
+    Since this is used in many places and we should only initialize it once we have
+    this global object that lives for as long as the app runs.
+
+    The reason for the existence of this global object is that requests_html session
+    creates a browser instance to render javascript and re-doing this every time a
+    request happens is too much.
+    """
+    __instance: Optional['GlobalRequestsHTML'] = None
+    _session: HTMLSession
+
+    def __new__(cls) -> 'GlobalRequestsHTML':
+        if GlobalRequestsHTML.__instance is not None:
+            return GlobalRequestsHTML.__instance
+
+        GlobalRequestsHTML.__instance = object.__new__(cls)
+        GlobalRequestsHTML._session = HTMLSession()
+        return GlobalRequestsHTML.__instance
+
+    @staticmethod
+    def session() -> HTMLSession:
+        return GlobalRequestsHTML()._session
+
+    @staticmethod
+    def close() -> None:
+        instance = GlobalRequestsHTML()
+        instance._session.close()

--- a/rotkehlchen/externalapis/xratescom.py
+++ b/rotkehlchen/externalapis/xratescom.py
@@ -2,7 +2,6 @@ import logging
 from typing import Dict
 
 import requests
-from requests_html import HTMLSession
 
 from rotkehlchen.assets.asset import FiatAsset
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
@@ -13,6 +12,8 @@ from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import Price, Timestamp
 from rotkehlchen.utils.misc import timestamp_to_date
+
+from .session import GlobalRequestsHTML
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -26,14 +27,11 @@ def _scrape_xratescom_exchange_rates(url: str) -> Dict[FiatAsset, Price]:
     - RemoteError if we can't query x-rates.com
     """
     log.debug(f'Querying x-rates.com stats: {url}')
-    session = HTMLSession()
     prices = {}
     try:
-        response = session.get(url=url, timeout=DEFAULT_TIMEOUT_TUPLE)
+        response = GlobalRequestsHTML().session().get(url=url, timeout=DEFAULT_TIMEOUT_TUPLE)
     except requests.exceptions.RequestException as e:
         raise RemoteError(f'x-rates.com request {url} failed due to {str(e)}') from e
-
-    session.close()
 
     if response.status_code != 200:
         raise RemoteError(

--- a/rotkehlchen/externalapis/xratescom.py
+++ b/rotkehlchen/externalapis/xratescom.py
@@ -1,6 +1,8 @@
+import asyncio
 import logging
 from typing import Dict
 
+import asyncio_gevent
 import requests
 
 from rotkehlchen.assets.asset import FiatAsset
@@ -38,6 +40,10 @@ def _scrape_xratescom_exchange_rates(url: str) -> Dict[FiatAsset, Price]:
             f'x-rates.com request {url} failed with code: {response.status_code}'
             f' and response: {response.text}',
         )
+
+    # html.render() ends up using asyncio so we have to make sure asyncio uses gevent for greenlet
+    loop = asyncio_gevent.EventLoop()
+    asyncio.set_event_loop(loop)
     response.html.render()
 
     try:

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
 import os
 import signal
 
+import asyncio_gevent
 import gevent
 
 from rotkehlchen.api.server import APIServer, RestAPI
@@ -30,10 +32,14 @@ class RotkehlchenServer():
         self.args = arg_parser.parse_args()
         add_logging_level('TRACE', TRACE)
         configure_logging(self.args)
+
+        # set asyncio to work with gevent -- for compatibility with asyncio packages
+        asyncio.set_event_loop_policy(asyncio_gevent.EventLoopPolicy())
+
         self.rotkehlchen = Rotkehlchen(self.args)
         self.stop_event = gevent.event.Event()
         domain_list = []
-        GlobalRequestsHTML()  # initialize the llobal requests_html session
+        GlobalRequestsHTML()  # initialize the global requests_html session
         if self.args.api_cors:
             if "," in self.args.api_cors:
                 for domain in self.args.api_cors.split(","):

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -6,6 +6,7 @@ import gevent
 
 from rotkehlchen.api.server import APIServer, RestAPI
 from rotkehlchen.args import app_args
+from rotkehlchen.externalapis.session import GlobalRequestsHTML
 from rotkehlchen.logging import TRACE, RotkehlchenLogsAdapter, add_logging_level, configure_logging
 from rotkehlchen.rotkehlchen import Rotkehlchen
 
@@ -32,6 +33,7 @@ class RotkehlchenServer():
         self.rotkehlchen = Rotkehlchen(self.args)
         self.stop_event = gevent.event.Event()
         domain_list = []
+        GlobalRequestsHTML()  # initialize the llobal requests_html session
         if self.args.api_cors:
             if "," in self.args.api_cors:
                 for domain in self.args.api_cors.split(","):
@@ -48,6 +50,7 @@ class RotkehlchenServer():
         log.debug('Shutdown initiated')
         self.api_server.stop()
         self.stop_event.set()
+        GlobalRequestsHTML().close()  # close the global requests_html session
 
     def main(self) -> None:
         # disable printing hub exceptions in stderr. With using the hub to do various

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -1,7 +1,9 @@
+import asyncio
 import base64
 from contextlib import ExitStack
 from unittest.mock import patch
 
+import asyncio_gevent
 import pytest
 
 import rotkehlchen.tests.utils.exchanges as exchange_tests
@@ -36,6 +38,12 @@ from rotkehlchen.types import AVAILABLE_MODULES_MAP, Location
 @pytest.fixture(autouse=True, scope='session', name='global_requests_html')
 def fixture_global_requests_html() -> GlobalRequestsHTML:
     return GlobalRequestsHTML()
+
+
+@pytest.fixture(autouse=True, scope='session', name='asyncio_gevent')
+def fixture_asyncio_gevent() -> None:
+    """ set asyncio to work with gevent -- for compatibility with asyncio packages"""
+    asyncio.set_event_loop_policy(asyncio_gevent.EventLoopPolicy())
 
 
 @pytest.fixture(name='max_tasks_num')

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -11,6 +11,7 @@ from rotkehlchen.data_migrations.migrations.migration_4 import read_and_write_no
 from rotkehlchen.db.settings import DBSettings
 from rotkehlchen.db.upgrade_manager import DBUpgradeManager
 from rotkehlchen.exchanges.manager import EXCHANGES_WITH_PASSPHRASE
+from rotkehlchen.externalapis.session import GlobalRequestsHTML
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.rotkehlchen import Rotkehlchen
@@ -30,6 +31,11 @@ from rotkehlchen.tests.utils.factories import make_random_b64bytes
 from rotkehlchen.tests.utils.history import maybe_mock_historical_price_queries
 from rotkehlchen.tests.utils.substrate import wait_until_all_substrate_nodes_connected
 from rotkehlchen.types import AVAILABLE_MODULES_MAP, Location
+
+
+@pytest.fixture(autouse=True, scope='session', name='global_requests_html')
+def fixture_global_requests_html() -> GlobalRequestsHTML:
+    return GlobalRequestsHTML()
 
 
 @pytest.fixture(name='max_tasks_num')

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -23,6 +23,7 @@ from rotkehlchen.constants.assets import (
 )
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.externalapis.session import GlobalRequestsHTML
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
@@ -126,7 +127,9 @@ def test_fallback_to_cached_values_within_a_month(inquirer):  # pylint: disable=
     )]
     GlobalDBHandler().add_historical_prices(cache_data)
 
-    with patch('requests.get', side_effect=mock_api_remote_fail):
+    patch_requests_html_get = patch.object(GlobalRequestsHTML().session(), 'get', side_effect=mock_api_remote_fail)  # noqa: E501
+    patch_requests_get = patch('requests.get', side_effect=mock_api_remote_fail)
+    with patch_requests_get, patch_requests_html_get:
         # We fail to find a response but then go back 15 days and find the cached response
         result = inquirer._query_fiat_pair(
             A_EUR.resolve_to_fiat_asset(),


### PR DESCRIPTION
#### Fix xrates scraping by introducing requests_html

requests_html is a the most lightweight package I could find that does
scraping after succesfully rendering javascript

#### Move requests_html HTMLSession to a global object

It's a bit ugly but needed since initializing and killing the session
every time a request is made seems to re-create the browser instance
that renders javascript and this is a bit too much to do in every request.