### PR TITLE
Move BSQ resolution out of inquirer constructor

### DIFF
--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -127,11 +127,16 @@ class EVMTransactionDecoder():
                 if submodule_decoder:
                     if class_name in self.decoders:
                         raise ModuleLoadingError(f'Decoder with name {class_name} already loaded')
-                    self.decoders[class_name] = submodule_decoder(
-                        ethereum_manager=self.ethereum_manager,
-                        base_tools=self.base,
-                        msg_aggregator=self.msg_aggregator,
-                    )
+                    try:
+                        self.decoders[class_name] = submodule_decoder(
+                            ethereum_manager=self.ethereum_manager,
+                            base_tools=self.base,
+                            msg_aggregator=self.msg_aggregator,
+                        )
+                    except (UnknownAsset, WrongAssetType) as e:
+                        log.error(f'Failed at initialization of {class_name} decoder due to asset mismatch: {str(e)}')  # noqa: E501
+                        continue
+
                     address_results.update(self.decoders[class_name].addresses_to_decoders())
                     rules_results.extend(self.decoders[class_name].decoding_rules())
                     enricher_results.extend(self.decoders[class_name].enricher_rules())

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -134,7 +134,7 @@ class EVMTransactionDecoder():
                             msg_aggregator=self.msg_aggregator,
                         )
                     except (UnknownAsset, WrongAssetType) as e:
-                        log.error(f'Failed at initialization of {class_name} decoder due to asset mismatch: {str(e)}')  # noqa: E501
+                        self.msg_aggregator.add_error(f'Failed at initialization of {class_name} decoder due to asset mismatch: {str(e)}')  # noqa: E501
                         continue
 
                     address_results.update(self.decoders[class_name].addresses_to_decoders())

--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -185,10 +185,10 @@ class UniswapOracle(CurrentPriceOracleInterface, CacheableMixIn):
         return []
 
     def get_price(
-        self,
-        from_asset: AssetWithOracles,
-        to_asset: AssetWithOracles,
-        block_identifier: BlockIdentifier,
+            self,
+            from_asset: AssetWithOracles,
+            to_asset: AssetWithOracles,
+            block_identifier: BlockIdentifier,
     ) -> Price:
         """
         Return the price of from_asset to to_asset at the block block_identifier.

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -448,8 +448,8 @@ class ChainManager(CacheableMixIn, LockableQueryMixIn):
                 msg_aggregator=self.msg_aggregator,
                 **kwargs,
             )
-        except ModuleInitializationFailure as e:
-            log.error(f'Failed to activate {module_name} due to: {str(e)}')
+        except (ModuleInitializationFailure, UnknownAsset, WrongAssetType) as e:
+            self.msg_aggregator.add_error(f'Failed to activate {module_name} due to: {str(e)}')
             return None
 
         self.eth_modules[module_name] = instance

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -354,8 +354,8 @@ class Inquirer():
         try:
             Inquirer.usd = A_USD.resolve_to_fiat_asset()
             Inquirer.weth = A_WETH.resolve_to_evm_token()
-        except UnknownAsset as e:
-            message = f'One of the base assets was deleted from the DB: {str(e)}'
+        except (UnknownAsset, WrongAssetType) as e:
+            message = f'One of the base assets was deleted/modified from the DB: {str(e)}'
             log.critical(message)
             raise RuntimeError(message + '. Add it back manually or contact support') from e
 
@@ -684,8 +684,8 @@ class Inquirer():
         if asset == A_BSQ:
             try:
                 bsq = A_BSQ.resolve_to_crypto_asset()
-            except UnknownAsset:
-                log.error('Asked for BSQ price but BSQ is missing from the global DB')
+            except (UnknownAsset, WrongAssetType):
+                log.error('Asked for BSQ price but BSQ is missing or misclassified in the global DB')  # noqa: E501
                 return Price(ZERO), oracle
 
             try:


### PR DESCRIPTION
The problem that was noticed was an interesting one in an old laptop.

The assets in the global DB were quite old. About a year old. When initializing the global DB upgrade worked fine. But then when initializing the inquirer BSQ resolution failed since it did not exist in the DB and as such the entire app crashes and could not open.

That shows that the approach with the resolution is rather brittle and will need at least in some places rethinking.

But the solution is simple. Move the BSQ resolution only where it's used. And warn the user very clearly if the 2 base assets USD and WETH are removed.
