### PR TITLE
Use specific types for querying amms

### DIFF
--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/types.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/types.py
@@ -124,6 +124,10 @@ class EventType(Enum):
         raise RuntimeError(f'Corrupt value {self} for EventType -- Should never happen')
 
 
+UNISWAP_EVENTS_TYPES = (EventType.MINT_UNISWAP, EventType.BURN_UNISWAP)
+SUSHISWAP_EVENTS_TYPES = (EventType.MINT_SUSHISWAP, EventType.BURN_SUSHISWAP)
+
+
 LiquidityPoolEventDBTuple = (
     tuple[
         bytes,  # tx_hash

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING, Optional
 from rotkehlchen.chain.ethereum.graph import Graph
 from rotkehlchen.chain.ethereum.interfaces.ammswap.ammswap import AMMSwapPlatform
 from rotkehlchen.chain.ethereum.interfaces.ammswap.types import (
+    SUSHISWAP_EVENTS_TYPES,
     AddressEvents,
     AddressEventsBalances,
     AddressToLPBalances,
     AssetToPrice,
     DDAddressEvents,
-    EventType,
 )
 from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import SUBGRAPH_REMOTE_ERROR_MSG
 from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP_V2
@@ -101,7 +101,7 @@ class Sushiswap(AMMSwapPlatform, EthereumModule):
         if new_addresses:
             start_ts = Timestamp(0)
             for address in new_addresses:
-                for event_type in EventType:
+                for event_type in SUSHISWAP_EVENTS_TYPES:
                     new_address_events = self._get_events_graph(
                         address=address,
                         start_ts=start_ts,
@@ -123,7 +123,7 @@ class Sushiswap(AMMSwapPlatform, EthereumModule):
         # Request existing DB addresses' events
         if existing_addresses and to_timestamp > min_end_ts:
             for address in existing_addresses:
-                for event_type in EventType:
+                for event_type in SUSHISWAP_EVENTS_TYPES:
                     address_new_events = self._get_events_graph(
                         address=address,
                         start_ts=min_end_ts,
@@ -154,7 +154,7 @@ class Sushiswap(AMMSwapPlatform, EthereumModule):
             for address in addresses:
                 db_events = self.database.get_amm_events(
                     cursor=cursor,
-                    events=[EventType.MINT_SUSHISWAP, EventType.BURN_SUSHISWAP],
+                    events=SUSHISWAP_EVENTS_TYPES,
                     from_ts=from_timestamp,
                     to_ts=to_timestamp,
                     address=address,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
@@ -7,12 +7,12 @@ from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.graph import Graph
 from rotkehlchen.chain.ethereum.interfaces.ammswap.ammswap import AMMSwapPlatform
 from rotkehlchen.chain.ethereum.interfaces.ammswap.types import (
+    UNISWAP_EVENTS_TYPES,
     AddressEvents,
     AddressEventsBalances,
     AddressToLPBalances,
     AssetToPrice,
     DDAddressEvents,
-    EventType,
     LiquidityPoolAsset,
     ProtocolBalance,
 )
@@ -170,7 +170,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
         if new_addresses:
             start_ts = Timestamp(0)
             for address in new_addresses:
-                for event_type in EventType:
+                for event_type in UNISWAP_EVENTS_TYPES:
                     new_address_events = self._get_events_graph(
                         address=address,
                         start_ts=start_ts,
@@ -192,7 +192,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
         # Request existing DB addresses' events
         if existing_addresses and to_timestamp > min_end_ts:
             for address in existing_addresses:
-                for event_type in EventType:
+                for event_type in UNISWAP_EVENTS_TYPES:
                     address_new_events = self._get_events_graph(
                         address=address,
                         start_ts=min_end_ts,
@@ -223,7 +223,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
             for address in addresses:
                 db_events = self.database.get_amm_events(
                     cursor=cursor,
-                    events=[EventType.MINT_UNISWAP, EventType.BURN_UNISWAP],
+                    events=UNISWAP_EVENTS_TYPES,
                     from_ts=from_timestamp,
                     to_ts=to_timestamp,
                     address=address,

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -7,7 +7,7 @@ import tempfile
 from collections import defaultdict
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import Any, Iterator, Literal, Optional, Sequence, Union, cast, overload
+from typing import Any, Iterable, Iterator, Literal, Optional, Sequence, Union, cast, overload
 
 from gevent.lock import Semaphore
 from pysqlcipher3 import dbapi2 as sqlcipher
@@ -922,7 +922,7 @@ class DBHandler:
     def get_amm_events(
             self,
             cursor: 'DBCursor',
-            events: list[EventType],
+            events: Iterable[EventType],
             from_ts: Optional[Timestamp] = None,
             to_ts: Optional[Timestamp] = None,
             address: Optional[ChecksumEvmAddress] = None,

--- a/rotkehlchen/tests/api/test_sushiswap.py
+++ b/rotkehlchen/tests/api/test_sushiswap.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.chain.ethereum.interfaces.ammswap.types import EventType
+from rotkehlchen.chain.ethereum.interfaces.ammswap.types import SUSHISWAP_EVENTS_TYPES, EventType
 from rotkehlchen.chain.ethereum.modules.sushiswap import (
     SUSHISWAP_EVENTS_PREFIX,
     SushiswapPoolEvent,
@@ -213,7 +213,7 @@ def test_get_events_history_filtering_by_timestamp(
 
     with rotki.data.db.conn.read_ctx() as cursor:
         # Make sure they end up in the DB
-        events = rotki.data.db.get_amm_events(cursor, [EventType.MINT_SUSHISWAP, EventType.BURN_SUSHISWAP])  # noqa: E501
+        events = rotki.data.db.get_amm_events(cursor, SUSHISWAP_EVENTS_TYPES)
         assert len(events) != 0
         # test sushiswap data purging from the db works
         response = requests.delete(api_url_for(
@@ -222,5 +222,5 @@ def test_get_events_history_filtering_by_timestamp(
             module_name='sushiswap',
         ))
         assert_simple_ok_response(response)
-        events = rotki.data.db.get_amm_events(cursor, [EventType.MINT_SUSHISWAP, EventType.BURN_SUSHISWAP])  # noqa: E501
+        events = rotki.data.db.get_amm_events(cursor, SUSHISWAP_EVENTS_TYPES)
         assert len(events) == 0

--- a/rotkehlchen/tests/api/test_uniswap.py
+++ b/rotkehlchen/tests/api/test_uniswap.py
@@ -8,7 +8,7 @@ import requests
 from flaky import flaky
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.chain.ethereum.interfaces.ammswap.types import EventType
+from rotkehlchen.chain.ethereum.interfaces.ammswap.types import UNISWAP_EVENTS_TYPES, EventType
 from rotkehlchen.chain.ethereum.modules.uniswap import (
     UNISWAP_EVENTS_PREFIX,
     UniswapPoolEvent,
@@ -355,7 +355,7 @@ def test_get_events_history_filtering_by_timestamp_case1(
 
     with rotki.data.db.conn.read_ctx() as cursor:
         # Make sure they end up in the DB
-        events = rotki.data.db.get_amm_events(cursor, [EventType.MINT_UNISWAP, EventType.BURN_UNISWAP])  # noqa: E501
+        events = rotki.data.db.get_amm_events(cursor, UNISWAP_EVENTS_TYPES)
         assert len(events) != 0
         # test uniswap data purging from the db works
         response = requests.delete(api_url_for(
@@ -364,7 +364,7 @@ def test_get_events_history_filtering_by_timestamp_case1(
             module_name='uniswap',
         ))
         assert_simple_ok_response(response)
-        events = rotki.data.db.get_amm_events(cursor, [EventType.MINT_UNISWAP, EventType.BURN_UNISWAP])  # noqa: E501
+        events = rotki.data.db.get_amm_events(cursor, UNISWAP_EVENTS_TYPES)
         assert len(events) == 0
 
 
@@ -442,7 +442,7 @@ def test_get_events_history_filtering_by_timestamp_case2(
 
     with rotki.data.db.conn.read_ctx() as cursor:
         # Make sure they end up in the DB
-        events = rotki.data.db.get_amm_events(cursor, [EventType.MINT_UNISWAP, EventType.BURN_UNISWAP])  # noqa: E501
+        events = rotki.data.db.get_amm_events(cursor, UNISWAP_EVENTS_TYPES)
         assert len(events) != 0
         # test all data purging from the db works and also deletes uniswap data
         response = requests.delete(api_url_for(
@@ -450,7 +450,7 @@ def test_get_events_history_filtering_by_timestamp_case2(
             'ethereummoduledataresource',
         ))
         assert_simple_ok_response(response)
-        events = rotki.data.db.get_amm_events(cursor, [EventType.MINT_UNISWAP, EventType.BURN_UNISWAP])  # noqa: E501
+        events = rotki.data.db.get_amm_events(cursor, UNISWAP_EVENTS_TYPES)
         assert len(events) == 0
 
 


### PR DESCRIPTION
Don't iterate over sushiswap / uniswap events types when it is not needed