### PR TITLE
Bump to v1.26

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.3
+current_version = 1.26.0
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.26.0 <2022-10-28>`
 * :feature:`2607` Users can now add general and section specific notes in rotki by clicking on the note icon on the top right menu.
 * :feature:`4906` Add supports for custom assets.
 * :feature:`4675` Added YFIETH-f curve pool to the list of known assets.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2018-2020, Eleftherios Karapetsas. 2020-2022, Rotki Solutions GmbH'
 author = 'The rotki team'
 
 # The short X.Y version
-version = '1.25.3'
+version = '1.26.0'
 # The full version, including alpha/beta/rc tags
-release = '1.25.3'
+release = '1.26.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.25.3",
+  "version": "1.26.0",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "author": "Rotki Solutions GmbH <info@rotki.com>",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
     },
     "app": {
       "name": "rotki",
-      "version": "1.25.3",
+      "version": "1.26.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -738,6 +738,26 @@ KNOWN_ETH_SPAM_TOKENS: Dict[ChecksumEvmAddress, Dict[str, Any]] = {
         'symbol': 'EthFork2.com',
         'decimals': 18,
     },
+    string_to_evm_address('0x70c18F2fDcb00d27494f767503874788e35c9940'): {
+        'name': 'lenusd.shop',
+        'symbol': 'Claim at [lenusd.shop]',
+        'decimals': 6,
+    },
+    string_to_evm_address('0xc9dA518dB3AbdB90A82c4d1838B7Cf9b0C945E7e'): {
+        'name': '(apord.site)',
+        'symbol': 'This token holders can claim reward token. Please Visit https://apord.site and claim rewards.',  # noqa: E501
+        'decimals': 18,
+    },
+    string_to_evm_address('0xCdC94877E4164D2e915fC5E8310155D661A995F1'): {
+        'name': 'spingame.me',
+        'symbol': 'Enjoy [https://spingame.me]',
+        'decimals': 6,
+    },
+    string_to_evm_address('0x38715Ab4b9d4e00890773D7338d94778b0dFc0a8'): {
+        'name': 'ausd.shop',
+        'symbol': 'Visit [ausd.shop] and supply or borrow USDT',
+        'decimals': 6,
+    },
 }
 
 

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -36,6 +36,8 @@ class DBEth2():
     def get_validators_to_query_for_stats(self, up_to_ts: Timestamp) -> List[Tuple[int, Timestamp]]:  # noqa: E501
         """Gets a list of validators that need to be queried for new daily stats
 
+        Validators need to be queried if last time they are queried was more than 2 days.
+
         Returns a list of tuples. First entry is validator index and second entry is
         last queried timestamp for daily stats of that validator.
         """
@@ -50,7 +52,10 @@ class DBEth2():
         cursor = self.db.conn.cursor()
         result = cursor.execute(
             query_str,
-            (up_to_ts, DAY_IN_SECONDS),
+            # 2 days since stats page only appears once day is over. So if today is
+            # 27/10 19:46 the last full day it has is 26/10 00:00, which is more than a day
+            # but less than 2
+            (up_to_ts, DAY_IN_SECONDS * 2 + 1),
         )
         return result.fetchall()
 

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -15,6 +15,7 @@ from rotkehlchen.chain.ethereum.modules.eth2.structures import (
 from rotkehlchen.chain.ethereum.modules.eth2.utils import scrape_validator_daily_stats
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.constants.misc import ONE, ZERO
+from rotkehlchen.constants.timing import DAY_IN_SECONDS
 from rotkehlchen.db.eth2 import DBEth2
 from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
 from rotkehlchen.fval import FVal
@@ -400,8 +401,7 @@ def test_get_validators_to_query_for_stats(database):
         end_amount=FVal(32),
     )])
     assert db.get_validators_to_query_for_stats(now) == [(2, 0), (3, 1617512800)]
-
-    assert db.get_validators_to_query_for_stats(1617512800 + 100000) == [(2, 0), (3, 1617512800)]
+    assert db.get_validators_to_query_for_stats(1617512800 + DAY_IN_SECONDS * 2 + 2) == [(2, 0), (3, 1617512800)]  # noqa: E501
 
 
 @pytest.mark.parametrize('default_mock_price_value', [FVal(1.55)])

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ directory = pathlib.Path(__file__).parent
 requirements = directory.joinpath('requirements.txt').read_text()
 requirements = [str(r) for r in parse_requirements(requirements)]
 
-version = '1.25.3'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.26.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='rotkehlchen',


### PR DESCRIPTION
- Bump to 1.26
- more spam assets
- don't query stats for validators if more recent than 2 days. Means each time we go to staking view we won't query again and again