### PR TITLE
Add Binance Savings endpoint & PnL support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12194,3 +12194,86 @@ Add EVM Transaction By Hash
    :statuscode 409: No user is currently logged in.
    :statuscode 500: Internal rotki error.
    :statuscode 502: An external service used in the query such as etherscan could not be reached or returned unexpected response.
+
+
+Get Binance Savings Interests History
+=======================================
+
+.. http:get:: /api/(version)/(location)/savings
+
+   Doing a GET on this endpoint will return all history events relating to interest payments for the specified location.
+   .. note::
+      This endpoint can also be queried asynchronously by using ``"async_query": true``.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      GET /api/1/binance/savings HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "only_cache": false}
+
+   :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not.
+   :reqjson int limit: Optional. This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
+   :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
+   :reqjson list[string] order_by_attributes: Optional. This is the list of attributes of the history by which to order the results. If none is given 'timestamp' is assumed. Valid values are: ['timestamp', 'location', 'amount'].
+   :reqjson list[bool] ascending: Optional. False by default. Defines the order by which results are returned depending on the chosen order by attribute.
+   :reqjson int from_timestamp: The timestamp from which to query. Can be missing in which case we query from 0.
+   :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
+   :reqjson bool only_cache: Optional.If this is true then the equivalent exchange/location is not queried, but only what is already in the DB is returned.
+   :reqjson string location: This represents the exchange's name. Can only be one of `"binance"` or `"binanceus"`.
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+    {
+        "result": {
+            "events": [
+                {
+                    "timestamp": 1587233562,
+                    "location": "binance",
+                    "asset": "eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "amount": "0.00987654",
+                    "usd_value": "0.05432097"
+                },
+                {
+                    "timestamp": 1577233578,
+                    "location": "binance",
+                    "asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+                    "amount": "0.00006408",
+                    "usd_value": "0.00070488"
+                }
+            ],
+            "entries_found": 2,
+            "entries_limit": 100,
+            "entries_total": 2,
+            "total_usd_value": "0.05502585",
+            "assets": ["eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53", "eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F"],
+            "received": [{"asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53", "amount": "0.00006408", "usd_value": "0.00070488"}, {"asset": "eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F", "amount": "0.00987654", "usd_value": "0.05432097"}]
+        },
+        "message": ""
+    }
+
+   :resjsonarr int timestamp: The timestamp at which the event occurred.
+   :resjsonarr string location: A valid location at which the event happened.
+   :resjsonarr string amount: The amount related to the event.
+   :resjsonarr string asset: Asset involved in the event.
+   :resjsonarr string message: It won't be empty if the query to external services fails for some reason.
+   :resjson int entries_found: The number of entries found for the current filter. Ignores pagination.
+   :resjson int entries_limit: The limit of entries if free version. -1 for premium.
+   :resjson int entries_total: The number of total entries ignoring all filters.
+   :resjsonarr string total_usd_value: Sum of the USD value for the assets received computed at the time of acquisition of each event.
+   :resjson list[string] assets: Assets involved in events ignoring all filters.
+   :resjson list[object] received: Assets received with the total amount received for each asset and the aggregated USD value at time of acquisition.
+
+   :statuscode 200: The balances were returned successfully.
+   :statuscode 400: Invalid location provided.
+   :statuscode 409: No user is currently logged in.
+   :statuscode 500: Internal rotki error.
+   :statuscode 502: An external service used in the query such as binance could not be reached or returned unexpected response.

--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -359,10 +359,16 @@ class StakingEvent:
 
     def serialize(self) -> dict[str, Any]:
         data = {
-            'event_type': self.event_type.serialize(),
             'asset': self.asset.identifier,
             'timestamp': self.timestamp,
             'location': str(self.location),
         }
+        # binance has only one type of event, so serializing it is not needed.
+        if not (
+            self.location == Location.BINANCE and
+            self.event_type == HistoryEventSubType.INTEREST_PAYMENT
+        ):
+            data['event_type'] = self.event_type.serialize()
+
         balance = abs(self.balance).serialize()
         return {**data, **balance}

