### PR TITLE
Add multiple address/chain id combo query to evm tx query endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2287,34 +2287,42 @@ Query supported ethereum modules
 Querying evm transactions
 =================================
 
-.. http:get:: /api/(version)/blockchains/evm/transactions/(address)
-
-   .. note::
-      This endpoint also accepts parameters as query arguments.
+.. http:post:: /api/(version)/blockchains/evm/transactions/
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a GET on the evm transactions endpoint will query all evm transactions for all the tracked user addresses. Caller can also specify a chain and/or an address to further filter the query. Also they can limit the queried transactions by timestamps and can filter transactions by related event's properties (asset, protocols and whether to exclude transactions with ignored assets). If the user is not premium and has more than the transaction limit then the returned transaction will be limited to that number. Any filtering will also be limited. Transactions are returned most recent first.
+   Doing a POST on the evm transactions endpoint will query all evm transactions for all the tracked user addresses. Caller can also specify a chain and/or an address to further filter the query. Also they can limit the queried transactions by timestamps and can filter transactions by related event's properties (asset, protocols and whether to exclude transactions with ignored assets). If the user is not premium and has more than the transaction limit then the returned transaction will be limited to that number. Any filtering will also be limited. Transactions are returned most recent first.
 
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/blockchains/evm/transactions/0xdAC17F958D2ee523a2206206994597C13D831ec7/ HTTP/1.1
+      POST /api/1/blockchains/evm/transactions HTTP/1.1
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"from_timestamp": 1514764800, "to_timestamp": 1572080165, "only_cache": false}
+      {
+          "accounts": [{
+	      "address": "0x3CAdbeB58CB5162439908edA08df0A305b016dA8",
+	      "evm_chain": "optimism"
+	  }, {
+	      "address": "0xF2Eb18a344b2a9dC769b1914ad035Cbb614Fd238"
+	  }],
+          "from_timestamp": 1514764800,
+	  "to_timestamp": 1572080165,
+	  "only_cache": false
+      }
 
    :reqjson int limit: This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson list[string] order_by_attributes: This is the list of attributes of the transaction by which to order the results.
    :reqjson list[bool] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
+   :reqjson list[string] accounts: List of accounts to filter by. Each account contains an ``"address"`` key which is required and is an evm address. It can also contains an ``"evm_chain"`` field which is the specific chain for which to limit the address.
    :reqjson int from_timestamp: The timestamp after which to return transactions. If not given zero is considered as the start.
    :reqjson int to_timestamp: The timestamp until which to return transactions. If not given all transactions from ``from_timestamp`` until now are returned.
    :reqjson bool only_cache: If true then only the ethereum transactions in the DB are queried.
-   :reqjson string evm_chain: Optional. The name of the evm chain by which to filter transactions. ``"ethereum"``, ``"optimism"`` etc.
+   :reqjson string evm_chain: Optional. The name of the evm chain by which to filter all transactions. ``"ethereum"``, ``"optimism"`` etc.
    :reqjson string asset: Optional. Serialized asset to filter by.
    :reqjson list protocols: Optional. Protocols (counterparties) to filter by. List of strings.
    :reqjson bool exclude_ignored_assets: Optional. Whether to exclude transactions with ignored assets. Default true.
@@ -2524,18 +2532,18 @@ Querying evm transactions
 Request transactions event decoding
 =======================================
 
-.. http:post:: /api/(version)/blockchains/evm/transactions
+.. http:put:: /api/(version)/blockchains/evm/transactions
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a POST on the evm transactions endpoint will request a decoding of the given transactions and generation of decoded events. That basically entails querying the transaction receipts for each transaction hash and then decoding all events. If events are already queried and ignore_cache is true they will be deleted and requeried.
+   Doing a PUT on the evm transactions endpoint will request a decoding of the given transactions and generation of decoded events. That basically entails querying the transaction receipts for each transaction hash and then decoding all events. If events are already queried and ignore_cache is true they will be deleted and requeried.
 
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests
 
