### PR TITLE
Updates build runner to ubuntu 20.04

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -100,7 +100,7 @@ jobs:
     env:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: create_draft
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #4746 

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

> **Note** We might need to cherry-pick this to bugfixes after the end of March

The deprecation is in two weeks and they have at least two more 24h brownouts planned

- March 21, 00.00 UTC – March 22, 00.00 UTC
- March 28, 00.00 UTC – March 29, 00.00 UTC