### PR TITLE
Test that the price used for assets in trades is nominated using the main currency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Changelog
 * :feature:`-` Swaps made via uniswap v3 auto routers (both v1 and v2) will now be decoded correctly.
 * :feature:`3231` Optimism is now supported. Optimism balances will be shown and optimism transactions will be decoded.
 * :feature:`1756` Uniswap and sushiswap pool join/exit events are now properly decoded and taken into account during PnL report.
+* :bug:`-` Fixed an issue where price for pairs of fiat currencies was not queried properly.
 * :bug:`-` Customized ownership proportions of validators owned by eth1 addresses will now be properly respected.
 
 * :release:`1.26.3 <2022-12-30>`

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -383,8 +383,9 @@ class DBHandler:
                 'last_data_upload_ts',
                 'premium_should_sync',
                 'ongoing_upgrade_from_version',
+                'main_currency',
             ],
-            value: Union[int, Timestamp],
+            value: Union[int, Timestamp, Asset],
     ) -> None:
         write_cursor.execute(
             'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',


### PR DESCRIPTION
The bug in 1.26.3 was making that when the price used for assets in the PnL report  was not available in oracles and was calculated based in trade  then it was not using the main currency as reference.

This behavior changed along the changes made to the accounting process for 1.27 and this PR adds a test to verify this. The provided test fails (with the wrong price) in 1.26.3 and works fine in 1.27
