### PR TITLE
Send websocket messages immediately in all cases

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -111,3 +111,16 @@ At the user DB migrations when a new evm chain is introduced rotki will do a mig
 	    "address": "0xFeebabE6b0418eC13b30aAdF129F5DcDd4f70CeA"
 	}]
     }
+
+
+EVM Token Detection
+=======================
+
+While we are processing EVM transactions new tokens may be detected and added to the Database. Some of them can be spam tokens. Using this message we can let the frontend know which tokens are detected. Then they can in turn allow the user to see an aggregated list of all detected tokens and using that list, easily mark spam assets if any.
+
+::
+
+    {
+        "type": "new_evm_token_detected",
+        "data": [{"token_identifier": "eip155:1/erc20:0x76dc5F01A1977F37b483F2C5b06618ed8FcA898C"}]
+    }

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -73,6 +73,11 @@ class RotkiNotifier():
             failure_callback: Optional[Callable] = None,
             failure_callback_args: Optional[dict[str, Any]] = None,
     ) -> None:
+        """Broadcasts a websocket message
+
+        A callback to run on message success and a callback to run on message
+        failure can be optionally provided.
+        """
         message_data = {'type': str(message_type), 'data': to_send_data}
         try:
             message = json.dumps(message_data)
@@ -91,11 +96,7 @@ class RotkiNotifier():
                 to_remove_indices.add(idx)
                 continue
 
-            self.greenlet_manager.spawn_and_track(
-                after_seconds=None,
-                task_name=f'Websocket send for {str(message_type)}',
-                exception_is_error=True,
-                method=_ws_send_impl,
+            _ws_send_impl(
                 websocket=websocket,
                 lock=self.locks[websocket],
                 to_send_msg=message,

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -16,6 +16,8 @@ class WSMessageType(Enum):
     LOGIN_STATUS = auto()
     # Used for evm address migration after new chain integration
     EVM_ADDRESS_MIGRATION = auto()
+    # Used for when a new token is found and saved via processing evm transactions
+    NEW_EVM_TOKEN_DETECTED = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -1,6 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
+from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles, EvmToken, UnderlyingToken
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.types import AssetType
@@ -201,6 +202,10 @@ def get_or_create_evm_token(
                 # newly queried data
                 GlobalDBHandler().edit_evm_token(ethereum_token)
             else:
+                userdb.msg_aggregator.add_message(  # inform frontend new token detected
+                    message_type=WSMessageType.NEW_EVM_TOKEN_DETECTED,
+                    data={'token_identifier': identifier},
+                )
                 # This can but should not raise InputError since it should not already exist.
                 add_ethereum_token_to_db(token_data=ethereum_token)
 

--- a/rotkehlchen/user_messages.py
+++ b/rotkehlchen/user_messages.py
@@ -73,6 +73,13 @@ class MessagesAggregator():
             message_type: WSMessageType,
             data: Union[dict[str, Any], list[Any]],
     ) -> None:
+        """Sends a websocket message
+
+        Specify its type and data.
+
+        `wait_on_send` is used to determine if the message should be sent asynchronously
+        by spawning a greenlet or if it should just do it synchronously.
+        """
         fallback_msg = json.dumps({'type': str(message_type), 'data': data})  # noqa: E501  # kind of silly to repeat it here. Same code in broadcast
 
         if self.rotki_notifier is not None:


### PR DESCRIPTION
### Send websocket messages immediately 
This is important as we rely on websockets to show progress and updates, and scheduling a greenlet to send messes with that as we don't know when that greenlet will be scheduled to run.

Made it configurable so we still have the option to send asynchronously but not sure if that should be an option at all

### Add new websocket message to inform frontend for new token detection

While we are processing EVM transactions new tokens may be detected and added to the Database. Some of them can be spam tokens. Using this message we can let the frontend know which tokens are detected. Then they can in turn allow the user to see an aggregated list of all detected tokens and using that list, easily mark spam assets if any.
