### PR TITLE
improve speed in the slowest tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ test-assets:
 
 create-cassettes:
 	RECORD_CASSETTES=true && python pytestgeventwrapper.py -m vcr rotkehlchen/tests
+
+create-cassette:
+	RECORD_CASSETTES=true && python pytestgeventwrapper.py -m vcr $(TEST)

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -35,6 +35,7 @@ from rotkehlchen.tests.utils.checks import assert_serialized_lists_equal
 from rotkehlchen.tests.utils.constants import TXHASH_HEX_TO_BYTES
 from rotkehlchen.tests.utils.ethereum import (
     TEST_ADDR1,
+    TEST_ADDR2,
     TEST_ADDR3,
     extended_transactions_setup_test,
     setup_ethereum_transactions_test,
@@ -1505,6 +1506,7 @@ def test_no_value_eth_transfer(rotkehlchen_api_server: 'APIServer'):
     assert result['entries'][0]['decoded_events'][0]['entry']['balance']['amount'] == '0'
 
 
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1, TEST_ADDR2]])
 def test_decoding_missing_transactions(rotkehlchen_api_server: 'APIServer') -> None:
     """Test that decoding all pending transactions works fine"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -1554,6 +1556,7 @@ def test_decoding_missing_transactions(rotkehlchen_api_server: 'APIServer') -> N
     assert outcome['result']['decoded_tx_number'] == {}
 
 
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1, TEST_ADDR2]])
 def test_decoding_missing_transactions_by_address(rotkehlchen_api_server: 'APIServer') -> None:
     """Test that decoding all pending transactions works fine when a filter by address is set"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen

--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -53,6 +53,8 @@ TEST_V2_ACC2 = '0x915C4580dFFD112db25a6cf06c76cDd9009637b7'
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
 @pytest.mark.parametrize('should_mock_price_queries', [True])
 @pytest.mark.parametrize('default_mock_price_value', [ONE])
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.freeze_time('2023-01-24 22:45:45 GMT')
 def test_query_yearn_vault_balances(rotkehlchen_api_server, ethereum_accounts):
     async_query = random.choice([True, False])
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen

--- a/rotkehlchen/tests/integration/test_transactions.py
+++ b/rotkehlchen/tests/integration/test_transactions.py
@@ -1,23 +1,31 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from flaky import flaky
 
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.tests.utils.ethereum import (
-    ETHERSCAN_AND_INFURA_PARAMS,
+    TEST_ADDR1,
+    TEST_ADDR2,
     setup_ethereum_transactions_test,
 )
 
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
+    from rotkehlchen.db.dbhandler import DBHandler
+
 
 @flaky(max_runs=3, min_passes=1)  # failed in a flaky way sometimes in the CI due to etherscan
-@pytest.mark.parametrize(*ETHERSCAN_AND_INFURA_PARAMS)
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1, TEST_ADDR2]])
 @pytest.mark.parametrize('transaction_already_queried', [True, False])
+@pytest.mark.freeze_time('2023-01-24 22:45:45 GMT')
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_get_transaction_receipt(
-        database,
-        eth_transactions,
-        call_order,  # pylint: disable=unused-argument
-        transaction_already_queried,
-):
+        database: 'DBHandler',
+        eth_transactions: 'EthereumTransactions',
+        transaction_already_queried: bool,
+) -> None:
     """Test that getting a transaction receipt from the network and saving it in the DB works"""
     transactions, receipts = setup_ethereum_transactions_test(
         database=database,

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -11,7 +11,11 @@ from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.premium.premium import Premium, PremiumCredentials, SubscriptionStatus
 from rotkehlchen.tasks.manager import PREMIUM_STATUS_CHECK, TaskManager
-from rotkehlchen.tests.utils.ethereum import setup_ethereum_transactions_test
+from rotkehlchen.tests.utils.ethereum import (
+    TEST_ADDR1,
+    TEST_ADDR2,
+    setup_ethereum_transactions_test,
+)
 from rotkehlchen.tests.utils.mock import mock_evm_chains_with_transactions
 from rotkehlchen.tests.utils.premium import VALID_PREMIUM_KEY, VALID_PREMIUM_SECRET
 from rotkehlchen.types import ChainID, Location, SupportedBlockchain
@@ -186,6 +190,7 @@ def test_maybe_schedule_exchange_query_ignore_exchanges(
 
 
 @pytest.mark.parametrize('one_receipt_in_db', [True, False])
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1, TEST_ADDR2]])
 def test_maybe_schedule_ethereum_txreceipts(
         task_manager,
         ethereum_manager,

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -70,6 +70,7 @@ ETHERSCAN_AND_INFURA_AND_ALCHEMY: tuple[str, list[tuple]] = ('ethereum_manager_c
     ),
 ])
 TEST_ADDR1 = string_to_evm_address('0x443E1f9b1c866E54e914822B7d3d7165EdB6e9Ea')
+TEST_ADDR2 = string_to_evm_address('0x442068F934BE670aDAb81242C87144a851d56d16')
 TEST_ADDR3 = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
 
 
@@ -161,18 +162,9 @@ def setup_ethereum_transactions_test(
         one_receipt_in_db: bool = False,
         second_receipt_in_db: bool = False,
 ) -> tuple[list[EvmTransaction], list[EvmTxReceipt]]:
+    """This setup assummes that TEST_ADDR1 and TEST_ADDR2 are already present in the db"""
     dbevmtx = DBEvmTx(database)
     tx_hash1 = deserialize_evm_tx_hash('0x692f9a6083e905bdeca4f0293f3473d7a287260547f8cbccc38c5cb01591fcda')  # noqa: E501
-    addr2 = string_to_evm_address('0x442068F934BE670aDAb81242C87144a851d56d16')
-    with database.user_write() as cursor:
-        database.add_blockchain_accounts(
-            cursor,
-            account_data=[
-                BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address=TEST_ADDR1),
-                BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address=addr2),
-            ],
-        )
-
     transaction1 = EvmTransaction(
         tx_hash=tx_hash1,
         chain_id=ChainID.ETHEREUM,
@@ -193,7 +185,7 @@ def setup_ethereum_transactions_test(
         chain_id=ChainID.ETHEREUM,
         timestamp=Timestamp(1631013757),
         block_number=13178342,
-        from_address=addr2,
+        from_address=TEST_ADDR2,
         to_address=string_to_evm_address('0xEaDD9B69F96140283F9fF75DA5FD33bcF54E6296'),
         value=0,
         gas=77373,
@@ -206,7 +198,7 @@ def setup_ethereum_transactions_test(
     if transaction_already_queried is True:
         with database.user_write() as cursor:
             dbevmtx.add_evm_transactions(cursor, evm_transactions=[transaction1], relevant_address=TEST_ADDR1)  # noqa: E501
-            dbevmtx.add_evm_transactions(cursor, evm_transactions=[transaction2], relevant_address=addr2)  # noqa: E501
+            dbevmtx.add_evm_transactions(cursor, evm_transactions=[transaction2], relevant_address=TEST_ADDR2)  # noqa: E501
             result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(chain_id=ChainID.ETHEREUM), True)  # noqa: E501
         assert result == transactions
 


### PR DESCRIPTION
This PR:

- mocks the slowest tests we had
- add a new make rule `create-cassette` to record a single test
- avoids the creation of extra ethereum addresses that were getting queried in the tests

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
