### PR TITLE
Handle possible errors when resolving assets in decoders

### DIFF
--- a/rotkehlchen/chain/ethereum/decoding/interfaces.py
+++ b/rotkehlchen/chain/ethereum/decoding/interfaces.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Tuple
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
+    from rotkehlchen.accounting.structures.base import HistoryBaseEntry
     from rotkehlchen.chain.ethereum.decoding.base import BaseDecoderTools
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.user_messages import MessagesAggregator
@@ -15,14 +16,16 @@ class DecoderInterface(metaclass=ABCMeta):
             self,
             ethereum_manager: 'EthereumManager',  # pylint: disable=unused-argument
             base_tools: 'BaseDecoderTools',  # pylint: disable=unused-argument
-            msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
+            msg_aggregator: 'MessagesAggregator',
     ) -> None:
         """This is the Decoder interface initialization signature
 
         To have smaller objects and since few decoders use most of the given objects
-        we do not save anything here at the moment, but instead let it up to the individual
-        decoder to choose what to keep"""
-        return None
+        we do not save anything here at the moment (except for the msg_aggregator used to send
+        possible errors to the user), but instead let it up to the individual
+        decoder to choose what to keep.
+        """
+        self.msg_aggregator = msg_aggregator
 
     def addresses_to_decoders(self) -> Dict[ChecksumEvmAddress, Tuple[Any, ...]]:  # pylint: disable=no-self-use  # noqa: E501
         """Subclasses may implement this to return the mappings of addresses to decode functions"""
@@ -54,3 +57,15 @@ class DecoderInterface(metaclass=ABCMeta):
         Returns only new mappings of addresses to decode functions
         """
         return {}
