### PR TITLE
Do not perform any migrations for a fresh user DB

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -80,20 +80,20 @@ The messages sent by rotki when a user is logging in and a db upgrade is happeni
 
     {
         "type": "db_upgrade_status",
-	"data": {
-	    "start_version": 26,
-	    "target_version": 35,
-	    "current_upgrade": {
-		"to_version": 30,
-		"total_steps": 8,
-		"current_step": 5
-	    }
-	}
+        "data": {
+            "start_version": 26,
+            "target_version": 35,
+            "current_upgrade": {
+                "to_version": 30,
+                "total_steps": 8,
+                "current_step": 5
+            }
+        }
     }
 
 
 - ``start_version``: DB version that user's database had before any upgrades began. This is the version of the DB when rotki first starts.
-- ``current_upgrade``: Structure that holds information about currently running upgrade. Contains: ``to_version`` - version of the the database upgrade that is currently being applied; ``total_steps`` - total number of steps that currently running upgrade consists of; ``current_step`` - step that the upgrade is at as of this websocket message. 
+- ``current_upgrade``: Structure that holds information about currently running upgrade. Contains: ``to_version`` - version of the the database upgrade that is currently being applied; ``total_steps`` - total number of steps that currently running upgrade consists of; ``current_step`` - step that the upgrade is at as of this websocket message.
 - ``target_version``: The target version of the DB. When this is reached, the upgrade process will have finished.
 
 
@@ -108,15 +108,15 @@ The messages sent by rotki when a user is logging in and a db upgrade is happeni
     {
         "type": "data_migration_status",
         "data": {
-	    "start_version": 1,
-	    "target_version": 8,
-	    "current_migration": {
-		"version": 8,
-		"total_steps": 20,
-		"current_step": 3,
-		"description": "Checking 0xbd96cDCc6Ae1ffB73ace84E16601E1CF909D5749 EVM chain activity"
-	    }
-	}
+            "start_version": 1,
+            "target_version": 8,
+            "current_migration": {
+                "version": 8,
+                "total_steps": 20,
+                "current_step": 3,
+                "description": "Checking 0xbd96cDCc6Ae1ffB73ace84E16601E1CF909D5749 EVM chain activity"
+            }
+        }
     }
 
 
@@ -135,12 +135,12 @@ At the user DB migrations when a new evm chain is introduced rotki will do a mig
     {
         "type": "evm_address_migration",
         "data": [{
-	    "evm_chain": "optimism",
-	    "address": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12"
-	}, {
-	    "evm_chain": "optimism",
-	    "address": "0xFeebabE6b0418eC13b30aAdF129F5DcDd4f70CeA"
-	}]
+            "evm_chain": "optimism",
+            "address": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12"
+        }, {
+            "evm_chain": "optimism",
+            "address": "0xFeebabE6b0418eC13b30aAdF129F5DcDd4f70CeA"
+        }]
     }
 
 

