### PR TITLE
Make sure curve pools are queried at decoding time

### DIFF
--- a/rotkehlchen/chain/ethereum/manager.py
+++ b/rotkehlchen/chain/ethereum/manager.py
@@ -1,27 +1,16 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from rotkehlchen.chain.ethereum.modules.curve.pools_cache import (
-    clear_curve_pools_cache,
-    update_curve_metapools_cache,
-    update_curve_registry_pools_cache,
-)
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
 from rotkehlchen.chain.evm.manager import EvmManager
 from rotkehlchen.errors.misc import InputError
-from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, GeneralCacheType
-from rotkehlchen.utils.mixins.lockable import LockableQueryMixIn, protect_with_lock
+from rotkehlchen.types import ChecksumEvmAddress
 
 from .decoding.decoder import EthereumTransactionDecoder
 from .tokens import EthereumTokens
-from .utils import should_update_protocol_cache
 
 if TYPE_CHECKING:
-
-    from rotkehlchen.chain.ethereum.decoding.decoder import EVMTransactionDecoder
-
     from .node_inquirer import EthereumInquirer
 
 
@@ -39,7 +28,7 @@ CURVE_POOLS_MAPPING_TYPE = dict[
 ]
 
 
-class EthereumManager(EvmManager, LockableQueryMixIn):
+class EthereumManager(EvmManager):
     """EthereumManager inherits from EvmManager and defines Ethereum-specific methods
     such as curve cache manipulation."""
     def __init__(
@@ -65,52 +54,26 @@ class EthereumManager(EvmManager, LockableQueryMixIn):
         )
         self.node_inquirer: 'EthereumInquirer'  # just to make the type specific
 
-    def _update_curve_decoder(self, tx_decoder: 'EVMTransactionDecoder') -> None:
+    def assure_curve_cache_is_queried_and_decoder_updated(self) -> None:
+        """
+        Make sure that information that needs to be queried is queried and if not query it.
+
+        1. Deletes all previous cache values
+        2. Queries information about curve pools' addresses, lp tokens and used coins
+        3. Saves queried information in the cache in globaldb
+
+        Also updates the curve decoder
+        """
+        if self.node_inquirer.assure_curve_protocol_cache_is_queried() is False:
+            return
+
         try:
-            curve_decoder = tx_decoder.decoders['Curve']
+            curve_decoder = self.transactions_decoder.decoders['Curve']
         except KeyError as e:
             raise InputError(
                 'Expected to find Curve decoder but it was not loaded. '
                 'Please open an issue on github.com/rotki/rotki/issues if you saw this.',
             ) from e
-        new_mappings = curve_decoder.reload()
-        tx_decoder.rules.address_mappings.update(new_mappings)
-
-    @protect_with_lock()
-    def curve_protocol_cache_is_queried(
-            self,
-            tx_decoder: Optional['EVMTransactionDecoder'],
-    ) -> bool:
-        """
-        Make sure that information that needs to be queried is queried and if not query it.
-        Returns true if the cache was modified or false otherwise.
-        If the tx_decoder provided is None no information for the decoders is reloaded
-        Updates curve pools cache.
-        1. Deletes all previous cache values
-        2. Queries information about curve pools' addresses, lp tokens and used coins
-        3. Saves queried information in the cache in globaldb
-        """
-        if should_update_protocol_cache(GeneralCacheType.CURVE_LP_TOKENS) is False:
-            if tx_decoder is not None:
-                self._update_curve_decoder(tx_decoder)
-            return False
-
-        curve_address_provider = self.node_inquirer.contracts.contract('CURVE_ADDRESS_PROVIDER')
-        # Using savepoint to not end up having partially populated cache
-        with GlobalDBHandler().conn.savepoint_ctx() as savepoint_cursor:
-            # Delete current cache. Need to do this in case curve removes some pools
-            clear_curve_pools_cache(write_cursor=savepoint_cursor)
-            # query values and update the cache
-            update_curve_registry_pools_cache(
-                ethereum=self.node_inquirer,
-                curve_address_provider=curve_address_provider,
-            )
-            update_curve_metapools_cache(
-                ethereum=self.node_inquirer,
-                curve_address_provider=curve_address_provider,
-            )
-
-        if tx_decoder is not None:
-            self._update_curve_decoder(tx_decoder)
-
-        return True
+        new_mappings = curve_decoder.reload_data()  # type: ignore  # we know type here
+        if new_mappings:
+            self.transactions_decoder.rules.address_mappings.update(new_mappings)

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 
 from rotkehlchen.types import ChecksumEvmAddress
 
