### PR TITLE
Introduces batching to asset cache to reduce number of requests

### DIFF
--- a/frontend/app/tests/unit/store/assets/asset-cache.spec.ts
+++ b/frontend/app/tests/unit/store/assets/asset-cache.spec.ts
@@ -32,7 +32,7 @@ describe('store::assets/cache', () => {
     const firstRetrieval: ComputedRef<AssetInfo | null> = store.retrieve('KEY');
     const secondRetrieval: ComputedRef<AssetInfo | null> =
       store.retrieve('KEY');
-    vi.advanceTimersToNextTimer();
+    vi.advanceTimersByTime(2500);
     await flushPromises();
     expect(useAssetInfoApi().assetMapping).toHaveBeenCalledOnce();
     expect(get(firstRetrieval)).toEqual(asset);
@@ -40,6 +40,7 @@ describe('store::assets/cache', () => {
   });
 
   it('should not request failed assets twice unless they expire', async () => {
+    vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue({});
     const firstRetrieval: ComputedRef<AssetInfo | null> = store.retrieve('KEY');
     const secondRetrieval: ComputedRef<AssetInfo | null> =
       store.retrieve('KEY');
@@ -93,24 +94,25 @@ describe('store::assets/cache', () => {
     );
 
     store.retrieve(`AST-0`);
-    vi.advanceTimersToNextTimer();
+    vi.advanceTimersByTime(3000);
     await flushPromises();
 
     for (let i = 1; i < 50; i++) {
       store.retrieve(`AST-${i}`);
-      vi.advanceTimersToNextTimer();
-      await flushPromises();
     }
 
+    vi.advanceTimersByTime(4000);
+    await flushPromises();
+
     store.retrieve(`AST-0`);
-    vi.advanceTimersToNextTimer();
+    vi.advanceTimersByTime(4000);
     await flushPromises();
 
     for (let i = 51; i < 505; i++) {
       store.retrieve(`AST-${i}`);
-      vi.advanceTimersToNextTimer();
-      await flushPromises();
     }
+    vi.advanceTimersByTime(4000);
+    await flushPromises();
 
     const entries = Object.entries(get(store.cache));
     expect(entries).toHaveLength(500);


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.


## Notes

Instead of doing a single request per identifier as the initial implementation was doing, the caching mechanism will now fetch in batches. For example, all the identifiers requested in a window of 800ms will be put into one request instead.
