### PR TITLE
Fixes trades refresh to only check connected exchanges

### DIFF
--- a/frontend/app/src/components/history/transactions/TransactionEventNote.vue
+++ b/frontend/app/src/components/history/transactions/TransactionEventNote.vue
@@ -132,7 +132,9 @@ const formatNotes = (
 </script>
 <template>
   <div>
-    <template v-for="(note, index) in formatNotes(notes, amount, asset, noTxHash)">
+    <template
+      v-for="(note, index) in formatNotes(notes, amount, asset, noTxHash)"
+    >
       <span
         v-if="note.type === 'address' || note.type === 'tx'"
         :key="index"

--- a/frontend/app/src/components/staking/KrakenPage.vue
+++ b/frontend/app/src/components/staking/KrakenPage.vue
@@ -2,15 +2,15 @@
 import FullSizeContent from '@/components/common/FullSizeContent.vue';
 import ProgressScreen from '@/components/helper/ProgressScreen.vue';
 import KrakenStaking from '@/components/staking/kraken/KrakenStaking.vue';
-import { useExchangeBalancesStore } from '@/store/balances/exchanges';
 import { useKrakenStakingStore } from '@/store/staking/kraken';
 import { SupportedExchange } from '@/types/exchanges';
 import { Section } from '@/types/status';
+import { useAssociatedLocationsStore } from '@/store/history/associated-locations';
 
 const { shouldShowLoadingScreen } = useSectionLoading();
 const { load } = useKrakenStakingStore();
 
-const { connectedExchanges } = storeToRefs(useExchangeBalancesStore());
+const { connectedExchanges } = storeToRefs(useAssociatedLocationsStore());
 const isKrakenConnected = computed(() => {
   const exchanges = get(connectedExchanges);
   return exchanges.some(

--- a/frontend/app/src/pages/balances/exchange/index.vue
+++ b/frontend/app/src/pages/balances/exchange/index.vue
@@ -11,6 +11,7 @@ import { type SupportedExchange } from '@/types/exchanges';
 import { TaskType } from '@/types/task-type';
 import { Zero } from '@/utils/bignumbers';
 import { uniqueStrings } from '@/utils/data';
+import { useAssociatedLocationsStore } from '@/store/history/associated-locations';
 
 const props = defineProps({
   exchange: {
@@ -23,7 +24,7 @@ const props = defineProps({
 const { exchange } = toRefs(props);
 const { isTaskRunning } = useTasks();
 const store = useExchangeBalancesStore();
-const { connectedExchanges } = storeToRefs(store);
+const { connectedExchanges } = storeToRefs(useAssociatedLocationsStore());
 
 const selectedExchange = ref<string>('');
 const usedExchanges = computed<SupportedExchange[]>(() => {

--- a/frontend/app/src/store/balances/exchanges.ts
+++ b/frontend/app/src/store/balances/exchanges.ts
@@ -36,11 +36,11 @@ import {
 import { sortDesc } from '@/utils/bignumbers';
 import { assetSum } from '@/utils/calculation';
 import { updateBalancesPrices } from '@/utils/prices';
+import { useAssociatedLocationsStore } from '@/store/history/associated-locations';
 
 export const useExchangeBalancesStore = defineStore(
   'balances/exchanges',
   () => {
-    const connectedExchanges: Ref<Exchange[]> = ref([]);
     const exchangeBalances: Ref<ExchangeData> = ref({});
 
     const { t, tc } = useI18n();
@@ -54,6 +54,7 @@ export const useExchangeBalancesStore = defineStore(
     const { assetPrice } = useBalancePricesStore();
     const { queryRemoveExchange, queryExchangeBalances, querySetupExchange } =
       useExchangeApi();
+    const { connectedExchanges } = storeToRefs(useAssociatedLocationsStore());
 
     const exchanges: ComputedRef<ExchangeInfo[]> = computed(() => {
       const balances = get(exchangeBalances);

--- a/frontend/app/src/store/history/associated-locations.ts
+++ b/frontend/app/src/store/history/associated-locations.ts
@@ -3,6 +3,7 @@ import { useHistoryApi } from '@/services/history';
 import { useNotificationsStore } from '@/store/notifications';
 import { type TradeLocation } from '@/types/history/trade-location';
 import { logger } from '@/utils/logging';
+import { type Exchange } from '@/types/exchanges';
 
 export const useAssociatedLocationsStore = defineStore(
   'history/associated-locations',
@@ -10,6 +11,7 @@ export const useAssociatedLocationsStore = defineStore(
     const { notify } = useNotificationsStore();
     const { t } = useI18n();
     const associatedLocations: Ref<TradeLocation[]> = ref([]);
+    const connectedExchanges: Ref<Exchange[]> = ref([]);
     const { fetchAssociatedLocations: fetchAssociatedLocationsApi } =
       useHistoryApi();
 
@@ -35,6 +37,7 @@ export const useAssociatedLocationsStore = defineStore(
     };
 
     return {
+      connectedExchanges,
       associatedLocations,
       fetchAssociatedLocations
     };


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

With this, the `only_cache=False` requests will happen only for connected exchanges