### PR TITLE
Kill evm tx greenlets on account deletion

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -135,6 +135,7 @@ from rotkehlchen.errors.misc import (
     DBSchemaError,
     DBUpgradeError,
     EthSyncError,
+    GreenletKilledError,
     InputError,
     ModuleInactive,
     RemoteError,
@@ -286,6 +287,15 @@ class RestAPI():
         except AttributeError:
             task_id = None
             task_str = 'Main greenlet'
+
+        if isinstance(greenlet.exception, GreenletKilledError):
+            log.debug(
+                f'Greenlet for task id {task_id} with name {task_str} was killed. '
+                f'{str(greenlet.exception)}',
+            )
+            # Setting empty message to signify that the death of the greenlet is expected.
+            self._write_task_result(task_id, {'result': None, 'message': ''})
+            return
 
         log.error(
             f'{task_str} dies with exception: {greenlet.exception}.\n'

--- a/rotkehlchen/errors/misc.py
+++ b/rotkehlchen/errors/misc.py
@@ -68,3 +68,7 @@ class BlockchainQueryError(Exception):
 
 class DBSchemaError(Exception):
     """May be raised during database sanity check"""
+
+
+class GreenletKilledError(Exception):
+    """Raised when a greenlet is killed"""

--- a/rotkehlchen/greenlets/manager.py
+++ b/rotkehlchen/greenlets/manager.py
@@ -3,6 +3,7 @@ import traceback
 from typing import Any, Callable, Optional
 
 import gevent
+from rotkehlchen.errors.misc import GreenletKilledError
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.user_messages import MessagesAggregator
@@ -52,8 +53,12 @@ class GreenletManager():
             log.error('went in handle_killed_greenlets without an exception')
             return
 
-        exception_is_error = getattr(greenlet, 'exception_is_error', True)
         task_name = getattr(greenlet, 'task_name', 'Unknown task')
+        if isinstance(greenlet.exception, GreenletKilledError):
+            log.debug(f'Greenlet for task {task_name} was killed')
+            return
+
+        exception_is_error = getattr(greenlet, 'exception_is_error', True)
         first_line = f'{task_name} died with exception: {greenlet.exception}'
         if not exception_is_error:
             log.warning(f'{first_line} but that is not treated as an error')


### PR DESCRIPTION
This PR makes sure that all the greenlets are killed and locks are acquired when deleting an EVM account.

The main bug that caused me spent so much time is the following scenario:

1. An EVM address that has transactions in both ethereum and optimism is added.
2. Frontend queries transactions for the ethereum address. It does this by calling `/evm/transactions` API endpoint with `accounts` being a list with a single item `{'address': 'the-address', 'evm_chain': 'ethereum'}` and `evm_chain` (another standalone argument) being `null`.
3. Same happens for the optimism address.

Since `evm_chain` is `None` in both API calls, this causes the backend to [iterate](https://github.com/rotki/rotki/blob/b725daf8cc2357b690cb3e67ef1fbdc8c85fb98b/rotkehlchen/api/rest.py#L3290) through all supported evm chains and ask them for transactions. Before #5522 this caused that for both of the API calls, the transactions would be asked for both ethereum and optimism. So there were duplicated greenlets for both ethereum and optimism transactions.

These duplicated greenlets would not run simultaneously due to the locks existence, but they would queue one after another and later, when the user would try to delete a transaction, one of the greenlets would be killed and the other one would immediately re-acquire the lock and block the account deletion.

Since #5522 is merged, this is no longer an issue and the greenlets are killed fine. However, I have question. @LefterisJP why not to change the evm transactions endpoint so that it accepts only a single chain argument? I mean, currently there are 2 arguments. `accounts` which is a list of (`address`, `evm_chain`) and another, standalone argument `evm_chain` which caused these discrepancies. Can we maybe change it so that `accounts` becomes just a list of addresses and the chain is determined only by a single `evm_chain` argument?