### PR TITLE
Start of pytest tests speedup, start being more careful with networking

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ coverage==6.5.0
 psutil==5.9.4
 pytest-freezegun==0.4.2
 pytest-deadfixtures==2.2.1
+pytest-socket==0.5.1
 freezegun==1.2.2
 flaky==3.7.0
 

--- a/rotkehlchen/db/upgrades/v35_v36.py
+++ b/rotkehlchen/db/upgrades/v35_v36.py
@@ -463,11 +463,11 @@ def _upgrade_rpc_nodes(write_cursor: 'DBCursor') -> None:
     """
     log.debug('Enter _upgrade_rpc_nodes')
 
-    # using "ETH" directly since at this point all blockchain column values should beETH
+    # using "ETH" directly since at this point all blockchain column values should be ETH
     # and there may be a problem (noticed it in the premium DB pulling tests) where
-    # web3_nodes did not run through v34->v35 upgrade properly so blockchain column is missing
-    # I suspect the tests I noticed it were developer who created the DB error, but
-    # since this is equivalent to reading the blockchain column, better safe thansorry
+    # web3_nodes did not run through v34->v35 upgrade properly so blockchain column is missing.
+    # I suspect the tests I noticed it were due to the developer who created the DB error, but
+    # since this is equivalent to reading the blockchain column, better safe than sorry
     nodes_tuples = write_cursor.execute(
         'SELECT name, endpoint, owned, active, weight, "ETH" from web3_nodes',
     ).fetchall()

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -40,6 +40,11 @@ def pytest_addoption(parser):
         default=29870,
         help='Base port number used to avoid conflicts while running parallel tests.',
     )
+    parser.addoption(
+        '--no-network-mocking',
+        action='store_true',
+        help='If set then all tests that are aware of their mocking the network will not do that. Use this in order to easily skip mocks and test that using the network, the remote queries are still working fine and mocks dont need any changing.',  # noqa: E501
+    )
     parser.addoption('--profiler', default=None, choices=['flamegraph-trace'])
 
 

--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -43,3 +43,13 @@ def added_exchanges() -> Sequence[Location]:
         Location.BITSTAMP,
         Location.BITFINEX,
     )
+
+
+@pytest.fixture
+def network_mocking(request):
+    """Uses the --no-network-mocking argument. By default when not passed, the network
+    is mocked in all tests that are aware of it (by using this fixture).
+    Once the --no-network-mocking argument is passed all tests that use this fixture
+    switch to using the network instead.
+    """
+    return request.config.option.no_network_mocking is False

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -282,7 +282,7 @@ def test_case_does_not_matter_for_asset_constructor():
     'CI' in os.environ,
     reason='SLOW TEST -- it executes locally every time we check the assets so can be skipped',
 )
-def test_coingecko_identifiers_are_reachable():
+def test_coingecko_identifiers_are_reachable(socket_enabled):  # pylint: disable=unused-argument
     """
     Test that all assets have a coingecko entry and that all the identifiers exist in coingecko
     """

--- a/rotkehlchen/tests/unit/test_avalanche_manager.py
+++ b/rotkehlchen/tests/unit/test_avalanche_manager.py
@@ -1,21 +1,183 @@
+from contextlib import nullcontext
 from unittest.mock import patch
 
-from flaky import flaky
+from web3.datastructures import AttributeDict
 
 from rotkehlchen.types import deserialize_evm_tx_hash
+from rotkehlchen.utils.hexbytes import HexBytes
+
+covalent_tx_receipt_result = {
+    'block_height': 2716404,
+    'block_signed_at': '2021-07-19T21:49:58Z',
+    'fees_paid': '29086200000000000',
+    'from_address': '0x4f59ae4374d93b7087f2afa6db95815b43d1c2da',
+    'from_address_label': None,
+    'gas_offered': 195000,
+    'gas_price': 225000000000,
+    'gas_quote': 0.3087283978471756,
+    'gas_quote_rate': 10.614256858825684,
+    'gas_spent': 129272,
+    'log_events': [{'block_height': 2716404,
+                    'block_signed_at': '2021-07-19T21:49:58Z',
+                    'decoded': {
+                        'name': 'Swap',
+                        'params': [
+                            {'decoded': True, 'indexed': True, 'name': 'sender', 'type': 'address', 'value': '0xe54ca86531e17ef3616d22ca28b0d458b6c89106'},  # noqa: E501
+                            {'decoded': True, 'indexed': False, 'name': 'amount0In', 'type': 'uint256', 'value': '115951490920000000000'},  # noqa: E501
+                            {'decoded': True, 'indexed': False, 'name': 'amount1In', 'type': 'uint256', 'value': '0'},  # noqa: E501
+                            {'decoded': True, 'indexed': False, 'name': 'amount0Out', 'type': 'uint256', 'value': '0'},  # noqa: E501
+                            {'decoded': True, 'indexed': False, 'name': 'amount1Out', 'type': 'uint256', 'value': '1173514056'},  # noqa: E501
+                            {'decoded': True, 'indexed': True, 'name': 'to', 'type': 'address', 'value': '0x4f59ae4374d93b7087f2afa6db95815b43d1c2da'},  # noqa: E501
+                        ],
+                        'signature': 'Swap(indexed address sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, indexed address to)'},  # noqa: E501
+                    'log_offset': 9,
+                    'raw_log_data': '0x000000000000000000000000000000000000000000000006492672a787881000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045f26748',  # noqa: E501
+                    'raw_log_topics': [
+                        '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822',
+                        '0x000000000000000000000000e54ca86531e17ef3616d22ca28b0d458b6c89106',
+                        '0x0000000000000000000000004f59ae4374d93b7087f2afa6db95815b43d1c2da'],
+                    'sender_address': '0x9ee0a4e21bd333a6bb2ab298194320b8daa26516',
+                    'sender_address_label': None,
+                    'sender_contract_decimals': 18,
+                    'sender_contract_ticker_symbol': 'PGL',
+                    'sender_logo_url': 'https://logos.covalenthq.com/tokens/43114/0x9ee0a4e21bd333a6bb2ab298194320b8daa26516.png',  # noqa: E501
+                    'sender_name': 'Pangolin Liquidity',
+                    'tx_hash': '0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d',  # noqa: E501
+                    'tx_offset': 1},
+                   {'block_height': 2716404,
+                    'block_signed_at': '2021-07-19T21:49:58Z',
+                    'decoded': {'name': 'Sync',
+                                'params': [
+                                    {'decoded': True, 'indexed': False, 'name': 'reserve0', 'type': 'uint112', 'value': '156407372466602947364673'},  # noqa: E501
+                                    {'decoded': True, 'indexed': False, 'name': 'reserve1', 'type': 'uint112', 'value': '1586543339131'}],  # noqa: E501
+                                'signature': 'Sync(uint112 reserve0, uint112 reserve1)'},
+                    'log_offset': 8,
+                    'raw_log_data': '0x00000000000000000000000000000000000000000000211edc53a099b0dbc74100000000000000000000000000000000000000000000000000000171655a267b',  # noqa: E501
+                    'raw_log_topics': [
+                        '0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1',
+                    ],
+                    'sender_address': '0x9ee0a4e21bd333a6bb2ab298194320b8daa26516',
+                    'sender_address_label': None,
+                    'sender_contract_decimals': 18,
+                    'sender_contract_ticker_symbol': 'PGL',
+                    'sender_logo_url': 'https://logos.covalenthq.com/tokens/43114/0x9ee0a4e21bd333a6bb2ab298194320b8daa26516.png',  # noqa: E501
+                    'sender_name': 'Pangolin Liquidity',
+                    'tx_hash': '0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d',  # noqa: E501
+                    'tx_offset': 1},
+                   {'block_height': 2716404,
+                    'block_signed_at': '2021-07-19T21:49:58Z',
+                    'decoded': {'name': 'Transfer',
+                                'params': [
+                                    {'decoded': True, 'indexed': True, 'name': 'from', 'type': 'address', 'value': '0x9ee0a4e21bd333a6bb2ab298194320b8daa26516'},  # noqa: E501
+                                    {'decoded': True, 'indexed': True, 'name': 'to', 'type': 'address', 'value': '0x4f59ae4374d93b7087f2afa6db95815b43d1c2da'},  # noqa: E501
+                                    {'decoded': True, 'indexed': False, 'name': 'value', 'type': 'uint256', 'value': '1173514056'}],  # noqa: E501
+                                'signature': 'Transfer(indexed address from, indexed address to, uint256 value)'},  # noqa: E501
+                    'log_offset': 7,
+                    'raw_log_data': '0x0000000000000000000000000000000000000000000000000000000045f26748',  # noqa: E501
+                    'raw_log_topics': [
+                        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+                        '0x0000000000000000000000009ee0a4e21bd333a6bb2ab298194320b8daa26516',
+                        '0x0000000000000000000000004f59ae4374d93b7087f2afa6db95815b43d1c2da'],
+                    'sender_address': '0xde3a24028580884448a5397872046a019649b084',
+                    'sender_address_label': None,
+                    'sender_contract_decimals': 6,
+                    'sender_contract_ticker_symbol': 'USDT',
+                    'sender_logo_url': 'https://logos.covalenthq.com/tokens/43114/0xde3a24028580884448a5397872046a019649b084.png',  # noqa: E501
+                    'sender_name': 'Tether USD',
+                    'tx_hash': '0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d',  # noqa: E501
+                    'tx_offset': 1},
+                   {'block_height': 2716404,
+                    'block_signed_at': '2021-07-19T21:49:58Z',
+                    'decoded': {'name': 'Transfer',
+                                'params': [
+                                    {'decoded': True, 'indexed': True, 'name': 'from', 'type': 'address', 'value': '0xe54ca86531e17ef3616d22ca28b0d458b6c89106'},  # noqa: E501
+                                    {'decoded': True, 'indexed': True, 'name': 'to', 'type': 'address', 'value': '0x9ee0a4e21bd333a6bb2ab298194320b8daa26516'},  # noqa: E501
+                                    {'decoded': True, 'indexed': False, 'name': 'value', 'type': 'uint256', 'value': '115951490920000000000'}],  # noqa: E501
+                                'signature': 'Transfer(indexed address from, indexed address to, uint256 value)'},  # noqa: E501
+                    'log_offset': 6,
+                    'raw_log_data': '0x000000000000000000000000000000000000000000000006492672a787881000',  # noqa: E501
+                    'raw_log_topics': [
+                        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+                        '0x000000000000000000000000e54ca86531e17ef3616d22ca28b0d458b6c89106',
+                        '0x0000000000000000000000009ee0a4e21bd333a6bb2ab298194320b8daa26516'],
+                    'sender_address': '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7',
+                    'sender_address_label': None,
+                    'sender_contract_decimals': 18,
+                    'sender_contract_ticker_symbol': 'WAVAX',
+                    'sender_logo_url': 'https://logos.covalenthq.com/tokens/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7.png',  # noqa: E501
+                    'sender_name': 'Wrapped AVAX',
+                    'tx_hash': '0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d',  # noqa: E501
+                    'tx_offset': 1},
+                   {'block_height': 2716404,
+                    'block_signed_at': '2021-07-19T21:49:58Z',
+                    'decoded': {'name': 'Deposit',
+                                'params': [
+                                    {'decoded': True, 'indexed': True, 'name': 'dst', 'type': 'address', 'value': '0xe54ca86531e17ef3616d22ca28b0d458b6c89106'},  # noqa: E501
+                                    {'decoded': True, 'indexed': False, 'name': 'wad', 'type': 'uint256', 'value': '115951490920000000000'}],  # noqa: E501
+                                'signature': 'Deposit(indexed address dst, uint256 wad)'},
+                    'log_offset': 5,
+                    'raw_log_data': '0x000000000000000000000000000000000000000000000006492672a787881000',  # noqa: E501
+                    'raw_log_topics': [
+                        '0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c',
+                        '0x000000000000000000000000e54ca86531e17ef3616d22ca28b0d458b6c89106'],
+                    'sender_address': '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7',
+                    'sender_address_label': None,
+                    'sender_contract_decimals': 18,
+                    'sender_contract_ticker_symbol': 'WAVAX',
+                    'sender_logo_url': 'https://logos.covalenthq.com/tokens/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7.png',  # noqa: E501
+                    'sender_name': 'Wrapped AVAX',
+                    'tx_hash': '0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d',  # noqa: E501
+                    'tx_offset': 1}],
+    'successful': True,
+    'timestamp': 1626731398,
+    'to_address': '0xe54ca86531e17ef3616d22ca28b0d458b6c89106',
+    'to_address_label': None,
+    'tx_hash': '0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d',
+    'tx_offset': 1,
+    'value': '115951490920000000000',
+    'value_quote': 1230.738907788674,
+}
+
+web3_tx_receipt_result = AttributeDict({
+    'blockHash': HexBytes('0x3ed1c9e40e6b07355e05683cf0078167149c95f00a81ecc2885896119a16fd1a'),
+    'blockNumber': 2716404,
+    'from': '0x4F59aE4374D93b7087F2aFa6Db95815b43d1C2dA',
+    'gas': 195000,
+    'gasPrice': 225000000000,
+    'hash': HexBytes('0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d'),
+    'input': '0xa2a1623d0000000000000000000000000000000000000000000000000000000045e2330c00000000000000000000000000000000000000000000000000000000000000800000000000000000000000004f59ae4374d93b7087f2afa6db95815b43d1c2da0000000000000000000000000000000000000000000000000000000060f5f8330000000000000000000000000000000000000000000000000000000000000002000000000000000000000000b31f66aa3c1e785363f0875a1b74e27b85fd66c7000000000000000000000000de3a24028580884448a5397872046a019649b084',  # noqa: E501
+    'nonce': 35808,
+    'to': '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106',
+    'transactionIndex': 1,
+    'value': 115951490920000000000,
+    'type': '0x0',
+    'chainId': '0xa86a',
+    'v': 86263,
+    'r': HexBytes('0xe7a10b563221d5d3e19a9cb8b489d1c548dd1ce1a11969f9db246547c0540b61'),
+    's': HexBytes('0x14f16512139c96884d72da842427d5e9802566a3651caa257431a6678dd6adae')})
 
 
-@flaky(max_runs=3, min_passes=1)  # covalent api might be really flaky
-def test_get_transaction_receipt(avalanche_manager):
+def test_get_transaction_receipt(avalanche_manager, network_mocking):
+    covalent_no_data_patch = patch.object(
+        avalanche_manager.covalent,
+        'get_transaction_receipt',
+        side_effect=lambda *args: None,  # None means no data from covalent so we go to w3
+    )
     covalent_patch = patch.object(
         avalanche_manager.covalent,
         'get_transaction_receipt',
-        side_effect=lambda *args: None,  # None means no data from covalent,
-    )
+        return_value=covalent_tx_receipt_result,
+    ) if network_mocking else nullcontext()
+    w3_patch = patch.object(
+        avalanche_manager.w3.eth,
+        'get_transaction',
+        return_value=web3_tx_receipt_result,
+    ) if network_mocking else nullcontext()
 
     tx_hash = deserialize_evm_tx_hash('0x7e7dee4b821331437524d0fd176a5090abbe4e857c849b06dfe9224f00e22f4d')  # noqa: E501
-    covalent_result = avalanche_manager.get_transaction_receipt(tx_hash=tx_hash)
     with covalent_patch:
+        covalent_result = avalanche_manager.get_transaction_receipt(tx_hash=tx_hash)
+    with covalent_no_data_patch, w3_patch:
         web3_result = avalanche_manager.get_transaction_receipt(tx_hash=tx_hash)
 
     assert covalent_result['hash'] == web3_result['hash'] == tx_hash

--- a/rotkehlchen/tests/unit/test_defi_oracles.py
+++ b/rotkehlchen/tests/unit/test_defi_oracles.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
-def test_uniswap_oracles_asset_to_asset(inquirer_defi):
+def test_uniswap_oracles_asset_to_asset(inquirer_defi, socket_enabled):  # pylint: disable=unused-argument  # noqa: E501
     """
     Test that the uniswap oracles return a price close to the one reported by
     coingecko.
