### PR TITLE
Removes dots from docker dev build version

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -288,7 +288,7 @@ jobs:
         run: |
           ROTKI_VERSION=$(cat .bumpversion.cfg | grep 'current_version = ' | sed -n -e 's/current_version = //p')
           POSTFIX=$(if git describe --tags --exact-match "$REVISION" &>/dev/null; then echo ''; else echo '-dev'; fi)
-          ROTKI_VERSION=${ROTKI_VERSION}${POSTFIX}-$(date +'%Y.%m.%d')
+          ROTKI_VERSION=${ROTKI_VERSION}${POSTFIX}$(date +'%Y%m%d')
           echo "version=${ROTKI_VERSION}" >> $GITHUB_OUTPUT
       - name: Build Information
         id: build_information


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Notes
At least from the logs, it seemed that it didn't like what we put after -dev because it didn't seem to conform with PEP 440 or something. 

At least from a quick reading, it seems that using numbers is fine but `.` not.