### PR TITLE
Allow to run tests in matrix for backend

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     name: 'Backend tests'
     timeout-minutes: 90
+    strategy:
+      matrix:
+        test-group: [api, others]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -73,6 +76,7 @@ jobs:
         env:
           PYTEST_ARGS: '--durations=150'
           FORCE_COLOR: 1
+          MATIX_JOB: ${{ matrix.test-group }}
         run: |
           if [ "${{ runner.os }}" == 'macOS' ];
           then
@@ -80,8 +84,16 @@ jobs:
           else
             COVERAGE_ARGS='--cov=./'
           fi          
+
           export CASSETTES_DIR=$HOME/work/rotki/rotki/test-caching
-          python pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS rotkehlchen/tests
+
+          if [ "${{ matrix.test-group }}" == 'api' ]
+          then
+            python pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS rotkehlchen/tests/api
+          else
+            python pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS --ignore=rotkehlchen/tests/api rotkehlchen/tests/
+          fi
+          
           python pytestgeventwrapper.py --dead-fixtures
         shell: bash
       - name: Upload coverage

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1465,7 +1465,7 @@ def test_ignored_assets(rotkehlchen_api_server, ethereum_accounts):
     assert result['entries_limit'] == FREE_ETH_TX_LIMIT
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x59ABf3837Fa962d6853b4Cc0a19513AA031fd32b']])  # noqa: E501
 @patch.object(EthereumTransactions, '_get_internal_transactions_for_ranges', lambda *args, **kargs: None)  # noqa: E501
 @patch.object(EthereumTransactions, '_get_erc20_transfers_for_ranges', lambda *args, **kargs: None)

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -677,7 +677,7 @@ def test_query_historical_dsr_with_a_zero_withdrawal(
     assert len(errors) == 0
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662']])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_dsr']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/utils/database.py
+++ b/rotkehlchen/tests/utils/database.py
@@ -25,9 +25,14 @@ def maybe_include_etherscan_key(db: DBHandler, include_etherscan_key: bool) -> N
     if not include_etherscan_key:
         return
     # Add the tests only etherscan API key
+    if os.environ.get('MATIX_JOB', 'others') == 'api':
+        eth_api_key = 'R7QNMZJF1Z5EZM96GMSZSQKHQK3V2TBKW5'
+    else:
+        eth_api_key = '8JT7WQBB2VQP5C3416Y8X3S8GBA3CVZKP4'
+
     db.add_external_service_credentials([ExternalServiceApiCredentials(
         service=ExternalService.ETHERSCAN,
-        api_key=ApiKey('8JT7WQBB2VQP5C3416Y8X3S8GBA3CVZKP4'),
+        api_key=ApiKey(eth_api_key),
     )])
     db.add_external_service_credentials([ExternalServiceApiCredentials(
         service=ExternalService.OPTIMISM_ETHERSCAN,


### PR DESCRIPTION
Create a matrix job for the backend to speed up CI execution. Due to limits in the req/min in the api keys I've added a random function to pick them
