### PR TITLE
Add slow usdc vault test to nightlies

### DIFF
--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -526,6 +526,7 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
     )
 
 
+@requires_env([TestEnvironment.NIGHTLY])
 @flaky(max_runs=3, min_passes=1)  # some makerdao vault tests take long time and may time out
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])


### PR DESCRIPTION
Also wanna see how tests fare in general in timing. 

In a recent run the following timings were shown:

```
77.65s call     rotkehlchen/tests/api/test_makerdao_vaults.py::test_query_vaults_usdc[default_mock_price_value0-mocked_price_queries0-True-ethereum_modules0-1]
31.32s call     rotkehlchen/tests/unit/accounting/test_basic.py::test_asset_and_price_not_found_in_history_processing[False]
28.55s call     rotkehlchen/tests/unit/test_tokens.py::test_detect_tokens_for_addresses[ignored_assets0]
22.27s call     rotkehlchen/tests/unit/test_ethereum_airdrops.py::test_check_airdrops[True-2]
18.39s call     rotkehlchen/tests/api/test_bitcoin.py::test_add_delete_xpub_multiple_chains[0]
16.43s setup    rotkehlchen/tests/api/test_blockchain.py::test_add_ksm_blockchain_account_ens_domain[kusama_manager_connect_at_start0-0]
16.39s setup    rotkehlchen/tests/api/test_blockchain.py::test_add_ksm_blockchain_account[kusama_manager_connect_at_start0-0]
15.12s call     rotkehlchen/tests/api/test_makerdao_dsr.py::test_dsr_for_account_with_proxy_but_no_dsr[True-ethereum_modules0-ethereum_accounts0]
10.51s call     rotkehlchen/tests/exchanges/test_gemini.py::test_gemini_query_all_trades_pagination
10.51s call     rotkehlchen/tests/integration/test_blockchain.py::test_multiple_concurrent_ethereum_blockchain_queries[0]
10.24s call     rotkehlchen/tests/unit/test_defi_oracles.py::test_uniswap_oracles_asset_to_asset[False-True]
10.09s call     rotkehlchen/tests/unit/test_ethereum_inquirer.py::test_use_open_nodes
9.92s call     rotkehlchen/tests/exchanges/test_gemini.py::test_gemini_query_trades
9.75s call     rotkehlchen/tests/unit/decoders/test_convex.py::test_convex_pools
```

The top ones apart from the vault one don't make much sense and wonder why they were so slow.