@@ -52,7 +52,7 @@ def test_uniswap_oracles_asset_to_asset(inquirer_defi):
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
-def test_uniswap_oracles_special_cases(inquirer_defi):
+def test_uniswap_oracles_special_cases(inquirer_defi, socket_enabled):  # pylint: disable=unused-argument  # noqa: E501
     """
     Test special cases for the uniswap oracles
     """
@@ -71,7 +71,7 @@ def test_uniswap_oracles_special_cases(inquirer_defi):
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
-def test_uniswap_no_decimals(inquirer_defi):
+def test_uniswap_no_decimals(inquirer_defi, socket_enabled):  # pylint: disable=unused-argument
     """Test that if a token has no information about the number of decimals a proper error
     is raised"""
     asset_resolver = AssetResolver()

--- a/rotkehlchen/tests/unit/test_ens.py
+++ b/rotkehlchen/tests/unit/test_ens.py
@@ -20,6 +20,41 @@ from rotkehlchen.tests.utils.ethereum import (
 from rotkehlchen.types import SupportedBlockchain
 
 
+@pytest.mark.parametrize('should_mock_web3', [True])
+@pytest.mark.parametrize('web3_mock_data', [{
+    'eth_call': {
+        '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e': {
+            '0x0178b8bf59bf8936dba1550677fa0e3950bc703b90b92ab9423bfbced145233f4050bff6': {
+                # getting resolver addr for api.zerion.eth
+                'latest': '0x000000000000000000000000daaf96c344f63131acadd0ea35170e7892d3dfba',
+            },
+            '0x0178b8bfa92039d81cb82a6a9c69005ef09df58f6d692d7f28a09aa558d5a12655688e9b': {
+                # getting resolver addr for rotki.eth
+                'latest': '0x000000000000000000000000226159d592e2b063810a10ebf6dcbada94ed68b8',
+            },
+            '0x0178b8bf4a2f620499c726cf4ddce49f75d6144f224907afc459d76c3769c26091f0bc30': {
+                # getting resolver addr for ishouldprobablynotexist.eth or dsadsad
+                'latest': '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+            '0x0178b8bfde0df0b6cfb5f37a4131be127532dd375bd06f0eb43f98ebc15a0460c3719953': {
+                # getting resolver addr for ishouldprobablynotexist.eth or dsadsad
+                'latest': '0x0000000000000000000000000000000000000000000000000000000000000000',
+            },
+        },
+        '0xDaaF96c344f63131acadD0Ea35170E7892d3dfBA': {
+            '0x3b3b57de59bf8936dba1550677fa0e3950bc703b90b92ab9423bfbced145233f4050bff6': {
+                # calling addr() on resolver for api.zerion.eth
+                'latest': '0x00000000000000000000000006fe76b2f432fdfecaef1a7d4f6c3d41b5861672',
+            },
+        },
+        '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8': {
+            '0x3b3b57dea92039d81cb82a6a9c69005ef09df58f6d692d7f28a09aa558d5a12655688e9b': {
+                # calling addr() on resolver for rotki.eth
+                'latest': '0x0000000000000000000000009531c059098e3d194ff87febb587ab07b30b1306',
+            },
+        },
+    },
+}])
 @pytest.mark.parametrize(*ETHEREUM_TEST_PARAMETERS)
 def test_ens_lookup(ethereum_inquirer, call_order, ethereum_manager_connect_at_start):
     """Test that ENS lookup works. Both with etherscan and with querying a real node"""
@@ -39,11 +74,35 @@ def test_ens_lookup(ethereum_inquirer, call_order, ethereum_manager_connect_at_s
 
     result = ethereum_inquirer.ens_lookup('ishouldprobablynotexist.eth', call_order=call_order)
     assert result is None
-
     result = ethereum_inquirer.ens_lookup('dsadsad', call_order=call_order)
     assert result is None
 
 
+@pytest.mark.parametrize('should_mock_web3', [True])
+@pytest.mark.parametrize('web3_mock_data', [{
+    'eth_call': {
+        '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e': {
+            '0x0178b8bf9de0b76f3b87380f0bcb9e41b403c69b88b01fbeaf785e83f38a6879902af71b': {
+                # getting resolver addr for bruno.eth
+                'latest': '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
+            },
+        },
+        '0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41': {
+            '0x3b3b57de9de0b76f3b87380f0bcb9e41b403c69b88b01fbeaf785e83f38a6879902af71b': {
+                # calling addr() on resolver for bruno.eth
+                'latest': '0x000000000000000000000000b9b8ef61b7851276b0239757a039d54a23804cbb',
+            },
+            '0xf1cb7e069de0b76f3b87380f0bcb9e41b403c69b88b01fbeaf785e83f38a6879902af71b0000000000000000000000000000000000000000000000000000000000000000': {  # noqa: E501
+                # calling addr() on resolver for bruno.eth and coin type Bitcoin
+                'latest': '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001976a9147f1fff38da2809b9368262284e0608dfb5c4537988ac00000000000000',  # noqa: E501
+            },
+            '0xf1cb7e069de0b76f3b87380f0bcb9e41b403c69b88b01fbeaf785e83f38a6879902af71b00000000000000000000000000000000000000000000000000000000000001b2': {  # noqa: E501
+                # calling addr() on resolver for bruno.eth and coin type Kusama
+                'latest': '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000200aff6865635ae11013a83835c019d44ec3f865145943f487ae82a8e7bed3a66b',  # noqa: E501
+            },
+        },
+    },
+}])
 @pytest.mark.parametrize(*ETHEREUM_TEST_PARAMETERS)
 def test_ens_lookup_multichain(
         ethereum_inquirer,
@@ -85,6 +144,60 @@ def test_ens_lookup_multichain(
     assert result == ENS_BRUNO_SUBSTRATE_PUBLIC_KEY
 
 
+@pytest.mark.parametrize('should_mock_web3', [True])
+@pytest.mark.parametrize('web3_mock_data', [{
+    'eth_call': {
+        '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e': {
+            '0x0178b8bfe4ce152682c62d25dbc668723afbc7d9b6baa21b5c1e9a19f94213198a2e5efb': {
+                # getting resolver addr for lefteris.eth
+                'latest': '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
+            },
+            '0x0178b8bf9f5cd92e2589fadd191e7e7917b9328d03dc84b7a67773db26efb7d0a4635677': {
+                # getting resolver addr for abc.eth
+                'latest': '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
+            },
+            '0x0178b8bfa92039d81cb82a6a9c69005ef09df58f6d692d7f28a09aa558d5a12655688e9b': {
+                # getting resolver addr for rotki.eth
+                'latest': '0x000000000000000000000000226159d592e2b063810a10ebf6dcbada94ed68b8',
+            },
+        },
+        '0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41': {
+            '0x3b3b57dee4ce152682c62d25dbc668723afbc7d9b6baa21b5c1e9a19f94213198a2e5efb': {
+                # calling addr() on resolver for lefteris.eth
+                'latest': '0x0000000000000000000000002b888954421b424c5d3d9ce9bb67c9bd47537d12',
+            },
+            '0x3b3b57de9f5cd92e2589fadd191e7e7917b9328d03dc84b7a67773db26efb7d0a4635677': {
+                # calling addr() on resolver for abc.eth
+                'latest': '0x000000000000000000000000a4b73b39f73f73655e9fdc5d167c21b3fa4a1ed6',
+            },
+        },
+        '0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C': {
+            '0xcbf8b66c0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000071c7656ec7ab88b098defb751b7401b5f6d8976f0000000000000000000000002b888954421b424c5d3d9ce9bb67c9bd47537d12': {  # noqa: E501
+                # getNames() on ens reverse records for
+                # '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+                # '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
+                'latest': '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c6c656674657269732e6574680000000000000000000000000000000000000000',  # noqa: E501
+            },
+            '0xcbf8b66c00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a4b73b39f73f73655e9fdc5d167c21b3fa4a1ed60000000000000000000000009531c059098e3d194ff87febb587ab07b30b1306': {  # noqa: E501
+                # getNames() on ens reverse records for
+                # '0xA4b73b39F73F73655e9fdC5D167c21b3fA4A1eD6',
+                # '0x9531C059098e3d194fF87FebB587aB07B30B1306'
+                'latest': '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000076162632e657468000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009726f746b692e6574680000000000000000000000000000000000000000000000',  # noqa: E501
+            },
+            '0xcbf8b66c000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000005b2ed2ef8f480cc165a600ac451d9d9ebf521e94': {  # noqa: E501
+                # getNames() on ens reverse records for
+                # '0x5b2Ed2eF8F480cC165A600aC451D9D9Ebf521e94'
+                'latest': '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000',  # noqa: E501
+            },
+        },
+        '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8': {
+            '0x3b3b57dea92039d81cb82a6a9c69005ef09df58f6d692d7f28a09aa558d5a12655688e9b': {
+                # calling addr() on resolver for rotki.eth
+                'latest': '0x0000000000000000000000009531c059098e3d194ff87febb587ab07b30b1306',
+            },
+        },
+    },
+}])
 def test_ens_reverse_lookup(ethereum_inquirer):
     """This test could be flaky because it assumes
         that all used ens names exist
@@ -94,7 +207,7 @@ def test_ens_reverse_lookup(ethereum_inquirer):
         'call_contract',
         wraps=ethereum_inquirer.call_contract,
     )
-    # Mocking addresses per reverse ens query to check that chunking works correctly
+    # The patch is just to to check that chunking works correctly
     # We do 2 requests - first without splitting in chunks and in the second one addresses
     # should be split. We confirm it by checking call_count attribute of the call contract patch.
     addrs_in_chunk_patch = patch(

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -71,7 +71,7 @@ TEST_ADDR3 = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
 
 # Test with etherscan and infura
 ETHEREUM_TEST_PARAMETERS: tuple[str, list[tuple]]
-if 'GITHUB_WORKFLOW' in os.environ:
+if 'GITHUB_WORKFLOW' in os.environ:  # TODO: Undo this if once all tests where it's used are mockable  # noqa: E501
     # For Github actions don't use infura. It seems that connecting to it
     # from Github actions hangs and times out
     ETHEREUM_TEST_PARAMETERS = ('ethereum_manager_connect_at_start, call_order', [

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -1,8 +1,13 @@
 import json
+import re
 from collections import namedtuple
 from typing import Any, Optional
+from unittest.mock import patch
 
 from hexbytes import HexBytes
+
+MOCK_WEB3_LAST_BLOCK_INT = 16210873
+MOCK_WEB3_LAST_BLOCK_HEX = '0xf75bb9'
 
 
 class MockResponse():
@@ -60,3 +65,99 @@ class MockWeb3():
     @property
     def net(self):
         return namedtuple('Version', ['version'])(version=1)
+
+
+def patch_web3_request(test_specific_mock_data):
+    """Patches all requests going to web3 through the rpc provider
+
+    Has some pre-determined mock responses but also accepts test_specific_mock_data
+    to determine certain responses per-test
+    """
+    counter = 0
+    method_dict = {
+        'web3_clientVersion': 'Geth/v1.10.23-omnibus-b38477ec/linux-amd64/go1.18.5',
+        'net_version': '1',
+        'eth_blockNumber': MOCK_WEB3_LAST_BLOCK_HEX,
+        'eth_chainId': '0x1',
+    }
+    method_dict.update(test_specific_mock_data)
+
+    def mock_web3_make_request(method: str, params: tuple):
+        """A mock for all web3 rpc requests"""
+        nonlocal counter
+        final_result = None
+        result = method_dict.get(method)
+        if result is None:
+            raise AssertionError(f'No web3 mock for {method} and {params}')
+
+        if isinstance(result, str):
+            final_result = result
+        elif isinstance(result, dict):
+            if method != 'eth_call':
+                raise AssertionError(f'Got dict result for non eth_call mock: {method} and {params}')  # noqa: E501
+            contract_to = params[0]['to']
+            if contract_to not in result:
+                raise AssertionError(f'eth_call to {contract_to} has no mock')
+
+            data = params[0]['data']
+            if data not in result[contract_to]:
+                raise AssertionError(f'eth_call to {contract_to} for {data} has no mock')
+
+            block = params[1]
+            if block not in result[contract_to][data]:
+                raise AssertionError(f'eth_call to {contract_to} for {data} and block {block} has no mock')  # noqa: E501
+
+            final_result = result[contract_to][data][block]
+        else:
+            raise AssertionError(f'Unrecognized web3 mock result type: {type(result)}')
+
+        json_result = {'id': counter, 'jsonrpc': '2.0', 'result': final_result}
+        counter += 1
+        return json_result
+
+    return patch(
+        'web3.providers.rpc.HTTPProvider.make_request',
+        wraps=mock_web3_make_request,
+    )
+
+
+ETHERSCAN_ETH_CALL_RE = re.compile('.*action=(.*)&to=(.*)&data=(.*)&.*')
+
+
+def patch_etherscan_request(etherscan, mock_data):
+    """Patches all requests going to the passed etherscan object with the given data"""
+    counter = 0
+
+    def mock_etherscan_query(url, **kwargs):  # pylint: disable=unused-argument
+        nonlocal counter
+        match = ETHERSCAN_ETH_CALL_RE.search(url)
+        if match is None:  # only for eth_call for now
+            raise AssertionError(f'Could not parse etherscan query: {url}')
+
+        contract_to = match.group(2)
+        data = match.group(3)
+
+        eth_call_data = mock_data.get('eth_call')
+        if eth_call_data is None:
+            raise AssertionError(f'No eth_call mock data given in test for {contract_to=} and {data=}')  # noqa: E501
+
+        contract_result = eth_call_data.get(contract_to)
+        if contract_result is None:
+            raise AssertionError(f'{contract_to=} not found in eth_call mock data')
+
+        data_result = contract_result.get(data)
+        if data_result is None:
+            raise AssertionError(f'{data=} not found in eth_call mock data for contract {contract_to}')  # noqa: E501
+
+        if 'latest' not in data_result:
+            raise AssertionError(f'No latest mock result given in test for {contract_to=} and {data=}')  # noqa: E501
+
+        result = data_result['latest']
+        contents = f'{{"id": {counter}, "jsonrpc": "2.0", "result": "{result}"}}'
+        return MockResponse(200, contents)
+
+    return patch.object(
+        etherscan.session,
+        'get',
+        wraps=mock_etherscan_query,
+    )


### PR DESCRIPTION
This PR introduces a few things and starts changing some tests to speed our test suite up by aiming to reduce network queries. Read the individual commits to see more details but what this does in a TL;DR is:

- Add pytest-socket.  By adding the `--disable-socket` cli argument in a test run there will be failure when there is an attempt to connect to the network. This helps figure out if there is any network calls in a test run and if yes where they are so they can be mocked.
- Add `--no-network-mocking` cli argument for pytest. For tests that are aware of their networking calls (tests we need to touch, such as the ones in this PR), this skips mocking and uses the actual network. This ends up being a fixture variable `network_mocking` which can be read in the tests.
- Since not all tests are properly made to mock and be aware of it, and since most networks calls are web3 related we add the parametrizable fixture `should_mock_web3`. Where this is parametrized as true all web3 stuff (web3 rpc, etherscan, other related apis are mocked. The reason this is different from the `network_mocking` is that we need to go step by step for each test and make it mockable and mock aware. So we just add this to all tests that are properly mocked. Once this has covered the entire suite we can fall back to `network_mocking` fixture and `should_mock_web3` can go away.
- Mocking web3 is annoying in each test with different patches etc. Started a "framework" of sorts where both etherscan and web3 and related apis are mocked from the very start, at the fixture initialization. And each test can parametrize the mocking on its own. This will probably evolve as it is used in more tests and replaces older mocks.