### PR TITLE
Fix events reshuffling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 * :bug:`-` Fixes bug where navigation bar on the left didn't expand by default.
 * :bug:`-` Fixes curve deposits and withdrawals accounting.
 * :bug:`5561` Fixes average cost basis calculation.
+* :bug:`-` Fixes bug when some decoded events in transactions would disappear. 
 
 * :release:`1.27.0 <2023-02-03>`
 * :feature:`5015` EVM assets across multiple chains will now appear together in the dashboard, with an option to break them down into their per-chain holding.

--- a/rotkehlchen/chain/evm/decoding/utils.py
+++ b/rotkehlchen/chain/evm/decoding/utils.py
@@ -32,6 +32,8 @@ def maybe_reshuffle_events(
 
     # If given, check the events list to make sure events are consecutive
     if events_list is not None:
+        # Sort by sequence index to avoid getting duplicate indices further down the line
+        events_list.sort(key=lambda event: event.sequence_index)
         events_num = len(events_list)
         for idx, event in enumerate(events_list):
             if event == out_event:

--- a/rotkehlchen/tests/unit/decoders/test_compound.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound.py
@@ -107,7 +107,7 @@ def test_compound_ether_withdraw(database, ethereum_inquirer):
             counterparty=CPT_COMPOUND,
         ), HistoryBaseEntry(
             event_identifier=tx_hash,
-            sequence_index=2,
+            sequence_index=50,
             timestamp=1598813490000,
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -578,7 +578,7 @@ def test_curve_remove_liquidity_with_internal(database, ethereum_transaction_dec
             extra_data={'withdrawal_events_num': 1},
         ), HistoryBaseEntry(
             event_identifier=evmhash,
-            sequence_index=2,
+            sequence_index=193,
             timestamp=1650276061000,
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,
@@ -811,7 +811,7 @@ def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts
             counterparty=CPT_CURVE,
         ), HistoryBaseEntry(
             event_identifier=evmhash,
-            sequence_index=77,
+            sequence_index=78,
             timestamp=TimestampMS(1675186487000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.DEPOSIT,
@@ -823,7 +823,7 @@ def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts
             counterparty=CPT_CURVE,
         ), HistoryBaseEntry(
             event_identifier=evmhash,
-            sequence_index=78,
+            sequence_index=79,
             timestamp=TimestampMS(1675186487000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.DEPOSIT,
@@ -835,7 +835,7 @@ def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts
             counterparty=CPT_CURVE,
         ), HistoryBaseEntry(
             event_identifier=evmhash,
-            sequence_index=79,
+            sequence_index=80,
             timestamp=TimestampMS(1675186487000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.DEPOSIT,

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -118,7 +118,7 @@ def make_ethereum_event(
         event_subtype: HistoryEventSubType = HistoryEventSubType.NONE,
 ) -> HistoryBaseEntry:
     if tx_hash is None:
-        tx_hash = make_random_bytes(42)
+        tx_hash = make_random_bytes(32)
     return HistoryBaseEntry(
         event_identifier=tx_hash,
         sequence_index=index,


### PR DESCRIPTION
Removes the possibility of the appearance of duplicated indices when reshuffling events.