### PR TITLE
Claiming COMP after comptroller refill correct decoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Ethereum transactions claiming COMP after comptroller's COMP ran out and has been refilled will now be decoded correctly as COMP rewards.
 * :bug:`-` Fixed an edge case where removing an EVM account multiple times in a row, while a transactions querying task ran, would result in an error.
 * :bug:`-` Ignoring forked assets ETC, BCH and BSV for accounting should now also remove any pre-fork references of them and completely omit them from the PnL report.
 * :bug:`-` Users with kraken accounts with old data that were never purged and repulled will no longer have missing events.

--- a/rotkehlchen/chain/ethereum/modules/compound/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/decoder.py
@@ -24,6 +24,7 @@ log = RotkehlchenLogsAdapter(logger)
 MINT_COMPOUND_TOKEN = b'L \x9b_\xc8\xadPu\x8f\x13\xe2\xe1\x08\x8b\xa5jV\r\xffi\n\x1co\xef&9OL\x03\x82\x1cO'  # noqa: E501
 REDEEM_COMPOUND_TOKEN = b'\xe5\xb7T\xfb\x1a\xbb\x7f\x01\xb4\x99y\x1d\x0b\x82\n\xe3\xb6\xaf4$\xac\x1cYv\x8e\xdbS\xf4\xec1\xa9)'  # noqa: E501
 DISTRIBUTED_SUPPLIER_COMP = b',\xae\xcd\x17\xd0/V\xfa\x89w\x05\xdc\xc7@\xda-#|7?phoN\r\x9b\xd3\xbf\x04\x00\xeaz'  # noqa: E501
+DISTRIBUTED_BORROWER_COMP = b'\x1f\xc3\xec\xc0\x87\xd8\xd2\xd1^#\xd0\x03*\xf5\xa4pY\xc3\x89-\x00=\x8e\x13\x9f\xdc\xb6\xbb2|\x99\xa6'  # noqa: E501
 
 
 class CompoundDecoder(DecoderInterface):
@@ -150,21 +151,30 @@ class CompoundDecoder(DecoderInterface):
     ) -> tuple[Optional[HistoryBaseEntry], list[ActionItem]]:
         """Example tx:
         https://etherscan.io/tx/0x024bd402420c3ba2f95b875f55ce2a762338d2a14dac4887b78174254c9ab807
+        https://etherscan.io/tx/0x25d341421044fa27006c0ec8df11067d80f69b2d2135065828f1992fa6868a49
+
+        A Distributed[Supplier/Borrower]Comp event can happen without a transfer. Just accrues
+        comp in the Comptroller until enough for a transfer is there. Also a transfer may
+        not happen if comptroller does not have enough comp at the time. And next
+        time any such event happens even if compdelta is 0 a big transfer can happen.
+        For example check the 2nd transaction has above.
+
+        So the solution for an approach is to count any COMP transfer to the user from
+        the comptroller as a reward so long as at least 1 such event exists in the transaction.
+
+        contract code: https://etherscan.io/address/0xBafE01ff935C7305907c33BF824352eE5979B526#code
         """
-        if tx_log.topics[0] != DISTRIBUTED_SUPPLIER_COMP:
+        if tx_log.topics[0] not in (DISTRIBUTED_SUPPLIER_COMP, DISTRIBUTED_BORROWER_COMP):
             return None, []
+
+        # Transactions with comp claim have many such "distributed" events. We need to do a
+        # decoded evens iteration only at the end but can't think of a good way to avoid
+        # the possibility of checking all such events
 
         supplier_address = hex_or_bytes_to_address(tx_log.topics[2])
         if not self.base.is_tracked(supplier_address):
             return None, []
 
-        comp_raw_amount = hex_or_bytes_to_int(tx_log.data[0:32])
-        if comp_raw_amount == 0:
-            return None, []  # do not count zero comp collection
-
-        # A DistributedSupplierComp event can happen without a transfer. Just accrues
-        # comp in the Comptroller until enough for a transfer is there. We should only
-        # count a payout if the transfer occurs
         for event in decoded_events:
             if event.event_type == HistoryEventType.RECEIVE and event.location_label == supplier_address and event.asset == A_COMP and event.counterparty == COMPTROLLER_PROXY_ADDRESS:  # noqa: E501
                 event.event_subtype = HistoryEventSubType.REWARD

