### PR TITLE
Specify that it's not possible to enable debug logs in dappnode

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -17,10 +17,13 @@ Before reporting an issue, make sure to check the issue tracker for similar ones
 Run rotki in debug mode
 =========================
 
-For running rotki in debug mode, you can do it either via a config file or the app UI:
+For running rotki in debug mode, you can do it either via a config file or the app UI. Choice will depend on how you run rotki.
 
-- **Config file**: see the section :ref:`set-the-backend-s-arguments`.
-- **App UI**: before log in, click the cog wheel at the bottom right corner and select "Debug" (image below). Press the save button and proceed to log in as usual.
+- **Config file**: see the section :ref:`set-the-backend-s-arguments`. This is possible in the **electron app** and the **docker version**. For docker you can even use environment variables as explained `here <https://rotki.readthedocs.io/en/latest/installation_guide.html?#configuring-backend-in-docker>`_.
+- **App UI**: before log in, click the cog wheel at the bottom right corner and select "Debug" (image below). Press the save button and proceed to log in as usual. This is only possible in the **electron app**.
+
+.. warning::
+    At the moment if you use the dappnode rotki package it is **not possible** to enable debug logs. For updates follow: `this issue <https://github.com/dappnode/DAppNodePackage-rotki/issues/29>`_.
 
 .. image:: images/rotki_debug_mode_set.png
    :alt: Run rotki in debug mode via app UI


### PR DESCRIPTION
Follow https://github.com/dappnode/DAppNodePackage-rotki/issues/29 for updates

![2023-01-31_15-05](https://user-images.githubusercontent.com/1658405/215782525-c8c71993-e6ef-4647-879b-5e215ab60861.png)
