### PR TITLE
Add information about where new tokens are first seen

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -118,9 +118,27 @@ EVM Token Detection
 
 While we are processing EVM transactions new tokens may be detected and added to the database. Some of them can be spam tokens. Using this message we can let the frontend know which tokens are detected. Then they can in turn allow the user to see an aggregated list of all detected tokens and using that list, easily mark spam assets if any.
 
+This also contains two optional, mutually excluse keys. If one exists the other shold not. But also both can be missing.
+
+- ``"seen_tx_hash"``: A transaction hash in the same chain as the token in which the token was first seen.
+- ``"seen_description"``: A description of the action in which the token was first seen and added to the DB. For example, querying curve pools, querying yearn pools etc.
+
 ::
 
     {
         "type": "new_evm_token_detected",
-        "data": {"token_identifier": "eip155:1/erc20:0x76dc5F01A1977F37b483F2C5b06618ed8FcA898C"}
+        "data": {
+            "token_identifier": "eip155:1/erc20:0x76dc5F01A1977F37b483F2C5b06618ed8FcA898C",
+            "seen_tx_hash": "0x06a8b9f758b0471886186c2a48dea189b3044916c7f94ee7f559026fefd91c39"
+        }
+    }
+
+::
+
+   {
+        "type": "new_evm_token_detected",
+        "data": {
+            "token_identifier": "eip155:1/erc20:0x87Dd56068Af560B0D8472C4EF41CB902FCbF5ebE",
+            "seen_description": "Querying curve pools"
+        }
     }

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
@@ -17,7 +17,7 @@ from gevent.lock import Semaphore
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.graph import (
     GRAPH_QUERY_LIMIT,
     GRAPH_QUERY_SKIP_LIMIT,
@@ -299,6 +299,7 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                     chain_id=ChainID.ETHEREUM,
                     name=token0_['name'],
                     decimals=token0_['decimals'],
+                    seen=TokenSeenAt(tx_hash=tx_hash_deserialized),
                 )
                 token1 = get_or_create_evm_token(
                     userdb=self.database,
@@ -307,6 +308,7 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                     chain_id=ChainID.ETHEREUM,
                     name=token1_['name'],
                     decimals=int(token1_['decimals']),
+                    seen=TokenSeenAt(tx_hash=tx_hash_deserialized),
                 )
                 lp_event = LiquidityPoolEvent(
                     tx_hash=tx_hash_deserialized,
@@ -524,6 +526,7 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                         chain_id=ChainID.ETHEREUM,
                         name=token['name'],
                         decimals=int(token['decimals']),
+                        seen=TokenSeenAt(description=f'Querying {self.location} balances'),
                     )
                     if asset.has_oracle():
                         known_tokens.add(asset)
@@ -594,6 +597,7 @@ class AMMSwapPlatform(metaclass=abc.ABCMeta):
                     protocol=protocol,
                     name=name,
                     symbol=symbol,
+                    seen=TokenSeenAt(description=f'Querying {protocol} balances'),
                 )
 
     @abc.abstractmethod