--- a/rotkehlchen/chain/evm/nodes.py
+++ b/rotkehlchen/chain/evm/nodes.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rotkehlchen.fval import FVal
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.drivers.gevent import DBCursor
+
+
+def populate_rpc_nodes_in_database(write_cursor: 'DBCursor') -> None:
+    """Populates the rpc nodes in the datatabase from nodes.json
+
+    This is supposed to run for a clean new DB
+    """
+    dir_path = Path(__file__).resolve().parent.parent.parent
+    with open(dir_path / 'data' / 'nodes.json') as f:
+        nodes_info = json.loads(f.read())
+
+    nodes_tuples = [
+        (node['name'], node['endpoint'], False, True, str(FVal(node['weight'])), node['blockchain'])  # noqa: E501
+        for node in nodes_info
+    ]
+    write_cursor.executemany(
+        'INSERT OR IGNORE INTO rpc_nodes(name, endpoint, owned, active, weight, blockchain) VALUES (?, ?, ?, ?, ?, ?)',  # noqa: E501
+        nodes_tuples,
+    )

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -5,6 +5,7 @@ from rotkehlchen.accounting.ledger_actions import LedgerActionType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.constants.timing import YEAR_IN_SECONDS
+from rotkehlchen.data_migrations.manager import LAST_DATA_MIGRATION
 from rotkehlchen.db.utils import str_to_bool
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.types import DEFAULT_HISTORICAL_PRICE_ORACLES_ORDER, HistoricalPriceOracle
@@ -50,7 +51,7 @@ DEFAULT_TAXABLE_LEDGER_ACTIONS = [
 DEFAULT_PNL_CSV_WITH_FORMULAS = True
 DEFAULT_PNL_CSV_HAVE_SUMMARY = False
 DEFAULT_SSF_0GRAPH_MULTIPLIER = 0
-DEFAULT_LAST_DATA_MIGRATION = 0
+DEFAULT_LAST_DATA_MIGRATION = LAST_DATA_MIGRATION
 DEFAULT_COST_BASIS_METHOD = CostBasisMethod.FIFO
 DEFAULT_TREAT_ETH2_AS_ETH = False
 DEFAULT_ETH_STAKING_TAXABLE_AFTER_WITHDRAWAL_ENABLED = False

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -109,7 +109,6 @@ def test_query_owned_assets(
 
 
 @pytest.mark.parametrize('new_db_unlock_actions', [None])
-@pytest.mark.parametrize('data_migration_version', [0])
 def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
     """Test that using the ignored assets endpoint to modify the ignored assets list works fine"""
     rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -35,7 +35,7 @@ def _create_invalid_icon(icon_identifier: str, icons_dir: Path) -> Path:
 
 
 @pytest.mark.parametrize('use_custom_database', ['data_migration_v0.db'])
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [0])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 def test_migration_1(rotkehlchen_api_server):
@@ -132,8 +132,9 @@ def test_migration_1(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('use_custom_database', ['data_migration_v0.db'])
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [0])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
+@pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 def test_failed_migration(rotkehlchen_api_server):
     """Test that a failed migration does not update DB setting and logs error"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -158,7 +159,7 @@ def test_failed_migration(rotkehlchen_api_server):
 
     with db.conn.read_ctx() as cursor:
         settings = db.get_settings(cursor)
-    assert settings.last_data_migration == 0, 'no upgrade should have happened'
+    assert settings.last_data_migration == 0, 'no migration should have happened'
     errors = rotki.msg_aggregator.consume_errors()
     warnings = rotki.msg_aggregator.consume_warnings()
     assert len(warnings) == 0
@@ -166,7 +167,7 @@ def test_failed_migration(rotkehlchen_api_server):
     assert errors[0] == 'Failed to run soft data migration to version 1 due to ngmi'
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [2])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -192,11 +193,10 @@ def test_migration_3(rotkehlchen_api_server):
     assert eth_iconpath.is_file() is False
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [3])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
 def test_migration_4(rotkehlchen_api_server):
     """
     Test that the fourth data migration for rotki works. This migration adds the ethereum nodes
@@ -243,11 +243,10 @@ def test_migration_4(rotkehlchen_api_server):
         assert rpc_nodes[owned_index].node_info.endpoint == 'https://localhost:5222'
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [3])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
 def test_migration_4_no_own_endpoint(rotkehlchen_api_server):
     """
     Test that the fourth data migration for rotki works when there is no custom node
@@ -273,11 +272,10 @@ def test_migration_4_no_own_endpoint(rotkehlchen_api_server):
         assert len(rpc_nodes) >= len(nodes)
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [4])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
 def test_migration_5(rotkehlchen_api_server):
     """
     Test that the fifth data migration for rotki works.
