### PR TITLE
Fetch usd price when redecoding events

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3242,6 +3242,11 @@ class RestAPI():
             ignore_cache: bool,
             tx_hashes: Optional[List[EVMTxHash]],
     ) -> Dict[str, Any]:
+        """
+        Decode a set of transactions selected by their transaction hash. If the tx_hashes
+        value is None all the transactions in the database will be attempted to be decoded.
+        If the tx_hashes argument is provided then the USD price for their events will be queried.
+        """
         try:
             decoded_events = self.rotkehlchen.eth_tx_decoder.decode_transaction_hashes(
                 ignore_cache=ignore_cache,
@@ -3249,6 +3254,7 @@ class RestAPI():
             )
             task_manager = self.rotkehlchen.task_manager
             if tx_hashes is not None and task_manager is not None:
+                # Trigger the task to query the missing prices for the decoded events
                 events_filter = HistoryEventFilterQuery.make(
                     event_identifiers=[event.event_identifier for event in decoded_events],
                 )

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -315,7 +315,7 @@ class EVMTransactionDecoder():
                 events = self.dbevents.get_history_events(
                     cursor=write_cursor,
                     filter_query=HistoryEventFilterQuery.make(
-                        event_identifier=transaction.tx_hash,
+                        event_identifiers=[transaction.tx_hash],
                     ),
                     has_premium=True,  # for this function we don't limit anything
                 )


### PR DESCRIPTION
When re-decoding a transaction currently the USD value of the transaction is deleted as for how the decoders work. With this PR what we do is if we are re-decoding a set of transactions trigger the task that fetches their prices.

This improves the UX since before you had to wait for the periodic task to reload the price and now it will be shown at the moment of clicking in the re-decode button in the frontend.

Also the performance as for my tests doesn't get noticeable affected and most of the time you avoid a external request since the price is already cached in the database.