### PR TITLE
Cryptocom cashback reversal

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 * :bug:`-` Fix an edge-case problem with synchronizing database with the server.
 * :bug:`-` Users will be able to edit EVM tokens again and the information about underlying tokens will be correctly displayed.
 * :bug:`-` Fix an issue with nginx websocket proxying on docker.
+* :bug:`-` Now `Card Cashback Reversal` entries from cryptocom csv will be imported correctly.
 
 * :release:`1.26.1 <2022-11-04>`
 * :feature:`5080` For custom assets with custom price there should no longer be any double conversion. So 1 euro should always be one euro.

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -66,7 +66,6 @@ class CryptocomImporter(BaseExchangeImporter):
         if row_type in (
             'crypto_purchase',
             'crypto_exchange',
-            'card_cashback_reverted',
             'viban_purchase',
             'crypto_viban_exchange',
             'recurring_buy_order',
@@ -180,7 +179,7 @@ class CryptocomImporter(BaseExchangeImporter):
                 notes=notes,
             )
             self.add_ledger_action(cursor, action)
-        elif row_type in ('crypto_payment', 'reimbursement_reverted'):
+        elif row_type in ('crypto_payment', 'reimbursement_reverted', 'card_cashback_reverted'):
             asset = asset_from_cryptocom(csv_row['Currency'])
             amount = abs(deserialize_asset_amount(csv_row['Amount']))
             action = LedgerAction(

--- a/rotkehlchen/tests/data/cryptocom_special_events.csv
+++ b/rotkehlchen/tests/data/cryptocom_special_events.csv
@@ -14,3 +14,4 @@ Timestamp (UTC),Transaction Description,Currency,Amount,To Currency,To Amount,Na
 2021-01-01 21:00:00,Invest Deposit,ETC,-1.0,,,USD,-100,-100,invest_deposit
 2021-10-28 03:16:37,Supercharger Reward,AXS,0.00356292,,,EUR,0.38,0.4430698990794,supercharger_reward_to_app_credited
 2021-10-28 03:16:38,USDC -> EUR,USDC,-12.94,,,EUR,-11.3,-12.64961995,card_top_up
+2021-10-29 03:16:38,Card Cashback Reversal,CRO,-0.5678,,,USD,0.25,0.25,card_cashback_reverted

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -464,6 +464,17 @@ def assert_cryptocom_special_events_import_results(rotki: Rotkehlchen):
     assert len(warnings) == 0
 
     expected_actions = [LedgerAction(
+        identifier=7,
+        timestamp=Timestamp(1635477398),
+        action_type=LedgerActionType.EXPENSE,
+        location=Location.CRYPTOCOM,
+        amount=AssetAmount(FVal('0.5678')),
+        asset=asset_from_cryptocom('CRO'),
+        rate=None,
+        rate_asset=None,
+        link=None,
+        notes=get_cryptocom_note('Card Cashback Reversal'),
+    ), LedgerAction(
         identifier=6,
         timestamp=Timestamp(1635390997),
         action_type=LedgerActionType.INCOME,


### PR DESCRIPTION
Fix importation of cryptocom cashback reversal

Until this PR cashback reversal (which happens when a user receives cashback for using their cryptocom card but then cryptocom decides that the user doesn't deserve this cashback and deducts it) was treated as a Trade with type Buy.

Now I made it a Ledger action with type Expense 