### PR TITLE
Fixes automatic changelog generation

### DIFF
--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -26,11 +26,9 @@ jobs:
         id: change_log
         run: |
           version=$(echo $RELEASE_VERSION | sed 's/^v//g')
-          changes=$(python3 tools/scripts/generate_changelog.py -f docs/changelog.rst -v $version)
-          changes="${changes//'%'/'%25'}"
-          changes="${changes//$'\n'/'%0A'}"
-          changes="${changes//$'\r'/'%0D'}"        
-          echo "changes=${changes}" >> $GITHUB_OUTPUT
+          echo 'changes<<EOF' >> $GITHUB_OUTPUT
+          python3 tools/scripts/generate_changelog.py -f docs/changelog.rst -v $version >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
@@ -280,7 +278,7 @@ jobs:
           draft: true
           files: |
             dist/*.sha512
-            dist/rotki-core-*-macos.zip    
+            dist/rotki-core-*-macos.zip
 
   windows:
     name: 'Build windows binary'
@@ -323,7 +321,7 @@ jobs:
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: |            
+          path: |
             ${{ steps.pnpm-cache.outputs.STORE_PATH }}
             frontend/app/components.d.ts
             ~\AppData\Local\Cypress
@@ -386,7 +384,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |            
+          tags: |
             ${{ github.repository }}:${{ steps.rotki_version.outputs.version }}
           build-args: |
             REVISION=${{ github.sha }}

--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -1,3 +1,5 @@
+name: Backend Tests
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -1,3 +1,5 @@
+name: E2E tests
+
 on:
   workflow_call:
 


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

So after searching a bit the previous way was the way to handle multiline strings with the old set-output.

For the new way with the environment variable, you need a slightly different approach.

https://trstringer.com/github-actions-multiline-strings/

I tested it on my fork and it works fine.