-      POST /api/1/blockchains/evm/transactions HTTP/1.1
+      PUT /api/1/blockchains/evm/transactions HTTP/1.1
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -223,11 +223,6 @@ URLS_V1: URLS = [
     ('/blockchains/supported', SupportedChainsResource),
     ('/blockchains/evm/transactions', EvmTransactionsResource),
     ('/blockchains/evm/transactions/decode', EvmPendingTransactionsDecodingResource),
-    (
-        '/blockchains/evm/transactions/<string:address>',
-        EvmTransactionsResource,
-        'per_address_evm_transactions_resource',
-    ),
     ('/blockchains/ETH2/validators', Eth2ValidatorsResource),
     ('/blockchains/ETH2/stake/deposits', Eth2StakeDepositsResource),
     ('/blockchains/ETH2/stake/details', Eth2StakeDetailsResource),

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -108,7 +108,7 @@ from rotkehlchen.api.v1.schemas import (
     OptionalAddressesWithBlockchainsListSchema,
     OptionalEthereumAddressSchema,
     QueriedAddressesSchema,
-    RequiredEthereumAddressSchema,
+    RequiredEvmAddressSchema,
     ReverseEnsSchema,
     RpcAddNodeSchema,
     RpcNodeEditSchema,
@@ -469,13 +469,13 @@ class AssociatedLocations(BaseMethodView):
 
 
 class EvmTransactionsResource(BaseMethodView):
-    get_schema = EvmTransactionQuerySchema()
-    post_schema = EvmTransactionDecodingSchema()
+    post_schema = EvmTransactionQuerySchema()
+    put_schema = EvmTransactionDecodingSchema()
     delete_schema = EvmTransactionPurgingSchema()
 
     @require_loggedin_user()
-    @ignore_kwarg_parser.use_kwargs(get_schema, location='json_and_query_and_view_args')
-    def get(
+    @use_kwargs(post_schema, location='json_and_query')
+    def post(
             self,
             async_query: bool,
             only_cache: bool,
@@ -490,8 +490,8 @@ class EvmTransactionsResource(BaseMethodView):
         )
 
     @require_loggedin_user()
-    @use_kwargs(post_schema, location='json_and_query')
-    def post(
+    @use_kwargs(put_schema, location='json_and_query')
+    def put(
             self,
             async_query: bool,
             ignore_cache: bool,
@@ -793,7 +793,7 @@ class AssetsReplaceResource(BaseMethodView):
 class EthereumAssetsResource(BaseMethodView):
 
     get_schema = OptionalEthereumAddressSchema()
-    delete_schema = RequiredEthereumAddressSchema()
+    delete_schema = RequiredEvmAddressSchema()
 
     def make_edit_schema(self) -> ModifyEvmTokenSchema:
         return ModifyEvmTokenSchema(

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -8,6 +8,7 @@ from gevent.lock import Semaphore
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.api.websockets.typedefs import TransactionStatusStep, WSMessageType
+from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.chain.structures import TimestampOrBlockRange
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
@@ -117,9 +118,9 @@ class EvmTransactions(metaclass=ABCMeta):  # noqa: B024
         - pysqlcipher3.dbapi2.OperationalError if the SQL query fails due to
         invalid filtering arguments.
         """
-        query_addresses = filter_query.addresses
-        if query_addresses is not None:
-            accounts = query_addresses
+        query_accounts = filter_query.accounts
+        if query_accounts is not None:
+            accounts = [x.address for x in query_accounts]
         else:
             with self.database.conn.read_ctx() as cursor:
                 accounts = self.database.get_blockchain_accounts(cursor).get(
@@ -521,7 +522,7 @@ class EvmTransactions(metaclass=ABCMeta):  # noqa: B024
                 )
             else:
                 tx_filter_query = EvmTransactionsFilterQuery.make(
-                    addresses=addresses,
+                    accounts=[EvmAccount(address=x) for x in addresses],
                     chain_id=self.evm_inquirer.chain_id,
                 )
 

--- a/rotkehlchen/chain/evm/types.py
+++ b/rotkehlchen/chain/evm/types.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from typing import Any, Literal, NamedTuple
+from typing import Any, Literal, NamedTuple, Optional
 
 from eth_typing import HexAddress, HexStr
 
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import ChecksumEvmAddress, SupportedBlockchain
+from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ChecksumEvmAddress, SupportedBlockchain
 
 
 def string_to_evm_address(value: str) -> ChecksumEvmAddress:
@@ -79,3 +79,8 @@ class WeightedNode:
             weight=FVal(data['weight']) / 100,
             active=bool(data['active']),
         )
+
+
+class EvmAccount(NamedTuple):
+    address: ChecksumEvmAddress
+    chain_id: Optional[SUPPORTED_CHAIN_IDS] = None

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, get_args
 from rotkehlchen.chain.ethereum.constants import ETHEREUM_BEGIN
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
+from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.chain.optimism.constants import OPTIMISM_BEGIN
 from rotkehlchen.db.constants import HISTORY_MAPPING_STATE_DECODED
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery, TransactionsNotDecodedFilterQuery
@@ -536,7 +537,7 @@ class DBEvmTx():
                 cursor=cursor,
                 filter_=EvmTransactionsFilterQuery.make(
                     tx_hash=GENESIS_HASH,
-                    addresses=[account],
+                    accounts=[EvmAccount(address=account)],
                     chain_id=chain_id,
                 ),
                 has_premium=True,

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -359,7 +359,7 @@ class EventsHistorian:
         tx_filter_query = EvmTransactionsFilterQuery.make(
             limit=None,
             offset=None,
-            addresses=None,
+            accounts=None,
             # We need to have history of transactions since before the range
             from_ts=Timestamp(0),
             to_ts=end_ts,

--- a/rotkehlchen/tests/api/test_evm_transactions.py
+++ b/rotkehlchen/tests/api/test_evm_transactions.py
@@ -37,7 +37,7 @@ def test_query_transactions(rotkehlchen_api_server: 'APIServer'):
     """
     async_query = random.choice([False, True])
     # Ask for all evm transactions (test addy has both optimism and mainnet)
-    response = requests.get(
+    response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
             'evmtransactionsresource',
@@ -69,7 +69,7 @@ def test_query_transactions(rotkehlchen_api_server: 'APIServer'):
 
     # After querying make sure pagination and only_cache work properly for multiple chains
     for evm_chain in ('ethereum', 'optimism'):
-        response = requests.get(
+        response = requests.post(
             api_url_for(
                 rotkehlchen_api_server,
                 'evmtransactionsresource',

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -293,7 +293,7 @@ def test_event_with_details(rotkehlchen_api_server: 'APIServer'):
             history=[event1, event2],
         )
 
-    response = requests.get(
+    response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
             'evmtransactionsresource',

--- a/rotkehlchen/tests/db/test_db_filters.py
+++ b/rotkehlchen/tests/db/test_db_filters.py
@@ -1,5 +1,6 @@
 import pytest
 
+from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.db.filtering import (
     DBETHTransactionJoinsFilter,
     DBFilterOrder,
@@ -14,18 +15,18 @@ from rotkehlchen.types import Location, Timestamp
 
 
 def test_ethereum_transaction_filter():
-    addresses = [make_evm_address()]
+    address = make_evm_address()
     filter_query = EvmTransactionsFilterQuery.make(
         limit=10,
         offset=10,
-        addresses=addresses,
+        accounts=[EvmAccount(address=address)],
         from_ts=Timestamp(1),
         to_ts=Timestamp(999),
     )
     query, bindings = filter_query.prepare()
-    assert query == ' INNER JOIN evmtx_address_mappings WHERE evm_transactions.tx_hash=evmtx_address_mappings.tx_hash AND evmtx_address_mappings.address IN (?)  AND ((timestamp >= ? AND timestamp <= ?)) ORDER BY timestamp ASC LIMIT 10 OFFSET 10'  # noqa: E501
+    assert query == ' INNER JOIN evmtx_address_mappings WHERE evm_transactions.tx_hash=evmtx_address_mappings.tx_hash AND ((evmtx_address_mappings.address = ?))  AND ((timestamp >= ? AND timestamp <= ?)) ORDER BY timestamp ASC LIMIT 10 OFFSET 10'  # noqa: E501
     assert bindings == [
-        addresses[0],
+        address,
         filter_query.from_ts,
         filter_query.to_ts,
     ]
@@ -41,8 +42,8 @@ def test_ethereum_transaction_filter():
 def test_filter_arguments(and_op, order_by, pagination):
     """This one is just like the ethereum transactions filter test, but also using
     it as a testbed to test combinations of arguments"""
-    addresses = [make_evm_address(), make_evm_address()]
-    address_filter = DBETHTransactionJoinsFilter(and_op=False, addresses=addresses)
+    accounts = [EvmAccount(make_evm_address()), EvmAccount(make_evm_address())]
+    address_filter = DBETHTransactionJoinsFilter(and_op=False, accounts=accounts)
     time_filter = DBTimestampFilter(and_op=True, from_ts=Timestamp(1), to_ts=Timestamp(999))
     location_filter = DBLocationFilter(and_op=True, location=Location.KRAKEN)
     order_by_obj = DBFilterOrder(rules=[('timestamp', True)], case_sensitive=True) if order_by else None  # noqa: E501
@@ -57,9 +58,9 @@ def test_filter_arguments(and_op, order_by, pagination):
     query, bindings = filter_query.prepare()
 
     if and_op:
-        expected_query = ' INNER JOIN evmtx_address_mappings WHERE evm_transactions.tx_hash=evmtx_address_mappings.tx_hash AND evmtx_address_mappings.address IN (?,?)  AND ((timestamp >= ? AND timestamp <= ?) AND (location=?))'  # noqa: E501
+        expected_query = ' INNER JOIN evmtx_address_mappings WHERE evm_transactions.tx_hash=evmtx_address_mappings.tx_hash AND ((evmtx_address_mappings.address = ?) OR (evmtx_address_mappings.address = ?))  AND ((timestamp >= ? AND timestamp <= ?) AND (location=?))'  # noqa: E501
     else:
-        expected_query = ' INNER JOIN evmtx_address_mappings WHERE evm_transactions.tx_hash=evmtx_address_mappings.tx_hash AND evmtx_address_mappings.address IN (?,?)  AND ((timestamp >= ? AND timestamp <= ?) OR (location=?))'  # noqa: E501
+        expected_query = ' INNER JOIN evmtx_address_mappings WHERE evm_transactions.tx_hash=evmtx_address_mappings.tx_hash AND ((evmtx_address_mappings.address = ?) OR (evmtx_address_mappings.address = ?))  AND ((timestamp >= ? AND timestamp <= ?) OR (location=?))'  # noqa: E501
 
     if order_by:
         expected_query += ' ORDER BY timestamp ASC'
@@ -69,8 +70,8 @@ def test_filter_arguments(and_op, order_by, pagination):
 
     assert query == expected_query
     assert bindings == [
-        addresses[0],
-        addresses[1],
+        accounts[0].address,
+        accounts[1].address,
         time_filter.from_ts,
         time_filter.to_ts,
         location_filter.location.serialize_for_db(),

--- a/rotkehlchen/tests/db/test_evmtx.py
+++ b/rotkehlchen/tests/db/test_evmtx.py
@@ -1,4 +1,5 @@
 from rotkehlchen.chain.accounts import BlockchainAccountData
+from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
@@ -116,7 +117,14 @@ def test_add_get_evm_transactions(data_dir, username, sql_vm_instructions_cb):
         assert result == []
 
         # Now try transaction by relevant addresses
-        result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(addresses=[ETH_ADDRESS1, make_evm_address()], chain_id=ChainID.ETHEREUM), has_premium=True)  # noqa: E501
+        result = dbevmtx.get_evm_transactions(
+            cursor=cursor,
+            filter_=EvmTransactionsFilterQuery.make(
+                accounts=[EvmAccount(ETH_ADDRESS1), EvmAccount(make_evm_address())],
+                chain_id=ChainID.ETHEREUM,
+            ),
+            has_premium=True,
+        )
         assert result == [tx1, tx3]
 
 
@@ -266,7 +274,10 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
 
         result, total_filter_count = dbevmtx.get_evm_transactions_and_limit_info(
             cursor=cursor,
-            filter_=EvmTransactionsFilterQuery.make(addresses=[ETH_ADDRESS3], chain_id=ChainID.ETHEREUM),  # noqa: E501
+            filter_=EvmTransactionsFilterQuery.make(
+                accounts=[EvmAccount(ETH_ADDRESS3, chain_id=ChainID.ETHEREUM)],
+                chain_id=ChainID.ETHEREUM,
+            ),
             has_premium=True,
         )
         assert {x.tx_hash for x in result} == {b'1', b'3', b'4'}
@@ -276,7 +287,9 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
         # internal tx mappings
         result, total_filter_count = dbevmtx.get_evm_transactions_and_limit_info(
             cursor=cursor,
-            filter_=EvmTransactionsFilterQuery.make(addresses=[ETH_ADDRESS1], chain_id=ChainID.ETHEREUM),  # noqa: E501
+            filter_=EvmTransactionsFilterQuery.make(
+                accounts=[EvmAccount(ETH_ADDRESS1)],
+                chain_id=ChainID.ETHEREUM),
             has_premium=True,
         )
         assert result == [tx1, tx3, tx4, tx5]
@@ -284,14 +297,20 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
 
         result = dbevmtx.get_evm_transactions(
             cursor=cursor,
-            filter_=EvmTransactionsFilterQuery.make(addresses=[address_4], chain_id=ChainID.ETHEREUM),  # noqa: E501
+            filter_=EvmTransactionsFilterQuery.make(
+                accounts=[EvmAccount(address_4)],
+                chain_id=ChainID.ETHEREUM,
+            ),
             has_premium=True,
         )
         assert result == [tx3]
 
         result = dbevmtx.get_evm_transactions(
             cursor=cursor,
-            filter_=EvmTransactionsFilterQuery.make(addresses=[ETH_ADDRESS3], chain_id=ChainID.ETHEREUM),  # noqa: E501
+            filter_=EvmTransactionsFilterQuery.make(
+                accounts=[EvmAccount(ETH_ADDRESS3)],
+                chain_id=ChainID.ETHEREUM,
+            ),
             has_premium=True,
         )
         assert result == [tx1, tx3, tx4]

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -9,7 +9,7 @@ from rotkehlchen.accounting.structures.base import (
     HistoryEventType,
 )
 from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
-from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_SAI
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
@@ -36,7 +36,7 @@ def test_tx_decode(ethereum_transaction_decoder, database):
         transactions = dbevmtx.get_evm_transactions(
             cursor=cursor,
             filter_=EvmTransactionsFilterQuery.make(
-                addresses=[addr1],
+                accounts=[EvmAccount(addr1)],
                 tx_hash=approve_tx_hash,
                 chain_id=ChainID.ETHEREUM,
             ),


### PR DESCRIPTION
- Add multiple address/chain id combo query to evm tx query endpoint
- It now works by giving an optional list of accounts which consist of address and optional chain id keys
- Changed the transaction query verb from GET to POST
- Changed the transaction decoding verb from POST to PUT
- Adjusted tests

For @lukicenturi 