### PR TITLE
Change yearn subgraph to an updated working version

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/yearn/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/graph.py
@@ -93,7 +93,7 @@ class YearnVaultsV2Graph:
         self.database = database
         self.msg_aggregator = msg_aggregator
         self.premium = premium
-        self.graph = Graph('https://api.thegraph.com/subgraphs/name/salazarguille/yearn-vaults-v2-subgraph-mainnet')  # noqa: E501
+        self.graph = Graph('https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet')  # noqa: E501
 
     def _process_event(
         self,

--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -642,7 +642,6 @@ def test_query_yearn_vault_v2_balances(rotkehlchen_api_server, ethereum_accounts
         assert FVal(vault['underlying_value']['usd_value']) > ZERO
 
 
-@pytest.mark.skip('subgraph is dead. Fix via https://github.com/rotki/rotki/issues/4891')
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_V2_ACC2]])
 @pytest.mark.parametrize('ethereum_modules', [['yearn_vaults_v2']])
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])


### PR DESCRIPTION
The yearn subgraph stopped indexing and two PRs were made to the repository to fix the issue but haven't been merged. @rareweasel created this PR https://github.com/yearn/yearn-vaults-v2-subgraph/pull/189 that is deployed at https://thegraph.com/hosted-service/subgraph/rareweasel/yearn-vaults-v2-subgraph-mainnet and is the one I've put in use in the repo since it seems to be stable.

As discussed the usage of the subgraphs should be removed but until then this will make the functionality keep working in the app

