### PR TITLE
feat: scramble numbers with custom multiplier

### DIFF
--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -282,6 +282,7 @@
     "useRound": true,
     "useRoute": true,
     "useRouter": true,
+    "useScramble": true,
     "useScreenOrientation": true,
     "useScreenSafeArea": true,
     "useScriptTag": true,

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -283,6 +283,7 @@ declare global {
   const useRound: typeof import('@vueuse/math')['useRound']
   const useRoute: typeof import('vue-router/composables')['useRoute']
   const useRouter: typeof import('vue-router/composables')['useRouter']
+  const useScramble: typeof import('./composables/scramble')['useScramble']
   const useScreenOrientation: typeof import('@vueuse/core')['useScreenOrientation']
   const useScreenSafeArea: typeof import('@vueuse/core')['useScreenSafeArea']
   const useScriptTag: typeof import('@vueuse/core')['useScriptTag']
@@ -649,6 +650,7 @@ declare module 'vue' {
     readonly useRound: UnwrapRef<typeof import('@vueuse/math')['useRound']>
     readonly useRoute: UnwrapRef<typeof import('vue-router/composables')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router/composables')['useRouter']>
+    readonly useScramble: UnwrapRef<typeof import('./composables/scramble')['useScramble']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>
     readonly useScriptTag: UnwrapRef<typeof import('@vueuse/core')['useScriptTag']>

--- a/frontend/app/src/components/AssetBalances.vue
+++ b/frontend/app/src/components/AssetBalances.vue
@@ -99,6 +99,7 @@ const sortItems = getSortItems(asset => get(assetInfo(asset)));
     <template #item.usdPrice="{ item }">
       <amount-display
         v-if="item.usdPrice && item.usdPrice.gte(0)"
+        no-scramble
         show-currency="symbol"
         :price-asset="item.asset"
         :price-of-asset="item.usdPrice"

--- a/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
+++ b/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
@@ -327,6 +327,7 @@ const showDeleteConfirmation = (item: NonFungibleBalance) => {
               :price-asset="item.priceAsset"
               :amount="item.priceInAsset"
               :value="item.usdPrice"
+              no-scramble
               show-currency="symbol"
               fiat-currency="USD"
             />

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -175,6 +175,7 @@ const showDeleteConfirmation = (id: number) => {
       <template #item.usdPrice="{ item }">
         <amount-display
           v-if="item.usdPrice && item.usdPrice.gte(0)"
+          no-scramble
           show-currency="symbol"
           :price-asset="item.asset"
           :price-of-asset="item.usdPrice"

--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -227,6 +227,7 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
       <template #item.usdPrice="{ item }">
         <amount-display
           v-if="item.usdPrice && item.usdPrice.gte(0)"
+          no-scramble
           show-currency="symbol"
           :price-asset="item.asset"
           :price-of-asset="item.usdPrice"

--- a/frontend/app/src/components/dashboard/LiquidityProviderBalanceDetails.vue
+++ b/frontend/app/src/components/dashboard/LiquidityProviderBalanceDetails.vue
@@ -94,6 +94,7 @@ const transformAssets = (assets: XswapAsset[]): AssetBalanceWithPrice[] => {
       <template #item.usdPrice="{ item }">
         <amount-display
           v-if="item.usdPrice && item.usdPrice.gte(0)"
+          no-scramble
           show-currency="symbol"
           :price-asset="item.asset"
           :price-of-asset="item.usdPrice"

--- a/frontend/app/src/components/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/NftBalanceTable.vue
@@ -222,6 +222,7 @@ onMounted(async () => {
           </template>
           <template #item.usdPrice="{ item }">
             <amount-display
+              no-scramble
               :price-asset="item.priceAsset"
               :amount="item.priceInAsset"
               :value="item.usdPrice"

--- a/frontend/app/src/components/display/AccountDisplay.vue
+++ b/frontend/app/src/components/display/AccountDisplay.vue
@@ -7,7 +7,6 @@ import {
 import { truncateAddress } from '@/filters';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
 import { useSessionSettingsStore } from '@/store/settings/session';
-import { randomHex } from '@/utils/data';
 
 const AssetIcon = defineAsyncComponent(
   () => import('@/components/helper/display/icons/AssetIcon.vue')
@@ -26,17 +25,19 @@ const props = withDefaults(
 );
 
 const { account, useAliasName } = toRefs(props);
-const { scrambleData, shouldShowAmount } = storeToRefs(
-  useSessionSettingsStore()
-);
+
+const sessionSettingsStore = useSessionSettingsStore();
+const { scrambleData, shouldShowAmount } = storeToRefs(sessionSettingsStore);
+const { scrambleHex } = sessionSettingsStore;
 
 const { addressNameSelector } = useAddressesNamesStore();
 
 const address = computed<string>(() => {
+  const address = get(account).address;
   if (!get(scrambleData)) {
-    return get(account).address;
+    return address;
   }
-  return randomHex();
+  return scrambleHex(address);
 });
 
 const aliasName = computed<string | null>(() => {

--- a/frontend/app/src/components/display/AccountDisplay.vue
+++ b/frontend/app/src/components/display/AccountDisplay.vue
@@ -6,7 +6,6 @@ import {
 } from '@rotki/common/lib/blockchain';
 import { truncateAddress } from '@/filters';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
-import { useSessionSettingsStore } from '@/store/settings/session';
 
 const AssetIcon = defineAsyncComponent(
   () => import('@/components/helper/display/icons/AssetIcon.vue')
@@ -25,11 +24,7 @@ const props = withDefaults(
 );
 
 const { account, useAliasName } = toRefs(props);
-
-const sessionSettingsStore = useSessionSettingsStore();
-const { scrambleData, shouldShowAmount } = storeToRefs(sessionSettingsStore);
-const { scrambleHex } = sessionSettingsStore;
-
+const { scrambleData, shouldShowAmount, scrambleHex } = useScramble();
 const { addressNameSelector } = useAddressesNamesStore();
 
 const address = computed<string>(() => {

--- a/frontend/app/src/components/display/AmountDisplay.vue
+++ b/frontend/app/src/components/display/AmountDisplay.vue
@@ -54,7 +54,8 @@ const props = defineProps({
   },
 
   // This prop to give color to the text based on the value
-  pnl: { required: false, type: Boolean, default: false }
+  pnl: { required: false, type: Boolean, default: false },
+  noScramble: { required: false, type: Boolean, default: false }
 });
 
 const {
@@ -66,7 +67,8 @@ const {
   priceOfAsset,
   priceAsset,
   integer,
-  forceCurrency
+  forceCurrency,
+  noScramble
 } = toRefs(props);
 
 const {
@@ -75,7 +77,7 @@ const {
   floatingPrecision
 } = storeToRefs(useGeneralSettingsStore());
 
-const { scrambleData, shouldShowAmount } = storeToRefs(
+const { scrambleData, shouldShowAmount, scrambleMultiplier } = storeToRefs(
   useSessionSettingsStore()
 );
 
@@ -115,16 +117,7 @@ const convertFiat = (
   return valueVal.multipliedBy(multiplierRate).dividedBy(dividerRate);
 };
 
-const realValue = computed<BigNumber>(() => {
-  // Return a random number if scrambleData is on
-  if (get(scrambleData) || !get(shouldShowAmount)) {
-    const multiplier = [10, 100, 1000];
-
-    return BigNumber.random().multipliedBy(
-      multiplier[Math.floor(Math.random() * multiplier.length)]
-    );
-  }
-
+const internalValue: ComputedRef<BigNumber> = computed<BigNumber>(() => {
   // If there is no `sourceCurrency`, it means that no fiat currency, or the unit is asset not fiat, hence we should just show the `value` passed.
   // If `forceCurrency` is true, we should also just return the value.
   if (!get(sourceCurrency) || get(forceCurrency)) return get(value);
@@ -134,7 +127,7 @@ const realValue = computed<BigNumber>(() => {
   const priceAssetVal = get(priceAsset);
   const isCurrentCurrencyVal = get(isCurrentCurrency);
 
-  // If `priceAsset` is defined, it means we will not use value from `value`, but calculate it ourself from the price of `priceAsset`
+  // If `priceAsset` is defined, it means we will not use value from `value`, but calculate it ourselves from the price of `priceAsset`
   if (priceAssetVal) {
     if (priceAssetVal === currentCurrencyVal) {
       return get(amount);
@@ -153,6 +146,15 @@ const realValue = computed<BigNumber>(() => {
   }
 
   return get(value);
+});
+
+const realValue: ComputedRef<BigNumber> = computed(() => {
+  // Return scrambled number if scrambleData is on
+  if (!get(noScramble) && (get(scrambleData) || !get(shouldShowAmount))) {
+    return get(internalValue).multipliedBy(get(scrambleMultiplier));
+  }
+
+  return get(internalValue);
 });
 
 // Check if the `realValue` is NaN

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -2,7 +2,6 @@
 import { type GeneralAccount } from '@rotki/common/lib/account';
 import { truncateAddress, truncationPoints } from '@/filters';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
-import { useSessionSettingsStore } from '@/store/settings/session';
 
 const { t } = useI18n();
 
@@ -12,12 +11,9 @@ const props = defineProps<{
 
 const { account } = toRefs(props);
 const { currentBreakpoint } = useTheme();
-
-const sessionSettingsStore = useSessionSettingsStore();
-const { scrambleData, shouldShowAmount } = storeToRefs(sessionSettingsStore);
-const { scrambleHex } = sessionSettingsStore;
-
+const { scrambleData, shouldShowAmount, scrambleHex } = useScramble();
 const { addressNameSelector } = useAddressesNamesStore();
+
 const aliasName = computed<string | null>(() => {
   if (get(scrambleData)) {
     return null;

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -3,7 +3,6 @@ import { type GeneralAccount } from '@rotki/common/lib/account';
 import { truncateAddress, truncationPoints } from '@/filters';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
 import { useSessionSettingsStore } from '@/store/settings/session';
-import { randomHex } from '@/utils/data';
 
 const { t } = useI18n();
 
@@ -13,9 +12,10 @@ const props = defineProps<{
 
 const { account } = toRefs(props);
 const { currentBreakpoint } = useTheme();
-const { scrambleData, shouldShowAmount } = storeToRefs(
-  useSessionSettingsStore()
-);
+
+const sessionSettingsStore = useSessionSettingsStore();
+const { scrambleData, shouldShowAmount } = storeToRefs(sessionSettingsStore);
+const { scrambleHex } = sessionSettingsStore;
 
 const { addressNameSelector } = useAddressesNamesStore();
 const aliasName = computed<string | null>(() => {
@@ -31,7 +31,11 @@ const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
 const smAndDown = computed(() => get(currentBreakpoint).smAndDown);
 
 const address = computed<string>(() => {
-  return get(scrambleData) ? randomHex() : get(account).address;
+  const address = get(account).address;
+  if (!get(scrambleData)) {
+    return address;
+  }
+  return scrambleHex(address);
 });
 
 const breakpoint = computed<string>(() => {

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -19,6 +19,10 @@ const { scrambleData, shouldShowAmount } = storeToRefs(
 
 const { addressNameSelector } = useAddressesNamesStore();
 const aliasName = computed<string | null>(() => {
+  if (get(scrambleData)) {
+    return null;
+  }
+
   const { address, chain } = get(account);
   return get(addressNameSelector(address, chain));
 });

--- a/frontend/app/src/components/display/PercentageDisplay.vue
+++ b/frontend/app/src/components/display/PercentageDisplay.vue
@@ -26,12 +26,10 @@ const props = defineProps({
 });
 
 const { assetPadding, value } = toRefs(props);
-const { shouldShowPercentage, scrambleData } = storeToRefs(
-  useSessionSettingsStore()
-);
+const { shouldShowPercentage } = storeToRefs(useSessionSettingsStore());
 
 const displayValue = computed<string>(() => {
-  if (get(scrambleData) || !get(shouldShowPercentage)) {
+  if (!get(shouldShowPercentage)) {
     return (Math.random() * 100 + 1).toFixed(2);
   }
 

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -1,14 +1,13 @@
 ﻿<script setup lang="ts">
 import { Blockchain } from '@rotki/common/lib/blockchain';
 import { truncateAddress } from '@/filters';
-import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
-import { useFrontendSettingsStore } from '@/store/settings/frontend';
-import { useSessionSettingsStore } from '@/store/settings/session';
 import {
   type Chains,
   type ExplorerUrls,
   explorerUrls
 } from '@/types/asset-urls';
+import { useFrontendSettingsStore } from '@/store/settings/frontend';
+import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
 
 const props = withDefaults(
   defineProps<{
@@ -40,10 +39,7 @@ const props = withDefaults(
 );
 
 const { text, baseUrl, chain, tx } = toRefs(props);
-
-const sessionSettingsStore = useSessionSettingsStore();
-const { scrambleData, shouldShowAmount } = storeToRefs(sessionSettingsStore);
-const { scrambleHex } = sessionSettingsStore;
+const { scrambleData, shouldShowAmount, scrambleHex } = useScramble();
 
 const { explorers } = storeToRefs(useFrontendSettingsStore());
 const { dark } = useTheme();

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -9,7 +9,6 @@ import {
   type ExplorerUrls,
   explorerUrls
 } from '@/types/asset-urls';
-import { randomHex } from '@/utils/data';
 
 const props = withDefaults(
   defineProps<{
@@ -42,9 +41,10 @@ const props = withDefaults(
 
 const { text, baseUrl, chain, tx } = toRefs(props);
 
-const { scrambleData, shouldShowAmount } = storeToRefs(
-  useSessionSettingsStore()
-);
+const sessionSettingsStore = useSessionSettingsStore();
+const { scrambleData, shouldShowAmount } = storeToRefs(sessionSettingsStore);
+const { scrambleHex } = sessionSettingsStore;
+
 const { explorers } = storeToRefs(useFrontendSettingsStore());
 const { dark } = useTheme();
 
@@ -59,11 +59,12 @@ const aliasName = computed<string | null>(() => {
 });
 
 const displayText = computed<string>(() => {
+  const textVal = get(text);
   if (!get(scrambleData)) {
-    return get(text);
+    return textVal;
   }
-  const length = get(tx) ? 64 : 40;
-  return randomHex(length);
+
+  return scrambleHex(textVal);
 });
 
 const base = computed<string>(() => {

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -50,12 +50,12 @@ const { dark } = useTheme();
 
 const { addressNameSelector } = useAddressesNamesStore();
 
-const ethName = computed<string | null>(() => {
-  if (!get(scrambleData) || get(tx)) {
-    return get(addressNameSelector(text, chain));
+const aliasName = computed<string | null>(() => {
+  if (get(scrambleData) || get(tx)) {
+    return null;
   }
 
-  return null;
+  return get(addressNameSelector(text, chain));
 });
 
 const displayText = computed<string>(() => {
@@ -132,7 +132,7 @@ const { getBlockie } = useBlockie();
             v-bind="attrs"
             v-on="on"
           >
-            <span v-if="ethName">{{ ethName }}</span>
+            <span v-if="aliasName">{{ aliasName }}</span>
             <span v-else>
               {{ truncateAddress(displayText, truncateLength) }}
             </span>

--- a/frontend/app/src/components/history/transactions/TransactionEventType.vue
+++ b/frontend/app/src/components/history/transactions/TransactionEventType.vue
@@ -3,7 +3,6 @@ import { type Blockchain } from '@rotki/common/lib/blockchain';
 import { type ActionDataEntry } from '@/store/types';
 import { getEventCounterpartyData, useEventTypeData } from '@/utils/history';
 import { type EthTransactionEventEntry } from '@/types/history/tx';
-import { useSessionSettingsStore } from '@/store/settings/session';
 
 const props = defineProps<{
   event: EthTransactionEventEntry;
@@ -19,9 +18,7 @@ const attrs = computed<ActionDataEntry>(() => {
   return getEventTypeData(get(event));
 });
 
-const sessionSettingsStore = useSessionSettingsStore();
-const { scrambleData } = storeToRefs(sessionSettingsStore);
-const { scrambleHex } = sessionSettingsStore;
+const { scrambleData, scrambleHex } = useScramble();
 
 const counterparty = computed<ActionDataEntry | null>(() => {
   return getEventCounterpartyData(

--- a/frontend/app/src/components/history/transactions/TransactionEventType.vue
+++ b/frontend/app/src/components/history/transactions/TransactionEventType.vue
@@ -3,6 +3,7 @@ import { type Blockchain } from '@rotki/common/lib/blockchain';
 import { type ActionDataEntry } from '@/store/types';
 import { getEventCounterpartyData, useEventTypeData } from '@/utils/history';
 import { type EthTransactionEventEntry } from '@/types/history/tx';
+import { useSessionSettingsStore } from '@/store/settings/session';
 
 const props = defineProps<{
   event: EthTransactionEventEntry;
@@ -18,8 +19,15 @@ const attrs = computed<ActionDataEntry>(() => {
   return getEventTypeData(get(event));
 });
 
+const sessionSettingsStore = useSessionSettingsStore();
+const { scrambleData } = storeToRefs(sessionSettingsStore);
+const { scrambleHex } = sessionSettingsStore;
+
 const counterparty = computed<ActionDataEntry | null>(() => {
-  return getEventCounterpartyData(get(event));
+  return getEventCounterpartyData(
+    get(event),
+    get(scrambleData) ? scrambleHex : undefined
+  );
 });
 
 const { t } = useI18n();

--- a/frontend/app/src/components/settings/frontend/ScrambleDataSetting.vue
+++ b/frontend/app/src/components/settings/frontend/ScrambleDataSetting.vue
@@ -1,30 +1,62 @@
 <script setup lang="ts">
 import { useSessionSettingsStore } from '@/store/settings/session';
 
-const { scrambleData: enabled } = useSessionSettingsStore();
+const { scrambleData: enabled, scrambleMultiplier: multiplier } =
+  useSessionSettingsStore();
 
 const scrambleData = ref<boolean>(false);
+const scrambleMultiplier = ref<string>('0');
+
 onMounted(() => {
   set(scrambleData, get(enabled));
+  set(scrambleMultiplier, get(multiplier).toString());
 });
 
 const { t, tc } = useI18n();
+const css = useCssModule();
 </script>
 
 <template>
-  <settings-option
-    #default="{ error, success, update }"
-    setting="scrambleData"
-    session-setting
-    :error-message="tc('frontend_settings.validation.scramble.error')"
-  >
-    <v-switch
-      v-model="scrambleData"
-      class="general-settings__fields__scramble-data"
-      :label="t('frontend_settings.label.scramble')"
-      :success-messages="success"
-      :error-messages="error"
-      @change="update"
-    />
-  </settings-option>
+  <div>
+    <settings-option
+      #default="{ error, success, update }"
+      setting="scrambleData"
+      session-setting
+      :error-message="tc('frontend_settings.validation.scramble.error')"
+    >
+      <v-switch
+        v-model="scrambleData"
+        class="general-settings__fields__scramble-data"
+        :label="t('frontend_settings.label.scramble')"
+        :success-messages="success"
+        :error-messages="error"
+        @change="update"
+      />
+    </settings-option>
+    <settings-option
+      #default="{ error, success, update }"
+      class="pt-4"
+      setting="scrambleMultiplier"
+      session-setting
+    >
+      <div :class="css.multiplier">
+        <amount-input
+          v-model="scrambleMultiplier"
+          class="general-settings__fields__scramble-multiplier"
+          :label="t('frontend_settings.label.scramble_multiplier')"
+          :hint="t('frontend_settings.subtitle.scramble_multiplier')"
+          outlined
+          :disabled="!scrambleData"
+          :success-messages="success"
+          :error-messages="error"
+          @change="update"
+        />
+      </div>
+    </settings-option>
+  </div>
 </template>
+<style module lang="scss">
+.multiplier {
+  max-width: 520px;
+}
+</style>

--- a/frontend/app/src/composables/scramble.ts
+++ b/frontend/app/src/composables/scramble.ts
@@ -1,0 +1,38 @@
+import { useSessionSettingsStore } from '@/store/settings/session';
+
+export const useScramble = () => {
+  const alphaNumerics =
+    '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  const { scrambleData, shouldShowAmount, scrambleMultiplier } = storeToRefs(
+    useSessionSettingsStore()
+  );
+
+  const scrambleHex = (hex: string): string => {
+    const isEth = hex.startsWith('0x');
+    const multiplier = get(scrambleMultiplier) * 100;
+
+    const trimmedHex = isEth ? hex.slice(2).toUpperCase() : hex;
+
+    return (
+      (isEth ? '0x' : '') +
+      trimmedHex
+        .split('')
+        .map(char => {
+          const index = alphaNumerics.indexOf(char);
+          if (index === -1) return char;
+          return alphaNumerics.charAt(
+            Math.floor(index * multiplier * 100) %
+              (isEth ? 16 : alphaNumerics.length)
+          );
+        })
+        .join('')
+    );
+  };
+
+  return {
+    scrambleData,
+    shouldShowAmount,
+    scrambleHex
+  };
+};

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2067,6 +2067,7 @@
       "refresh": "Set the automatic refresh period",
       "refresh_enabled": "Enabled",
       "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions.",
+      "scramble_multiplier": "Scramble multiplier",
       "show_graph_range_selector": "Show graph range selector for line chart",
       "zero_based": "Use zero as the lowest y-axis value for the graphs",
       "zero_based_hint": "By default the lowest value is the minimum in the selected period"
@@ -2076,6 +2077,7 @@
       "alias_names": "Alias name for addresses",
       "graph_basis": "Graph basis",
       "include_nfts": "Include NFTs in graphs and total amounts",
+      "scramble_multiplier": "Multiplier number used when scrambling balances. This will affects amount and fiat value.",
       "query": "Periodic status query",
       "refresh": "Automatic balance refresh",
       "show_graph_range_selector": "Show graph range selector"

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -2008,6 +2008,7 @@
       "refresh": "Set the automatic refresh period",
       "refresh_enabled": "Enabled",
       "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions.",
+      "scramble_multiplier": "Scramble multiplier",
       "show_graph_range_selector": "Show graph range selector for line chart",
       "zero_based": "Use zero as the lowest y-axis value for the graphs",
       "zero_based_hint": "By default the lowest value is the minimum in the selected period"
@@ -2017,6 +2018,7 @@
       "alias_names": "Alias name for addresses",
       "graph_basis": "Graph basis",
       "include_nfts": "Include NFTs in graphs and total amounts",
+      "scramble_multiplier": "Multiplier number used when scrambling balances. This will affects amount and fiat value.",
       "query": "Periodic status query",
       "refresh": "Automatic balance refresh",
       "show_graph_range_selector": "Show graph range selector"

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -2014,6 +2014,7 @@
       "refresh": "Set the automatic refresh period",
       "refresh_enabled": "Enabled",
       "scramble": "Scramble data. Use this when sharing screenshots with others, e.g. when filing bug reports. NOTE: This setting does not persist between sessions.",
+      "scramble_multiplier": "Scramble multiplier",
       "show_graph_range_selector": "Show graph range selector for line chart",
       "zero_based": "Use zero as the lowest y-axis value for the graphs",
       "zero_based_hint": "By default the lowest value is the minimum in the selected period"
@@ -2023,6 +2024,7 @@
       "alias_names": "Alias name for addresses",
       "graph_basis": "Graph basis",
       "include_nfts": "Include NFTs in graphs and total amounts",
+      "scramble_multiplier": "Multiplier number used when scrambling balances. This will affects amount and fiat value.",
       "query": "Periodic status query",
       "refresh": "Automatic balance refresh",
       "show_graph_range_selector": "Show graph range selector"

--- a/frontend/app/src/store/settings/session.ts
+++ b/frontend/app/src/store/settings/session.ts
@@ -11,13 +11,20 @@ const isAnimationEnabledSetting = useSharedLocalStorage(
 export interface SessionSettings {
   privacyMode: PrivacyMode;
   scrambleData: boolean;
+  scrambleMultiplier: number;
   timeframe: TimeFramePeriod;
   animationsEnabled: boolean;
 }
 
+const generateRandomScrambleMultiplier = () => {
+  // Generate random number from 0.5 to 10
+  return Math.floor(500 + Math.random() * 9500) / 1000;
+};
+
 const defaultSessionSettings = (): SessionSettings => ({
   privacyMode: PrivacyMode.NORMAL,
   scrambleData: false,
+  scrambleMultiplier: generateRandomScrambleMultiplier(),
   timeframe: TimeFramePeriod.ALL,
   animationsEnabled: get(isAnimationEnabledSetting)
 });
@@ -27,6 +34,7 @@ export const useSessionSettingsStore = defineStore('settings/session', () => {
 
   const privacyMode = computed(() => settings.privacyMode);
   const scrambleData = computed(() => settings.scrambleData);
+  const scrambleMultiplier = computed(() => settings.scrambleMultiplier);
   const timeframe = computed(() => settings.timeframe);
   const animationsEnabled = computed(() => settings.animationsEnabled);
 
@@ -57,6 +65,7 @@ export const useSessionSettingsStore = defineStore('settings/session', () => {
     animationsEnabled,
     shouldShowAmount,
     shouldShowPercentage,
+    scrambleMultiplier,
     setAnimationsEnabled,
     update
   };

--- a/frontend/app/src/store/settings/session.ts
+++ b/frontend/app/src/store/settings/session.ts
@@ -51,6 +51,31 @@ export const useSessionSettingsStore = defineStore('settings/session', () => {
     settings.animationsEnabled = enabled;
   };
 
+  const alphaNumerics =
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+  const scrambleHex = (hex: string): string => {
+    const isEth = hex.startsWith('0x');
+    const multiplier = get(scrambleMultiplier) * 100;
+
+    const trimmedHex = isEth ? hex.slice(2).toUpperCase() : hex;
+
+    return (
+      (isEth ? '0x' : '') +
+      trimmedHex
+        .split('')
+        .map(char => {
+          const index = alphaNumerics.indexOf(char);
+          if (index === -1) return char;
+          return alphaNumerics.charAt(
+            Math.floor(index * multiplier * 100) %
+              (isEth ? 16 : alphaNumerics.length)
+          );
+        })
+        .join('')
+    );
+  };
+
   const update = (sessionSettings: Partial<SessionSettings>): ActionStatus => {
     Object.assign(settings, sessionSettings);
     return {
@@ -66,6 +91,7 @@ export const useSessionSettingsStore = defineStore('settings/session', () => {
     shouldShowAmount,
     shouldShowPercentage,
     scrambleMultiplier,
+    scrambleHex,
     setAnimationsEnabled,
     update
   };

--- a/frontend/app/src/store/settings/session.ts
+++ b/frontend/app/src/store/settings/session.ts
@@ -51,31 +51,6 @@ export const useSessionSettingsStore = defineStore('settings/session', () => {
     settings.animationsEnabled = enabled;
   };
 
-  const alphaNumerics =
-    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-
-  const scrambleHex = (hex: string): string => {
-    const isEth = hex.startsWith('0x');
-    const multiplier = get(scrambleMultiplier) * 100;
-
-    const trimmedHex = isEth ? hex.slice(2).toUpperCase() : hex;
-
-    return (
-      (isEth ? '0x' : '') +
-      trimmedHex
-        .split('')
-        .map(char => {
-          const index = alphaNumerics.indexOf(char);
-          if (index === -1) return char;
-          return alphaNumerics.charAt(
-            Math.floor(index * multiplier * 100) %
-              (isEth ? 16 : alphaNumerics.length)
-          );
-        })
-        .join('')
-    );
-  };
-
   const update = (sessionSettings: Partial<SessionSettings>): ActionStatus => {
     Object.assign(settings, sessionSettings);
     return {
@@ -91,7 +66,6 @@ export const useSessionSettingsStore = defineStore('settings/session', () => {
     shouldShowAmount,
     shouldShowPercentage,
     scrambleMultiplier,
-    scrambleHex,
     setAnimationsEnabled,
     update
   };

--- a/frontend/app/src/utils/data.ts
+++ b/frontend/app/src/utils/data.ts
@@ -77,15 +77,3 @@ export const size = (bytes: number): string => {
   const symbol = 'KMGTPEZY'[i - 1] || '';
   return `${bytes.toFixed(2)}  ${symbol}B`;
 };
-
-export function randomHex(characters = 40): string {
-  let hex = '';
-  for (let i = 0; i < characters - 2; i++) {
-    const randByte = Number.parseInt(
-      (Math.random() * 16).toString(),
-      10
-    ).toString(16);
-    hex += randByte;
-  }
-  return `0x${hex}ff`;
-}

--- a/frontend/app/src/utils/history.ts
+++ b/frontend/app/src/utils/history.ts
@@ -107,12 +107,12 @@ export const getEventCounterpartyData = (
     };
   }
 
-  const scrambled = scrambler ? scrambler(counterparty) : counterparty;
+  const counterpartyAddress = scrambler?.(counterparty) ?? counterparty;
 
   return {
     identifier: '',
-    label: scrambled,
-    image: getBlockie(scrambled)
+    label: counterpartyAddress,
+    image: getBlockie(counterpartyAddress)
   };
 };
 

--- a/frontend/app/src/utils/history.ts
+++ b/frontend/app/src/utils/history.ts
@@ -68,7 +68,8 @@ export const useEventTypeData = createSharedComposable(() => {
 const { getBlockie } = useBlockie();
 
 export const getEventCounterpartyData = (
-  event: EthTransactionEventEntry
+  event: EthTransactionEventEntry,
+  scrambler?: (hex: string) => string
 ): ActionDataEntry | null => {
   const { counterparty } = event;
 
@@ -106,10 +107,12 @@ export const getEventCounterpartyData = (
     };
   }
 
+  const scrambled = scrambler ? scrambler(counterparty) : counterparty;
+
   return {
     identifier: '',
-    label: counterparty,
-    image: getBlockie(counterparty)
+    label: scrambled,
+    image: getBlockie(scrambled)
   };
 };
 


### PR DESCRIPTION
Closes #(issue_number)

So I add the option to fill the multiplier of the scrambling.
I disable the scramble for the prices, because if it's not disabled, then the observer can calculate the `constant` used by comparing it with the real price.

![image](https://user-images.githubusercontent.com/26648140/219594389-4abaf1e4-b321-478c-8cf2-b41d48b1aec5.png)
