### PR TITLE
Handle missing payment token in opensea response

### DIFF
--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -243,8 +243,8 @@ class Opensea(ExternalServiceWithApiKey):
             )
 
         try:
-            last_sale = entry.get('last_sale')
-            if last_sale:
+            last_sale: Optional[Dict[str, Any]] = entry.get('last_sale')
+            if last_sale is not None and last_sale.get('payment_token') is not None:
                 if last_sale['payment_token']['symbol'] in ('ETH', 'WETH'):
                     payment_asset = self.eth_asset
                 else:


### PR DESCRIPTION
There is a response from opensea that included

```
'2021-03-30T20:55:45', 'auction_type': 'dutch', 'total_price': '70000000000000000000', 'payment_token': None,
```

resulting in an error querying the nft balances