### PR TITLE
installation-guide: Fix public warning recommendation

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -276,7 +276,7 @@ If you prefer to use docker compose, a docker-compose.yml template is provided b
 Using docker over a public network
 ----------------------------------
 
-Since rotki was designed to run over a public network it is :ref:`generally advised <docker warning>` to avoid
+Since rotki was not designed to run over a public network it is :ref:`generally advised <docker warning>` to avoid
 directly exposing your rotki instance over public network.
 
 If you still want to access rotki over a public network it is suggested to use at least a proxy with


### PR DESCRIPTION
Rotki wasn't designed for a public network and advising not to be run on a public network. It was designed for private networks and advising not to be run on a public network.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
