### PR TITLE
Refactor updates

### DIFF
--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -75,15 +75,17 @@ class Asset:
     def serialize(self) -> str:
         return self.identifier
 
-    def check_existence(self) -> 'Asset':
+    def check_existence(self, query_packaged_db: bool = True) -> 'Asset':
         """
         If this asset exists, returns the instance. If it doesn't, throws an error.
+        When the `query_packaged_db` is set to True and the checked asset is in the list
+        of constant asset we try to copy it from the packaged global db.
         May raise:
         - UnknownAsset
         """
         # We don't need asset type, but using `get_asset_type` since it has all the functionality
         # that we need here
-        AssetResolver().get_asset_type(self.identifier)
+        AssetResolver().get_asset_type(self.identifier, query_packaged_db=query_packaged_db)
         return self
 
     def is_nft(self) -> bool:

--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -88,7 +88,7 @@ class AssetResolver():
         return asset
 
     @staticmethod
-    def get_asset_type(identifier: str) -> AssetType:
+    def get_asset_type(identifier: str, query_packaged_db: bool = True) -> AssetType:
         # TODO: This is ugly here but is here to avoid a cyclic import in the Assets file
         # Couldn't find a reorg that solves this cyclic import
         from rotkehlchen.constants.assets import CONSTANT_ASSETS  # pylint: disable=import-outside-toplevel  # isort:skip  # noqa: E501
@@ -102,7 +102,7 @@ class AssetResolver():
         try:
             asset_type = GlobalDBHandler().get_asset_type(identifier)
         except UnknownAsset:
-            if identifier not in CONSTANT_ASSETS:
+            if identifier not in CONSTANT_ASSETS or query_packaged_db is False:
                 raise
 
             log.debug(f'Attempt to get asset_type for {identifier} using the packaged database')


### PR DESCRIPTION
This PR addresses two related problems:

- First is a bug that was copying assets from the packaged globaldb to the user's globaldb during updates. This caused a bug resulting in an infinite loop trying to solve conflicts
- Second problem solved is preventing the globaldb from getting modified during the assets update. To do this we first query all the needed files and then apply the updates in a critical section