@@ -356,11 +354,10 @@ def _write_nodes_and_migrate(
     return nodes_in_db
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [5])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
-@pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
+@pytest.mark.parametrize('new_db_unlock_actions', [None])
 def test_migration_6_default_rpc_nodes(rotkehlchen_api_server):
     """
     Test that the sixth data migration works when the user has not customized the nodes.
@@ -376,11 +373,10 @@ def test_migration_6_default_rpc_nodes(rotkehlchen_api_server):
     assert FVal(sum(FVal(node[3]) for node in nodes_in_db)) == ONE
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [5])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
-@pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
+@pytest.mark.parametrize('new_db_unlock_actions', [None])
 def test_migration_6_customized_rpc_nodes(rotkehlchen_api_server):
     """
     Test that the sixth data migration works when the user has customized the rpc nodes.
@@ -406,11 +402,10 @@ def test_migration_6_customized_rpc_nodes(rotkehlchen_api_server):
     assert set(nodes_in_db) == expected_nodes
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [5])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
-@pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
+@pytest.mark.parametrize('new_db_unlock_actions', [None])
 def test_migration_6_own_node(rotkehlchen_api_server):
     """
     Test that the sixth data migration works when user has no customized nodes but has
@@ -429,11 +424,9 @@ def test_migration_6_own_node(rotkehlchen_api_server):
     assert set(nodes_in_db) == expected_nodes
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [6])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
-@pytest.mark.parametrize('use_clean_caching_directory', [True])
-@pytest.mark.parametrize('perform_nodes_insertion', [False])
 def test_migration_7_nodes(rotkehlchen_api_server: 'APIServer'):
     """
     Test that the seventh data migration works adding llamanode to the list of eth nodes.
@@ -464,10 +457,9 @@ def test_migration_7_nodes(rotkehlchen_api_server: 'APIServer'):
     assert llama_node_in_db is True
 
 
-@pytest.mark.parametrize('data_migration_version', [None])
+@pytest.mark.parametrize('data_migration_version', [7])
 @pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
-@pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('ethereum_accounts', [[make_evm_address(), make_evm_address(), make_evm_address(), make_evm_address()]])  # noqa: E501
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])
 def test_migration_8(rotkehlchen_api_server, ethereum_accounts, websocket_connection):

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -36,7 +36,6 @@ def _create_invalid_icon(icon_identifier: str, icons_dir: Path) -> Path:
 
 @pytest.mark.parametrize('use_custom_database', ['data_migration_v0.db'])
 @pytest.mark.parametrize('data_migration_version', [0])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 def test_migration_1(rotkehlchen_api_server):
     """
@@ -133,7 +132,6 @@ def test_migration_1(rotkehlchen_api_server):
 
 @pytest.mark.parametrize('use_custom_database', ['data_migration_v0.db'])
 @pytest.mark.parametrize('data_migration_version', [0])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 def test_failed_migration(rotkehlchen_api_server):
     """Test that a failed migration does not update DB setting and logs error"""
@@ -168,7 +166,6 @@ def test_failed_migration(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [2])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_migration_3(rotkehlchen_api_server):
@@ -194,7 +191,6 @@ def test_migration_3(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [3])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_migration_4(rotkehlchen_api_server):
@@ -244,7 +240,6 @@ def test_migration_4(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [3])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_migration_4_no_own_endpoint(rotkehlchen_api_server):
@@ -273,7 +268,6 @@ def test_migration_4_no_own_endpoint(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [4])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_migration_5(rotkehlchen_api_server):
@@ -355,7 +349,6 @@ def _write_nodes_and_migrate(
 
 
 @pytest.mark.parametrize('data_migration_version', [5])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('new_db_unlock_actions', [None])
 def test_migration_6_default_rpc_nodes(rotkehlchen_api_server):
@@ -374,7 +367,6 @@ def test_migration_6_default_rpc_nodes(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [5])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('new_db_unlock_actions', [None])
 def test_migration_6_customized_rpc_nodes(rotkehlchen_api_server):
@@ -403,7 +395,6 @@ def test_migration_6_customized_rpc_nodes(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [5])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('new_db_unlock_actions', [None])
 def test_migration_6_own_node(rotkehlchen_api_server):
@@ -425,7 +416,6 @@ def test_migration_6_own_node(rotkehlchen_api_server):
 
 
 @pytest.mark.parametrize('data_migration_version', [6])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 def test_migration_7_nodes(rotkehlchen_api_server: 'APIServer'):
     """
