### PR TITLE
Do not send user message but just log warning for remote sync check

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -405,7 +405,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
                 return False, message
 
             if not synchronized:
-                self.etherscan.msg_aggregator.add_warning(
+                log.warning(
                     f'We could not verify that {self.chain_name} node {node} is '
                     'synchronized with the network. Balances and other queries '
                     'may be incorrect.',

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -198,7 +198,7 @@ class SubstrateManager():
         try:
             chain_metadata = self._request_chain_metadata()
         except RemoteError:
-            self.msg_aggregator.add_warning(
+            log.warning(
                 f'Unable to verify that {self.chain} node at endpoint {node_interface.url} '
                 f'is synced with the chain. Balances and other queries may be incorrect.',
             )


### PR DESCRIPTION
It can happen way too often that a remote is ~10 blocks away from the "source of truth" ... or that the source of truth is itself wrong.

So just log a warning in the logs and don't bother the user