### PR TITLE
Properly double indent all function/method definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ISORT_PARAMS = --ignore-whitespace --skip-glob '*/node_modules/*' $(ALL_LINT_PAT
 ISORT_CHECK_PARAMS = --diff --check-only
 
 lint:
+	double-indent --dry-run $(ALL_LINT_PATHS)
 	isort $(ISORT_PARAMS) $(ISORT_CHECK_PARAMS)
 	ruff $(ALL_LINT_PATHS)
 	flake8 $(ALL_LINT_PATHS)
@@ -15,6 +16,7 @@ lint:
 format:
 	ruff $(ALL_LINT_PATHS) --fix
 	isort $(ISORT_PARAMS)
+	double-indent $(ALL_LINT_PATHS)
 
 
 clean:

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -3,6 +3,7 @@ mypy-extensions==0.4.3
 pylint==2.15.10
 astroid==2.13.2  # engine of pylint, upgrade them together
 ruff==0.0.222
+double-indent-rotki==0.1.7  # our fork of double indent
 flake8==6.0.0
 flake8-commas==2.1.0
 flake8-bugbear==23.1.14

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1335,10 +1335,10 @@ class RestAPI():
         return api_response(result_dict, status_code=HTTPStatus.OK)
 
     def user_change_password(
-        self,
-        name: str,
-        current_password: str,
-        new_password: str,
+            self,
+            name: str,
+            current_password: str,
+            new_password: str,
     ) -> Response:
         result_dict: dict[str, Any] = {'result': None, 'message': ''}
 
@@ -1635,9 +1635,9 @@ class RestAPI():
         )
 
     def rebuild_assets_information(
-        self,
-        reset: Literal['soft', 'hard'],
-        ignore_warnings: bool,
+            self,
+            reset: Literal['soft', 'hard'],
+            ignore_warnings: bool,
     ) -> Response:
         msg = 'Invalid value for reset'
         if reset == 'soft':
@@ -1919,8 +1919,8 @@ class RestAPI():
         return api_response(_wrap_in_ok_result(result), status_code=HTTPStatus.OK)
 
     def _add_xpub(
-        self,
-        xpub_data: 'XpubData',
+            self,
+            xpub_data: 'XpubData',
     ) -> dict[str, Any]:
         try:
             XpubManager(self.rotkehlchen.chains_aggregator).add_bitcoin_xpub(xpub_data=xpub_data)
