### PR TITLE
Prevent error when assets have incomplete information

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`-` Connecting to substrate nodes will no longer timeout prematurely for systems with slow connections.
 * :bug:`-` Transfers between tracked accounts will now have a correct label in the UI.
+* :bug:`-` Users will be able to finish balance queries if they have assets with missing information.
 * :bug:`5038` Premium users with big databases should no longer see the error: "Upload data to server died with exception: database plaintext is locked"
 
 


### PR DESCRIPTION
There was a problem reported by an user where the balance query was not finishing because of an unhanlded error in the case when the asset was missing the decimals or name fields.

```
Exception Name: <class 'rotkehlchen.errors.asset.UnknownAsset'>
Exception Info: Unknown asset eip155:1/erc20:0x3031745E732dcE8fECccc94AcA13D5fa18F1012d provided.
Traceback:
   File "src\\gevent\\greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen\api\rest.py", line 298, in _do_query_async
  File "rotkehlchen\api\rest.py", line 664, in _query_blockchain_balances
  File "rotkehlchen\utils\mixins\lockable.py", line 46, in wrapper
  File "rotkehlchen\utils\mixins\cacheable.py", line 97, in wrapper
  File "rotkehlchen\chain\manager.py", line 616, in query_balances
  File "rotkehlchen\utils\mixins\lockable.py", line 46, in wrapper
  File "rotkehlchen\utils\mixins\cacheable.py", line 97, in wrapper
  File "rotkehlchen\chain\manager.py", line 1149, in query_ethereum_balances
  File "rotkehlchen\chain\manager.py", line 1115, in query_defi_balances
  File "rotkehlchen\chain\ethereum\defi\chad.py", line 36, in query_defi_balances
  File "rotkehlchen\chain\ethereum\defi\zerionsdk.py", line 310, in all_balances_for_account
  File "rotkehlchen\chain\ethereum\defi\zerionsdk.py", line 364, in _get_single_balance
  File "rotkehlchen\chain\ethereum\defi\zerionsdk.py", line 412, in handle_protocols
  File "rotkehlchen\assets\utils.py", line 157, in get_crypto_asset_by_symbol
  File "rotkehlchen\globaldb\handler.py", line 1145, in get_assets_with_symbol
  File "rotkehlchen\utils\serialization.py", line 99, in deserialize_asset_with_oracles_from_db
```
