### PR TITLE
Nft api improvements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10830,66 +10830,6 @@ Querying  NFTs
    :statuscode 502: An external service used in the query such as opensea could not be reached or returned unexpected response.
 
 
-Querying a single NFT
-=====================
-
-.. http:post:: /api/(version)/nfts
-
-   .. note::
-      This endpoint also accepts parameters as query arguments.
-
-   Doing a POST on the NFTs endpoint will query the information for the provided NFT in the local database.
-
-   **Example Request**:
-
-   .. http:example:: curl wget httpie python-requests
-
-      POST /api/1/nfts HTTP/1.1
-      Host: localhost:5042
-      Content-Type: application/json;charset=UTF-8
-
-      {"nft_id": "_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041"}
-
-   :param string nft_id: Id of the NFT to query
-
-
-   **Example Response**:
-
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      {
-        "result": {
-          "id": "_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041",
-          "name": "yabir.eth",
-          "price_asset': "ETH",
-          "manually_input': false,
-          "is_lp": false,
-          "image_url": "https://openseauserdata.com/files/3f7c0c7d1ba51e61fe05ef53875f9f7e.svg",
-          "collection_name": "ENS Ethereum Name Service",
-          "usd_price": "0",
-          "price_in_asset": "0"
-        },
-        "message": ""
-      }
-
-
-   :resjson string id: The identifier of the specific NFT token for the given contract type. This is not a unique id across all NFTs.
-   :resjson string image_url: [Optional]. Link to the image of the NFT. Can be Null.
-   :resjson string name: [Optional] The name of the NFT. Can be Null.
-   :resjson string price_asset: The asset used to value the NFT.
-   :resjson string price_in_asset: The last known price of the NFT in the `price_asset` asset. Can be zero.
-   :resjson string usd_price: The last known price of the NFT in USD. Can be zero.
-   :reqjson string collection_name: [Optional]. Optional nfts collection_name to filter by.
-   :resjson boolean is_lp: [Optional] Whether the NFT is an LP position or not.
-   :statuscode 200: NFTs successfully queried
-   :statuscode 400: Provided JSON is in some way malformed
-   :statuscode 409: User is not logged in or nft module is not activated.
-   :statuscode 500: Internal rotki error
-
-
 Show NFT Balances
 =======================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1105,7 +1105,7 @@ Query the latest price of assets
 Get current price and custom price for NFT assets
 ==================================================
 
-.. http:get:: /api/(version)/nfts/prices
+.. http:post:: /api/(version)/nfts/prices
 
    Get current prices and whether they have been manually input or not for NFT assets.
 
@@ -1114,11 +1114,13 @@ Get current price and custom price for NFT assets
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/nfts/prices HTTP/1.1
+      POST /api/1/nfts/prices HTTP/1.1
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {}
+      {"lps_handling": "all_nfts"}
+
+    :reqjson string[optional] lps_handling: A flag to specify how to handle LP NFTs. Possible values are `'all_nfts'` (default), `'only_lps'` and `'exclude_lps'`. You can use 'only_lps' if you want to only include LPs NFTs in the result or you can use 'exclude_lps' if you want the NFTs not marked as LP positions.
 
 
    **Example Response**:
@@ -10749,7 +10751,7 @@ User selected Binance markets
 
 
 Querying  NFTs
-============================
+==============
 
 .. http:get:: /api/(version)/nfts
 
@@ -10828,6 +10830,66 @@ Querying  NFTs
    :statuscode 502: An external service used in the query such as opensea could not be reached or returned unexpected response.
 
 
+Querying a single NFT
+=====================
+
+.. http:post:: /api/(version)/nfts
+
+   .. note::
+      This endpoint also accepts parameters as query arguments.
+
+   Doing a POST on the NFTs endpoint will query the information for the provided NFT in the local database.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      POST /api/1/nfts HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {"nft_id": "_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041"}
+
+   :param string nft_id: Id of the NFT to query
+
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "result": {
+          "id": "_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041",
+          "name": "yabir.eth",
+          "price_asset': "ETH",
+          "manually_input': false,
+          "is_lp": false,
+          "image_url": "https://openseauserdata.com/files/3f7c0c7d1ba51e61fe05ef53875f9f7e.svg",
+          "collection_name": "ENS Ethereum Name Service",
+          "usd_price": "0",
+          "price_in_asset": "0"
+        },
+        "message": ""
+      }
+
+
+   :resjson string id: The identifier of the specific NFT token for the given contract type. This is not a unique id across all NFTs.
+   :resjson string image_url: [Optional]. Link to the image of the NFT. Can be Null.
+   :resjson string name: [Optional] The name of the NFT. Can be Null.
+   :resjson string price_asset: The asset used to value the NFT.
+   :resjson string price_in_asset: The last known price of the NFT in the `price_asset` asset. Can be zero.
+   :resjson string usd_price: The last known price of the NFT in USD. Can be zero.
+   :reqjson string collection_name: [Optional]. Optional nfts collection_name to filter by.
+   :resjson boolean is_lp: [Optional] Whether the NFT is an LP position or not.
+   :statuscode 200: NFTs successfully queried
+   :statuscode 400: Provided JSON is in some way malformed
+   :statuscode 409: User is not logged in or nft module is not activated.
+   :statuscode 500: Internal rotki error
+
+
 Show NFT Balances
 =======================
 
@@ -10861,6 +10923,7 @@ Show NFT Balances
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson list[string][optional] order_by_attributes: This is the list of attributes of the nft by which to order the results. By default we sort using ``name``.
    :reqjson list[bool][optional] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
