### PR TITLE
Updates job checker action

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -24,12 +24,12 @@ jobs:
       backend_tasks: ${{ steps.checker.outputs.backend_tasks }}
       frontend_tasks: ${{ steps.checker.outputs.frontend_tasks }}
       documentation_tasks: ${{ steps.checker.outputs.documentation_tasks }}
-      test_environment: ${{env.TEST_ENVIRONMENT}}
+      test_environment: ${{ steps.checker.outputs.test_environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run check action
-        uses: rotki/action-job-checker@v1
+        uses: rotki/action-job-checker@v2
         id: checker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.


## Notes

Initially, due to a misconception, the action was setting an environment variable. 
Since environment variables are not actually available outside of a job's steps and 
you have to re-export this was changed to an output for consistency:
https://github.com/rotki/action-job-checker/pull/3

The version bumping happened because otherwise the regular ci would break