### PR TITLE
Remove `geventwebsocket` debug logs

### DIFF
--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -463,6 +463,8 @@ class APIServer():
             environ={'rotki_notifier': self.rotki_notifier},
             error_log=wsgi_logger,
         )
+        # this is to prevent littering logs with geventwebsocket upgrade messages
+        logging.getLogger('geventwebsocket.handler').setLevel(logging.ERROR)
 
         if 'pytest' not in sys.modules:  # do not check
             if __debug__:


### PR DESCRIPTION
Fixes https://discord.com/channels/657906918408585217/1050071468152733736/1050076437652181062

Example:
```sh
[06/12/2022 10:23:49 WAT] INFO geventwebsocket.handler 127.0.0.1 - - [2022-12-06 10:23:49] "GET /api/1/users HTTP/1.1" 200 339 0.002334
[06/12/2022 10:23:49 WAT] DEBUG geventwebsocket.handler Initializing WebSocket
[06/12/2022 10:23:49 WAT] DEBUG geventwebsocket.handler Validating WebSocket request
```