### PR TITLE
Fix error in periodic task querying prices

### DIFF
--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -457,7 +457,7 @@ class MaybeAssetField(fields.Field):
             asset = Asset(identifier=value).resolve_to_asset_with_oracles()
         except DeserializationError as e:
             raise ValidationError(str(e)) from e
-        except UnknownAsset:
+        except (UnknownAsset, WrongAssetType):
             log.error(f'Failed to deserialize asset {value}')
             return None
 

--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.ethereum.modules.makerdao.constants import RAY
 from rotkehlchen.constants.ethereum import AAVE_V1_LENDING_POOL, AAVE_V2_LENDING_POOL
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import ModuleInitializationFailure, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -135,7 +135,7 @@ class Aave(EthereumModule):
 
                 try:
                     token = EvmToken(ethaddress_to_identifier(token_address))
-                except UnknownAsset:
+                except (UnknownAsset, WrongAssetType):
                     log.warning(f'Found aave DeFi balance for unknown token {token_address}. Skipping')  # noqa: E501
                     continue
                 reserve_address, _ = _get_reserve_address_decimals(token)

--- a/rotkehlchen/chain/ethereum/modules/aave/structures.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/structures.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Literal, Optional, Tuple
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import deserialize_optional_to_fval
@@ -204,7 +204,7 @@ def aave_event_from_db(event_tuple: AAVE_EVENT_DB_TUPLE) -> AaveEvent:
     if event_tuple[9] is not None:
         try:
             asset2 = CryptoAsset(event_tuple[9])
