### PR TITLE
Ignore macos tmpdir for dead fixtures

### DIFF
--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -110,6 +110,7 @@ if sys.platform == 'darwin':
         created as a sub directory of the base temporary
         directory.  The returned object is a `py.path.local`_
         path object.
+        # pytest-deadfixtures ignore
         """
         name = request.node.name
         name = re.sub(r'[\W]', '_', name)


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
