### PR TITLE
Not connected, not syncing exchange query won't query all

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Changelog
 * :feature:`5463` Deposits into the eth2 contract should now be decoded correctly
 * :bug:`-` Fixed an issue where price for pairs of fiat currencies was not queried properly.
 * :bug:`-` Customized ownership proportions of validators owned by eth1 addresses will now be properly respected.
+* :bug:`-` If an exchange location is set as non-syncing but has also been removed, attempting to query for it will no longer query all exchanges.
 
 * :release:`1.26.3 <2022-12-30>`
 * :bug:`5315` Fix issue where balance is not fully refreshed after detect tokens button pressed.

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -124,11 +124,10 @@ class EventsHistorian:
         with self.db.conn.read_ctx() as cursor:
             excluded_locations = {exchange.location for exchange in self.db.get_settings(cursor).non_syncing_exchanges}  # noqa: E501
 
-        if (
-            location is not None and
-            location not in excluded_locations
-        ):
-            self.query_location_latest_trades(location=location, from_ts=from_ts, to_ts=to_ts)
+        if location is not None:
+            if location not in excluded_locations:
+                self.query_location_latest_trades(location=location, from_ts=from_ts, to_ts=to_ts)
+
             return
 
         # else query all CEXes


### PR DESCRIPTION
Due to a faulty if condition if an exchange that used to be connected to and is now removed is attempted to be queried, for all trades then all exchanges would be queried instead if that exchange was also in the non-syncing exchanges list.

This commit adds a test for and fixes it.

This was uncovered due to frontend querying FTX with cache_only being False while API key are removed (which is separately fixed in #5554 )