### PR TITLE
fix: remove tag flaw

### DIFF
--- a/frontend/app/src/utils/tags.ts
+++ b/frontend/app/src/utils/tags.ts
@@ -13,7 +13,7 @@ const removeTag = (tags: string[] | null, tagName: string): string[] | null => {
   const index = tags.indexOf(tagName);
 
   if (index < 0) {
-    return null;
+    return tags;
   }
 
   return [...tags.slice(0, index), ...tags.slice(index + 1)];


### PR DESCRIPTION
Closes #(issue_number)

Just small bugfix
to reproduce the bug:

1. You have ETH account with tag `a`
2. You have XPUB account with tag `b`
3. You delete tag `a`, ETH label should be empty, XPUB label should not be empty. But what happened is XPUB label is become null.
