### PR TITLE
Invalidate cache when deleting latest price

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3937,13 +3937,14 @@ class RestAPI():
                 asset=asset,
             )
         try:
-            GlobalDBHandler().delete_manual_latest_price(asset=asset)
+            to_asset = GlobalDBHandler().delete_manual_latest_price(asset=asset)
         except InputError as e:
             return api_response(
                 result=wrap_in_fail_result(message=str(e)),
                 status_code=HTTPStatus.CONFLICT,
             )
 
+        Inquirer().remove_cached_current_price_entry(cache_key=(asset, to_asset))
         return api_response(result=OK_RESULT)
 
     def get_database_info(self) -> Response:

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -18,6 +18,7 @@ from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.constants.assets import A_ETH, A_LQTY, A_LUSD, A_USD
 from rotkehlchen.constants.ethereum import LIQUITY_TROVE_MANAGER
 from rotkehlchen.errors.misc import ModuleInitializationFailure, RemoteError
+from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.price import PriceHistorian
@@ -438,7 +439,7 @@ class Liquity(HasDSProxy):
                         sequence_number=str(change['sequenceNumber']),
                     )
                     result[owner].append(event)
-                except (DeserializationError, KeyError) as e:
+                except (DeserializationError, KeyError, NoPriceForGivenTimestamp) as e:
                     log.debug(f'Failed to deserialize Liquity trove event: {change}')
                     msg = str(e)
                     if isinstance(e, KeyError):


### PR DESCRIPTION
This PR addresses two issues:

- The cache of the inquirer for latest prices was being invalidated when adding latest prices but not when removing one.
- Liquity module was not caching errors related to missing prices when reading events