### PR TITLE
Fix duplicated last_queried_ts

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1308,6 +1308,10 @@ class DBHandler:
         returned_list = []
         for (key, value) in cursor:
             if key == ACCOUNTS_DETAILS_LAST_QUERIED_TS:
+                # At the moment last_queried_timestamp is not used. It used to be a cache for the
+                # query but since we made token detection not run it is no longer used, but is
+                # written. This will probably change in the future again. Related issue:
+                # https://github.com/rotki/rotki/issues/5252
                 last_queried_ts = deserialize_timestamp(value)
             else:  # should be ACCOUNTS_DETAILS_TOKENS
                 try:
@@ -1361,10 +1365,10 @@ class DBHandler:
         )
         # Delete previous entries for tokens
         write_cursor.execute(
-            'DELETE FROM accounts_details WHERE account=? AND blockchain=? AND KEY=?',
-            (address, blockchain.serialize(), ACCOUNTS_DETAILS_TOKENS),
+            'DELETE FROM accounts_details WHERE account=? AND blockchain=? AND KEY IN(?, ?)',
+            (address, blockchain.serialize(), ACCOUNTS_DETAILS_TOKENS, ACCOUNTS_DETAILS_LAST_QUERIED_TS),  # noqa: E501
         )
-        # Timestamp will get replaced
+        # Insert new values
         write_cursor.executemany(
             'INSERT OR REPLACE INTO accounts_details '
             '(account, blockchain, key, value) VALUES (?, ?, ?, ?)',

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flaky import flaky
@@ -8,6 +9,7 @@ from rotkehlchen.chain.evm.tokens import EvmTokens, generate_multicall_chunks
 from rotkehlchen.constants.assets import A_OMG
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.constants import A_LPT
+from rotkehlchen.utils.misc import ts_now
 
 
 @pytest.fixture(name='evmtokens')
@@ -72,3 +74,44 @@ def test_generate_chunks():
         ],
     ]
     assert generated_chunks == expected_chunks
+
+
+def test_last_queried_ts(evmtokens, freezer):
+    """
+    Checks that after detecting evm tokens last_queried_timestamp is updated and there
+    are no duplicates.
+    """
+    # We don't need to query the chain here, so mock tokens list
+    evm_tokens_patch = patch(
+        'rotkehlchen.globaldb.handler.GlobalDBHandler.get_ethereum_tokens',
+        new=lambda _, exceptions=None, except_protocols=None, protocol=None: [],
+    )
+    beginning = ts_now()
+    address = '0x4bBa290826C253BD854121346c370a9886d1bC26'
+    with evm_tokens_patch:
+        # Detect for the first time
+        evmtokens.detect_tokens(
+            only_cache=False,
+            addresses=[address],
+        )
+        after_first_query = evmtokens.db.conn.execute(
+            'SELECT key, value FROM accounts_details',
+        ).fetchall()
+        assert len(after_first_query) == 1
+        assert after_first_query[0][0] == 'last_queried_timestamp'
+        assert int(after_first_query[0][1]) >= beginning
+
+        continuation = beginning + 10
+        freezer.move_to(datetime.fromtimestamp(continuation))
+        # Detect again
+        evmtokens.detect_tokens(
+            only_cache=False,
+            addresses=['0x4bBa290826C253BD854121346c370a9886d1bC26'],
+        )
+        # Check that last_queried_timestamp was updated and that there are no duplicates
+        after_second_query = evmtokens.db.conn.execute(
+            'SELECT key, value FROM accounts_details',
+        ).fetchall()
+        assert len(after_second_query) == 1
+        assert after_second_query[0][0] == 'last_queried_timestamp'
+        assert int(after_second_query[0][1]) >= continuation


### PR DESCRIPTION
Fix duplicated last_queried_ts.

Before this PR each time tokens were detected, a new `last_queried_ts` entry was added into the db without removing the previous ones.