### PR TITLE
Detect which chains an evm address is active

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9172,7 +9172,7 @@ Adding EVM accounts to all EVM chains
 
 .. http:put:: /api/(version)/blockchains/evm/accounts
 
-   Doing a PUT on the EVM accounts endpoint functions just like the add blockchain accounts endpoint but adds the addresses for all evm chains.
+   Doing a PUT on the EVM accounts endpoint functions just like the add blockchain accounts endpoint but adds the addresses for all evm chains. It will follow the folowing logic. Take ethereum mainnet as the parent chain. If it's a contract there, it will only add it to the mainnet. If it's an EoA it will try all chains one by one and see if they have any transactions/activity and add it to the ones that do.
 
 
    **Example Request**:

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -8,6 +8,7 @@ from rotkehlchen.data_migrations.migrations.migration_4 import data_migration_4
 from rotkehlchen.data_migrations.migrations.migration_5 import data_migration_5
 from rotkehlchen.data_migrations.migrations.migration_6 import data_migration_6
 from rotkehlchen.data_migrations.migrations.migration_7 import data_migration_7
+from rotkehlchen.data_migrations.migrations.migration_8 import data_migration_8
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
@@ -31,6 +32,7 @@ MIGRATION_LIST = [
     MigrationRecord(version=5, function=data_migration_5),
     MigrationRecord(version=6, function=data_migration_6),
     MigrationRecord(version=7, function=data_migration_7),
+    MigrationRecord(version=8, function=data_migration_8),
 ]
 LAST_DATA_MIGRATION = len(MIGRATION_LIST)
 

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -388,6 +388,21 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
 
         yield _hashes_tuple_to_list(hashes)
 
+    def has_activity(self, account: ChecksumEvmAddress) -> bool:
+        """Queries transactions, internal_txs and tokentx for an address with limit=1
+        just to quickly determine if the account has had any activity in the chain"""
+        options = {'address': str(account), 'page': 1, 'offset': 1}
+        result = self._query(module='account', action='txlist', options=options)
+        if len(result) != 0:
+            return True
+        result = self._query(module='account', action='txlistinternal', options=options)
+        if len(result) != 0:
+            return True
+        result = self._query(module='account', action='tokentx', options=options)
+        if len(result) != 0:
+            return True
+        return False
+
     def get_latest_block_number(self) -> int:
         """Gets the latest block number
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -542,7 +542,8 @@ class Rotkehlchen():
         """Adds each account for all evm addresses
 
         Counting ethereum mainnet as the main chain we check if the account is a contract
-        in mainnet. If not we add it for all other chains.
+        in mainnet. If not we check if there is any transactions/activity in that chain for
+        the address and if yes we add it too.
         If it's already added in a chain we just ignore that chain.
 
         Returns a list of tuples of the address and the chain it was added in

--- a/rotkehlchen/tests/unit/test_chains_aggregator.py
+++ b/rotkehlchen/tests/unit/test_chains_aggregator.py
@@ -1,7 +1,13 @@
+from contextlib import ExitStack
+from unittest.mock import patch
+
 import pytest
 
 from rotkehlchen.chain.aggregator import _module_name_to_class
-from rotkehlchen.types import AVAILABLE_MODULES_MAP
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.factories import make_evm_address
+from rotkehlchen.types import AVAILABLE_MODULES_MAP, SupportedBlockchain
 
 
 @pytest.mark.parametrize('ethereum_modules', [[]])
@@ -20,3 +26,78 @@ def test_module_deactivation(blockchain):
         assert isinstance(blockchain.eth_modules[module_name], expected_module_type)
         blockchain.deactivate_module(module_name)
         assert module_name not in blockchain.eth_modules
+
+
+def test_filter_active_evm_addresses(blockchain):
+
+    contract_addy = make_evm_address()
+    all_addy = make_evm_address()
+    optimism_addy = make_evm_address()
+    avalanche_addy = make_evm_address()
+
+    def mock_ethereum_get_code(account):
+        if account == contract_addy:
+            return '0xsomecode'
+        return '0x'
+
+    def mock_avax_get_tx_count(account):
+        if account in (all_addy, avalanche_addy):
+            return 1
+        return 0
+
+    def mock_avax_balance(account):
+        if account in (all_addy, avalanche_addy):
+            return FVal(1)
+        return ZERO
+
+    def mock_optimism_has_activity(account):
+        if account in (all_addy, optimism_addy):
+            return True
+        return False
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(
+            blockchain.ethereum.node_inquirer,
+            'get_code',
+            side_effect=mock_ethereum_get_code,
+        ))
+        stack.enter_context(patch.object(
+            blockchain.avalanche.w3.eth,
+            'get_transaction_count',
+            side_effect=mock_avax_get_tx_count,
+        ))
+        stack.enter_context(patch.object(
+            blockchain.avalanche,
+            'get_avax_balance',
+            side_effect=mock_avax_balance,
+        ))
+        stack.enter_context(patch.object(
+            blockchain.optimism.node_inquirer.etherscan,
+            'has_activity',
+            side_effect=mock_optimism_has_activity,
+        ))
+
+        assert set(blockchain.filter_active_evm_addresses([contract_addy])) == {
+            (SupportedBlockchain.ETHEREUM, contract_addy),
+        }
+        assert set(blockchain.filter_active_evm_addresses([all_addy])) == {
+            (SupportedBlockchain.ETHEREUM, all_addy),
+            (SupportedBlockchain.AVALANCHE, all_addy),
+            (SupportedBlockchain.OPTIMISM, all_addy),
+        }
+        assert set(blockchain.filter_active_evm_addresses([avalanche_addy])) == {
+            (SupportedBlockchain.ETHEREUM, avalanche_addy),
+            (SupportedBlockchain.AVALANCHE, avalanche_addy),
+        }
+        assert set(blockchain.filter_active_evm_addresses([optimism_addy])) == {
+            (SupportedBlockchain.ETHEREUM, optimism_addy),
+            (SupportedBlockchain.OPTIMISM, optimism_addy),
+        }
+        assert set(blockchain.filter_active_evm_addresses([optimism_addy, all_addy, contract_addy])) == {  # noqa: E501
+            (SupportedBlockchain.ETHEREUM, contract_addy),
+            (SupportedBlockchain.ETHEREUM, all_addy),
+            (SupportedBlockchain.AVALANCHE, all_addy),
+            (SupportedBlockchain.OPTIMISM, all_addy),
+            (SupportedBlockchain.ETHEREUM, optimism_addy),
+            (SupportedBlockchain.OPTIMISM, optimism_addy),
+        }


### PR DESCRIPTION
- Add functionality to detect at which evm chains an address is active.
- At evm chain addition, only add it for chains that it is active
- For 1.27 add a data migration to duplicate ethereum addresses to optimism and avalanche only if they have had activity there