### PR TITLE
use ORACLE_PENALTY_TS correctly

### DIFF
--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -521,7 +521,10 @@ def test_punishing_of_oracles_works(inquirer):
                 assert coingecko_mock.called is True
                 assert defillama_mock.called is True
 
+        # move the current time forward and check that coingecko is still penalized
+        with freeze_time(datetime.utcfromtimestamp(ts_now() + ORACLE_PENALTY_TS / 2)):
+            assert inquirer._coingecko.is_penalized() is True
+
         # move the current time forward and check that coingecko is no longer penalized
-        with freeze_time(datetime.fromtimestamp(ts_now() + ORACLE_PENALTY_TS + 1)):
+        with freeze_time(datetime.utcfromtimestamp(ts_now() + ORACLE_PENALTY_TS + 1)):
             assert inquirer._coingecko.is_penalized() is False
-            assert inquirer.find_usd_price(A_BTC, ignore_cache=True) > Price(ZERO)

--- a/rotkehlchen/utils/mixins/penalizable_oracle.py
+++ b/rotkehlchen/utils/mixins/penalizable_oracle.py
@@ -40,4 +40,4 @@ class PenalizablePriceOracleMixin:
         if self.penalty_info.query_failures_count == ORACLE_PENALTY_THRESHOLD_COUNT:
             self.penalty_info.note_failure_or_penalize()
 
-        return ts_now() - self.penalty_info.last_penalized_ts <= ORACLE_PENALTY_THRESHOLD_COUNT
+        return ts_now() - self.penalty_info.last_penalized_ts <= ORACLE_PENALTY_TS


### PR DESCRIPTION
- noticed that `ORACLE_PENALTY_TS` variable is unused, so added a test that fails to reflect this
- changed 
    ```py
    freeze_time(datetime.fromtimestamp(ts_now() + k))
    ```
    to

    ```py
    freezetime(datetime.utcfromtimestamp(ts_now() + k))
    ```
    because the first instance freezes to local time, which introduces additional delay (as seen from UTC) in `ts_now()`

created a reproducible example here - https://replit.com/@crunchy-roll/EvilLooseSystemsoftware#main.py