### PR TITLE
Tweak address scramble algorithm

### DIFF
--- a/frontend/app/src/composables/scramble.ts
+++ b/frontend/app/src/composables/scramble.ts
@@ -10,7 +10,7 @@ export const useScramble = () => {
 
   const scrambleHex = (hex: string): string => {
     const isEth = hex.startsWith('0x');
-    const multiplier = get(scrambleMultiplier) * 100;
+    const multiplier = get(scrambleMultiplier);
 
     const trimmedHex = isEth ? hex.slice(2).toUpperCase() : hex;
 
@@ -18,11 +18,11 @@ export const useScramble = () => {
       (isEth ? '0x' : '') +
       trimmedHex
         .split('')
-        .map(char => {
+        .map((char, charIndex) => {
           const index = alphaNumerics.indexOf(char);
           if (index === -1) return char;
           return alphaNumerics.charAt(
-            Math.floor(index * multiplier * 100) %
+            Math.floor(index * (multiplier + charIndex)) %
               (isEth ? 16 : alphaNumerics.length)
           );
         })


### PR DESCRIPTION
Should fix 
<img width="774" alt="image" src="https://user-images.githubusercontent.com/26648140/221786798-54737648-7c02-4f3b-9500-ca36d40c7b12.png">

The reason there are many duplicate characters, is that we multiplied the index with constant `10000`, which this value has `16` (num of possible characters) as one of its factor.

This is updated version, looks better
<img width="582" alt="image" src="https://user-images.githubusercontent.com/26648140/221787142-8591a842-e586-4c97-8298-71eded31e17b.png">