@@ -64,12 +64,6 @@ class DecoderInterface(metaclass=ABCMeta):
         """
         return []
 
-    def reload(self) -> Mapping[ChecksumEvmAddress, tuple[Any, ...]]:  # pylint: disable=no-self-use  # noqa: E501
-        """Subclasses may implement this to be able to reload some of the decoder's properties
-        Returns only new mappings of addresses to decode functions
-        """
-        return {}
-
     def notify_user(self, event: 'HistoryBaseEntry', counterparty: str) -> None:
         """
         Notify the user about a problem during the decoding of ethereum transactions. At the
@@ -81,3 +75,13 @@ class DecoderInterface(metaclass=ABCMeta):
             f'Make sure that it has all the required properties (name, symbol and decimals) and '
             f'try to decode the event again {event.event_identifier.hex()}.',
         )
+
+
+class ReloadableDecoderMixin(metaclass=ABCMeta):
+
+    @abstractmethod
+    def reload_data(self) -> Optional[Mapping[ChecksumEvmAddress, tuple[Any, ...]]]:  # pylint: disable=no-self-use  # noqa: E501
+        """Subclasses may implement this to be able to reload some of the decoder's properties
+        Returns only new mappings of addresses to decode functions
+        """
+        ...

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -771,8 +771,7 @@ class Inquirer():
         Returns the price of 1 LP token from the pool
         """
         ethereum = self.get_ethereum_manager()
-        # Make sure that the curve cache is queried
-        ethereum.curve_protocol_cache_is_queried(tx_decoder=None)
+        ethereum.assure_curve_cache_is_queried_and_decoder_updated()
 
         pool_addresses_in_cache = GlobalDBHandler().get_general_cache_values(
             key_parts=[GeneralCacheType.CURVE_POOL_ADDRESS, lp_token.evm_address],

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -415,7 +415,7 @@ class Rotkehlchen():
             deactivate_premium=self.deactivate_premium_status,
             activate_premium=self.activate_premium_status,
             query_balances=self.query_balances,
-            update_curve_pools_cache=self.chains_aggregator.ethereum.curve_protocol_cache_is_queried,  # noqa: E501
+            update_curve_pools_cache=self.chains_aggregator.ethereum.assure_curve_cache_is_queried_and_decoder_updated,  # noqa: E501
             msg_aggregator=self.msg_aggregator,
         )
 

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -567,13 +567,11 @@ class TaskManager():
         if should_update_protocol_cache(GeneralCacheType.CURVE_LP_TOKENS) is False:
             return None
 
-        ethereum = self.chains_aggregator.get_chain_manager(SupportedBlockchain.ETHEREUM)
         return [self.greenlet_manager.spawn_and_track(
             after_seconds=None,
             task_name='Update curve pools cache',
             exception_is_error=True,
             method=self.update_curve_pools_cache,
-            tx_decoder=ethereum.transactions_decoder,
         )]
 
     def _maybe_update_yearn_vaults(self) -> Optional[list[gevent.Greenlet]]:

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -24,6 +24,7 @@ from rotkehlchen.db.settings import DEFAULT_BTC_DERIVATION_GAP_LIMIT
 from rotkehlchen.externalapis.beaconchain import BeaconChain
 from rotkehlchen.externalapis.covalent import Covalent
 from rotkehlchen.premium.premium import Premium
+from rotkehlchen.tests.utils.decoders import patch_decoder_reload_data
 from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.evm import maybe_mock_evm_inquirer
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -234,11 +235,12 @@ def fixture_ethereum_transaction_decoder(
         ethereum_inquirer,
         eth_transactions,
 ):
-    return EthereumTransactionDecoder(
-        database=database,
-        ethereum_inquirer=ethereum_inquirer,
-        transactions=eth_transactions,
-    )
+    with patch_decoder_reload_data():
+        yield EthereumTransactionDecoder(
+            database=database,
+            ethereum_inquirer=ethereum_inquirer,
+            transactions=eth_transactions,
+        )
 
 
 @pytest.fixture(name='eth_transactions')
@@ -301,11 +303,12 @@ def fixture_optimism_transaction_decoder(
         optimism_inquirer,
         optimism_transactions,
 ):
-    return OptimismTransactionDecoder(
-        database=database,
-        optimism_inquirer=optimism_inquirer,
-        transactions=optimism_transactions,
-    )
+    with patch_decoder_reload_data():
+        yield OptimismTransactionDecoder(
+            database=database,
+            optimism_inquirer=optimism_inquirer,
+            transactions=optimism_transactions,
+        )
 
 
 @pytest.fixture(name='ksm_rpc_endpoint')

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -27,6 +27,7 @@ from rotkehlchen.tests.utils.database import (
     maybe_include_etherscan_key,
     mock_db_schema_sanity_check,
 )
+from rotkehlchen.tests.utils.decoders import patch_decoder_reload_data
 from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.evm import maybe_mock_evm_inquirer
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
@@ -404,6 +405,8 @@ def fixture_rotkehlchen_api_server(
 
             if mocked_proxies is not None:
                 stack.enter_context(mock_proxies(mocked_proxies))
+
+            stack.enter_context(patch_decoder_reload_data())
 
         yield api_server
 

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -52,7 +52,7 @@ def _populate_curve_pools(evm_tx_decoder):
             )
 
     curve_decoder = evm_tx_decoder.decoders['Curve']
-    new_mappings = curve_decoder.reload()
+    new_mappings = curve_decoder.reload_data()
     evm_tx_decoder.rules.address_mappings.update(new_mappings)
 
 

--- a/rotkehlchen/tests/unit/test_general_cache.py
+++ b/rotkehlchen/tests/unit/test_general_cache.py
@@ -93,9 +93,7 @@ def test_curve_pools_cache(rotkehlchen_instance):
 
     future_timestamp = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=WEEK_IN_SECONDS)  # noqa: E501
     with freeze_time(future_timestamp), call_contract_patch:
-        rotkehlchen_instance.chains_aggregator.ethereum.curve_protocol_cache_is_queried(
-            tx_decoder=None,
-        )
+        rotkehlchen_instance.chains_aggregator.ethereum.assure_curve_cache_is_queried_and_decoder_updated()  # noqa: E501
 
     lp_tokens_to_pools_in_cache = {}
     pool_coins_in_cache = {}

--- a/rotkehlchen/tests/utils/decoders.py
+++ b/rotkehlchen/tests/utils/decoders.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING
+from unittest.mock import _patch, patch
+
+from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.drivers.gevent import DBCursor
+
+
+def patch_decoder_reload_data() -> _patch:
+    """Patch decoder so reload data does not reload on-chain data at each decoding"""
+    def patched_reload_data(self, cursor: 'DBCursor') -> None:
+        self.base.refresh_tracked_accounts(cursor)
+        for _, decoder in self.decoders.items():
+            if isinstance(decoder, CustomizableDateMixin):
+                decoder.reload_settings(cursor)
+
+    return patch('rotkehlchen.chain.evm.decoding.decoder.EVMTransactionDecoder.reload_data', patched_reload_data)  # noqa: E501

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -22,6 +22,7 @@ from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.tests.utils.decoders import patch_decoder_reload_data
 from rotkehlchen.types import (
     ChainID,
     EvmTransaction,
@@ -388,4 +389,6 @@ def get_decoded_events_of_transaction(
         raise AssertionError('Unsupported chainID at tests')
 
     transactions.get_or_query_transaction_receipt(tx_hash=tx_hash)
-    return decoder.decode_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash]), decoder
+    with patch_decoder_reload_data():
+        result = decoder.decode_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash])
+    return result, decoder


### PR DESCRIPTION
This is a start of generalizing the "Decoder that needs some external data to exist at decoding time" approach.

- Made a new mixin for Decoders that require this and made sure that at start of transaction decoding whatever needs to be queried per decoder is queried.
- Split out the curve protocol cache query from EthereumManager to EthereumNodeInquirer since this is the only thing that is actually used to query the chain.
- Made sure that when querying from the decoder the EthereumNodeinquirer version is used, but if used from outside the `EthereumManager` is used which also encapsulates an update to the decoder.

