### PR TITLE
Handle wrong asset type in price resolution during PnL report

### DIFF
--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -223,6 +223,7 @@ class PriceHistorian():
                 PriceQueryUnsupportedAsset,
                 NoPriceForGivenTimestamp,
                 UnknownAsset,
+                WrongAssetType,
             ):
                 continue
             except RemoteError as e:

--- a/rotkehlchen/history/types.py
+++ b/rotkehlchen/history/types.py
@@ -9,9 +9,9 @@ from .deserialization import deserialize_price
 if TYPE_CHECKING:
     from rotkehlchen.externalapis.coingecko import Coingecko
     from rotkehlchen.externalapis.cryptocompare import Cryptocompare
+    from rotkehlchen.globaldb.manual_price_oracles import ManualPriceOracle
 
-
-HistoricalPriceOracleInstance = Union['Coingecko', 'Cryptocompare']
+HistoricalPriceOracleInstance = Union['Coingecko', 'Cryptocompare', 'ManualPriceOracle']
 
 
 class HistoricalPriceOracle(DBEnumMixIn):


### PR DESCRIPTION
The PnL was doing a resolution to asset with oracles during the price query but is not possible for custom assets. In this case I opted for not an early resolution and let the error happen and then catch it for performance.

About the solution implemented it will work if one of the two assets has oracles and if is not the case then the user will be prompted to add a custom price