### PR TITLE
Skip pools with no liquidity in uni-v3 oracle

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Uniswap V3 oracle will now correctly skip assets with no liquidity when querying prices.
+
 * :release:`1.26.1 <2022-11-04>`
 * :feature:`5080` For custom assets with custom price there should no longer be any double conversion. So 1 euro should always be one euro.
 * :feature:`5046` Users who deleted important assets from their rotki instance will now have a fallback and won't get their rotki stuck.

--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -319,7 +319,11 @@ class UniswapV3Oracle(UniswapOracle):
             )
             if pool_liquidity > max_liquidity:
                 best_pool = pool_address
+                max_liquidity = pool_liquidity
 
+        if max_liquidity == 0:
+            # if there is no pool with assets don't return any pool
+            return []
         return [best_pool]
 
     def get_pool_price(

--- a/rotkehlchen/tests/unit/test_defi_oracles.py
+++ b/rotkehlchen/tests/unit/test_defi_oracles.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -10,7 +11,11 @@ from rotkehlchen.errors.defi import DefiPoolError
 from rotkehlchen.errors.price import PriceQueryUnsupportedAsset
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import CurrentPriceOracle
+from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Price
+
+if TYPE_CHECKING:
+    from rotkehlchen.inquirer import Inquirer
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -102,3 +107,27 @@ def test_uniswap_no_decimals(inquirer_defi):
             inquirer_defi._uniswapv2.query_current_price(weth, A_USDC, False)
         with pytest.raises(DefiPoolError):
             inquirer_defi._uniswapv3.query_current_price(weth, A_USDC, False)
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_pool_with_no_liquidity(inquirer_defi: 'Inquirer'):
+    """
+    Test that a pool with no liquidity on range is skipped when using uni-v3 oracle
+    """
+    old_steram = EvmToken('eip155:1/erc20:0x0Cf0Ee63788A0849fE5297F3407f701E122cC023')
+
+    def mock_requests_get(_url, timeout):  # pylint: disable=unused-argument
+        response = """{"jsonrpc":"2.0","id":1,"result":"0x0000000000000000000000000000000000000000000000000000000000f2aa4700000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"}"""  # noqa: E501
+        return MockResponse(200, response)
+
+    assert inquirer_defi._ethereum is not None
+    assert inquirer_defi._uniswapv3 is not None
+
+    etherscan_patch = patch.object(
+        target=inquirer_defi._ethereum.etherscan.session,
+        attribute='get',
+        wraps=mock_requests_get,
+    )
+    with etherscan_patch:
+        path = inquirer_defi._uniswapv3.get_pool(old_steram, A_USDC.resolve_to_evm_token())
+    assert path == []


### PR DESCRIPTION
There was a fault in the logic that was allowing pools with 0 liquidity to be used causing almost infinite prices