### PR TITLE
Fix local only tests

### DIFF
--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -576,11 +576,11 @@ def test_query_yearn_vault_history(rotkehlchen_api_server, ethereum_accounts):
     ))
     assert_simple_ok_response(response)
     with rotki.data.db.conn.read_ctx() as cursor:
-        events = rotki.data.db.get_yearn_vaults_events(
-            cursor,
-            TEST_ACC1,
-            test_vault,
-            rotki.data.msg_aggregator,
+        events = get_yearn_vaults_events(
+            cursor=cursor,
+            address=TEST_ACC1,
+            vault=test_vault,
+            msg_aggregator=rotki.data.msg_aggregator,
         )
     assert len(events) == 0
 


### PR DESCRIPTION
All tests with `@pytest.mark.skipif('CI' in os.environ, reason='XXX')` pass except:
- `tests/api/test_yearn_vaults.py/test_query_yearn_vault_v2_history` due to obvious reasons -- subgraph isn't indexing.
- `tests/api/test_yearn_vaults.py/test_query_yearn_vault_history` 👇🏾 

```bash
FAILED rotkehlchen/tests/api/test_yearn_vaults.py::test_query_yearn_vault_history[ethereum_manager_connect_at_start0-True-default_mock_price_value0-True-True-ethereum_modules0-ethereum_accounts0] - AttributeError: 'DBHandler' object has no attribute 'get_yearn_vaults_events'
```