### PR TITLE
Keep information in extra_data field when editing events using the api

### DIFF
--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -71,6 +71,21 @@ HISTORY_EVENT_DB_TUPLE_WRITE = tuple[
     Optional[str],  # extra_data
 ]
 
+HISTORY_EVENT_DB_TUPLE_WRITE_NO_EXTRA_DATA = tuple[
+    bytes,          # event_identifier
+    int,            # sequence_index
+    int,            # timestamp
+    str,            # location
+    Optional[str],  # location label
+    str,            # asset
+    str,            # amount
+    str,            # usd value
+    Optional[str],  # notes
+    str,            # type
+    str,            # subtype
+    Optional[str],  # counterparty
+]
+
 SUB_SWAPS_DETAILS = 'sub_swaps'
 LIQUITY_STAKING_DETAILS = 'liquity_staking'
 
@@ -115,6 +130,14 @@ class HistoryBaseEntry(AccountingEventMixin):
     extra_data: Optional[dict[str, Any]] = None
 
     def serialize_for_db(self) -> HISTORY_EVENT_DB_TUPLE_WRITE:
+        extra_data = json.dumps(self.extra_data) if self.extra_data else None
+        return self.serialize_for_db_without_extra_data() + (extra_data,)
+
+    def serialize_for_db_without_extra_data(self) -> HISTORY_EVENT_DB_TUPLE_WRITE_NO_EXTRA_DATA:
+        """
+        Serialize information for the database excluding the extra data field.
+        This is used when writting information edited by the user
+        """
         return (
             self.event_identifier,
             self.sequence_index,
@@ -128,7 +151,6 @@ class HistoryBaseEntry(AccountingEventMixin):
             self.event_type.serialize(),
             self.event_subtype.serialize(),
             self.counterparty,
-            json.dumps(self.extra_data) if self.extra_data else None,
         )
 
     @classmethod

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -88,14 +88,17 @@ class DBHistoryEvents():
             )
 
     def edit_history_event(self, event: HistoryBaseEntry) -> tuple[bool, str]:
-        """Edit a history entry to the DB. Returns the edited entry"""
+        """
+        Edit a history entry to the DB with information provided by the user.
+        NOTE: It edits all the fields except the extra_data one.
+        """
         with self.db.user_write() as cursor:
             try:
                 cursor.execute(
                     'UPDATE history_events SET event_identifier=?, sequence_index=?, timestamp=?, '
                     'location=?, location_label=?, asset=?, amount=?, usd_value=?, notes=?, '
-                    'type=?, subtype=?, counterparty=?, extra_data=? WHERE identifier=?',
-                    (*event.serialize_for_db(), event.identifier),
+                    'type=?, subtype=?, counterparty=? WHERE identifier=?',
+                    (*event.serialize_for_db_without_extra_data(), event.identifier),
                 )
             except sqlcipher.IntegrityError:  # pylint: disable=no-member
                 msg = (


### PR DESCRIPTION
The API was overwritting the extra data field whne saving events. Since this is a field that we don't expose to the user what I did was retrieve the information before saving it and addint the field to the saved object.

I created a new function to avoid mixing the logic of the db query with the API code handling the addition flow

Closes #5734
