### PR TITLE
ETC, BCH, BSV are now fully ignored in accounting if set

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Ignoring forked assets ETC, BCH and BSV for accounting should now also remove any pre-fork references of them and completely omit them from the PnL report.
 * :bug:`-` Users with kraken accounts with old data that were never purged and repulled will no longer have missing events.
 * :bug:`-` PnL report will now correctly show progress bar percentage if user has connected but non-syncing exchanges.
 

--- a/rotkehlchen/accounting/cost_basis/prefork.py
+++ b/rotkehlchen/accounting/cost_basis/prefork.py
@@ -21,6 +21,7 @@ def handle_prefork_asset_acquisitions(
         asset: Asset,
         amount: FVal,
         price: Price,
+        ignored_asset_ids: set[str],
         starting_index: int,
 ) -> list['ProcessedAccountingEvent']:
     """
@@ -46,6 +47,8 @@ def handle_prefork_asset_acquisitions(
 
     events = []
     for acquisition in acquisitions:
+        if acquisition[0].identifier in ignored_asset_ids:
+            continue
         event = ProcessedAccountingEvent(
             type=AccountingEventType.PREFORK_ACQUISITION,
             notes=acquisition[1],

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -46,6 +46,8 @@ class AccountingPot(CustomizableDateMixin):
             msg_aggregator: MessagesAggregator,
     ) -> None:
         super().__init__(database=database)
+        with database.conn.read_ctx() as cursor:
+            self.ignored_asset_ids = database.get_ignored_asset_ids(cursor)
         self.profit_currency = self.settings.main_currency.resolve_to_asset_with_oracles()
         self.cost_basis = CostBasisCalculator(
             database=database,
@@ -104,6 +106,8 @@ class AccountingPot(CustomizableDateMixin):
             report_id: int,
     ) -> None:
         self.settings = settings
+        with self.database.conn.read_ctx() as cursor:
+            self.ignored_asset_ids = self.database.get_ignored_asset_ids(cursor)
         self.report_id = report_id
         self.profit_currency = self.settings.main_currency.resolve_to_asset_with_oracles()
         self.query_start_ts = start_ts
@@ -154,6 +158,7 @@ class AccountingPot(CustomizableDateMixin):
             asset=asset,
             amount=amount,
             price=price,
+            ignored_asset_ids=self.ignored_asset_ids,
             starting_index=len(self.processed_events),
         )
         for prefork_event in prefork_events:


### PR DESCRIPTION
There was a bug where ETC, BCH and BSV prefork acquisition events (all after-fork were properly ignored) were still taken into account if any of those assets was set to ignored for accounting.

This is now fixed