@@ -1935,9 +1935,9 @@ class RestAPI():
         return OK_RESULT
 
     def add_xpub(
-        self,
-        xpub_data: 'XpubData',
-        async_query: bool,
+            self,
+            xpub_data: 'XpubData',
+            async_query: bool,
     ) -> Response:
         if async_query is True:
             return self._query_async(
@@ -1974,9 +1974,9 @@ class RestAPI():
         return OK_RESULT
 
     def delete_xpub(
-        self,
-        xpub_data: 'XpubData',
-        async_query: bool,
+            self,
+            xpub_data: 'XpubData',
+            async_query: bool,
     ) -> Response:
         if async_query is True:
             return self._query_async(
@@ -1997,8 +1997,8 @@ class RestAPI():
         return api_response(process_result(result_dict), status_code=status_code)
 
     def edit_xpub(
-        self,
-        xpub_data: 'XpubData',
+            self,
+            xpub_data: 'XpubData',
     ) -> Response:
         try:
             with self.rotkehlchen.data.db.user_write() as write_cursor:
@@ -3203,11 +3203,11 @@ class RestAPI():
         )
 
     def get_liquity_trove_events(
-        self,
-        async_query: bool,
-        reset_db_data: bool,  # pylint: disable=unused-argument
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            async_query: bool,
+            reset_db_data: bool,  # pylint: disable=unused-argument
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> Response:
         return self._api_query_for_eth_module(
             async_query=async_query,
@@ -3220,11 +3220,11 @@ class RestAPI():
         )
 
     def get_liquity_stake_events(
-        self,
-        async_query: bool,
-        reset_db_data: bool,  # pylint: disable=unused-argument
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            async_query: bool,
+            reset_db_data: bool,  # pylint: disable=unused-argument
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> Response:
         return self._api_query_for_eth_module(
             async_query=async_query,
@@ -3847,9 +3847,9 @@ class RestAPI():
         return _wrap_in_ok_result(info)
 
     def get_token_information(
-        self,
-        token_address: ChecksumEvmAddress,
-        async_query: bool,
+            self,
+            token_address: ChecksumEvmAddress,
+            async_query: bool,
     ) -> Response:
 
         if async_query is True:
@@ -4022,10 +4022,10 @@ class RestAPI():
         )
 
     def _get_avalanche_transactions(
-        self,
-        address: ChecksumEvmAddress,
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            address: ChecksumEvmAddress,
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> dict[str, Any]:
         avalanche = self.rotkehlchen.chains_aggregator.avalanche
         try:
@@ -4059,11 +4059,11 @@ class RestAPI():
         return {'result': result, 'message': msg, 'status_code': HTTPStatus.OK}
 
     def get_avalanche_transactions(
-        self,
-        async_query: bool,
-        address: ChecksumEvmAddress,
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            async_query: bool,
+            address: ChecksumEvmAddress,
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> Response:
         if async_query is True:
             return self._query_async(
@@ -4366,10 +4366,10 @@ class RestAPI():
         )
 
     def _query_kraken_staking_events(
-        self,
-        only_cache: bool,
-        query_filter: HistoryEventFilterQuery,
-        value_filter: HistoryEventFilterQuery,
+            self,
+            only_cache: bool,
+            query_filter: HistoryEventFilterQuery,
+            value_filter: HistoryEventFilterQuery,
     ) -> dict[str, Any]:
         history_events_db = DBHistoryEvents(self.rotkehlchen.data.db)
         table_filter = HistoryEventFilterQuery.make(
@@ -4637,9 +4637,9 @@ class RestAPI():
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
     def _get_ens_mappings(
-        self,
-        addresses: list[ChecksumEvmAddress],
-        ignore_cache: bool,
+            self,
+            addresses: list[ChecksumEvmAddress],
+            ignore_cache: bool,
     ) -> dict[str, Any]:
         mappings_to_send: dict[ChecksumEvmAddress, str] = {}
         try:
@@ -4675,9 +4675,9 @@ class RestAPI():
         return api_response(process_result(result_dict), status_code=status_code)
 
     def import_user_snapshot(
-        self,
-        balances_snapshot_file: Path,
-        location_data_snapshot_file: Path,
+            self,
+            balances_snapshot_file: Path,
+            location_data_snapshot_file: Path,
     ) -> Response:
         dbsnapshot = DBSnapshot(
             db_handler=self.rotkehlchen.data.db,

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -2068,11 +2068,11 @@ class LiquityTrovesHistoryResource(BaseMethodView):
     @require_premium_user(active_check=False)
     @use_kwargs(get_schema, location='json_and_query')
     def get(
-        self,
-        async_query: bool,
-        reset_db_data: bool,
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            async_query: bool,
+            reset_db_data: bool,
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> Response:
         return self.rest_api.get_liquity_trove_events(
             async_query=async_query,
@@ -2089,11 +2089,11 @@ class LiquityStakingHistoryResource(BaseMethodView):
     @require_premium_user(active_check=False)
     @use_kwargs(get_schema, location='json_and_query')
     def get(
-        self,
-        async_query: bool,
-        reset_db_data: bool,
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            async_query: bool,
+            reset_db_data: bool,
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> Response:
         return self.rest_api.get_liquity_stake_events(
             async_query=async_query,
@@ -2309,11 +2309,11 @@ class HistoricalAssetsPriceResource(BaseMethodView):
 
     @use_kwargs(put_schema, location='json')
     def put(
-        self,
-        from_asset: Asset,
-        to_asset: Asset,
-        price: Price,
-        timestamp: Timestamp,
+            self,
+            from_asset: Asset,
+            to_asset: Asset,
+            price: Price,
+            timestamp: Timestamp,
     ) -> Response:
         return self.rest_api.add_manual_price(
             from_asset=from_asset,
@@ -2324,11 +2324,11 @@ class HistoricalAssetsPriceResource(BaseMethodView):
 
     @use_kwargs(patch_schema, location='json')
     def patch(
-        self,
-        from_asset: Asset,
-        to_asset: Asset,
-        price: Price,
-        timestamp: Timestamp,
+            self,
+            from_asset: Asset,
+            to_asset: Asset,
+            price: Price,
+            timestamp: Timestamp,
     ) -> Response:
         return self.rest_api.edit_manual_price(
             from_asset=from_asset,
@@ -2343,10 +2343,10 @@ class HistoricalAssetsPriceResource(BaseMethodView):
 
     @use_kwargs(delete_schema)
     def delete(
-        self,
-        from_asset: Asset,
-        to_asset: Asset,
-        timestamp: Timestamp,
+            self,
+            from_asset: Asset,
+            to_asset: Asset,
+            timestamp: Timestamp,
     ) -> Response:
         return self.rest_api.delete_manual_price(from_asset, to_asset, timestamp)
 
@@ -2434,11 +2434,11 @@ class AvalancheTransactionsResource(BaseMethodView):
     @require_loggedin_user()
     @use_kwargs(get_schema, location='json_and_query_and_view_args')
     def get(
-        self,
-        async_query: bool,
-        address: ChecksumEvmAddress,
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            async_query: bool,
+            address: ChecksumEvmAddress,
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> Response:
         return self.rest_api.get_avalanche_transactions(
             async_query=async_query,
@@ -2646,9 +2646,9 @@ class AddressbookResource(BaseMethodView):
     @require_loggedin_user()
     @use_kwargs(post_delete_schema, location='json_and_view_args')
     def post(
-        self,
-        book_type: AddressbookType,
-        addresses: Optional[list[OptionalChainAddress]],
+            self,
+            book_type: AddressbookType,
+            addresses: Optional[list[OptionalChainAddress]],
     ) -> Response:
         return self.rest_api.get_addressbook_entries(
             book_type=book_type,

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -377,11 +377,11 @@ class CustomAsset(AssetWithNameAndType):
 
     @classmethod
     def initialize(
-        cls: type['CustomAsset'],
-        identifier: str,
-        name: str,
-        custom_asset_type: str,
-        notes: Optional[str] = None,
+            cls: type['CustomAsset'],
+            identifier: str,
+            name: str,
+            custom_asset_type: str,
+            notes: Optional[str] = None,
     ) -> 'CustomAsset':
         asset = CustomAsset(identifier=identifier)
         object.__setattr__(asset, 'asset_type', AssetType.CUSTOM_ASSET)

--- a/rotkehlchen/balances/manual.py
+++ b/rotkehlchen/balances/manual.py
@@ -41,8 +41,8 @@ class ManuallyTrackedBalanceWithValue(NamedTuple):
 
 
 def get_manually_tracked_balances(
-    db: 'DBHandler',
-    balance_type: Optional[BalanceType] = None,
+        db: 'DBHandler',
+        balance_type: Optional[BalanceType] = None,
 ) -> list[ManuallyTrackedBalanceWithValue]:
     """Gets the manually tracked balances"""
     with db.conn.read_ctx() as cursor:

--- a/rotkehlchen/chain/bitcoin/xpub.py
+++ b/rotkehlchen/chain/bitcoin/xpub.py
@@ -176,9 +176,9 @@ class XpubManager():
         self.lock = Semaphore()
 
     def _derive_xpub_addresses(
-        self,
-        xpub_data: XpubData,
-        new_xpub: bool,
+            self,
+            xpub_data: XpubData,
+            new_xpub: bool,
     ) -> None:
         """Derives new xpub addresses, and adds all those until the addresses that
         have not had any transactions to the tracked bitcoin addresses
@@ -307,8 +307,8 @@ class XpubManager():
             self.chains_aggregator.sync_bitcoin_accounts_with_db(write_cursor, xpub_data.blockchain)  # noqa: E501
 
     def check_for_new_xpub_addresses(
-        self,
-        blockchain: Literal[SupportedBlockchain.BITCOIN, SupportedBlockchain.BITCOIN_CASH],
+            self,
+            blockchain: Literal[SupportedBlockchain.BITCOIN, SupportedBlockchain.BITCOIN_CASH],
     ) -> None:
         """Checks all xpub addresses and sees if new addresses got used.
         If they did it adds them for tracking.

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
@@ -106,10 +106,10 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
             raise NotImplementedError(f'AMM platform with location {self.location} not valid.')
 
     def _calculate_events_balances(
-        self,
-        address: ChecksumEvmAddress,
-        events: list[LiquidityPoolEvent],
-        balances: list[LiquidityPool],
+            self,
+            address: ChecksumEvmAddress,
+            events: list[LiquidityPoolEvent],
+            balances: list[LiquidityPool],
     ) -> list[LiquidityPoolEventsBalance]:
         """Given an address, its LP events and the current LPs participating in
         (`balances`), process each event (grouped by pool) aggregating the

--- a/rotkehlchen/chain/ethereum/modules/aave/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/graph.py
@@ -679,16 +679,16 @@ class AaveGraphInquirer(AaveInquirer):
         )
 
     def _process_graph_query_result(
-        self,
-        query: dict[str, Any],
-        deposits: list[AaveDepositWithdrawalEvent],
-        withdrawals: list[AaveDepositWithdrawalEvent],
-        borrows: list[AaveBorrowEvent],
-        repays: list[AaveRepayEvent],
-        liquidation_calls: list[AaveLiquidationEvent],
-        user_merged_data: dict[str, Any],
-        from_ts: Timestamp,
-        to_ts: Timestamp,
+            self,
+            query: dict[str, Any],
+            deposits: list[AaveDepositWithdrawalEvent],
+            withdrawals: list[AaveDepositWithdrawalEvent],
+            borrows: list[AaveBorrowEvent],
+            repays: list[AaveRepayEvent],
+            liquidation_calls: list[AaveLiquidationEvent],
+            user_merged_data: dict[str, Any],
+            from_ts: Timestamp,
+            to_ts: Timestamp,
     ) -> None:
         """
         Given a query result from the graph this function extracts information for:

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -1070,8 +1070,8 @@ class Balancer(EthereumModule):
             )
 
     def get_balances(
-        self,
-        addresses: list[ChecksumEvmAddress],
+            self,
+            addresses: list[ChecksumEvmAddress],
     ) -> AddressToPoolBalances:
         """Get the balances of the given addresses in any Balancer pool
 
@@ -1090,11 +1090,11 @@ class Balancer(EthereumModule):
         return protocol_balance.address_to_pool_balances
 
     def get_events_history(
-        self,
-        addresses: list[ChecksumEvmAddress],
-        reset_db_data: bool,
-        from_timestamp: Timestamp,
-        to_timestamp: Timestamp,
+            self,
+            addresses: list[ChecksumEvmAddress],
+            reset_db_data: bool,
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
     ) -> AddressToPoolEventsBalances:
         """Get the events history of the given addresses
 

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -53,11 +53,11 @@ class CurveDecoder(DecoderInterface):
         self.curve_pools = read_curve_pools()
 
     def _decode_curve_remove_events(
-        self,
-        tx_log: EvmTxReceiptLog,
-        transaction: EvmTransaction,
-        decoded_events: list[HistoryBaseEntry],
-        user_address: ChecksumEvmAddress,
+            self,
+            tx_log: EvmTxReceiptLog,
+            transaction: EvmTransaction,
+            decoded_events: list[HistoryBaseEntry],
+            user_address: ChecksumEvmAddress,
     ) -> tuple[Optional[HistoryBaseEntry], list[ActionItem]]:
         """Decode information related to withdrawing assets from curve pools"""
         for event in decoded_events:
@@ -104,10 +104,10 @@ class CurveDecoder(DecoderInterface):
         return None, []
 
     def _decode_curve_deposit_events(
-        self,
-        tx_log: EvmTxReceiptLog,
-        decoded_events: list[HistoryBaseEntry],
-        user_address: ChecksumEvmAddress,
+            self,
+            tx_log: EvmTxReceiptLog,
+            decoded_events: list[HistoryBaseEntry],
+            user_address: ChecksumEvmAddress,
     ) -> tuple[Optional[HistoryBaseEntry], list[ActionItem]]:
         """Decode information related to depositing assets in curve pools"""
         for event in decoded_events:

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -51,13 +51,13 @@ def _legacy_contracts_basic_info(tx_log: EvmTxReceiptLog) -> tuple[ChecksumEvmAd
 
 
 def _maybe_update_events_legacy_contrats(
-    decoded_events: list[HistoryBaseEntry],
-    sender: ChecksumEvmAddress,
-    source_asset: CryptoAsset,
-    destination_asset: CryptoAsset,
-    spent_amount: FVal,
-    return_amount: FVal,
-    notify_user: Callable[[HistoryBaseEntry, str], None],
+        decoded_events: list[HistoryBaseEntry],
+        sender: ChecksumEvmAddress,
+        source_asset: CryptoAsset,
+        destination_asset: CryptoAsset,
+        spent_amount: FVal,
+        return_amount: FVal,
+        notify_user: Callable[[HistoryBaseEntry, str], None],
 ) -> None:
     """
     Use the information from a trade transaction to modify the HistoryEvents from receive/send to

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
@@ -48,8 +48,8 @@ class PickleFinance(EthereumModule):
         self.pickle = A_PICKLE.resolve_to_evm_token()
 
     def get_dill_balances(
-        self,
-        addresses: list[ChecksumEvmAddress],
+            self,
+            addresses: list[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, DillBalance]:
         """
         Query information for amount locked, pending rewards and time until unlock
@@ -120,8 +120,8 @@ class PickleFinance(EthereumModule):
         return api_output
 
     def balances_in_protocol(
-        self,
-        addresses: list[ChecksumEvmAddress],
+            self,
+            addresses: list[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, list['AssetBalance']]:
         """Queries all the pickles deposited and available to claim in the protocol"""
         dill_balances = self.get_dill_balances(addresses)

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
@@ -188,8 +188,8 @@ class Sushiswap(AMMSwapPlatform, EthereumModule):
         return address_events_balances
 
     def get_balances(
-        self,
-        addresses: list[ChecksumEvmAddress],
+            self,
+            addresses: list[ChecksumEvmAddress],
     ) -> AddressToLPBalances:
         """Get the addresses' balances in the Sushiswap protocol
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
@@ -257,8 +257,8 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
         return address_events_balances
 
     def get_balances(
-        self,
-        addresses: list[ChecksumEvmAddress],
+            self,
+            addresses: list[ChecksumEvmAddress],
     ) -> AddressToLPBalances:
         """Get the addresses' balances in the Uniswap protocol
 

--- a/rotkehlchen/chain/ethereum/modules/yearn/graph.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/graph.py
@@ -85,9 +85,9 @@ class YearnVaultsV2Graph:
         self.graph = Graph('https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet')  # noqa: E501
 
     def _process_event(
-        self,
-        events: list[dict[str, Any]],
-        event_type: Literal['deposit', 'withdraw'],
+            self,
+            events: list[dict[str, Any]],
+            event_type: Literal['deposit', 'withdraw'],
     ) -> list[YearnVaultEvent]:
         result = []
 
@@ -203,10 +203,10 @@ class YearnVaultsV2Graph:
         return result
 
     def get_all_events(
-        self,
-        addresses: list[EvmAddress],
-        from_block: int,
-        to_block: int,
+            self,
+            addresses: list[EvmAddress],
+            from_block: int,
+            to_block: int,
     ) -> dict[ChecksumEvmAddress, dict[str, list[YearnVaultEvent]]]:
 
         param_types = {

--- a/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
@@ -144,8 +144,8 @@ class YearnVaultsV2(EthereumModule):
         return result
 
     def get_balances(
-        self,
-        given_eth_balances: 'GIVEN_ETH_BALANCES',
+            self,
+            given_eth_balances: 'GIVEN_ETH_BALANCES',
     ) -> dict[ChecksumEvmAddress, dict[ChecksumEvmAddress, YearnVaultBalance]]:
 
         if isinstance(given_eth_balances, dict):

--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -70,18 +70,18 @@ class UniswapOracle(CurrentPriceOracleInterface, CacheableMixIn):
 
     @abc.abstractmethod
     def get_pool(
-        self,
-        token_0: EvmToken,
-        token_1: EvmToken,
+            self,
+            token_0: EvmToken,
+            token_1: EvmToken,
     ) -> list[str]:
         """Given two tokens returns a list of pools where they can be swapped"""
         ...
 
     @abc.abstractmethod
     def get_pool_price(
-        self,
-        pool_addr: ChecksumEvmAddress,
-        block_identifier: BlockIdentifier = 'latest',
+            self,
+            pool_addr: ChecksumEvmAddress,
+            block_identifier: BlockIdentifier = 'latest',
     ) -> PoolPrice:
         """Returns the price for the tokens in the given pool and the token0 and
         token1 of the pool.
@@ -91,10 +91,10 @@ class UniswapOracle(CurrentPriceOracleInterface, CacheableMixIn):
         ...
 
     def _find_pool_for(
-        self,
-        asset: EvmToken,
-        link_asset: EvmToken,
-        path: list[str],
+            self,
+            asset: EvmToken,
+            link_asset: EvmToken,
+            path: list[str],
     ) -> bool:
         pools = self.get_pool(asset, link_asset)
         for pool in pools:
@@ -326,9 +326,9 @@ class UniswapV3Oracle(UniswapOracle):
         return [best_pool]
 
     def get_pool_price(
-        self,
-        pool_addr: ChecksumEvmAddress,
-        block_identifier: BlockIdentifier = 'latest',
+            self,
+            pool_addr: ChecksumEvmAddress,
+            block_identifier: BlockIdentifier = 'latest',
     ) -> PoolPrice:
         """
         Returns the units of token1 that one token0 can buy
@@ -389,9 +389,9 @@ class UniswapV2Oracle(UniswapOracle):
 
     @cache_response_timewise()
     def get_pool(
-        self,
-        token_0: EvmToken,
-        token_1: EvmToken,
+            self,
+            token_0: EvmToken,
+            token_1: EvmToken,
     ) -> list[str]:
         result = self.uniswap_v2_factory.call(
             node_inquirer=self.ethereum,
@@ -404,9 +404,9 @@ class UniswapV2Oracle(UniswapOracle):
         return [result]
 
     def get_pool_price(
-        self,
-        pool_addr: ChecksumEvmAddress,
-        block_identifier: BlockIdentifier = 'latest',
+            self,
+            pool_addr: ChecksumEvmAddress,
+            block_identifier: BlockIdentifier = 'latest',
     ) -> PoolPrice:
         """
         Returns the units of token1 that one token0 can buy

--- a/rotkehlchen/chain/evm/types.py
+++ b/rotkehlchen/chain/evm/types.py
@@ -65,8 +65,8 @@ class WeightedNode:
 
     @classmethod
     def deserialize(
-        cls: type['WeightedNode'],
-        data: dict[str, str],
+            cls: type['WeightedNode'],
+            data: dict[str, str],
     ) -> 'WeightedNode':
         return WeightedNode(
             identifier=int(data['identifier']),

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -286,11 +286,11 @@ class CryptocomImporter(BaseExchangeImporter):
             )
 
     def _import_cryptocom_associated_entries(
-        self,
-        cursor: DBCursor,
-        data: Any,
-        tx_kind: str,
-        timestamp_format: str = '%Y-%m-%d %H:%M:%S',
+            self,
+            cursor: DBCursor,
+            data: Any,
+            tx_kind: str,
+            timestamp_format: str = '%Y-%m-%d %H:%M:%S',
     ) -> None:
         """Look for events that have associated entries and handle them as trades.
 

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -269,8 +269,8 @@ class DBHistoryEvents():
         return events, cursor.fetchone()[0]  # count always has value
 
     def rows_missing_prices_in_base_entries(
-        self,
-        filter_query: HistoryEventFilterQuery,
+            self,
+            filter_query: HistoryEventFilterQuery,
     ) -> list[tuple[str, FVal, Asset, Timestamp]]:
         """
         Get missing prices for history base entries based on filter query

--- a/rotkehlchen/exchanges/ftx.py
+++ b/rotkehlchen/exchanges/ftx.py
@@ -170,13 +170,13 @@ class Ftx(ExchangeInterface):
         return True, ''
 
     def _make_request(
-        self,
-        endpoint: str,
-        start_time: Optional[Timestamp] = None,
-        end_time: Optional[Timestamp] = None,
-        min_id: Optional[int] = None,
-        limit: int = PAGINATION_LIMIT,
-        order: Optional[str] = FTX_QUERY_ORDER,
+            self,
+            endpoint: str,
+            start_time: Optional[Timestamp] = None,
+            end_time: Optional[Timestamp] = None,
+            min_id: Optional[int] = None,
+            limit: int = PAGINATION_LIMIT,
+            order: Optional[str] = FTX_QUERY_ORDER,
     ) -> Union[list[dict[str, Any]], dict[str, list[Any]]]:
         """Performs an FTX API Query for endpoint adding the needed information to
         authenticate user and handling errors.
@@ -502,9 +502,9 @@ class Ftx(ExchangeInterface):
         return trades, (start_ts, end_ts)
 
     def _deserialize_asset_movement(
-        self,
-        raw_data: dict[str, Any],
-        movement_type: AssetMovementCategory,
+            self,
+            raw_data: dict[str, Any],
+            movement_type: AssetMovementCategory,
     ) -> Optional[AssetMovement]:
         """Processes a single deposit/withdrawal from FTX and deserializes it
 

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -108,9 +108,9 @@ def kraken_ledger_entry_type_to_ours(value: str) -> HistoryEventType:
 
 
 def history_event_from_kraken(
-    events: list[dict[str, Any]],
-    name: str,
-    msg_aggregator: MessagesAggregator,
+        events: list[dict[str, Any]],
+        name: str,
+        msg_aggregator: MessagesAggregator,
 ) -> tuple[list[HistoryBaseEntry], bool]:
     """
     This function gets raw data from kraken and creates a list of related history events
@@ -966,8 +966,8 @@ class Kraken(ExchangeInterface):
         return trade
 
     def process_kraken_trades(
-        self,
-        raw_data: list[HistoryBaseEntry],
+            self,
+            raw_data: list[HistoryBaseEntry],
     ) -> tuple[list[Trade], Timestamp]:
         """
         Given a list of history events we process them to create Trade objects. The valid

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -236,8 +236,8 @@ class Cryptocompare(ExternalServiceWithApiKey, HistoricalPriceOracleInterface, P
         return can_query
 
     def rate_limited_in_last(
-        self,
-        seconds: Optional[int] = CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME,
+            self,
+            seconds: Optional[int] = CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME,
     ) -> bool:
         """Checks when we were last rate limited by CC and if it was within the given seconds"""
         if seconds is None:

--- a/rotkehlchen/globaldb/assets_management.py
+++ b/rotkehlchen/globaldb/assets_management.py
@@ -23,9 +23,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 def import_assets_from_file(
-    path: Path,
-    msg_aggregator: 'MessagesAggregator',
-    db_handler: 'DBHandler',
+        path: Path,
+        msg_aggregator: 'MessagesAggregator',
+        db_handler: 'DBHandler',
 ) -> None:
     """
     Import assets from the file at the defined path.
@@ -95,8 +95,8 @@ def import_assets_from_file(
 
 
 def export_assets_from_file(
-    dirpath: Optional[Path],
-    db_handler: 'DBHandler',
+        dirpath: Optional[Path],
+        db_handler: 'DBHandler',
 ) -> Path:
     """
     Creates a zip file with a json file containing the assets added by the user.

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -1408,8 +1408,8 @@ class GlobalDBHandler():
 
     @staticmethod
     def get_manual_prices(
-        from_asset: Optional[Asset],
-        to_asset: Optional[Asset],
+            from_asset: Optional[Asset],
+            to_asset: Optional[Asset],
     ) -> list[dict[str, Union[int, str]]]:
         """Returns prices added to the database by the user for an asset"""
         querystr = (
@@ -1600,7 +1600,7 @@ class GlobalDBHandler():
 
     @staticmethod
     def get_general_cache_last_queried_ts_by_key(
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+            key_parts: Iterable[Union[str, GeneralCacheType]],
     ) -> Timestamp:
         """
         Get the last_queried_ts of the oldest stored element by key_parts. If there is no such

--- a/rotkehlchen/globaldb/manual_price_oracles.py
+++ b/rotkehlchen/globaldb/manual_price_oracles.py
@@ -32,10 +32,10 @@ class ManualPriceOracle:
 
     @classmethod
     def query_historical_price(
-        cls,
-        from_asset: Asset,
-        to_asset: Asset,
-        timestamp: Timestamp,
+            cls,
+            from_asset: Asset,
+            to_asset: Asset,
+            timestamp: Timestamp,
     ) -> Price:
         price_entry = GlobalDBHandler().get_historical_price(
             from_asset=from_asset,

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -250,7 +250,7 @@ class EventsHistorian:
         return asset_movements, filter_total_found
 
     def query_history_events(
-        self,
+            self,
             cursor: 'DBCursor',
             filter_query: HistoryEventFilterQuery,
             only_cache: bool,

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -116,9 +116,9 @@ class PriceHistorian():
 
     @staticmethod
     def get_price_for_special_asset(
-        from_asset: Asset,
-        to_asset: Asset,
-        timestamp: Timestamp,
+            from_asset: Asset,
+            to_asset: Asset,
+            timestamp: Timestamp,
     ) -> Optional[Price]:
         """
         Query the historical price on `timestamp` for `from_asset` in `to_asset`

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -366,9 +366,9 @@ class Inquirer():
 
     @staticmethod
     def add_defi_oracles(
-        uniswap_v2: Optional['UniswapV2Oracle'],
-        uniswap_v3: Optional['UniswapV3Oracle'],
-        saddle: Optional['SaddleOracle'],
+            uniswap_v2: Optional['UniswapV2Oracle'],
+            uniswap_v3: Optional['UniswapV3Oracle'],
+            saddle: Optional['SaddleOracle'],
     ) -> None:
         Inquirer()._uniswapv2 = uniswap_v2
         Inquirer()._uniswapv3 = uniswap_v3
@@ -875,8 +875,8 @@ class Inquirer():
         return (assets_price * FVal(data[0])) / (10 ** lp_token.decimals)
 
     def find_yearn_price(
-        self,
-        token: EvmToken,
+            self,
+            token: EvmToken,
     ) -> Optional[Price]:
         """
         Query price for a yearn vault v2 token using the pricePerShare method

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -219,9 +219,9 @@ class PremiumSyncManager():
         return self._sync_data_from_server_and_replace_local()
 
     def _sync_if_allowed(
-        self,
-        sync_approval: Literal['yes', 'no', 'unknown'],
-        result: SyncCheckResult,
+            self,
+            sync_approval: Literal['yes', 'no', 'unknown'],
+            result: SyncCheckResult,
     ) -> None:
         if result.can_sync == CanSync.ASK_USER:
             if sync_approval == 'unknown':

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -333,7 +333,7 @@ def deserialize_trade_pair(pair: str) -> TradePair:
 
 
 def deserialize_asset_movement_category(
-    value: Union[str, HistoryEventType],
+        value: Union[str, HistoryEventType],
 ) -> AssetMovementCategory:
     """Takes a string and determines whether to accept it as an asset movement category
 

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -375,8 +375,8 @@ class TaskManager():
         )]
 
     def get_base_entries_missing_prices(
-        self,
-        query_filter: HistoryEventFilterQuery,
+            self,
+            query_filter: HistoryEventFilterQuery,
     ) -> list[tuple[str, FVal, Asset, Timestamp]]:
         """
         Searches base entries missing usd prices that have not previously been checked in
@@ -398,8 +398,8 @@ class TaskManager():
         return db.rows_missing_prices_in_base_entries(filter_query=new_query_filter)
 
     def query_missing_prices_of_base_entries(
-        self,
-        entries_missing_prices: list[tuple[str, FVal, Asset, Timestamp]],
+            self,
+            entries_missing_prices: list[tuple[str, FVal, Asset, Timestamp]],
     ) -> None:
         """Queries missing prices for HistoryBaseEntry in database updating
         the price if it is found. Otherwise we add the id to the ignore list

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -26,7 +26,7 @@ from rotkehlchen.tests.utils.api import (
 from rotkehlchen.tests.utils.checks import assert_asset_result_order
 from rotkehlchen.tests.utils.constants import A_GNO, A_RDN
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2
-from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.tests.utils.mock import MockResponse, patch_requests_for_cryptoscamdb
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
 from rotkehlchen.types import ChainID, Location
 
@@ -173,13 +173,14 @@ def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
         result = assert_proper_response_with_result(response)
         assert assets_after_deletion <= set(result)
 
-        # Fetch remote assets to be ignored
-        response = requests.post(
-            api_url_for(
-                rotkehlchen_api_server_with_exchanges,
-                'ignoredassetsresource',
-            ),
-        )
+        # Mock fetching remote assets to be ignored
+        with patch('requests.get', wraps=patch_requests_for_cryptoscamdb):
+            response = requests.post(
+                api_url_for(
+                    rotkehlchen_api_server_with_exchanges,
+                    'ignoredassetsresource',
+                ),
+            )
         result = assert_proper_response_with_result(response)
         assert result >= 1
         assert len(rotki.data.db.get_ignored_assets(cursor)) > len(assets_after_deletion)

--- a/rotkehlchen/tests/api/test_locations.py
+++ b/rotkehlchen/tests/api/test_locations.py
@@ -18,10 +18,10 @@ UNISWAP_ADDR = string_to_evm_address('0xcaf012cB72f2c7152b255E091837E3a628F739e7
 @pytest.mark.parametrize('ethereum_modules', [['uniswap']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 def test_get_associated_locations(
-    rotkehlchen_api_server_with_exchanges,
-    added_exchanges,
-    ethereum_accounts,  # pylint: disable=unused-argument
-    start_with_valid_premium,  # pylint: disable=unused-argument
+        rotkehlchen_api_server_with_exchanges,
+        added_exchanges,
+        ethereum_accounts,  # pylint: disable=unused-argument
+        start_with_valid_premium,  # pylint: disable=unused-argument
 ):
     rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen
     mock_exchange_data_in_db(added_exchanges, rotki)

--- a/rotkehlchen/tests/api/test_snapshots.py
+++ b/rotkehlchen/tests/api/test_snapshots.py
@@ -152,8 +152,8 @@ def _write_location_data_csv_row(writer: 'csv.DictWriter', timestamp: Timestamp)
 
 
 def _write_balances_csv_row_with_invalid_headers(
-    writer: 'csv.DictWriter',
-    timestamp: Timestamp,
+        writer: 'csv.DictWriter',
+        timestamp: Timestamp,
 ) -> None:
     writer.writerow(
         {

--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -313,10 +313,10 @@ def test_bittrex_query_deposits_withdrawals(bittrex):
     """Test the happy case of bittrex deposit withdrawal query"""
 
     def mock_get_deposit_withdrawal(
-        url,
-        method,
-        json,
-        **kwargs,
+            url,
+            method,
+            json,
+            **kwargs,
     ):  # pylint: disable=unused-argument
         if 'deposit' in url:
             response_str = BITTREX_DEPOSIT_HISTORY_RESPONSE
@@ -395,10 +395,10 @@ def test_bittrex_query_asset_movement_int_transaction_id(bittrex):
 """
 
     def mock_get_deposit_withdrawal(
-        url,
-        method,
-        json,
-        **kwargs,
+            url,
+            method,
+            json,
+            **kwargs,
     ):  # pylint: disable=unused-argument
         if 'deposit' in url:
             response_str = problematic_deposit
@@ -447,10 +447,10 @@ def test_bittrex_query_deposits_withdrawals_unexpected_data(bittrex):
     def mock_bittrex_and_query(deposits, withdrawals, expected_warnings_num, expected_errors_num):
 
         def mock_get_deposit_withdrawal(
-            url,
-            method,
-            json,
-            **kwargs,
+                url,
+                method,
+                json,
+                **kwargs,
         ):  # pylint: disable=unused-argument
             if 'deposit' in url:
                 response_str = deposits

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -256,9 +256,9 @@ def _create_inquirer(
         return mocked_prices.get((from_asset, to_asset), FVal('1.5'))
 
     def mock_find_usd_price(
-        asset,
-        ignore_cache: bool = False,  # pylint: disable=unused-argument
-        coming_from_latest_price: bool = False,   # pylint: disable=unused-argument
+            asset,
+            ignore_cache: bool = False,  # pylint: disable=unused-argument
+            coming_from_latest_price: bool = False,   # pylint: disable=unused-argument
     ):
         return mocked_prices.get(asset, FVal('1.5'))
 

--- a/rotkehlchen/tests/unit/uniswap/test_get_balances_graph.py
+++ b/rotkehlchen/tests/unit/uniswap/test_get_balances_graph.py
@@ -83,8 +83,8 @@ def test_pagination(
 
     @store_call_args
     def mock_response(
-        *args,  # pylint: disable=unused-argument
-        **kwargs,
+            *args,  # pylint: disable=unused-argument
+            **kwargs,
     ):
         return next(get_response)
 

--- a/rotkehlchen/tests/unit/uniswap/test_get_unknown_asset_price.py
+++ b/rotkehlchen/tests/unit/uniswap/test_get_unknown_asset_price.py
@@ -54,8 +54,8 @@ def test_pagination(
 
     @store_call_args
     def mock_response(
-        *args,  # pylint: disable=unused-argument
-        **kwargs,
+            *args,  # pylint: disable=unused-argument
+            **kwargs,
     ):
         return next(get_response)
 

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -110,12 +110,12 @@ CUSTOM_USDT = EvmToken.initialize(
 
 
 def make_ethereum_event(
-    index: int,
-    tx_hash: Optional[bytes] = None,
-    asset: CryptoAsset = CUSTOM_USDT,
-    counterparty: Optional[str] = None,
-    event_type: HistoryEventType = HistoryEventType.UNKNOWN,
-    event_subtype: HistoryEventSubType = HistoryEventSubType.NONE,
+        index: int,
+        tx_hash: Optional[bytes] = None,
+        asset: CryptoAsset = CUSTOM_USDT,
+        counterparty: Optional[str] = None,
+        event_type: HistoryEventType = HistoryEventType.UNKNOWN,
+        event_subtype: HistoryEventSubType = HistoryEventSubType.NONE,
 ) -> HistoryBaseEntry:
     if tx_hash is None:
         tx_hash = make_random_bytes(42)
@@ -134,7 +134,7 @@ def make_ethereum_event(
 
 
 def generate_tx_entries_response(
-    data: list[tuple[EvmTransaction, list[HistoryBaseEntry]]],
+        data: list[tuple[EvmTransaction, list[HistoryBaseEntry]]],
 ) -> list:
     result = []
     for tx, events in data:

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from typing import Any, Optional
 from unittest.mock import patch
 
+import requests
 from hexbytes import HexBytes
 
 from rotkehlchen.tests.utils.avalanche import AVALANCHE_ACC1_AVAX_ADDR, AVALANCHE_ACC2_AVAX_ADDR
 
+original_requests_get = requests.get
 MOCK_WEB3_LAST_BLOCK_INT = 16210873
 MOCK_WEB3_LAST_BLOCK_HEX = '0xf75bb9'
 
@@ -70,6 +72,14 @@ class MockWeb3():
     @property
     def net(self):
         return namedtuple('Version', ['version'])(version=1)
+
+
+def patch_requests_for_cryptoscamdb(url, *args, **kwargs):
+    if url == 'https://api.cryptoscamdb.org/v1/addresses':
+        return MockResponse(200, '{"success": true, "result":{}}')
+
+    # else
+    return original_requests_get(url, *args, **kwargs)
 
 
 def patch_web3_request(test_specific_mock_data):

--- a/tools/profiling/sampler.py
+++ b/tools/profiling/sampler.py
@@ -210,11 +210,11 @@ class SignalSampler:
     """Signal based sampler."""
 
     def __init__(
-        self,
-        collector,
-        timer: int = TIMER,
-        interval: float = INTERVAL_SECONDS,
-        timer_signal: int = TIMER_SIGNAL,
+            self,
+            collector,
+            timer: int = TIMER,
+            interval: float = INTERVAL_SECONDS,
+            timer_signal: int = TIMER_SIGNAL,
     ) -> None:
 
         self.collector = collector

--- a/tools/profiling/timer.py
+++ b/tools/profiling/timer.py
@@ -12,11 +12,11 @@ SignalHandler = Callable[[int, FrameType], None]
 
 class Timer:
     def __init__(
-        self,
-        callback: SignalHandler,
-        timer: int = TIMER,
-        interval: float = INTERVAL_SECONDS,
-        timer_signal: int = TIMER_SIGNAL,
+            self,
+            callback: SignalHandler,
+            timer: int = TIMER,
+            interval: float = INTERVAL_SECONDS,
+            timer_signal: int = TIMER_SIGNAL,
     ) -> None:
 
         assert callable(callback), "callback must be callable"


### PR DESCRIPTION
Using a tool I found for that: https://github.com/theendlessriver13/double-indent

Unfortunately the author did not want the improvements I added, so I forked the project and added them to our fork: https://github.com/LefterisJP/double-indent

This will now as dry-run for `make lint` and will change all files with `make format`.

I won't ever need to tell you to do double indentation ever again :smile: 