### PR TITLE
Make sure to query receipts before decoding

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3355,6 +3355,11 @@ class RestAPI():
             evm_addresses: Optional[list[ChecksumEvmAddress]],
     ) -> dict[str, Any]:
         dbevmtx = DBEvmTx(self.rotkehlchen.data.db)
+        ethereum_manager = self.rotkehlchen.chains_aggregator.ethereum
+        # make sure that all the receipts are already queried
+        ethereum_manager.transactions.get_receipts_for_transactions_missing_them(
+            addresses=evm_addresses,
+        )
         amount_of_tx_to_decode = dbevmtx.count_hashes_not_decoded(
             addresses=evm_addresses,
             chain_id=ChainID.ETHEREUM,
@@ -3373,6 +3378,17 @@ class RestAPI():
             async_query: bool,
             evm_addresses: Optional[list[ChecksumEvmAddress]],
     ) -> Response:
+        """
+        This method should be called after querying ethereum transactions and does the following:
+        - Query missing receipts
+        - Decode ethereum transactions
+
+        It can be a slow process and this is why it is important to set the list of addresses
+        queried per module that need to be decoded.
+
+        This logic is executed by the frontend in pages where the set of transactions needs to be
+        up to date, for example, the liquity module.
+        """
         if async_query is True:
             return self._query_async(
                 command=self._decode_pending_ethereum_transactions,

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -246,7 +246,7 @@ class DBEvmTx():
             limit: Optional[int],
     ) -> list[EVMTxHash]:
         cursor = self.db.conn.cursor()
-        querystr = 'SELECT DISTINCT tx_hash FROM evm_transactions '
+        querystr = 'SELECT DISTINCT evm_transactions.tx_hash FROM evm_transactions '
         bindings = ()
         if tx_filter_query is not None:
             filter_query, bindings = tx_filter_query.prepare(with_order=False, with_pagination=False)  # type: ignore  # noqa: E501
@@ -254,7 +254,7 @@ class DBEvmTx():
         else:
             querystr += ' WHERE '
 
-        querystr += 'tx_hash NOT IN (SELECT tx_hash from evmtx_receipts)'
+        querystr += 'evm_transactions.tx_hash NOT IN (SELECT tx_hash from evmtx_receipts)'
         if limit is not None:
             querystr += 'LIMIT ?'
             bindings = (*bindings, limit)  # type: ignore


### PR DESCRIPTION
The transactions were not being correctly decoded because the receipt logs were not stored locally. Since this endpoint is used to decode everything pending I opted for downloading the missing receipts. In the worst case this can be a slow task but is needed to obtain accurate history.

Also we have a periodic task that does this in the background so it shouldn't be in the average case a slow task