### PR TITLE
Ignore specific settings keys that should be cache

### DIFF
--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -9,7 +9,6 @@ from typing import (
     Any,
     Callable,
     DefaultDict,
-    Final,
     Literal,
     Optional,
     TypeVar,
@@ -98,6 +97,7 @@ from rotkehlchen.utils.mixins.cacheable import CacheableMixIn, cache_response_ti
 from rotkehlchen.utils.mixins.lockable import LockableQueryMixIn, protect_with_lock
 
 from .balances import BlockchainBalances, BlockchainBalancesUpdate
+from .constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.avalanche.manager import AvalancheManager
@@ -139,7 +139,6 @@ def _module_name_to_class(module_name: ModuleName) -> type[EthereumModule]:
 
 DEFI_BALANCES_REQUERY_SECONDS = 600
 
-LAST_EVM_ACCOUNTS_DETECT_KEY: Final = 'last_evm_accounts_detect_ts'
 
 # Mapping to token symbols to ignore. True means all
 DEFI_PROTOCOLS_TO_SKIP_ASSETS = {

--- a/rotkehlchen/chain/constants.py
+++ b/rotkehlchen/chain/constants.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from rotkehlchen.types import SUPPORTED_BLOCKCHAIN_TO_CHAINID, SupportedBlockchain
 
 DEFAULT_EVM_RPC_TIMEOUT = 10
@@ -7,3 +9,5 @@ NON_BITCOIN_CHAINS = [
     SupportedBlockchain.ETHEREUM_BEACONCHAIN,
     SupportedBlockchain.KUSAMA,
 ] + list(SUPPORTED_BLOCKCHAIN_TO_CHAINID.keys())
+
+LAST_EVM_ACCOUNTS_DETECT_KEY: Final = 'last_evm_accounts_detect_ts'

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -3,6 +3,7 @@ from typing import Any, NamedTuple, Optional, Union
 
 from rotkehlchen.accounting.ledger_actions import LedgerActionType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
+from rotkehlchen.chain.constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.constants.timing import YEAR_IN_SECONDS
 from rotkehlchen.data_migrations.manager import LAST_DATA_MIGRATION
@@ -92,6 +93,7 @@ STRING_KEYS = (
     'frontend_settings',
 )
 TIMESTAMP_KEYS = ('last_write_ts', 'last_data_upload_ts', 'last_balance_save')
+IGNORED_KEYS = (LAST_EVM_ACCOUNTS_DETECT_KEY,)
 
 
 class DBSettings(NamedTuple):
@@ -211,6 +213,8 @@ def db_settings_from_dict(
             specified_args[key] = int(value)
         elif key in STRING_KEYS:
             specified_args[key] = str(value)
+        elif key in IGNORED_KEYS:  # temp until https://github.com/rotki/rotki/issues/5684 is done
+            continue  # some keys are using the settings table in lieu of a key-value cache
         elif key == 'taxfree_after_period':
             # taxfree_after_period can also be None, to signify disabled setting
             if value is None:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -8,8 +8,8 @@ import gevent
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
-from rotkehlchen.chain.aggregator import LAST_EVM_ACCOUNTS_DETECT_KEY
 from rotkehlchen.chain.bitcoin.xpub import XpubManager
+from rotkehlchen.chain.constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 from rotkehlchen.chain.ethereum.modules.makerdao.cache import (
     query_ilk_registry_and_maybe_update_cache,
 )


### PR DESCRIPTION
When retreiving settings from the DB, ignore specific settings keys that should have been in the not-yet existing cache table.

Related issue: https://github.com/rotki/rotki/issues/5684

This elif check should be temporary until that issue is complete.
