### PR TITLE
Unskip and simplify bisq market test

### DIFF
--- a/rotkehlchen/tests/external_apis/test_bisq_market.py
+++ b/rotkehlchen/tests/external_apis/test_bisq_market.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from rotkehlchen.constants.assets import A_3CRV, A_BSQ
@@ -7,11 +9,10 @@ from rotkehlchen.externalapis.bisq_market import get_bisq_market_price
 from rotkehlchen.types import Price
 
 
-@pytest.mark.skip('bisq.markets API is unreliable. Check #4849')
 def test_market_request():
     """Test that we can query bisq for market prices"""
-    price = get_bisq_market_price(A_BSQ)
-    assert price != Price(ZERO)
+    price_in_btc = get_bisq_market_price(A_BSQ.resolve_to_crypto_asset())
+    assert price_in_btc != Price(ZERO)
     # Test that error is correctly raised when there is no market
-    with pytest.raises(RemoteError):
-        get_bisq_market_price(A_3CRV)
+    with patch('rotkehlchen.externalapis.bisq_market.DEFAULT_TIMEOUT_TUPLE', new=(1, 1)), pytest.raises(RemoteError):  # noqa: E501
+        get_bisq_market_price(A_3CRV.resolve_to_crypto_asset())


### PR DESCRIPTION
The API seems to work fine now. Am patching the default timeout to
fail faster.

Could not see any other API for the token. If it misbehaves again we
can just remove the test.