### PR TITLE
Use the same price as in trade for fee if it was one of the traded assets

### DIFF
--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -316,7 +316,8 @@ class AccountingPot(CustomizableDateMixin):
             fee: Optional[FVal],
             fee_asset: Optional[Asset],
     ) -> Optional[Tuple[Price, Price]]:
-        """Calculates the prices for assets going in and out of a swap/trade.
+        """
+        Calculates the prices for assets going in and out of a swap/trade.
 
         The rules are:
         - For the asset_in we get the equivalent rate from asset_out + fee if any.

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -7,7 +7,7 @@ from rotkehlchen.accounting.mixins.event import AccountingEventMixin, Accounting
 from rotkehlchen.accounting.structures.types import ActionType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_binance
-from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.crypto import sha3
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.fval import FVal
@@ -410,6 +410,14 @@ class Trade(AccountingEventMixin):
 
         if self.fee is not None and self.fee_currency is not None and self.fee != ZERO:
             # also checking fee_asset != None due to https://github.com/rotki/rotki/issues/4172
+            fee_price = None
+            if self.fee_currency == accounting.profit_currency:
+                fee_price = Price(ONE)
+            elif self.fee_currency == asset_in:
+                fee_price = prices[1]
+            elif self.fee_currency == asset_out:
+                fee_price = prices[0]
+
             accounting.add_spend(
                 event_type=AccountingEventType.FEE,
                 notes=notes + 'Fee',
@@ -418,6 +426,7 @@ class Trade(AccountingEventMixin):
                 asset=self.fee_currency,
                 amount=self.fee,
                 taxable=True,
+                given_price=fee_price,
                 # By setting the taxable amount ratio we determine how much of the fee
                 # spending should be a taxable spend and how much free.
                 taxable_amount_ratio=trade_taxable_amount / amount_out,

--- a/rotkehlchen/tests/unit/accounting/test_basic.py
+++ b/rotkehlchen/tests/unit/accounting/test_basic.py
@@ -245,7 +245,7 @@ def test_asset_and_price_not_found_in_history_processing(accountant):
     trade = Trade(
         timestamp=time,
         location=Location.KRAKEN,
-        base_asset=fgp,
+        base_asset=A_EUR,
         quote_asset=A_BTC,
         trade_type=TradeType.BUY,
         amount=FVal('2.5'),

--- a/rotkehlchen/tests/unit/accounting/test_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_settings.py
@@ -55,7 +55,7 @@ def test_nocrypto2crypto(accountant, google_service):
     no_message_errors(accountant.msg_aggregator)
     expected_pnls = PnlTotals({
         AccountingEventType.TRADE: PNL(taxable=ZERO, free=FVal('264693.433642820')),
-        AccountingEventType.FEE: PNL(taxable=FVal('-1.1708853227087498964'), free=ZERO),
+        AccountingEventType.FEE: PNL(taxable=FVal('-1.172677782721563021308995038'), free=ZERO),
     })
     check_pnls_and_csv(accountant, expected_pnls, google_service)
 
@@ -84,8 +84,8 @@ def test_big_taxfree_period(accountant, google_service):
     expected_pnls = PnlTotals({
         AccountingEventType.TRADE: PNL(taxable=ZERO, free=FVal('265253.1283582327833875')),
         AccountingEventType.FEE: PNL(
-            taxable=FVal('-1.170885322708749896'),
-            free=FVal('0.932017192728761755465893'),
+            taxable=FVal('-1.172677782721563021308995038'),
+            free=FVal('0.9338096527415748803748880375'),
         ),
     })
     check_pnls_and_csv(accountant, expected_pnls, google_service)


### PR DESCRIPTION
When creating the spend/adquisition events we had a calculated prices for the asset in the trades/swaps but the fee was querying the oracles. This made that the price for the fee and the asset in the trade could be different. 