### PR TITLE
Address the problem with the ledger action spends with fiat assets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,8 @@ Changelog
 * :feature:`-` An ethereum address's tokens can now be manually detected by pressing a specific button in the UI.
 * :feature:`-` Transactions involving uniswap v2 and uniswap v3 will now be properly decoded in the ethereum transactions view
 * :bug:`-` When force sync fails a proper error message is displayed
-* :bug:`-` Now if something is wrong with an asset update, it won't end up having partial information. 
+* :bug:`-` If something is wrong with an asset update, it won't end up having partial information. 
+* :bug:`4930` Taxable ledger actions that spend fiat currencies should now be properly seen as taxable 
   
 * :release:`1.25.3 <2022-09-02>`
 * :bug:`4781` Failure in one specific binance endpoint during balance query won't fail the entire binance balances query unless it's the main spot balances endpoint.

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -212,8 +212,8 @@ class AccountingPot(CustomizableDateMixin):
         if amount == ZERO:  # do nothing for zero spends
             return ZERO, ZERO
 
-        if asset.is_fiat() and event_type != AccountingEventType.FEE:
-            taxable = False
+        if asset.is_fiat() and event_type == AccountingEventType.TRADE:
+            taxable = False  # for buys with fiat do not count it as taxable
 
         handle_prefork_asset_spends(
             cost_basis=self.cost_basis,


### PR DESCRIPTION
This should probably fix https://github.com/rotki/rotki/issues/4930 and the problem described there where
ledger actions where you spend a fiat currency that are set as taxable are not.