### PR TITLE
fix for optimism ExtraDataLengthError and add require logged in decorator

### DIFF
--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1239,6 +1239,7 @@ class StatisticsNetvalueResource(BaseMethodView):
 
     get_schema = StatisticsNetValueSchema()
 
+    @require_loggedin_user()
     @use_kwargs(get_schema, location='json_and_query')
     def get(self, include_nfts: bool) -> Response:
         return self.rest_api.query_netvalue_data(include_nfts)

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -20,6 +20,7 @@ from web3.exceptions import (
     BlockNotFound,
     TransactionNotFound,
 )
+from web3.middleware import geth_poa_middleware
 from web3.types import BlockIdentifier, FilterParams
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
@@ -44,6 +45,7 @@ from rotkehlchen.serialization.serialize import process_result
 from rotkehlchen.types import (
     SUPPORTED_CHAIN_IDS,
     SUPPORTED_EVM_CHAINS,
+    ChainID,
     ChecksumEvmAddress,
     EvmTokenKind,
     EvmTransaction,
@@ -346,6 +348,9 @@ class EvmNodeInquirer(metaclass=ABCMeta):
             log.warning(message)
             return False, message
 
+        if self.chain_id == ChainID.OPTIMISM:  # for now only optimism needs this
+            # https://web3py.readthedocs.io/en/stable/middleware.html#why-is-geth-poa-middleware-necessary
+            web3.middleware_onion.inject(geth_poa_middleware, layer=0)
         try:
             is_connected = web3.isConnected()
         except AssertionError:


### PR DESCRIPTION
This is how the optimism error manifested and this hopefully fixes it:

```
[14/01/2023 01:48:17 CET] DEBUG web3.providers.HTTPProvider Getting response HTTP. URI: https://optimism-mainnet.public.blastapi.io, Method: eth_getBlockByNumber, Response: {'jsonrpc': '2.0', 'id': 3, 'result': {'difficulty': '0x2', 'extraData': '0xd98301090a846765746889676f312e31352e3133856c696e7578000000000000164ceacea438eecf259f65a1172d93b44127f89f5dd0dbf51e8e80a71819c117325b21ff1f333f30e2f0b2dc0c5c5028816d04d6fcba5f9af9a9b51b462edd1d01', 'gasLimit': '0xe4e1c0', 'gasUsed': '0x45395', 'hash': '0xb32d70cfa643aff8ead2740248ec263b7d59402a622f494dc0afbe597edaf786', 'logsBloom': '0x00000000000000000000000080000000000000000000000100040000041000000000000000000080000020100002050000000000000800000040010a00200000020000000000000000000008000000820000000000400040000000000000000000000000020000400000001000000800000000000000040000000018000000000800000000000100000000000000000000000000002001020000000000000000020004000000000000000008000040000000000000000000000000000000000000000002000000000000000000000000000000100000000000000002000020000010000000200000000000000000000000000000000000200010000418000000', 'miner': '0x0000000000000000000000000000000000000000', 'mixHash': '0x0000000000000000000000000000000000000000000000000000000000000000', 'nonce': '0x0000000000000000', 'number': '0x85f554', 'parentHash': '0x590a5ca481c877137e83cbfdf9c371321bca20f4356795004dcd94876bfa0dd9', 'receiptsRoot': '0xfbdf3f630d558cd07d12811748fb288e3d1f27199104ba389170edd8861358cd', 'sha3Uncles': '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347', 'size': '0x412', 'stateRoot': '0xf3630a4aa8c17439b8d96d868b4859809a600118cc68725057ed808ad8707d2d', 'timestamp': '0x628a2472', 'totalDifficulty': '0x10beaa9', 'transactions': ['0x8394c39e1f030a04aa8359f0322257632282a7dfa419b3c9ffc8ab61205a815d'], 'transactionsRoot': '0xde249d5884bb35a870f8afb4a382686a91fe40a98d0be9a6d3a57822703f035b', 'uncles': []}}
[14/01/2023 01:48:17 CET] ERROR rotkehlchen.api.rest Greenlet with id 139723894896576: Greenlet for task 80 dies with exception: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer to http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('0xd98301090a846765746889676f312e31352e3133856c696e7578000000000000164ceacea438eecf259f65a1172d93b44127f89f5dd0dbf51e8e80a71819c117325b21ff1f333f30e2f0b2dc0c5c5028816d04d6fcba5f9af9a9b51b462edd1d01').
Exception Name: <class 'web3.exceptions.ExtraDataLengthError'>
Exception Info: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer to http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('0xd98301090a846765746889676f312e31352e3133856c696e7578000000000000164ceacea438eecf259f65a1172d93b44127f89f5dd0dbf51e8e80a71819c117325b21ff1f333f30e2f0b2dc0c5c5028816d04d6fcba5f9af9a9b51b462edd1d01')
Traceback:
   File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 311, in _do_query_async
    result = command(**kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/api/rest.py", line 3304, in _get_evm_transactions
    evm_manager.transactions.query_chain(filter_query)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/transactions.py", line 134, in query_chain
    self.single_address_query_transactions(
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/transactions.py", line 87, in single_address_query_transactions
    self._get_internal_transactions_for_ranges(
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/transactions.py", line 325, in _get_internal_transactions_for_ranges
    self._query_and_save_internal_transactions_for_range(
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/transactions.py", line 266, in _query_and_save_internal_transactions_for_range
    transaction = self.evm_inquirer.get_transaction_by_hash(internal_tx.parent_tx_hash)  # noqa: E501
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/node_inquirer.py", line 699, in get_transaction_by_hash
    return self._query(
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/node_inquirer.py", line 441, in _query
    result = method(web3, **kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/node_inquirer.py", line 681, in _get_transaction_by_hash
    transaction = deserialize_evm_transaction(
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/serialization/deserialize.py", line 541, in deserialize_evm_transaction
    block_data = evm_inquirer.get_block_by_number(block_number)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/node_inquirer.py", line 481, in get_block_by_number
    return self._query(
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/node_inquirer.py", line 441, in _query
    result = method(web3, **kwargs)
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/chain/evm/node_inquirer.py", line 499, in _get_block_by_number
    block_data: MutableAttributeDict = MutableAttributeDict(web3.eth.get_block(num))  # type: ignore # pylint: disable=no-member  # noqa: E501
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/eth.py", line 690, in get_block
    return self._get_block(block_identifier, full_transactions)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/module.py", line 57, in caller
    result = w3.manager.request_blocking(method_str,
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/manager.py", line 197, in request_blocking
    response = self._make_request(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/manager.py", line 150, in _make_request
    return request_func(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/formatting.py", line 94, in middleware
    response = make_request(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/gas_price_strategy.py", line 90, in middleware
    return make_request(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/formatting.py", line 94, in middleware
    response = make_request(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/attrdict.py", line 33, in middleware
    response = make_request(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/formatting.py", line 94, in middleware
    response = make_request(method, params)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/formatting.py", line 96, in middleware
    return _apply_response_formatters(method=method, response=response, **formatters)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/formatting.py", line 51, in _apply_response_formatters
    return _format_response("result", result_formatters[method])
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/formatting.py", line 47, in _format_response
    response, response_type, method_response_formatter(appropriate_response)
  File "cytoolz/functoolz.pyx", line 249, in cytoolz.functoolz.curry.__call__
    return self.func(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/eth_utils/applicators.py", line 72, in apply_formatter_if
    return formatter(value)
  File "cytoolz/functoolz.pyx", line 249, in cytoolz.functoolz.curry.__call__
    return self.func(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/eth_utils/functional.py", line 45, in inner
    return callback(fn(*args, **kwargs))
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/eth_utils/applicators.py", line 84, in apply_formatters_to_dict
    yield key, formatters[key](item)
  File "/home/lefteris/.virtualenvs/rotkipy39/lib/python3.9/site-packages/web3/middleware/validation.py", line 73, in _check_extradata_length
    raise ExtraDataLengthError(

[14/01/2023 01:48:17 CET] DEBUG rotkehlchen.externalapis.etherscan Greenlet-14: Got response: {"status":"0","message":"NOTOK","result":"Max rate limit reached, rate limit of 5/1sec applied"} from optimism etherscan. Will backoff for 1 seconds.
[14/01/2023 01:48:17 CET] DEBUG web3.RequestManager Making request. Method: eth_getBlockByNumber
```

What's more added the required decorator for checking logged in user during netvalue api query