--- a/rotkehlchen/accounting/structures/types.py
+++ b/rotkehlchen/accounting/structures/types.py
@@ -66,6 +66,7 @@ class HistoryEventSubType(SerializableEnumMixin):
     # for DXDAO Mesa, Gnosis cowswap etc.
     PLACE_ORDER = auto()
     LIQUIDATE = auto()
+    INTEREST_PAYMENT = auto()
     CANCEL_ORDER = auto()  # for cancelling orders like ETH orders in cowswap
     REFUND = auto()  # for refunding, e.g. refunding ETH in cowswap
 

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -43,6 +43,7 @@ from rotkehlchen.api.v1.resources import (
     BalancerBalancesResource,
     BalancerEventsHistoryResource,
     BinanceAvailableMarkets,
+    BinanceSavingsResource,
     BinanceUserMarkets,
     BlockchainBalancesResource,
     BlockchainsAccountsResource,
@@ -183,6 +184,7 @@ URLS_V1: URLS = [
     ('/asset_movements', AssetMovementsResource),
     ('/tags', TagsResource),
     ('/exchanges/binance/pairs', BinanceAvailableMarkets),
+    ('/exchanges/<string:location>/savings', BinanceSavingsResource),  # this can only be Binance/BinanceUS  # noqa: E501
     ('/exchanges/binance/pairs/<string:name>', BinanceUserMarkets),
     ('/exchanges/data', ExchangesDataResource),
     ('/exchanges/data/<string:location>', ExchangesDataResource, 'named_exchanges_data_resource'),

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -45,6 +45,7 @@ from rotkehlchen.api.v1.schemas import (
     BaseXpubSchema,
     BinanceMarketsSchema,
     BinanceMarketsUserSchema,
+    BinanceSavingsSchema,
     BlockchainAccountsDeleteSchema,
     BlockchainAccountsGetSchema,
     BlockchainAccountsPatchSchema,
@@ -2419,6 +2420,28 @@ class BinanceUserMarkets(BaseMethodView):
     @use_kwargs(get_schema, location='json_and_query_and_view_args')
     def get(self, name: str, location: Location) -> Response:
         return self.rest_api.get_user_binance_pairs(name=name, location=location)
+
+
+class BinanceSavingsResource(BaseMethodView):
+
+    post_schema = BinanceSavingsSchema()
+
+    @use_kwargs(post_schema, location='json_and_query_and_view_args')
+    def post(
+            self,
+            async_query: bool,
+            only_cache: bool,
+            location: Literal[Location.BINANCE, Location.BINANCEUS],
+            query_filter: 'HistoryEventFilterQuery',
+            value_filter: 'HistoryEventFilterQuery',
+    ) -> Response:
+        return self.rest_api.get_binance_savings_history(
+            async_query=async_query,
+            location=location,
+            only_cache=only_cache,
+            query_filter=query_filter,
+            value_filter=value_filter,
+        )
 
 
 class AvalancheTransactionsResource(BaseMethodView):

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -979,6 +979,7 @@ class DBHandler:
         - {exchange_location_name}_asset_movements_{exchange_name}
         - {exchange_location_name}_ledger_actions_{exchange_name}
         - {location}_history_events_{optional_label}
+        - {exchange_location_name}_lending_history_{exchange_name}
         - aave_events_{address}
         - yearn_vaults_events_{address}
         - yearn_vaults_v2_events_{address}

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -275,7 +275,11 @@ def deserialize_asset_amount_force_positive(amount: AcceptableFValInitInput) -> 
     """Acts exactly like deserialize_asset_amount but also forces the number to be positive
 
     Is needed for some places like some exchanges that list the withdrawal amounts as
-    negative numbers because it's a withdrawal"""
+    negative numbers because it's a withdrawal.
+
+    May raise:
+    - DeserializationError
+    """
     result = deserialize_asset_amount(amount)
     if result < ZERO:
         result = AssetAmount(abs(result))

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -10,7 +10,7 @@ import requests
 
 from rotkehlchen.accounting.structures.types import ActionType
 from rotkehlchen.constants import ONE
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.assets import A_BTC, A_BUSD, A_DAI, A_ETH, A_EUR, A_USDT
 from rotkehlchen.constants.limits import FREE_ASSET_MOVEMENTS_LIMIT, FREE_TRADES_LIMIT
 from rotkehlchen.db.constants import KRAKEN_ACCOUNT_TYPE_KEY
 from rotkehlchen.db.filtering import AssetMovementsFilterQuery, TradesFilterQuery
@@ -39,6 +39,7 @@ from rotkehlchen.tests.utils.api import (
 from rotkehlchen.tests.utils.exchanges import (
     assert_binance_balances_result,
     assert_poloniex_balances_result,
+    mock_api_query_for_binance_lending,
     patch_binance_balances_query,
     patch_poloniex_balances_query,
     try_get_first_exchange,
@@ -1245,3 +1246,82 @@ def test_binance_query_pairs(rotkehlchen_api_server_with_exchanges):
     assert 'FTTBNB' not in result
     if ci_run is False:
         assert binance_pairs_num > binanceus_pairs_num
+
+
+@pytest.mark.parametrize('default_mock_price_value', [FVal('5.5')])
+@pytest.mark.parametrize('added_exchanges', [(Location.BINANCE,)])
+def test_get_binance_savings_balance(rotkehlchen_api_server_with_exchanges):
+    """Check that querying the binance savings balance endpoint returns the expected response."""
+    async_query = random.choice([True, False])
+
+    # check for errors
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server_with_exchanges,
+            'binancesavingsresource',
+            location=Location.KRAKEN.name.lower(),
+        ),
+    )
+    assert_error_response(response, 'is not one of binance,binanceus')
+    test_vars = {
+        'interest_daily_call_count': 0,
+        'interest_customized_fixed_call_count': 0,
+        'interest_activity_call_count': 0,
+        'ranges_queried': set(),
+    }
+
+    def mock_api_query(api_type, method, options):
+        return mock_api_query_for_binance_lending(
+            api_type=api_type,
+            method=method,
+            options=options,
+            test_vars=test_vars,
+        )
+
+    with patch('rotkehlchen.exchanges.binance.Binance.api_query', side_effect=mock_api_query):
+        response = requests.post(
+            api_url_for(
+                rotkehlchen_api_server_with_exchanges,
+                'binancesavingsresource',
+                location=Location.BINANCE.name.lower(),
+            ),
+            json={'async_query': async_query},
+        )
+        if async_query is True:
+            task_id = assert_ok_async_response(response)
+            result = wait_for_async_task_with_result(rotkehlchen_api_server_with_exchanges, task_id)  # noqa: E501
+        else:
+            result = assert_proper_response_with_result(response)
+
+        test_vars.pop('ranges_queried')
+        for key, value in test_vars.items():
+            if key == 'interest_daily_call_count':
+                assert value == 2
+            else:
+                assert value == 1
+
+        result.pop('events')
+        assert result == {
+            'entries_found': 4,
+            'entries_limit': 100,
+            'entries_total': 4,
+            'total_usd_value': '0.09284682',
+            'assets': [A_USDT.identifier, A_BUSD.identifier, A_DAI.identifier],
+            'received': [
+                {
+                    'asset': A_BUSD.identifier,
+                    'amount': '0.00012816',
+                    'usd_value': '0.00070488',
+                },
+                {
+                    'asset': A_DAI.identifier,
+                    'amount': '0.00987654',
+                    'usd_value': '0.05432097',
+                },
+                {
+                    'asset': A_USDT.identifier,
+                    'amount': '0.00687654',
+                    'usd_value': '0.03782097',
+                },
+            ],
+        }

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -891,7 +891,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
     )
     assert_error_response(
         response=response,
-        contained_in_msg='Database query error retrieving misssing prices no such column',
+        contained_in_msg='Database query error retrieving missing prices no such column',
         status_code=HTTPStatus.CONFLICT,
     )
 

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -308,6 +308,8 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
             payload = '[]'
         elif 'fiat/payments' in url:
             payload = '[]'
+        elif 'lending/union/interestHistory':
+            payload = '[]'
         else:
             raise RuntimeError(f'Binance test mock got unexpected/unmocked url {url}')
 


### PR DESCRIPTION
Backend aspect of #1505

## Checklist
- [x] Add endpoint for breakdown of Binance Savings into balances & interest accrued.
- [x] Take interests history into PnL calculations.
- [x] Write tests.  