+
+    def notify_user(self, event: 'HistoryBaseEntry', counterparty: str) -> None:
+        """
+        Notify the user about a problem during the decoding of ethereum transactions. At the
+        moment it doesn't take any error type but in the future it could be added if needed.
+        Related issue: https://github.com/rotki/rotki/issues/4965
+        """
+        self.msg_aggregator.add_error(
+            f'Could not identify asset {event.asset} decoding ethereum event in {counterparty}. '
+            f'Make sure that it has all the required properties (name, symbol and decimals) and '
+            f'try to decode the event again {event.event_identifier.hex()}.',
+        )

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -39,6 +39,11 @@ class GitcoinDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             event: HistoryBaseEntry,
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> bool:
+        """
+        May raise:
+        - UnknownAsset
+        - WrongAssetType
+        """
         if transaction.to_address not in (
                 '0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
                 '0x7d655c57f71464B6f83811C55D84009Cd9f5221C',

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -9,7 +10,9 @@ from rotkehlchen.chain.ethereum.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
@@ -24,6 +27,9 @@ KYBER_TRADE_LEGACY = b'\xf7$\xb4\xdff\x17G6\x12\xb5=\x7f\x88\xec\xc6\xea\x980t\x
 KYBER_LEGACY_CONTRACT = string_to_evm_address('0x9ae49C0d7F8F9EF4B864e004FE86Ac8294E20950')
 KYBER_LEGACY_CONTRACT_MIGRATED = string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd')  # noqa: E501
 KYBER_LEGACY_CONTRACT_UPGRADED = string_to_evm_address('0x9AAb3f75489902f3a48495025729a0AF77d4b11e')  # noqa: E501
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 def _legacy_contracts_basic_info(tx_log: EthereumTxReceiptLog) -> Tuple[ChecksumEvmAddress, Optional[CryptoAsset], Optional[CryptoAsset]]:  # noqa: E501
@@ -51,6 +57,7 @@ def _maybe_update_events_legacy_contrats(
     destination_asset: CryptoAsset,
     spent_amount: FVal,
     return_amount: FVal,
+    notify_user: Callable[[HistoryBaseEntry, str], None],
 ) -> None:
     """
     Use the information from a trade transaction to modify the HistoryEvents from receive/send to
@@ -58,7 +65,11 @@ def _maybe_update_events_legacy_contrats(
     """
     in_event = out_event = None
     for event in decoded_events:
-        crypto_asset = event.asset.resolve_to_crypto_asset()
+        try:
+            crypto_asset = event.asset.resolve_to_crypto_asset()
+        except (UnknownAsset, WrongAssetType):
+            notify_user(event, CPT_KYBER)
+            continue
         if event.event_type == HistoryEventType.SPEND and event.location_label == sender and event.asset == source_asset and event.balance.amount == spent_amount:  # noqa: E501
             event.event_type = HistoryEventType.TRADE
             event.event_subtype = HistoryEventSubType.SPEND
@@ -75,16 +86,18 @@ def _maybe_update_events_legacy_contrats(
         maybe_reshuffle_events(out_event=out_event, in_event=in_event)
 
 
-class KyberDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
-    def __init__(  # pylint: disable=super-init-not-called
+class KyberDecoder(DecoderInterface):
+    def __init__(
             self,
             ethereum_manager: 'EthereumManager',
             base_tools: 'BaseDecoderTools',
             msg_aggregator: MessagesAggregator,
     ) -> None:
-        self.ethereum_manager = ethereum_manager
-        self.base = base_tools
-        self.msg_aggregator = msg_aggregator
+        super().__init__(
+            ethereum_manager=ethereum_manager,
+            base_tools=base_tools,
+            msg_aggregator=msg_aggregator,
+        )
 
     def _decode_legacy_trade(  # pylint: disable=no-self-use
         self,
@@ -112,6 +125,7 @@ class KyberDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             destination_asset=destination_asset,
             spent_amount=spent_amount,
             return_amount=return_amount,
+            notify_user=self.notify_user,
         )
 
         return None, None
@@ -142,6 +156,7 @@ class KyberDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             destination_asset=destination_asset,
             spent_amount=spent_amount,
             return_amount=return_amount,
+            notify_user=self.notify_user,
         )
 
         return None, None

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
@@ -24,12 +24,12 @@ HISTORY = b'\x89M\xbf\x12b\x19\x9c$\xe1u\x02\x98\xa3\x84\xc7\t\x16\x0fI\xd1cB,\x
 SWAPPED = b'\xe2\xce\xe3\xf6\x83`Y\x82\x0bg9C\x85:\xfe\xbd\x9b0&\x12]\xab\rwB\x84\xe6\xf2\x8aHU\xbe'  # noqa: E501
 
 
-class Oneinchv1Decoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
+class Oneinchv1Decoder(DecoderInterface):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             ethereum_manager: 'EthereumManager',  # pylint: disable=unused-argument
             base_tools: 'BaseDecoderTools',
-            msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
+            msg_aggregator: 'MessagesAggregator',
     ) -> None:
         self.base = base_tools
 

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
@@ -21,13 +21,13 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 
-class PickleFinanceDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
+class PickleFinanceDecoder(DecoderInterface):
 
     def __init__(
             self,
-            ethereum_manager: 'EthereumManager',  # pylint: disable=unused-argument
-            base_tools: 'BaseDecoderTools',  # pylint: disable=unused-argument
-            msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
+            ethereum_manager: 'EthereumManager',
+            base_tools: 'BaseDecoderTools',
+            msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(
             ethereum_manager=ethereum_manager,
@@ -45,7 +45,12 @@ class PickleFinanceDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
             event: HistoryBaseEntry,
             action_items: List[ActionItem],  # pylint: disable=unused-argument
     ) -> bool:
-        """Enrich tranfer transactions to address for jar deposits and withdrawals"""
+        """
+        Enrich tranfer transactions to address for jar deposits and withdrawals
+        May raise:
+        - UnknownAsset
+        - WrongAssetType
+        """
         crypto_asset = event.asset.resolve_to_crypto_asset()
         if not (
             hex_or_bytes_to_address(tx_log.topics[2]) in self.pickle_contracts or

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -50,6 +50,7 @@ class SushiswapDecoder(DecoderInterface):
                 counterparty=CPT_SUSHISWAP_V2,
                 database=self.database,
                 ethereum_manager=self.ethereum_manager,
+                notify_user=self.notify_user,
             )
 
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -50,6 +50,7 @@ class Uniswapv2Decoder(DecoderInterface):
                 counterparty=CPT_UNISWAP_V2,
                 database=self.database,
                 ethereum_manager=self.ethereum_manager,
+                notify_user=self.notify_user,
             )
 
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional, Tuple
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -7,16 +8,39 @@ from rotkehlchen.chain.ethereum.decoding.structures import ActionItem
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import CPT_VOTIUM
 
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.ethereum.manager import EthereumManager
+    from rotkehlchen.user_messages import MessagesAggregator
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
 VOTIUM_CLAIM = b'Gf\x92\x1f\\Ydm"\xd7\xd2f\xa2\x91d\xc8\xe9b6\x84\xd8\xdf\xdb\xd91s\x1d\xfd\xca\x02R8'  # noqa: E501
 VOTIUM_CONTRACT = string_to_evm_address('0x378Ba9B73309bE80BF4C2c027aAD799766a7ED5A')
 
 
-class VotiumDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
+class VotiumDecoder(DecoderInterface):
+
+    def __init__(
+            self,
+            ethereum_manager: 'EthereumManager',
+            base_tools: 'BaseDecoderTools',
+            msg_aggregator: 'MessagesAggregator',
+    ) -> None:
+        super().__init__(
+            ethereum_manager=ethereum_manager,
+            base_tools=base_tools,
+            msg_aggregator=msg_aggregator,
+        )
+        self.msg_aggregator = msg_aggregator
 
     def _decode_claim(  # pylint: disable=no-self-use
         self,
@@ -40,9 +64,13 @@ class VotiumDecoder(DecoderInterface):  # lgtm[py/missing-call-to-init]
 
         for event in decoded_events:
             if event.event_type == HistoryEventType.RECEIVE and event.location_label == receiver and event.balance.amount == amount and claimed_token == event.asset:  # noqa: E501
+                try:
+                    crypto_asset = event.asset.resolve_to_crypto_asset()
+                except (UnknownAsset, WrongAssetType):
+                    self.notify_user(event=event, counterparty=CPT_VOTIUM)
+                    continue
                 event.event_subtype = HistoryEventSubType.REWARD
                 event.counterparty = CPT_VOTIUM
-                crypto_asset = event.asset.resolve_to_crypto_asset()
                 event.notes = f'Receive {event.balance.amount} {crypto_asset.symbol} from votium bribe'  # noqa: E501
 
         return None, None


### PR DESCRIPTION
It is possible that assets have missing information like symbol or name. In those cases the resolution would fail as `.resolve_to_crypto_asset` expects a complete asset. What this PR does is catching this errors and warn the urser