### PR TITLE
Introduce immutable cache decorator

### DIFF
--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -280,9 +280,9 @@ class UniswapV3Oracle(UniswapOracle):
 
     @cache_response_timewise()
     def get_pool(
-        self,
-        token_0: EvmToken,
-        token_1: EvmToken,
+            self,
+            token_0: EvmToken,
+            token_1: EvmToken,
     ) -> List[str]:
         result = self.eth_manager.multicall_specific(
             contract=UNISWAP_V3_FACTORY,

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -186,9 +186,8 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
 @pytest.mark.parametrize('endpoint', ['nftsbalanceresource', 'nftsresource'])
 def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
     """Check that ignoring NFTs work as expected"""
-    # return data of `_get_all_nft_data`
-    result = (
-        {
+    def mock_get_all_nft_data(addresses, **kwargs):  # pylint: disable=unused-argument
+        nft_map = {
             '0xc37b40ABdB939635068d3c5f13E7faF686F03B65': [
                 NFT(
                     token_identifier='_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041',  # noqa: E501
@@ -208,10 +207,10 @@ def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
                     ),
                 ),
             ],
-        },
-        1,
-    )
-    get_all_nft_data_patch = patch('rotkehlchen.chain.ethereum.modules.nfts.Nfts._get_all_nft_data', return_value=result)  # noqa: E501
+        }
+        return nft_map, 1
+
+    get_all_nft_data_patch = patch('rotkehlchen.chain.ethereum.modules.nfts.Nfts._get_all_nft_data', side_effect=mock_get_all_nft_data)  # noqa: E501
 
     # ignore the nft
     response = requests.put(

--- a/rotkehlchen/utils/mixins/cacheable.py
+++ b/rotkehlchen/utils/mixins/cacheable.py
@@ -138,9 +138,10 @@ def cache_response_timewise_immutable(
     """ Same as cache_response_timewise but resulting dict is a copy so, the cache
     itself can't be mutated.
     """
-    def _cache_response_timewise(f: Callable) -> Callable:
+    def _cache_response_timewise_immutable(f: Callable) -> Callable:
         @wraps(f)
         def wrapper(wrappingobj: CacheableMixIn, *args: Any, **kwargs: Any) -> Any:
+            # return f(wrappingobj, *args, **kwargs)
             cache_miss, cache_key, now, kwargs = _cache_response_timewise_base(
                 wrappingobj,
                 f,
@@ -158,4 +159,4 @@ def cache_response_timewise_immutable(
             return deepcopy(wrappingobj.results_cache[cache_key].result)
 
         return wrapper
-    return _cache_response_timewise
+    return _cache_response_timewise_immutable

--- a/rotkehlchen/utils/mixins/lockable.py
+++ b/rotkehlchen/utils/mixins/lockable.py
@@ -30,7 +30,7 @@ def protect_with_lock(arguments_matter: bool = False) -> Callable:
         - all the exchanges
         - the Blockchain object
     """
-    def _cache_response_timewise(f: Callable) -> Callable:
+    def _protect_with_lock(f: Callable) -> Callable:
         @wraps(f)
         def wrapper(wrappingobj: LockableQueryMixIn, *args: Any, **kwargs: Any) -> Any:
             lock_key = function_sig_key(
@@ -47,4 +47,4 @@ def protect_with_lock(arguments_matter: bool = False) -> Callable:
                 return result
 
         return wrapper
-    return _cache_response_timewise
+    return _protect_with_lock


### PR DESCRIPTION
Follow up from: https://github.com/rotki/rotki/pull/4957#discussion_r1008350169

cache_response_timewise saves the cache in a dict, which is
mutable. It returns a reference to it which must not be mutated by the
callers.

We now introduce a cache decorator which creates a copy of the cached
result before returning it.

If any caller wants to mutate the reference to the cache they
should use this decorator.

Also use it in get_all_nft_data