### PR TITLE
Ensure correct behaviour of periodic tasks

### DIFF
--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -7,6 +7,7 @@ from rotkehlchen.chain.constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.constants.timing import YEAR_IN_SECONDS
 from rotkehlchen.data_migrations.manager import LAST_DATA_MIGRATION
+from rotkehlchen.db.updates import LAST_DATA_UPDATES_KEY
 from rotkehlchen.db.utils import str_to_bool
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.types import DEFAULT_HISTORICAL_PRICE_ORACLES_ORDER, HistoricalPriceOracle
@@ -93,7 +94,7 @@ STRING_KEYS = (
     'frontend_settings',
 )
 TIMESTAMP_KEYS = ('last_write_ts', 'last_data_upload_ts', 'last_balance_save')
-IGNORED_KEYS = (LAST_EVM_ACCOUNTS_DETECT_KEY,)
+IGNORED_KEYS = (LAST_EVM_ACCOUNTS_DETECT_KEY, LAST_DATA_UPDATES_KEY)
 
 
 class DBSettings(NamedTuple):

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -12,6 +12,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.utils.misc import ts_now
 from rotkehlchen.utils.network import query_file
 
 if TYPE_CHECKING:
@@ -127,3 +128,9 @@ class RotkiDataUpdater:
         latest_spam_assets_version = remote_information[UpdateType.SPAM_ASSETS.value]['latest']
         if local_spam_assets_version < latest_spam_assets_version:
             self.update_spam_assets(local_spam_assets_version, latest_spam_assets_version)
+
+        with self.user_db.user_write() as cursor:
+            cursor.execute(  # remember last time data updates were detected
+                'INSERT OR REPLACE INTO settings (name, value) VALUES (?, ?)',
+                (LAST_DATA_UPDATES_KEY, str(ts_now())),
+            )

--- a/rotkehlchen/tasks/utils.py
+++ b/rotkehlchen/tasks/utils.py
@@ -23,5 +23,5 @@ def should_run_periodic_task(
     if timestamp_in_db is None:
         return True
 
-    last_update_ts = deserialize_timestamp(timestamp_in_db)
+    last_update_ts = deserialize_timestamp(timestamp_in_db[0])
     return ts_now() - last_update_ts >= refresh_period


### PR DESCRIPTION
Make the tasks that read from the user db the last queried timestamp work as expected. Also make sure to record the last queried timestamp for data updates


