### PR TITLE
Downgrades vue-tsc to 1.0.13

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -118,7 +118,7 @@
     "vitest": "0.26.0",
     "vue-i18n-extract": "2.0.7",
     "vue-template-compiler": "2.7.14",
-    "vue-tsc": "1.0.14",
+    "vue-tsc": "1.0.13",
     "workbox-window": "6.5.4"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
       vue-i18n-extract: 2.0.7
       vue-router: 3.6.5
       vue-template-compiler: 2.7.14
-      vue-tsc: 1.0.14
+      vue-tsc: 1.0.13
       vuetify: 2.6.13
       webpack: 5.75.0
       workbox-window: 6.5.4
@@ -195,7 +195,7 @@ importers:
       vitest: 0.26.0_sass@1.32.13
       vue-i18n-extract: 2.0.7
       vue-template-compiler: 2.7.14
-      vue-tsc: 1.0.14_typescript@4.9.4
+      vue-tsc: 1.0.13_typescript@4.9.4
       workbox-window: 6.5.4
 
   common:
@@ -2426,31 +2426,31 @@ packages:
       - terser
     dev: true
 
-  /@volar/language-core/1.0.14:
-    resolution: {integrity: sha512-j1tMQgw0qCV2amM4qDJNG/zc0yj3ay8HoWNt05IaiCPsULtSSpF/9+F6Izvn0DF7nWOd6MUHTxaQAeZwLfr56Q==}
+  /@volar/language-core/1.0.13:
+    resolution: {integrity: sha512-aJhRiNjKFgLLB3nRJOfAeyle4StnEQgOKa0UpJU+k5EZd3QdiMfQmekXjxYeQj7NOZNQU7zCBEIvQ3gy15I7tA==}
     dependencies:
-      '@volar/source-map': 1.0.14
+      '@volar/source-map': 1.0.13
       '@vue/reactivity': 3.2.45
       muggle-string: 0.1.0
     dev: true
 
-  /@volar/source-map/1.0.14:
-    resolution: {integrity: sha512-8pHCbEWHWaSDGb/FM9zRIW1lY1OAo16MENVSQGCgTwz7PWf3Gw6WW3TFVKCtzaFhLjPH0i5e9hALy7vBPbSHoA==}
+  /@volar/source-map/1.0.13:
+    resolution: {integrity: sha512-dU0plR9BS+bLs7u4chWay+VEIFTrLF15rG2634lGcu7o+z01bRO1U2cegZuIPy46SNkN3ONErLHwS09NBM+Ucg==}
     dependencies:
       muggle-string: 0.1.0
     dev: true
 
-  /@volar/typescript/1.0.14:
-    resolution: {integrity: sha512-67qcjjz7KGFhMCG9EKMA9qJK3BRGQecO4dGyAKfMfClZ/PaVoKfDvJvYo89McGTQ8SeczD48I9TPnaJM0zK8JQ==}
+  /@volar/typescript/1.0.13:
+    resolution: {integrity: sha512-CfJ4higRZrLDAHVGY84gZ444ZUcA3ktPqVMW0fM3mgHDbzYViB3/tsvXOtZk76D3HK2ap6n4cDwBSv3cY4xqlg==}
     dependencies:
-      '@volar/language-core': 1.0.14
+      '@volar/language-core': 1.0.13
     dev: true
 
-  /@volar/vue-language-core/1.0.14:
-    resolution: {integrity: sha512-grJ4dQ7c/suZmBBmZtw2O2XeDX+rtgpdBtHxMug1NMPRDxj5EZ9WGphWtGnMQj8RyVgpz9ByvV5GbQjk4/wfBw==}
+  /@volar/vue-language-core/1.0.13:
+    resolution: {integrity: sha512-DRUg7yk4w2+5XFk8LS1dbXEM0na2uAddOj3KWHROPQmn78pfgXEH3r0NGDCnxElWJX5Y16iameisOjtOhevxog==}
     dependencies:
-      '@volar/language-core': 1.0.14
-      '@volar/source-map': 1.0.14
+      '@volar/language-core': 1.0.13
+      '@volar/source-map': 1.0.13
       '@vue/compiler-dom': 3.2.45
       '@vue/compiler-sfc': 3.2.45
       '@vue/reactivity': 3.2.45
@@ -2459,11 +2459,11 @@ packages:
       vue-template-compiler: 2.7.14
     dev: true
 
-  /@volar/vue-typescript/1.0.14:
-    resolution: {integrity: sha512-2P0QeGLLY05fDTu8GqY8SR2+jldXRTrkQdD2Nc0sVOjMJ7j3RYYY0wJyZ9hCBDuxV4Micc6jdB8nKS0yxQgNvA==}
+  /@volar/vue-typescript/1.0.13:
+    resolution: {integrity: sha512-iEdkF5l6G10fv/G5hs7WcvtT48AT6y/Pm7pvafnB6SxPhm2uHQ+130x3zeWLMaUel5t6h5LBw2pFsF5Bh85QAQ==}
     dependencies:
-      '@volar/typescript': 1.0.14
-      '@volar/vue-language-core': 1.0.14
+      '@volar/typescript': 1.0.13
+      '@volar/vue-language-core': 1.0.13
     dev: true
 
   /@vue/compiler-core/3.2.45:
@@ -9448,14 +9448,14 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc/1.0.14_typescript@4.9.4:
-    resolution: {integrity: sha512-HeqtyxMrSRUCnU5nxB0lQc3o7zirMppZ/V6HLL3l4FsObGepH3A3beNmNehpLQs0Gt7DkSWVi3CpVCFgrf+/sQ==}
+  /vue-tsc/1.0.13_typescript@4.9.4:
+    resolution: {integrity: sha512-DORISA3Fu9595xbg5HQqUj4XZVvkyRkcZFJCkCt1CeN7tIMgVRQ8ow07AKcbuHoEkqg7OI4qLu1wyC/VH3o5Ug==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/vue-language-core': 1.0.14
-      '@volar/vue-typescript': 1.0.14
+      '@volar/vue-language-core': 1.0.13
+      '@volar/vue-typescript': 1.0.13
       typescript: 4.9.4
     dev: true
 


### PR DESCRIPTION
There is an incompatibility with `vite-plugin-checker` that causes an error

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