@@ -458,7 +448,6 @@ def test_migration_7_nodes(rotkehlchen_api_server: 'APIServer'):
 
 
 @pytest.mark.parametrize('data_migration_version', [7])
-@pytest.mark.parametrize('perform_migrations_at_unlock', [False])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
 @pytest.mark.parametrize('ethereum_accounts', [[make_evm_address(), make_evm_address(), make_evm_address(), make_evm_address()]])  # noqa: E501
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -10,7 +10,6 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccounts
 from rotkehlchen.constants.misc import DEFAULT_SQL_VM_INSTRUCTIONS_CB
-from rotkehlchen.data_migrations.migrations.migration_4 import read_and_write_nodes_in_database
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.tests.utils.database import (
     _use_prepared_db,
@@ -21,6 +20,7 @@ from rotkehlchen.tests.utils.database import (
     maybe_include_cryptocompare_key,
     maybe_include_etherscan_key,
     mock_db_schema_sanity_check,
+    perform_new_db_unlock_actions,
 )
 from rotkehlchen.user_messages import MessagesAggregator
 
@@ -173,7 +173,7 @@ def database(
         manually_tracked_balances,
         data_migration_version,
         use_custom_database,
-        perform_nodes_insertion,
+        new_db_unlock_actions,
         sql_vm_instructions_cb,
 ) -> Optional[DBHandler]:
     if not start_with_logged_in_user:
@@ -194,9 +194,8 @@ def database(
         use_custom_database=use_custom_database,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
     )
-    if perform_nodes_insertion:
-        with db_handler.user_write() as cursor:
-            read_and_write_nodes_in_database(write_cursor=cursor)
+    if new_db_unlock_actions is not None:
+        perform_new_db_unlock_actions(db=db_handler, new_db_unlock_actions=new_db_unlock_actions)
     return db_handler
 
 

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -6,7 +6,7 @@ import pytest
 
 import rotkehlchen.tests.utils.exchanges as exchange_tests
 from rotkehlchen.constants.misc import DEFAULT_MAX_LOG_SIZE_IN_MB
-from rotkehlchen.data_migrations.manager import LAST_DATA_MIGRATION, DataMigrationManager
+from rotkehlchen.data_migrations.manager import LAST_DATA_MIGRATION
 from rotkehlchen.db.settings import DBSettings
 from rotkehlchen.db.upgrade_manager import DBUpgradeManager
 from rotkehlchen.exchanges.constants import EXCHANGES_WITH_PASSPHRASE
@@ -91,12 +91,6 @@ def fixture_cli_args(data_dir, ethrpc_endpoint, max_size_in_mb_all_logs):
     return default_args(data_dir=data_dir, ethrpc_endpoint=ethrpc_endpoint, max_size_in_mb_all_logs=max_size_in_mb_all_logs)  # noqa: E501
 
 
-@pytest.fixture(name='perform_migrations_at_unlock')
-def fixture_perform_migrations_at_unlock():
-    """Perform data migrations as normal during user unlock"""
-    return False
-
-
 @pytest.fixture(name='perform_upgrades_at_unlock')
 def fixture_perform_upgrades_at_unlock():
     """Perform user DB upgrades as normal during user unlock"""
@@ -142,7 +136,6 @@ def initialize_mock_rotkehlchen_instance(
         data_migration_version,
         use_custom_database,
         user_data_dir,
-        perform_migrations_at_unlock,
         perform_upgrades_at_unlock,
         new_db_unlock_actions,
         current_price_oracles_order,
@@ -207,14 +200,6 @@ def initialize_mock_rotkehlchen_instance(
         stack.enter_context(sleep_patch)
         if use_custom_database is not None:
             stack.enter_context(mock_db_schema_sanity_check())
-
-        if perform_migrations_at_unlock is False:
-            migrations_patch = patch.object(
-                DataMigrationManager,
-                'maybe_migrate_data',
-                side_effect=lambda *args: None,
-            )
-            stack.enter_context(migrations_patch)
 
         if new_db_unlock_actions is None:
             new_db_unlock_actions_patch = patch('rotkehlchen.rotkehlchen.Rotkehlchen._perform_new_db_actions', side_effect=lambda *args: None)  # noqa: E501
@@ -338,7 +323,6 @@ def fixture_rotkehlchen_api_server(
         data_migration_version,
         use_custom_database,
         user_data_dir,
-        perform_migrations_at_unlock,
         perform_upgrades_at_unlock,
         new_db_unlock_actions,
         current_price_oracles_order,
@@ -383,7 +367,6 @@ def fixture_rotkehlchen_api_server(
         data_migration_version=data_migration_version,
         use_custom_database=use_custom_database,
         user_data_dir=user_data_dir,
-        perform_migrations_at_unlock=perform_migrations_at_unlock,
         perform_upgrades_at_unlock=perform_upgrades_at_unlock,
         new_db_unlock_actions=new_db_unlock_actions,
         current_price_oracles_order=current_price_oracles_order,
@@ -446,7 +429,6 @@ def rotkehlchen_instance(
         data_migration_version,
         use_custom_database,
         user_data_dir,
-        perform_migrations_at_unlock,
         perform_upgrades_at_unlock,
         new_db_unlock_actions,
         current_price_oracles_order,
@@ -481,7 +463,6 @@ def rotkehlchen_instance(
         data_migration_version=data_migration_version,
         use_custom_database=use_custom_database,
         user_data_dir=user_data_dir,
-        perform_migrations_at_unlock=perform_migrations_at_unlock,
         perform_upgrades_at_unlock=perform_upgrades_at_unlock,
         new_db_unlock_actions=new_db_unlock_actions,
         current_price_oracles_order=current_price_oracles_order,

--- a/rotkehlchen/tests/utils/database.py
+++ b/rotkehlchen/tests/utils/database.py
@@ -7,8 +7,10 @@ from typing import Any, Optional
 from unittest.mock import _patch, patch
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.spam_assets import update_spam_assets
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccountData, BlockchainAccounts
+from rotkehlchen.chain.evm.nodes import populate_rpc_nodes_in_database
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.errors.misc import InputError
@@ -154,3 +156,12 @@ def _use_prepared_db(user_data_dir: Path, filename: str) -> None:
         os.path.join(os.path.dirname(dir_path), 'data', filename),
         user_data_dir / 'rotkehlchen.db',
     )
+
+
+def perform_new_db_unlock_actions(db: DBHandler, new_db_unlock_actions: tuple[str]) -> None:
+    """Decide actions to perform at new DB unlock for a specific test depending on arguments"""
+    if 'rpc_nodes' in new_db_unlock_actions:
+        with db.user_write() as write_cursor:
+            populate_rpc_nodes_in_database(write_cursor)
+    if 'spam_assets' in new_db_unlock_actions:
+        update_spam_assets(db)


### PR DESCRIPTION
In the past we had a new DB run all data migrations. This was not
needed. The only reason it was being done was to do two things:

1. Spam assets addition (Migration: 3)
2. Read and write rpc nodes to the DB (Migrations: 4, 6, 7)

This commit starts a fresh DB at latest migration, so no migrations
run for a fresh DB. Instead those actions are now set apart as actions
to perform to populate a fresh DB.

Tests and their fixtures/mocks are also adjusted properly.

What's more the `perform_migrations_at_unlock` test fixture is removed, since now a fresh user DB does not go through migrations this is not needed