### PR TITLE
Some adjustments and bugfixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Users with kraken accounts with old data that were never purged and repulled will no longer have missing events.
 * :bug:`-` PnL report will now correctly show progress bar percentage if user has connected but non-syncing exchanges.
 
 * :release:`1.27.1 <2023-02-24>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` PnL report will now correctly show progress bar percentage if user has connected but non-syncing exchanges.
+
 * :release:`1.27.1 <2023-02-24>`
 * :feature:`-` Transactions involving Sai CDP migration to Dai CDP are now properly decoded.
 * :bug:`-` Fixed a bug where token balance detection for EVM tokens with many addresses may not have worked properly.

--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -50,7 +50,7 @@ HISTORY_EVENT_DB_TUPLE_READ = tuple[
     str,            # usd value
     Optional[str],  # notes
     str,            # type
-    str,            # subtype
+    Optional[str],  # subtype
     Optional[str],  # counterparty
     Optional[str],  # extra_data
 ]
@@ -147,6 +147,17 @@ class HistoryBaseEntry(AccountingEventMixin):
                     f'{entry} from the DB due to {str(e)}. Setting it to null',
                 )
 
+        # The DB Schema still allows a null subtype though the HistoryBaseEntry structure
+        # has replaced it with HistoryEventSubType.NONE. They are practically the
+        # same but need to handle this here otherwise all null subtype DB entries fail here
+        # This happens for people with old Kraken data (like Lefteris -- since there has
+        # been no DB migration or upgrade. TODO: Do the schema change to make it not nullable and
+        # then change all null subtypes to HistoryEventSubType.NONE in DB and get rid of this check
+        if entry[11] is not None:
+            subtype = HistoryEventSubType.deserialize(entry[11])
+        else:
+            subtype = HistoryEventSubType.NONE
+
         try:
             return cls(
                 identifier=entry[0],
@@ -162,7 +173,7 @@ class HistoryBaseEntry(AccountingEventMixin):
                 ),
                 notes=entry[9],
                 event_type=HistoryEventType.deserialize(entry[10]),
