### PR TITLE
Make VCR ignore responses that are not 200

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -21,6 +21,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: Checkout test caching
+        uses: actions/checkout@v3
+        with:
+          repository: rotki/test-caching
+          path: test-caching
       - name: Load env
         uses: rotki/action-env@v1
         with:
@@ -35,11 +40,6 @@ jobs:
         with:
           path: ~/.cache/.rotkehlchen-test-dir
           key: ${{ runner.os }}-testdir
-      - name: Cache rotkehlchen tests cassettes (network mocks) directory
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/.rotkehlchen-cassettes-dir
-          key: ${{ runner.os }}-cassettesdir
       - name: Setup minupnpc
         if: runner.os == 'Windows'
         run: |          
@@ -69,16 +69,9 @@ jobs:
       - name: Install pytest annotation plugin
         run: |     
           pip install pytest-github-actions-annotate-failures
-      - name: Parse commit message for vcrpy cassette rewrite path
-        id: parse-cassette-rewrite-path
-        run: |
-          commit_message=$(git log --max-count=1 --format=%B HEAD)
-          result=$(echo $commit_message | sed '/CASSETTE_REWRITE_PATH/!d' | cut -d "=" -f 2)
-          echo "result=${result}" >> $GITHUB_OUTPUT
       - name: Run tests
         env:
-          CASSETTE_REWRITE_PATH: ${{steps.parse-cassette-rewrite-path.result}}
-          PYTEST_ARGS: '--durations=150 --disable-recording'
+          PYTEST_ARGS: '--durations=150'
           FORCE_COLOR: 1
         run: |
           if [ "${{ runner.os }}" == 'macOS' ];
@@ -87,7 +80,7 @@ jobs:
           else
             COVERAGE_ARGS='--cov=./'
           fi          
-          
+          export CASSETTES_DIR=$HOME/work/rotki/rotki/test-caching
           python pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS rotkehlchen/tests
           python pytestgeventwrapper.py --dead-fixtures
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ format:
 clean:
 	rm -rf build/ dist/ rotkehlchen_py_dist/ htmlcov/ rotkehlchen.egg-info/ *.dmg frontend/app/dist/ frontend/app/build/
 
+
 docker-image:
 	packaging/docker-image.sh
+
 
 test-assets:
 	python pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_binance.py::test_binance_assets_are_known
@@ -48,3 +50,7 @@ test-assets:
 	python pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_independentreserve.py::test_assets_are_known
 	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_zerionsdk.py::test_protocol_names_are_known
 	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_zerionsdk.py::test_query_all_protocol_balances_for_account
+
+
+create-cassettes:
+	RECORD_CASSETTES=true && python pytestgeventwrapper.py -m vcr rotkehlchen/tests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,7 @@ psutil==5.9.4
 pytest-freezer==0.4.6
 git+https://github.com/rotki/pytest-deadfixtures@87d2be8#egg=pytest-deadfixtures # temporarily due to false positive
 pytest-socket==0.5.1
-pytest-recording==0.12.1
+pytest-vcr==1.0.2
 freezegun==1.2.2
 flaky==3.7.0
 

--- a/rotkehlchen/tests/api/test_bitcoin.py
+++ b/rotkehlchen/tests/api/test_bitcoin.py
@@ -258,6 +258,7 @@ def test_add_delete_xpub(rotkehlchen_api_server):
     assert len(result) == 0, 'all xpub mappings should have been deleted'
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 def test_add_delete_xpub_multiple_chains(rotkehlchen_api_server):
     # Disable caching of query results

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1463,6 +1463,7 @@ def test_ignored_assets(rotkehlchen_api_server, ethereum_accounts):
     assert result['entries_limit'] == FREE_ETH_TX_LIMIT
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x59ABf3837Fa962d6853b4Cc0a19513AA031fd32b']])  # noqa: E501
 @patch.object(EthereumTransactions, '_get_internal_transactions_for_ranges', lambda *args, **kargs: None)  # noqa: E501
 @patch.object(EthereumTransactions, '_get_erc20_transfers_for_ranges', lambda *args, **kargs: None)

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -677,6 +677,7 @@ def test_query_historical_dsr_with_a_zero_withdrawal(
     assert len(errors) == 0
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662']])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_dsr']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -6,8 +6,10 @@ import tempfile
 import warnings as test_warnings
 from contextlib import suppress
 from enum import auto
+from http import HTTPStatus
+from json import JSONDecodeError
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import py
 import pytest
@@ -17,6 +19,10 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import TRACE, add_logging_level, configure_logging
 from rotkehlchen.tests.utils.args import default_args
 from rotkehlchen.utils.mixins.serializableenum import SerializableEnumMixin
