### PR TITLE
Don't query trades for locations ignored

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`-` Connecting to substrate nodes will no longer timeout prematurely for systems with slow connections.
 * :bug:`-` Transfers between tracked accounts will now have a correct label in the UI.
 * :bug:`-` Users will be able to finish balance queries if they have assets with missing information.
+* :bug:`-` Visiting the trades page won't query now trades from exchanges that are ignored.
 * :bug:`5038` Premium users with big databases should no longer see the error: "Upload data to server died with exception: database plaintext is locked"
 * :bug:`-` Tokens added by the Balancer module will now have the name field correctly set.
 * :bug:`-` If a user removes the API keys for an exchange, actions on that exchange will no longer be excluded from PnL reports.

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -122,7 +122,13 @@ class EventsHistorian:
         from_ts = filter_query.from_ts
         to_ts = filter_query.to_ts
 
-        if location is not None:
+        with self.db.conn.read_ctx() as cursor:
+            excluded_locations = {exchange.location for exchange in self.db.get_settings(cursor).non_syncing_exchanges}  # noqa: E501
+
+        if (
+            location is not None and
+            location not in excluded_locations
+        ):
             self.query_location_latest_trades(location=location, from_ts=from_ts, to_ts=to_ts)
             return
 


### PR DESCRIPTION
Closes #5265 

I've checked other places where trades are queried and they properly ignore the excluded locations. Added a test for the task manager to verify that the logic doesn't change there