### PR TITLE
Put all get_or_create_evm_token under a lock

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3600,7 +3600,7 @@ class RestAPI():
     def _get_token_info(self, address: ChecksumEvmAddress) -> Dict[str, Any]:
         eth_manager = self.rotkehlchen.chain_manager.ethereum
         try:
-            info, _ = eth_manager.get_basic_contract_info(address=address)
+            info = eth_manager.get_basic_contract_info(address=address)
         except BadFunctionCallOutput:
             return wrap_in_fail_result(
                 f'Address {address} seems to not be a deployed contract',

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
@@ -207,9 +207,9 @@ def uniswap_v3_lp_token_balances(
         tokens_a, tokens_b = [], []
         for position in positions:
             try:
-                token1_info, _ = ethereum.get_basic_contract_info(to_checksum_address(position[2]))
+                token1_info = ethereum.get_basic_contract_info(to_checksum_address(position[2]))
                 tokens_a.append(token1_info)
-                token2_info, _ = ethereum.get_basic_contract_info(to_checksum_address(position[3]))
+                token2_info = ethereum.get_basic_contract_info(to_checksum_address(position[3]))
                 tokens_b.append(token2_info)
             except (BadFunctionCallOutput, ValueError) as e:
                 log.error(

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -23,6 +23,7 @@ from typing import (
     overload,
 )
 
+from gevent.lock import Semaphore
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.accounting.structures.balance import BalanceType
@@ -264,6 +265,8 @@ class DBHandler:
         }
         self.conn: DBConnection = None  # type: ignore
         self.conn_transient: DBConnection = None  # type: ignore
+        # Lock to make sure that 2 callers of get_or_create_evm_token do not go in at the same time
+        self.get_or_create_evm_token_lock = Semaphore()
         self._connect(password)
         self._run_actions_after_first_connection(password)
         with self.user_write() as cursor:

--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -370,8 +370,7 @@ def test_jsonloads_list():
 
 
 def test_retrieve_old_token_info(ethereum_manager):
-    info, remote_query = ethereum_manager.get_basic_contract_info('0x2C4Bd064b998838076fa341A83d007FC2FA50957')  # noqa: E501
-    assert remote_query is True
+    info = ethereum_manager.get_basic_contract_info('0x2C4Bd064b998838076fa341A83d007FC2FA50957')  # noqa: E501
     assert info['symbol'] == 'UNI-V1'
     assert info['name'] == 'Uniswap V1'
 


### PR DESCRIPTION
The previous attempts to prevent context switch with user DB critical section would not work as there is also multiple other places where globalDB is also touched (all EVMToken() constructor or initialize calls) so at that point using a single lock becomes the easiest/simplest approach.
