### PR TITLE
Add websocket message for user DB migration at evm chain addition

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -92,3 +92,22 @@ The messages sent by rotki when a user is logging in and a db upgrade is happeni
 - ``start_db_version``: DB version that user's database had before any upgrades began. This is the version of the DB when rotki first starts.
 - ``current_upgrade``: Structure that holds information about currently running upgrade. Contains: `from_db_version` - version of the database that currently running upgrade is being applied to; `total_steps` - total number of steps that currently running upgrade consists of; `current_step` - step that the upgrade is at as of this websocket message. 
 - ``target_db_version``: The target version of the DB. When this is reached, the upgrade process will have finished.
+
+
+EVM Addresses Migrations
+============================
+
+At the user DB migrations when a new evm chain is introduced rotki will do a migration that will add any addresses used in mainnet to the new evm chain. At the same time it needs to notify the frontend that new evm chain/ evm address combination was added at migration so the frontend can do extra actions such as detecting tokens. The message is simple and just contains the list of migrated addresses if any.
+
+::
+
+    {
+        "type": "evm_address_migration",
+        "data": [{
+	    "evm_chain": "optimism",
+	    "address": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12"
+	}, {
+	    "evm_chain": "optimism",
+	    "address": "0xFeebabE6b0418eC13b30aAdF129F5DcDd4f70CeA"
+	}]
+    }

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from gevent.lock import Semaphore
 from geventwebsocket import WebSocketApplication
@@ -67,7 +67,7 @@ class RotkiNotifier():
     def broadcast(
             self,
             message_type: 'WSMessageType',
-            to_send_data: dict[str, Any],
+            to_send_data: Union[dict[str, Any], list[Any]],
             success_callback: Optional[Callable] = None,
             success_callback_args: Optional[dict[str, Any]] = None,
             failure_callback: Optional[Callable] = None,

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -14,6 +14,8 @@ class WSMessageType(Enum):
     EVM_TRANSACTION_STATUS = auto()
     PREMIUM_STATUS_UPDATE = auto()
     LOGIN_STATUS = auto()
+    # Used for evm address migration after new chain integration
+    EVM_ADDRESS_MIGRATION = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/data_migrations/migrations/migration_8.py
+++ b/rotkehlchen/data_migrations/migrations/migration_8.py
@@ -1,6 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
+from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -51,5 +52,12 @@ def data_migration_8(rotki: 'Rotkehlchen') -> None:
                         address=account,
                     )],  # not duplicating label and tags as it's chain specific
                 )
+
+        # notify frontend of which accounts were migrated, so they can order token detection
+        if len(to_add_accounts) != 0:
+            rotki.msg_aggregator.add_message(
+                message_type=WSMessageType.EVM_ADDRESS_MIGRATION,
+                data=[{'evm_chain': x[0], 'address': x[1]} for x in to_add_accounts],
+            )
 
     log.debug('Exit data_migration_8')

--- a/rotkehlchen/user_messages.py
+++ b/rotkehlchen/user_messages.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import deque
-from typing import TYPE_CHECKING, Any, Deque, Optional
+from typing import TYPE_CHECKING, Any, Deque, Optional, Union
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -71,7 +71,7 @@ class MessagesAggregator():
     def add_message(
             self,
             message_type: WSMessageType,
-            data: dict[str, Any],
+            data: Union[dict[str, Any], list[Any]],
     ) -> None:
         fallback_msg = json.dumps({'type': str(message_type), 'data': data})  # noqa: E501  # kind of silly to repeat it here. Same code in broadcast
 


### PR DESCRIPTION
This websocket message is useful for telling us that an address was added to the DB after the v1.26.XX -> v1.27 user DB migration. Armed with that knowledg the frontend can do stuff, notify the user and order token detection.

Note that: For this migration it will show migrations for `optimism` and `avalanche`.

Frontend should 100% order token detection for optimism. Needs to do nothing for avalanche.

But we could also use this information to let the user know that the given addresses were also detected to have activity in the avalanche/optimism chain and as such were added.