### PR TITLE
Add uniswap auto routers decoder

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 * :bug:`-` Transfers of ether between tracked accounts will now have a correct label in the UI.
 * :bug:`-` Trades involving delisted bitfinex pairs will now be properly read by rotki.
 * :feature:`784` Add support for OKX exchange
+* :feature:`-` Swaps made via uniswap v3 auto routers (both v1 and v2) will now be decoded correctly.
 
 * :release:`1.26.3 <2022-12-30>`
 * :bug:`5315` Fix issue where balance is not fully refreshed after detect tokens button pressed.

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -3,7 +3,10 @@ from typing import TYPE_CHECKING, Callable, Optional
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP_V2
-from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import decode_uniswap_v2_like_swap
+from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import (
+    SUSHISWAP_ROUTER,
+    decode_uniswap_v2_like_swap,
+)
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import ActionItem
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -42,7 +45,7 @@ class SushiswapDecoder(DecoderInterface):
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
     ) -> None:
-        if tx_log.topics[0] == SWAP_SIGNATURE:
+        if tx_log.topics[0] == SWAP_SIGNATURE and transaction.to_address == SUSHISWAP_ROUTER:
             decode_uniswap_v2_like_swap(
                 tx_log=tx_log,
                 decoded_events=decoded_events,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -7,13 +7,19 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 import requests
 from web3.types import BlockIdentifier
 
+from rotkehlchen.accounting.structures.base import HistoryBaseEntry
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.defi.zerionsdk import ZERION_ADAPTER_ADDRESS
 from rotkehlchen.chain.ethereum.interfaces.ammswap.types import LiquidityPool
 from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import _decode_result
+from rotkehlchen.chain.ethereum.modules.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
+from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
+from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.types import WeightedNode
 from rotkehlchen.constants import ZERO
+from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
@@ -235,3 +241,85 @@ def find_uniswap_v2_lp_price(
     numerator = (token0_supply * token0_price + token1_supply * token1_price)
     share_value = numerator / total_supply
     return Price(share_value)
+
+
+def decode_basic_uniswap_info(
+        amount_sent: int,
+        amount_received: int,
+        decoded_events: list[HistoryBaseEntry],
+        counterparty: str,
+        notify_user: Callable[[HistoryBaseEntry, str], None],
+) -> None:
+    """
+    Check last three events and if they are related to the swap, label them as such.
+    We check three events because potential events are: spend, (optionally) approval, receive.
+    Earlier events are not related to the current swap.
+    """
+    spend_event, approval_event, receive_event = None, None, None
+    for event in reversed(decoded_events):
+        try:
+            crypto_asset = event.asset.resolve_to_crypto_asset()
+        except (UnknownAsset, WrongAssetType):
+            notify_user(event, counterparty)
+            return
+
+        if (
+            event.event_type == HistoryEventType.INFORMATIONAL and
+            event.event_subtype == HistoryEventSubType.APPROVE and
+            approval_event is None
+        ):
+            approval_event = event
+        elif (
+            event.balance.amount == asset_normalized_value(amount=amount_sent, asset=crypto_asset) and  # noqa: E501
+            event.event_type == HistoryEventType.SPEND and
+            # don't touch ETH since there may be multiple ETH transfers
+            # and they are better handled by the aggregator decoder.
+            event.asset != A_ETH and
+            spend_event is None
+        ):
+            event.event_type = HistoryEventType.TRADE
+            event.event_subtype = HistoryEventSubType.SPEND
+            event.counterparty = counterparty
+            event.notes = f'Swap {event.balance.amount} {crypto_asset.symbol} in {counterparty}'  # noqa: E501
+            spend_event = event
+        elif (
+            event.balance.amount == asset_normalized_value(amount=amount_received, asset=crypto_asset) and  # noqa: E501
+            event.event_type == HistoryEventType.RECEIVE and
+            event.asset != A_ETH and
+            receive_event is None
+        ):
+            event.event_type = HistoryEventType.TRADE
+            event.event_subtype = HistoryEventSubType.RECEIVE
+            event.counterparty = counterparty
+            event.notes = f'Receive {event.balance.amount} {crypto_asset.symbol} as a result of a {counterparty} swap'  # noqa: E501
+            receive_event = event
+        elif (
+            event.counterparty in {CPT_UNISWAP_V2, CPT_UNISWAP_V3} and
+            event.event_type == HistoryEventType.TRADE
+        ):
+            # The structure of swaps is the following:
+            # 1.1 Optional approval event
+            # 1.2 Optional spend event
+            # 1.3 Optional receive event
+            # 1.4 SWAP_SIGNATURE event
+            # 2.1 Optional approval event
+            # 2.2 Optional spend event
+            # 2.3 Optional receive event
+            # 2.4 SWAP_SIGNATURE event
+            # etc.
+            # So if we are at SWAP_SIGNATURE № 2 then all events that are before SWAP_SIGNATURE № 1
+            # should have already been decoded, have counterparty set and have type Trade.
+            break
+        else:
+            # If what described in the comment above is not met then it is an error.
+            log.error(
+                f'Found unexpected event {event.serialize()} during decoding a uniswap swap '
+                f'in transaction {event.event_identifier.hex()}',
+            )
+            break
+
+    # Make sure that the approval event is NOT between the spend and receive events.
+    if spend_event is not None and approval_event is not None:
+        maybe_reshuffle_events(out_event=approval_event, in_event=spend_event)
+    if spend_event is not None and receive_event is not None:
+        maybe_reshuffle_events(out_event=spend_event, in_event=receive_event)

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -3,11 +3,17 @@ from typing import TYPE_CHECKING, Callable, Optional
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.modules.uniswap.constants import CPT_UNISWAP_V2
-from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import decode_uniswap_v2_like_swap
+from rotkehlchen.chain.ethereum.modules.uniswap.utils import decode_basic_uniswap_info
+from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import (
+    UNISWAP_V2_ROUTER,
+    decode_uniswap_v2_like_swap,
+)
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import ActionItem
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.types import EvmTransaction
+from rotkehlchen.utils.misc import hex_or_bytes_to_int
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -34,6 +40,34 @@ class Uniswapv2Decoder(DecoderInterface):
         self.database = ethereum_inquirer.database
         self.ethereum_inquirer = ethereum_inquirer
 
+    def _decode_basic_swap_info(
+            self,
+            tx_log: EvmTxReceiptLog,
+            decoded_events: list[HistoryBaseEntry],
+    ) -> None:
+        """
+        Decodes only basic swap info. Basic swap info includes trying to find approval, spend and
+        receive events for this particular swap but doesn't include ensuring order of events if the
+        swap was made by an aggregator.
+        """
+        # amount_in is the amount that enters the pool and amount_out the one
+        # that leaves the pool
+        amount_in_token_0, amount_in_token_1 = hex_or_bytes_to_int(tx_log.data[0:32]), hex_or_bytes_to_int(tx_log.data[32:64])  # noqa: E501
+        amount_out_token_0, amount_out_token_1 = hex_or_bytes_to_int(tx_log.data[64:96]), hex_or_bytes_to_int(tx_log.data[96:128])  # noqa: E501
+        amount_in, amount_out = amount_in_token_0, amount_out_token_0
+        if amount_in == ZERO:
+            amount_in = amount_in_token_1
+        if amount_out == ZERO:
+            amount_out = amount_out_token_1
+
+        decode_basic_uniswap_info(
+            amount_sent=amount_in,
+            amount_received=amount_out,
+            decoded_events=decoded_events,
+            counterparty=CPT_UNISWAP_V2,
+            notify_user=self.notify_user,
+        )
+
     def _maybe_decode_v2_swap(  # pylint: disable=no-self-use
             self,
             token: Optional[EvmToken],  # pylint: disable=unused-argument
@@ -44,15 +78,23 @@ class Uniswapv2Decoder(DecoderInterface):
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
     ) -> None:
         if tx_log.topics[0] == SWAP_SIGNATURE:
-            decode_uniswap_v2_like_swap(
-                tx_log=tx_log,
-                decoded_events=decoded_events,
-                transaction=transaction,
-                counterparty=CPT_UNISWAP_V2,
-                database=self.database,
-                ethereum_inquirer=self.ethereum_inquirer,
-                notify_user=self.notify_user,
-            )
+            if transaction.to_address == UNISWAP_V2_ROUTER:
+                # If uniswap v2 router is used, then we can decode an entire swap.
+                # Uniswap v2 router is a simple router that always has a single spend and a single
+                # receive event.
+                decode_uniswap_v2_like_swap(
+                    tx_log=tx_log,
+                    decoded_events=decoded_events,
+                    transaction=transaction,
+                    counterparty=CPT_UNISWAP_V2,
+                    database=self.database,
+                    ethereum_inquirer=self.ethereum_inquirer,
+                    notify_user=self.notify_user,
+                )
+            else:
+                # Else some aggregator (potentially complex) is used, so we decode only basic info
+                # and other properties should be decoded by the aggregator decoding methods later.
+                self._decode_basic_swap_info(tx_log=tx_log, decoded_events=decoded_events)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -1,23 +1,24 @@
 import logging
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, NamedTuple, Optional
+from rotkehlchen.accounting.structures.balance import Balance
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.ethereum.modules.uniswap.utils import decode_basic_uniswap_info
+from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import ActionItem
-from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
+from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import EvmTransaction
-from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.types import EvmTransaction, Location
+from rotkehlchen.utils.misc import hex_or_bytes_to_int
 
-from ..constants import CPT_UNISWAP_V3
+from ..constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -31,7 +32,77 @@ log = RotkehlchenLogsAdapter(logger)
 # https://docs.uniswap.org/protocol/reference/core/interfaces/pool/IUniswapV3PoolEvents#swap
 SWAP_SIGNATURE = b'\xc4 y\xf9JcP\xd7\xe6#_)\x17I$\xf9(\xcc*\xc8\x18\xebd\xfe\xd8\x00N\x11_\xbc\xcag'  # noqa: E501
 
-UNISWAP_V3_ROUTER = string_to_evm_address('0xE592427A0AEce92De3Edee1F18E0157C05861564')
+UNISWAP_AUTO_ROUTER_V1 = string_to_evm_address('0xE592427A0AEce92De3Edee1F18E0157C05861564')
+UNISWAP_AUTO_ROUTER_V2 = string_to_evm_address('0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45')
+
+UNISWAP_ROUTERS = {UNISWAP_AUTO_ROUTER_V1, UNISWAP_AUTO_ROUTER_V2}
+
+
+class SwapData(NamedTuple):
+    from_asset: Optional[Asset]
+    from_amount: FVal
+    to_asset: Optional[Asset]
+    to_amount: FVal
+
+
+def _find_from_asset_and_amount(events: list[HistoryBaseEntry]) -> Optional[tuple[Asset, FVal]]:
+    """
+    Searches for uniswap v2/v3 swaps, detects `from_asset` and sums up `from_amount`.
+    Works only with `from_asset` being the same for all swaps.
+    """
+    from_asset: Optional[Asset] = None
+    from_amount = ZERO
+    for event in events:
+        if (
+            event.event_type == HistoryEventType.TRADE and
+            event.event_subtype == HistoryEventSubType.SPEND and
+            event.counterparty in {CPT_UNISWAP_V2, CPT_UNISWAP_V3}
+        ):
+            if from_asset is None:
+                from_asset = event.asset
+            elif from_asset != event.asset:  # We currently support only single `from_asset`.
+                return None  # unexpected event
+
+            from_amount += event.balance.amount
+
+    if from_asset is None:
+        return None
+    return from_asset, from_amount
+
+
+def _find_to_asset_and_amount(events: list[HistoryBaseEntry]) -> Optional[tuple[Asset, FVal]]:
+    """
+    Searches for uniswap v2/v3 swaps, detects `to_asset` and sums up `to_amount`.
+    Works only with `to_asset` being the same for all swaps.
+    Also works with a special case where there is only one receive event at the end.
+    """
+    to_asset: Optional[Asset] = None
+    to_amount = ZERO
+    for event in events:
+        if (
+            event.event_type == HistoryEventType.TRADE and
+            event.event_subtype == HistoryEventSubType.RECEIVE and
+            event.counterparty in {CPT_UNISWAP_V2, CPT_UNISWAP_V3}
+        ):
+            # Some swaps have many receive events. The structure is:
+            # spend1, receive1, spend2, receive2, ..., spendN, receiveN
+            # In this case they will be decoded as trades and we check them here.
+            if to_asset is None:
+                to_asset = event.asset
+            elif to_asset != event.asset:  # We currently support only single `to_asset`.
+                return None  # unexpected event
+            to_amount += event.balance.amount
+        elif event.event_type == HistoryEventType.RECEIVE and to_asset is None:
+            # Some other swaps have only a single receive event. The structure is:
+            # spend1, spend2, ..., spendN, receive
+            # In this case the receive event won't be decoded as a trade and we check it here.
+            # to_asset should be None here since it should be the only receive event.
+            to_asset = event.asset
+            to_amount = event.balance.amount
+
+    if to_asset is None:
+        return None
+    return to_asset, to_amount
 
 
 class Uniswapv3Decoder(DecoderInterface):
@@ -57,93 +128,194 @@ class Uniswapv3Decoder(DecoderInterface):
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
     ) -> None:
-        """Decode trade for uniswap v3. The approach is to read the events and detect the ones
-        where the user sends and receives any asset. The swap events need to be consecutive and
-        for that we use maybe_reshuffle_events.
-
-        The swap method has as data the delta on the pool for the assets swapped so we make sure
-        to use signed integers to detect the amounts.
         """
-        out_event = in_event = None
-        if tx_log.topics[0] == SWAP_SIGNATURE:
-            received_eth = ZERO
-            for event in decoded_events:
-                if event.asset == A_ETH and event.event_type == HistoryEventType.RECEIVE:
-                    received_eth += event.balance.amount
+        Detect some basic uniswap v3 events. This method doesn't ensure the order of the events
+        and other things, but just labels some of the events as uniswap v3 events.
+        The order should be ensured by the post-decoding rules.
+        """
+        if tx_log.topics[0] != SWAP_SIGNATURE:
+            return
 
-            buyer = hex_or_bytes_to_address(tx_log.topics[2])
-            # Uniswap V3 represents the delta of tokens in the pool with a signed integer
-            # for each token. In the transaction we have the difference of tokens in the pool
-            # for the token0 [0:32] and the token1 [32:64]. If that difference is negative it
-            # means that the tokens are leaving the pool (the user receives them) and if it is
-            # positive they get into the pool (the user sends them to the pool)
-            delta_token_0 = hex_or_bytes_to_int(tx_log.data[0:32], signed=True)
-            delta_token_1 = hex_or_bytes_to_int(tx_log.data[32:64], signed=True)
-            if delta_token_0 > 0:
-                amount_received, amount_sent = delta_token_1, delta_token_0
-            else:
-                amount_received, amount_sent = delta_token_0, delta_token_1
-            # We take the absolute value since we have it negative and we need it positive
-            amount_received = abs(amount_received)
+        # Uniswap V3 represents the delta of tokens in the pool with a signed integer
+        # for each token. In the transaction we have the difference of tokens in the pool
+        # for the token0 [0:32] and the token1 [32:64]. If that difference is negative it
+        # means that the tokens are leaving the pool (the user receives them) and if it is
+        # positive they get into the pool (the user sends them to the pool)
+        delta_token_0 = hex_or_bytes_to_int(tx_log.data[0:32], signed=True)
+        delta_token_1 = hex_or_bytes_to_int(tx_log.data[32:64], signed=True)
+        if delta_token_0 > 0:
+            amount_sent, amount_received = delta_token_0, -delta_token_1
+        else:
+            amount_sent, amount_received = delta_token_1, -delta_token_0
 
-            for event in decoded_events:
-                # When swapping token for ETH the WETH contract is called by the router and the
-                # swap is not executed with the user in the topic but the router. This is when
-                try:
-                    crypto_asset = event.asset.resolve_to_crypto_asset()
-                except (UnknownAsset, WrongAssetType):
-                    self.notify_user(event=event, counterparty=CPT_UNISWAP_V3)
-                    continue
-                if (
-                    event.event_type == HistoryEventType.SPEND and
-                    (event.location_label == buyer or tx_log.topics[1] == tx_log.topics[2]) and
-                    (
-                        event.balance.amount == (spent_amount := asset_normalized_value(
-                            amount=amount_sent,
-                            asset=crypto_asset,
-                        )) or
-                        event.asset == A_ETH and spent_amount + received_eth == event.balance.amount  # noqa: E501
-                    )
-                ):
-                    event.event_type = HistoryEventType.TRADE
-                    event.event_subtype = HistoryEventSubType.SPEND
-                    event.counterparty = CPT_UNISWAP_V3
-                    event.notes = f'Swap {event.balance.amount} {crypto_asset.symbol} in uniswap-v3 from {event.location_label}'  # noqa: E501
-                    out_event = event
-                elif (
-                    (
-                        (event.event_type in (HistoryEventType.RECEIVE, HistoryEventType.TRANSFER)) and  # noqa: E501
-                        (event.location_label == buyer or event.asset == A_ETH) and
-                        event.balance.amount == asset_normalized_value(
-                            amount=amount_received,
-                            asset=crypto_asset,
-                        )
-                    )
-                ):
-                    # In this branch of the condition we also add the transfer to correctly decode
-                    # the case where ETH was sent to the user in a multi-step swap that was decoded
-                    # by the event in the previous step. The check for the location label and the
-                    # amount ensure that we are decoding the right event.
-                    event.event_type = HistoryEventType.TRADE
-                    event.event_subtype = HistoryEventSubType.RECEIVE
-                    event.counterparty = CPT_UNISWAP_V3
-                    event.notes = f'Receive {event.balance.amount} {crypto_asset.symbol} in uniswap-v3 from {event.location_label}'  # noqa: E501
-                    in_event = event
-                elif (
-                    event.event_type == HistoryEventType.RECEIVE and
-                    event.balance.amount != asset_normalized_value(
-                        amount=amount_received,
-                        asset=crypto_asset,
-                    ) and event.counterparty == UNISWAP_V3_ROUTER
-                ):
-                    # this is to make sure its the amm issuing the refund and not an agreggator making a swap  # noqa: E501
-                    # Those are assets returned due to a change in the swap price
-                    event.event_type = HistoryEventType.TRANSFER
-                    event.event_subtype = HistoryEventSubType.NONE
-                    event.counterparty = CPT_UNISWAP_V3
-                    event.notes = f'Refund of {event.balance.amount} {crypto_asset.symbol} in uniswap-v3 due to price change'  # noqa: E501
+        # Uniswap V3 pools are used with complex routers/aggregators and there can be
+        # multiple spend and multiple receive events that are hard to decode by looking only
+        # at a single swap event. Because of that here we decode only basic info, leaving the rest
+        # of the work to the router/aggregator-specific decoding methods.
+        decode_basic_uniswap_info(
+            amount_sent=amount_sent,
+            amount_received=amount_received,
+            decoded_events=decoded_events,
+            counterparty=CPT_UNISWAP_V3,
+            notify_user=self.notify_user,
+        )
 
-        maybe_reshuffle_events(out_event=out_event, in_event=in_event)
+    # --- Routers methods ---
+
+    def _decode_eth_to_token_swap(
+            self,
+            decoded_events: list[HistoryBaseEntry],
+            send_eth_event: HistoryBaseEntry,
+    ) -> Optional[SwapData]:
+        """
+        Decode a swap of ETH to a token. Such swap consists of 3 events:
+        1. Sending ETH to the router.
+        2. If there is a refund, receiving ETH from the router.
+        3. Receiving tokens from the router.
+        """
+        from_amount = send_eth_event.balance.amount
+        for event in decoded_events:
+            if event.asset == A_ETH and event.event_type == HistoryEventType.RECEIVE:
+                # Optional refund event. Can be only one at max. Exists if price has changed.
+                from_amount -= event.balance.amount
+                break
+
+        to_data = _find_to_asset_and_amount(decoded_events)
+        if to_data is None:
+            return None
+
+        return SwapData(
+            from_asset=A_ETH,
+            from_amount=from_amount,
+            to_asset=to_data[0],
+            to_amount=to_data[1],
+        )
+
+    def _decode_token_to_eth_swap(
+            self,
+            decoded_events: list[HistoryBaseEntry],
+            receive_eth_event: HistoryBaseEntry,
+    ) -> Optional[SwapData]:
+        from_data = _find_from_asset_and_amount(decoded_events)
+        if from_data is None:
+            return None
+
+        return SwapData(
+            from_asset=from_data[0],
+            from_amount=from_data[1],
+            to_asset=A_ETH,
+            to_amount=receive_eth_event.balance.amount,
+        )
+
+    def _decode_token_to_token_swap(
+            self,
+            decoded_events: list[HistoryBaseEntry],
+    ) -> Optional[SwapData]:
+        from_data = _find_from_asset_and_amount(decoded_events)
+        to_data = _find_to_asset_and_amount(decoded_events)
+        if from_data is None or to_data is None:
+            return None
+
+        return SwapData(
+            from_asset=from_data[0],
+            from_amount=from_data[1],
+            to_asset=to_data[0],
+            to_amount=to_data[1],
+        )
+
+    def _routers_post_decoding(
+            self,
+            transaction: EvmTransaction,
+            decoded_events: list[HistoryBaseEntry],
+            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+    ) -> list[HistoryBaseEntry]:
+        """
+        Ensures that if an auto router (either v1 or v2) is used, events have correct order and
+        are properly combined (i.e. each swap consists only of one spend and one receive event).
+
+        Right now supports only swaps that are made through official uniswap auto routers and have
+        only one source / destination token.
+
+        If it fails to decode a swap, it will return the original list of events.
+
+        This function checks for three types of swaps:
+        1. Swap from eth to token
+        2. Swap from token to eth
+        3. Swap from token to token (with a single receive or multiple receive events)
+        """
+        if transaction.to_address not in UNISWAP_ROUTERS:
+            return decoded_events  # work only with the known routers for now
+        if len(decoded_events) < 3:
+            # The minimum is 3 events: gas, spend, receive.
+            return decoded_events
+
+        eth_event = None
+        for event in decoded_events:
+            if event.asset == A_ETH and event.counterparty != CPT_GAS:
+                eth_event = event
+                break
+
+        # Since we check that the to_address is a known router, we can be sure that the ETH
+        # transfer event (and other events) are parts of the swap.
+        if eth_event is not None:
+            if eth_event.event_type == HistoryEventType.SPEND:
+                # This is a swap from eth to token
+                swap_data = self._decode_eth_to_token_swap(decoded_events, eth_event)
+            else:  # Receive
+                # This is a swap from token to eth
+                swap_data = self._decode_token_to_eth_swap(decoded_events, eth_event)
+        else:
+            # Then this should be a swap from token to token
+            swap_data = self._decode_token_to_token_swap(decoded_events)
+
+        if swap_data is None or swap_data.from_asset is None or swap_data.to_asset is None:
+            log.error(f'Failed to decode a uniswap swap for transaction {transaction.tx_hash.hex()}')  # noqa: E501
+            return decoded_events
+
+        # These should never raise any errors since `from_asset` and `to_asset` are either ETH or
+        # have already been resolved to tokens during erc20 transfers decoding.
+        from_crypto_asset = swap_data.from_asset.resolve_to_crypto_asset()
+        to_crypto_asset = swap_data.to_asset.resolve_to_crypto_asset()
+
+        gas_event = None
+        for event in decoded_events:
+            if event.counterparty == CPT_GAS:
+                gas_event = event
+                break
+
+        assert gas_event is not None, 'Gas event should always exist when interacting with a uniswap auto router'  # noqa: E501
+        gas_event.sequence_index = 0
+
+        timestamp = decoded_events[0].timestamp  # all events have same timestamp
+        from_event = HistoryBaseEntry(
+            event_identifier=transaction.tx_hash,
+            sequence_index=1,
+            timestamp=timestamp,
+            location=Location.BLOCKCHAIN,
+            location_label=transaction.from_address,
+            asset=from_crypto_asset,
+            balance=Balance(amount=swap_data.from_amount),
+            notes=f'Swap {swap_data.from_amount} {from_crypto_asset.symbol} via {CPT_UNISWAP_V3} auto router',  # noqa: E501
+            event_type=HistoryEventType.TRADE,
+            event_subtype=HistoryEventSubType.SPEND,
+            counterparty=CPT_UNISWAP_V3,
+        )
+
+        to_event = HistoryBaseEntry(
+            event_identifier=transaction.tx_hash,
+            sequence_index=2,
+            timestamp=timestamp,
+            location=Location.BLOCKCHAIN,
+            location_label=transaction.from_address,
+            asset=to_crypto_asset,
+            balance=Balance(amount=swap_data.to_amount),
+            notes=f'Receive {swap_data.to_amount} {to_crypto_asset.symbol} as the result of a swap via {CPT_UNISWAP_V3} auto router',  # noqa: E501
+            event_type=HistoryEventType.TRADE,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            counterparty=CPT_UNISWAP_V3,
+        )
+
+        return [gas_event, from_event, to_event]
 
     # -- DecoderInterface methods
 
@@ -154,3 +326,6 @@ class Uniswapv3Decoder(DecoderInterface):
 
     def counterparties(self) -> list[str]:
         return [CPT_UNISWAP_V3]
+
+    def post_decoding_rules(self) -> list[tuple[int, Callable]]:
+        return [(0, self._routers_post_decoding)]

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -271,14 +271,16 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
             transaction: EvmTransaction,
             decoded_events: list[HistoryBaseEntry],
             all_logs: list[EvmTxReceiptLog],
-    ) -> None:
+    ) -> list[HistoryBaseEntry]:
         """
         Runs all post-decoding rules from self.rules.post_decoding_rules.
         The post-decoding rules list consists of tuples (priority, rule) and must be sorted by
         priority in ascending order. The higher the priority number the later the rule is run.
         """
         for (_, rule) in self.rules.post_decoding_rules:
-            rule(transaction=transaction, decoded_events=decoded_events, all_logs=all_logs)  # noqa: E501
+            decoded_events = rule(transaction=transaction, decoded_events=decoded_events, all_logs=all_logs)  # noqa: E501
+
+        return decoded_events
 
     def decode_transaction(
             self,
@@ -314,7 +316,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
             if event:
                 events.append(event)
 
-        self.run_all_post_decoding_rules(
+        events = self.run_all_post_decoding_rules(
             transaction=transaction,
             decoded_events=events,
             all_logs=tx_receipt.logs,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -316,7 +316,6 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
             if event:
                 events.append(event)
 
-        events.sort(key=lambda x: x.sequence_index, reverse=False)
         events = self.run_all_post_decoding_rules(
             transaction=transaction,
             decoded_events=events,
@@ -337,7 +336,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
                 (transaction.tx_hash, self.evm_inquirer.chain_id.serialize_for_db(), HISTORY_MAPPING_STATE_DECODED),  # noqa: E501
             )
 
-        return events
+        return sorted(events, key=lambda x: x.sequence_index, reverse=False)
 
     def get_and_decode_undecoded_transactions(
             self,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -316,6 +316,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
             if event:
                 events.append(event)
 
+        events.sort(key=lambda x: x.sequence_index, reverse=False)
         events = self.run_all_post_decoding_rules(
             transaction=transaction,
             decoded_events=events,
@@ -336,7 +337,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
                 (transaction.tx_hash, self.evm_inquirer.chain_id.serialize_for_db(), HISTORY_MAPPING_STATE_DECODED),  # noqa: E501
             )
 
-        return sorted(events, key=lambda x: x.sequence_index, reverse=False)
+        return events
 
     def get_and_decode_undecoded_transactions(
             self,

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -52,7 +52,7 @@ def test_1inchv1_swap(database, ethereum_inquirer):
             asset=A_USDC,
             balance=Balance(amount=FVal('138.75')),
             location_label=ADDY,
-            notes=f'Swap 138.75 USDC in uniswap-v2 from {ADDY}',
+            notes=f'Swap 138.75 USDC in {CPT_UNISWAP_V2}',
             counterparty=CPT_UNISWAP_V2,
         ), HistoryBaseEntry(
             event_identifier=tx_hash,


### PR DESCRIPTION
This PR adds decoding methods for uniswap auto routers and makes sure that if an auto router is used, events have correct order and if a swap happened in multiple steps, the steps are combined.

There are 4 different types of swaps that can happen via an auto router:
1. Swap from eth to token https://etherscan.io/tx/0xaf8755f0ab8a0cfa8901fe2a9250a8727cca54825210061aab90f34b7a3ed9ba
2. Swap from token to eth https://etherscan.io/tx/0x1b6c3fe84ed4f8f273a54c3e3f6ba80f843522c6a19220a05089104fc54b09ba
3. Swap from token to token
    a) Multiple spend events, but a single receipt https://etherscan.io/tx/0x3ae92fa63a9cf672906036beb18ece09592a8a471bd7f15e4385ca5011615e51
    b) Multiple spend events and multiple receipt events https://etherscan.io/tx/0xa4e0dbf77bf7a9721e1ba4ecf44ed6ea8dcb1c16e9e784b6fefa30749f64e7c0

There are two auto routers from uniswap. The v1 router uses only uni v3 pools and v2 router uses both uni v3 and v2 pools. This PR ensures the correct order of events for both of them.

For uni v2 swaps:
1. If a swap happened through a uni v2 router (not an auto router), decode using the old logic and keep everything as is.
2. If a swap happened through some other router / aggregator (a uniswap auto router or any other router), decode only basic info (i.e.. try to find spend and receive events, but don't change the order of the events)

For uni v3 swaps always decode only basic info.

If only basic info was decoded for swap, then we expect that some aggregator-specific functionality will later ensure the order of the events and will combine them if needed. For uniswap auto routers this logic is located in uniswap v3 decoder's post-decoding rules.

These rules check which type of swap it is and process the events accordingly. For each swap `from_asset`, `to_asset`, `from_amount` and `to_amount` are determined and then used to create proper swap events.