### PR TITLE
Refactor node querying logic

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -5016,15 +5016,17 @@ class RestAPI():
                 tx_hash=tx_hash,
                 associated_address=associated_address,
             )
-        except (KeyError, DeserializationError, RemoteError, sqlcipher.IntegrityError) as e:  # pylint: disable=no-member  # noqa: E501
+        except (KeyError, DeserializationError, RemoteError, sqlcipher.IntegrityError, InputError) as e:  # pylint: disable=no-member  # noqa: E501
             if isinstance(e, sqlcipher.IntegrityError):  # pylint: disable=no-member
                 status_code = HTTPStatus.CONFLICT
+            elif isinstance(e, InputError):
+                status_code = HTTPStatus.NOT_FOUND
             else:
                 status_code = HTTPStatus.BAD_GATEWAY
 
             return wrap_in_fail_result(
                 message=(
-                    f'Unable to add transaction with hash {tx_hash.hex()} for chain  '
+                    f'Unable to add transaction with hash {tx_hash.hex()} for chain '
                     f'{evm_chain} and associated address {associated_address} due to {str(e)}'
                 ),
                 status_code=status_code,

--- a/rotkehlchen/chain/ethereum/constants.py
+++ b/rotkehlchen/chain/ethereum/constants.py
@@ -1,6 +1,7 @@
 from rotkehlchen.chain.evm.types import NodeName, WeightedNode, string_to_evm_address
 from rotkehlchen.constants.misc import ONE
-from rotkehlchen.types import SupportedBlockchain, Timestamp
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import SupportedBlockchain, Timestamp, deserialize_evm_tx_hash
 
 ETHEREUM_ETHERSCAN_NODE_NAME = 'etherscan'
 MODULES_PACKAGE = 'rotkehlchen.chain.ethereum.modules'
@@ -29,3 +30,9 @@ RAY_DIGITS = 27
 RAY = 10**RAY_DIGITS
 
 ETH_MANTISSA = 10 ** DEFAULT_TOKEN_DECIMALS
+
+ARCHIVE_NODE_CHECK_ADDRESS = string_to_evm_address('0x50532e4Be195D1dE0c2E6DfA46D9ec0a4Fee6861')
+ARCHIVE_NODE_CHECK_BLOCK = 87042
+ARCHIVE_NODE_CHECK_EXPECTED_BALANCE = FVal('5.1063307')
+
+PRUNED_NODE_CHECK_TX_HASH = deserialize_evm_tx_hash('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')  # noqa: E501

--- a/rotkehlchen/chain/evm/types.py
+++ b/rotkehlchen/chain/evm/types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, NamedTuple, Optional
 
 from eth_typing import HexAddress, HexStr
+from web3 import Web3
 
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ChecksumEvmAddress, SupportedBlockchain
@@ -84,3 +85,10 @@ class WeightedNode:
 class EvmAccount(NamedTuple):
     address: ChecksumEvmAddress
     chain_id: Optional[SUPPORTED_CHAIN_IDS] = None
+
+
+class Web3Node(NamedTuple):
+    """This represents an EVM node with its capabilities."""
+    web3_instance: Web3
+    is_pruned: bool
+    is_archive: bool

--- a/rotkehlchen/chain/optimism/constants.py
+++ b/rotkehlchen/chain/optimism/constants.py
@@ -1,6 +1,7 @@
-from rotkehlchen.chain.evm.types import NodeName, WeightedNode
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode, string_to_evm_address
 from rotkehlchen.constants.misc import ONE
-from rotkehlchen.types import SupportedBlockchain, Timestamp
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import SupportedBlockchain, Timestamp, deserialize_evm_tx_hash
 
 OPTIMISM_ETHERSCAN_NODE_NAME = 'optimism etherscan'
 OPTIMISM_GENESIS = Timestamp(1636666246)
@@ -16,3 +17,9 @@ OPTIMISM_ETHERSCAN_NODE = WeightedNode(
 )
 
 CPT_OPTIMISM = 'optimism'
+
+ARCHIVE_NODE_CHECK_ADDRESS = string_to_evm_address('0x76a05Df20bFEF5EcE3eB16afF9cb10134199A921')
+ARCHIVE_NODE_CHECK_BLOCK = 74000
+ARCHIVE_NODE_CHECK_EXPECTED_BALANCE = FVal('0.05')
+
+PRUNED_NODE_CHECK_TX_HASH = deserialize_evm_tx_hash('0x5e77a04531c7c107af1882d76cbff9486d0a9aa53701c30888509d4f5f2b003a')  # noqa: E501

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -9,6 +9,7 @@ from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.tests.utils.checks import assert_serialized_dicts_equal
 from rotkehlchen.tests.utils.ethereum import (
     ETHEREUM_FULL_TEST_PARAMETERS,
+    ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED,
     ETHEREUM_TEST_PARAMETERS,
     wait_until_all_nodes_connected,
 )
@@ -305,3 +306,22 @@ def test_get_blocknumber_by_time_subgraph(ethereum_inquirer):
 def test_get_blocknumber_by_time_etherscan(ethereum_inquirer):
     """Queries etherscan for known block times"""
     _test_get_blocknumber_by_time(ethereum_inquirer, True)
+
+
+@pytest.mark.parametrize(*ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
+def test_ethereum_nodes_prune_and_archive_status(
+        ethereum_inquirer,
+        ethereum_manager_connect_at_start,
+):
+    """Checks that connecting to a set of ethereum nodes, the capabilities of those nodes are known and stored."""  # noqa: E501
+    wait_until_all_nodes_connected(
+        connect_at_start=ethereum_manager_connect_at_start,
+        evm_inquirer=ethereum_inquirer,
+    )
+    for node_name, web3_node in ethereum_inquirer.web3_mapping.items():
+        if node_name.endpoint == 'https://ethereum.publicnode.com':
+            assert web3_node.is_pruned
+            assert not web3_node.is_archive
+        else:
+            assert not web3_node.is_pruned
+            assert web3_node.is_archive

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -1,5 +1,4 @@
 from unittest.mock import patch
-
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
 from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
 from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery

--- a/rotkehlchen/tests/unit/test_makerdao.py
+++ b/rotkehlchen/tests/unit/test_makerdao.py
@@ -10,12 +10,16 @@ from rotkehlchen.chain.ethereum.modules.makerdao.vaults import (
     MakerdaoVaults,
     create_collateral_type_mapping,
 )
+from rotkehlchen.chain.evm.types import Web3Node
 from rotkehlchen.constants.assets import A_BAT, A_DAI, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.fval import FVal
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.tests.utils.blockchain import get_web3_from_inquirer, set_web3_in_inquirer
+from rotkehlchen.tests.utils.blockchain import (
+    get_web3_node_from_inquirer,
+    set_web3_node_in_inquirer,
+)
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.tests.utils.makerdao import VaultTestData, create_web3_mock
 
@@ -92,9 +96,12 @@ def fixture_makerdao_vaults(
         makerdao_test_data,
 ):
     if not use_etherscan:
-        set_web3_in_inquirer(ethereum_inquirer, Web3())
-        web3_instance = get_web3_from_inquirer(ethereum_inquirer)
-        web3_patch = create_web3_mock(web3=web3_instance, ethereum=ethereum_inquirer, test_data=makerdao_test_data)  # noqa: E501
+        set_web3_node_in_inquirer(
+            ethereum_inquirer=ethereum_inquirer,
+            web3node=Web3Node(web3_instance=Web3(), is_pruned=False, is_archive=True),
+        )
+        web3_node = get_web3_node_from_inquirer(ethereum_inquirer)
+        web3_patch = create_web3_mock(web3=web3_node.web3_instance, ethereum=ethereum_inquirer, test_data=makerdao_test_data)  # noqa: E501
     else:
         web3_patch = nullcontext()
 
@@ -115,8 +122,8 @@ def fixture_makerdao_vaults(
 @pytest.mark.parametrize('number_of_eth_accounts', [2])
 @pytest.mark.parametrize('mocked_proxies', [{}])
 def test_get_vaults(makerdao_vaults, makerdao_test_data, ethereum_inquirer):
-    web3_instance = get_web3_from_inquirer(makerdao_vaults.ethereum)
-    web3_patch = create_web3_mock(web3=web3_instance, ethereum=ethereum_inquirer, test_data=makerdao_test_data)  # noqa: E501
+    web3_node = get_web3_node_from_inquirer(makerdao_vaults.ethereum)
+    web3_patch = create_web3_mock(web3=web3_node.web3_instance, ethereum=ethereum_inquirer, test_data=makerdao_test_data)  # noqa: E501
     with web3_patch:
         vaults = makerdao_vaults.get_vaults()
 

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -4,6 +4,11 @@ from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.optimism import OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
 
 
+@pytest.mark.vcr(
+    match_on=['uri', 'method', 'raw_body'],
+    filter_query_parameters=['apikey'],
+    allow_playback_repeats=True,
+)
 @pytest.mark.parametrize(*OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 def test_optimism_nodes_prune_and_archive_status(
         optimism_manager_connect_at_start,
@@ -29,3 +34,5 @@ def test_optimism_nodes_prune_and_archive_status(
             assert web3_node.is_archive
         else:
             raise AssertionError(f'Unknown node {node_name} encountered.')
+
+    assert len(optimism_inquirer.web3_mapping) == len(optimism_manager_connect_at_start)

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -1,0 +1,31 @@
+import pytest
+
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
+from rotkehlchen.tests.utils.optimism import OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
+
+
+@pytest.mark.parametrize(*OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
+def test_optimism_nodes_prune_and_archive_status(
+        optimism_manager_connect_at_start,
+        optimism_inquirer,
+):
+    """Checks that connecting to a set of optimism nodes, the capabilities of those nodes are known and stored."""  # noqa: E501
+    wait_until_all_nodes_connected(
+        connect_at_start=optimism_manager_connect_at_start,
+        evm_inquirer=optimism_inquirer,
+    )
+    for node_name, web3_node in optimism_inquirer.web3_mapping.items():
+        if node_name.endpoint == 'https://rpc.ankr.com/optimism':
+            assert not web3_node.is_pruned
+            assert not web3_node.is_archive
+        elif node_name.endpoint == 'https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4':  # noqa: E501
+            assert not web3_node.is_pruned
+            assert not web3_node.is_archive
+        elif node_name.endpoint == 'https://mainnet.optimism.io':
+            assert not web3_node.is_pruned
+            assert web3_node.is_archive
+        elif node_name.endpoint == 'https://optimism-mainnet.public.blastapi.io':
+            assert not web3_node.is_pruned
+            assert web3_node.is_archive
+        else:
+            raise AssertionError(f'Unknown node {node_name} encountered.')

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -7,7 +7,7 @@ from web3._utils.abi import get_abi_input_types, get_abi_output_types
 
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.ethereum.defi.zerionsdk import ZERION_ADAPTER_ADDRESS
-from rotkehlchen.chain.evm.types import NodeName
+from rotkehlchen.chain.evm.types import NodeName, Web3Node
 from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
@@ -581,8 +581,8 @@ def compare_account_data(expected: list[dict], got: list[dict]) -> None:
         assert found, msg
 
 
-def get_web3_from_inquirer(ethereum_inquirer: 'EthereumInquirer') -> Web3:
-    """Util function to simplify getting the testing web3 object from an ethereum inquirer"""
+def get_web3_node_from_inquirer(ethereum_inquirer: 'EthereumInquirer') -> Web3Node:
+    """Util function to simplify getting the testing web3 node object from an ethereum inquirer"""
     node_name = NodeName(
         name='own',
         endpoint='bla',
@@ -592,15 +592,15 @@ def get_web3_from_inquirer(ethereum_inquirer: 'EthereumInquirer') -> Web3:
     return ethereum_inquirer.web3_mapping[node_name]
 
 
-def set_web3_in_inquirer(ethereum_inquirer: 'EthereumInquirer', web3: Web3) -> None:
-    """Util function to simplify setting the testing web3 object from an ethereum inquirer"""
+def set_web3_node_in_inquirer(ethereum_inquirer: 'EthereumInquirer', web3node: Web3Node) -> None:
+    """Util function to simplify setting the testing web3 node object from an ethereum inquirer"""
     node_name = NodeName(
         name='own',
         endpoint='bla',
         owned=True,
         blockchain=SupportedBlockchain.ETHEREUM,
     )
-    ethereum_inquirer.web3_mapping[node_name] = web3
+    ethereum_inquirer.web3_mapping[node_name] = web3node
 
 
 def setup_filter_active_evm_addresses_mock(

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -48,6 +48,17 @@ INFURA_TEST = random.choice([
 ])
 ALCHEMY_TEST = 'https://eth-mainnet.alchemyapi.io/v2/ga1GtB7R26UgzjextaVpbaWZ49nSi2zt'
 
+PRUNED_AND_NOT_ARCHIVED_NODE = WeightedNode(
+    node_info=NodeName(
+        name='Public Node',
+        endpoint='https://ethereum.publicnode.com',
+        owned=True,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    ),
+    active=True,
+    weight=ONE,
+)
+
 ETHERSCAN_AND_INFURA_PARAMS: tuple[str, list[tuple]] = ('ethereum_manager_connect_at_start, call_order', [  # noqa: E501
     ((), (ETHEREUM_ETHERSCAN_NODE,)),
     (
@@ -74,6 +85,16 @@ TEST_ADDR1 = string_to_evm_address('0x443E1f9b1c866E54e914822B7d3d7165EdB6e9Ea')
 TEST_ADDR2 = string_to_evm_address('0x442068F934BE670aDAb81242C87144a851d56d16')
 TEST_ADDR3 = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
 
+ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED = (
+    'ethereum_manager_connect_at_start',
+    [
+        (
+            PRUNED_AND_NOT_ARCHIVED_NODE,
+            ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][1][0][0],
+            ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][2][0][0],
+        ),
+    ],
+)
 
 # Test with etherscan and infura
 ETHEREUM_TEST_PARAMETERS: tuple[str, list[tuple]]
@@ -89,7 +110,7 @@ else:
     ETHEREUM_TEST_PARAMETERS = ETHERSCAN_AND_INFURA_PARAMS
 
 
-# Test with multipe node types and etherscan
+# Test with multiple node types and etherscan
 ETHEREUM_FULL_TEST_PARAMETERS: tuple[str, list[tuple]]
 if 'GITHUB_WORKFLOW' in os.environ:
     # For Github actions don't use infura. It seems that connecting to it

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -90,7 +90,17 @@ ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED = (
     [
         (
             PRUNED_AND_NOT_ARCHIVED_NODE,
-            ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][1][0][0],
+            WeightedNode(
+                node_info=NodeName(
+                    name='Infura',
+                    endpoint='https://mainnet.infura.io/v3/a6b269b6e5ad44ed943e9fff244dfe25',
+                    owned=True,
+                    blockchain=SupportedBlockchain.ETHEREUM,
+                ),
+                active=True,
+                weight=ONE,
+            ),
+            ETHEREUM_ETHERSCAN_NODE,
             ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][2][0][0],
         ),
     ],

--- a/rotkehlchen/tests/utils/evm.py
+++ b/rotkehlchen/tests/utils/evm.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from rotkehlchen.chain.evm.types import Web3Node
 from rotkehlchen.tests.utils.mock import (
     MOCK_WEB3_LAST_BLOCK_INT,
     patch_etherscan_request,
@@ -21,7 +22,11 @@ def maybe_mock_evm_inquirer(
     # we have to mock connect to given nodes, and patch their requests
     for mocked_node in manager_connect_at_start:
         web3, _ = evm_inquirer._init_web3(mocked_node.node_info)
-        evm_inquirer.web3_mapping[mocked_node.node_info] = web3
+        evm_inquirer.web3_mapping[mocked_node.node_info] = Web3Node(
+            web3_instance=web3,
+            is_pruned=False,
+            is_archive=True,
+        )
         parent_stack.enter_context(patch_web3_request(web3, mock_data))
     parent_stack.enter_context(patch.object(
         evm_inquirer,

--- a/rotkehlchen/tests/utils/optimism.py
+++ b/rotkehlchen/tests/utils/optimism.py
@@ -1,0 +1,46 @@
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode
+from rotkehlchen.constants import ONE
+from rotkehlchen.types import SupportedBlockchain
+
+OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED: tuple[str, list[tuple]] = (
+    'optimism_manager_connect_at_start',
+    [(WeightedNode(
+        node_info=NodeName(
+            name='own',
+            endpoint='https://mainnet.optimism.io',
+            owned=False,
+            blockchain=SupportedBlockchain.OPTIMISM,
+        ),
+        active=True,
+        weight=ONE,
+    ), WeightedNode(
+        node_info=NodeName(
+            name='node real',
+            # does not offer archive nodes for optimism
+            # https://docs.nodereal.io/docs/archive-node
+            endpoint='https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4',
+            owned=True,
+            blockchain=SupportedBlockchain.OPTIMISM,
+        ),
+        active=True,
+        weight=ONE,
+    ), WeightedNode(
+        node_info=NodeName(
+            name='blast api',
+            endpoint='https://optimism-mainnet.public.blastapi.io',
+            owned=True,
+            blockchain=SupportedBlockchain.OPTIMISM,
+        ),
+        active=True,
+        weight=ONE,
+    ), WeightedNode(
+        node_info=NodeName(
+            name='ankr',
+            endpoint='https://rpc.ankr.com/optimism',
+            owned=False,
+            blockchain=SupportedBlockchain.OPTIMISM,
+        ),
+        active=True,
+        weight=ONE,
+    ))],
+)


### PR DESCRIPTION
## Checklist
This PR does the following:

- Upon node connection, its capabalities are determined i.e whether it's pruned, archive node or not.
- Refactor typing of node methods e.g `get_transaction_by_hash`, `get_transaction_receipt`
- Handle cases where a tx hash does not exist on-chain in evm txn addition by hash
- Add and refactor tests to handle these changes.

Also, it fixes [`rotkehlchen/tests/conftest.py`](https://github.com/rotki/rotki/blob/2de468cae60907d1cfa685c4c98d9a0c5d891610/rotkehlchen/tests/conftest.py#L258) issue with the `caching_dir` filepath on Mac