### PR TITLE
Improve accessibility of links in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/rotki/rotki/develop/frontend/app/public/assets/images/rotkehlchen_no_text.png" width="250">
 
-rotki is an open source portfolio tracking, analytics, accounting and tax reporting tool that protects your privacy.  The mission of rotki is to bring transparency into the crypto and financial sectors through the use of open source. Most importantly unlike virtually every other competing service which consists of closed source SaaS onto which you are forced to hand over all your financial data, with rotki your data is stored encrypted locally in your computer. It enables you to take ownership of your financial data!
-
+rotki is an open source portfolio tracking, analytics, accounting, and tax reporting tool that protects your privacy.  The mission of rotki is to bring transparency into the crypto and financial sectors through the use of open source. Most importantly, unlike virtually every other competing service which consists of closed source SaaS onto which you are forced to hand over all your financial data, with rotki your data is stored encrypted locally in your computer. It enables you to take ownership of your financial data!
 
 [![GitHub release](https://img.shields.io/github/release/rotki/rotki.svg)](https://GitHub.com/rotki/rotki/releases/)
 [![Docker Image Version (tag latest semver)](https://img.shields.io/docker/v/rotki/rotki/latest?label=Docker)](https://hub.docker.com/layers/rotki/rotki/dev/images/sha256-acbd52985ccea0fb42820a655d994312d322a0895ee5777733582b017a89f3b0?context=explore)
@@ -16,45 +15,41 @@ rotki is an open source portfolio tracking, analytics, accounting and tax report
 [![Twitter Follow](https://img.shields.io/twitter/follow/rotkiapp.svg?style=social)](https://twitter.com/rotkiapp)
 [![Discord](https://img.shields.io/discord/657906918408585217.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/aGCxHG7)
 
-
 ## Documentation
 
-For documentation look [here](https://rotki.readthedocs.io/en/latest/)
+Read the [documentation](https://rotki.readthedocs.io/en/latest/) for a complete guide, frequently-asked questions, API reference, and more.
 
-Some quick links to useful parts of the documentation follow below for your convenience
+Some quick links to useful parts of the documentation follow below for your convenience.
 
 ### Installation
 
-For a guide on how to install rotki please see [here](https://rotki.readthedocs.io/en/latest/installation_guide.html#introduction).
-
+Learn how to get rotki setup in the [installation guide](https://rotki.readthedocs.io/en/latest/installation_guide.html#introduction).
 
 ### Usage
 
-For a detailed guide on how to use rotki see [here](https://rotki.readthedocs.io/en/latest/usage_guide.html).
+To get started using rotki, check out the [detailed usage guide](https://rotki.readthedocs.io/en/latest/usage_guide.html).
 
-## Changelog
+### Changelog
 
-Click [here](https://rotki.readthedocs.io/en/latest/changelog.html) for the latest changelog.
-
+Review the latest updates in [the changelog](https://rotki.readthedocs.io/en/latest/changelog.html).
 
 ## Contribute
 
-rotki is an open source project and as such any and all help is really appreciated.
+rotki is an open source project. As such, any and all help is really appreciated.
 
 ### Issues or code
 
-If you would like to contribute by testing the software please open any issues you find in the github issue tracker. If you would like to contribute by code check out our open issues [here](https://github.com/rotki/rotki/issues) and if you would like to solve any of them please contribute by opening a PR all the while following the [contributing guide](https://rotki.readthedocs.io/en/latest/contribute.html).
+If you would like to contribute by testing the software please open any issues you find in the GitHub issue tracker. If you would like to contribute by code, check out our [open issues](https://github.com/rotki/rotki/issues). If you would like to solve any of them, please contribute by opening a PR in accordance with the [contribution guide](https://rotki.readthedocs.io/en/latest/contribute.html).
 
 ### Contributor badges
 
-If you have ever contributed even a single commit to our codebase you can get a contributor badge (a POAP) for each year you did. Go [here](https://www.gitpoap.io/rp/62) to claim yours.
+You can get a contributor badge (a POAP) for each year in which you have ever contributed even a single commit to our codebase. Go [claim yours](https://www.gitpoap.io/rp/62) now.
 
 ### Work with us
 
-If you are interested to work in the project full-time or part-time we are always looking for skilled people to join our core team. Check out our open positions [here](https://rotki.com/jobs/).
+If you are interested to work in the project full-time or part-time we are always looking for skilled people to join our core team. Check out our [open positions](https://rotki.com/jobs/).
 
 ### Financially
-
 
 #### Purchase a premium subscription
 
@@ -62,15 +57,15 @@ The best way to contribute financially and all the while help with the developme
 
 #### GitHub sponsor
 
-You can sponsor us through GitHub [here](https://github.com/sponsors/rotki/) and get some nice badges in return.
+You can [sponsor us through GitHub](https://github.com/sponsors/rotki/), and get some nice badges in return.
 
 #### Donations
 
 For people who don't want to purchase a subscription but would still like to support the development of rotki we also accept donations in BTC and ETH or tokens.
 
- - Send **BTC donations** to: 1PfvkW8MC7Ns2y8zn6CE2P2t5f19KF8XiW
- - Send **ETH donations** to: `rotki.eth` (0x9531c059098e3d194ff87febb587ab07b30b1306)
+- Send **BTC donations** to: 1PfvkW8MC7Ns2y8zn6CE2P2t5f19KF8XiW
+- Send **ETH donations** to: `rotki.eth` (0x9531c059098e3d194ff87febb587ab07b30b1306)
 
 #### Gitcoin Grant
 
-You can also support us via a [Gitcoin grant](https://gitcoin.co/grants/149/rotki) and receive kudos and other NFTs in the Gitcoin platform.
+You can also support us via a [Gitcoin grant](https://gitcoin.co/grants/149/rotki), and receive kudos and other NFTs in the Gitcoin platform.


### PR DESCRIPTION
Screen readers and other accessibility tools do much better with a descriptive link text, rather 'click here' linked text. I've converted the 'here' links to contextual, meaningful words to make links more a11y friendly.

A few other very minor grammatical and white-space related cleanups are included as well, to improve readability.

Closes: N/A

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
