### PR TITLE
fix bug with weth decoder

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/weth/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/weth/decoder.py
@@ -76,6 +76,7 @@ class WethDecoder(DecoderInterface):
         deposited_amount_raw = hex_or_bytes_to_int(tx_log.data[:32])
         deposited_amount = asset_normalized_value(amount=deposited_amount_raw, asset=self.eth)
 
+        out_event = None
         for event in decoded_events:
             if (
                 event.event_type == HistoryEventType.SPEND and
@@ -90,6 +91,10 @@ class WethDecoder(DecoderInterface):
                 event.event_type = HistoryEventType.DEPOSIT
                 event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
                 event.notes = f'Wrap {deposited_amount} {self.eth.symbol} in {self.weth.symbol}'  # noqa: E501
+                out_event = event
+
+        if out_event is None:
+            return None, None
 
         in_event = HistoryBaseEntry(
             event_identifier=transaction.tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -9,7 +9,7 @@ from rotkehlchen.chain.ethereum.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.uniswap.constants import CPT_UNISWAP_V3
 from rotkehlchen.chain.ethereum.structures import EthereumTxReceipt, EthereumTxReceiptLog
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
-from rotkehlchen.constants.assets import A_ETH, A_USDC, A_WETH
+from rotkehlchen.constants.assets import A_ETH, A_USDC
 from rotkehlchen.constants.misc import EXP18, ZERO
 from rotkehlchen.db.ethtx import DBEthTx
 from rotkehlchen.fval import FVal
@@ -105,7 +105,7 @@ def test_uniswap_v3_swap(database, ethereum_manager, eth_transactions):
         )
         events = decoder.decode_transaction(cursor, transaction=transaction, tx_receipt=receipt)
 
-    assert len(events) == 4
+    assert len(events) == 3
     expected_events = [
         HistoryBaseEntry(
             event_identifier=HistoryBaseEntry.deserialize_event_identifier(tx_hex),
@@ -133,18 +133,6 @@ def test_uniswap_v3_swap(database, ethereum_manager, eth_transactions):
             balance=Balance(amount=FVal('0.632989659350357136'), usd_value=ZERO),
             location_label='0xb63e0C506dDBa7b0dd106d1937d6D13BE2C62aE2',
             notes='Swap 0.632989659350357136 ETH in uniswap-v3 from 0xb63e0C506dDBa7b0dd106d1937d6D13BE2C62aE2',  # noqa: E501
-            counterparty=CPT_UNISWAP_V3,
-        ), HistoryBaseEntry(
-            event_identifier=HistoryBaseEntry.deserialize_event_identifier(tx_hex),
-            sequence_index=2,
-            timestamp=1646375440000,
-            location=Location.BLOCKCHAIN,
-            event_type=HistoryEventType.TRANSFER,
-            event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
-            asset=A_WETH,
-            balance=Balance(amount=FVal('0.632989659350357136'), usd_value=ZERO),
-            location_label='0xE592427A0AEce92De3Edee1F18E0157C05861564',
-            notes='Refund of 0.632989659350357136 WETH in uniswap-v3 due to price change',
             counterparty=CPT_UNISWAP_V3,
         ), HistoryBaseEntry(
             event_identifier=HistoryBaseEntry.deserialize_event_identifier(tx_hex),

--- a/rotkehlchen/tests/unit/decoders/test_weth.py
+++ b/rotkehlchen/tests/unit/decoders/test_weth.py
@@ -299,3 +299,59 @@ def test_weth_interaction_with_protocols_withdrawal(database, ethereum_manager):
         ),
     ]
     assert events == expected_events
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d']])  # noqa: E501
+def test_weth_interaction_errors(database, ethereum_manager):
+    # check that if no out event occurs, an in event should not be created for deposit event
+    # https://etherscan.io/tx/0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d
+    msg_aggregator = MessagesAggregator()
+    tx_hex = '0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d'
+    evmhash = deserialize_evm_tx_hash(tx_hex)
+    events = get_decoded_events_of_transaction(
+        ethereum_manager=ethereum_manager,
+        database=database,
+        msg_aggregator=msg_aggregator,
+        tx_hash=evmhash,
+    )
+    assert len(events) == 3
+    expected_events = [
+        HistoryBaseEntry(
+            event_identifier=evmhash,
+            sequence_index=0,
+            timestamp=1666800983000,
+            location=Location.BLOCKCHAIN,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            balance=Balance(amount=FVal(0.003535483550478045)),
+            location_label='0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d',
+            notes='Burned 0.003535483550478045 ETH for gas',
+            counterparty=CPT_GAS,
+        ), HistoryBaseEntry(
+            event_identifier=evmhash,
+            sequence_index=1,
+            timestamp=1666800983000,
+            location=Location.BLOCKCHAIN,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_ETH,
+            balance=Balance(amount=FVal(0.06693824468797216)),
+            location_label='0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d',
+            notes='Send 0.06693824468797216 ETH to 0xe66B31678d6C16E9ebf358268a790B763C133750',
+            counterparty='0xe66B31678d6C16E9ebf358268a790B763C133750',
+        ), HistoryBaseEntry(
+            event_identifier=evmhash,
+            timestamp=1666800983000,
+            sequence_index=181,
+            location=Location.BLOCKCHAIN,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_USDC,
+            balance=Balance(amount=FVal(103.562282)),
+            location_label='0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d',
+            notes='Receive 103.562282 USDC from 0xe66B31678d6C16E9ebf358268a790B763C133750 to 0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d',  # noqa: E501,
+            counterparty='0xe66B31678d6C16E9ebf358268a790B763C133750',
+        ),
+    ]
+    assert events == expected_events


### PR DESCRIPTION
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/72208758/198102481-01b067fe-bccd-42e6-88fe-ce77bb3a95c1.png">

Resolve cases whereby an `Receive XXX WETH` is created for a `Deposit()` event that an outward transaction(out_event) didn't occur for.

https://etherscan.io/tx/0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d