--- a/rotkehlchen/tests/unit/decoders/test_compound.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound.py
@@ -9,10 +9,11 @@ from rotkehlchen.constants.assets import A_CDAI, A_CETH, A_COMP, A_DAI, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
-from rotkehlchen.types import Location, deserialize_evm_tx_hash
+from rotkehlchen.types import Location, Timestamp, deserialize_evm_tx_hash
 
 ADDY = '0x5727c0481b90a129554395937612d8b9301D6c7b'
 ADDY2 = '0x87Dd56068Af560B0D8472C4EF41CB902FCbF5ebE'
+ADDY3 = '0xb99CC7e10Fe0Acc68C50C7829F473d81e23249cc'
 
 
 @pytest.mark.vcr()
@@ -187,6 +188,97 @@ def test_compound_deposit_with_comp_claim(
             balance=Balance(amount=wrapped_amount),
             location_label=ADDY2,
             notes=f'Receive {wrapped_amount} cDAI from compound',
+            counterparty=CPT_COMPOUND,
+        )]
+    assert events == expected_events
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[ADDY3]])
+def test_compound_multiple_comp_claim(database, ethereum_inquirer):
+    """Test that a transaction with multiple comp claims decodes all of them as rewards
+
+    This is to test against a regression of a bug that decoded the last reward claim
+    as a simple receive.
+    """
+    tx_hash = deserialize_evm_tx_hash('0x25d341421044fa27006c0ec8df11067d80f69b2d2135065828f1992fa6868a49')  # noqa: E501
+    timestamp = Timestamp(1622430975000)
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        database=database,
+        tx_hash=tx_hash,
+    )
+    expected_events = [
+        HistoryBaseEntry(
+            event_identifier=tx_hash,
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            balance=Balance(amount=FVal('0.074799254'), usd_value=ZERO),
+            location_label=ADDY3,
+            notes='Burned 0.074799254 ETH for gas',
+            counterparty=CPT_GAS,
+        ), HistoryBaseEntry(
+            event_identifier=tx_hash,
+            sequence_index=25,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=A_COMP,
+            balance=Balance(amount=FVal('3.037897781413961524'), usd_value=ZERO),
+            location_label=ADDY3,
+            notes='Collect 3.037897781413961524 COMP from compound',
+            counterparty=CPT_COMPOUND,
+        ), HistoryBaseEntry(
+            event_identifier=tx_hash,
+            sequence_index=29,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=A_COMP,
+            balance=Balance(amount=FVal('0.03855352439614718'), usd_value=ZERO),
+            location_label=ADDY3,
+            notes='Collect 0.03855352439614718 COMP from compound',
+            counterparty=CPT_COMPOUND,
+        ), HistoryBaseEntry(
+            event_identifier=tx_hash,
+            sequence_index=36,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=A_COMP,
+            balance=Balance(amount=FVal('0.000186677589499495'), usd_value=ZERO),
+            location_label=ADDY3,
+            notes='Collect 0.000186677589499495 COMP from compound',
+            counterparty=CPT_COMPOUND,
+        ), HistoryBaseEntry(
+            event_identifier=tx_hash,
+            sequence_index=39,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=A_COMP,
+            balance=Balance(amount=FVal('0.001710153220923912'), usd_value=ZERO),
+            location_label=ADDY3,
+            notes='Collect 0.001710153220923912 COMP from compound',
+            counterparty=CPT_COMPOUND,
+        ), HistoryBaseEntry(  # this appeared as Receive at time of writing the test
+            event_identifier=tx_hash,
+            sequence_index=44,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=A_COMP,
+            balance=Balance(amount=FVal('0.000000000000000015'), usd_value=ZERO),
+            location_label=ADDY3,
+            notes='Collect 0.000000000000000015 COMP from compound',
             counterparty=CPT_COMPOUND,
         )]
     assert events == expected_events


### PR DESCRIPTION
This fixes a bug where there was COMP reward accumulated in the controll but failed to be paid out in an older transaction due to (probably) being out of COMP.

Code is here:
https://etherscan.io/address/0xBafE01ff935C7305907c33BF824352eE5979B526#code

After being refilled the Distributed[Supplier/Borrower] events won't match the transfers.

This commit fixes that bug by forcing the transfer search even if compdelta is zero, as accumulation of rewards can have happend in a previous transaction.