--- a/rotkehlchen/chain/ethereum/modules/balancer/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/utils.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken, UnderlyingToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
@@ -91,6 +91,7 @@ def deserialize_bpt_event(
             chain_id=ChainID.ETHEREUM,
             name=token_name,
             decimals=token_decimals,
+            seen=TokenSeenAt(tx_hash=tx_hash),
         )
         underlying_tokens.append(UnderlyingToken(
             address=token.evm_address,
@@ -108,6 +109,7 @@ def deserialize_bpt_event(
         protocol='balancer',
         decimals=18,  # all BPT tokens have 18 decimals
         underlying_tokens=underlying_tokens,
+        seen=TokenSeenAt(tx_hash=tx_hash),
     )
     bpt_event = BalancerBPTEvent(
         tx_hash=tx_hash,
@@ -212,6 +214,7 @@ def deserialize_pool_share(
             chain_id=ChainID.ETHEREUM,
             name=token_name,
             decimals=token_decimals,
+            seen=TokenSeenAt(description='Balancer pools query'),
         )
         if token_total_amount == ZERO:
             raise DeserializationError(f'Token {token.identifier} balance is zero.')
@@ -243,6 +246,7 @@ def deserialize_pool_share(
         protocol='balancer',
         decimals=18,  # All BPT tokens have 18 decimals
         underlying_tokens=pool_tokens,
+        seen=TokenSeenAt(description='Balancer pools query'),
     )
     pool = BalancerPoolBalance(
         pool_token=balancer_pool_token,

--- a/rotkehlchen/chain/ethereum/modules/curve/pools_cache.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/pools_cache.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional
 from eth_utils import to_checksum_address
 
 from rotkehlchen.assets.asset import UnderlyingToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -68,6 +68,7 @@ def ensure_curve_tokens_existence(
             chain_id=ChainID.ETHEREUM,
             evm_inquirer=ethereum_inquirer,
             protocol=CURVE_POOL_PROTOCOL,
+            seen=TokenSeenAt(description='Querying curve pools'),
         )
 
         # Ensure pool coins exist in the globaldb.
@@ -84,6 +85,7 @@ def ensure_curve_tokens_existence(
                     evm_address=token_address,
                     chain_id=ChainID.ETHEREUM,
                     evm_inquirer=ethereum_inquirer,
+                    seen=TokenSeenAt(description='Querying curve pools'),
                 )
         else:
             # Otherwise, coins and underlying coins lists represent a
@@ -97,6 +99,7 @@ def ensure_curve_tokens_existence(
                     evm_address=underlying_token_address,
                     chain_id=ChainID.ETHEREUM,
                     evm_inquirer=ethereum_inquirer,
+                    seen=TokenSeenAt(description='Querying curve pools'),
                 )
                 # and ensure token exists
                 get_or_create_evm_token(
@@ -109,6 +112,7 @@ def ensure_curve_tokens_existence(
                         token_kind=EvmTokenKind.ERC20,
                         weight=ONE,
                     )],
+                    seen=TokenSeenAt(description='Querying curve pools'),
                 )
 
 

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -85,6 +85,7 @@ class SushiswapDecoder(DecoderInterface):
                 database=self.ethereum.database,
                 factory_address=SUSHISWAP_V2_FACTORY,
                 init_code_hash=SUSHISWAP_V2_INIT_CODE_HASH,
+                tx_hash=transaction.tx_hash,
             )
         if tx_log.topics[0] == BURN_SIGNATURE:
             return decode_uniswap_like_deposit_and_withdrawals(
@@ -97,6 +98,7 @@ class SushiswapDecoder(DecoderInterface):
                 database=self.ethereum.database,
                 factory_address=SUSHISWAP_V2_FACTORY,
                 init_code_hash=SUSHISWAP_V2_INIT_CODE_HASH,
+                tx_hash=transaction.tx_hash,
             )
         return None, []
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -126,6 +126,7 @@ class Uniswapv2Decoder(DecoderInterface):
                 database=self.database,
                 factory_address=UNISWAP_V2_FACTORY,
                 init_code_hash=UNISWAP_V2_INIT_CODE_HASH,
+                tx_hash=transaction.tx_hash,
             )
         if tx_log.topics[0] == BURN_SIGNATURE:
             return decode_uniswap_like_deposit_and_withdrawals(
@@ -138,6 +139,7 @@ class Uniswapv2Decoder(DecoderInterface):
                 database=self.database,
                 factory_address=UNISWAP_V2_FACTORY,
                 init_code_hash=UNISWAP_V2_INIT_CODE_HASH,
+                tx_hash=transaction.tx_hash,
             )
         return None, []
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.modules.uniswap.utils import decode_basic_uniswap_info
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -430,6 +430,7 @@ class Uniswapv3Decoder(DecoderInterface):
                 chain_id=ChainID.ETHEREUM,
                 token_kind=EvmTokenKind.ERC20,
                 evm_inquirer=self.ethereum_inquirer,
+                seen=TokenSeenAt(tx_hash=transaction.tx_hash),
             )
             token_with_data = self.eth if token_with_data == A_WETH else token_with_data
             resolved_assets_and_amounts.append(CryptoAssetAmount(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
@@ -8,7 +8,7 @@ from web3.exceptions import BadFunctionCallOutput
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.interfaces.ammswap.types import AssetToPrice, LiquidityPoolAsset
 from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import (
     TokenDetails,
@@ -489,6 +489,7 @@ def _decode_uniswap_v3_result(
                 chain_id=ChainID.ETHEREUM,
                 name=token.name,
                 decimals=token.decimals,
+                seen=TokenSeenAt(description='Uniswap v3 LP positions query'),
             )
             asset_balance = token.amount
         except NotERC20Conformant as e:

--- a/rotkehlchen/chain/ethereum/modules/yearn/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import requests
 
 from rotkehlchen.assets.asset import UnderlyingToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.errors.misc import RemoteError
@@ -90,6 +90,7 @@ def query_yearn_vaults(db: 'DBHandler') -> None:
                 decimals=vault['token']['decimals'],
                 name=vault['token']['name'],
                 symbol=vault['token']['symbol'],
+                seen=TokenSeenAt(description=f'Querying {vault_type} balances'),
             )
             vault_token = get_or_create_evm_token(
                 userdb=db,
@@ -104,6 +105,7 @@ def query_yearn_vaults(db: 'DBHandler') -> None:
                     token_kind=EvmTokenKind.ERC20,
                     weight=ONE,
                 )],
+                seen=TokenSeenAt(description=f'Querying {vault_type} balances'),
             )
         except KeyError as e:
             log.error(

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import AssetWithOracles, EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import ReloadableDecoderMixin
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
@@ -664,6 +664,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
                     chain_id=self.evm_inquirer.chain_id,
                     token_kind=token_kind,
                     evm_inquirer=self.evm_inquirer,
+                    seen=TokenSeenAt(tx_hash=transaction.tx_hash),
                 )
             except NotERC20Conformant:
                 return None, []  # ignore non-ERC20 transfers for now


### PR DESCRIPTION
Add new argument in `get_or_create_evm_token` which allows specifying where a token newly added to the DB was first seen.

The value can either be missing or it can be a transaction hash or a string description of an action.

This is used in the websocket messages sent to notify the frontend.

