### PR TITLE
Large premium user DBs should no longer hit plaintext database error

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Transfers between tracked accounts will now have a correct label in the UI.
+* :bug:`5038` Premium users with big databases should no longer see the error: "Upload data to server died with exception: database plaintext is locked"
 
 
 * :release:`1.26.2 <2022-12-09>`

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -192,8 +192,7 @@ class DataHandler():
 
         Returns a b64 encoded binary blob"""
         compressor = zlib.compressobj(level=9)
-        prefix = str(ts_now())  # not sure if NamedTemporaryFile always gives new name. So force it
-        with tempfile.NamedTemporaryFile(delete=False, prefix=prefix, suffix='.db') as tempdbfile:
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.db') as tempdbfile:
             tempdbpath = Path(tempdbfile.name)
             log.info(f'Compress and encrypt DB at temporary path: {tempdbpath}')
             tempdbfile.close()  # close the file to allow re-opening by export_unencrypted in windows https://github.com/rotki/rotki/issues/5051  # noqa: E501

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -4,6 +4,8 @@ import shutil
 from enum import Enum
 from typing import Any, Dict, Literal, NamedTuple, Optional, Tuple, Union
 
+from gevent.lock import Semaphore
+
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.data_migrations.manager import DataMigrationManager
 from rotkehlchen.errors.api import PremiumAuthenticationError, RotkehlchenPermissionError
@@ -45,6 +47,7 @@ class PremiumSyncManager():
         self.migration_manager = migration_manager
         self.password = password
         self.premium: Optional[Premium] = None
+        self.upload_lock = Semaphore()
 
     def _can_sync_data_from_server(self, new_account: bool) -> SyncCheckResult:
         """
@@ -142,9 +145,9 @@ class PremiumSyncManager():
         return True
 
     def maybe_upload_data_to_server(self, force_upload: bool = False) -> bool:
-        assert self.premium is not None, 'caller should make sure premium exists'
-        log.debug('Starting maybe_upload_data_to_server')
-        with self.data.db.user_write() as cursor:
+        with self.upload_lock:
+            assert self.premium is not None, 'caller should make sure premium exists'
+            log.debug('Starting maybe_upload_data_to_server')
             try:
                 metadata = self.premium.query_last_data_metadata()
             except (RemoteError, PremiumAuthenticationError) as e:
@@ -162,7 +165,8 @@ class PremiumSyncManager():
                 # same hash -- no need to upload anything
                 return False
 
-            our_last_write_ts = self.data.db.get_setting(cursor=cursor, name='last_write_ts')
+            with self.data.db.conn.read_ctx() as cursor:
+                our_last_write_ts = self.data.db.get_setting(cursor=cursor, name='last_write_ts')
             if our_last_write_ts <= metadata.last_modify_ts and not force_upload:
                 # Server's DB was modified after our local DB
                 log.debug(
@@ -194,9 +198,10 @@ class PremiumSyncManager():
 
             # update the last data upload value
             self.last_data_upload_ts = ts_now()
-            self.data.db.set_setting(cursor, name='last_data_upload_ts', value=self.last_data_upload_ts)  # noqa: E501
+            with self.data.db.user_write() as cursor:
+                self.data.db.set_setting(cursor, name='last_data_upload_ts', value=self.last_data_upload_ts)  # noqa: E501
 
-        log.debug('upload to server -- success')
+            log.debug('upload to server -- success')
         return True
 
     def sync_data(self, action: Literal['upload', 'download']) -> Tuple[bool, str]:

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -470,3 +470,44 @@ def test_premium_toggle_chain_manager(blockchain, rotki_premium_credentials):
     blockchain.deactivate_premium_status()
     for _, module in blockchain.iterate_modules():
         assert module.premium is None
+
+
+@pytest.mark.parametrize('sql_vm_instructions_cb', [10])
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_upload_data_to_server_big_db(rotkehlchen_instance, db_password):
+    """Test that if the server has bigger DB size and context switch happens it
+    all works out. Essentially a test for https://github.com/rotki/rotki/issues/5038
+
+    We emulate bigger size by just lowering sql_vm_instructions_cb to force a context switch
+    """
+    with rotkehlchen_instance.data.db.user_write() as cursor:
+        last_ts = rotkehlchen_instance.data.db.get_setting(cursor, name='last_data_upload_ts')
+        assert last_ts == 0
+        # Write anything in the DB to set a non-zero last_write_ts
+        rotkehlchen_instance.data.db.set_settings(cursor, ModifiableDBSettings(main_currency=A_EUR))  # noqa: E501
+    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(db_password)
+    remote_hash = get_different_hash(our_hash)
+
+    patched_put = patch.object(
+        rotkehlchen_instance.premium.session,
+        'put',
+        return_value=None,
+    )
+    patched_get = create_patched_requests_get_for_premium(
+        session=rotkehlchen_instance.premium.session,
+        metadata_last_modify_ts=0,
+        metadata_data_hash=remote_hash,
+        # larger DB than ours
+        metadata_data_size=9999999999,
+        saved_data='foo',
+    )
+
+    with patched_get, patched_put as put_mock:
+        a = gevent.spawn(rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server)
+        b = gevent.spawn(rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server)
+        greenlets = [a, b]
+        gevent.joinall(greenlets)
+        for g in greenlets:
+            assert g.exception is None, f'One of the greenlets had an exception: {g.exception}'
+        # The upload mock should not have been called since the hash is the same
+        assert not put_mock.called


### PR DESCRIPTION
It happened due to context switching during the attaching of the database, some stuff happening elsewhere and in the meantime the upload task starting again

