### PR TITLE
ExchangeSettings: fix incorrectly shown error notification

### DIFF
--- a/frontend/app/src/components/settings/api-keys/ExchangeSettings.vue
+++ b/frontend/app/src/components/settings/api-keys/ExchangeSettings.vue
@@ -171,7 +171,7 @@ const toggleSync = async (exchange: Exchange) => {
     nonSyncingExchanges: data
   });
 
-  if ('message' in status) {
+  if (!status.success) {
     const { notify } = useNotifications();
     notify({
       title: tc('exchange_settings.sync.messages.title'),


### PR DESCRIPTION
Before

https://user-images.githubusercontent.com/120989846/208551293-cb011f9c-a868-4001-92ec-69d4e455bbbc.mov

---

After

https://user-images.githubusercontent.com/120989846/208551274-e99f4a0b-75b9-48f6-b96b-5ddd29d885a2.mov