+   :reqjson string[optional] lps_handling: A flag to specify how to handle LP NFTs. Possible values are `'all_nfts'` (default), `'only_lps'` and `'exclude_lps'`. You can use 'only_lps' if you want to only include LPs NFTs in the result or you can use 'exclude_lps' if you want the NFTs not marked as LP positions.
 
 
    **Example Response**:
@@ -10897,7 +10960,8 @@ Show NFT Balances
                     }],
                 },
                 "entries_found": 5,
-                "entries_total": 10
+                "entries_total": 10,
+                "total_usd_value": "2651.70"
             },
             "message": ""
         }
@@ -10906,6 +10970,7 @@ Show NFT Balances
    :resjson object entries: A mapping of ethereum addresses to list assets and balances. ``name`` can also be null. ``collection_name`` can be null if nft does not have a collection.
    :resjson int entries_found: The number of entries found for the current filter. Ignores pagination.
    :resjson int entries_total: The number of total entries ignoring all filters.
+   :resjson int total_usd_value: Total usd value of the nfts in the filter.
    :statuscode 200: NFT balances successfully queried
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 409: User is not logged in or nft module is not activated.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2257,7 +2257,7 @@ Querying ethereum transactions
                 "notes": "Burned 0.00863351371344 ETH for gas",
                 "sequence_index": 0,
                 "timestamp": 1642802807,
-                "extra_notes": null
+                "extra_data": null
               },
               "customized": false
             }, {
@@ -2357,7 +2357,7 @@ Querying ethereum transactions
                 "notes": "Send 0.096809163374771208 ETH 0x6e15887E2CEC81434C16D587709f64603b39b545 -> 0xA090e606E30bD747d4E6245a1517EbE430F0057e",
                 "sequence_index": 1,
                 "timestamp": 1642802807,
-                "extra_notes": null
+                "extra_data": null
               },
               "customized": true
             }]
@@ -2390,7 +2390,7 @@ Querying ethereum transactions
                 "notes": "Burned 0.00863351371344 ETH for gas",
                 "sequence_index": 0,
                 "timestamp": 1642802807,
-                "extra_notes": null
+                "extra_data": null
               },
               "customized": false
             }]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3057,7 +3057,8 @@ Get asset identifiers mappings
         "identifiers": [
             "eip155:1/erc20:0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
             "DCR",
-            "eip155:1/erc20:0xcC4eF9EEAF656aC1a2Ab886743E98e97E090ed38"
+            "eip155:1/erc20:0xcC4eF9EEAF656aC1a2Ab886743E98e97E090ed38",
+	    "_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041"
         ]
       }
 
@@ -3085,17 +3086,24 @@ Get asset identifiers mappings
                   "symbol": "DDF",
                   "evm_chain": "ethereum",
                   "asset_type": "evm token"
-              }
+              },
+	      "_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041"": {
+	          "name": "Mooncat 151",
+		  "asset_type": "nft",
+		  "collection_name": "Mooncats",
+		  "image_url": "https://myimg.com"
+	      }
           },
           "message": ""
       }
 
-   :resjson object result: A mapping of identifiers to their name, symbol & chain(if available).
-   :resjson string name: Name of the asset.
-   :resjson string symbol: Symbol of the asset.
-   :resjson string evm_chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token.
+   :resjson object result: A mapping of identifiers to (1) their name, symbol & chain(if available) if they are assets. And to (2) their name, collection name and image url if they are nfts.
+   :resjson string name: Name of the asset/nft.
+   :resjson string symbol: Symbol of the asset. Will only exist for non-nft assets.
+   :resjson string evm_chain: This value might not be included in all the results. Full name of the EVM chain where the asset is located if the asset is an EVM token. This is not included for NFTs.
    :resjson string custom_asset_type: This value might not be included in all the results. It represents the custom asset type for a custom asset.
-   :resjson bool is_custom_asset: A boolean to represent whether the asset is a custom asset or not.
+   :resjson string collection_name: Only included for NFTs. May be null if nft has no collection. If it does then this is its name.
+   :resjson string image_url: Only included for NFTs. May be null if nft has no image. If it does this is a url to the image.
    :statuscode 200: Assets successfully queried.
    :statuscode 400: One of the identifiers is not valid. Provided JSON is in some way malformed.
    :statuscode 500: Internal rotki error.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1120,7 +1120,7 @@ Get current price and custom price for NFT assets
 
       {"lps_handling": "all_nfts"}
 
-    :reqjson string[optional] lps_handling: A flag to specify how to handle LP NFTs. Possible values are `'all_nfts'` (default), `'only_lps'` and `'exclude_lps'`. You can use 'only_lps' if you want to only include LPs NFTs in the result or you can use 'exclude_lps' if you want the NFTs not marked as LP positions.
+    :reqjson string[optional] lps_handling: A flag to specify how to handle LP NFTs. Possible values are `'all_nfts'` (default), `'only_lps'` and `'exclude_lps'`. You can use 'only_lps' if you want to only include LPs NFTs in the result or you can use 'exclude_lps' if you want NFTs not marked as LP positions.
 
 
    **Example Response**:
@@ -10923,7 +10923,7 @@ Show NFT Balances
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson list[string][optional] order_by_attributes: This is the list of attributes of the nft by which to order the results. By default we sort using ``name``.
    :reqjson list[bool][optional] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
