### PR TITLE
fix: per field error from endpoint not showed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Fixes bug where error message is not showed when some input filled with incorrect value.
 * :bug:`-` Fixes bug where Maker Vault Collateralization Ratio can't be edited in watcher form.
 * :bug:`-` Fixes bug where wrong account label was used in asset location breakdown.
 * :bug:`5560` EVM transaction events should now be properly ignored in accounting.

--- a/frontend/app/src/components/accounts/blockchain/Eth2Input.vue
+++ b/frontend/app/src/components/accounts/blockchain/Eth2Input.vue
@@ -8,6 +8,7 @@ import {
   minValue,
   requiredUnless
 } from '@vuelidate/validators';
+import isEmpty from 'lodash/isEmpty';
 import { type Eth2Validator } from '@/types/balances';
 import { type ValidationErrors } from '@/types/api/errors';
 
@@ -20,6 +21,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:validator', validator: Eth2Validator | null): void;
 }>();
+
 const { validator, errorMessages } = toRefs(props);
 const validatorIndex = ref('');
 const publicKey = ref('');
@@ -61,6 +63,12 @@ const v$ = useVuelidate(
     $externalResults: errorMessages
   }
 );
+
+watch(errorMessages, errors => {
+  if (!isEmpty(errors)) {
+    get(v$).$validate();
+  }
+});
 
 onMounted(() => updateProperties(validator.value));
 

--- a/frontend/app/src/components/accounts/blockchain/XpubInput.vue
+++ b/frontend/app/src/components/accounts/blockchain/XpubInput.vue
@@ -3,6 +3,7 @@
 import { Blockchain } from '@rotki/common/lib/blockchain';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
+import isEmpty from 'lodash/isEmpty';
 import { type XpubPayload } from '@/store/balances/types';
 import { trimOnPaste } from '@/utils/event';
 import {
@@ -22,7 +23,9 @@ const props = defineProps<{
   blockchain: BtcChains;
 }>();
 
-const emit = defineEmits(['update:xpub']);
+const emit = defineEmits<{
+  (e: 'update:xpub', event: XpubPayload | null): void;
+}>();
 
 const { t, tc } = useI18n();
 
@@ -129,6 +132,12 @@ const v$ = useVuelidate(
     $externalResults: errorMessages
   }
 );
+
+watch(errorMessages, errors => {
+  if (!isEmpty(errors)) {
+    get(v$).$validate();
+  }
+});
 </script>
 
 <template>

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalancesForm.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalancesForm.vue
@@ -131,6 +131,7 @@ const save = async () => {
     const errorMessages = deserializeApiErrorMessage(status.message);
     if (errorMessages) {
       set(errors, (errorMessages?.balances[0] as any) ?? {});
+      await get(v$).$validate();
     } else {
       const obj = { message: status.message };
       setMessage({
@@ -165,6 +166,8 @@ watch(label, label => {
     const { label, ...data } = get(errors);
     set(errors, data);
   }
+
+  get(v$).label.$validate();
 });
 
 const customAssetFormRef: Ref<InstanceType<typeof CustomAssetForm> | null> =
@@ -250,7 +253,6 @@ onMounted(async () => {
     await form?.searchAssetPrice(editPayload.asset);
   }
 });
-
 defineExpose({
   save
 });

--- a/frontend/app/src/components/asset-manager/MergeDialog.vue
+++ b/frontend/app/src/components/asset-manager/MergeDialog.vue
@@ -47,6 +47,7 @@ async function merge() {
       ...get(errorMessages),
       result.message ?? t('merge_dialog.error').toString()
     ]);
+    get(v$).$validate();
   }
   set(pending, false);
 }

