### PR TITLE
assets mappings endpoint now skips invalid identifer(s)

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -308,8 +308,6 @@ class GlobalDBHandler():
         """
         Given a list of asset identifiers, return a list of asset information(id, name, symbol)
         for those identifiers.
-        May raise:
-        - InputError if one of the identifiers does not exist
         """
         result = {}
         identifiers_query = f'assets.identifier IN ({",".join("?" * len(identifiers))})'
@@ -333,8 +331,6 @@ class GlobalDBHandler():
                 if entry[5] is not None:
                     result[entry[0]].update({'custom_asset_type': entry[5]})
 
-            if len(result) != len(identifiers):
-                raise InputError('One or more of the given identifiers could not be found in the database')  # noqa: E501
         return result
 
     @staticmethod

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -562,7 +562,7 @@ def test_get_assets_mappings(rotkehlchen_api_server):
             assert 'custom_asset_type' not in details.keys()
             assert not details['is_custom_asset']
 
-    # check that providing a wrong identifier fails
+    # check that providing an invalid identifier returns only valid ones if any.
     response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
@@ -570,7 +570,9 @@ def test_get_assets_mappings(rotkehlchen_api_server):
         ),
         json={'identifiers': ['BTC', 'TRY', 'invalid']},
     )
-    assert_error_response(response, contained_in_msg='One or more of the given identifiers could not be found in the database')  # noqa: E501
+    result = assert_proper_response_with_result(response)
+    assert len(result) == 2
+    assert all([identifier in ('BTC', 'TRY') for identifier in result.keys()])
 
 
 def test_search_assets(rotkehlchen_api_server):


### PR DESCRIPTION
## Checklist

- [x] Assets mappings endpoint now skips invalid identifier(s) encountered and returns only mappings of valid identifiers.