-   :reqjson string[optional] lps_handling: A flag to specify how to handle LP NFTs. Possible values are `'all_nfts'` (default), `'only_lps'` and `'exclude_lps'`. You can use 'only_lps' if you want to only include LPs NFTs in the result or you can use 'exclude_lps' if you want the NFTs not marked as LP positions.
+   :reqjson string[optional] lps_handling: A flag to specify how to handle LP NFTs. Possible values are `'all_nfts'` (default), `'only_lps'` and `'exclude_lps'`. You can use 'only_lps' if you want to only include LPs NFTs in the result or you can use 'exclude_lps' if you want NFTs not marked as LP positions.
 
 
    **Example Response**:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,11 +2,12 @@
 Changelog
 =========
 
-* :feature:`4940` Users will now be able to reset the modified information of all the assets without loosing the assets added manually.
+* :feature:`4940` Users will now be able to reset the assets database without losing any custom information they may have added.
 * :bug:`5124` Users will now correctly see all the events related to lending in the defi view.
 * :bug:`5126` APR and APY for borrowing and lending in Aave should properly show again.
 * :bug:`5128` Ethereum transactions where no value was transferred will now be correctly decoded.
 * :bug:`-` Uniswap V3 oracle will now correctly skip assets with no liquidity when querying prices.
+
 
 * :release:`1.26.1 <2022-11-04>`
 * :feature:`5144` Add HIFO and ACB options for cost basis method.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`4940` Users will now be able to reset the modified information of all the assets without loosing the assets added manually.
 * :bug:`5124` Users will now correctly see all the events related to lending in the defi view.
 * :bug:`5126` APR and APY for borrowing and lending in Aave should properly show again.
 * :bug:`5128` Ethereum transactions where no value was transferred will now be correctly decoded.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3900,7 +3900,6 @@ class RestAPI():
                 uniswap_nfts=uniswap_result['result'],
                 return_zero_values=True,
                 ignore_cache=True,
-
             )
 
         return self._eth_module_query(
@@ -3946,13 +3945,25 @@ class RestAPI():
             })
         return api_response(_wrap_in_ok_result(prices_information), status_code=HTTPStatus.OK)
 
-    def get_nfts_with_price(self) -> Response:
+    def get_nfts_with_price(self, lps_handling) -> Response:
         return self._api_query_for_eth_module(
             async_query=False,
             module_name='nfts',
             method='get_nfts_with_price',
             query_specific_balances_before=None,
+            lps_handling=lps_handling,
         )
+
+    def get_nft_by_id(self, nft_id: str) -> Response:
+        response = self._eth_module_query(
+            module_name='nfts',
+            method='get_single_nft',
+            query_specific_balances_before=None,
+            nft_id=nft_id,
+        )
+        status_code = _get_status_code_from_async_response(response)
+        result_dict = {'result': response['result'], 'message': response['message']}
+        return api_response(process_result(result_dict), status_code=status_code)
 
     def add_manual_latest_price(
             self,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3955,17 +3955,6 @@ class RestAPI():
             lps_handling=lps_handling,
         )
 
-    def get_nft_by_id(self, nft_id: str) -> Response:
-        response = self._eth_module_query(
-            module_name='nfts',
-            method='get_single_nft',
-            query_specific_balances_before=None,
-            nft_id=nft_id,
-        )
-        status_code = _get_status_code_from_async_response(response)
-        result_dict = {'result': response['result'], 'message': response['message']}
-        return api_response(process_result(result_dict), status_code=status_code)
-
     def add_manual_latest_price(
             self,
             from_asset: Asset,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -65,6 +65,7 @@ from rotkehlchen.balances.manual import (
 from rotkehlchen.chain.bitcoin.xpub import XpubManager
 from rotkehlchen.chain.ethereum.airdrops import check_airdrops
 from rotkehlchen.chain.ethereum.modules.eth2.constants import FREE_VALIDATORS_LIMIT
+from rotkehlchen.chain.ethereum.modules.nfts import NftLpHandling
 from rotkehlchen.chain.ethereum.names import find_ens_mappings, search_for_addresses_names
 from rotkehlchen.chain.ethereum.types import WeightedNode
 from rotkehlchen.chain.evm.manager import EvmManager
@@ -177,7 +178,7 @@ from rotkehlchen.types import (
     TradeType,
     UserNote,
 )
-from rotkehlchen.utils.misc import NftLpHandling, combine_dicts
+from rotkehlchen.utils.misc import combine_dicts
 from rotkehlchen.utils.snapshots import parse_import_snapshot_data
 from rotkehlchen.utils.version_check import get_current_version
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -177,7 +177,7 @@ from rotkehlchen.types import (
     TradeType,
     UserNote,
 )
-from rotkehlchen.utils.misc import combine_dicts
+from rotkehlchen.utils.misc import NftLpHandling, combine_dicts
 from rotkehlchen.utils.snapshots import parse_import_snapshot_data
 from rotkehlchen.utils.version_check import get_current_version
 
@@ -3945,7 +3945,7 @@ class RestAPI():
             })
         return api_response(_wrap_in_ok_result(prices_information), status_code=HTTPStatus.OK)
 
