### PR TITLE
Adds an independent lint step to check for missing return types

### DIFF
--- a/frontend/app/src/main.ts
+++ b/frontend/app/src/main.ts
@@ -38,7 +38,7 @@ if (import.meta.env.MODE === 'production' && import.meta.env.VITE_TEST) {
 
 Vue.directive('blur', {
   inserted: function (el) {
-    el.onfocus = ({ target }) => {
+    el.onfocus = ({ target }): void => {
       if (!target) {
         return;
       }
@@ -57,7 +57,7 @@ if (isDevelopment) {
 setActivePinia(pinia);
 
 new Vue({
-  setup() {
+  setup(): void {
     provide('premium', usePremiumApi());
   },
   vuetify,

--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -254,14 +254,14 @@ const loading: ComputedRef<boolean> = computed(
     get(isQueryingBlockchain)
 );
 
-const createAccount = () => {
+const createAccount = (): void => {
   set(accountToEdit, null);
   set(dialogTitle, t('blockchain_balances.form_dialog.add_title').toString());
   set(dialogSubtitle, '');
   set(openDialog, true);
 };
 
-const editAccount = (account: BlockchainAccountWithBalance) => {
+const editAccount = (account: BlockchainAccountWithBalance): void => {
   set(accountToEdit, account);
   set(dialogTitle, t('blockchain_balances.form_dialog.edit_title').toString());
   set(
@@ -271,7 +271,7 @@ const editAccount = (account: BlockchainAccountWithBalance) => {
   set(openDialog, true);
 };
 
-const clearDialog = async () => {
+const clearDialog = async (): Promise<void> => {
   set(openDialog, false);
   setTimeout(async () => {
     if (get(form)) {
@@ -281,7 +281,7 @@ const clearDialog = async () => {
   }, 300);
 };
 
-const saveAccount = async () => {
+const saveAccount = async (): Promise<void> => {
   if (!get(form)) {
     return;
   }

--- a/frontend/app/src/premium/premium-apis.ts
+++ b/frontend/app/src/premium/premium-apis.ts
@@ -118,7 +118,7 @@ export const adexApi = (): AdexApi => {
   const { adexBalances, adexHistory } = storeToRefs(store);
   const { fetchAdex } = store;
   return {
-    async fetchAdex(refresh: boolean) {
+    async fetchAdex(refresh: boolean): Promise<void> {
       await fetchAdex(refresh);
     },
     adexHistory: adexHistory as Ref<AdexHistory>,

--- a/frontend/app/src/premium/register-components.ts
+++ b/frontend/app/src/premium/register-components.ts
@@ -56,7 +56,7 @@ import { logger } from '@/utils/logging';
 /**
  * Vuetify components that are used in the premium components
  */
-const vuetifyRegister = () => {
+const vuetifyRegister = (): void => {
   // version 17 - 1.24
   Vue.component('VCol', VCol);
   Vue.component('VRow', VRow);
@@ -76,7 +76,7 @@ const vuetifyRegister = () => {
   Vue.component('VDataTableHeader', VDataTableHeader);
 };
 
-export function registerComponents() {
+export function registerComponents(): void {
   // Globally registered components are also provided to the premium components.
   Vue.component('AmountDisplay', AmountDisplay);
   // version: 1

--- a/frontend/app/src/premium/setup-premium.ts
+++ b/frontend/app/src/premium/setup-premium.ts
@@ -5,7 +5,7 @@ import ChartJsPluginZoom from 'chartjs-plugin-zoom';
 import * as Vue from 'vue';
 import * as zod from 'zod';
 
-export const setupPremium = async () => {
+export const setupPremium = async (): Promise<void> => {
   window.Vue = Vue;
   window.VueUse = VueUse;
   window.Chart = Chart;

--- a/frontend/app/src/py-handler.ts
+++ b/frontend/app/src/py-handler.ts
@@ -19,7 +19,7 @@ const streamToString = (
   const bufferChunks: Buffer[] = [];
   const stringChunks: string[] = [];
 
-  const onData = (chunk: any) => {
+  const onData = (chunk: any): void => {
     if (typeof chunk === 'string') {
       stringChunks.push(chunk);
     } else {
@@ -27,7 +27,7 @@ const streamToString = (
     }
   };
 
-  const onEnd = () => {
+  const onEnd = (): void => {
     if (bufferChunks.length > 0) {
       try {
         stringChunks.push(Buffer.concat(bufferChunks).toString('utf8'));
@@ -96,8 +96,8 @@ export default class PyHandler {
   private onChildExit?: (code: number, signal: any) => void;
   private logDirectory?: string;
   private stdioListeners = {
-    outOff: () => {},
-    errOff: () => {}
+    outOff: (): void => {},
+    errOff: (): void => {}
   };
 
   constructor(private app: App) {
@@ -531,7 +531,7 @@ export default class PyHandler {
   }
 
   private async waitForTermination(tasks: Task[], processes: number[]) {
-    function stillRunning() {
+    function stillRunning(): number {
       return tasks.filter(({ pid }) => processes.includes(pid)).length;
     }
 

--- a/frontend/app/src/services/axios-tranformers.ts
+++ b/frontend/app/src/services/axios-tranformers.ts
@@ -36,7 +36,7 @@ const isObject = (data: any): boolean =>
   !(data instanceof Date) &&
   !(data instanceof BigNumber);
 
-export function getUpdatedKey(key: string, camelCase: boolean) {
+export function getUpdatedKey(key: string, camelCase: boolean): string {
   if (camelCase) {
     return key.includes('_')
       ? key.replace(/_(.)/gu, (_, p1) => p1.toUpperCase())
@@ -117,7 +117,7 @@ export const setupJsonTransformer: (
 export function setupTransformer(
   numericKeys: string[] | null = null,
   skipRoot = false
-) {
+): AxiosResponseTransformer[] {
   return [
     setupJsonTransformer(numericKeys),
     skipRoot ? axiosNoRootCamelCaseTransformer : axiosCamelCaseTransformer

--- a/frontend/app/src/services/balances/balances-api.ts
+++ b/frontend/app/src/services/balances/balances-api.ts
@@ -98,7 +98,7 @@ export class BalancesApi {
   async editEth2Validator({
     ownershipPercentage,
     validatorIndex
-  }: Eth2Validator) {
+  }: Eth2Validator): Promise<boolean> {
     const response = await this.axios.patch<ActionResult<boolean>>(
       '/blockchains/ETH2/validators',
       axiosSnakeCaseTransformer({ ownershipPercentage, validatorIndex }),

--- a/frontend/app/src/services/rotkehlchen-api.ts
+++ b/frontend/app/src/services/rotkehlchen-api.ts
@@ -63,7 +63,7 @@ export class RotkehlchenApi {
     return this._serverUrl === this.defaultServerUrl;
   }
 
-  public cancel() {
+  public cancel(): void {
     this.signal.cancel('cancelling all pending requests');
     this.signal = axios.CancelToken.source();
   }

--- a/frontend/app/src/store/balances/ethereum-names.ts
+++ b/frontend/app/src/store/balances/ethereum-names.ts
@@ -60,7 +60,10 @@ export const useEthNamesStore = defineStore('ethNames', () => {
     return changed;
   };
 
-  const fetchEnsNames = async (addresses: string[], forceUpdate = false) => {
+  const fetchEnsNames = async (
+    addresses: string[],
+    forceUpdate = false
+  ): Promise<void> => {
     if (addresses.length < 1) return;
 
     const changed = updateEnsAddresses(addresses);
@@ -84,7 +87,7 @@ export const useEthNamesStore = defineStore('ethNames', () => {
     }
   };
 
-  const fetchEthNames = async () => {
+  const fetchEthNames = async (): Promise<void> => {
     const addresses = [
       ...get(ethAddressBookGlobal).map(item => item.address),
       ...get(ethAddressBookPrivate).map(item => item.address),

--- a/frontend/app/src/store/balances/index.ts
+++ b/frontend/app/src/store/balances/index.ts
@@ -38,7 +38,7 @@ export const useBalancesStore = defineStore('balances', () => {
   const { tc } = useI18n();
   const { currencySymbol, currency } = storeToRefs(useGeneralSettingsStore());
 
-  const adjustPrices = (prices: MaybeRef<AssetPrices>) => {
+  const adjustPrices = (prices: MaybeRef<AssetPrices>): void => {
     const pricesConvertedToUsd = { ...get(prices) };
 
     const mainCurrency = get(currencySymbol);

--- a/frontend/app/src/store/balances/manual.ts
+++ b/frontend/app/src/store/balances/manual.ts
@@ -156,7 +156,7 @@ export const useManualBalancesStore = defineStore('balances/manual', () => {
       return assets;
     });
 
-  const fetchManualBalances = async () => {
+  const fetchManualBalances = async (): Promise<void> => {
     const { getStatus, setStatus, resetStatus } = useStatusUpdater(
       Section.MANUAL_BALANCES
     );
@@ -250,7 +250,7 @@ export const useManualBalancesStore = defineStore('balances/manual', () => {
     }
   };
 
-  const deleteManualBalance = async (id: number) => {
+  const deleteManualBalance = async (id: number): Promise<void> => {
     try {
       const { balances } = await deleteManualBalances([id]);
       set(manualBalancesData, balances);

--- a/frontend/app/src/store/balances/non-fungible.ts
+++ b/frontend/app/src/store/balances/non-fungible.ts
@@ -127,7 +127,7 @@ export const useNonFungibleBalancesStore = defineStore(
           return;
         }
 
-        const fetchOnlyCache = async () => {
+        const fetchOnlyCache = async (): Promise<void> => {
           set(balances, await fetchNfBalancesHandler(true));
         };
 

--- a/frontend/app/src/store/debug.ts
+++ b/frontend/app/src/store/debug.ts
@@ -46,7 +46,7 @@ const getState = (key: string) => {
   });
 };
 
-const setState = (key: string, state: any) => {
+const setState = (key: string, state: any): void => {
   storage.setItem(key, JSON.stringify(convert(state)));
 };
 

--- a/frontend/app/src/store/defi/compound/index.ts
+++ b/frontend/app/src/store/defi/compound/index.ts
@@ -45,7 +45,7 @@ export const useCompoundStore = defineStore('defi/compound', () => {
     toProfitLossModel(get(history).liquidationProfit)
   );
 
-  const fetchBalances = async (refresh = false) => {
+  const fetchBalances = async (refresh = false): Promise<void> => {
     if (!get(activeModules).includes(Module.COMPOUND)) {
       return;
     }
@@ -87,7 +87,7 @@ export const useCompoundStore = defineStore('defi/compound', () => {
     setStatus(Status.LOADED, section);
   };
 
-  const fetchHistory = async (refresh = false) => {
+  const fetchHistory = async (refresh = false): Promise<void> => {
     if (!get(activeModules).includes(Module.COMPOUND) || !get(premium)) {
       return;
     }
@@ -134,7 +134,7 @@ export const useCompoundStore = defineStore('defi/compound', () => {
     setStatus(Status.LOADED, section);
   };
 
-  const reset = () => {
+  const reset = (): void => {
     set(balances, {});
     set(history, defaultCompoundHistory());
     resetStatus(Section.DEFI_COMPOUND_BALANCES);

--- a/frontend/app/src/utils/backups.ts
+++ b/frontend/app/src/utils/backups.ts
@@ -1,7 +1,10 @@
 import { Ref } from 'vue';
 import { UserDbBackup } from '@/types/backup';
 
-export const getFilepath = (db: UserDbBackup, directory: Ref<string>) => {
+export const getFilepath = (
+  db: UserDbBackup,
+  directory: Ref<string>
+): string => {
   const file = `${db.time}_rotkehlchen_db_v${db.version}.backup`;
   return `${directory.value}${file}`;
 };

--- a/frontend/app/src/utils/balances.ts
+++ b/frontend/app/src/utils/balances.ts
@@ -71,7 +71,7 @@ export const appendAssetBalance = (
   value: AssetBalance,
   assets: AssetBalances,
   getAssociatedAssetIdentifier: (identifier: string) => ComputedRef<string>
-) => {
+): void => {
   const identifier = getAssociatedAssetIdentifier(value.asset);
   const associatedAsset: string = get(identifier);
   const ownedAsset = assets[associatedAsset];
@@ -167,7 +167,7 @@ export const btcAccountsWithBalances = (
   accountsData: BtcAccountData,
   balances: BtcBalances,
   blockchain: Blockchain.BTC | Blockchain.BCH
-) => {
+): BlockchainAccountWithBalance[] => {
   const accounts: BlockchainAccountWithBalance[] = [];
 
   const { standalone, xpubs } = accountsData;

--- a/frontend/app/src/utils/bignumbers.ts
+++ b/frontend/app/src/utils/bignumbers.ts
@@ -1,7 +1,7 @@
 import { Balance, BigNumber } from '@rotki/common';
 import { Ref } from 'vue';
 
-export function bigNumberify(value: string | number) {
+export function bigNumberify(value: string | number): BigNumber {
   return new BigNumber(value);
 }
 
@@ -26,4 +26,5 @@ export const zeroBalance = (): Balance => {
   };
 };
 
-export const sortDesc = (a: BigNumber, b: BigNumber) => b.minus(a).toNumber();
+export const sortDesc = (a: BigNumber, b: BigNumber): number =>
+  b.minus(a).toNumber();

--- a/frontend/app/src/utils/data.ts
+++ b/frontend/app/src/utils/data.ts
@@ -29,7 +29,7 @@ export function nonNullProperties<T extends object>(object: T): Partial<T> {
   return partial;
 }
 
-export const size = (bytes: number) => {
+export const size = (bytes: number): string => {
   let i = 0;
 
   for (i; bytes > 1024; i++) {

--- a/frontend/app/src/utils/date.ts
+++ b/frontend/app/src/utils/date.ts
@@ -87,7 +87,7 @@ export function isValidDate(date: string, dateFormat: string): boolean {
   return dayjs(date, dateFormat, true).isValid();
 }
 
-export function setupDayjs() {
+export function setupDayjs(): void {
   dayjs.extend(customParseFormat);
   dayjs.extend(utc);
   dayjs.extend(timezone);

--- a/frontend/app/src/utils/download.ts
+++ b/frontend/app/src/utils/download.ts
@@ -1,4 +1,4 @@
-export const downloadFileByUrl = (url: string, fileName: string) => {
+export const downloadFileByUrl = (url: string, fileName: string): void => {
   const link = document.createElement('a');
   link.setAttribute('href', url);
   link.setAttribute('download', fileName);

--- a/frontend/app/src/utils/env-utils.ts
+++ b/frontend/app/src/utils/env-utils.ts
@@ -1,3 +1,3 @@
-export const checkIfDevelopment = () => {
+export const checkIfDevelopment = (): boolean => {
   return import.meta.env.DEV;
 };

--- a/frontend/app/src/utils/index.ts
+++ b/frontend/app/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/utils/logging';
 
-export const startPromise = <T>(promise: Promise<T>) => {
+export const startPromise = <T>(promise: Promise<T>): void => {
   promise.then().catch(e => logger.debug(e));
 };

--- a/frontend/app/src/utils/message-handling.ts
+++ b/frontend/app/src/utils/message-handling.ts
@@ -25,7 +25,7 @@ export const handleSnapshotError = (
 
 export const handleEthereumTransactionStatus = (
   message: WebsocketMessage<SocketMessageType>
-) => {
+): void => {
   const data = EthereumTransactionQueryData.parse(message.data);
   const { setQueryStatus } = useTxQueryStatus();
   setQueryStatus(data);

--- a/frontend/app/src/utils/nft.ts
+++ b/frontend/app/src/utils/nft.ts
@@ -5,7 +5,7 @@ export const isVideo = (url: string | null): boolean => {
   );
 };
 
-export const isNft = (address?: string) => {
+export const isNft = (address?: string): boolean => {
   if (!address) return false;
   return address.startsWith('_nft_');
 };

--- a/frontend/app/src/utils/setup-formatter.ts
+++ b/frontend/app/src/utils/setup-formatter.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@rotki/common';
 import { checkIfDevelopment } from '@/utils/env-utils';
 
-export function setupFormatter() {
+export function setupFormatter(): void {
   if (!checkIfDevelopment()) {
     return;
   }
@@ -14,7 +14,7 @@ export function setupFormatter() {
         }
         return ['div', {}, obj.toString()];
       },
-      hasBody: function () {
+      hasBody: function (): boolean {
         return false;
       }
     }

--- a/frontend/app/src/utils/total-collateral.ts
+++ b/frontend/app/src/utils/total-collateral.ts
@@ -1,10 +1,11 @@
-import { Ref } from 'vue';
+import { BigNumber } from '@rotki/common';
+import { ComputedRef, Ref } from 'vue';
 import { Collateral, CollateralizedLoan } from '@/types/defi';
 import { Zero } from '@/utils/bignumbers';
 
 export const totalCollateral = (
   loan: Ref<CollateralizedLoan<Collateral<string>[]>>
-) => {
+): ComputedRef<BigNumber> => {
   return computed(() =>
     get(loan)
       .collateral.map(({ usdValue }) => usdValue)

--- a/frontend/app/src/utils/validation-errors.ts
+++ b/frontend/app/src/utils/validation-errors.ts
@@ -7,5 +7,5 @@ import { ErrorObject } from '@vuelidate/core';
  * @param errors ErrorObject
  * @return string[]
  */
-export const toMessages = (errors: ErrorObject[]) =>
+export const toMessages = (errors: ErrorObject[]): string[] =>
   errors.map(e => get(e.$message));

--- a/frontend/app/src/utils/xpub.ts
+++ b/frontend/app/src/utils/xpub.ts
@@ -58,9 +58,13 @@ export const keyType: XpubType[] = [
   }
 ];
 
-export const isPrefixed = (value: string) => value.match(/([xzy]pub)(.*)/);
+export const isPrefixed = (value: string): RegExpMatchArray | null =>
+  value.match(/([xzy]pub)(.*)/);
 
-export const xpubToPayload = (xpub: string, path: string | null) => {
+export const xpubToPayload = (
+  xpub: string,
+  path: string | null
+): XpubPayload => {
   const match = isPrefixed(xpub);
   let key = xpub;
   let prefix: XpubPrefix = XpubPrefix.XPUB;

--- a/frontend/common/src/index.ts
+++ b/frontend/common/src/index.ts
@@ -41,4 +41,4 @@ export interface HasBalance {
 
 export { BigNumber as BigNumber }
 
-export const onlyIfTruthy = <T>(value: T) => value ? value : undefined
+export const onlyIfTruthy = <T>(value: T): T | undefined => value ? value : undefined

--- a/frontend/common/src/settings/graphs.ts
+++ b/frontend/common/src/settings/graphs.ts
@@ -83,7 +83,7 @@ function createTimeframe(
   let timestampRange = 0;
 
   if (frame === TimeFramePeriod.ALL) {
-    start = () => 0;
+    start = (): number => 0;
     timestampRange = Infinity;
   } else {
     let startUnit: TimeUnit;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "lint:fix": "npm run lint:fix -w common && npm run lint -w app",
     "check": "npm run lint && npm run build && npm run test:unit -w app",
     "check:all": "npm run lint && npm run build && npm run test:unit --w app && npm run test:integration-ci -w app",
+    "check:return-type": "eslint --no-eslintrc --env \"node\" --parser \"@typescript-eslint/parser\" --plugin \"@typescript-eslint\",\"import\" --rule \"{@typescript-eslint/explicit-function-return-type:warn}\" '{app,common}/src/**/*.ts'",
     "clean:modules": "rimraf node_modules app/node_modules common/node_modules app/dist app/electron-build common/lib",
     "dev": "node start-dev.js",
     "dev:web": "node start-dev.js --web"


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.


> **Note** I am adding a temporary `npm run check:return-type` that we need to run by hand currently and it only checks methods for missing return types. The reason for this is related to [TypeScript Compiler Performance](https://github.com/microsoft/TypeScript/wiki/Performance#using-type-annotations) optimizations. I am not putting it on the main eslint config since cannot apply globally. At the moment we will have to run it manually.
 