### PR TITLE
Enforce smaller DB transactions in evm transactions querying

### DIFF
--- a/rotkehlchen/tests/integration/test_transactions.py
+++ b/rotkehlchen/tests/integration/test_transactions.py
@@ -24,8 +24,7 @@ def test_get_transaction_receipt(
         transaction_already_queried=transaction_already_queried,
         one_receipt_in_db=False,
     )
-    with database.user_write() as cursor:
-        receipt = eth_transactions.get_or_query_transaction_receipt(cursor, transactions[0].tx_hash)  # noqa: E501
+    receipt = eth_transactions.get_or_query_transaction_receipt(transactions[0].tx_hash)
     assert receipt == receipts[0]
     filter_query = EvmTransactionsFilterQuery.make(tx_hash=transactions[0].tx_hash)
     eth_transactions.query_chain(filter_query)

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -226,11 +226,10 @@ def test_maybe_schedule_ethereum_txreceipts(
     except gevent.Timeout as e:
         raise AssertionError(f'receipts query was not completed within {timeout} seconds') from e  # noqa: E501
 
-    with database.user_write() as cursor:
-        receipt1 = eth_transactions.get_or_query_transaction_receipt(cursor, tx_hash_1)
-        assert receipt1 == receipts[0]
-        receipt2 = eth_transactions.get_or_query_transaction_receipt(cursor, tx_hash_2)
-        assert receipt2 == receipts[1]
+    receipt1 = eth_transactions.get_or_query_transaction_receipt(tx_hash_1)
+    assert receipt1 == receipts[0]
+    receipt2 = eth_transactions.get_or_query_transaction_receipt(tx_hash_2)
+    assert receipt2 == receipts[1]
 
 
 @pytest.mark.parametrize('max_tasks_num', [7])

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -395,6 +395,5 @@ def get_decoded_events_of_transaction(
     else:
         raise AssertionError('Unsupported chainID at tests')
 
-    with database.user_write() as cursor:
-        transactions.get_or_query_transaction_receipt(cursor, tx_hash=tx_hash)
+    transactions.get_or_query_transaction_receipt(tx_hash=tx_hash)
     return decoder.decode_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash]), decoder


### PR DESCRIPTION
- Part of https://github.com/rotki/rotki/issues/5222, where we want to make sure DB write transactions do not stay open for long as this creates problems described in the issue
- Remove old forgotten gevent.sleep(0) context switches