### PR TITLE
Bumps timeout of backend tests to 90 minutes

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -15,7 +15,7 @@ jobs:
       TEST_ENVIRONMENT: ${{ inputs.test_environment }}
     runs-on: ${{ inputs.os }}
     name: 'Backend tests'
-    timeout-minutes: 70
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

@LefterisJP @yabirgb until we resolve the issue of the slow backend tests.