+from rotkehlchen.utils.serialization import jsonloads_dict
+
+if TYPE_CHECKING:
+    from vcr import VCR
 
 
 TESTS_ROOT_DIR = Path(__file__).parent
@@ -158,41 +164,69 @@ def get_cassette_dir(request: pytest.FixtureRequest) -> Path:
     return Path(request.node.path).relative_to(TESTS_ROOT_DIR).with_suffix('')
 
 
-@pytest.fixture
-def vcr_config(request: pytest.FixtureRequest, default_cassette_name: str) -> dict[str, Any]:
+def is_etherscan_rate_limited(response: dict[str, Any]) -> bool:
+    result = False
+    with suppress(JSONDecodeError, KeyError):
+        body = jsonloads_dict(response['body']['string'])
+        result = int(body['status']) == 0 and 'rate limit reached' in body['result']
+    return result
+
+
+@pytest.fixture(scope='module', name='vcr')
+def vcr_fixture(vcr: 'VCR') -> 'VCR':
+    """
+    Update VCR instance to discard error responses during the record mode.
+    This target directly etherscan that is the service we are first focusing on
+    # pytest-deadfixtures ignore
+    """
+
+    def before_record_response(response: dict[str, Any]) -> Optional[dict[str, Any]]:
+        if (
+            'RECORD_CASSETTES' in os.environ and
+            response['status']['code'] != HTTPStatus.OK or
+            is_etherscan_rate_limited(response)
+        ):
+            return None
+
+        return response
+
+    vcr.before_record_response = before_record_response
+    return vcr
+
+
+@pytest.fixture(scope='module')
+def vcr_config() -> dict[str, Any]:
     """
     vcrpy config
     - record_mode: allow rewriting multiple cassettes using CASSETTE_REWRITE_PATH env variable
-      e.g. `CASSETTE_REWRITE_PATH=unit/decoders` will rewrite all decoder cassettes
-           `CASSETTE_REWRITE_PATH=*` will rewrite all cassettes
-    - decode_compressed_response: decode if not in CI (for readability)
+    - decode_compressed_response: True to correctly inspect the responses
+    - ignore_localhost: Don't record queries made to localhost
     # pytest-deadfixtures ignore
     ^^^ this allows our fork of pytest-deadfixtures to ignore this fixture for usage detection
     since it cannot detect dynamic usage (request.getfixturevalue) in pytest-recording
     """
-    rewrite_path = os.environ.get('CASSETTE_REWRITE_PATH')
-    cassette_dir = get_cassette_dir(request)
-    cassette_path = cassette_dir / default_cassette_name
-
-    if rewrite_path and (cassette_path.is_relative_to(rewrite_path) or rewrite_path == '*'):
-        record_mode = 'rewrite'
-    else:
+    if 'RECORD_CASSETTES' in os.environ:
         record_mode = 'once'
-
-    decode_compressed_response = 'CI' not in os.environ
+    else:
+        record_mode = 'none'
 
     return {
         'record_mode': record_mode,
-        'decode_compressed_response': decode_compressed_response,
+        'decode_compressed_response': True,
+        'ignore_localhost': True,
     }
 
 
 @pytest.fixture(scope='module')
 def vcr_cassette_dir(request: pytest.FixtureRequest) -> str:
-    """Override pytest-recording's bundled fixture to store cassettes outside source code"""
+    """
+    Override pytest-vcr's bundled fixture to store cassettes outside source code
+    # pytest-deadfixtures ignore
+    """
     if 'CI' in os.environ:
-        base_dir = Path.home() / '.cache' / '.rotkehlchen-cassettes-dir'
+        base_dir = Path(os.environ['CASSETTES_DIR']) / 'cassettes'
     else:
         base_dir = default_data_directory().parent / 'cassettes'
+
     cassette_dir = get_cassette_dir(request)
     return str(base_dir / cassette_dir)

--- a/rotkehlchen/tests/unit/decoders/test_element_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_element_finance.py
@@ -15,7 +15,7 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_claim_aidrop(database, ethereum_inquirer):
+def test_claim_airdrop(database, ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b
     """

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -19,6 +19,7 @@ def fixture_ethereumtokens(ethereum_inquirer, database, inquirer):  # pylint: di
     return EthereumTokens(database, ethereum_inquirer)
 
 
+@pytest.mark.vcr
 @flaky(max_runs=3, min_passes=1)  # failed in a flaky way sometimes in the CI due to etherscan
 @pytest.mark.parametrize('ignored_assets', [[A_LPT]])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])


### PR DESCRIPTION
At the moment VCR doesn't have any filter on the response status code. What I did was adding a new step to the processing rules that doesn't store any response that doesn't have status code 200
