### PR TITLE
Allow more trade formats from binance CSV exports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`5170` Fix issue where loopring balances is not updated when blockchain balances are manually refreshed.
+* :bug:`-` Users will now be able to import binance trades of type Buy + Transaction Related from CSV exports.
 * :bug:`5127` Uniswap V3 swap transactions are now decoded properly.
 * :bug:`5124` Users will now correctly see all the events related to lending in the defi view.
 * :bug:`5126` APR and APY for borrowing and lending in Aave should properly show again.

--- a/rotkehlchen/data_import/importers/binance.py
+++ b/rotkehlchen/data_import/importers/binance.py
@@ -110,15 +110,12 @@ class BinanceTradeEntry(BinanceMultipleEntry):
             - (Buy + Transaction Related) * N
         """
         counted = Counter(requested_operations)
-        fee = counted.pop('Fee', None)
+        counted.pop('Fee', None)
         keys = set(counted.keys())
         return (
-            (
-                keys == {'Buy', 'Sell'} and counted['Buy'] % 2 == 0 and counted['Sell'] % 2 == 0 and  # noqa: E501
-                (not fee or counted['Sell'] + counted['Buy'] == fee * 2)
-            ) or
-            (keys == {'Buy'} and counted['Buy'] % 2 == 0 and (not fee or counted['Buy'] == fee * 2)) or  # noqa: E501
-            (keys == {'Sell'} and counted['Sell'] % 2 == 0 and (not fee or counted['Sell'] == fee * 2)) or  # noqa: E501
+            (keys == {'Buy', 'Sell'} and counted['Buy'] % 2 == 0 and counted['Sell'] % 2 == 0) or
+            (keys == {'Buy'} and counted['Buy'] % 2 == 0) or  # noqa: E501
+            (keys == {'Sell'} and counted['Sell'] % 2 == 0) or  # noqa: E501
             (keys == {'Transaction Related'} and counted['Transaction Related'] % 2 == 0) or
             (keys == {'Small assets exchange BNB'} and counted['Small assets exchange BNB'] % 2 == 0) or  # noqa: E501
             (keys == {'ETH 2.0 Staking'} and counted['ETH 2.0 Staking'] % 2 == 0) or

--- a/rotkehlchen/tests/data/binance_history.csv
+++ b/rotkehlchen/tests/data/binance_history.csv
@@ -46,3 +46,5 @@ User_ID,UTC_Time,Account,Operation,Coin,Change,Remark
 1,2020-12-01 15:51:47,Spot,Fee,BNB,-0.041427214681599996,""
 1,2020-12-01 15:51:47,Spot,Fee,BNB,-0.0462623227152,""
 1,2020-12-01 15:51:47,Spot,Buy,BTC,0.09564009919439999,""
+1,2020-12-02 22:30:01,Spot,Buy,IOTA,882,"Trade with no fee for test"
+1,2020-12-02 22:30:01,Spot,Buy,USDT,-1146.3354,

--- a/rotkehlchen/tests/data/binance_history.csv
+++ b/rotkehlchen/tests/data/binance_history.csv
@@ -40,3 +40,9 @@ User_ID,UTC_Time,Account,Operation,Coin,Change,Remark
 1,2020-11-20 22:30:01,Spot,Buy,USDT,-1146.3354,
 1,2020-12-01 20:06:44,Spot,Withdraw,KNC,-0.16,Withdraw fee is included
 1,2020-12-01 20:06:45,Spot,ABC,ETH,-15,This is to test non-existent row type
+1,2020-12-01 15:51:47,Spot,Transaction Related,ETH,-1.01065076,""
+1,2020-12-01 15:51:47,Spot,Buy,BTC,0.10680859385,""
+1,2020-12-01 15:51:47,Spot,Transaction Related,ETH,-0.9049715199999999,""
+1,2020-12-01 15:51:47,Spot,Fee,BNB,-0.041427214681599996,""
+1,2020-12-01 15:51:47,Spot,Fee,BNB,-0.0462623227152,""
+1,2020-12-01 15:51:47,Spot,Buy,BTC,0.09564009919439999,""

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -1343,6 +1343,32 @@ def assert_binance_import_results(rotki: Rotkehlchen):
             link='',
             notes='Imported from binance CSV file. Binance operation: Buy / Sell',
         ),
+        Trade(
+            timestamp=Timestamp(1606837907),
+            location=Location.BINANCE,
+            base_asset=A_BTC,
+            quote_asset=A_ETH,
+            trade_type=TradeType.BUY,
+            amount=AssetAmount(FVal('0.10680859385')),
+            rate=Price(FVal('0.1056829896907216494845360825')),
+            fee=Fee(FVal('-0.0462623227152')),
+            fee_currency=EvmToken('eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52'),
+            link='',
+            notes='Imported from binance CSV file. Binance operation: Buy / Sell',
+        ),
+        Trade(
+            timestamp=Timestamp(1606837907),
+            location=Location.BINANCE,
+            base_asset=A_BTC,
+            quote_asset=A_ETH,
+            trade_type=TradeType.BUY,
+            amount=AssetAmount(FVal('0.09564009919439999')),
+            rate=Price(FVal('0.1056829934210526322069222047')),
+            fee=Fee(FVal('-0.041427214681599996')),
+            fee_currency=EvmToken('eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52'),
+            link='',
+            notes='Imported from binance CSV file. Binance operation: Buy / Sell',
+        ),
     ]
     expected_asset_movements = [
         AssetMovement(

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -1369,6 +1369,19 @@ def assert_binance_import_results(rotki: Rotkehlchen):
             link='',
             notes='Imported from binance CSV file. Binance operation: Buy / Sell',
         ),
+        Trade(
+            timestamp=Timestamp(1606948201),
+            location=Location.BINANCE,
+            base_asset=CryptoAsset('IOTA'),
+            quote_asset=A_USDT,
+            trade_type=TradeType.BUY,
+            amount=AssetAmount(FVal('882')),
+            rate=Price(FVal('0.7694083249980764791875048088')),
+            fee=None,
+            fee_currency=None,
+            link='',
+            notes='Imported from binance CSV file. Binance operation: Buy / Sell',
+        ),
     ]
     expected_asset_movements = [
         AssetMovement(


### PR DESCRIPTION
Allows to import trades of the form Buy + Transaction Related from CSV imports

**Note**

Before Alexey made the importer in a way that didn't allow for trades with no fee when grouping multiple in the same timestamp but after discussing this we agreed that it doesn't make much sense.

The case is for example when we have 3 buys and 2 fees. Before the behavior was skipping and now it will create 2 trades with 2 fees and 1 trade with no fee. A row testing this was added to the test also
