### PR TITLE
Remove post/api/1/assets/ignore api endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10339,18 +10339,6 @@ Dealing with ignored assets
    :statuscode 409: User is not logged in. One of the assets provided is not on the list.
    :statuscode 500: Internal rotki error
 
-.. http:post:: /api/(version)/assets/ignored/
-
-   Doing a POST on the ignored assets endpoint will update the list of ignored assets using cryptoscamdb as source.
-
-   .. note::
-      This endpoint can also be queried asynchronously by using ``"async_query": true``.
-
-   :resjson int result: The number of assets that were added to the ignore list.
-   :statuscode 200: Ignored assets successfully updated
-   :statuscode 500: Internal rotki error
-   :statuscode 502: Remote error downloading list of assets from cryptoscamdb
-
 Dealing with ignored actions
 ==============================
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -56,7 +56,6 @@ from rotkehlchen.assets.asset import (
     FiatAsset,
 )
 from rotkehlchen.assets.resolver import AssetResolver
-from rotkehlchen.assets.spam_assets import update_spam_assets
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.balances.manual import (
     ManuallyTrackedBalance,
@@ -4705,18 +4704,6 @@ class RestAPI():
         except InputError as e:
             return api_response(wrap_in_fail_result(str(e)), status_code=HTTPStatus.CONFLICT)
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
-
-    def _pull_spam_assets(self) -> dict[str, Any]:
-        assets_updated = update_spam_assets(db=self.rotkehlchen.data.db)
-        return {'result': assets_updated, 'message': '', 'status_code': HTTPStatus.OK}
-
-    def pull_spam_assets(self, async_query: bool) -> Response:
-        if async_query is True:
-            return self._query_async(
-                command=self._pull_spam_assets,
-            )
-        response_result = self._pull_spam_assets()
-        return api_response(result=response_result, status_code=response_result['status_code'])
 
     def get_all_counterparties(self) -> Response:
         return api_response(

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1588,7 +1588,6 @@ class BTCXpubResource(BaseMethodView):
 class IgnoredAssetsResource(BaseMethodView):
 
     modify_schema = IgnoredAssetsSchema()
-    post_schema = AsyncQueryArgumentSchema()
 
     @require_loggedin_user()
     def get(self) -> Response:
@@ -1603,10 +1602,6 @@ class IgnoredAssetsResource(BaseMethodView):
     @use_kwargs(modify_schema, location='json')
     def delete(self, assets: list[Asset]) -> Response:
         return self.rest_api.remove_ignored_assets(assets=assets)
-
-    @use_kwargs(post_schema, location='json_and_query')
-    def post(self, async_query: bool) -> Response:
-        return self.rest_api.pull_spam_assets(async_query)
 
 
 class IgnoredActionsResource(BaseMethodView):

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -163,17 +163,6 @@ def test_ignored_assets_modification(rotkehlchen_api_server_with_exchanges):
         result = assert_proper_response_with_result(response)
         assert assets_after_deletion <= set(result)
 
-        # Mock fetching remote assets to be ignored
-        response = requests.post(
-            api_url_for(
-                rotkehlchen_api_server_with_exchanges,
-                'ignoredassetsresource',
-            ),
-        )
-        result = assert_proper_response_with_result(response)
-        assert result >= 1
-        assert len(rotki.data.db.get_ignored_assets(cursor)) > len(assets_after_deletion)
-
 
 @pytest.mark.parametrize('perform_migrations_at_unlock', [True])
 @pytest.mark.parametrize('method', ['put', 'delete'])


### PR DESCRIPTION
Since we removed pulling of ignored assets from cryptoscamdb this endpoint is no longer needed.

