### PR TITLE
Fix last tag deletion

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1117,7 +1117,8 @@ class DBHandler:
         # Delete the current tag mappings for all affected accounts
         write_cursor.executemany(
             'DELETE FROM tag_mappings WHERE '
-            'object_reference = ?;', [(f'{x.chain}{x.address}',) for x in account_data],
+            # Using chain.value since it has to match the key generated in `_prepare_tag_mappings`.
+            'object_reference = ?;', [(f'{x.chain.value}{x.address}',) for x in account_data],
         )
 
         # Update the blockchain account labels in the DB


### PR DESCRIPTION
Now if the user will want to delete all the remaining tags of a blockchain account they will be able to do so.