### PR TITLE
Fix maybe_kill_running_tx_query_tasks edge case

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Fixed an edge case where removing an EVM account multiple times in a row, while a transactions querying task ran, would result in an error.
 * :bug:`-` Ignoring forked assets ETC, BCH and BSV for accounting should now also remove any pre-fork references of them and completely omit them from the PnL report.
 * :bug:`-` Users with kraken accounts with old data that were never purged and repulled will no longer have missing events.
 * :bug:`-` PnL report will now correctly show progress bar percentage if user has connected but non-syncing exchanges.

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -192,6 +192,7 @@ class Rotkehlchen():
             account_tuple = (address, blockchain.to_chain_id())
             for greenlet in self.api_task_greenlets:
                 is_evm_tx_greenlet = (
+                    greenlet.dead is False and
                     len(greenlet.args) >= 1 and
                     isinstance(greenlet.args[0], MethodType) and
                     greenlet.args[0].__func__.__qualname__ == 'RestAPI._get_evm_transactions'
@@ -205,7 +206,7 @@ class Rotkehlchen():
 
             tx_query_task_greenlets = self.task_manager.running_greenlets.get(self.task_manager._maybe_query_evm_transactions, [])  # noqa: E501
             for greenlet in tx_query_task_greenlets:
-                if greenlet.kwargs['address'] in addresses:
+                if greenlet.dead is False and greenlet.kwargs['address'] in addresses:
                     greenlet.kill(exception=GreenletKilledError('Killed due to request for evm address removal'))  # noqa: E501
 
     def reset_after_failed_account_creation_or_login(self) -> None:

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -16,6 +16,7 @@ from rotkehlchen.tests.utils.ethereum import (
     TEST_ADDR2,
     setup_ethereum_transactions_test,
 )
+from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.tests.utils.mock import mock_evm_chains_with_transactions
 from rotkehlchen.tests.utils.premium import VALID_PREMIUM_KEY, VALID_PREMIUM_SECRET
 from rotkehlchen.types import ChainID, Location, SupportedBlockchain
@@ -401,3 +402,43 @@ def test_try_start_same_task(rotkehlchen_api_server):
             rotki.task_manager._maybe_update_snapshot_balances,
             simple_task,
         }
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[make_evm_address()]])
+def test_maybe_kill_running_tx_query_tasks(rotkehlchen_api_server, ethereum_accounts):
+    """Test that using maybe_kill_running_tx_query_tasks deletes greenlet from the running tasks
+
+    Also test that if called two times without a schedule() in between, no KeyErrors happen.
+    These used to happen before a fix was introduced since the killed greenlet
+    was not removed from the tx_query_task_greenlets and/or api_task_greenlets.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    address = ethereum_accounts[0]
+    rotki.task_manager.potential_tasks = [rotki.task_manager._maybe_query_evm_transactions]
+    eth_manager = rotki.chains_aggregator.get_chain_manager(SupportedBlockchain.ETHEREUM)
+
+    def patched_address_query_transactions(self, address, start_ts, end_ts):  # pylint: disable=unused-argument  # noqa: E501
+        while True:  # busy wait :D just for the test
+            gevent.sleep(1)
+
+    query_patch = patch.object(
+        eth_manager.transactions,
+        'single_address_query_transactions',
+        wraps=patched_address_query_transactions,
+    )
+
+    with query_patch:
+        rotki.task_manager.schedule()  # Schedule the query
+        greenlet = rotki.task_manager.running_greenlets[rotki.task_manager._maybe_query_evm_transactions][0]  # noqa: E501
+        assert greenlet.dead is False
+        assert 'Query ethereum transaction' in greenlet.task_name
+        # Running it twice to see it's handled properly and dead greenlet does not raise KeyErrors
+        rotki.maybe_kill_running_tx_query_tasks(SupportedBlockchain.ETHEREUM, [address])
+        assert greenlet.dead is True
+        rotki.maybe_kill_running_tx_query_tasks(SupportedBlockchain.ETHEREUM, [address])
+        assert greenlet.dead is True
+
+        # Do a reschedule to see that this clears running greenlets
+        rotki.task_manager.potential_tasks = []
+        rotki.task_manager.schedule()
+        assert len(rotki.task_manager.running_greenlets) == 0


### PR DESCRIPTION
Fixed an edge case where maybe_kill_running_tx_query_tasks ran 2 times between two task schedulings. The second time the greenlet was already killed but had not been removed by the list and was still there. Trying to access kwargs of a dead greenlet raised an exception.

Fixed it and also wrote a regression test for it.

