### PR TITLE
Add name field to the balancer tokens

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :bug:`-` Transfers between tracked accounts will now have a correct label in the UI.
 * :bug:`-` Users will be able to finish balance queries if they have assets with missing information.
 * :bug:`5038` Premium users with big databases should no longer see the error: "Upload data to server died with exception: database plaintext is locked"
+* :bug:`-` Tokens added by the Balancer module will now have the name field correctly set.
 * :bug:`-` If a user removes the API keys for an exchange, actions on that exchange will no longer be excluded from PnL reports.
 
 * :release:`1.26.2 <2022-12-09>`

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -103,6 +103,7 @@ def deserialize_bpt_event(
         userdb=userdb,
         evm_address=pool_address,
         chain=ChainID.ETHEREUM,
+        name='Balancer Pool Token',
         symbol='BPT',
         protocol='balancer',
         decimals=18,  # all BPT tokens have 18 decimals
@@ -236,6 +237,7 @@ def deserialize_pool_share(
     pool_token_balances.sort(key=lambda x: x.token.evm_address)
     balancer_pool_token = get_or_create_evm_token(
         userdb=userdb,
+        name='Balancer Pool Token',
         symbol='BPT',
         evm_address=pool_address,
         chain=ChainID.ETHEREUM,

--- a/rotkehlchen/tests/api/test_balancer.py
+++ b/rotkehlchen/tests/api/test_balancer.py
@@ -50,6 +50,7 @@ BALANCER_TEST_ADDR2_POOL1 = EvmToken.initialize(
     address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
     chain=ChainID.ETHEREUM,
     token_kind=EvmTokenKind.ERC20,
+    name='Balancer Pool Token',
     symbol='BPT',
     protocol='balancer',
     underlying_tokens=[
@@ -61,6 +62,7 @@ BALANCER_TEST_ADDR2_POOL2 = EvmToken.initialize(
     address=string_to_evm_address('0x574FdB861a0247401B317a3E68a83aDEAF758cf6'),
     chain=ChainID.ETHEREUM,
     token_kind=EvmTokenKind.ERC20,
+    name='Balancer Pool Token',
     symbol='BPT',
     protocol='balancer',
     underlying_tokens=[
@@ -373,6 +375,12 @@ def test_get_events_history_1(
 
     assert len(pool_event_balances) == 1
     pool_events_balance = pool_event_balances[0]
+
+    # check that the tokens were correctly created
+    bpt_token = EvmToken(BALANCER_TEST_ADDR2_POOL1.identifier)
+    assert bpt_token.name == 'Balancer Pool Token'
+    assert bpt_token.symbol == 'BPT'
+    assert bpt_token.decimals == 18
 
     assert pool_events_balance == BALANCER_TEST_ADDR2_EXPECTED_HISTORY_POOL1.serialize()
 


### PR DESCRIPTION
The logic in the balancer module was creating pool tokens (`BPT`) but was not setting the name of those. The side effect of this was that when they were being used for balance queries "basic information" was missing and this was raising unexpected errors (handled already in other PR).