-                event_subtype=HistoryEventSubType.deserialize(entry[11]),
+                event_subtype=subtype,
                 counterparty=entry[12],
                 extra_data=extra_data,
             )

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -29,6 +29,7 @@ from rotkehlchen.chain.bitcoin.xpub import XpubManager
 from rotkehlchen.chain.ethereum.defi.chad import DefiChad
 from rotkehlchen.chain.ethereum.defi.structures import DefiProtocolBalances
 from rotkehlchen.chain.ethereum.modules import (
+    MODULE_NAME_TO_PATH,
     Aave,
     Balancer,
     Compound,
@@ -118,14 +119,20 @@ log = RotkehlchenLogsAdapter(logger)
 
 def _module_name_to_class(module_name: ModuleName) -> type[EthereumModule]:
     class_name = ''.join(word.title() for word in module_name.split('_'))
+    extra_path = MODULE_NAME_TO_PATH.get(module_name)
+    search_path = 'rotkehlchen.chain.ethereum.modules'
+    if extra_path is not None:
+        search_path += extra_path
+
     try:
-        ethereum_modules_module = import_module('rotkehlchen.chain.ethereum.modules')
+        module = import_module(search_path)
     except ModuleNotFoundError as e:
-        # This should never happen
-        raise AssertionError('Could not load ethereum modules') from e
-    module = getattr(ethereum_modules_module, class_name, None)
-    assert module, f'Could not find object {class_name} in ethereum modules'
-    return module
+        raise AssertionError(f'Could not find {search_path} in ethereum modules') from e
+    # else
+
+    klass = getattr(module, class_name, None)
+    assert klass, f'Could not find object {class_name} in {search_path}'
+    return klass
 
 
 DEFI_BALANCES_REQUERY_SECONDS = 600

--- a/rotkehlchen/chain/ethereum/modules/__init__.py
+++ b/rotkehlchen/chain/ethereum/modules/__init__.py
@@ -12,8 +12,13 @@ __all__ = [
     'Sushiswap',
     'Liquity',
     'PickleFinance',
-    'Nfts',
+    'MODULE_NAME_TO_PATH',
 ]
+
+# to avoid some circular imports some of the paths are moved in a mapping here
+MODULE_NAME_TO_PATH = {
+    'nfts': '.nft.nfts',
+}
 
 from .aave.aave import Aave
 from .balancer.balancer import Balancer
@@ -23,7 +28,6 @@ from .l2.loopring import Loopring
 from .liquity.trove import Liquity
 from .makerdao.dsr import MakerdaoDsr
 from .makerdao.vaults import MakerdaoVaults
-from .nft.nfts import Nfts
 from .pickle_finance import PickleFinance
 from .sushiswap.sushiswap import Sushiswap
 from .uniswap.uniswap import Uniswap

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -236,8 +236,6 @@ class Eth2(EthereumModule):
         """Go through the list of eth1 addresses and find all eth2 validators associated
         with them along with their details.
 
-
-
         May raise RemoteError due to beaconcha.in API"""
         indices = []
         index_to_address = {}

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -38,6 +38,9 @@ class ExchangeManager():
 
         return str(location)
 
+    def connected_and_syncing_exchanges_num(self) -> int:
+        return len(list(self.iterate_exchanges()))
+
     def get_exchange(self, name: str, location: Location) -> Optional[ExchangeInterface]:
         """Get the exchange object for an exchange with a given name and location
 
@@ -54,7 +57,7 @@ class ExchangeManager():
         return None
 
     def iterate_exchanges(self) -> Iterator[ExchangeInterface]:
-        """Iterate all connected exchanges"""
+        """Iterate all connected and syncing exchanges"""
         with self.database.conn.read_ctx() as cursor:
             excluded = self.database.get_settings(cursor).non_syncing_exchanges
         for _, exchanges in self.connected_exchanges.items():

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -120,6 +120,7 @@ def test_query_aave_balances(rotkehlchen_api_server, ethereum_accounts):
         test_warnings.warn(UserWarning(f'Test account {AAVE_BALANCESV2_TEST_ACC} has no aave v2 balances'))  # noqa: E501
 
 
+@pytest.mark.skip('Subgraph down: https://thegraph.com/hosted-service/subgraph/aave/protocol-v2')
 @flaky(max_runs=3, min_passes=1)  # open nodes some times time out
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_V2_TEST_ACC]])
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
@@ -552,6 +553,7 @@ def _query_simple_aave_history_test_v2(
     )
 
 
+@pytest.mark.skip('Subgraph down: https://thegraph.com/hosted-service/subgraph/aave/protocol-v2')
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_TEST_ACC_2]])
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -578,6 +580,7 @@ def test_query_aave_history(rotkehlchen_api_server, ethereum_accounts):  # pylin
     _query_simple_aave_history_test(setup, rotkehlchen_api_server, async_query)
 
 
+@pytest.mark.skip('Subgraph down: https://thegraph.com/hosted-service/subgraph/aave/protocol-v2')
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_TEST_ACC_2]])
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -791,6 +794,7 @@ def _query_borrowing_aave_history_test(setup: BalancesTestSetup, server: APIServ
     )
 
 
+@pytest.mark.skip('Subgraph down: https://thegraph.com/hosted-service/subgraph/aave/protocol-v2')
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_TEST_ACC_3]])
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -853,6 +857,7 @@ def _test_for_duplicates_and_negatives(setup: BalancesTestSetup, server: APIServ
         events_set.add(event_hash)
 
 
+@pytest.mark.skip('Subgraph down: https://thegraph.com/hosted-service/subgraph/aave/protocol-v2')
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_TEST_ACC_1]])
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])


### PR DESCRIPTION
- [Add a way to avoid loading all modules when importing eth module](https://github.com/rotki/rotki/commit/23aa80dc4e1c96f4d9b6dfe036577f25c4c76ade)
- [PnL now shows correct progress % for connected but non-syncing CEXes](https://github.com/rotki/rotki/commit/393cd0d803ba4d88e4740e16134fc010e0600039)
- [Set DB null history event subtype to subtype none](https://github.com/rotki/rotki/commit/b7fdeb2e4f314b81b8e8cbb807af4f3d97e63483)

For [that last commit](https://github.com/rotki/rotki/commit/b7fdeb2e4f314b81b8e8cbb807af4f3d97e63483) @yabirgb have a look. I left a TODO for the future. I saw it with my own kraken account, in a few thousand events. I checked them thoroughly and I think replacing with `subtype.None` will work. We never made an upgrade for when it was null, did we?