### PR TITLE
Replaces set-output command on github actions workflow

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run check action
-        uses: rotki/action-job-checker@d428e09451023925afa886459d3a3bb32fe72318
+        uses: rotki/action-job-checker@v1
         id: checker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -274,7 +274,7 @@ jobs:
           ROTKI_VERSION=$(cat .bumpversion.cfg | grep 'current_version = ' | sed -n -e 's/current_version = //p')
           POSTFIX=$(if git describe --tags --exact-match "$REVISION" &>/dev/null; then echo ''; else echo '-dev'; fi)
           ROTKI_VERSION=${ROTKI_VERSION}${POSTFIX}-$(date +'%Y.%m.%d')
-          echo "::set-output name=version::${ROTKI_VERSION}"
+          echo "version=${ROTKI_VERSION}" >> $GITHUB_OUTPUT
       - name: Build Information
         id: build_information
         run: |
@@ -285,8 +285,8 @@ jobs:
             PLATFORMS=linux/amd64
             TAG=dev
           fi
-          echo "::set-output name=tag::$TAG"
-          echo "::set-output name=platforms::$PLATFORMS"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "platforms=$PLATFORMS" >> $GITHUB_OUTPUT
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v3


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Info

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/