### PR TITLE
feat: add new detected token view

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -122,5 +122,5 @@ While we are processing EVM transactions new tokens may be detected and added to
 
     {
         "type": "new_evm_token_detected",
-        "data": [{"token_identifier": "eip155:1/erc20:0x76dc5F01A1977F37b483F2C5b06618ed8FcA898C"}]
+        "data": {"token_identifier": "eip155:1/erc20:0x76dc5F01A1977F37b483F2C5b06618ed8FcA898C"}
     }

--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -254,6 +254,7 @@
     "useMutationObserver": true,
     "useNavigatorLanguage": true,
     "useNetwork": true,
+    "useNewlyDetectedTokens": true,
     "useNow": true,
     "useObjectUrl": true,
     "useOffsetPagination": true,

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -255,6 +255,7 @@ declare global {
   const useMutationObserver: typeof import('@vueuse/core')['useMutationObserver']
   const useNavigatorLanguage: typeof import('@vueuse/core')['useNavigatorLanguage']
   const useNetwork: typeof import('@vueuse/core')['useNetwork']
+  const useNewlyDetectedTokens: typeof import('./composables/assets/newly-detected-tokens')['useNewlyDetectedTokens']
   const useNow: typeof import('@vueuse/core')['useNow']
   const useObjectUrl: typeof import('@vueuse/core')['useObjectUrl']
   const useOffsetPagination: typeof import('@vueuse/core')['useOffsetPagination']
@@ -620,6 +621,7 @@ declare module 'vue' {
     readonly useMutationObserver: UnwrapRef<typeof import('@vueuse/core')['useMutationObserver']>
     readonly useNavigatorLanguage: UnwrapRef<typeof import('@vueuse/core')['useNavigatorLanguage']>
     readonly useNetwork: UnwrapRef<typeof import('@vueuse/core')['useNetwork']>
+    readonly useNewlyDetectedTokens: UnwrapRef<typeof import('./composables/assets/newly-detected-tokens')['useNewlyDetectedTokens']>
     readonly useNow: UnwrapRef<typeof import('@vueuse/core')['useNow']>
     readonly useObjectUrl: UnwrapRef<typeof import('@vueuse/core')['useObjectUrl']>
     readonly useOffsetPagination: UnwrapRef<typeof import('@vueuse/core')['useOffsetPagination']>

--- a/frontend/app/src/components/CurrencyDropdown.vue
+++ b/frontend/app/src/components/CurrencyDropdown.vue
@@ -73,7 +73,11 @@ const calculateFontSize = (symbol: string) => {
     >
       <template #activator="{ on }">
         <menu-tooltip-button
-          :tooltip="tc('currency_drop_down.profit_currency')"
+          :tooltip="
+            tc('currency_drop_down.profit_currency', 0, {
+              currency: currency.tickerSymbol
+            })
+          "
           class-name="secondary--text text--lighten-4"
           :on-menu="on"
         >

--- a/frontend/app/src/components/account-management/DbUpgradeProgress.vue
+++ b/frontend/app/src/components/account-management/DbUpgradeProgress.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { type CurrentDbUpgradeProgress } from '@/types/login';
+
+const props = defineProps<{
+  progress: CurrentDbUpgradeProgress | null;
+}>();
+
+const { progress } = toRefs(props);
+
+const { tc } = useI18n();
+
+const multipleUpgrades = computed(() => {
+  if (isDefined(progress)) {
+    const { toVersion, fromVersion } = get(progress);
+    return toVersion - fromVersion > 1;
+  }
+  return false;
+});
+</script>
+
+<template>
+  <v-alert v-if="progress" type="warning" text>
+    <template #prepend>
+      <div class="mr-4">
+        <v-progress-circular
+          rounded
+          :value="progress.percentage"
+          size="45"
+          width="4"
+          color="warning"
+        >
+          <div v-if="multipleUpgrades">
+            <v-progress-circular
+              :value="progress.totalPercentage"
+              color="warning"
+            />
+          </div>
+        </v-progress-circular>
+      </div>
+    </template>
+
+    <div>
+      <div>
+        {{ tc('login.upgrading_db.warning', 0, progress) }}
+      </div>
+      <v-divider class="my-2" />
+      <div>
+        {{ tc('login.upgrading_db.current', 0, progress) }}
+      </div>
+    </div>
+  </v-alert>
+</template>

--- a/frontend/app/src/components/asset-manager/ManagedAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/ManagedAssetTable.vue
@@ -115,13 +115,9 @@ const getAsset = (item: SupportedAsset) => {
 const { setMessage } = useMessageStore();
 const { isAssetIgnored, ignoreAsset, unignoreAsset } = useIgnoredAssetsStore();
 
-const isIgnored = (identifier: string) => {
-  return isAssetIgnored(identifier);
-};
-
 const toggleIgnoreAsset = async (identifier: string) => {
   let success = false;
-  if (get(isIgnored(identifier))) {
+  if (get(isAssetIgnored(identifier))) {
     const response = await unignoreAsset(identifier);
     success = response.success;
   } else {
@@ -137,7 +133,7 @@ const toggleIgnoreAsset = async (identifier: string) => {
 const massIgnore = async (ignored: boolean) => {
   const ids = get(selected)
     .filter(item => {
-      const isItemIgnored = get(isIgnored(item.identifier));
+      const isItemIgnored = get(isAssetIgnored(item.identifier));
       return ignored ? !isItemIgnored : isItemIgnored;
     })
     .map(item => item.identifier)
@@ -325,7 +321,7 @@ const css = useCssModule();
       <template #item.ignored="{ item }">
         <div class="d-flex justify-center">
           <v-switch
-            :input-value="isIgnored(item.identifier)"
+            :input-value="isAssetIgnored(item.identifier)"
             @change="toggleIgnoreAsset(item.identifier)"
           />
         </div>

--- a/frontend/app/src/components/asset-manager/ManagedAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/ManagedAssetTable.vue
@@ -114,6 +114,7 @@ const getAsset = (item: SupportedAsset) => {
 
 const { setMessage } = useMessageStore();
 const { isAssetIgnored, ignoreAsset, unignoreAsset } = useIgnoredAssetsStore();
+const { getChain } = useSupportedChains();
 
 const toggleIgnoreAsset = async (identifier: string) => {
   let success = false;
@@ -309,7 +310,11 @@ const css = useCssModule();
         />
       </template>
       <template #item.address="{ item }">
-        <hash-link v-if="item.address" :text="item.address" />
+        <hash-link
+          v-if="item.address"
+          :text="item.address"
+          :chain="getChain(item.evmChain)"
+        />
       </template>
       <template #item.started="{ item }">
         <date-display v-if="item.started" :timestamp="item.started" />

--- a/frontend/app/src/components/asset-manager/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/NewlyDetectedAssetTable.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { type DataTableHeader } from 'vuetify';
+import { type ComputedRef, type Ref } from 'vue';
+import { useNewlyDetectedTokens } from '@/composables/assets/newly-detected-tokens';
+import { type NewDetectedToken } from '@/types/websocket-messages';
+import { useMessageStore } from '@/store/message';
+import { useIgnoredAssetsStore } from '@/store/assets/ignored';
+import { uniqueStrings } from '@/utils/data';
+import { getAddressFromEvmIdentifier } from '@/utils/assets';
+
+const { tc } = useI18n();
+
+const { tokens, removeNewDetectedTokens } = useNewlyDetectedTokens();
+
+const mappedTokens: ComputedRef<NewDetectedToken[]> = computed(() => {
+  return get(tokens).map(tokenIdentifier => ({
+    tokenIdentifier,
+    address: getAddressFromEvmIdentifier(tokenIdentifier)
+  }));
+});
+
+const tableHeaders = computed<DataTableHeader[]>(() => [
+  {
+    text: tc('common.asset'),
+    value: 'tokenIdentifier'
+  },
+  {
+    text: tc('common.address'),
+    value: 'address'
+  }
+]);
+
+const selected: Ref<NewDetectedToken[]> = ref([]);
+
+const selectDeselectAllTokens = () => {
+  const selectedLength = get(selected).length;
+  const existLength = get(mappedTokens).length;
+
+  if (selectedLength === existLength) {
+    set(selected, []);
+  } else {
+    set(selected, get(mappedTokens));
+  }
+};
+
+const removeTokens = () => {
+  removeNewDetectedTokens(
+    get(selected).map(({ tokenIdentifier }) => tokenIdentifier)
+  );
+
+  set(selected, []);
+};
+
+const { setMessage } = useMessageStore();
+const { isAssetIgnored, ignoreAsset } = useIgnoredAssetsStore();
+
+const ignoreTokens = async () => {
+  const ids = get(selected)
+    .filter(item => {
+      return !get(isAssetIgnored(item.tokenIdentifier));
+    })
+    .map(({ tokenIdentifier }) => tokenIdentifier)
+    .filter(uniqueStrings);
+
+  if (ids.length === 0) {
+    setMessage({
+      success: false,
+      title: tc('ignore.no_items.title', 1),
+      description: tc('ignore.no_items.description', 1)
+    });
+    return;
+  }
+
+  const status = await ignoreAsset(ids);
+
+  if (status.success) {
+    removeTokens();
+  }
+};
+</script>
+<template>
+  <card outlined-body>
+    <template #title>
+      {{ tc('asset_table.newly_detected.title') }}
+    </template>
+    <template #subtitle>
+      {{ tc('asset_table.newly_detected.subtitle') }}
+    </template>
+    <template #actions>
+      <div class="d-flex align-center">
+        <div class="mr-8">
+          <v-btn outlined @click="selectDeselectAllTokens">
+            <v-icon>mdi-checkbox-multiple-marked-outline</v-icon>
+            <span class="ml-2">
+              {{ tc('asset_table.newly_detected.select_deselect_all_tokens') }}
+            </span>
+          </v-btn>
+          <div class="d-flex mt-4">
+            <div class="mr-4 mt-1">
+              {{ tc('asset_table.selected', 0, { count: selected.length }) }}
+            </div>
+            <v-btn
+              small
+              text
+              :disabled="selected.length === 0"
+              @click="selected = []"
+            >
+              {{ tc('common.actions.clear_selection') }}
+            </v-btn>
+          </div>
+        </div>
+        <v-divider vertical class="mr-8" />
+
+        <v-tooltip bottom>
+          <template #activator="{ on }">
+            <v-btn
+              fab
+              outlined
+              color="primary"
+              class="mr-4"
+              :disabled="selected.length === 0"
+              @click="removeTokens"
+              v-on="on"
+            >
+              <v-icon> mdi-playlist-remove </v-icon>
+            </v-btn>
+          </template>
+          <span>{{ tc('asset_table.newly_detected.remove_from_list') }}</span>
+        </v-tooltip>
+
+        <v-tooltip bottom>
+          <template #activator="{ on }">
+            <v-btn
+              color="red"
+              fab
+              outlined
+              :disabled="selected.length === 0"
+              @click="ignoreTokens"
+              v-on="on"
+            >
+              <v-icon>mdi-eye-off</v-icon>
+            </v-btn>
+          </template>
+          <span>
+            {{ tc('asset_table.newly_detected.ignore_selected') }}
+          </span>
+        </v-tooltip>
+      </div>
+    </template>
+    <data-table
+      v-model="selected"
+      :items="mappedTokens"
+      :headers="tableHeaders"
+      :single-select="false"
+      item-key="tokenIdentifier"
+      show-select
+    >
+      <template #item.tokenIdentifier="{ item }">
+        <asset-details opens-details :asset="item.tokenIdentifier" />
+      </template>
+
+      <template #item.address="{ item }">
+        <hash-link :text="item.address" />
+      </template>
+    </data-table>
+  </card>
+</template>

--- a/frontend/app/src/components/asset-manager/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/NewlyDetectedAssetTable.vue
@@ -160,7 +160,7 @@ const ignoreTokens = async () => {
       </template>
 
       <template #item.address="{ item }">
-        <hash-link :text="item.address" />
+        <hash-link :text="item.address" no-link />
       </template>
     </data-table>
   </card>

--- a/frontend/app/src/components/dashboard/ExportSnapshotDialog.vue
+++ b/frontend/app/src/components/dashboard/ExportSnapshotDialog.vue
@@ -39,8 +39,7 @@ const formattedSelectedBalance = computed<BigNumber | null>(() => {
 const downloadSnapshot = async () => {
   const resp = await snapshotApi.downloadSnapshot(get(timestamp));
 
-  const blob = new Blob([resp.data], { type: 'application/zip' });
-  const url = window.URL.createObjectURL(blob);
+  const url = window.URL.createObjectURL(resp.request.response);
 
   const date = dayjs(get(timestamp) * 1000).format('YYYYDDMMHHmmss');
   const fileName = `${date}-snapshot.zip`;

--- a/frontend/app/src/components/status/notifications/Notification.vue
+++ b/frontend/app/src/components/status/notifications/Notification.vue
@@ -53,6 +53,11 @@ const copy = async () => {
 };
 
 const { fontStyle } = useTheme();
+
+const action = async (notification: NotificationData) => {
+  const action = notification.action?.action;
+  action?.();
+};
 </script>
 
 <template>
@@ -67,9 +72,20 @@ const { fontStyle } = useTheme();
         <v-list-item-title class="mt-2">
           {{ notification.title }}
         </v-list-item-title>
-        <span class="mt-1" :style="fontStyle" :class="$style.message">
-          {{ notification.message }}
-        </span>
+        <div class="mt-1" :style="fontStyle" :class="$style.message">
+          <div>{{ notification.message }}</div>
+
+          <v-btn
+            v-if="notification.action"
+            depressed
+            color="primary"
+            small
+            class="mt-2"
+            @click="action(notification)"
+          >
+            {{ notification.action.label }}
+          </v-btn>
+        </div>
         <span class="text-caption text--secondary">
           {{ date }}
         </span>

--- a/frontend/app/src/components/status/notifications/NotificationSidebar.vue
+++ b/frontend/app/src/components/status/notifications/NotificationSidebar.vue
@@ -50,7 +50,7 @@ const showConfirmation = () => {
 };
 
 const notifications = computed(() => {
-  return orderBy(data.value, 'id', 'desc');
+  return orderBy(data.value, 'date', 'desc');
 });
 
 const { isMobile } = useTheme();

--- a/frontend/app/src/composables/assets/newly-detected-tokens.ts
+++ b/frontend/app/src/composables/assets/newly-detected-tokens.ts
@@ -1,0 +1,30 @@
+import { type Ref } from 'vue';
+import { uniqueStrings } from '@/utils/data';
+
+const MAX_SIZE = 500;
+
+export const useNewlyDetectedTokens = createSharedComposable(() => {
+  const tokens: Ref<string[]> = useLocalStorage(
+    'rotki.newly_detected_tokens',
+    []
+  );
+
+  const addNewDetectedToken = (identifier: string) => {
+    set(
+      tokens,
+      [identifier, ...get(tokens)].filter(uniqueStrings).slice(0, MAX_SIZE)
+    );
+  };
+
+  const removeNewDetectedTokens = (tokensToRemove: string[]) => {
+    const filtered = get(tokens).filter(item => !tokensToRemove.includes(item));
+
+    set(tokens, filtered);
+  };
+
+  return {
+    tokens,
+    removeNewDetectedTokens,
+    addNewDetectedToken
+  };
+});

--- a/frontend/app/src/composables/message-handling.ts
+++ b/frontend/app/src/composables/message-handling.ts
@@ -147,14 +147,11 @@ export const useMessageHandling = () => {
     const count = (notification?.groupCount || 0) + 1;
 
     return {
-      title: tc('notification_messages.new_detected_token.title'),
-      message: !notification
-        ? tc('notification_messages.new_detected_token.message', 0, {
-            identifier: data.tokenIdentifier
-          })
-        : tc('notification_messages.new_detected_token.multiple_message', 0, {
-            count
-          }),
+      title: tc('notification_messages.new_detected_token.title', count),
+      message: tc('notification_messages.new_detected_token.message', count, {
+        identifier: data.tokenIdentifier,
+        count
+      }),
       display: true,
       severity: Severity.INFO,
       action: {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1015,6 +1015,13 @@
     "managed": {
       "subtitle": "Add, edit, remove tokens and assets. Changes in the assets will be reflected across all your accounts"
     },
+    "newly_detected": {
+      "ignore_selected": "Ignore selected tokens",
+      "remove_from_list": "Remove selected tokens from list",
+      "select_deselect_all_tokens": "Select/deselect all tokens",
+      "subtitle": "Clear the list of newly detected tokens, or set them ignored if you think they are spam assets",
+      "title": "Newly detected tokens"
+    },
     "notes": "Notes",
     "only_show_ignored": "Only show ignored assets",
     "only_show_owned": "Only show owned assets",
@@ -1444,7 +1451,7 @@
   },
   "currency_drop_down": {
     "hint": "Select as the main currency",
-    "profit_currency": "Profit Currency"
+    "profit_currency": "Profit Currency ({currency})"
   },
   "dashboard": {
     "blockchain_balances": {
@@ -2875,7 +2882,8 @@
     "manage_assets": "Manage Assets",
     "manage_assets_sub": {
       "custom_assets": "Custom Assets",
-      "managed_assets": "Managed Assets"
+      "managed_assets": "Managed Assets",
+      "newly_detected": "Newly Detected Tokens"
     },
     "manage_address_book": "Manage Address Book",
     "manage_prices": "Manage Prices",
@@ -3013,6 +3021,12 @@
         "network_problem_message": "We couldn't verify your premium subscription due to network problems.",
         "title": "Premium features deactivated"
       }
+    },
+    "new_detected_token": {
+      "action": "See more",
+      "title": "New Token(s) Detected",
+      "message": "New token with identifier {identifier} is detected from EVM transactions.",
+      "multiple_message": "{count} new tokens is detected from EVM transactions."
     },
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3024,9 +3024,8 @@
     },
     "new_detected_token": {
       "action": "See more",
-      "title": "New Token(s) Detected",
-      "message": "New token with identifier {identifier} is detected from EVM transactions.",
-      "multiple_message": "{count} new tokens is detected from EVM transactions."
+      "title": "New Token Detected|New Tokens Detected",
+      "message": "New token with identifier {identifier} is detected from EVM transactions.|{count} new tokens are detected from EVM transactions."
     },
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -2952,9 +2952,8 @@
     },
     "new_detected_token": {
       "action": "See more",
-      "title": "New Token(s) Detected",
-      "message": "New token with identifier {identifier} is detected from EVM transactions.",
-      "multiple_message": "{count} new tokens is detected from EVM transactions."
+      "title": "New Token Detected|New Tokens Detected",
+      "message": "New token with identifier {identifier} is detected from EVM transactions.|{count} new tokens are detected from EVM transactions."
     },
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -1414,7 +1414,7 @@
   },
   "currency_drop_down": {
     "hint": "Seleccionar como la divisa principal",
-    "profit_currency": "Divisa de ganancias"
+    "profit_currency": "Divisa de ganancias ({currency})"
   },
   "dashboard": {
     "blockchain_balances": {
@@ -2950,9 +2950,19 @@
         "title": "Premium features deactivated"
       }
     },
+    "new_detected_token": {
+      "action": "See more",
+      "title": "New Token(s) Detected",
+      "message": "New token with identifier {identifier} is detected from EVM transactions.",
+      "multiple_message": "{count} new tokens is detected from EVM transactions."
+    },
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",
       "title": "Balance Snapshot failed"
+    },
+    "address_migration": {
+      "title": "Address has been added to {chain}|Addresses have been added to {chain}",
+      "message": "The following address has been added to {chain}: {addresses}|The following addresses have been added to {chain}: {addresses}"
     }
   },
   "notification_popup": {

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -1420,7 +1420,7 @@
   },
   "currency_drop_down": {
     "hint": "Select as the main currency",
-    "profit_currency": "Profit Currency"
+    "profit_currency": "Profit Currency ({currency})"
   },
   "dashboard": {
     "blockchain_balances": {
@@ -2971,6 +2971,12 @@
         "network_problem_message": "We couldn't verify your premium subscription due to network problems.",
         "title": "Premium features deactivated"
       }
+    },
+    "new_detected_token": {
+      "action": "See more",
+      "title": "New Token(s) Detected",
+      "message": "New token with identifier {identifier} is detected from EVM transactions.",
+      "multiple_message": "{count} new tokens is detected from EVM transactions."
     },
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -2974,9 +2974,8 @@
     },
     "new_detected_token": {
       "action": "See more",
-      "title": "New Token(s) Detected",
-      "message": "New token with identifier {identifier} is detected from EVM transactions.",
-      "multiple_message": "{count} new tokens is detected from EVM transactions."
+      "title": "New Token Detected|New Tokens Detected",
+      "message": "New token with identifier {identifier} is detected from EVM transactions.|{count} new tokens are detected from EVM transactions."
     },
     "snapshot_failed": {
       "message": "Could not save the balance snapshot at {location}. {error}",

--- a/frontend/app/src/pages/asset-manager/index.vue
+++ b/frontend/app/src/pages/asset-manager/index.vue
@@ -8,7 +8,11 @@ const { appRoutes } = useAppRoutes();
 
 const tabs: ComputedRef<TabContent[]> = computed(() => {
   const Routes = get(appRoutes);
-  return [Routes.ASSET_MANAGER_MANAGED, Routes.ASSET_MANAGER_CUSTOM];
+  return [
+    Routes.ASSET_MANAGER_MANAGED,
+    Routes.ASSET_MANAGER_CUSTOM,
+    Routes.ASSET_MANAGER_NEWLY_DETECTED
+  ];
 });
 </script>
 

--- a/frontend/app/src/pages/asset-manager/newly-detected/index.vue
+++ b/frontend/app/src/pages/asset-manager/newly-detected/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <newly-detected-asset-table />
+</template>

--- a/frontend/app/src/router/index.ts
+++ b/frontend/app/src/router/index.ts
@@ -280,6 +280,12 @@ const routes = setupLayouts([
         component: async () =>
           import('../pages/asset-manager/custom/index.vue'),
         props: (route: Route) => ({ identifier: route.query.id ?? null })
+      },
+      {
+        path: Routes.ASSET_MANAGER_NEWLY_DETECTED,
+        name: 'asset-manager-newly-detected',
+        component: async () =>
+          import('../pages/asset-manager/newly-detected/index.vue')
       }
     ]
   },

--- a/frontend/app/src/router/routes.ts
+++ b/frontend/app/src/router/routes.ts
@@ -33,6 +33,7 @@ enum RouteNames {
   ASSET_MANAGER = 'ASSET_MANAGER',
   ASSET_MANAGER_MANAGED = 'ASSET_MANAGER_MANAGED',
   ASSET_MANAGER_CUSTOM = 'ASSET_MANAGER_CUSTOM',
+  ASSET_MANAGER_NEWLY_DETECTED = 'ASSET_MANAGER_NEWLY_DETECTED',
   PRICE_MANAGER = 'PRICE_MANAGER',
   PRICE_MANAGER_LATEST = 'PRICE_MANAGER_LATEST',
   PRICE_MANAGER_HISTORIC = 'PRICE_MANAGER_HISTORIC',
@@ -90,6 +91,7 @@ export const Routes: AppRouteMap<string> = {
   ASSET_MANAGER: '/asset-manager',
   ASSET_MANAGER_MANAGED: '/asset-manager/managed',
   ASSET_MANAGER_CUSTOM: '/asset-manager/custom',
+  ASSET_MANAGER_NEWLY_DETECTED: '/asset-manager/newly-added',
   PRICE_MANAGER: '/price-manager',
   PRICE_MANAGER_LATEST: '/price-manager/latest',
   PRICE_MANAGER_HISTORIC: '/price-manager/historic',
@@ -260,6 +262,11 @@ export const useAppRoutes = createSharedComposable(() => {
       route: Routes.ASSET_MANAGER_CUSTOM,
       icon: 'mdi-database-edit',
       text: tc('navigation_menu.manage_assets_sub.custom_assets')
+    },
+    ASSET_MANAGER_NEWLY_DETECTED: {
+      route: Routes.ASSET_MANAGER_NEWLY_DETECTED,
+      icon: 'mdi-database-edit',
+      text: tc('navigation_menu.manage_assets_sub.newly_detected')
     },
     PRICE_MANAGER: {
       route: Routes.PRICE_MANAGER,

--- a/frontend/app/src/services/assets/index.ts
+++ b/frontend/app/src/services/assets/index.ts
@@ -11,6 +11,7 @@ import { type ConflictResolution } from '@/services/assets/types';
 import { type ActionStatus } from '@/store/types';
 import { assert } from '@/utils/assertions';
 import { api } from '@/services/rotkehlchen-api';
+import { downloadFileByUrl } from '@/utils/download';
 
 export const useAssetsApi = () => {
   const checkForAssetUpdate = async (): Promise<PendingTask> => {
@@ -117,14 +118,8 @@ export const useAssetsApi = () => {
           }
         );
         if (response.status === 200) {
-          const url = window.URL.createObjectURL(response.data);
-          const link = document.createElement('a');
-          link.id = 'custom-assets-link';
-          link.href = url;
-          link.setAttribute('download', 'assets.zip');
-          document.body.append(link);
-          link.click();
-          link.remove();
+          const url = window.URL.createObjectURL(response.request.response);
+          downloadFileByUrl(url, 'assets.zip');
           return { success: true };
         }
         const body = await (response.data as Blob).text();

--- a/frontend/app/src/services/reports/index.ts
+++ b/frontend/app/src/services/reports/index.ts
@@ -56,7 +56,7 @@ export const useReportsApi = () => {
       });
 
       if (response.status === 200) {
-        const url = window.URL.createObjectURL(response.data);
+        const url = window.URL.createObjectURL(response.request.response);
         downloadFileByUrl(url, 'reports.zip');
         return { success: true };
       }

--- a/frontend/app/src/services/settings/snapshot-api.ts
+++ b/frontend/app/src/services/settings/snapshot-api.ts
@@ -61,7 +61,7 @@ export const useSnapshotApi = () => {
     return api.instance.get<any>(`/snapshots/${timestamp}`, {
       params: axiosSnakeCaseTransformer({ action: 'download' }),
       validateStatus: validWithoutSessionStatus,
-      responseType: 'arraybuffer'
+      responseType: 'blob'
     });
   };
 

--- a/frontend/app/src/store/notifications/index.ts
+++ b/frontend/app/src/store/notifications/index.ts
@@ -112,6 +112,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
       const newNotification = {
         ...notification,
         date: new Date(),
+        title: newData.title,
         message: newData.message,
         groupCount: newData.groupCount,
         display: newData.display ?? false

--- a/frontend/app/src/types/login.ts
+++ b/frontend/app/src/types/login.ts
@@ -40,3 +40,13 @@ export interface UnlockPayload {
   username: string;
   fetchData?: boolean;
 }
+
+export interface CurrentDbUpgradeProgress {
+  percentage: number;
+  totalPercentage: number;
+  currentStep: number;
+  totalSteps: number;
+  currentVersion: number;
+  fromVersion: number;
+  toVersion: number;
+}

--- a/frontend/app/src/types/websocket-messages.ts
+++ b/frontend/app/src/types/websocket-messages.ts
@@ -60,13 +60,20 @@ export const MigratedAddresses = z.array(EvmChainAddress);
 
 export type MigratedAddresses = z.infer<typeof MigratedAddresses>;
 
+export const NewDetectedToken = z.object({
+  tokenIdentifier: z.string()
+});
+
+export type NewDetectedToken = z.infer<typeof NewDetectedToken>;
+
 export const SocketMessageType = {
   LEGACY: 'legacy',
   BALANCES_SNAPSHOT_ERROR: 'balance_snapshot_error',
   EVM_TRANSACTION_STATUS: 'evm_transaction_status',
   PREMIUM_STATUS_UPDATE: 'premium_status_update',
   LOGIN_STATUS: 'login_status',
-  EVM_ADDRESS_MIGRATION: 'evm_address_migration'
+  EVM_ADDRESS_MIGRATION: 'evm_address_migration',
+  NEW_EVM_TOKEN_DETECTED: 'new_evm_token_detected'
 } as const;
 
 export type SocketMessageType =
@@ -102,12 +109,18 @@ const MigratedAccountsMessage = z.object({
   data: MigratedAddresses
 });
 
+const NewEvmTokenDetectedMessage = z.object({
+  type: z.literal(SocketMessageType.NEW_EVM_TOKEN_DETECTED),
+  data: NewDetectedToken
+});
+
 export const WebsocketMessage = LegacyWebsocketMessage.or(
   BalancesSnapshotErrorMessage
 )
   .or(EvmTransactionStatusMessage)
   .or(PremiumStatusUpdateMessage)
   .or(LoginStatusMessage)
-  .or(MigratedAccountsMessage);
+  .or(MigratedAccountsMessage)
+  .or(NewEvmTokenDetectedMessage);
 
 export type WebsocketMessage = z.infer<typeof WebsocketMessage>;

--- a/frontend/app/tests/unit/store/notifications/index.spec.ts
+++ b/frontend/app/tests/unit/store/notifications/index.spec.ts
@@ -1,0 +1,66 @@
+import { NotificationGroup } from '@rotki/common/lib/messages';
+import { useNotificationsStore } from '@/store/notifications';
+
+describe('store::notifications/index', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test('normal notification', () => {
+    const notificationsStore = useNotificationsStore();
+    const { data } = storeToRefs(notificationsStore);
+    const { notify, remove } = notificationsStore;
+
+    notify({
+      title: 'notification-title-1',
+      message: 'notification-message-1'
+    });
+
+    const dataVal = get(data);
+
+    expect(dataVal).toMatchObject([
+      {
+        title: 'notification-title-1',
+        message: 'notification-message-1'
+      }
+    ]);
+
+    remove(dataVal[0].id);
+  });
+
+  test('group notification', () => {
+    const notificationsStore = useNotificationsStore();
+    const { data } = storeToRefs(notificationsStore);
+    const { notify } = notificationsStore;
+
+    notify({
+      title: 'notification-title-1',
+      message: 'notification-message-1',
+      group: NotificationGroup.NEW_DETECTED_TOKENS
+    });
+
+    expect(get(data)).toMatchObject([
+      {
+        title: 'notification-title-1',
+        message: 'notification-message-1',
+        group: NotificationGroup.NEW_DETECTED_TOKENS
+      }
+    ]);
+
+    notify({
+      title: 'notification-title-1',
+      message: 'notification-message-2',
+      group: NotificationGroup.NEW_DETECTED_TOKENS,
+      groupCount: 2
+    });
+
+    expect(get(data)).toMatchObject([
+      {
+        title: 'notification-title-1',
+        message: 'notification-message-2',
+        group: NotificationGroup.NEW_DETECTED_TOKENS,
+        groupCount: 2
+      }
+    ]);
+  });
+});

--- a/frontend/common/src/messages/index.ts
+++ b/frontend/common/src/messages/index.ts
@@ -6,16 +6,28 @@ export enum Severity {
   INFO = 'info'
 }
 
+export enum NotificationGroup {
+  NEW_DETECTED_TOKENS = 'NEW_DETECTED_TOKENS'
+}
+
 export interface Message {
   readonly title: string;
   readonly description: string;
   readonly success: boolean;
 }
 
+export interface NotificationAction {
+  readonly label: string;
+  readonly action: () => void;
+}
+
 interface NotificationBase {
   readonly title: string;
   readonly message: string;
   readonly severity: Severity;
+  readonly action?: NotificationAction;
+  readonly group?: NotificationGroup;
+  readonly groupCount?: number;
 }
 
 export interface NotificationPayload extends NotificationBase {


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [x] Receive the messages from the websocket (that a new asset was detected)
- [x]  Aggregate the list of the detected assets (see if we can also persist them in local storage for a period of time/number of entries)
- [x] Group notifications for this, and add actions there
- [x] New page under asset manager where you can go by clicking the action button or navigate normally
- [x] The new page has a list of the aggregated assets where you can select which of these assets you want to ignore.
- [x] Actions in that page

- [x] Fix download zip error (found by isaac)
- [x] Show currency on currency button tooltip