### PR TITLE
Solve issue querying exchanges if previously attemped a log in to a broken db

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -171,6 +171,7 @@ class Rotkehlchen():
         to sync premium databases we relogged in
         """
         self.cryptocompare.db = None
+        self.exchange_manager.delete_all_exchanges()
         self.data.logout()
 
     def unlock_user(


### PR DESCRIPTION
Description of the error:
1. I tried to log in to a database that has an invalid schema due to being partially migrated.
2. https://github.com/rotki/rotki/blob/0fa9a7cc2dee688db0621750a31b2c6c49c31108/rotkehlchen/rotkehlchen.py#L268 worked and the exchanges were initialized
3. Then later the log in failed reaching https://github.com/rotki/rotki/blob/0fa9a7cc2dee688db0621750a31b2c6c49c31108/rotkehlchen/api/rest.py#L1213 BUT the exchange list didn't clean.
4. I attempted to log in with a database that was fine
5. since the exchange manager already had the exchange initialized the data handler stored in the intialized exchanges was to a disconnected database.

Also a side effect of this was double balances in exchanges since I had initialized exchanges again later (this time with the correct database)

Closes #5067
