### PR TITLE
Make the create user endpoint async

### DIFF
--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1148,6 +1148,7 @@ class UsersResource(BaseMethodView):
     @use_kwargs(put_schema, location='json')
     def put(
             self,
+            async_query: bool,
             name: str,
             password: str,
             premium_api_key: str,
@@ -1156,6 +1157,7 @@ class UsersResource(BaseMethodView):
             initial_settings: Optional[ModifiableDBSettings],
     ) -> Response:
         return self.rest_api.create_new_user(
+            async_query=async_query,
             name=name,
             password=password,
             premium_api_key=premium_api_key,

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1186,7 +1186,7 @@ class UserPremiumSyncSchema(AsyncQueryArgumentSchema):
     )
 
 
-class NewUserSchema(BaseUserSchema):
+class NewUserSchema(BaseUserSchema, AsyncQueryArgumentSchema):
     premium_api_key = fields.String(load_default='')
     premium_api_secret = fields.String(load_default='')
     sync_database = fields.Boolean(load_default=True)


### PR DESCRIPTION
This PR makes the endpoint to create user async in order to allow ws messages during the sync process in frontend
