### PR TITLE
Create lock to avoid race conditions when adding tokens

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -665,7 +665,7 @@ class Balancer(EthereumModule):
                         underlying_tokens=underlying_tokens,
                         protocol='balancer',
                     )
-                    balancer_pool = add_ethereum_token_to_db(token_data)
+                    balancer_pool = add_ethereum_token_to_db(token_data=token_data, globaldb=GlobalDBHandler())  # noqa: E501
                     balancer_pools.append(balancer_pool)
 
                 # Aggregate the <BalancerInvestEvent> token amounts related with the

--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -395,6 +395,19 @@ class DBConnection:
         """
         self._modify_savepoint(rollback_or_release='RELEASE', savepoint_name=savepoint_name)
 
+    @contextmanager
+    def critical_section(self) -> Generator[None, None, None]:
+        with self.in_callback:
+            if __debug__:
+                logger.trace(f'entering critical section for {self.connection_type}')
+            self._conn.set_progress_handler(None, 0)
+        yield
+
+        with self.in_callback:
+            if __debug__:
+                logger.trace(f'exiting critical section for {self.connection_type}')
+            self._set_progress_handler()
+
     @property
     def total_changes(self) -> int:
         """total number of database rows that have been modified, inserted,


### PR DESCRIPTION
It happened that during the migration process two tasks tried to add the same token to the database. The sequence was:

1. greenlet A checks existence of token and fails
2. greenlet B checks existence of token and fails
3. greenlet A adds the token
4. greenlet B tries to add the token but it already exists

The sections that checks existence and adds the token is critic and should be protected