### PR TITLE
Fix database plaintext is locked error

### DIFF
--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -193,8 +193,8 @@ class DataHandler():
         Returns a b64 encoded binary blob"""
         log.info('Compress and encrypt DB')
         compressor = zlib.compressobj(level=9)
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            tempdb = Path(tmpdirname) / 'temp.db'
+        with tempfile.NamedTemporaryFile(delete=True, suffix='.db') as tempdbfile:
+            tempdb = Path(tempdbfile.name)
             self.db.export_unencrypted(tempdb)
             source_data = bytearray()
             compressed_data = bytearray()
@@ -226,7 +226,6 @@ class DataHandler():
         - SystemPermissionError if the DB file permissions are not correct
         """
         log.info('Decompress and decrypt DB')
-
         # First make a backup of the DB we are about to replace
         date = timestamp_to_date(ts=ts_now(), formatstr='%Y_%m_%d_%H_%M_%S', treat_as_local=True)
         shutil.copyfile(

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -133,6 +133,7 @@ class PremiumSyncManager():
 
     def maybe_upload_data_to_server(self, force_upload: bool = False) -> bool:
         assert self.premium is not None, 'caller should make sure premium exists'
+        log.debug('Starting maybe_upload_data_to_server')
         with self.data.db.user_write() as cursor:
             try:
                 metadata = self.premium.query_last_data_metadata()
@@ -190,7 +191,6 @@ class PremiumSyncManager():
 
     def sync_data(self, action: Literal['upload', 'download']) -> Tuple[bool, str]:
         msg = ''
-
         if action == 'upload':
             if self.check_if_should_sync(force_upload=True) is False:
                 success = False

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -141,6 +141,8 @@ class TaskManager():
         assert self.premium_sync_manager is not None, 'caller should make sure premium sync manager exists'  # noqa: E501
         if self.premium_sync_manager.check_if_should_sync(force_upload=False) is False:
             return None
+
+        log.debug('Scheduling task for DB upload to server')
         return self.greenlet_manager.spawn_and_track(
             after_seconds=None,
             task_name='Upload data to server',


### PR DESCRIPTION
Fix #5038

What was happening is at some very rare case we were getting into the `maybe_upload_db` through two different greenlets.

Mind you this should not happen easily. Instead of putting a lock as the task can't be scheduled at the same time and it can only happen if both a user presses to push to server and the periodic task happen at the same time we just protect it if it does happen.

We do that by making sure the name is unique each time. Before `TemporaryDirectory()` was always returning the same directory, we were trying the same filename for the DB in the directory and then BOOM.

We fix this by using a uniquely named temporary file each time.
