### PR TITLE
Send websocket messages immediately in all cases

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -116,7 +116,7 @@ At the user DB migrations when a new evm chain is introduced rotki will do a mig
 EVM Token Detection
 =======================
 
-While we are processing EVM transactions new tokens may be detected and added to the Database. Some of them can be spam tokens. Using this message we can let the frontend know which tokens are detected. Then they can in turn allow the user to see an aggregated list of all detected tokens and using that list, easily mark spam assets if any.
+While we are processing EVM transactions new tokens may be detected and added to the database. Some of them can be spam tokens. Using this message we can let the frontend know which tokens are detected. Then they can in turn allow the user to see an aggregated list of all detected tokens and using that list, easily mark spam assets if any.
 
 ::
 

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -73,6 +73,11 @@ class RotkiNotifier():
             failure_callback: Optional[Callable] = None,
             failure_callback_args: Optional[dict[str, Any]] = None,
     ) -> None:
+        """Broadcasts a websocket message
+
+        A callback to run on message success and a callback to run on message
+        failure can be optionally provided.
+        """
         message_data = {'type': str(message_type), 'data': to_send_data}
         try:
             message = json.dumps(message_data)
@@ -91,11 +96,7 @@ class RotkiNotifier():
                 to_remove_indices.add(idx)
                 continue
 
-            self.greenlet_manager.spawn_and_track(
-                after_seconds=None,
-                task_name=f'Websocket send for {str(message_type)}',
-                exception_is_error=True,
-                method=_ws_send_impl,
+            _ws_send_impl(
                 websocket=websocket,
                 lock=self.locks[websocket],
                 to_send_msg=message,

--- a/rotkehlchen/tests/websocketsapi/test_legacy.py
+++ b/rotkehlchen/tests/websocketsapi/test_legacy.py
@@ -1,4 +1,3 @@
-import gevent
 import pytest
 
 
@@ -14,32 +13,3 @@ def test_query_legacy_message(rotkehlchen_api_server, websocket_connection):
     msg2 = websocket_connection.pop_message()
     assert msg2 == {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'This is a warning'}}  # noqa: E501
     assert websocket_connection.messages_num() == 0
-
-
-def _send_stuff(msg_aggregator, websocket_connection):
-    for _ in range(10):
-        # We need big strings in order to replicate. Small messages do not hit it
-        msg_aggregator.add_error('x' * 1000000)
-        msg_aggregator.add_warning('y' * 100000)
-        if websocket_connection.messages_num() != 0:
-            websocket_connection.pop_message()
-
-
-@pytest.mark.parametrize('legacy_messages_via_websockets', [True])
-def test_websockets_concurrent_use(rotkehlchen_api_server, websocket_connection):
-    """Up until 1.26.3 there was no lock per websocket connection and that could under
-    very heavy and specific circumstances cause concurrent websocket access from multiple
-    greenlets.
-
-    This test replicates that scenario and it fails before the addition of the lock.
-    Serves as a regression test.
-    """
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    g1 = gevent.spawn(_send_stuff, rotki.msg_aggregator, websocket_connection)
-    _send_stuff(rotki.msg_aggregator, websocket_connection)
-    g2 = gevent.spawn(_send_stuff, rotki.msg_aggregator, websocket_connection)
-    gevent.joinall([g1, g2])
-    assert all(
-        isinstance(x.exception, gevent.exceptions.ConcurrentObjectUseError) is False
-        for x in rotki.greenlet_manager.greenlets
-    ), 'At least one ConcurrentObjectUseError exception happened'

--- a/rotkehlchen/tests/websocketsapi/test_misc.py
+++ b/rotkehlchen/tests/websocketsapi/test_misc.py
@@ -1,0 +1,35 @@
+import gevent
+import pytest
+
+
+def _send_stuff(msg_aggregator, websocket_connection):
+    for _ in range(10):
+        # We need big strings in order to replicate. Small messages do not hit it
+        # But not too big since it can cause `WebSocketPayloadException` and that
+        # can make this test run forever
+        #  <bound method WebsocketReader.read_forever of <rotkehlchen.tests.fixtures.websockets.WebsocketReader object at 0x7ff6f3136f70>>> failed with WebSocketPayloadException  # noqa: E501
+        msg_aggregator.add_error('x' * 100000)
+        msg_aggregator.add_warning('y' * 100000)
+        if websocket_connection.messages_num() != 0:
+            websocket_connection.pop_message()
+
+
+@pytest.mark.parametrize('legacy_messages_via_websockets', [True])
+def test_websockets_concurrent_use(rotkehlchen_api_server, websocket_connection):
+    """Up until 1.26.3 there was no lock per websocket connection and that could under
+    very heavy and specific circumstances cause concurrent websocket access from multiple
+    greenlets.
+
+    This test replicates that scenario and it fails before the addition of the lock.
+    Serves as a regression test. Should fail if locks are removed in websockets.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    with gevent.Timeout(10):
+        g1 = gevent.spawn(_send_stuff, rotki.msg_aggregator, websocket_connection)
+        _send_stuff(rotki.msg_aggregator, websocket_connection)
+        g2 = gevent.spawn(_send_stuff, rotki.msg_aggregator, websocket_connection)
+        gevent.joinall([g1, g2])
+        assert all(
+            isinstance(x.exception, gevent.exceptions.ConcurrentObjectUseError) is False
+            for x in [g1, g2] + rotki.greenlet_manager.greenlets
+        ), 'At least one ConcurrentObjectUseError exception happened'

--- a/rotkehlchen/user_messages.py
+++ b/rotkehlchen/user_messages.py
@@ -73,6 +73,13 @@ class MessagesAggregator():
             message_type: WSMessageType,
             data: Union[dict[str, Any], list[Any]],
     ) -> None:
+        """Sends a websocket message
+
+        Specify its type and data.
+
+        `wait_on_send` is used to determine if the message should be sent asynchronously
+        by spawning a greenlet or if it should just do it synchronously.
+        """
         fallback_msg = json.dumps({'type': str(message_type), 'data': data})  # noqa: E501  # kind of silly to repeat it here. Same code in broadcast
 
         if self.rotki_notifier is not None:


### PR DESCRIPTION
This is important as we rely on websockets to show progress and updates, and scheduling a greenlet for sending a message, messes with that as we don't know when that greenlet will be scheduled to run.