-        except UnknownAsset as e:
+        except (UnknownAsset, WrongAssetType) as e:
             raise DeserializationError(
                 f'Unknown asset {event_tuple[6]} encountered during deserialization '
                 f'of Aave event from DB for asset2',

--- a/rotkehlchen/chain/ethereum/modules/adex/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/adex/utils.py
@@ -3,7 +3,7 @@ from typing import Union
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.serialization.deserialize import (
@@ -138,7 +138,7 @@ def deserialize_adex_event_from_db(
                 token = EvmToken(event_tuple[13])
             else:
                 raise UnknownAsset('None')
-        except UnknownAsset as e:
+        except (UnknownAsset, WrongAssetType) as e:
             raise DeserializationError(
                 f'Unknown token {event_tuple[13]} found while processing adex event. '
                 f'Unexpected data: {event_tuple}',

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -6,7 +6,7 @@ from rotkehlchen.assets.asset import EvmToken, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -149,7 +149,7 @@ def deserialize_invest_event(
     pool_address = deserialize_evm_address(raw_pool_address)
     try:
         pool_address_token = EvmToken(ethaddress_to_identifier(pool_address))
-    except UnknownAsset as e:
+    except (UnknownAsset, WrongAssetType) as e:
         raise DeserializationError(
             f'Balancer pool token with address {pool_address} should have been in the DB',
         ) from e

--- a/rotkehlchen/chain/ethereum/modules/compound/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/compound.py
@@ -13,7 +13,7 @@ from rotkehlchen.constants.assets import A_COMP, A_ETH
 from rotkehlchen.constants.ethereum import CTOKEN_ABI, ERC20TOKEN_ABI, ETH_SPECIAL_ADDRESS
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import BlockchainQueryError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import query_usd_price_zero_if_error
@@ -464,7 +464,7 @@ class Compound(EthereumModule):
             timestamp = entry['blockTime']
             try:
                 ctoken_asset = _compound_symbol_to_token(symbol=ctoken_symbol, timestamp=timestamp)
-            except UnknownAsset:
+            except (UnknownAsset, WrongAssetType):
                 log.error(
                     f'Found unexpected cTokenSymbol {ctoken_symbol} during graph query. Skipping.')
                 continue
@@ -475,7 +475,7 @@ class Compound(EthereumModule):
                     symbol=underlying_symbol,
                     evm_chain=ChainID.ETHEREUM,
                 )
-            except UnknownAsset:
+            except (UnknownAsset, WrongAssetType):
                 log.error(
                     f'Found unexpected token symbol {underlying_symbol} during '
                     f'graph query. Skipping.',

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -17,7 +17,7 @@ from rotkehlchen.constants.ethereum import UNISWAP_V2_LP_ABI, ZERION_ABI
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -212,7 +212,7 @@ def find_uniswap_v2_lp_price(
     try:
         token0 = EvmToken(ethaddress_to_identifier(decoded[0]))
         token1 = EvmToken(ethaddress_to_identifier(decoded[1]))
-    except UnknownAsset:
+    except (UnknownAsset, WrongAssetType):
         log.debug(f'Unknown assets while querying uniswap v2 lp price {decoded[0]} {decoded[1]}')
         return None
 

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -8,7 +8,7 @@ from rotkehlchen.assets.asset import CryptoAsset, EvmToken
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.ethereum import ETH_SPECIAL_ADDRESS
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset, WrongAssetType
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
@@ -139,7 +139,7 @@ def ethaddress_to_asset(address: ChecksumEvmAddress) -> Optional[CryptoAsset]:
 
     try:
         asset = EvmToken(ethaddress_to_identifier(address))
-    except UnknownAsset:
+    except (UnknownAsset, WrongAssetType):
         log.error(f'Could not find asset/token for address {address}')
         return None
 

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -70,7 +70,7 @@ from rotkehlchen.db.eth2 import DBEth2
 from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
 from rotkehlchen.db.queried_addresses import QueriedAddresses
 from rotkehlchen.db.utils import BlockchainAccounts
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import (
     EthSyncError,
     InputError,
@@ -1344,7 +1344,7 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
 
             try:
                 token = EvmToken(ethaddress_to_identifier(entry.base_balance.token_address))
-            except UnknownAsset:
+            except (UnknownAsset, WrongAssetType):
                 log.warning(
                     f'Found unknown asset {entry.base_balance.token_symbol} in DeFi '
                     f'balances for account: {account} and '

--- a/rotkehlchen/icons.py
+++ b/rotkehlchen/icons.py
@@ -12,7 +12,7 @@ import requests
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset, WrongAssetType
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.coingecko import DELISTED_ASSETS, Coingecko
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -130,7 +130,7 @@ class IconManager():
         # Then our only chance is coingecko
         try:
             asset = asset.resolve_to_asset_with_oracles()
-        except UnknownAsset:
+        except (UnknownAsset, WrongAssetType):
             return None
 
         needed_path = self.iconfile_path(asset)

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -18,7 +18,7 @@ from rotkehlchen.accounting.structures.types import HistoryEventType
 from rotkehlchen.assets.asset import AssetWithOracles, EvmToken
 from rotkehlchen.assets.utils import get_crypto_asset_by_symbol
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
+from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, WrongAssetType
 from rotkehlchen.errors.serialization import ConversionError, DeserializationError
 from rotkehlchen.externalapis.utils import read_hash, read_integer
 from rotkehlchen.fval import AcceptableFValInitInput, FVal
@@ -474,7 +474,7 @@ def deserialize_ethereum_token_from_db(identifier: str) -> EvmToken:
     """Takes an identifier and returns the <EvmToken>"""
     try:
         ethereum_token = EvmToken(identifier)
-    except UnknownAsset as e:
+    except (UnknownAsset, WrongAssetType) as e:
         raise DeserializationError(
             f'Could not initialize an ethereum token with identifier {identifier}',
         ) from e

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -16,7 +16,7 @@ from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.db.filtering import DBEqualsFilter, DBIgnoreValuesFilter, HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.api import PremiumAuthenticationError
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.exchanges.manager import ExchangeManager
@@ -160,7 +160,7 @@ class TaskManager():
         for asset in assets:
             try:
                 asset = asset.resolve_to_asset_with_oracles()
-            except UnknownAsset:
+            except (UnknownAsset, WrongAssetType):
                 continue  # cryptocompare does not work with non-oracles assets
 
             if asset.is_fiat() and main_currency.is_fiat():


### PR DESCRIPTION
I detected an error with a periodic task that tried to query cc prices for a custom asset. The problem was that the wrong asset type error was not being catched. I fixed it and added the error to other places where it was missing
