### PR TITLE
Fix two minor issues backend

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1146,7 +1146,7 @@ class RestAPI():
             message = (
                 f'Can not create a new user because user '
                 f'{self.rotkehlchen.data.username} is already logged in. '
-                f'Log out of that user first',
+                f'Log out of that user first'
             )
             return {
                 'result': None,

--- a/rotkehlchen/chain/ethereum/node_inquirer.py
+++ b/rotkehlchen/chain/ethereum/node_inquirer.py
@@ -254,9 +254,9 @@ class EthereumInquirer(EvmNodeInquirer, LockableQueryMixIn):
         curve_address_provider = self.contracts.contract('CURVE_ADDRESS_PROVIDER')
         pools = query_curve_registry_pools(ethereum=self, curve_address_provider=curve_address_provider)  # noqa: E501
         pools.update(query_curve_meta_pools(ethereum=self, curve_address_provider=curve_address_provider))  # noqa: E501
-        ensure_curve_tokens_existence(ethereum_inquirer=self, pools_mapping=pools)
+        updated_pools = ensure_curve_tokens_existence(ethereum_inquirer=self, pools_mapping=pools)
         with GlobalDBHandler().conn.write_ctx() as write_cursor:
-            save_curve_pools_to_cache(write_cursor=write_cursor, pools_mapping=pools)
+            save_curve_pools_to_cache(write_cursor=write_cursor, pools_mapping=updated_pools)
 
         return True
 


### PR DESCRIPTION
This PR:
- solves an error with message being a tuple instead of a string
- prevents the curve module from raising `NotERC20Conformant` since the curve pool tokens follow the standard. The special case was `0x6b8734ad31D42F5c05A86594314837C416ADA984`