-    def get_nfts_with_price(self, lps_handling) -> Response:
+    def get_nfts_with_price(self, lps_handling: NftLpHandling) -> Response:
         return self._api_query_for_eth_module(
             async_query=False,
             module_name='nfts',

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -110,7 +110,6 @@ from rotkehlchen.api.v1.schemas import (
     SingleAssetIdentifierSchema,
     SingleAssetWithOraclesIdentifierSchema,
     SingleFileSchema,
-    SingleNftSchema,
     SnapshotEditingSchema,
     SnapshotImportingSchema,
     SnapshotQuerySchema,
@@ -2430,17 +2429,11 @@ class AvalancheTransactionsResource(BaseMethodView):
 
 class NFTSResource(BaseMethodView):
     get_schema = AsyncIgnoreCacheQueryArgumentSchema()
-    post_schema = SingleNftSchema()
 
     @require_loggedin_user()
     @use_kwargs(get_schema, location='json_and_query')
     def get(self, async_query: bool, ignore_cache: bool) -> Response:
         return self.rest_api.get_nfts(async_query=async_query, ignore_cache=ignore_cache)
-
-    @require_loggedin_user()
-    @use_kwargs(post_schema, location='json_and_query')
-    def post(self, nft_id: str) -> Response:
-        return self.rest_api.get_nft_by_id(nft_id=nft_id)
 
 
 class NFTSBalanceResource(BaseMethodView):

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -95,7 +95,6 @@ from rotkehlchen.api.v1.schemas import (
     ManualPriceRegisteredSchema,
     ManualPriceSchema,
     ModifyEvmTokenSchema,
-    NFTFilterQuerySchema2,
     NameDeleteSchema,
     NamedEthereumModuleDataSchema,
     NamedOracleCacheCreateSchema,
@@ -103,6 +102,7 @@ from rotkehlchen.api.v1.schemas import (
     NamedOracleCacheSchema,
     NewUserSchema,
     NFTFilterQuerySchema,
+    NFTFilterQuerySchema2,
     OptionalEthereumAddressSchema,
     QueriedAddressesSchema,
     RequiredEthereumAddressSchema,
@@ -197,6 +197,7 @@ from rotkehlchen.types import (
     TradeType,
     UserNote,
 )
+from rotkehlchen.utils.misc import NftLpHandling
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.bitcoin.hdkey import HDKey
@@ -2437,7 +2438,7 @@ class NFTSResource(BaseMethodView):
         return self.rest_api.get_nfts(async_query=async_query, ignore_cache=ignore_cache)
 
     @require_loggedin_user()
-    @use_kwargs(get_schema, location='json_and_query')
+    @use_kwargs(post_schema, location='json_and_query')
     def post(self, nft_id: str) -> Response:
         return self.rest_api.get_nft_by_id(nft_id=nft_id)
 
@@ -2463,7 +2464,7 @@ class NFTSPricesResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(post_schema, location='json_and_query')
-    def post(self, lps_handling) -> Response:
+    def post(self, lps_handling: NftLpHandling) -> Response:
         return self.rest_api.get_nfts_with_price(lps_handling)
 
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -102,7 +102,7 @@ from rotkehlchen.api.v1.schemas import (
     NamedOracleCacheSchema,
     NewUserSchema,
     NFTFilterQuerySchema,
-    NFTFilterQuerySchema2,
+    NFTLpFilterSchema,
     OptionalEthereumAddressSchema,
     QueriedAddressesSchema,
     RequiredEthereumAddressSchema,
@@ -153,6 +153,7 @@ from rotkehlchen.assets.asset import (
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.bitcoin.xpub import XpubData
+from rotkehlchen.chain.ethereum.modules.nfts import NftLpHandling
 from rotkehlchen.chain.ethereum.types import NodeName, WeightedNode
 from rotkehlchen.data_import.manager import DataImportSource
 from rotkehlchen.db.filtering import (
@@ -197,7 +198,6 @@ from rotkehlchen.types import (
     TradeType,
     UserNote,
 )
-from rotkehlchen.utils.misc import NftLpHandling
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.bitcoin.hdkey import HDKey
@@ -2460,7 +2460,7 @@ class NFTSBalanceResource(BaseMethodView):
 
 
 class NFTSPricesResource(BaseMethodView):
-    post_schema = NFTFilterQuerySchema2
+    post_schema = NFTLpFilterSchema
 
     @require_loggedin_user()
     @use_kwargs(post_schema, location='json_and_query')

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -95,6 +95,7 @@ from rotkehlchen.api.v1.schemas import (
     ManualPriceRegisteredSchema,
     ManualPriceSchema,
     ModifyEvmTokenSchema,
+    NFTFilterQuerySchema2,
     NameDeleteSchema,
     NamedEthereumModuleDataSchema,
     NamedOracleCacheCreateSchema,
@@ -109,6 +110,7 @@ from rotkehlchen.api.v1.schemas import (
     SingleAssetIdentifierSchema,
     SingleAssetWithOraclesIdentifierSchema,
     SingleFileSchema,
+    SingleNftSchema,
     SnapshotEditingSchema,
     SnapshotImportingSchema,
     SnapshotQuerySchema,
@@ -2427,11 +2429,17 @@ class AvalancheTransactionsResource(BaseMethodView):
 
 class NFTSResource(BaseMethodView):
     get_schema = AsyncIgnoreCacheQueryArgumentSchema()
+    post_schema = SingleNftSchema()
 
     @require_loggedin_user()
     @use_kwargs(get_schema, location='json_and_query')
     def get(self, async_query: bool, ignore_cache: bool) -> Response:
         return self.rest_api.get_nfts(async_query=async_query, ignore_cache=ignore_cache)
+
+    @require_loggedin_user()
+    @use_kwargs(get_schema, location='json_and_query')
+    def post(self, nft_id: str) -> Response:
+        return self.rest_api.get_nft_by_id(nft_id=nft_id)
 
 
 class NFTSBalanceResource(BaseMethodView):
@@ -2451,10 +2459,12 @@ class NFTSBalanceResource(BaseMethodView):
 
 
 class NFTSPricesResource(BaseMethodView):
+    post_schema = NFTFilterQuerySchema2
 
     @require_loggedin_user()
-    def get(self) -> Response:
-        return self.rest_api.get_nfts_with_price()
+    @use_kwargs(post_schema, location='json_and_query')
+    def post(self, lps_handling) -> Response:
+        return self.rest_api.get_nfts_with_price(lps_handling)
 
 
 class StakingResource(BaseMethodView):

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -105,7 +105,7 @@ from rotkehlchen.types import (
     UserNote,
 )
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
-from rotkehlchen.utils.misc import create_order_by_rules_list, ts_now
+from rotkehlchen.utils.misc import NftLpHandling, create_order_by_rules_list, ts_now
 from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
 
 from .fields import (
@@ -2717,6 +2717,7 @@ class NFTFilterQuerySchema(
     name = fields.String(load_default=None)
     collection_name = fields.String(load_default=None)
     ignored_assets_handling = SerializableEnumField(enum_class=IgnoredAssetsHandling, load_default=IgnoredAssetsHandling.NONE)  # noqa: E501
+    lps_handling = SerializableEnumField(enum_class=NftLpHandling, load_default=NftLpHandling.ALL_NFTS)
 
     def __init__(self, db: 'DBHandler') -> None:
         super().__init__()
@@ -2752,9 +2753,18 @@ class NFTFilterQuerySchema(
             name=data['name'],
             collection_name=data['collection_name'],
             ignored_assets_filter_params=ignored_assets_filter_params,
+            lps_handling=data['lps_handling']
         )
         return {
             'async_query': data['async_query'],
             'ignore_cache': data['ignore_cache'],
             'filter_query': filter_query,
         }
+
+
+class NFTFilterQuerySchema2(Schema):
+    lps_handling = SerializableEnumField(enum_class=NftLpHandling, load_default=NftLpHandling.ALL_NFTS)
+
+
+class SingleNftSchema(Schema):
+    nft_id = fields.String(required=True)

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2768,7 +2768,3 @@ class NFTFilterQuerySchema(
             'ignore_cache': data['ignore_cache'],
             'filter_query': filter_query,
         }
-
-
-class SingleNftSchema(Schema):
-    nft_id = fields.String(required=True)

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2717,7 +2717,10 @@ class NFTFilterQuerySchema(
     name = fields.String(load_default=None)
     collection_name = fields.String(load_default=None)
     ignored_assets_handling = SerializableEnumField(enum_class=IgnoredAssetsHandling, load_default=IgnoredAssetsHandling.NONE)  # noqa: E501
-    lps_handling = SerializableEnumField(enum_class=NftLpHandling, load_default=NftLpHandling.ALL_NFTS)
+    lps_handling = SerializableEnumField(
+        enum_class=NftLpHandling,
+        load_default=NftLpHandling.ALL_NFTS,
+    )
 
     def __init__(self, db: 'DBHandler') -> None:
         super().__init__()
@@ -2753,7 +2756,7 @@ class NFTFilterQuerySchema(
             name=data['name'],
             collection_name=data['collection_name'],
             ignored_assets_filter_params=ignored_assets_filter_params,
-            lps_handling=data['lps_handling']
+            lps_handling=data['lps_handling'],
         )
         return {
             'async_query': data['async_query'],
@@ -2763,7 +2766,10 @@ class NFTFilterQuerySchema(
 
 
 class NFTFilterQuerySchema2(Schema):
-    lps_handling = SerializableEnumField(enum_class=NftLpHandling, load_default=NftLpHandling.ALL_NFTS)
+    lps_handling = SerializableEnumField(
+        enum_class=NftLpHandling,
+        load_default=NftLpHandling.ALL_NFTS,
+    )
 
 
 class SingleNftSchema(Schema):

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -44,6 +44,7 @@ from rotkehlchen.chain.bitcoin.hdkey import HDKey, XpubType
 from rotkehlchen.chain.bitcoin.utils import is_valid_btc_address, scriptpubkey_to_btc_address
 from rotkehlchen.chain.constants import NON_BITCOIN_CHAINS
 from rotkehlchen.chain.ethereum.manager import EthereumManager
+from rotkehlchen.chain.ethereum.modules.nfts import NftLpHandling
 from rotkehlchen.chain.ethereum.types import ETHERSCAN_NODE_NAME
 from rotkehlchen.chain.substrate.types import (
     KusamaAddress,
@@ -105,7 +106,7 @@ from rotkehlchen.types import (
     UserNote,
 )
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
-from rotkehlchen.utils.misc import NftLpHandling, create_order_by_rules_list, ts_now
+from rotkehlchen.utils.misc import create_order_by_rules_list, ts_now
 from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
 
 from .fields import (
@@ -2708,7 +2709,15 @@ class EditCustomAssetSchema(BaseCustomAssetSchema):
         return {'custom_asset': custom_asset}
 
 
+class NFTLpFilterSchema(Schema):
+    lps_handling = SerializableEnumField(
+        enum_class=NftLpHandling,
+        load_default=NftLpHandling.ALL_NFTS,
+    )
+
+
 class NFTFilterQuerySchema(
+        NFTLpFilterSchema,
         AsyncIgnoreCacheQueryArgumentSchema,
         DBPaginationSchema,
         DBOrderBySchema,
@@ -2717,10 +2726,6 @@ class NFTFilterQuerySchema(
     name = fields.String(load_default=None)
     collection_name = fields.String(load_default=None)
     ignored_assets_handling = SerializableEnumField(enum_class=IgnoredAssetsHandling, load_default=IgnoredAssetsHandling.NONE)  # noqa: E501
-    lps_handling = SerializableEnumField(
-        enum_class=NftLpHandling,
-        load_default=NftLpHandling.ALL_NFTS,
-    )
 
     def __init__(self, db: 'DBHandler') -> None:
         super().__init__()
@@ -2763,13 +2768,6 @@ class NFTFilterQuerySchema(
             'ignore_cache': data['ignore_cache'],
             'filter_query': filter_query,
         }
-
-
-class NFTFilterQuerySchema2(Schema):
-    lps_handling = SerializableEnumField(
-        enum_class=NftLpHandling,
-        load_default=NftLpHandling.ALL_NFTS,
-    )
 
 
 class SingleNftSchema(Schema):

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -8,7 +8,6 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.eth2 import ETH2_DEPOSITS_PREFIX, DBEth2
-from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
 from rotkehlchen.errors.api import PremiumPermissionError
 from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.fval import FVal
@@ -41,6 +40,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
+    from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
     from rotkehlchen.externalapis.beaconchain import BeaconChain
 
 logger = logging.getLogger(__name__)
@@ -368,7 +368,7 @@ class Eth2(EthereumModule):
     def get_validator_daily_stats(
             self,
             cursor: 'DBCursor',
-            filter_query: Eth2DailyStatsFilterQuery,
+            filter_query: 'Eth2DailyStatsFilterQuery',
             only_cache: bool,
             msg_aggregator: MessagesAggregator,
     ) -> Tuple[List[ValidatorDailyStats], int, FVal, FVal]:

--- a/rotkehlchen/chain/ethereum/modules/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nfts.py
@@ -166,18 +166,6 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):  # lgtm [py/miss
             entries_limit=FREE_NFT_LIMIT,
         )
 
-    def get_single_nft(self, nft_id: str) -> Optional[Dict[str, Any]]:
-        with self.db.conn.read_ctx() as cursor:
-            query, bindings = NFTFilterQuery.make(
-                nft_id=nft_id,
-            ).prepare(with_pagination=False)
-            cursor.execute(NFT_INFO_SQL_QUERY + query, bindings)
-            db_entry = cursor.fetchone()
-        if db_entry is None:
-            return None
-
-        return _serialize_nft_from_db(db_entry)
-
     def get_db_nft_balances(self, filter_query: NFTFilterQuery) -> Dict[str, Any]:
         """Filters (with `filter_query`) and returns cached nft balances in the nfts table"""
         entries = defaultdict(list)

--- a/rotkehlchen/chain/ethereum/modules/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nfts.py
@@ -9,7 +9,6 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.ethereum.modules.uniswap.v3.types import AddressToUniswapV3LPBalances
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.db.filtering import NFTFilterQuery
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.externalapis.opensea import NFT, Opensea
@@ -27,6 +26,7 @@ from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.filtering import NFTFilterQuery
     from rotkehlchen.premium.premium import Premium
 
 logger = logging.getLogger(__name__)
@@ -179,7 +179,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):  # lgtm [py/miss
             entries_limit=FREE_NFT_LIMIT,
         )
 
-    def get_db_nft_balances(self, filter_query: NFTFilterQuery) -> Dict[str, Any]:
+    def get_db_nft_balances(self, filter_query: 'NFTFilterQuery') -> Dict[str, Any]:
         """Filters (with `filter_query`) and returns cached nft balances in the nfts table"""
         entries = defaultdict(list)
         query, bindings = filter_query.prepare()
@@ -198,8 +198,8 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):  # lgtm [py/miss
             entries_found = 0
             for db_entry in cursor:
                 _, _, usd_price = _deserialize_nft_price(
-                    last_price=db_entry[2],
-                    last_price_asset=db_entry[3],
+                    last_price=db_entry[0],
+                    last_price_asset=db_entry[1],
                 )
                 total_usd_value += usd_price
                 entries_found += 1

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3435,7 +3435,7 @@ class DBHandler:
         result = {}
         with self.conn.read_ctx() as cursor:
             cursor.execute(
-                f'SELECT identifier, name, collection_name FROM nfts WHERE '
+                f'SELECT identifier, name, collection_name, image_url FROM nfts WHERE '
                 f'identifier IN ({",".join("?" * len(identifiers))})',
                 identifiers,
             )
@@ -3445,6 +3445,7 @@ class DBHandler:
                     'name': entry[1],
                     'asset_type': serialized_nft_type,
                     'collection_name': entry[2],
+                    'image_url': entry[3],
                 }
 
         return result

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -11,7 +11,6 @@ from rotkehlchen.chain.ethereum.modules.eth2.structures import (
 )
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.timing import DAY_IN_SECONDS
-from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
 from rotkehlchen.db.utils import form_query_to_filter_timestamps
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.fval import FVal
@@ -21,6 +20,7 @@ from rotkehlchen.types import ChecksumEvmAddress, Timestamp, Tuple, Union
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
+    from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
 
 ETH2_DEPOSITS_PREFIX = 'eth2_deposits'
 
@@ -154,7 +154,7 @@ class DBEth2():
     def get_validator_daily_stats_and_limit_info(
             self,
             cursor: 'DBCursor',
-            filter_query: Eth2DailyStatsFilterQuery,
+            filter_query: 'Eth2DailyStatsFilterQuery',
     ) -> Tuple[List[ValidatorDailyStats], int, FVal, FVal]:
         """Gets all eth2 daily stats for the query from the DB
 
@@ -186,7 +186,7 @@ class DBEth2():
     def get_validator_daily_stats(
             self,
             cursor: 'DBCursor',
-            filter_query: Eth2DailyStatsFilterQuery,
+            filter_query: 'Eth2DailyStatsFilterQuery',
     ) -> List[ValidatorDailyStats]:
         """Gets all DB entries for validator daily stats according to the given filter"""
         query, bindings = filter_query.prepare()

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -1171,13 +1171,11 @@ class NFTFilterQuery(DBFilterQuery):
                 value=NftLpHandling.ONLY_LPS == lps_handling,
             ))
         if nft_id is not None:
-            filters.append(
-                DBSubStringFilter(
-                    and_op=True,
-                    field='identifier',
-                    search_string=nft_id,
-                )
-            )
+            filters.append(DBSubStringFilter(
+                and_op=True,
+                field='identifier',
+                search_string=nft_id,
+            ))
         filter_query.filters = filters
         return filter_query
 

--- a/rotkehlchen/db/reports.py
+++ b/rotkehlchen/db/reports.py
@@ -18,7 +18,6 @@ from pysqlcipher3 import dbapi2 as sqlcipher
 from rotkehlchen.accounting.constants import FREE_PNL_EVENTS_LIMIT, FREE_REPORTS_LOOKUP_LIMIT
 from rotkehlchen.accounting.pnl import PnlTotals
 from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
-from rotkehlchen.db.filtering import ReportDataFilterQuery
 from rotkehlchen.db.settings import DBSettings
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -32,6 +31,7 @@ log = RotkehlchenLogsAdapter(logger)
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
+    from rotkehlchen.db.filtering import ReportDataFilterQuery
 
 
 @overload
@@ -275,7 +275,7 @@ class DBAccountingReports():
 
     def get_report_data(
             self,
-            filter_: ReportDataFilterQuery,
+            filter_: 'ReportDataFilterQuery',
             with_limit: bool,
     ) -> Tuple[List[ProcessedAccountingEvent], int]:
         """Retrieve the event data of a PnL report depending on the given filter

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -49,7 +49,7 @@ log = RotkehlchenLogsAdapter(logger)
 @dataclasses.dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=False)  # noqa: E501
 class Collection:
     name: str
-    banner_image: str
+    banner_image: Optional[str]
     description: Optional[str]
     large_image: str
     floor_price: Optional[FVal] = None

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -257,6 +257,20 @@ def deserialize_optional_to_optional_fval(
     return deserialize_fval(value=value, name=name, location=location)
 
 
+def deserialize_fval_or_zero(
+        value: Optional[AcceptableFValInitInput],
+        name: str,
+        location: str,
+) -> FVal:
+    """
+    Deserializes an FVal from a field that was optional and if None returns ZERO
+    """
+    if value is None:
+        return ZERO
+
+    return deserialize_fval(value=value, name=name, location=location)
+
+
 def deserialize_asset_amount(amount: AcceptableFValInitInput) -> AssetAmount:
     try:
         result = AssetAmount(FVal(amount))

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1350,8 +1350,8 @@ def test_ignored_assets(rotkehlchen_api_server, ethereum_accounts):
 
 @pytest.mark.parametrize('should_mock_price_queries', [True])
 @pytest.mark.parametrize('default_mock_price_value', [ONE])
-def test_extra_notes_serialization(rotkehlchen_api_server, ethereum_accounts):
-    """This test tests that decoded transactions correctly include the extra_data key"""
+def test_extra_data_serialization(rotkehlchen_api_server, ethereum_accounts):
+    """Assert decoded transactions correctly include the extra_data key"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     db = rotki.data.db
     dbethtx = DBEthTx(db)

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -232,7 +232,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         'offset': 2,
     })
     result = assert_proper_response_with_result(response)
-    assert result['entries_found'] == 2
+    assert result['entries_found'] == 4
     assert result['entries_total'] == 4
 
     # ignore an nft
@@ -251,6 +251,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
     ), json={'async_query': False, 'ignore_cache': False, 'ignored_assets_handling': 'none'})
     result = assert_proper_response_with_result(response)
     assert result['entries_found'] == 4
+    assert result['entries_total'] == 4
     assert result['entries'][TEST_ACC4][0]['id'] == NFT_ID_FOR_TEST_ACC4
     assert result['entries'][TEST_ACC5][0]['id'] == NFT_ID_FOR_TEST_ACC5
     assert result['entries'][TEST_ACC6][0]['id'] == NFT_ID_FOR_TEST_ACC6_1
@@ -261,6 +262,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
     ), json={'async_query': False, 'ignore_cache': False, 'ignored_assets_handling': 'exclude'})
     result = assert_proper_response_with_result(response)
     assert result['entries_found'] == 2
+    assert result['entries_total'] == 4
     expected_nfts_without_ignored = {NFT_ID_FOR_TEST_ACC5, NFT_ID_FOR_TEST_ACC6_1}
     assert {entry[0]['id'] for entry in result['entries'].values()} == expected_nfts_without_ignored  # noqa: E501
     response = requests.get(api_url_for(
@@ -269,6 +271,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
     ), json={'async_query': False, 'ignore_cache': False, 'ignored_assets_handling': 'show only'})
     result = assert_proper_response_with_result(response)
     assert result['entries_found'] == 2
+    assert result['entries_total'] == 4
     assert result['entries'][TEST_ACC4][0]['id'] == NFT_ID_FOR_TEST_ACC4
     assert result['entries'][TEST_ACC6][0]['id'] == NFT_ID_FOR_TEST_ACC6_2
 
@@ -293,19 +296,14 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
     # check that getting information from the database works as expected
     response = requests.post(api_url_for(
         rotkehlchen_api_server,
-        'nftsresource',
+        'assetsmappingresource',
     ), json={
-        'nft_id': NFT_ID_FOR_TEST_ACC4,
+        'identifiers': [NFT_ID_FOR_TEST_ACC4],
     })
-    result = assert_proper_response_with_result(response)
-    result.pop('usd_price')
-    result.pop('price_in_asset')
+    result = assert_proper_response_with_result(response)[NFT_ID_FOR_TEST_ACC4]
     assert result == {
-        'id': '_nft_0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85_26612040215479394739615825115912800930061094786769410446114278812336794170041',  # noqa: E501
         'name': 'yabir.eth',
-        'price_asset': 'ETH',
-        'manually_input': False,
-        'is_lp': False,
+        'asset_type': 'nft',
         'image_url': 'https://openseauserdata.com/files/3f7c0c7d1ba51e61fe05ef53875f9f7e.svg',
         'collection_name': 'ENS: Ethereum Name Service',
     }

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -10,7 +10,7 @@ from flaky import flaky
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.interfaces.ammswap.types import LiquidityPoolAsset
-from rotkehlchen.chain.ethereum.modules.nfts import FREE_NFT_LIMIT
+from rotkehlchen.chain.ethereum.modules.nfts import FREE_NFT_LIMIT, NftLpHandling
 from rotkehlchen.chain.ethereum.modules.uniswap.v3.types import NFTLiquidityPool
 from rotkehlchen.chain.ethereum.types import string_to_evm_address
 from rotkehlchen.constants.misc import ZERO
@@ -25,7 +25,6 @@ from rotkehlchen.tests.utils.api import (
 )
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Price
-from rotkehlchen.utils.misc import NftLpHandling
 
 TEST_ACC1 = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'  # lefteris.eth
 TEST_ACC2 = '0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF'

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -135,6 +135,6 @@ def requires_env(allowed_envs: List[TestEnvironment]):
         env = TestEnvironment.STANDARD
 
     return pytest.mark.skipif(
-        env not in allowed_envs,
+        'CI' in os.environ and env not in allowed_envs,
         reason=f'Not suitable envrionment {env} for current test',
     )

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -9,7 +9,8 @@ from rotkehlchen.accounting.pnl import PNL, PnlTotals
 from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
-from rotkehlchen.db.reports import DBAccountingReports, ReportDataFilterQuery
+from rotkehlchen.db.filtering import ReportDataFilterQuery
+from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TradeType

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -7,7 +7,6 @@ import platform
 import re
 import sys
 import time
-from enum import auto
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
@@ -31,7 +30,6 @@ from eth_utils.address import to_checksum_address
 from rotkehlchen.errors.serialization import ConversionError, DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp, TimestampMS
-from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
 
 if TYPE_CHECKING:
     from requests import Session
@@ -396,9 +394,3 @@ def create_order_by_rules_list(
     order_by_attribute = data['order_by_attributes'] if data['order_by_attributes'] is not None else [default_order_by_field]  # noqa: E501
     ascending = data['ascending'] if data['ascending'] is not None else [is_ascending_by_default]
     return list(zip(order_by_attribute, ascending))
-
-
-class NftLpHandling(SerializableEnumMixin):
-    ALL_NFTS = auto()
-    ONLY_LPS = auto()
-    EXCLUDE_LPS = auto()

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -1,5 +1,6 @@
 import calendar
 import datetime
+from enum import auto
 import functools
 import logging
 import operator
@@ -30,6 +31,7 @@ from eth_utils.address import to_checksum_address
 from rotkehlchen.errors.serialization import ConversionError, DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp, TimestampMS
+from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
 
 if TYPE_CHECKING:
     from requests import Session
@@ -394,3 +396,9 @@ def create_order_by_rules_list(
     order_by_attribute = data['order_by_attributes'] if data['order_by_attributes'] is not None else [default_order_by_field]  # noqa: E501
     ascending = data['ascending'] if data['ascending'] is not None else [is_ascending_by_default]
     return list(zip(order_by_attribute, ascending))
+
+
+class NftLpHandling(SerializableEnumMixin):
+    ALL_NFTS = auto()
+    ONLY_LPS = auto()
+    EXCLUDE_LPS = auto()

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -1,6 +1,5 @@
 import calendar
 import datetime
-from enum import auto
 import functools
 import logging
 import operator
@@ -8,6 +7,7 @@ import platform
 import re
 import sys
 import time
+from enum import auto
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,


### PR DESCRIPTION
This PR modifies different parts of the NFTs API doing the following:

- Filter the NFTs price endpoint by the `is_lp` attribute
- Filter the NFTs balance endpoint by the `is_lp` attribute
- Allow to retrieve a single NFT by id
- Fix error counting NFTs when pagination is used
- Add missing tests
- Add missing entry in the changelog

