### PR TITLE
feat: refetch empty page of histories

### DIFF
--- a/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
+++ b/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
@@ -232,15 +232,23 @@ watch(ignoredAssetsHandling, async (filters, oldValue) => {
     return;
   }
   let newOptions = null;
-  if (get(options)) {
+  const optionsVal = get(options);
+  if (optionsVal) {
     newOptions = {
-      ...get(options)!,
+      ...optionsVal,
       page: 1
     };
   }
 
   await updatePaginationHandler(newOptions);
 });
+
+const setPage = (page: number) => {
+  const optionsVal = get(options);
+  if (optionsVal) {
+    updatePaginationHandler({ ...optionsVal, page });
+  }
+};
 
 onMounted(async () => {
   await updatePayloadHandler();
@@ -287,7 +295,7 @@ const showDeleteConfirmation = (item: NonFungibleBalance) => {
       />
     </template>
 
-    <collection-handler :collection="balances">
+    <collection-handler :collection="balances" @set-page="setPage">
       <template #default="{ data, itemLength, totalUsdValue }">
         <data-table
           v-model="selected"

--- a/frontend/app/src/components/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/NftBalanceTable.vue
@@ -153,6 +153,13 @@ const updatePayloadHandler = async () => {
   await updateRequestPayload(payload);
 };
 
+const setPage = (page: number) => {
+  const optionsVal = get(options);
+  if (optionsVal) {
+    updatePaginationHandler({ ...optionsVal, page });
+  }
+};
+
 onMounted(async () => {
   await updatePayloadHandler();
 });
@@ -198,7 +205,7 @@ onMounted(async () => {
       />
     </template>
 
-    <collection-handler :collection="balances">
+    <collection-handler :collection="balances" @set-page="setPage">
       <template #default="{ data, itemLength }">
         <data-table
           :headers="tableHeaders"

--- a/frontend/app/src/components/helper/CollectionHandler.vue
+++ b/frontend/app/src/components/helper/CollectionHandler.vue
@@ -1,19 +1,32 @@
 <script setup lang="ts">
-import { type PropType } from 'vue';
 import { type Collection } from '@/types/collection';
 import { getCollectionData, setupEntryLimit } from '@/utils/collection';
+import { useFrontendSettingsStore } from '@/store/settings/frontend';
 
-const props = defineProps({
-  collection: {
-    required: true,
-    type: Object as PropType<Collection<any>>
-  }
-});
+const props = defineProps<{
+  collection: Collection<any>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'set-page', page: number): void;
+}>();
+
+const setPage = (page: number) => {
+  emit('set-page', page);
+};
 
 const { collection } = toRefs(props);
 
 const { data, limit, found, total, totalUsdValue } =
   getCollectionData(collection);
+
+const { itemsPerPage } = storeToRefs(useFrontendSettingsStore());
+watch([data, found, itemsPerPage], ([data, found, itemsPerPage]) => {
+  if (data.length === 0 && found > 0) {
+    const lastPage = Math.ceil(found / itemsPerPage);
+    setPage(lastPage);
+  }
+});
 
 const { showUpgradeRow, itemLength } = setupEntryLimit(limit, found, total);
 </script>

--- a/frontend/app/src/components/history/ClosedTrades.vue
+++ b/frontend/app/src/components/history/ClosedTrades.vue
@@ -300,15 +300,23 @@ watch(filters, async (filters, oldValue) => {
     return;
   }
   let newOptions = null;
-  if (get(options)) {
+  const optionsVal = get(options);
+  if (optionsVal) {
     newOptions = {
-      ...get(options)!,
+      ...optionsVal,
       page: 1
     };
   }
 
   await updatePaginationHandler(newOptions);
 });
+
+const setPage = (page: number) => {
+  const optionsVal = get(options);
+  if (optionsVal) {
+    updatePaginationHandler({ ...optionsVal, page });
+  }
+};
 
 const fetch = (refresh = false) => emit('fetch', refresh);
 
@@ -410,7 +418,7 @@ const showDeleteConfirmation = () => {
         </v-row>
       </template>
 
-      <collection-handler :collection="trades">
+      <collection-handler :collection="trades" @set-page="setPage">
         <template #default="{ data, limit, total, showUpgradeRow, itemLength }">
           <data-table
             v-model="selected"

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -166,15 +166,23 @@ watch(filters, async (filter, oldValue) => {
     return;
   }
   let newOptions = null;
-  if (get(options)) {
+  const optionsVal = get(options);
+  if (optionsVal) {
     newOptions = {
-      ...get(options)!,
+      ...optionsVal,
       page: 1
     };
   }
 
   await updatePaginationHandler(newOptions);
 });
+
+const setPage = (page: number) => {
+  const optionsVal = get(options);
+  if (optionsVal) {
+    updatePaginationHandler({ ...optionsVal, page });
+  }
+};
 
 const pageRoute = Routes.HISTORY_DEPOSITS_WITHDRAWALS;
 </script>
@@ -219,7 +227,7 @@ const pageRoute = Routes.HISTORY_DEPOSITS_WITHDRAWALS;
       </v-row>
     </template>
 
-    <collection-handler :collection="assetMovements">
+    <collection-handler :collection="assetMovements" @set-page="setPage">
       <template #default="{ data, limit, total, showUpgradeRow, itemLength }">
         <data-table
           v-model="selected"

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -203,15 +203,23 @@ watch(filters, async (filter, oldValue) => {
     return;
   }
   let newOptions = null;
-  if (get(options)) {
+  const optionsVal = get(options);
+  if (optionsVal) {
     newOptions = {
-      ...get(options)!,
+      ...optionsVal,
       page: 1
     };
   }
 
   await updatePaginationHandler(newOptions);
 });
+
+const setPage = (page: number) => {
+  const optionsVal = get(options);
+  if (optionsVal) {
+    updatePaginationHandler({ ...optionsVal, page });
+  }
+};
 
 const selected: Ref<LedgerActionEntry[]> = ref([]);
 
@@ -372,7 +380,7 @@ const showDeleteConfirmation = () => {
           </v-col>
         </v-row>
       </template>
-      <collection-handler :collection="ledgerActions">
+      <collection-handler :collection="ledgerActions" @set-page="setPage">
         <template #default="{ data, limit, total, showUpgradeRow, itemLength }">
           <data-table
             v-model="selected"

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -323,17 +323,24 @@ watch(filters, async (filter, oldValue) => {
   if (filter === oldValue) {
     return;
   }
-
   let newOptions = null;
-  if (get(options)) {
+  const optionsVal = get(options);
+  if (optionsVal) {
     newOptions = {
-      ...get(options)!,
+      ...optionsVal,
       page: 1
     };
   }
 
   await updatePaginationHandler(newOptions);
 });
+
+const setPage = (page: number) => {
+  const optionsVal = get(options);
+  if (optionsVal) {
+    updatePaginationHandler({ ...optionsVal, page });
+  }
+};
 
 watch(usedAccount, async () => {
   let newOptions = null;
@@ -461,7 +468,7 @@ const txChains = useArrayMap(txEvmChains, x => x.id);
         </v-row>
       </template>
 
-      <collection-handler :collection="transactions">
+      <collection-handler :collection="transactions" @set-page="setPage">
         <template #default="{ itemLength, showUpgradeRow, limit, total }">
           <data-table
             :expanded="data"

--- a/frontend/app/src/components/history/transactions/query-status/TransactionQueryStatus.vue
+++ b/frontend/app/src/components/history/transactions/query-status/TransactionQueryStatus.vue
@@ -83,7 +83,9 @@ const css = useCssModule();
               </v-icon>
             </div>
 
-            <evm-chain-icon :chain="item.evmChain" size="20px" />
+            <adaptive-wrapper>
+              <evm-chain-icon :chain="item.evmChain" size="20px" />
+            </adaptive-wrapper>
 
             <transaction-query-status-line :item="item" class="ms-2" />
           </div>

--- a/frontend/app/src/components/history/transactions/query-status/TransactionQueryStatusDialog.vue
+++ b/frontend/app/src/components/history/transactions/query-status/TransactionQueryStatusDialog.vue
@@ -39,7 +39,9 @@ const { queryStatus } = toRefs(useTxQueryStatusStore());
             :class="css.item"
           >
             <div class="d-flex align-center">
-              <evm-chain-icon :chain="item.evmChain" size="20px" />
+              <adaptive-wrapper>
+                <evm-chain-icon :chain="item.evmChain" size="20px" />
+              </adaptive-wrapper>
 
               <transaction-query-status-line :item="item" class="ms-2" />
 

--- a/frontend/app/src/pages/settings/api-keys/external/index.vue
+++ b/frontend/app/src/pages/settings/api-keys/external/index.vue
@@ -158,7 +158,9 @@ onMounted(async () => {
       </v-card>
       <v-tabs v-model="evmEtherscanTabIndex">
         <v-tab v-for="(_, chain) in evmEtherscanTabs" :key="chain">
-          <evm-chain-icon :chain="chain" />
+          <adaptive-wrapper>
+            <evm-chain-icon :chain="chain" />
+          </adaptive-wrapper>
           <div class="ml-2">{{ chain }}</div>
         </v-tab>
       </v-tabs>

--- a/frontend/app/src/store/history/consts.ts
+++ b/frontend/app/src/store/history/consts.ts
@@ -332,7 +332,8 @@ export const transactionEventTypeMapping: Record<
     [HistoryEventSubType.NONE]: TransactionEventType.APPROVAL
   },
   [HistoryEventType.TRANSFER]: {
-    [HistoryEventSubType.NONE]: TransactionEventType.TRANSFER
+    [HistoryEventSubType.NONE]: TransactionEventType.TRANSFER,
+    [HistoryEventSubType.BRIDGE]: TransactionEventType.BRIDGE
   },
   [HistoryEventType.TRADE]: {
     [HistoryEventSubType.SPEND]: TransactionEventType.SWAP_OUT,


### PR DESCRIPTION
Fix edge case when deleting trade, ledger action, or other sections, that use backend pagination

For example when you have 11 trades, 
and now you are on page 2 where there is only 1 trade on that page,
then you delete that 1 trade, you get empty page.

I think the better UX here is to move to page 1 instead.