### PR TITLE
Replace get or create evm token for a simpler version in spam tokens

### DIFF
--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -1059,23 +1059,19 @@ def query_token_spam_list() -> set[Asset]:
             protocol=SPAM_PROTOCOL,
             underlying_tokens=None,
         )
-        token_exists = True
+
         try:
             evm_token.check_existence()
-        except UnknownAsset:
-            token_exists = False
-
-        if token_exists is True:
-            # make sure that the token has the spam protocol
-            db_evm_token = EvmToken(evm_token.identifier)
-            if db_evm_token.protocol != SPAM_PROTOCOL:
-                GlobalDBHandler().edit_evm_token(entry=evm_token)
-        else:
+        except UnknownAsset:  # token does not exist
             GlobalDBHandler().add_asset(
                 asset_id=evm_token.identifier,
                 asset_type=AssetType.EVM_TOKEN,
                 data=evm_token,
             )
+        else:  # token exists, make sure it has spam protocol set
+            db_evm_token = EvmToken(evm_token.identifier)
+            if db_evm_token.protocol != SPAM_PROTOCOL:
+                GlobalDBHandler().edit_evm_token(entry=evm_token)
         # save the asset instead of the EvmToken as we don't need all the extra information later
         tokens_to_ignore.add(Asset(evm_token.identifier))
 

--- a/rotkehlchen/data_migrations/migrations/migration_8.py
+++ b/rotkehlchen/data_migrations/migrations/migration_8.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
+from rotkehlchen.assets.spam_assets import update_spam_assets
 from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -27,7 +28,8 @@ def data_migration_8(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressH
     # when we sync a remote database the migrations are executed but the chain_manager
     # has not been created yet
     if (chains_aggregator := getattr(rotki, 'chains_aggregator', None)) is not None:
-        progress_handler.set_total_steps(len(accounts.eth) + 1)
+        # steps are: ethereum accounts + potentially write to db + update spam assets
+        progress_handler.set_total_steps(len(accounts.eth) + 2)
         filtered_result = chains_aggregator.filter_active_evm_addresses(
             accounts=accounts.eth,
             progress_handler=progress_handler,
@@ -65,5 +67,11 @@ def data_migration_8(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressH
                 message_type=WSMessageType.EVM_ADDRESS_MIGRATION,
                 data=[{'evm_chain': str(x[0]), 'address': x[1]} for x in to_add_accounts],
             )
+    else:
+        # The only step is update the spam assets
+        progress_handler.set_total_steps(1)
 
+    # Also update the spam assets
+    progress_handler.new_step('Update the list of spam assets')
+    update_spam_assets(db=rotki.data.db)
     log.debug('Exit data_migration_8')

--- a/rotkehlchen/tests/api/blockchain/test_optimism.py
+++ b/rotkehlchen/tests/api/blockchain/test_optimism.py
@@ -19,13 +19,11 @@ from rotkehlchen.utils.misc import ts_now
 TEST_ADDY = '0x9531C059098e3d194fF87FebB587aB07B30B1306'
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 def test_add_optimism_blockchain_account(rotkehlchen_api_server):
     """Test adding an optimism account when there is none in the db
     works as expected and that balances are returned and tokens are detected.
-
-    TODO: Probably should mock this at some point. Atm just using
-    rotki's account in optimism
     """
     async_query = random.choice([False, True])
 

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -24,6 +24,9 @@ from rotkehlchen.types import BTCAddress, ChecksumEvmAddress, SupportedBlockchai
 from rotkehlchen.utils.misc import from_wei, satoshis_to_btc
 
 if TYPE_CHECKING:
+    from contextlib import ExitStack
+
+    from rotkehlchen.chain.aggregator import ChainsAggregator
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 
 
@@ -603,12 +606,12 @@ def set_web3_in_inquirer(ethereum_inquirer: 'EthereumInquirer', web3: Web3) -> N
 
 
 def setup_filter_active_evm_addresses_mock(
-        stack,
-        chains_aggregator,
-        contract_addresses,
-        avalanche_addresses,
-        optimism_addresses,
-):
+        stack: 'ExitStack',
+        chains_aggregator: 'ChainsAggregator',
+        contract_addresses: list[ChecksumEvmAddress],
+        avalanche_addresses: list[ChecksumEvmAddress],
+        optimism_addresses: list[ChecksumEvmAddress],
+) -> 'ExitStack':
     def mock_ethereum_get_code(account):
         if account in contract_addresses:
             return '0xsomecode'


### PR DESCRIPTION
This PR:

- changes the complicated logic of `get_or_create_evm_token` for somethig lighter 
- Mocks the calls for the optimism token detection test
- Adds for the last time as a hardcoded step the sync of spam assets