### PR TITLE
Let matrix jobs finish if one of them fails

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -17,6 +17,7 @@ jobs:
     name: 'Backend tests'
     timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
         test-group: [api, others]
     steps:


### PR DESCRIPTION
Disable fast fail in github CI matrix job for backend tests

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast