### PR TITLE
Fix uploading user DB for windows users with premium subscription

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`5050` Provide a fix for the edge case at 1.25.3->1.26.0 (v34->v35) DB upgrade that caused a FOREIGN key error and botched the upgrade.
+* :bug:`5051` Windows users with a premium subscription should be able to upload their user DB for backup to our server properly again.
 
 * :release:`1.26.0 <2022-10-28>`
 * :feature:`2607` Users can now add general and section specific notes in rotki by clicking on the note icon on the top right menu.


### PR DESCRIPTION
fix https://github.com/rotki/rotki/issues/5051

So apparently python's `tempfile.NamedTemporaryFile` works differently in
Windows than in Unix systems.

Quoting [the docs](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile):

> Whether the name can be used to open the file a second time, while the
> named temporary file is still open, varies across platforms (it can be
> so used on Unix; it cannot on Windows)

That means that in Windows the temporary file is opened once at the
context manager, stays open and when it's attempted to be opened by
sqlcipher as a DB it goes BOOM BOOM.

The solution for this to work on all platforms is to explicity close
it to allow reopening, to not delete file when closing and to do
cleanup manually at the end.

Kill me.