### PR TITLE
Robust price query for yearn vaults and other known protocol tokens

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :bug:`` Fixed a bug where balancer icon is not showed as transaction event counterparty.
+* :bug:`-` Yearn vault price queries will now work more robustly. If the underlying token is not in rotki's DB it will be queried from the chain.
+* :bug:`-` Fixed a bug where balancer icon is not showed as transaction event counterparty.
 * :bug:`5672` Exported csv files after using ACB as the cost basis calculation algorithm will now reflect the same numbers as shown in the app.
 * :bug:`-` Ethereum transactions claiming COMP after comptroller's COMP ran out and has been refilled will now be decoded correctly as COMP rewards.
 * :bug:`-` Fixed an edge case where removing an EVM account multiple times in a row, while a transactions querying task ran, would result in an error.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Yearn vault price queries will now work more robustly. If the underlying token is not in rotki's DB it will be queried from the chain.
+* :feature:`-` For known protocols like yearn, curve, uniswap etc, if the on-chain price query fails, external oracles will still be queried in case something is found there.
 * :bug:`-` Fixed a bug where balancer icon is not showed as transaction event counterparty.
 * :bug:`5672` Exported csv files after using ACB as the cost basis calculation algorithm will now reflect the same numbers as shown in the app.
 * :bug:`-` Ethereum transactions claiming COMP after comptroller's COMP ran out and has been refilled will now be decoded correctly as COMP rewards.


### PR DESCRIPTION
Our logic was really flawed. Two things fixed.

### [More robust price query for yearn vault tokens](https://github.com/rotki/rotki/commit/09f4e3f4ff2981717fb89007d9dc73f0c543f39f) 

If a yearn vault is for some reason missing the underlying token from
the global DB we query the chain for it and fill it in so that the
price query works properly. Also save it in the DB, so that next time the on-chain query is skipped.

### [If known protocol token chain price query fails, fallback to oracles](https://github.com/rotki/rotki/commit/7812001228a0028a05dcbb846d76dfa4cf157730) 

The code before exited immediately after the on-chain query failed,
thinking that the external oracles will not be able to give an answer.

But that's misguided. Both coingecko and defillama have lots of those
special tokens and even the ability to query by address (which we
already utilize at least for defillama).

A user tried to query for example [yvDAI](https://www.coingecko.com/en/coins/yvdai) and it failed due to missing underlying token. Then they edited coingecko id and it did not work. Neither did defillama. The problem was that if on-chain query failed we gave up.

This is now fixed.