--- a/frontend/app/src/components/history/ExternalTradeForm.vue
+++ b/frontend/app/src/components/history/ExternalTradeForm.vue
@@ -72,13 +72,13 @@ const baseSymbol = assetSymbol(base);
 const quoteSymbol = assetSymbol(quote);
 
 const rules = {
-  base: {
+  baseAsset: {
     required: helpers.withMessage(
       t('external_trade_form.validation.non_empty_base').toString(),
       required
     )
   },
-  quote: {
+  quoteAsset: {
     required: helpers.withMessage(
       t('external_trade_form.validation.non_empty_quote').toString(),
       required
@@ -119,8 +119,8 @@ const rules = {
 const v$ = useVuelidate(
   rules,
   {
-    base,
-    quote,
+    baseAsset: base,
+    quoteAsset: quote,
     amount,
     rate,
     quoteAmount,
@@ -231,6 +231,8 @@ const save = async (): Promise<boolean> => {
       errorMessages,
       convertKeys(deserializeApiErrorMessage(result.message) ?? {}, true, false)
     );
+
+    await get(v$).$validate();
   }
 
   return false;
@@ -289,6 +291,7 @@ const fetchPrice = async () => {
     set(errorMessages, {
       rate: [t('external_trade_form.rate_not_found').toString()]
     });
+    await get(v$).rate.$validate();
     useTimeoutFn(() => {
       set(errorMessages, {});
     }, 4000);
@@ -351,7 +354,6 @@ onMounted(() => {
               persistent-hint
               :hint="t('external_trade_form.date.hint')"
               :error-messages="errorMessages['timestamp']"
-              @focus="delete errorMessages['timestamp']"
             />
             <div data-cy="type">
               <v-radio-group
@@ -381,10 +383,9 @@ onMounted(() => {
                   outlined
                   required
                   data-cy="base-asset"
-                  :error-messages="v$.base.$errors.map(e => e.$message)"
+                  :error-messages="v$.baseAsset.$errors.map(e => e.$message)"
                   :hint="t('external_trade_form.base_asset.hint')"
                   :label="t('external_trade_form.base_asset.label')"
-                  @focus="delete errorMessages['baseAsset']"
                 />
               </v-col>
               <v-col cols="12" md="6" class="d-flex flex-row align-center">
@@ -396,10 +397,9 @@ onMounted(() => {
                   required
                   outlined
                   data-cy="quote-asset"
-                  :error-messages="v$.quote.$errors.map(e => e.$message)"
+                  :error-messages="v$.quoteAsset.$errors.map(e => e.$message)"
                   :hint="t('external_trade_form.quote_asset.hint')"
                   :label="t('external_trade_form.quote_asset.label')"
-                  @focus="delete errorMessages['quoteAsset']"
                 />
               </v-col>
             </v-row>
@@ -413,7 +413,6 @@ onMounted(() => {
                 :label="t('common.amount')"
                 persistent-hint
                 :hint="t('external_trade_form.amount.hint')"
-                @focus="delete errorMessages['amount']"
               />
               <div
                 :class="`external-trade-form__grouped-amount-input d-flex ${
@@ -438,7 +437,6 @@ onMounted(() => {
                   }`"
                   filled
                   persistent-hint
-                  @focus="delete errorMessages['rate']"
                 />
                 <amount-input
                   ref="quoteAmountInput"
@@ -454,7 +452,6 @@ onMounted(() => {
                   }`"
                   :label="t('external_trade_form.quote_amount.label')"
                   filled
-                  @focus="delete errorMessages['quote_amount']"
                 />
                 <v-btn
                   class="external-trade-form__grouped-amount-input__swap-button"
@@ -548,7 +545,6 @@ onMounted(() => {
               :label="t('external_trade_form.fee.label')"
               :hint="t('external_trade_form.fee.hint')"
               :error-messages="v$.fee.$errors.map(e => e.$message)"
-              @focus="delete errorMessages['fee']"
               @input="triggerFeeValidator"
             />
           </v-col>
@@ -563,7 +559,6 @@ onMounted(() => {
               :hint="t('external_trade_form.fee_currency.hint')"
               :required="!!fee"
               :error-messages="v$.feeCurrency.$errors.map(e => e.$message)"
-              @focus="delete errorMessages['feeCurrency']"
               @input="triggerFeeValidator"
             />
           </v-col>
@@ -577,7 +572,6 @@ onMounted(() => {
           persistent-hint
           :hint="t('external_trade_form.link.hint')"
           :error-messages="errorMessages['link']"
-          @focus="delete errorMessages['link']"
         />
         <v-textarea
           v-model="notes"
@@ -589,7 +583,6 @@ onMounted(() => {
           persistent-hint
           :hint="t('external_trade_form.notes.hint')"
           :error-messages="errorMessages['notes']"
-          @focus="delete errorMessages['notes']"
         />
       </v-col>
     </v-row>

--- a/frontend/app/src/components/history/LedgerActionForm.vue
+++ b/frontend/app/src/components/history/LedgerActionForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { helpers, required, requiredIf } from '@vuelidate/validators';
 import dayjs from 'dayjs';
 import { type PropType } from 'vue';
 import LocationSelector from '@/components/helper/LocationSelector.vue';
@@ -82,6 +82,18 @@ const rules = {
       t('ledger_action_form.location.validation.non_empty').toString(),
       required
     )
+  },
+  rate: {
+    required: helpers.withMessage(
+      t('ledger_action_form.rate.validation.non_empty').toString(),
+      requiredIf(refIsTruthy(rateAsset))
+    )
+  },
+  rateAsset: {
+    required: helpers.withMessage(
+      t('ledger_action_form.rate_asset.validation.non_empty').toString(),
+      requiredIf(refIsTruthy(rate))
+    )
   }
 };
 
@@ -90,7 +102,9 @@ const v$ = useVuelidate(
   {
     amount,
     asset,
-    location
+    location,
+    rate,
+    rateAsset
   },
   { $autoDirty: true, $externalResults: errorMessages }
 );
@@ -163,6 +177,8 @@ const save = async (): Promise<boolean> => {
       errorMessages,
       convertKeys(deserializeApiErrorMessage(result.message) ?? {}, true, false)
     );
+
+    await get(v$).$validate();
   }
 
   return false;
@@ -202,7 +218,6 @@ defineExpose({
       data-cy="location"
       :error-messages="v$.location.$errors.map(e => e.$message)"
       :label="tc('common.location')"
-      @focus="delete errorMessages['location']"
     />
 
     <date-time-picker
@@ -216,7 +231,6 @@ defineExpose({
       data-cy="datetime"
       :hint="tc('ledger_action_form.date.hint')"
       :error-messages="errorMessages['timestamp']"
-      @focus="delete errorMessages['timestamp']"
     />
 
     <v-row
@@ -234,7 +248,6 @@ defineExpose({
           required
           data-cy="asset"
           :error-messages="v$.asset.$errors.map(e => e.$message)"
-          @focus="delete errorMessages['asset']"
         />
       </v-col>
 
@@ -246,7 +259,6 @@ defineExpose({
           required
           data-cy="amount"
           :label="tc('common.amount')"
-          @focus="delete errorMessages['amount']"
         />
       </v-col>
 
@@ -261,7 +273,6 @@ defineExpose({
           required
           data-cy="action-type"
           :error-messages="errorMessages['actionType']"
-          @focus="delete errorMessages['actionType']"
         />
       </v-col>
     </v-row>
@@ -281,8 +292,7 @@ defineExpose({
           data-cy="rate"
           :hint="tc('ledger_action_form.rate.hint')"
           :label="tc('ledger_action_form.rate.label')"
-          :error-messages="errorMessages['rate']"
-          @focus="delete errorMessages['rate']"
+          :error-messages="v$.rate.$errors.map(e => e.$message)"
         />
       </v-col>
       <v-col cols="12" md="4">
@@ -293,8 +303,7 @@ defineExpose({
           :hint="tc('ledger_action_form.rate_asset.hint')"
           persistent-hint
           data-cy="rate-asset"
-          :error-messages="errorMessages['rateAsset']"
-          @focus="delete errorMessages['rateAsset']"
+          :error-messages="v$.rateAsset.$errors.map(e => e.$message)"
         />
       </v-col>
     </v-row>
@@ -308,7 +317,6 @@ defineExpose({
       :label="tc('ledger_action_form.link.label')"
       :hint="tc('ledger_action_form.link.hint')"
       :error-messages="errorMessages['link']"
-      @focus="delete errorMessages['link']"
     />
 
     <v-textarea
@@ -320,7 +328,6 @@ defineExpose({
       :label="tc('ledger_action_form.notes.label')"
       :hint="tc('ledger_action_form.notes.hint')"
       :error-messages="errorMessages['notes']"
-      @focus="delete errorMessages['notes']"
     />
   </v-form>
 </template>

--- a/frontend/app/src/components/history/TransactionEventForm.vue
+++ b/frontend/app/src/components/history/TransactionEventForm.vue
@@ -258,6 +258,7 @@ const save = async (): Promise<boolean> => {
     const errorFields = deserializeApiErrorMessage(result.message);
     if (errorFields) {
       set(errorMessages, convertKeys(errorFields, true, false));
+      await get(v$).$validate();
     } else {
       setMessage({
         description: result.message
@@ -368,7 +369,6 @@ defineExpose({
       data-cy="datetime"
       :hint="t('transactions.events.form.datetime.hint')"
       :error-messages="errorMessages['datetime']"
-      @focus="delete errorMessages['datetime']"
     />
 
     <v-row
@@ -485,7 +485,6 @@ defineExpose({
           data-cy="locationLabel"
           :label="t('transactions.events.form.location_label.label')"
           :error-messages="errorMessages['locationLabel']"
-          @focus="delete errorMessages['locationLabel']"
         />
       </v-col>
       <v-col cols="12" md="4">
@@ -495,7 +494,6 @@ defineExpose({
           data-cy="counterparty"
           :label="t('transactions.events.form.counterparty.label')"
           :error-messages="errorMessages['counterparty']"
-          @focus="delete errorMessages['counterparty']"
         />
       </v-col>
     </v-row>
@@ -509,7 +507,6 @@ defineExpose({
       :label="t('transactions.events.form.notes.label')"
       :hint="t('transactions.events.form.notes.hint')"
       :error-messages="errorMessages['notes']"
-      @focus="delete errorMessages['notes']"
     />
   </v-form>
 </template>

--- a/frontend/app/src/components/inputs/AssetSelect.vue
+++ b/frontend/app/src/components/inputs/AssetSelect.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { type PropType, type Ref } from 'vue';
+import { type PropType, type Ref, useListeners } from 'vue';
 import AssetDetailsBase from '@/components/helper/AssetDetailsBase.vue';
 import AssetIcon from '@/components/helper/display/icons/AssetIcon.vue';
 import NftDetails from '@/components/helper/NftDetails.vue';
@@ -166,6 +166,8 @@ onMounted(async () => {
 watch(value, async () => {
   await checkValue();
 });
+
+const listeners = useListeners();
 </script>
 
 <template>
@@ -193,6 +195,7 @@ watch(value, async () => {
     :outlined="outlined"
     no-filter
     :class="outlined ? 'asset-select--outlined' : null"
+    v-on="listeners"
     @input="input"
     @blur="blur"
   >

--- a/frontend/app/src/components/settings/general/rpc/EvmRpcNodeManager.vue
+++ b/frontend/app/src/components/settings/general/rpc/EvmRpcNodeManager.vue
@@ -71,6 +71,7 @@ const save = async () => {
       await api.addEvmNode(omit(node, 'identifier'));
     }
     await loadNodes();
+    clear();
   } catch (e: any) {
     const chainProp = get(chain);
     const errorTitle = editing
@@ -104,7 +105,6 @@ const save = async () => {
     }
   } finally {
     set(loading, false);
-    clear();
   }
 };
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2507,11 +2507,17 @@
     },
     "rate": {
       "hint": "[Optional] Custom rate of the action. If not given the rate for the asset at the given time will be used.",
-      "label": "Rate"
+      "label": "Rate",
+      "validation": {
+        "non_empty": "The rate cannot be empty when rate asset is inputted"
+      }
     },
     "rate_asset": {
       "hint": "[Optional] The asset used for the rate",
-      "label": "Rate asset"
+      "label": "Rate asset",
+      "validation": {
+        "non_empty": "The rate asset cannot be empty when asset is inputted"
+      }
     }
   },
   "ledger_action_settings": {


### PR DESCRIPTION
Closes #(issue_number)

So for the errors per field we show it like this
`$v.field.$errors.map(e => e.$message)`

I think in previous `vuelidate` version, it also pick up the external error from endpoint that we passed through `$externalResults`.
But in current version we use, it no longer picked up. So I have to merge `$errors` and `$externalResults` and show them.

We can move all to use `getErrorMessages` but I think we can do that later in develop instead, in this PR I only repair the ones that have `$externalResults`.