### PR TITLE
Correct filtering of web3 nodes

### DIFF
--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -262,9 +262,10 @@ class EvmManager(LockableQueryMixIn, metaclass=ABCMeta):
         ---> Average: 70 seconds
         """
         open_nodes = self.database.get_web3_nodes(blockchain=self.blockchain, only_active=True)  # noqa: E501
-        selection = list(open_nodes)
         if skip_etherscan:
-            selection = [wnode for wnode in open_nodes if wnode.node_info.name != self.etherscan_node_name]  # noqa: E501
+            selection = [wnode for wnode in open_nodes if wnode.node_info.name != self.etherscan_node_name and wnode.node_info.owned is False]  # noqa: E501
+        else:
+            selection = [wnode for wnode in open_nodes if wnode.node_info.owned is False]
 
         ordered_list = []
         while len(selection) != 0:


### PR DESCRIPTION
After migration the ethereum manager to the evm_manager this method got an older version and was not filtering properly the owned nodes out of the open nodes selection

