### PR TITLE
Refactor pagination and filters on history pages

### DIFF
--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -289,7 +289,7 @@
     "useHistoryAutoRefresh": true,
     "useHistoryEventTypeData": true,
     "useHistoryIgnoringApi": true,
-    "useHistoryPagination": true,
+    "useHistoryPaginationFilter": true,
     "useHistoryStore": true,
     "useI18n": true,
     "useIdle": true,

--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -289,6 +289,7 @@
     "useHistoryAutoRefresh": true,
     "useHistoryEventTypeData": true,
     "useHistoryIgnoringApi": true,
+    "useHistoryPagination": true,
     "useHistoryStore": true,
     "useI18n": true,
     "useIdle": true,

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -96,6 +96,7 @@
     "eslint": "8.34.0",
     "eslint-plugin-cypress": "2.12.1",
     "flush-promises": "1.0.2",
+    "msw": "^1.2.0",
     "postcss": "8.4.21",
     "postcss-html": "1.5.0",
     "postcss-scss": "4.0.6",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -96,7 +96,7 @@
     "eslint": "8.34.0",
     "eslint-plugin-cypress": "2.12.1",
     "flush-promises": "1.0.2",
-    "msw": "^1.2.0",
+    "msw": "1.2.1",
     "postcss": "8.4.21",
     "postcss-html": "1.5.0",
     "postcss-scss": "4.0.6",

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -286,6 +286,7 @@ declare global {
   const useHistoryAutoRefresh: typeof import('./composables/history/auto-refresh')['useHistoryAutoRefresh']
   const useHistoryEventTypeData: typeof import('./composables/history/transactions/event-data')['useHistoryEventTypeData']
   const useHistoryIgnoringApi: typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']
+  const useHistoryPagination: typeof import('./composables/history/paginate')['useHistoryPagination']
   const useHistoryStore: typeof import('./store/history/index')['useHistoryStore']
   const useI18n: typeof import('vue-i18n-composable')['useI18n']
   const useIdle: typeof import('@vueuse/core')['useIdle']
@@ -795,6 +796,7 @@ declare module 'vue' {
     readonly useHistoryAutoRefresh: UnwrapRef<typeof import('./composables/history/auto-refresh')['useHistoryAutoRefresh']>
     readonly useHistoryEventTypeData: UnwrapRef<typeof import('./composables/history/transactions/event-data')['useHistoryEventTypeData']>
     readonly useHistoryIgnoringApi: UnwrapRef<typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']>
+    readonly useHistoryPagination: UnwrapRef<typeof import('./composables/history/paginate')['useHistoryPagination']>
     readonly useHistoryStore: UnwrapRef<typeof import('./store/history/index')['useHistoryStore']>
     readonly useI18n: UnwrapRef<typeof import('vue-i18n-composable')['useI18n']>
     readonly useIdle: UnwrapRef<typeof import('@vueuse/core')['useIdle']>

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -286,7 +286,7 @@ declare global {
   const useHistoryAutoRefresh: typeof import('./composables/history/auto-refresh')['useHistoryAutoRefresh']
   const useHistoryEventTypeData: typeof import('./composables/history/transactions/event-data')['useHistoryEventTypeData']
   const useHistoryIgnoringApi: typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']
-  const useHistoryPagination: typeof import('./composables/history/paginate')['useHistoryPagination']
+  const useHistoryPaginationFilter: typeof import('./composables/history/filter-paginate')['useHistoryPaginationFilter']
   const useHistoryStore: typeof import('./store/history/index')['useHistoryStore']
   const useI18n: typeof import('vue-i18n-composable')['useI18n']
   const useIdle: typeof import('@vueuse/core')['useIdle']
@@ -796,7 +796,7 @@ declare module 'vue' {
     readonly useHistoryAutoRefresh: UnwrapRef<typeof import('./composables/history/auto-refresh')['useHistoryAutoRefresh']>
     readonly useHistoryEventTypeData: UnwrapRef<typeof import('./composables/history/transactions/event-data')['useHistoryEventTypeData']>
     readonly useHistoryIgnoringApi: UnwrapRef<typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']>
-    readonly useHistoryPagination: UnwrapRef<typeof import('./composables/history/paginate')['useHistoryPagination']>
+    readonly useHistoryPaginationFilter: UnwrapRef<typeof import('./composables/history/filter-paginate')['useHistoryPaginationFilter']>
     readonly useHistoryStore: UnwrapRef<typeof import('./store/history/index')['useHistoryStore']>
     readonly useI18n: UnwrapRef<typeof import('vue-i18n-composable')['useI18n']>
     readonly useIdle: UnwrapRef<typeof import('@vueuse/core')['useIdle']>

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -10,7 +10,7 @@ import { type TradeLocation } from '@/types/history/trade/location';
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
-import { type Matcher } from '@/composables/filters/asset-movement';
+import type { Filters, Matcher } from '@/composables/filters/asset-movement';
 
 const props = withDefaults(
   defineProps<{
@@ -97,6 +97,7 @@ const {
   AssetMovement,
   AssetMovementRequestPayload,
   AssetMovementEntry,
+  Filters,
   Matcher
 >(locationOverview, mainPage, useAssetMovementFilters, fetchAssetMovements);
 

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -92,6 +92,7 @@ const {
   setPage,
   setOptions,
   setFilter,
+  applyRouteFilter,
   fetchData
 } = useHistoryPaginationFilter<
   AssetMovement,
@@ -119,6 +120,10 @@ const getItemClass = (item: AssetMovementEntry) =>
   item.ignoredInAccounting ? 'darken-row' : '';
 
 const pageRoute = Routes.HISTORY_DEPOSITS_WITHDRAWALS;
+
+onBeforeMount(() => {
+  applyRouteFilter();
+});
 
 onMounted(async () => {
   await fetchData();

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -10,6 +10,7 @@ import { type TradeLocation } from '@/types/history/trade/location';
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
+import { type Matcher } from '@/composables/filters/asset-movement';
 
 const props = withDefaults(
   defineProps<{
@@ -95,7 +96,8 @@ const {
 } = useHistoryPaginationFilter<
   AssetMovement,
   AssetMovementRequestPayload,
-  AssetMovementEntry
+  AssetMovementEntry,
+  Matcher
 >(locationOverview, mainPage, useAssetMovementFilters, fetchAssetMovements);
 
 useHistoryAutoRefresh(fetchData);

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -92,7 +92,6 @@ const {
   setPage,
   setOptions,
   setFilter,
-  applyRouteFilter,
   fetchData
 } = useHistoryPaginationFilter<
   AssetMovement,
@@ -120,10 +119,6 @@ const getItemClass = (item: AssetMovementEntry) =>
   item.ignoredInAccounting ? 'darken-row' : '';
 
 const pageRoute = Routes.HISTORY_DEPOSITS_WITHDRAWALS;
-
-onBeforeMount(() => {
-  applyRouteFilter();
-});
 
 onMounted(async () => {
   await fetchData();

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -11,6 +11,7 @@ import {
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
+import { type Matcher } from '@/composables/filters/ledger-actions';
 
 const props = withDefaults(
   defineProps<{
@@ -101,7 +102,8 @@ const {
 } = useHistoryPaginationFilter<
   LedgerAction,
   LedgerActionRequestPayload,
-  LedgerActionEntry
+  LedgerActionEntry,
+  Matcher
 >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
 
 const newLedgerAction = () => {

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -11,7 +11,7 @@ import {
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
-import { type Matcher } from '@/composables/filters/ledger-actions';
+import type { Filters, Matcher } from '@/composables/filters/ledger-actions';
 
 const props = withDefaults(
   defineProps<{
@@ -103,6 +103,7 @@ const {
   LedgerAction,
   LedgerActionRequestPayload,
   LedgerActionEntry,
+  Filters,
   Matcher
 >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
 

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -98,6 +98,7 @@ const {
   setPage,
   setOptions,
   setFilter,
+  applyRouteFilter,
   fetchData
 } = useHistoryPaginationFilter<
   LedgerAction,
@@ -199,6 +200,10 @@ const getItemClass = (item: LedgerActionEntry) => {
 };
 
 const pageRoute = Routes.HISTORY_LEDGER_ACTIONS;
+
+onBeforeMount(() => {
+  applyRouteFilter();
+});
 
 onMounted(async () => {
   const query = get(route).query;

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -1,26 +1,15 @@
 <script setup lang="ts">
-import dropRight from 'lodash/dropRight';
-import { type ComputedRef, type Ref, type UnwrapRef } from 'vue';
 import { type DataTableHeader } from 'vuetify';
-import isEqual from 'lodash/isEqual';
-import { type MaybeRef } from '@vueuse/core';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
+import { type TradeLocation } from '@/types/history/trade/location';
 import {
   type LedgerAction,
   type LedgerActionEntry,
   type LedgerActionRequestPayload
 } from '@/types/history/ledger-action/ledger-actions';
-import { type TradeLocation } from '@/types/history/trade/location';
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
-import { type TablePagination } from '@/types/pagination';
-import {
-  type LocationQuery,
-  RouterPaginationOptionsSchema
-} from '@/types/route';
-import { type Collection } from '@/types/collection';
-import { defaultCollectionState, defaultOptions } from '@/utils/collection';
 import { SavedFilterLocation } from '@/types/filtering';
 
 const props = withDefaults(
@@ -36,39 +25,9 @@ const props = withDefaults(
 
 const { locationOverview, mainPage } = toRefs(props);
 
-const selected: Ref<LedgerActionEntry[]> = ref([]);
-const options: Ref<TablePagination<LedgerAction>> = ref(defaultOptions());
-const openDialog: Ref<boolean> = ref(false);
-const editableItem: Ref<LedgerActionEntry | null> = ref(null);
-const ledgerActionsToDelete: Ref<LedgerActionEntry[]> = ref([]);
-const confirmationMessage: Ref<string> = ref('');
-const expanded: Ref<LedgerActionEntry[]> = ref([]);
-const userAction: Ref<boolean> = ref(false);
-
-const { deleteLedgerAction, fetchLedgerActions, refreshLedgerActions } =
-  useLedgerActions();
-
 const { tc } = useI18n();
-
-const pageParams: ComputedRef<LedgerActionRequestPayload> = computed(() => {
-  const { itemsPerPage, page, sortBy, sortDesc } = get(options);
-  const offset = (page - 1) * itemsPerPage;
-
-  const selectedFilters = get(filters);
-  const overview = get(locationOverview);
-  if (overview) {
-    selectedFilters.location = overview;
-  }
-
-  return {
-    limit: itemsPerPage,
-    offset,
-    orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
-    ascending:
-      sortDesc.length > 1 ? dropRight(sortDesc).map(bool => !bool) : [false],
-    ...(selectedFilters as Partial<LedgerActionRequestPayload>)
-  };
-});
+const router = useRouter();
+const route = useRoute();
 
 const tableHeaders = computed<DataTableHeader[]>(() => {
   const headers: DataTableHeader[] = [
@@ -120,22 +79,30 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
   return headers;
 });
 
+const { deleteLedgerAction, fetchLedgerActions, refreshLedgerActions } =
+  useLedgerActions();
+
 const {
+  options,
+  selected,
+  openDialog,
+  editableItem,
+  itemsToDelete: ledgerActionsToDelete,
+  confirmationMessage,
+  expanded,
   isLoading,
   state: ledgerActions,
-  execute
-} = useAsyncState<
-  Collection<LedgerActionEntry>,
-  MaybeRef<LedgerActionRequestPayload>[]
->(args => fetchLedgerActions(args), defaultCollectionState(), {
-  immediate: false,
-  resetOnExecute: false,
-  delay: 0
-});
-
-const fetchData = async (): Promise<void> => {
-  await execute(0, pageParams);
-};
+  filters,
+  matchers,
+  setPage,
+  setOptions,
+  setFilter,
+  fetchData
+} = useHistoryPaginationFilter<
+  LedgerAction,
+  LedgerActionRequestPayload,
+  LedgerActionEntry
+>(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
 
 const newLedgerAction = () => {
   set(editableItem, null);
@@ -196,60 +163,8 @@ const deleteLedgerActionHandler = async () => {
     selected,
     selectedVal.filter(ledgerActions => !ids.includes(ledgerActions.identifier))
   );
+
   await fetchData();
-};
-
-const router = useRouter();
-const route = useRoute();
-
-const { filters, matchers, updateFilter, RouteFilterSchema } =
-  useLedgerActionsFilter();
-
-const applyRouteFilter = () => {
-  if (!get(mainPage)) {
-    return;
-  }
-
-  const query = get(route).query;
-  const parsedOptions = RouterPaginationOptionsSchema.parse(query);
-  const parsedFilters = RouteFilterSchema.parse(query);
-  updateFilter(parsedFilters);
-  set(options, {
-    ...get(options),
-    ...parsedOptions
-  });
-};
-
-watch(route, () => {
-  set(userAction, false);
-  applyRouteFilter();
-});
-
-onBeforeMount(() => {
-  applyRouteFilter();
-});
-
-watch(filters, async (filters, oldFilters) => {
-  if (isEqual(filters, oldFilters)) {
-    return;
-  }
-
-  set(options, { ...get(options), page: 1 });
-});
-
-const setPage = (page: number) => {
-  set(userAction, true);
-  set(options, { ...get(options), page });
-};
-
-const setOptions = (newOptions: TablePagination<LedgerAction>) => {
-  set(userAction, true);
-  set(options, newOptions);
-};
-
-const setFilter = (newFilter: UnwrapRef<typeof filters>) => {
-  set(userAction, true);
-  updateFilter(newFilter);
 };
 
 const { ignore } = useIgnore(
@@ -260,21 +175,6 @@ const { ignore } = useIgnore(
   selected,
   () => fetchData()
 );
-
-onMounted(async () => {
-  const query = get(route).query;
-
-  if (query.add) {
-    newLedgerAction();
-    await router.replace({ query: {} });
-  } else {
-    await fetchData();
-    await refreshLedgerActions();
-  }
-});
-
-const { isLoading: isSectionLoading } = useStatusStore();
-const loading = isSectionLoading(Section.LEDGER_ACTIONS);
 
 const { show } = useConfirmStore();
 
@@ -288,45 +188,25 @@ const showDeleteConfirmation = () => {
   );
 };
 
-const getItemClass = (item: LedgerActionEntry) =>
-  item.ignoredInAccounting ? 'darken-row' : '';
+const { isLoading: isSectionLoading } = useStatusStore();
+const loading = isSectionLoading(Section.LEDGER_ACTIONS);
+
+const getItemClass = (item: LedgerActionEntry) => {
+  return item.ignoredInAccounting ? 'darken-row' : '';
+};
 
 const pageRoute = Routes.HISTORY_LEDGER_ACTIONS;
 
-const getQuery = (): LocationQuery => {
-  const opts = get(options);
-  const { itemsPerPage, page, sortBy, sortDesc } = opts;
+onMounted(async () => {
+  const query = get(route).query;
 
-  const selectedFilters = get(filters);
-
-  const overview = get(locationOverview);
-  if (overview) {
-    selectedFilters.location = overview;
+  if (query.add) {
+    newLedgerAction();
+    await router.replace({ query: {} });
+  } else {
+    await fetchData();
+    await refreshLedgerActions();
   }
-
-  return {
-    itemsPerPage: itemsPerPage.toString(),
-    page: page.toString(),
-    sortBy,
-    sortDesc: sortDesc.map(x => x.toString()),
-    ...selectedFilters
-  };
-};
-
-watch(pageParams, async (params, op) => {
-  if (isEqual(params, op)) {
-    return;
-  }
-  if (get(userAction) && get(mainPage)) {
-    // Route should only be updated on user action otherwise it messes with
-    // forward navigation.
-    await router.push({
-      query: getQuery()
-    });
-    set(userAction, false);
-  }
-
-  await fetchData();
 });
 
 watch(loading, async (isLoading, wasLoading) => {

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -98,7 +98,6 @@ const {
   setPage,
   setOptions,
   setFilter,
-  applyRouteFilter,
   fetchData
 } = useHistoryPaginationFilter<
   LedgerAction,
@@ -200,10 +199,6 @@ const getItemClass = (item: LedgerActionEntry) => {
 };
 
 const pageRoute = Routes.HISTORY_LEDGER_ACTIONS;
-
-onBeforeMount(() => {
-  applyRouteFilter();
-});
 
 onMounted(async () => {
   const query = get(route).query;

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -194,9 +194,8 @@ const showDeleteConfirmation = () => {
 const { isLoading: isSectionLoading } = useStatusStore();
 const loading = isSectionLoading(Section.LEDGER_ACTIONS);
 
-const getItemClass = (item: LedgerActionEntry) => {
-  return item.ignoredInAccounting ? 'darken-row' : '';
-};
+const getItemClass = (item: LedgerActionEntry) =>
+  item.ignoredInAccounting ? 'darken-row' : '';
 
 const pageRoute = Routes.HISTORY_LEDGER_ACTIONS;
 

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -286,7 +286,7 @@ watch(loading, async (isLoading, wasLoading) => {
         data-cy="closed-trades__add-trade"
         @click="newExternalTrade()"
       >
-        <v-icon> mdi-plus</v-icon>
+        <v-icon> mdi-plus </v-icon>
       </v-btn>
       <template #title>
         <refresh-button
@@ -318,7 +318,7 @@ watch(loading, async (isLoading, wasLoading) => {
                     :disabled="selected.length === 0"
                     @click="massDelete"
                   >
-                    <v-icon> mdi-delete-outline</v-icon>
+                    <v-icon> mdi-delete-outline </v-icon>
                   </v-btn>
                 </v-col>
               </v-row>

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -132,6 +132,7 @@ const {
   setPage,
   setOptions,
   setFilter,
+  applyRouteFilter,
   fetchData
 } = useHistoryPaginationFilter<
   Trade,
@@ -253,6 +254,10 @@ const getItemClass = (item: TradeEntry) =>
   item.ignoredInAccounting ? 'darken-row' : '';
 
 const pageRoute = Routes.HISTORY_TRADES;
+
+onBeforeMount(() => {
+  applyRouteFilter();
+});
 
 onMounted(async () => {
   const query = get(route).query;

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import dropRight from 'lodash/dropRight';
-import { type ComputedRef, type Ref, type UnwrapRef } from 'vue';
+import { type Ref, type UnwrapRef } from 'vue';
 import { type DataTableHeader } from 'vuetify';
 import isEqual from 'lodash/isEqual';
-import { type MaybeRef } from '@vueuse/core';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
 import { type TradeLocation } from '@/types/history/trade/location';
@@ -19,8 +17,7 @@ import {
   type LocationQuery,
   RouterPaginationOptionsSchema
 } from '@/types/route';
-import { type Collection } from '@/types/collection';
-import { defaultCollectionState, defaultOptions } from '@/utils/collection';
+import { defaultOptions } from '@/utils/collection';
 import { assert } from '@/utils/assertions';
 import { SavedFilterLocation } from '@/types/filtering';
 
@@ -50,28 +47,28 @@ const hideIgnoredTrades: Ref<boolean> = ref(false);
 
 const { tc } = useI18n();
 
-const pageParams: ComputedRef<TradeRequestPayload> = computed(() => {
-  const { itemsPerPage, page, sortBy, sortDesc } = get(options);
-  const offset = (page - 1) * itemsPerPage;
-
-  const selectedFilters = get(filters);
-  const overview = get(locationOverview);
-  if (overview) {
-    selectedFilters.location = overview;
-  }
-
-  return {
-    ...(selectedFilters as Partial<TradeRequestPayload>),
-    includeIgnoredTrades: !get(hideIgnoredTrades),
-    limit: itemsPerPage,
-    offset,
-    orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
-    ascending:
-      sortDesc && sortDesc.length > 1
-        ? dropRight(sortDesc).map(bool => !bool)
-        : [false]
-  };
-});
+// const pageParams: ComputedRef<TradeRequestPayload> = computed(() => {
+//   const { itemsPerPage, page, sortBy, sortDesc } = get(options);
+//   const offset = (page - 1) * itemsPerPage;
+//
+//   const selectedFilters = get(filters);
+//   const overview = get(locationOverview);
+//   if (overview) {
+//     selectedFilters.location = overview;
+//   }
+//
+//   return {
+//     ...(selectedFilters as Partial<TradeRequestPayload>),
+//     includeIgnoredTrades: !get(hideIgnoredTrades),
+//     limit: itemsPerPage,
+//     offset,
+//     orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
+//     ascending:
+//       sortDesc && sortDesc.length > 1
+//         ? dropRight(sortDesc).map(bool => !bool)
+//         : [false]
+//   };
+// });
 
 const tableHeaders = computed<DataTableHeader[]>(() => {
   const overview = get(locationOverview);
@@ -149,19 +146,19 @@ const { assetSymbol } = assetInfoRetrievalStore;
 
 const { deleteExternalTrade, fetchTrades, refreshTrades } = useTrades();
 
-const {
-  isLoading,
-  state: trades,
-  execute
-} = useAsyncState<Collection<TradeEntry>, MaybeRef<TradeRequestPayload>[]>(
-  args => fetchTrades(args),
-  defaultCollectionState(),
-  {
-    immediate: false,
-    resetOnExecute: false,
-    delay: 0
-  }
-);
+// const {
+//   isLoading,
+//   state: trades,
+//   execute
+// } = useAsyncState<Collection<TradeEntry>, MaybeRef<TradeRequestPayload>[]>(
+//   args => fetchTrades(args),
+//   defaultCollectionState(),
+//   {
+//     immediate: false,
+//     resetOnExecute: false,
+//     delay: 0
+//   }
+// );
 
 const newExternalTrade = () => {
   set(editableItem, null);
@@ -369,6 +366,17 @@ const fetchData = async (): Promise<void> => {
 };
 
 useHistoryAutoRefresh(() => fetchData());
+const {
+  pageParams,
+  isLoading,
+  state: trades,
+  execute
+} = useHistoryPagination<Trade, TradeRequestPayload, TradeEntry>(
+  locationOverview,
+  mainPage,
+  useTradeFilters,
+  fetchTrades
+);
 
 watch(pageParams, async (params, op) => {
   if (isEqual(params, op)) {
@@ -439,7 +447,7 @@ watch(loading, async (isLoading, wasLoading) => {
                     :disabled="selected.length === 0"
                     @click="massDelete"
                   >
-                    <v-icon> mdi-delete-outline </v-icon>
+                    <v-icon> mdi-delete-outline</v-icon>
                   </v-btn>
                 </v-col>
               </v-row>
@@ -499,7 +507,7 @@ watch(loading, async (isLoading, wasLoading) => {
             <template #item.ignoredInAccounting="{ item, isMobile }">
               <div v-if="item.ignoredInAccounting">
                 <badge-display v-if="isMobile" color="grey">
-                  <v-icon small> mdi-eye-off </v-icon>
+                  <v-icon small> mdi-eye-off</v-icon>
                   <span class="ml-2">
                     {{ tc('common.ignored_in_accounting') }}
                   </span>
@@ -507,7 +515,7 @@ watch(loading, async (isLoading, wasLoading) => {
                 <v-tooltip v-else bottom>
                   <template #activator="{ on }">
                     <badge-display color="grey" v-on="on">
-                      <v-icon small> mdi-eye-off </v-icon>
+                      <v-icon small> mdi-eye-off</v-icon>
                     </badge-display>
                   </template>
                   <span>

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -103,6 +103,14 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
   return headers;
 });
 
+const extraParams = computed(() => ({
+  includeIgnoredTrades: !get(hideIgnoredTrades)
+}));
+
+watch(hideIgnoredTrades, () => {
+  setPage(1);
+});
+
 const assetInfoRetrievalStore = useAssetInfoRetrieval();
 const { assetSymbol } = assetInfoRetrievalStore;
 
@@ -129,7 +137,12 @@ const {
   mainPage,
   useTradeFilters,
   fetchTrades,
-  () => ({ includeIgnoredTrades: !get(hideIgnoredTrades) })
+  {
+    onUpdateFilters: () => {
+      set(hideIgnoredTrades, route.query.includeIgnoredTrades === 'false');
+    },
+    extraParams
+  }
 );
 
 useHistoryAutoRefresh(fetchData);
@@ -252,18 +265,10 @@ onMounted(async () => {
   }
 });
 
-watch(hideIgnoredTrades, () => {
-  setPage(1);
-});
-
 watch(loading, async (isLoading, wasLoading) => {
   if (!isLoading && wasLoading) {
     await fetchData();
   }
-});
-
-watch(route, ({ query }) => {
-  set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
 });
 </script>
 

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -138,8 +138,8 @@ const {
   useTradeFilters,
   fetchTrades,
   {
-    onUpdateFilters: () => {
-      set(hideIgnoredTrades, route.query.includeIgnoredTrades === 'false');
+    onUpdateFilters(query) {
+      set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
     },
     extraParams
   }

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -132,7 +132,6 @@ const {
   setPage,
   setOptions,
   setFilter,
-  applyRouteFilter,
   fetchData
 } = useHistoryPaginationFilter<
   Trade,
@@ -254,10 +253,6 @@ const getItemClass = (item: TradeEntry) =>
   item.ignoredInAccounting ? 'darken-row' : '';
 
 const pageRoute = Routes.HISTORY_TRADES;
-
-onBeforeMount(() => {
-  applyRouteFilter();
-});
 
 onMounted(async () => {
   const query = get(route).query;

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -12,7 +12,7 @@ import {
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
-import { type Matcher } from '@/composables/filters/trades';
+import type { Filters, Matcher } from '@/composables/filters/trades';
 
 const props = withDefaults(
   defineProps<{
@@ -133,18 +133,18 @@ const {
   setOptions,
   setFilter,
   fetchData
-} = useHistoryPaginationFilter<Trade, TradeRequestPayload, TradeEntry, Matcher>(
-  locationOverview,
-  mainPage,
-  useTradeFilters,
-  fetchTrades,
-  {
-    onUpdateFilters(query) {
-      set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
-    },
-    extraParams
-  }
-);
+} = useHistoryPaginationFilter<
+  Trade,
+  TradeRequestPayload,
+  TradeEntry,
+  Filters,
+  Matcher
+>(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+  onUpdateFilters(query) {
+    set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
+  },
+  extraParams
+});
 
 useHistoryAutoRefresh(fetchData);
 

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -12,6 +12,7 @@ import {
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
+import { type Matcher } from '@/composables/filters/trades';
 
 const props = withDefaults(
   defineProps<{
@@ -104,7 +105,7 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
 });
 
 const extraParams = computed(() => ({
-  includeIgnoredTrades: !get(hideIgnoredTrades)
+  includeIgnoredTrades: (!get(hideIgnoredTrades)).toString()
 }));
 
 watch(hideIgnoredTrades, () => {
@@ -132,7 +133,7 @@ const {
   setOptions,
   setFilter,
   fetchData
-} = useHistoryPaginationFilter<Trade, TradeRequestPayload, TradeEntry>(
+} = useHistoryPaginationFilter<Trade, TradeRequestPayload, TradeEntry, Matcher>(
   locationOverview,
   mainPage,
   useTradeFilters,

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -129,7 +129,7 @@ const {
   mainPage,
   useTradeFilters,
   fetchTrades,
-  { hideIgnoredTrades }
+  () => ({ includeIgnoredTrades: !get(hideIgnoredTrades) })
 );
 
 useHistoryAutoRefresh(fetchData);
@@ -260,6 +260,10 @@ watch(loading, async (isLoading, wasLoading) => {
   if (!isLoading && wasLoading) {
     await fetchData();
   }
+});
+
+watch(route, ({ query }) => {
+  set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
 });
 </script>
 

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -241,7 +241,7 @@ const showDeleteConfirmation = () => {
       title: tc('closed_trades.confirmation.title'),
       message: get(confirmationMessage)
     },
-    () => deleteTradeHandler()
+    deleteTradeHandler
   );
 };
 

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -71,9 +71,9 @@ const confirmationTitle: Ref<string> = ref('');
 const confirmationPrimaryAction: Ref<string> = ref('');
 const accounts: Ref<GeneralAccount[]> = ref([]);
 
-const usedTitle: ComputedRef<string> = computed(() => {
-  return get(sectionTitle) || tc('transactions.title');
-});
+const usedTitle: ComputedRef<string> = computed(
+  () => get(sectionTitle) || tc('transactions.title')
+);
 
 const usedAccounts: ComputedRef<Account<BlockchainSelection>[]> = computed(
   () => {
@@ -183,21 +183,17 @@ const {
         set(accounts, parsedAccounts.accounts);
       }
     },
-    extraParams: computed(() => {
-      return {
-        accounts: get(usedAccounts).map(
-          account => `${account.address}#${account.chain}`
-        )
-      };
-    }),
-    customPageParams: computed<Partial<TransactionRequestPayload>>(() => {
-      return {
-        protocols: get(protocols),
-        eventTypes: get(eventTypes),
-        eventSubtypes: get(eventSubTypes),
-        accounts: get(filteredAccounts)
-      };
-    })
+    extraParams: computed(() => ({
+      accounts: get(usedAccounts).map(
+        account => `${account.address}#${account.chain}`
+      )
+    })),
+    customPageParams: computed<Partial<TransactionRequestPayload>>(() => ({
+      protocols: get(protocols),
+      eventTypes: get(eventTypes),
+      eventSubtypes: get(eventSubTypes),
+      accounts: get(filteredAccounts)
+    }))
   }
 );
 

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -169,7 +169,7 @@ const {
   TransactionRequestPayload,
   EthTransactionEntry
 >(
-  ref(null),
+  null,
   mainPage,
   () => useTransactionFilter(get(protocols).length > 0),
   fetchTransactions,

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -25,6 +25,7 @@ import { getCollectionData } from '@/utils/collection';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { RouterAccountsSchema } from '@/types/route';
 import { SavedFilterLocation } from '@/types/filtering';
+import { type Matcher } from '@/composables/filters/transactions';
 
 const props = withDefaults(
   defineProps<{
@@ -62,7 +63,6 @@ const {
   onlyChains
 } = toRefs(props);
 
-const userAction = ref(false);
 const editableItem: Ref<EthTransactionEventEntry | null> = ref(null);
 const selectedTransaction: Ref<EthTransactionEntry | null> = ref(null);
 const eventToDelete: Ref<EthTransactionEventEntry | null> = ref(null);
@@ -156,6 +156,7 @@ const {
   openDialog,
   confirmationMessage,
   isLoading,
+  userAction,
   state: transactions,
   filters,
   matchers,
@@ -167,7 +168,8 @@ const {
 } = useHistoryPaginationFilter<
   EthTransaction,
   TransactionRequestPayload,
-  EthTransactionEntry
+  EthTransactionEntry,
+  Matcher
 >(
   null,
   mainPage,

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type Account, type GeneralAccount } from '@rotki/common/lib/account';
-import { type ComputedRef, type Ref, type UnwrapRef } from 'vue';
+import { type ComputedRef, type Ref } from 'vue';
 import { type DataTableHeader } from 'vuetify';
 import {
   type Blockchain,
@@ -12,7 +12,6 @@ import {
   type HistoryEventType,
   type TransactionEventProtocol
 } from '@rotki/common/lib/history/tx-events';
-import { type MaybeRef } from '@vueuse/core';
 import {
   type EthTransaction,
   type EthTransactionEntry,
@@ -22,20 +21,9 @@ import {
 } from '@/types/history/tx';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
-import {
-  defaultCollectionState,
-  defaultOptions,
-  getCollectionData
-} from '@/utils/collection';
+import { getCollectionData } from '@/utils/collection';
 import { IgnoreActionType } from '@/types/history/ignored';
-import { type TablePagination } from '@/types/pagination';
-import {
-  type LocationQuery,
-  RouterAccountsSchema,
-  RouterPaginationOptionsSchema
-} from '@/types/route';
-import { type Collection } from '@/types/collection';
-import { assert } from '@/utils/assertions';
+import { RouterAccountsSchema } from '@/types/route';
 import { SavedFilterLocation } from '@/types/filtering';
 
 const props = withDefaults(
@@ -74,9 +62,56 @@ const {
   onlyChains
 } = toRefs(props);
 
-const usedTitle: ComputedRef<string> = computed(
-  () => get(sectionTitle) || tc('transactions.title')
+const userAction = ref(false);
+const editableItem: Ref<EthTransactionEventEntry | null> = ref(null);
+const selectedTransaction: Ref<EthTransactionEntry | null> = ref(null);
+const eventToDelete: Ref<EthTransactionEventEntry | null> = ref(null);
+const transactionToIgnore: Ref<EthTransactionEntry | null> = ref(null);
+const confirmationTitle: Ref<string> = ref('');
+const confirmationPrimaryAction: Ref<string> = ref('');
+const accounts: Ref<GeneralAccount[]> = ref([]);
+
+const usedTitle: ComputedRef<string> = computed(() => {
+  return get(sectionTitle) || tc('transactions.title');
+});
+
+const usedAccounts: ComputedRef<Account<BlockchainSelection>[]> = computed(
+  () => {
+    if (get(useExternalAccountFilter)) {
+      return get(externalAccountFilter);
+    }
+    return get(accounts);
+  }
 );
+
+const filteredAccounts: ComputedRef<EvmChainAddress[]> = computed(() => {
+  const accounts = get(usedAccounts);
+
+  if (accounts.length === 0) {
+    return [];
+  }
+
+  const filterAccounts: EvmChainAddress[] = [];
+
+  accounts.forEach(account => {
+    if (account.chain === 'ALL') {
+      const chains = get(txEvmChains);
+      chains.forEach(chain => {
+        filterAccounts.push({
+          address: account.address,
+          evmChain: chain.evmChainName
+        });
+      });
+    } else {
+      filterAccounts.push({
+        address: account.address,
+        evmChain: getEvmChainName(account.chain)!
+      });
+    }
+  });
+
+  return filterAccounts;
+});
 
 const tableHeaders = computed<DataTableHeader[]>(() => [
   {
@@ -115,29 +150,53 @@ const {
   deleteTransactionEvent
 } = useTransactions();
 
-const openDialog: Ref<boolean> = ref(false);
-const editableItem: Ref<EthTransactionEventEntry | null> = ref(null);
-const selectedTransaction: Ref<EthTransactionEntry | null> = ref(null);
-const eventToDelete: Ref<EthTransactionEventEntry | null> = ref(null);
-const transactionToIgnore: Ref<EthTransactionEntry | null> = ref(null);
-const confirmationTitle: Ref<string> = ref('');
-const confirmationMessage: Ref<string> = ref('');
-const confirmationPrimaryAction: Ref<string> = ref('');
-
-const selected: Ref<EthTransactionEntry[]> = ref([]);
-
 const {
-  state: transactions,
+  options,
+  selected,
+  openDialog,
+  confirmationMessage,
   isLoading,
-  execute
-} = useAsyncState<
-  Collection<EthTransactionEntry>,
-  MaybeRef<TransactionRequestPayload>[]
->(args => fetchTransactions(args), defaultCollectionState(), {
-  immediate: false,
-  delay: 0,
-  resetOnExecute: false
-});
+  state: transactions,
+  filters,
+  matchers,
+  setPage,
+  setOptions,
+  setFilter,
+  updateFilter,
+  fetchData
+} = useHistoryPaginationFilter<
+  EthTransaction,
+  TransactionRequestPayload,
+  EthTransactionEntry
+>(
+  ref(null),
+  mainPage,
+  () => useTransactionFilter(get(protocols).length > 0),
+  fetchTransactions,
+  {
+    onUpdateFilters(query) {
+      const parsedAccounts = RouterAccountsSchema.parse(query);
+      if (parsedAccounts.accounts) {
+        set(accounts, parsedAccounts.accounts);
+      }
+    },
+    extraParams: computed(() => {
+      return {
+        accounts: get(usedAccounts).map(
+          account => `${account.address}#${account.chain}`
+        )
+      };
+    }),
+    customPageParams: computed<Partial<TransactionRequestPayload>>(() => {
+      return {
+        protocols: get(protocols),
+        eventTypes: get(eventTypes),
+        eventSubtypes: get(eventSubTypes),
+        accounts: get(filteredAccounts)
+      };
+    })
+  }
+);
 
 const { data } = getCollectionData<EthTransactionEntry>(transactions);
 
@@ -148,10 +207,6 @@ const redecodeEvents = async (all = false) => {
 
 const forceRedecodeEvents = async (transaction: EthTransactionEntry) => {
   await fetchTransactionEvents([transaction], true);
-};
-
-const fetchData = async () => {
-  await execute(0, pageParams);
 };
 
 const { ignore } = useIgnore(
@@ -238,103 +293,6 @@ const deleteEventHandler = async () => {
   set(confirmationPrimaryAction, '');
 };
 
-const options: Ref<TablePagination<EthTransaction>> = ref(defaultOptions());
-const accounts: Ref<GeneralAccount[]> = ref([]);
-
-const usedAccounts: ComputedRef<Account<BlockchainSelection>[]> = computed(
-  () => {
-    if (get(useExternalAccountFilter)) {
-      return get(externalAccountFilter);
-    }
-    return get(accounts);
-  }
-);
-
-const route = useRoute();
-
-const { filters, matchers, updateFilter, RouteFilterSchema } =
-  useTransactionFilter(get(protocols).length > 0);
-
-const applyRouteFilter = () => {
-  if (!get(mainPage)) {
-    return;
-  }
-
-  const query = get(route).query;
-  const parsedOptions = RouterPaginationOptionsSchema.parse(query);
-  const parsedFilters = RouteFilterSchema.parse(query);
-  const parsedAccounts = RouterAccountsSchema.parse(query);
-
-  updateFilter(parsedFilters);
-
-  if (parsedAccounts.accounts) {
-    set(accounts, parsedAccounts.accounts);
-  }
-
-  set(options, {
-    ...get(options),
-    ...parsedOptions
-  });
-};
-
-watch(route, () => {
-  set(userAction, false);
-  applyRouteFilter();
-});
-
-onBeforeMount(() => {
-  applyRouteFilter();
-});
-
-const userAction = ref(false);
-const router = useRouter();
-
-const filteredAccounts: ComputedRef<EvmChainAddress[]> = computed(() => {
-  const accounts = get(usedAccounts);
-
-  if (accounts.length === 0) {
-    return [];
-  }
-
-  const filterAccounts: EvmChainAddress[] = [];
-
-  accounts.forEach(account => {
-    if (account.chain === 'ALL') {
-      const chains = get(txEvmChains);
-      chains.forEach(chain => {
-        filterAccounts.push({
-          address: account.address,
-          evmChain: chain.evmChainName
-        });
-      });
-    } else {
-      filterAccounts.push({
-        address: account.address,
-        evmChain: getEvmChainName(account.chain)!
-      });
-    }
-  });
-
-  return filterAccounts;
-});
-
-const pageParams: ComputedRef<TransactionRequestPayload> = computed(() => {
-  const { itemsPerPage, page, sortBy, sortDesc } = get(options);
-  const offset = (page - 1) * itemsPerPage;
-
-  return {
-    protocols: get(protocols),
-    eventTypes: get(eventTypes),
-    eventSubtypes: get(eventSubTypes),
-    ...(get(filters) as Partial<TransactionRequestPayload>),
-    limit: itemsPerPage,
-    offset,
-    orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
-    ascending: sortDesc.map(bool => !bool),
-    accounts: get(filteredAccounts)
-  };
-});
-
 const getItemClass = (item: EthTransactionEntry) =>
   item.ignoredInAccounting ? 'darken-row' : '';
 
@@ -367,21 +325,6 @@ watch(
   }
 );
 
-const setPage = (page: number) => {
-  set(userAction, true);
-  set(options, { ...get(options), page });
-};
-
-const setOptions = (newOptions: TablePagination<EthTransaction>) => {
-  set(userAction, true);
-  set(options, newOptions);
-};
-
-const setFilter = (newFilter: UnwrapRef<typeof filters>) => {
-  set(userAction, true);
-  updateFilter(newFilter);
-};
-
 const { isLoading: isSectionLoading } = useStatusStore();
 const loading = isSectionLoading(Section.TX);
 
@@ -408,39 +351,6 @@ watch(
     }
   }
 );
-
-const getQuery = (): LocationQuery => {
-  const opts = get(options);
-  assert(opts);
-  const { itemsPerPage, page, sortBy, sortDesc } = opts;
-
-  return {
-    itemsPerPage: itemsPerPage.toString(),
-    page: page.toString(),
-    sortBy,
-    sortDesc: sortDesc.map(x => x.toString()),
-    ...get(filters),
-    accounts: get(usedAccounts).map(
-      account => `${account.address}#${account.chain}`
-    )
-  };
-};
-
-watch(pageParams, async (params, op) => {
-  if (isEqual(params, op)) {
-    return;
-  }
-  if (get(userAction) && get(mainPage)) {
-    // Route should only be updated on user action otherwise it messes with
-    // forward navigation.
-    await router.push({
-      query: getQuery()
-    });
-    set(userAction, false);
-  }
-
-  await fetchData();
-});
 
 onUnmounted(() => {
   pause();

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -163,7 +163,6 @@ const {
   setPage,
   setOptions,
   setFilter,
-  applyRouteFilter,
   updateFilter,
   fetchData
 } = useHistoryPaginationFilter<
@@ -377,10 +376,6 @@ const showDeleteConfirmation = () => {
 
 const { txEvmChains, getEvmChainName, getChain } = useSupportedChains();
 const txChains = useArrayMap(txEvmChains, x => x.id);
-
-onBeforeMount(() => {
-  applyRouteFilter();
-});
 
 onMounted(async () => {
   await fetchData();

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -163,6 +163,7 @@ const {
   setPage,
   setOptions,
   setFilter,
+  applyRouteFilter,
   updateFilter,
   fetchData
 } = useHistoryPaginationFilter<
@@ -355,10 +356,6 @@ watch(
   }
 );
 
-onUnmounted(() => {
-  pause();
-});
-
 const { show } = useConfirmStore();
 
 const resetPendingDeletion = () => {
@@ -381,9 +378,17 @@ const showDeleteConfirmation = () => {
 const { txEvmChains, getEvmChainName, getChain } = useSupportedChains();
 const txChains = useArrayMap(txEvmChains, x => x.id);
 
+onBeforeMount(() => {
+  applyRouteFilter();
+});
+
 onMounted(async () => {
   await fetchData();
   await refreshTransactions(get(onlyChains));
+});
+
+onUnmounted(() => {
+  pause();
 });
 
 watch(loading, async (isLoading, wasLoading) => {

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -53,6 +53,7 @@ const props = withDefaults(
 const { tc } = useI18n();
 
 const {
+  protocols,
   useExternalAccountFilter,
   externalAccountFilter,
   sectionTitle,
@@ -69,7 +70,6 @@ const transactionToIgnore: Ref<EthTransactionEntry | null> = ref(null);
 const confirmationTitle: Ref<string> = ref('');
 const confirmationPrimaryAction: Ref<string> = ref('');
 const accounts: Ref<GeneralAccount[]> = ref([]);
-const protocols: Ref<TransactionEventProtocol[]> = ref(props.protocols);
 
 const usedTitle: ComputedRef<string> = computed(
   () => get(sectionTitle) || tc('transactions.title')
@@ -305,14 +305,11 @@ watch(
       return;
     }
 
-    if (filterChanged) {
-      set(protocols, filters.protocols ?? []);
-      // Because the evmChain filter and the account filter can't be active
-      // at the same time we clear the account filter when the evmChain filter
-      // is set.
-      if (filters.evmChain) {
-        set(accounts, []);
-      }
+    // Because the evmChain filter and the account filter can't be active
+    // at the same time we clear the account filter when the evmChain filter
+    // is set.
+    if (filterChanged && filters.evmChain) {
+      set(accounts, []);
     }
 
     if (accountsChanged && usedAccounts.length > 0) {

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -25,7 +25,7 @@ import { getCollectionData } from '@/utils/collection';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { RouterAccountsSchema } from '@/types/route';
 import { SavedFilterLocation } from '@/types/filtering';
-import { type Matcher } from '@/composables/filters/transactions';
+import type { Filters, Matcher } from '@/composables/filters/transactions';
 
 const props = withDefaults(
   defineProps<{
@@ -169,6 +169,7 @@ const {
   EthTransaction,
   TransactionRequestPayload,
   EthTransactionEntry,
+  Filters,
   Matcher
 >(
   null,

--- a/frontend/app/src/composables/filters/asset-movement.ts
+++ b/frontend/app/src/composables/filters/asset-movement.ts
@@ -32,7 +32,7 @@ export type Matcher = SearchMatcher<
   AssetMovementFilterKeys,
   AssetMovementFilterValueKeys
 >;
-type Filters = MatchedKeyword<AssetMovementFilterValueKeys>;
+export type Filters = MatchedKeyword<AssetMovementFilterValueKeys>;
 
 export const useAssetMovementFilters = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/asset-movement.ts
+++ b/frontend/app/src/composables/filters/asset-movement.ts
@@ -28,11 +28,11 @@ enum AssetMovementFilterValueKeys {
   END = 'toTimestamp'
 }
 
-type Matcher = SearchMatcher<
+export type Matcher = SearchMatcher<
   AssetMovementFilterKeys,
   AssetMovementFilterValueKeys
 >;
-export type Filters = MatchedKeyword<AssetMovementFilterValueKeys>;
+type Filters = MatchedKeyword<AssetMovementFilterValueKeys>;
 
 export const useAssetMovementFilters = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/asset-movement.ts
+++ b/frontend/app/src/composables/filters/asset-movement.ts
@@ -32,7 +32,7 @@ type Matcher = SearchMatcher<
   AssetMovementFilterKeys,
   AssetMovementFilterValueKeys
 >;
-type Filters = MatchedKeyword<AssetMovementFilterValueKeys>;
+export type Filters = MatchedKeyword<AssetMovementFilterValueKeys>;
 
 export const useAssetMovementFilters = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/ledger-actions.ts
+++ b/frontend/app/src/composables/filters/ledger-actions.ts
@@ -32,7 +32,7 @@ type Matcher = SearchMatcher<
   LedgerActionFilterKeys,
   LedgerActionFilterValueKeys
 >;
-type Filters = MatchedKeyword<LedgerActionFilterValueKeys>;
+export type Filters = MatchedKeyword<LedgerActionFilterValueKeys>;
 
 export const useLedgerActionsFilter = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/ledger-actions.ts
+++ b/frontend/app/src/composables/filters/ledger-actions.ts
@@ -28,11 +28,11 @@ enum LedgerActionFilterValueKeys {
   LOCATION = 'location'
 }
 
-type Matcher = SearchMatcher<
+export type Matcher = SearchMatcher<
   LedgerActionFilterKeys,
   LedgerActionFilterValueKeys
 >;
-export type Filters = MatchedKeyword<LedgerActionFilterValueKeys>;
+type Filters = MatchedKeyword<LedgerActionFilterValueKeys>;
 
 export const useLedgerActionsFilter = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/ledger-actions.ts
+++ b/frontend/app/src/composables/filters/ledger-actions.ts
@@ -32,7 +32,7 @@ export type Matcher = SearchMatcher<
   LedgerActionFilterKeys,
   LedgerActionFilterValueKeys
 >;
-type Filters = MatchedKeyword<LedgerActionFilterValueKeys>;
+export type Filters = MatchedKeyword<LedgerActionFilterValueKeys>;
 
 export const useLedgerActionsFilter = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/trades.ts
+++ b/frontend/app/src/composables/filters/trades.ts
@@ -31,7 +31,7 @@ enum TradeFilterValueKeys {
 }
 
 type Matcher = SearchMatcher<TradeFilterKeys, TradeFilterValueKeys>;
-type Filters = MatchedKeyword<TradeFilterValueKeys>;
+export type Filters = MatchedKeyword<TradeFilterValueKeys>;
 
 export const useTradeFilters = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/trades.ts
+++ b/frontend/app/src/composables/filters/trades.ts
@@ -30,8 +30,8 @@ enum TradeFilterValueKeys {
   LOCATION = 'location'
 }
 
-type Matcher = SearchMatcher<TradeFilterKeys, TradeFilterValueKeys>;
-export type Filters = MatchedKeyword<TradeFilterValueKeys>;
+export type Matcher = SearchMatcher<TradeFilterKeys, TradeFilterValueKeys>;
+type Filters = MatchedKeyword<TradeFilterValueKeys>;
 
 export const useTradeFilters = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/trades.ts
+++ b/frontend/app/src/composables/filters/trades.ts
@@ -31,7 +31,7 @@ enum TradeFilterValueKeys {
 }
 
 export type Matcher = SearchMatcher<TradeFilterKeys, TradeFilterValueKeys>;
-type Filters = MatchedKeyword<TradeFilterValueKeys>;
+export type Filters = MatchedKeyword<TradeFilterValueKeys>;
 
 export const useTradeFilters = () => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/transactions.ts
+++ b/frontend/app/src/composables/filters/transactions.ts
@@ -29,7 +29,7 @@ enum TransactionFilterValueKeys {
   EVM_CHAIN = 'evmChain'
 }
 
-type Filters = MatchedKeyword<TransactionFilterValueKeys>;
+export type Filters = MatchedKeyword<TransactionFilterValueKeys>;
 type Matcher = SearchMatcher<TransactionFilterKeys, TransactionFilterValueKeys>;
 
 export const useTransactionFilter = (disableProtocols: boolean) => {

--- a/frontend/app/src/composables/filters/transactions.ts
+++ b/frontend/app/src/composables/filters/transactions.ts
@@ -29,11 +29,11 @@ enum TransactionFilterValueKeys {
   EVM_CHAIN = 'evmChain'
 }
 
-type Filters = MatchedKeyword<TransactionFilterValueKeys>;
 export type Matcher = SearchMatcher<
   TransactionFilterKeys,
   TransactionFilterValueKeys
 >;
+export type Filters = MatchedKeyword<TransactionFilterValueKeys>;
 
 export const useTransactionFilter = (disableProtocols: boolean) => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/filters/transactions.ts
+++ b/frontend/app/src/composables/filters/transactions.ts
@@ -29,8 +29,11 @@ enum TransactionFilterValueKeys {
   EVM_CHAIN = 'evmChain'
 }
 
-export type Filters = MatchedKeyword<TransactionFilterValueKeys>;
-type Matcher = SearchMatcher<TransactionFilterKeys, TransactionFilterValueKeys>;
+type Filters = MatchedKeyword<TransactionFilterValueKeys>;
+export type Matcher = SearchMatcher<
+  TransactionFilterKeys,
+  TransactionFilterValueKeys
+>;
 
 export const useTransactionFilter = (disableProtocols: boolean) => {
   const filters: Ref<Filters> = ref({});

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -26,7 +26,7 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
   mainPage: Ref<boolean>,
   filterSchema: () => FilterSchema,
   fetchAssetData: (payload: MaybeRef<R>) => Promise<Collection<S>>,
-  extraParams: Record<string, Ref<string | boolean>> = {}
+  extraParams?: () => Record<string, string | boolean | null>
 ) => {
   const router = useRouter();
   const route = useRoute();
@@ -53,7 +53,7 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
 
     return {
       ...selectedFilters,
-      ...extraParams,
+      ...extraParams?.call(null),
       limit: itemsPerPage,
       offset,
       orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
@@ -107,10 +107,7 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
       sortBy,
       sortDesc: sortDesc.map(x => x.toString()),
       ...selectedFilters,
-      ...Object.keys(extraParams).reduce((acc, k) => {
-        acc[k] = extraParams[k].value?.toString() ?? '';
-        return acc;
-      }, {} as Record<string, string>)
+      ...extraParams?.call(null)
     };
   };
 

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -141,10 +141,6 @@ export const useHistoryPaginationFilter = <
     updateFilter(newFilter);
   };
 
-  onBeforeMount(() => {
-    applyRouteFilter();
-  });
-
   watch(route, () => {
     set(userAction, false);
     applyRouteFilter();
@@ -190,6 +186,7 @@ export const useHistoryPaginationFilter = <
     setPage,
     setOptions,
     setFilter,
+    applyRouteFilter,
     updateFilter,
     fetchData
   };

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -10,6 +10,7 @@ import {
 } from '@/types/route';
 import { assert } from '@/utils/assertions';
 import { defaultCollectionState, defaultOptions } from '@/utils/collection';
+import { nonEmptyProperties } from '@/utils/data';
 
 interface FilterSchema<F, M> {
   filters: Ref<F>;
@@ -65,7 +66,7 @@ export const useHistoryPaginationFilter = <
     return {
       ...selectedFilters,
       ...get(extraParams),
-      ...get(customPageParams),
+      ...nonEmptyProperties(get(customPageParams) ?? {}),
       limit: itemsPerPage,
       offset,
       orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -11,19 +11,25 @@ import {
 import { type Collection } from '@/types/collection';
 import { assert } from '@/utils/assertions';
 
-interface FilterSchema<M> {
-  filters: Ref<LocationQuery>;
+interface FilterSchema<F, M> {
+  filters: Ref<F>;
   matchers: ComputedRef<M[]>;
 
-  updateFilter(filter: LocationQuery): void;
+  updateFilter(filter: F): void;
 
   RouteFilterSchema: ZodSchema;
 }
 
-export const useHistoryPaginationFilter = <T extends Object, U, V, X>(
+export const useHistoryPaginationFilter = <
+  T extends Object,
+  U,
+  V,
+  W extends Object,
+  X
+>(
   locationOverview: MaybeRef<string | null>,
   mainPage: Ref<boolean>,
-  filterSchema: () => FilterSchema<X>,
+  filterSchema: () => FilterSchema<W, X>,
   fetchAssetData: (payload: MaybeRef<U>) => Promise<Collection<V>>,
   options: {
     onUpdateFilters?: (query: LocationQuery) => void;
@@ -52,8 +58,8 @@ export const useHistoryPaginationFilter = <T extends Object, U, V, X>(
 
     const selectedFilters = get(filters);
     const overview = get(locationOverview);
-    if (overview) {
-      selectedFilters['location'] = overview;
+    if (overview && 'location' in selectedFilters) {
+      selectedFilters.location = overview;
     }
 
     return {
@@ -102,7 +108,7 @@ export const useHistoryPaginationFilter = <T extends Object, U, V, X>(
     const selectedFilters = get(filters);
 
     const overview = get(locationOverview);
-    if (overview) {
+    if (overview && 'location' in selectedFilters) {
       selectedFilters.location = overview;
     }
 
@@ -130,7 +136,7 @@ export const useHistoryPaginationFilter = <T extends Object, U, V, X>(
     set(paginationOptions, newOptions);
   };
 
-  const setFilter = (newFilter: UnwrapRef<Ref<LocationQuery>>) => {
+  const setFilter = (newFilter: UnwrapRef<Ref<W>>) => {
     set(userAction, true);
     updateFilter(newFilter);
   };

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -176,6 +176,7 @@ export const useHistoryPaginationFilter = <
 
   return {
     options: paginationOptions,
+    pageParams,
     selected,
     openDialog,
     editableItem,

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -31,7 +31,7 @@ interface FilterSchema {
 }
 
 export const useHistoryPaginationFilter = <T extends Object, U, V>(
-  locationOverview: Ref,
+  locationOverview: MaybeRef<string | null>,
   mainPage: Ref<boolean>,
   filterSchema: () => FilterSchema,
   fetchAssetData: (payload: MaybeRef<U>) => Promise<Collection<V>>,

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -21,27 +21,27 @@ interface FilterSchema {
   RouteFilterSchema: ZodSchema;
 }
 
-export const useHistoryPaginationFilter = <T extends Object, R, S>(
+export const useHistoryPaginationFilter = <T extends Object, U, V>(
   locationOverview: Ref,
   mainPage: Ref<boolean>,
   filterSchema: () => FilterSchema,
-  fetchAssetData: (payload: MaybeRef<R>) => Promise<Collection<S>>,
+  fetchAssetData: (payload: MaybeRef<U>) => Promise<Collection<V>>,
   extraParams?: () => Record<string, string | boolean | null>
 ) => {
   const router = useRouter();
   const route = useRoute();
   const options: Ref<TablePagination<T>> = ref(defaultOptions<T>());
-  const selected: Ref<S[]> = ref([]);
+  const selected: Ref<V[]> = ref([]);
   const openDialog: Ref<boolean> = ref(false);
-  const editableItem: Ref<S | null> = ref(null);
-  const itemsToDelete: Ref<S[]> = ref([]);
+  const editableItem: Ref<V | null> = ref(null);
+  const itemsToDelete: Ref<V[]> = ref([]);
   const confirmationMessage: Ref<string> = ref('');
-  const expanded: Ref<S[]> = ref([]);
+  const expanded: Ref<V[]> = ref([]);
   const userAction: Ref<boolean> = ref(false);
 
   const { filters, matchers, updateFilter, RouteFilterSchema } = filterSchema();
 
-  const pageParams: ComputedRef<R> = computed(() => {
+  const pageParams: ComputedRef<U> = computed(() => {
     const { itemsPerPage, page, sortBy, sortDesc } = get(options);
     const offset = (page - 1) * itemsPerPage;
 
@@ -65,8 +65,8 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
   });
 
   const { isLoading, state, execute } = useAsyncState<
-    Collection<S>,
-    MaybeRef<R>[]
+    Collection<V>,
+    MaybeRef<U>[]
   >(fetchAssetData, defaultCollectionState(), {
     immediate: false,
     resetOnExecute: false,

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -26,7 +26,7 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
   mainPage: Ref<boolean>,
   filterSchema: () => FilterSchema,
   fetchAssetData: (payload: MaybeRef<R>) => Promise<Collection<S>>,
-  extraParams?: Record<string, string | boolean>
+  extraParams: Record<string, Ref<string | boolean>> = {}
 ) => {
   const router = useRouter();
   const route = useRoute();
@@ -67,7 +67,7 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
   const { isLoading, state, execute } = useAsyncState<
     Collection<S>,
     MaybeRef<R>[]
-  >(args => fetchAssetData(args), defaultCollectionState(), {
+  >(fetchAssetData, defaultCollectionState(), {
     immediate: false,
     resetOnExecute: false,
     delay: 0
@@ -107,7 +107,10 @@ export const useHistoryPaginationFilter = <T extends Object, R, S>(
       sortBy,
       sortDesc: sortDesc.map(x => x.toString()),
       ...selectedFilters,
-      ...extraParams
+      ...Object.keys(extraParams).reduce((acc, k) => {
+        acc[k] = extraParams[k].value?.toString() ?? '';
+        return acc;
+      }, {} as Record<string, string>)
     };
   };
 

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -70,7 +70,7 @@ export const useHistoryPaginationFilter = <
       offset,
       orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
       ascending: sortBy?.length > 0 ? sortDesc.map(bool => !bool) : [false]
-    } as U;
+    } as U; // todo: figure out a way to not typecast
   });
 
   const { isLoading, state, execute } = useAsyncState<

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -1,15 +1,15 @@
+import { type MaybeRef } from '@vueuse/core';
+import isEqual from 'lodash/isEqual';
 import { type ComputedRef, type Ref, type UnwrapRef } from 'vue';
 import { type ZodSchema } from 'zod';
-import isEqual from 'lodash/isEqual';
-import { type MaybeRef } from '@vueuse/core';
+import { type Collection } from '@/types/collection';
 import { type TablePagination } from '@/types/pagination';
-import { defaultCollectionState, defaultOptions } from '@/utils/collection';
 import {
   type LocationQuery,
   RouterPaginationOptionsSchema
 } from '@/types/route';
-import { type Collection } from '@/types/collection';
 import { assert } from '@/utils/assertions';
+import { defaultCollectionState, defaultOptions } from '@/utils/collection';
 
 interface FilterSchema<F, M> {
   filters: Ref<F>;

--- a/frontend/app/src/composables/history/filter-paginate.ts
+++ b/frontend/app/src/composables/history/filter-paginate.ts
@@ -141,6 +141,10 @@ export const useHistoryPaginationFilter = <
     updateFilter(newFilter);
   };
 
+  onBeforeMount(() => {
+    applyRouteFilter();
+  });
+
   watch(route, () => {
     set(userAction, false);
     applyRouteFilter();

--- a/frontend/app/src/composables/history/paginate.ts
+++ b/frontend/app/src/composables/history/paginate.ts
@@ -1,0 +1,127 @@
+import { type ComputedRef, type Ref, type UnwrapRef } from 'vue';
+import dropRight from 'lodash/dropRight';
+import { type ZodSchema } from 'zod';
+import isEqual from 'lodash/isEqual';
+import { type MaybeRef } from '@vueuse/core';
+import { type TablePagination } from '@/types/pagination';
+import { defaultCollectionState, defaultOptions } from '@/utils/collection';
+import { RouterPaginationOptionsSchema } from '@/types/route';
+import { type Collection } from '@/types/collection';
+
+interface FilterSchema {
+  filters: Ref;
+  matchers: ComputedRef;
+
+  updateFilter(v: any): void;
+
+  RouteFilterSchema: ZodSchema;
+}
+
+export const useHistoryPagination = <T extends Object, R, S>(
+  locationOverview: Ref,
+  mainPage: Ref<boolean>,
+  filterSchema: () => FilterSchema,
+  fetchAssetData: (payload: MaybeRef<R>) => Promise<Collection<S>>,
+  extraParams?: {}
+) => {
+  const route = useRoute();
+  const options: Ref<TablePagination<T>> = ref(defaultOptions<T>());
+  const userAction: Ref<boolean> = ref(false);
+  const { filters, matchers, updateFilter, RouteFilterSchema } = filterSchema();
+
+  const pageParams: ComputedRef<R> = computed(() => {
+    const { itemsPerPage, page, sortBy, sortDesc } = get(options);
+    const offset = (page - 1) * itemsPerPage;
+
+    const selectedFilters = get(filters);
+    const overview = get(locationOverview);
+    if (overview) {
+      selectedFilters.location = overview;
+    }
+
+    return {
+      ...selectedFilters,
+      ...extraParams,
+      limit: itemsPerPage,
+      offset,
+      orderByAttributes: sortBy?.length > 0 ? sortBy : ['timestamp'],
+      ascending:
+        sortDesc && sortDesc.length > 1
+          ? dropRight(sortDesc).map(bool => !bool)
+          : [false]
+    };
+  });
+
+  const { isLoading, state, execute } = useAsyncState<
+    Collection<S>,
+    MaybeRef<R>[]
+  >(args => fetchAssetData(args), defaultCollectionState(), {
+    immediate: false,
+    resetOnExecute: false,
+    delay: 0
+  });
+
+  const applyRouteFilter = () => {
+    if (!get(mainPage)) {
+      return;
+    }
+
+    const query = get(route).query;
+    const parsedOptions = RouterPaginationOptionsSchema.parse(query);
+    const parsedFilters = RouteFilterSchema.parse(query);
+
+    updateFilter(parsedFilters);
+    set(options, {
+      ...get(options),
+      ...parsedOptions
+    });
+  };
+
+  // const fetchData = async (): Promise<void> => {
+  //     await execute(0, pageParams);
+  // };
+
+  watch(route, () => {
+    set(userAction, false);
+    applyRouteFilter();
+  });
+
+  onBeforeMount(() => {
+    applyRouteFilter();
+  });
+
+  watch(filters, async (filters, oldFilters) => {
+    if (isEqual(filters, oldFilters)) {
+      return;
+    }
+
+    set(options, { ...get(options), page: 1 });
+  });
+
+  const setPage = (page: number) => {
+    set(userAction, true);
+    set(options, { ...get(options), page });
+  };
+
+  const setOptions = (newOptions: TablePagination<T>) => {
+    set(userAction, true);
+    set(options, newOptions);
+  };
+
+  const setFilter = (newFilter: UnwrapRef<typeof filters>) => {
+    set(userAction, true);
+    updateFilter(newFilter);
+  };
+
+  return {
+    pageParams,
+    applyRouteFilter,
+    matchers,
+    setPage,
+    setOptions,
+    setFilter,
+    isLoading,
+    state,
+    execute
+  };
+};

--- a/frontend/app/tests/unit/fixtures/asset-movements.json
+++ b/frontend/app/tests/unit/fixtures/asset-movements.json
@@ -1,0 +1,170 @@
+{
+  "result": {
+    "entries": [
+      {
+        "entry": {
+          "identifier": "7290b52b03e8cb004610d4b97fbf3e23fabcd4621818dd0a2796b26adbfde20f",
+          "timestamp": 1672397802,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 125265501096",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3262151839558738176"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "320fc0eae375b9cc8da9c2254c7f5f0db243fcec5c325f75ae13b075ace70ff9",
+          "timestamp": 1671112421,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 124487556073",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3240586736304726273"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "05205fc450058e8a36c9b032513a2ae92cabe922886256003cfd1f189aeede05",
+          "timestamp": 1669840741,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 123556063180",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3219251476161962241"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "19dee45be662987067df1f37fcd7bb9ae146901fc1bbffb818a06af5476460ae",
+          "timestamp": 1668632261,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 122452515678",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3198976553334201345"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "82627fa6d8f54cd2d905a8f346e3915ac221b1c7f798298d9bfd4af3312f789c",
+          "timestamp": 1667984559,
+          "location": "binance",
+          "category": "deposit",
+          "address": "0xa13a1baf456e2b750a87b9e1987d1387cfdc05f6",
+          "transaction_id": "0x47bbfdfc89957e2ab9cca3e46bb49ccd66f4deedabdec9188517af97f365f985",
+          "asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "amount": "100",
+          "fee_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "fee": "0",
+          "link": "3188109910433394945"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "ae59b12d360ea761cb52fb27b899be769d9b78ce7a0082a78f9ef0751d90390f",
+          "timestamp": 1667307082,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 120543292378",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3176743733962463232"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "02f7e92c130f00b021f24f09f33c4cc8fd4f534cdfa7137128b8423668b86976",
+          "timestamp": 1665822646,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 119270677766",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3151839029864421377"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "364b47b9c35c9810727d0507f4e0a69439ea5fabce9631bed3cd520bef6d43da",
+          "timestamp": 1664654524,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "Internal transfer 118437087598",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "535.71",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3132241205896158976"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "5ea6a4d7d9b69a948c2b6731dd7a161565f0ff8630a4dec9cf091e99c850671a",
+          "timestamp": 1664581119,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "09f83e09bd382ac13f090aeebe2ea48be99f11fab024769f5a7b593bb0f36a3a",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "3426.396588",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3131009659222630145"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": "1ac97b480a6f05ded08dbb3ab7340f4deaf7b40538108150688d79db1919b04d",
+          "timestamp": 1664382069,
+          "location": "binance",
+          "category": "deposit",
+          "address": "TGfXpXekeDvUdf5pyx28ujfKbPWU9TvR4D",
+          "transaction_id": "c839cdb9ac18a4b2d4e478fecac38d6e5c620509c319936202f0415a1c020c73",
+          "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "amount": "19.464148",
+          "fee_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "fee": "0",
+          "link": "3127670168806235906"
+        },
+        "ignored_in_accounting": false
+      }
+    ],
+    "entries_total": 45,
+    "entries_found": 45,
+    "entries_limit": -1
+  },
+  "message": ""
+}

--- a/frontend/app/tests/unit/fixtures/evm-transactions.json
+++ b/frontend/app/tests/unit/fixtures/evm-transactions.json
@@ -1,9 +1,376 @@
 {
   "result": {
     "entries": [
+      {
+        "entry": {
+          "tx_hash": "0x886e440c29a3112bc006ed9a8c84f2f79d907aaade9e2ea6060e4d36dbe6eb36",
+          "timestamp": 1680002558,
+          "block_number": 84300708,
+          "from_address": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+          "to_address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796",
+          "value": "0",
+          "gas": "285796",
+          "gas_price": "1000000",
+          "gas_used": "229859",
+          "input_data": "0xeea0d7b20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a13a1baf456e2b750a87b9e1987d1387cfdc05f600000000000000000000000000000000000000000000000000000000a6d7559000000000000000000000000000000000000000000000000000000000009bb3db00000000000000000000000000000000000000000000000000000000a567cccb00000000000000000000000000000000000000000000000000000000642c083f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "nonce": 2,
+          "evm_chain": "optimism"
+        },
+        "decoded_events": [
+          {
+            "entry": {
+              "identifier": 1,
+              "event_identifier": "0x886e440c29a3112bc006ed9a8c84f2f79d907aaade9e2ea6060e4d36dbe6eb36",
+              "sequence_index": 0,
+              "timestamp": 1680002558,
+              "location": "optimism",
+              "asset": "ETH",
+              "balance": {
+                "amount": "0.000000229859",
+                "usd_value": "0.00039850195112"
+              },
+              "event_type": "spend",
+              "event_subtype": "fee",
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Burned 0.000000229859 ETH for gas",
+              "counterparty": "gas",
+              "product": null,
+              "address": null
+            },
+            "has_details": false,
+            "customized": false
+          },
+          {
+            "entry": {
+              "identifier": 2,
+              "event_identifier": "0x886e440c29a3112bc006ed9a8c84f2f79d907aaade9e2ea6060e4d36dbe6eb36",
+              "sequence_index": 1,
+              "timestamp": 1680002558,
+              "location": "optimism",
+              "asset": "eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+              "balance": {
+                "amount": "2799.13",
+                "usd_value": "2799.13"
+              },
+              "event_type": "spend",
+              "event_subtype": null,
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Send 2799.13 USDC from 0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25 to 0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796",
+              "counterparty": null,
+              "product": null,
+              "address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796"
+            },
+            "has_details": false,
+            "customized": false
+          },
+          {
+            "entry": {
+              "identifier": 3,
+              "event_identifier": "0x886e440c29a3112bc006ed9a8c84f2f79d907aaade9e2ea6060e4d36dbe6eb36",
+              "sequence_index": 2,
+              "timestamp": 1680002558,
+              "location": "optimism",
+              "asset": "eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+              "balance": {
+                "amount": "0",
+                "usd_value": "0"
+              },
+              "event_type": "informational",
+              "event_subtype": "approve",
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Revoke USDC spending approval of 0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25 by 0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796",
+              "counterparty": null,
+              "product": null,
+              "address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796"
+            },
+            "has_details": false,
+            "customized": false
+          }
+        ],
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "tx_hash": "0x286f9c959706f4ddeac1504ece65e6f21bb6c5b15db2718ac7f39dce57bad1e8",
+          "timestamp": 1680001971,
+          "block_number": 84298041,
+          "from_address": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+          "to_address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796",
+          "value": "0",
+          "gas": "285784",
+          "gas_price": "1000000",
+          "gas_used": "239447",
+          "input_data": "0xeea0d7b20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a13a1baf456e2b750a87b9e1987d1387cfdc05f60000000000000000000000000000000000000000000000000000000005f5e100000000000000000000000000000000000000000000000000000000000074ea2b00000000000000000000000000000000000000000000000000000000057966c100000000000000000000000000000000000000000000000000000000642c060800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "nonce": 1,
+          "evm_chain": "optimism"
+        },
+        "decoded_events": [
+          {
+            "entry": {
+              "identifier": 4,
+              "event_identifier": "0x286f9c959706f4ddeac1504ece65e6f21bb6c5b15db2718ac7f39dce57bad1e8",
+              "sequence_index": 0,
+              "timestamp": 1680001971,
+              "location": "optimism",
+              "asset": "ETH",
+              "balance": {
+                "amount": "0.000000239447",
+                "usd_value": "0.00041512447496"
+              },
+              "event_type": "spend",
+              "event_subtype": "fee",
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Burned 0.000000239447 ETH for gas",
+              "counterparty": "gas",
+              "product": null,
+              "address": null
+            },
+            "has_details": false,
+            "customized": false
+          },
+          {
+            "entry": {
+              "identifier": 5,
+              "event_identifier": "0x286f9c959706f4ddeac1504ece65e6f21bb6c5b15db2718ac7f39dce57bad1e8",
+              "sequence_index": 1,
+              "timestamp": 1680001971,
+              "location": "optimism",
+              "asset": "eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+              "balance": {
+                "amount": "100",
+                "usd_value": "100"
+              },
+              "event_type": "spend",
+              "event_subtype": null,
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Send 100 USDC from 0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25 to 0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796",
+              "counterparty": null,
+              "product": null,
+              "address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796"
+            },
+            "has_details": false,
+            "customized": false
+          },
+          {
+            "entry": {
+              "identifier": 6,
+              "event_identifier": "0x286f9c959706f4ddeac1504ece65e6f21bb6c5b15db2718ac7f39dce57bad1e8",
+              "sequence_index": 2,
+              "timestamp": 1680001971,
+              "location": "optimism",
+              "asset": "eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+              "balance": {
+                "amount": "2799.13",
+                "usd_value": "2799.13"
+              },
+              "event_type": "informational",
+              "event_subtype": "approve",
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Set USDC spending approval of 0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25 by 0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796 to 2799.13",
+              "counterparty": null,
+              "product": null,
+              "address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796"
+            },
+            "has_details": false,
+            "customized": false
+          }
+        ],
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "tx_hash": "0x736f0608a15fb90c18f9f56bd3e584cf93f191fab07571c99c6b090b81c8a7b1",
+          "timestamp": 1680001896,
+          "block_number": 84297662,
+          "from_address": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+          "to_address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+          "value": "0",
+          "gas": "53403",
+          "gas_price": "1000000",
+          "gas_used": "53067",
+          "input_data": "0x095ea7b30000000000000000000000002ad09850b0ca4c7c1b33f5acd6cbabcab5d6e79600000000000000000000000000000000000000000000000000000000accd3690",
+          "nonce": 0,
+          "evm_chain": "optimism"
+        },
+        "decoded_events": [
+          {
+            "entry": {
+              "identifier": 7,
+              "event_identifier": "0x736f0608a15fb90c18f9f56bd3e584cf93f191fab07571c99c6b090b81c8a7b1",
+              "sequence_index": 0,
+              "timestamp": 1680001896,
+              "location": "optimism",
+              "asset": "ETH",
+              "balance": {
+                "amount": "0.000000053067",
+                "usd_value": "0.00009200119656"
+              },
+              "event_type": "spend",
+              "event_subtype": "fee",
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Burned 0.000000053067 ETH for gas",
+              "counterparty": "gas",
+              "product": null,
+              "address": null
+            },
+            "has_details": false,
+            "customized": false
+          },
+          {
+            "entry": {
+              "identifier": 8,
+              "event_identifier": "0x736f0608a15fb90c18f9f56bd3e584cf93f191fab07571c99c6b090b81c8a7b1",
+              "sequence_index": 1,
+              "timestamp": 1680001896,
+              "location": "optimism",
+              "asset": "eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+              "balance": {
+                "amount": "2899.13",
+                "usd_value": "2899.13"
+              },
+              "event_type": "informational",
+              "event_subtype": "approve",
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Set USDC spending approval of 0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25 by 0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796 to 2899.13",
+              "counterparty": null,
+              "product": null,
+              "address": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796"
+            },
+            "has_details": false,
+            "customized": false
+          }
+        ],
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "tx_hash": "0xcb61d6ce04c2689b01f6c4d647b446bb8c87e5f6afd741715edcaba54f7e5748",
+          "timestamp": 1679997672,
+          "block_number": 84281603,
+          "from_address": "0x19e4057A38a730be37c4DA690b103267AAE1d75d",
+          "to_address": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+          "value": "1000000000000000",
+          "gas": "21000",
+          "gas_price": "1000000",
+          "gas_used": "21000",
+          "input_data": "0x",
+          "nonce": 29,
+          "evm_chain": "optimism"
+        },
+        "decoded_events": [
+          {
+            "entry": {
+              "identifier": 9,
+              "event_identifier": "0xcb61d6ce04c2689b01f6c4d647b446bb8c87e5f6afd741715edcaba54f7e5748",
+              "sequence_index": 0,
+              "timestamp": 1679997672,
+              "location": "optimism",
+              "asset": "ETH",
+              "balance": {
+                "amount": "0.001",
+                "usd_value": "1.73368"
+              },
+              "event_type": "receive",
+              "event_subtype": null,
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Receive 0.001 ETH from 0x19e4057A38a730be37c4DA690b103267AAE1d75d",
+              "counterparty": null,
+              "product": null,
+              "address": "0x19e4057A38a730be37c4DA690b103267AAE1d75d"
+            },
+            "has_details": false,
+            "customized": false
+          }
+        ],
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "tx_hash": "0x8319825d1b59ad4c1afcdcb2a5606292285f3d013c69ed1f6c83147a322aa7fd",
+          "timestamp": 1679990011,
+          "block_number": 84250569,
+          "from_address": "0x9531C059098e3d194fF87FebB587aB07B30B1306",
+          "to_address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+          "value": "0",
+          "gas": "58602",
+          "gas_price": "1000000",
+          "gas_used": "58602",
+          "input_data": "0xa9059cbb0000000000000000000000002f4c0f60f2116899fa6d4b9d8b979167ce963d2500000000000000000000000000000000000000000000000000000000accd3690",
+          "nonce": 61,
+          "evm_chain": "optimism"
+        },
+        "decoded_events": [
+          {
+            "entry": {
+              "identifier": 10,
+              "event_identifier": "0x8319825d1b59ad4c1afcdcb2a5606292285f3d013c69ed1f6c83147a322aa7fd",
+              "sequence_index": 0,
+              "timestamp": 1679990011,
+              "location": "optimism",
+              "asset": "eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+              "balance": {
+                "amount": "2899.13",
+                "usd_value": "2899.13"
+              },
+              "event_type": "receive",
+              "event_subtype": null,
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Receive 2899.13 USDC from 0x9531C059098e3d194fF87FebB587aB07B30B1306 to 0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "counterparty": null,
+              "product": null,
+              "address": "0x9531C059098e3d194fF87FebB587aB07B30B1306"
+            },
+            "has_details": false,
+            "customized": false
+          }
+        ],
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "tx_hash": "0xfa3a49a518c992dd28e4f377b0fe1c5a909211b37200fb9a7aaaabd4285c6482",
+          "timestamp": 1679915489,
+          "block_number": 84031596,
+          "from_address": "0x19e4057A38a730be37c4DA690b103267AAE1d75d",
+          "to_address": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+          "value": "100000000000000",
+          "gas": "21000",
+          "gas_price": "1000000",
+          "gas_used": "21000",
+          "input_data": "0x",
+          "nonce": 24,
+          "evm_chain": "optimism"
+        },
+        "decoded_events": [
+          {
+            "entry": {
+              "identifier": 11,
+              "event_identifier": "0xfa3a49a518c992dd28e4f377b0fe1c5a909211b37200fb9a7aaaabd4285c6482",
+              "sequence_index": 0,
+              "timestamp": 1679915489,
+              "location": "optimism",
+              "asset": "ETH",
+              "balance": {
+                "amount": "0.0001",
+                "usd_value": "0.171616"
+              },
+              "event_type": "receive",
+              "event_subtype": null,
+              "location_label": "0x2F4c0f60f2116899FA6D4b9d8B979167CE963d25",
+              "notes": "Receive 0.0001 ETH from 0x19e4057A38a730be37c4DA690b103267AAE1d75d",
+              "counterparty": null,
+              "product": null,
+              "address": "0x19e4057A38a730be37c4DA690b103267AAE1d75d"
+            },
+            "has_details": false,
+            "customized": false
+          }
+        ],
+        "ignored_in_accounting": false
+      }
     ],
-    "entries_total": 0,
-    "entries_found": 0,
+    "entries_found": 6,
+    "entries_total": 6,
     "entries_limit": -1
   },
   "message": ""

--- a/frontend/app/tests/unit/fixtures/evm-transactions.json
+++ b/frontend/app/tests/unit/fixtures/evm-transactions.json
@@ -1,0 +1,10 @@
+{
+  "result": {
+    "entries": [
+    ],
+    "entries_total": 0,
+    "entries_found": 0,
+    "entries_limit": -1
+  },
+  "message": ""
+}

--- a/frontend/app/tests/unit/fixtures/ledger-actions.json
+++ b/frontend/app/tests/unit/fixtures/ledger-actions.json
@@ -1,0 +1,55 @@
+{
+  "result": {
+    "entries": [
+      {
+        "entry": {
+          "identifier": 1,
+          "timestamp": 1679670151,
+          "action_type": "loss",
+          "location": "binance",
+          "amount": "10000",
+          "asset": "eip155:56/erc20:0x3019BF2a2eF8040C242C9a4c5c4BD4C81678b2A1",
+          "rate": "2",
+          "rate_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "link": null,
+          "notes": null
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": 2,
+          "timestamp": 1679670151,
+          "action_type": "loss",
+          "location": "binance",
+          "amount": "10000",
+          "asset": "eip155:56/erc20:0x3019BF2a2eF8040C242C9a4c5c4BD4C81678b2A1",
+          "rate": "2",
+          "rate_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "link": null,
+          "notes": null
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "identifier": 3,
+          "timestamp": 1679670151,
+          "action_type": "loss",
+          "location": "binance",
+          "amount": "10000",
+          "asset": "eip155:56/erc20:0x3019BF2a2eF8040C242C9a4c5c4BD4C81678b2A1",
+          "rate": "2",
+          "rate_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "link": null,
+          "notes": null
+        },
+        "ignored_in_accounting": false
+      }
+    ],
+    "entries_found": 3,
+    "entries_total": 3,
+    "entries_limit": -1
+  },
+  "message": ""
+}

--- a/frontend/app/tests/unit/fixtures/trades.json
+++ b/frontend/app/tests/unit/fixtures/trades.json
@@ -1,0 +1,180 @@
+{
+  "result": {
+    "entries": [
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01335104097915545600032298",
+          "fee": "4.06",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "195.80413395",
+          "notes": null,
+          "rate": "1.01601532",
+          "timestamp": 1679508792,
+          "trade_id": "1655447d6f8520c7f26e96363912d39e420b2ecc68f15cc60b364980f8804a69"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "link": "N01333257020398892032031798",
+          "fee": "9.00",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "434.13517241",
+          "notes": null,
+          "rate": "1.01581265",
+          "timestamp": 1679068414,
+          "trade_id": "51ed727b5f5a330962302092e8d42a9f59e23da8b3a411f585b99145853a3abe"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "link": "N01331816140785806336031398",
+          "fee": "20.0",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "961.55862069",
+          "notes": null,
+          "rate": "1.01917863",
+          "timestamp": 1678724882,
+          "trade_id": "d67c4c502692d86861f750827ca0aabbcc6dfa0358c6bb3060930d5a8c933232"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01331121412234752000031198",
+          "fee": "1.26",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "60.77768668",
+          "notes": null,
+          "rate": "1.01632693",
+          "timestamp": 1678559246,
+          "trade_id": "ea007548c97c213d68392b9224a67ae1a4fa975ca36e260a7ab1c1288bada28c"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01329996424622551040030898",
+          "fee": "3.74",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "180.37120308",
+          "notes": null,
+          "rate": "1.01601584",
+          "timestamp": 1678291028,
+          "trade_id": "545be2b5bbf184acaf469b4215ab9b3dd6350292fe9d28550c3379f2cb8a36a0"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01328079015137410048030398",
+          "fee": "4.02",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "194.06896552",
+          "notes": null,
+          "rate": "1.015",
+          "timestamp": 1677833882,
+          "trade_id": "0b5b507c36fa2dfd9859dbd3161ffbdb99306883704b6cdd68592e762a17d1ab"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01325698036389234688022498",
+          "fee": "4.0",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "193.10344828",
+          "notes": null,
+          "rate": "1.015",
+          "timestamp": 1677266212,
+          "trade_id": "1bd56f9e275599161d1d02013807a3818e013d3fec8ea53378a5f29dbe65bfe2"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01322639075280795648021698",
+          "fee": "34.56",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "1668.4137931",
+          "notes": null,
+          "rate": "1.015",
+          "timestamp": 1676536899,
+          "trade_id": "3e4b60a7585b96e5f526e1bcf74807c4599a945e315a2b99610c8a38f25d41bd"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "USD",
+          "trade_type": "buy",
+          "base_asset": "eip155:1/erc20:0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+          "link": "N01322468982898924544021598",
+          "fee": "3.22",
+          "fee_currency": "USD",
+          "location": "binance",
+          "amount": "155.44827586",
+          "notes": null,
+          "rate": "1.015",
+          "timestamp": 1676496346,
+          "trade_id": "bd669ce87f99d25c223d6cdfefe5eb588b34848baf6422e6756aabd7d49e959e"
+        },
+        "ignored_in_accounting": false
+      },
+      {
+        "entry": {
+          "quote_asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+          "trade_type": "sell",
+          "base_asset": "ETH",
+          "link": "1041360862",
+          "fee": "0.00009586",
+          "fee_currency": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+          "location": "binance",
+          "amount": "0.02620000",
+          "notes": null,
+          "rate": "1340.66000000",
+          "timestamp": 1670940791,
+          "trade_id": "5a1594e1f41c17d41de7bd3c52050757085ec36e00498dfbd85fb24a222aa41b"
+        },
+        "ignored_in_accounting": false
+      }
+    ],
+    "entries_found": 210,
+    "entries_total": 210,
+    "entries_limit": -1
+  },
+  "message": ""
+}

--- a/frontend/app/tests/unit/setup-files/handlers/asset-movements.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/asset-movements.ts
@@ -1,0 +1,10 @@
+import { rest } from 'msw';
+import assetMovements from '../../fixtures/asset-movements.json';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+
+export default [
+  rest.get(`${backendUrl}/api/1/asset_movements`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(assetMovements));
+  })
+];

--- a/frontend/app/tests/unit/setup-files/handlers/asset-movements.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/asset-movements.ts
@@ -4,7 +4,7 @@ import assetMovements from '../../fixtures/asset-movements.json';
 const backendUrl = process.env.VITE_BACKEND_URL;
 
 export default [
-  rest.get(`${backendUrl}/api/1/asset_movements`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(assetMovements));
-  })
+  rest.get(`${backendUrl}/api/1/asset_movements`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(assetMovements))
+  )
 ];

--- a/frontend/app/tests/unit/setup-files/handlers/evm-transactions.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/evm-transactions.ts
@@ -1,0 +1,13 @@
+import { rest } from 'msw';
+import evmTransactions from '../../fixtures/evm-transactions.json';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+
+export default [
+  rest.post(
+    `${backendUrl}/api/1/blockchains/evm/transactions`,
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(evmTransactions));
+    }
+  )
+];

--- a/frontend/app/tests/unit/setup-files/handlers/evm-transactions.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/evm-transactions.ts
@@ -6,8 +6,6 @@ const backendUrl = process.env.VITE_BACKEND_URL;
 export default [
   rest.post(
     `${backendUrl}/api/1/blockchains/evm/transactions`,
-    (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(evmTransactions));
-    }
+    (req, res, ctx) => res(ctx.status(200), ctx.json(evmTransactions))
   )
 ];

--- a/frontend/app/tests/unit/setup-files/handlers/ledger-actions.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/ledger-actions.ts
@@ -1,0 +1,10 @@
+import { rest } from 'msw';
+import ledgerActions from '../../fixtures/ledger-actions.json';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+
+export default [
+  rest.get(`${backendUrl}/api/1/ledgeractions`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(ledgerActions));
+  })
+];

--- a/frontend/app/tests/unit/setup-files/handlers/ledger-actions.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/ledger-actions.ts
@@ -4,7 +4,7 @@ import ledgerActions from '../../fixtures/ledger-actions.json';
 const backendUrl = process.env.VITE_BACKEND_URL;
 
 export default [
-  rest.get(`${backendUrl}/api/1/ledgeractions`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(ledgerActions));
-  })
+  rest.get(`${backendUrl}/api/1/ledgeractions`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(ledgerActions))
+  )
 ];

--- a/frontend/app/tests/unit/setup-files/handlers/trades.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/trades.ts
@@ -1,0 +1,10 @@
+import { rest } from 'msw';
+import trades from '../../fixtures/trades.json';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+
+export default [
+  rest.get(`${backendUrl}/api/1/trades`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(trades));
+  })
+];

--- a/frontend/app/tests/unit/setup-files/handlers/trades.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/trades.ts
@@ -4,7 +4,7 @@ import trades from '../../fixtures/trades.json';
 const backendUrl = process.env.VITE_BACKEND_URL;
 
 export default [
-  rest.get(`${backendUrl}/api/1/trades`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(trades));
-  })
+  rest.get(`${backendUrl}/api/1/trades`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(trades))
+  )
 ];

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -5,8 +5,15 @@ import { setupServer } from 'msw/node';
 import { mockT, mockTc } from '../i18n';
 import tradeHandlers from './handlers/trades';
 import assetMovementHandlers from './handlers/asset-movements';
+import ledgerActionHandlers from './handlers/ledger-actions';
+import transactionHandlers from './handlers/evm-transactions';
 
-const server = setupServer(...tradeHandlers, ...assetMovementHandlers);
+const server = setupServer(
+  ...tradeHandlers,
+  ...assetMovementHandlers,
+  ...ledgerActionHandlers,
+  ...transactionHandlers
+);
 
 beforeAll(() => {
   Vue.use(Vuetify);

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -1,11 +1,17 @@
 import { PiniaVuePlugin } from 'pinia';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
+import { setupServer } from 'msw/node';
 import { mockT, mockTc } from '../i18n';
+import tradeHandlers from './handlers/trades';
+import assetMovementHandlers from './handlers/asset-movements';
+
+const server = setupServer(...tradeHandlers, ...assetMovementHandlers);
 
 beforeAll(() => {
   Vue.use(Vuetify);
   Vue.use(PiniaVuePlugin);
+  server.listen();
 
   vi.mock('@/composables/api/assets/info', () => ({
     useAssetInfoApi: vi.fn().mockReturnValue({
@@ -65,3 +71,7 @@ beforeAll(() => {
       .mockImplementation(({ seed }) => `${seed.toLowerCase()}face`)
   }));
 });
+
+afterEach(() => server.resetHandlers());
+
+afterAll(() => server.close());

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
@@ -1,0 +1,165 @@
+import { afterEach } from 'vitest';
+import flushPromises from 'flush-promises';
+import type { Collection } from '@/types/collection';
+import type {
+  AssetMovement,
+  AssetMovementEntry,
+  AssetMovementRequestPayload
+} from '@/types/history/movements';
+import type {
+  Filters as AssetMovementFilters,
+  Matcher as AssetMovementMatcher
+} from '@/composables/filters/asset-movement';
+import type { Ref } from 'vue';
+import type Vue from 'vue';
+import type { MaybeRef } from '@vueuse/shared';
+
+vi.mock('vue-router/composables', () => ({
+  useRoute: vi.fn().mockReturnValue(
+    reactive({
+      query: {}
+    })
+  ),
+  useRouter: vi.fn().mockReturnValue({
+    push: vi.fn(({ query }) => {
+      useRoute().query = query;
+      return true;
+    })
+  })
+}));
+
+vi.mock('vue', async () => {
+  const mod = await vi.importActual<Vue>('vue');
+
+  return {
+    ...mod,
+    onBeforeMount: vi.fn()
+  };
+});
+
+describe('composables::history/filter-paginate', () => {
+  let fetchAssetMovements: (
+    payload: MaybeRef<AssetMovementRequestPayload>
+  ) => Promise<Collection<AssetMovementEntry>>;
+  const locationOverview: MaybeRef<string | null> = ref('');
+  const mainPage: Ref<boolean> = ref(false);
+  const router = useRouter();
+  const route = useRoute();
+
+  beforeAll(() => {
+    setActivePinia(createPinia());
+    fetchAssetMovements = useAssetMovements().fetchAssetMovements;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('components::history/trades/DepositsWithdrawalsContent', () => {
+    set(locationOverview, '');
+
+    beforeEach(() => {
+      set(mainPage, true);
+    });
+
+    test('initialize composable correctly', async () => {
+      const {
+        userAction,
+        filters,
+        options,
+        state,
+        fetchData,
+        applyRouteFilter,
+        isLoading
+      } = useHistoryPaginationFilter<
+        AssetMovement,
+        AssetMovementRequestPayload,
+        AssetMovementEntry,
+        AssetMovementFilters,
+        AssetMovementMatcher
+      >(
+        locationOverview,
+        mainPage,
+        useAssetMovementFilters,
+        fetchAssetMovements
+      );
+
+      expect(get(userAction)).toBe(false);
+      expect(get(isLoading)).toBe(false);
+      expect(get(filters)).to.toStrictEqual({});
+      expect(get(options).sortBy).toHaveLength(1);
+      expect(get(options).sortDesc).toHaveLength(1);
+      expect(get(state).data).toHaveLength(0);
+      expect(get(state).total).toEqual(0);
+
+      set(userAction, true);
+      applyRouteFilter();
+      fetchData();
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(state).total).toEqual(45);
+    });
+
+    test('check the return types', async () => {
+      const { isLoading, state, filters, matchers } =
+        useHistoryPaginationFilter<
+          AssetMovement,
+          AssetMovementRequestPayload,
+          AssetMovementEntry,
+          AssetMovementFilters,
+          AssetMovementMatcher
+        >(
+          locationOverview,
+          mainPage,
+          useAssetMovementFilters,
+          fetchAssetMovements
+        );
+
+      expect(get(isLoading)).toBe(false);
+
+      expectTypeOf(get(state)).toEqualTypeOf<Collection<AssetMovementEntry>>();
+      expectTypeOf(get(state).data).toEqualTypeOf<AssetMovementEntry[]>();
+      expectTypeOf(get(state).found).toEqualTypeOf<number>();
+      expectTypeOf(get(filters)).toEqualTypeOf<AssetMovementFilters>();
+      expectTypeOf(get(matchers)).toEqualTypeOf<AssetMovementMatcher[]>();
+    });
+
+    test('modify filters and fetch data correctly', async () => {
+      const pushSpy = vi.spyOn(router, 'push');
+      const query = { sortBy: ['category'], sortDesc: ['true'] };
+
+      const { isLoading, state } = useHistoryPaginationFilter<
+        AssetMovement,
+        AssetMovementRequestPayload,
+        AssetMovementEntry,
+        AssetMovementFilters,
+        AssetMovementMatcher
+      >(
+        locationOverview,
+        mainPage,
+        useAssetMovementFilters,
+        fetchAssetMovements
+      );
+
+      await router.push({
+        query
+      });
+
+      expect(pushSpy).toHaveBeenCalledOnce();
+      expect(pushSpy).toHaveBeenCalledWith({ query });
+      expect(route.query).toEqual(query);
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(isLoading)).toBe(false);
+
+      assertType<Collection<AssetMovementEntry>>(get(state));
+      assertType<AssetMovementEntry[]>(get(state).data);
+      assertType<number>(get(state).found);
+
+      expect(get(state).data).toHaveLength(10);
+      expect(get(state).found).toEqual(45);
+      expect(get(state).limit).toEqual(-1);
+      expect(get(state).total).toEqual(45);
+    });
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
@@ -1,18 +1,14 @@
-import { afterEach } from 'vitest';
 import flushPromises from 'flush-promises';
+import { type Ref } from 'vue';
+import type { Filters, Matcher } from '@/composables/filters/asset-movement';
 import type { Collection } from '@/types/collection';
 import type {
   AssetMovement,
   AssetMovementEntry,
   AssetMovementRequestPayload
 } from '@/types/history/movements';
-import type {
-  Filters as AssetMovementFilters,
-  Matcher as AssetMovementMatcher
-} from '@/composables/filters/asset-movement';
-import type { Ref } from 'vue';
-import type Vue from 'vue';
 import type { MaybeRef } from '@vueuse/shared';
+import type Vue from 'vue';
 
 vi.mock('vue-router/composables', () => ({
   useRoute: vi.fn().mockReturnValue(
@@ -75,8 +71,8 @@ describe('composables::history/filter-paginate', () => {
         AssetMovement,
         AssetMovementRequestPayload,
         AssetMovementEntry,
-        AssetMovementFilters,
-        AssetMovementMatcher
+        Filters,
+        Matcher
       >(
         locationOverview,
         mainPage,
@@ -94,7 +90,7 @@ describe('composables::history/filter-paginate', () => {
 
       set(userAction, true);
       applyRouteFilter();
-      fetchData();
+      fetchData().catch(() => {});
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       expect(get(state).total).toEqual(45);
@@ -106,8 +102,8 @@ describe('composables::history/filter-paginate', () => {
           AssetMovement,
           AssetMovementRequestPayload,
           AssetMovementEntry,
-          AssetMovementFilters,
-          AssetMovementMatcher
+          Filters,
+          Matcher
         >(
           locationOverview,
           mainPage,
@@ -120,8 +116,8 @@ describe('composables::history/filter-paginate', () => {
       expectTypeOf(get(state)).toEqualTypeOf<Collection<AssetMovementEntry>>();
       expectTypeOf(get(state).data).toEqualTypeOf<AssetMovementEntry[]>();
       expectTypeOf(get(state).found).toEqualTypeOf<number>();
-      expectTypeOf(get(filters)).toEqualTypeOf<AssetMovementFilters>();
-      expectTypeOf(get(matchers)).toEqualTypeOf<AssetMovementMatcher[]>();
+      expectTypeOf(get(filters)).toEqualTypeOf<Filters>();
+      expectTypeOf(get(matchers)).toEqualTypeOf<Matcher[]>();
     });
 
     test('modify filters and fetch data correctly', async () => {
@@ -132,8 +128,8 @@ describe('composables::history/filter-paginate', () => {
         AssetMovement,
         AssetMovementRequestPayload,
         AssetMovementEntry,
-        AssetMovementFilters,
-        AssetMovementMatcher
+        Filters,
+        Matcher
       >(
         locationOverview,
         mainPage,

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
@@ -1,0 +1,152 @@
+import { afterEach } from 'vitest';
+import flushPromises from 'flush-promises';
+import type { Collection } from '@/types/collection';
+import type {
+  LedgerAction,
+  LedgerActionEntry,
+  LedgerActionRequestPayload
+} from '@/types/history/ledger-action/ledger-actions';
+import type { Ref } from 'vue';
+import type Vue from 'vue';
+import type { MaybeRef } from '@vueuse/shared';
+import type { Filters, Matcher } from '@/composables/filters/ledger-actions';
+
+vi.mock('vue-router/composables', () => ({
+  useRoute: vi.fn().mockReturnValue(
+    reactive({
+      query: {}
+    })
+  ),
+  useRouter: vi.fn().mockReturnValue({
+    push: vi.fn(({ query }) => {
+      useRoute().query = query;
+      return true;
+    })
+  })
+}));
+
+vi.mock('vue', async () => {
+  const mod = await vi.importActual<Vue>('vue');
+
+  return {
+    ...mod,
+    onBeforeMount: vi.fn()
+  };
+});
+
+describe('composables::history/filter-paginate', () => {
+  let fetchLedgerActions: (
+    payload: MaybeRef<LedgerActionRequestPayload>
+  ) => Promise<Collection<LedgerActionEntry>>;
+  const locationOverview: MaybeRef<string | null> = ref('');
+  const mainPage: Ref<boolean> = ref(false);
+  const router = useRouter();
+  const route = useRoute();
+
+  beforeAll(() => {
+    setActivePinia(createPinia());
+    fetchLedgerActions = useLedgerActions().fetchLedgerActions;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('components::history/trades/LedgerActionContent', () => {
+    set(locationOverview, '');
+
+    beforeEach(() => {
+      set(mainPage, true);
+    });
+
+    test('initialize composable correctly', async () => {
+      const {
+        userAction,
+        filters,
+        options,
+        state,
+        fetchData,
+        applyRouteFilter,
+        isLoading
+      } = useHistoryPaginationFilter<
+        LedgerAction,
+        LedgerActionRequestPayload,
+        LedgerActionEntry,
+        Filters,
+        Matcher
+      >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
+
+      expect(get(userAction)).toBe(false);
+      expect(get(isLoading)).toBe(false);
+      expect(get(filters)).to.toStrictEqual({});
+      expect(get(options).sortBy).toHaveLength(1);
+      expect(get(options).sortDesc).toHaveLength(1);
+      expect(get(state).data).toHaveLength(0);
+      expect(get(state).total).toEqual(0);
+
+      set(userAction, true);
+      applyRouteFilter();
+      fetchData();
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(state).total).toEqual(3);
+    });
+
+    test('check the return types', async () => {
+      const { isLoading, state, filters, matchers } =
+        useHistoryPaginationFilter<
+          LedgerAction,
+          LedgerActionRequestPayload,
+          LedgerActionEntry,
+          Filters,
+          Matcher
+        >(
+          locationOverview,
+          mainPage,
+          useLedgerActionsFilter,
+          fetchLedgerActions
+        );
+
+      expect(get(isLoading)).toBe(false);
+
+      expectTypeOf(get(state)).toEqualTypeOf<Collection<LedgerActionEntry>>();
+      expectTypeOf(get(state).data).toEqualTypeOf<LedgerActionEntry[]>();
+      expectTypeOf(get(state).found).toEqualTypeOf<number>();
+      expectTypeOf(get(filters)).toEqualTypeOf<Filters>();
+      expectTypeOf(get(matchers)).toEqualTypeOf<Matcher[]>();
+    });
+
+    test('modify filters and fetch data correctly', async () => {
+      const pushSpy = vi.spyOn(router, 'push');
+      const query = { sortBy: ['location'], sortDesc: ['true'] };
+
+      const { isLoading, state } = useHistoryPaginationFilter<
+        LedgerAction,
+        LedgerActionRequestPayload,
+        LedgerActionEntry,
+        Filters,
+        Matcher
+      >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
+
+      await router.push({
+        query
+      });
+
+      expect(pushSpy).toHaveBeenCalledOnce();
+      expect(pushSpy).toHaveBeenCalledWith({ query });
+      expect(route.query).toEqual(query);
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(isLoading)).toBe(false);
+
+      assertType<Collection<LedgerActionEntry>>(get(state));
+      assertType<LedgerActionEntry[]>(get(state).data);
+      assertType<number>(get(state).found);
+
+      expect(get(state).data).toHaveLength(3);
+      expect(get(state).found).toEqual(3);
+      expect(get(state).limit).toEqual(-1);
+      expect(get(state).total).toEqual(3);
+    });
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
@@ -1,15 +1,14 @@
-import { afterEach } from 'vitest';
 import flushPromises from 'flush-promises';
+import { type Ref } from 'vue';
+import type { Filters, Matcher } from '@/composables/filters/ledger-actions';
 import type { Collection } from '@/types/collection';
 import type {
   LedgerAction,
   LedgerActionEntry,
   LedgerActionRequestPayload
 } from '@/types/history/ledger-action/ledger-actions';
-import type { Ref } from 'vue';
-import type Vue from 'vue';
 import type { MaybeRef } from '@vueuse/shared';
-import type { Filters, Matcher } from '@/composables/filters/ledger-actions';
+import type Vue from 'vue';
 
 vi.mock('vue-router/composables', () => ({
   useRoute: vi.fn().mockReturnValue(
@@ -86,7 +85,7 @@ describe('composables::history/filter-paginate', () => {
 
       set(userAction, true);
       applyRouteFilter();
-      fetchData();
+      fetchData().catch(() => {});
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       expect(get(state).total).toEqual(3);

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
@@ -1,16 +1,15 @@
-import { afterEach } from 'vitest';
+import { type MaybeRef } from '@vueuse/shared';
 import flushPromises from 'flush-promises';
-import { type LocationQuery } from '@/types/route';
+import { type Ref } from 'vue';
 import { type Collection } from '@/types/collection';
+import { type LocationQuery } from '@/types/route';
+import type { Filters, Matcher } from '@/composables/filters/trades';
 import type {
   Trade,
   TradeEntry,
   TradeRequestPayload
 } from '@/types/history/trade';
-import type { Ref } from 'vue';
 import type Vue from 'vue';
-import type { MaybeRef } from '@vueuse/shared';
-import type { Filters, Matcher } from '@/composables/filters/trades';
 
 vi.mock('vue-router/composables', () => ({
   useRoute: vi.fn().mockReturnValue(
@@ -98,7 +97,7 @@ describe('composables::history/filter-paginate', () => {
 
       set(userAction, true);
       applyRouteFilter();
-      fetchData();
+      fetchData().catch(() => {});
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       expect(get(state).total).toEqual(210);

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
@@ -1,0 +1,165 @@
+import { afterEach } from 'vitest';
+import flushPromises from 'flush-promises';
+import { type LocationQuery } from '@/types/route';
+import { type Collection } from '@/types/collection';
+import type {
+  Trade,
+  TradeEntry,
+  TradeRequestPayload
+} from '@/types/history/trade';
+import type { Ref } from 'vue';
+import type Vue from 'vue';
+import type { MaybeRef } from '@vueuse/shared';
+import type { Filters, Matcher } from '@/composables/filters/trades';
+
+vi.mock('vue-router/composables', () => ({
+  useRoute: vi.fn().mockReturnValue(
+    reactive({
+      query: {}
+    })
+  ),
+  useRouter: vi.fn().mockReturnValue({
+    push: vi.fn(({ query }) => {
+      useRoute().query = query;
+      return true;
+    })
+  })
+}));
+
+vi.mock('vue', async () => {
+  const mod = await vi.importActual<Vue>('vue');
+
+  return {
+    ...mod,
+    onBeforeMount: vi.fn()
+  };
+});
+
+describe('composables::history/filter-paginate', () => {
+  let fetchTrades: (
+    payload: MaybeRef<TradeRequestPayload>
+  ) => Promise<Collection<TradeEntry>>;
+  const locationOverview: MaybeRef<string | null> = ref('');
+  const mainPage: Ref<boolean> = ref(false);
+  const router = useRouter();
+  const route = useRoute();
+
+  beforeAll(() => {
+    setActivePinia(createPinia());
+    fetchTrades = useTrades().fetchTrades;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('components::history/trades/ClosedTrades', () => {
+    set(locationOverview, '');
+    const hideIgnoredTrades = ref(false);
+    const extraParams = computed(() => ({
+      includeIgnoredTrades: (!get(hideIgnoredTrades)).toString()
+    }));
+
+    const onUpdateFilters = (query: LocationQuery) => {
+      set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
+    };
+
+    beforeEach(() => {
+      set(mainPage, true);
+    });
+
+    test('initialize composable correctly', async () => {
+      const {
+        userAction,
+        filters,
+        options,
+        state,
+        fetchData,
+        applyRouteFilter,
+        isLoading
+      } = useHistoryPaginationFilter<
+        Trade,
+        TradeRequestPayload,
+        TradeEntry,
+        Filters,
+        Matcher
+      >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+        onUpdateFilters,
+        extraParams
+      });
+
+      expect(get(userAction)).toBe(false);
+      expect(get(isLoading)).toBe(false);
+      expect(get(filters)).to.toStrictEqual({});
+      expect(get(options).sortBy).toHaveLength(1);
+      expect(get(options).sortDesc).toHaveLength(1);
+      expect(get(state).data).toHaveLength(0);
+      expect(get(state).total).toEqual(0);
+
+      set(userAction, true);
+      applyRouteFilter();
+      fetchData();
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(state).total).toEqual(210);
+    });
+
+    test('check the return types', async () => {
+      const { isLoading, state, filters, matchers } =
+        useHistoryPaginationFilter<
+          Trade,
+          TradeRequestPayload,
+          TradeEntry,
+          Filters,
+          Matcher
+        >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+          onUpdateFilters,
+          extraParams
+        });
+
+      expect(get(isLoading)).toBe(false);
+
+      expectTypeOf(get(state)).toEqualTypeOf<Collection<TradeEntry>>();
+      expectTypeOf(get(state).data).toEqualTypeOf<TradeEntry[]>();
+      expectTypeOf(get(state).found).toEqualTypeOf<number>();
+      expectTypeOf(get(filters)).toEqualTypeOf<Filters>();
+      expectTypeOf(get(matchers)).toEqualTypeOf<Matcher[]>();
+    });
+
+    test('modify filters and fetch data correctly', async () => {
+      const pushSpy = vi.spyOn(router, 'push');
+      const query = { sortBy: ['type'], sortDesc: ['true'] };
+
+      const { isLoading, state } = useHistoryPaginationFilter<
+        Trade,
+        TradeRequestPayload,
+        TradeEntry,
+        Filters,
+        Matcher
+      >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+        onUpdateFilters,
+        extraParams
+      });
+
+      await router.push({
+        query
+      });
+
+      expect(pushSpy).toHaveBeenCalledOnce();
+      expect(pushSpy).toHaveBeenCalledWith({ query });
+      expect(route.query).toEqual(query);
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(isLoading)).toBe(false);
+
+      assertType<Collection<TradeEntry>>(get(state));
+      assertType<TradeEntry[]>(get(state).data);
+      assertType<number>(get(state).found);
+
+      expect(get(state).data).toHaveLength(10);
+      expect(get(state).found).toEqual(210);
+      expect(get(state).limit).toEqual(-1);
+      expect(get(state).total).toEqual(210);
+    });
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
@@ -1,15 +1,8 @@
-import { afterEach } from 'vitest';
-import flushPromises from 'flush-promises';
 import { Blockchain } from '@rotki/common/lib/blockchain';
+import flushPromises from 'flush-promises';
+import { type ComputedRef, type Ref } from 'vue';
 import { RouterAccountsSchema } from '@/types/route';
-import type { ComputedRef, Ref } from 'vue';
-import type {
-  HistoryEventSubType,
-  HistoryEventType,
-  TransactionEventProtocol
-} from '@rotki/common/lib/history/tx-events';
-import type { GeneralAccount } from '@rotki/common/src/account';
-import type { LocationQuery } from '@/types/route';
+import type { Filters, Matcher } from '@/composables/filters/transactions';
 import type { Collection } from '@/types/collection';
 import type {
   EthTransaction,
@@ -17,9 +10,15 @@ import type {
   EvmChainAddress,
   TransactionRequestPayload
 } from '@/types/history/tx';
-import type { Filters, Matcher } from '@/composables/filters/transactions';
-import type Vue from 'vue';
+import type { LocationQuery } from '@/types/route';
+import type {
+  HistoryEventSubType,
+  HistoryEventType,
+  TransactionEventProtocol
+} from '@rotki/common/lib/history/tx-events';
+import type { GeneralAccount } from '@rotki/common/src/account';
 import type { MaybeRef } from '@vueuse/shared';
+import type Vue from 'vue';
 
 vi.mock('vue-router/composables', () => ({
   useRoute: vi.fn().mockReturnValue(
@@ -148,7 +147,7 @@ describe('composables::history/filter-paginate', () => {
 
       set(userAction, true);
       applyRouteFilter();
-      fetchData();
+      fetchData().catch(() => {});
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       expect(get(state).total).toEqual(0);

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
@@ -1,0 +1,230 @@
+import { afterEach } from 'vitest';
+import flushPromises from 'flush-promises';
+import { Blockchain } from '@rotki/common/lib/blockchain';
+import { RouterAccountsSchema } from '@/types/route';
+import type { ComputedRef, Ref } from 'vue';
+import type {
+  HistoryEventSubType,
+  HistoryEventType,
+  TransactionEventProtocol
+} from '@rotki/common/lib/history/tx-events';
+import type { GeneralAccount } from '@rotki/common/src/account';
+import type { LocationQuery } from '@/types/route';
+import type { Collection } from '@/types/collection';
+import type {
+  EthTransaction,
+  EthTransactionEntry,
+  EvmChainAddress,
+  TransactionRequestPayload
+} from '@/types/history/tx';
+import type { Filters, Matcher } from '@/composables/filters/transactions';
+import type Vue from 'vue';
+import type { MaybeRef } from '@vueuse/shared';
+
+vi.mock('vue-router/composables', () => ({
+  useRoute: vi.fn().mockReturnValue(
+    reactive({
+      query: {}
+    })
+  ),
+  useRouter: vi.fn().mockReturnValue({
+    push: vi.fn(({ query }) => {
+      useRoute().query = query;
+      return true;
+    })
+  })
+}));
+
+vi.mock('vue', async () => {
+  const mod = await vi.importActual<Vue>('vue');
+
+  return {
+    ...mod,
+    onBeforeMount: vi.fn()
+  };
+});
+
+describe('composables::history/filter-paginate', () => {
+  let fetchTransactions: (
+    payload: MaybeRef<TransactionRequestPayload>
+  ) => Promise<Collection<EthTransactionEntry>>;
+  const locationOverview: MaybeRef<string | null> = null;
+  const mainPage: Ref<boolean> = ref(false);
+  const protocols: Ref<TransactionEventProtocol[]> = ref([]);
+  const eventTypes: Ref<HistoryEventType[]> = ref([]);
+  const eventSubTypes: Ref<HistoryEventSubType[]> = ref([]);
+  const accounts: Ref<GeneralAccount[]> = ref([
+    {
+      address: '0xa13A1BaF456e2B750a87B9e1987d1387CfdC05f6',
+      chain: Blockchain.OPTIMISM,
+      label: '',
+      tags: []
+    }
+  ]);
+  const router = useRouter();
+  const route = useRoute();
+
+  const filteredAccounts: ComputedRef<EvmChainAddress[]> = computed(() => [
+    {
+      address: '0xa13A1BaF456e2B750a87B9e1987d1387CfdC05f6',
+      evmChain: 'optimism'
+    }
+  ]);
+
+  beforeAll(() => {
+    setActivePinia(createPinia());
+    fetchTransactions = useTransactions().fetchTransactions;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('components::history/trades/TransactionContent', () => {
+    const onUpdateFilters = (query: LocationQuery) => {
+      const parsedAccounts = RouterAccountsSchema.parse(query);
+      if (parsedAccounts.accounts) {
+        set(accounts, parsedAccounts.accounts);
+      }
+    };
+
+    const extraParams = computed(() => {
+      return {
+        accounts: get(accounts).map(
+          account => `${account.address}#${account.chain}`
+        )
+      };
+    });
+
+    const customPageParams = computed<Partial<TransactionRequestPayload>>(
+      () => {
+        return {
+          protocols: get(protocols),
+          eventTypes: get(eventTypes),
+          eventSubtypes: get(eventSubTypes),
+          accounts: get(filteredAccounts)
+        };
+      }
+    );
+
+    beforeEach(() => {
+      set(mainPage, true);
+    });
+
+    test('initialize composable correctly', async () => {
+      const {
+        userAction,
+        filters,
+        options,
+        state,
+        fetchData,
+        applyRouteFilter,
+        isLoading
+      } = useHistoryPaginationFilter<
+        EthTransaction,
+        TransactionRequestPayload,
+        EthTransactionEntry,
+        Filters,
+        Matcher
+      >(
+        locationOverview,
+        mainPage,
+        () => useTransactionFilter(get(protocols).length > 0),
+        fetchTransactions,
+        {
+          onUpdateFilters,
+          extraParams,
+          customPageParams
+        }
+      );
+
+      expect(get(userAction)).toBe(false);
+      expect(get(isLoading)).toBe(false);
+      expect(get(filters)).to.toStrictEqual({});
+      expect(get(options).sortBy).toHaveLength(1);
+      expect(get(options).sortDesc).toHaveLength(1);
+      expect(get(state).data).toHaveLength(0);
+      expect(get(state).total).toEqual(0);
+
+      set(userAction, true);
+      applyRouteFilter();
+      fetchData();
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(state).total).toEqual(0);
+    });
+
+    test('check the return types', async () => {
+      const { isLoading, state, filters, matchers } =
+        useHistoryPaginationFilter<
+          EthTransaction,
+          TransactionRequestPayload,
+          EthTransactionEntry,
+          Filters,
+          Matcher
+        >(
+          locationOverview,
+          mainPage,
+          () => useTransactionFilter(get(protocols).length > 0),
+          fetchTransactions,
+          {
+            onUpdateFilters,
+            extraParams,
+            customPageParams
+          }
+        );
+
+      expect(get(isLoading)).toBe(false);
+
+      expectTypeOf(get(state)).toEqualTypeOf<Collection<EthTransactionEntry>>();
+      expectTypeOf(get(state).data).toEqualTypeOf<EthTransactionEntry[]>();
+      expectTypeOf(get(state).found).toEqualTypeOf<number>();
+      expectTypeOf(get(filters)).toEqualTypeOf<Filters>();
+      expectTypeOf(get(matchers)).toEqualTypeOf<Matcher[]>();
+    });
+
+    test('modify filters and fetch data correctly', async () => {
+      const pushSpy = vi.spyOn(router, 'push');
+      const query = { sortBy: ['timestamp'], sortDesc: ['false'] };
+
+      const { isLoading, state, pageParams } = useHistoryPaginationFilter<
+        EthTransaction,
+        TransactionRequestPayload,
+        EthTransactionEntry,
+        Filters,
+        Matcher
+      >(
+        locationOverview,
+        mainPage,
+        () => useTransactionFilter(get(protocols).length > 0),
+        fetchTransactions,
+        {
+          onUpdateFilters,
+          extraParams,
+          customPageParams
+        }
+      );
+
+      await router.push({
+        query
+      });
+
+      expect(pushSpy).toHaveBeenCalledOnce();
+      expect(pushSpy).toHaveBeenCalledWith({ query });
+      expect(route.query).toEqual(query);
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(isLoading)).toBe(false);
+
+      assertType<Collection<EthTransactionEntry>>(get(state));
+      assertType<EthTransactionEntry[]>(get(state).data);
+      assertType<number>(get(state).found);
+      expect(get(pageParams).accounts).toHaveLength(1);
+
+      expect(get(state).data).toHaveLength(0);
+      expect(get(state).found).toEqual(0);
+      expect(get(state).limit).toEqual(-1);
+      expect(get(state).total).toEqual(0);
+    });
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
@@ -87,23 +87,19 @@ describe('composables::history/filter-paginate', () => {
       }
     };
 
-    const extraParams = computed(() => {
-      return {
-        accounts: get(accounts).map(
-          account => `${account.address}#${account.chain}`
-        )
-      };
-    });
+    const extraParams = computed(() => ({
+      accounts: get(accounts).map(
+        account => `${account.address}#${account.chain}`
+      )
+    }));
 
     const customPageParams = computed<Partial<TransactionRequestPayload>>(
-      () => {
-        return {
-          protocols: get(protocols),
-          eventTypes: get(eventTypes),
-          eventSubtypes: get(eventSubTypes),
-          accounts: get(filteredAccounts)
-        };
-      }
+      () => ({
+        protocols: get(protocols),
+        eventTypes: get(eventTypes),
+        eventSubtypes: get(eventSubTypes),
+        accounts: get(filteredAccounts)
+      })
     );
 
     beforeEach(() => {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -78,6 +78,7 @@ importers:
       flush-promises: 1.0.2
       lodash: 4.17.21
       loglevel: 1.8.1
+      msw: ^1.2.0
       pinia: 2.0.32
       postcss: 8.4.21
       postcss-html: 1.5.0
@@ -182,6 +183,7 @@ importers:
       electron-store: 8.1.0
       eslint-plugin-cypress: 2.12.1_eslint@8.34.0
       flush-promises: 1.0.2
+      msw: 1.2.0_typescript@4.9.5
       postcss: 8.4.21
       postcss-html: 1.5.0
       postcss-scss: 4.0.6_postcss@8.4.21
@@ -2028,6 +2030,30 @@ packages:
     resolution: {integrity: sha512-Imag6npmfkBDi2Ze2jiZVAPTDIKLxhz2Sx82xJ2zctyAU5LYJejLI5ChnDwiD9bMkQfVuzEsI98Q8toHyC+HCg==}
     dev: true
 
+  /@mswjs/cookies/0.2.2:
+    resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@types/set-cookie-parser': 2.4.2
+      set-cookie-parser: 2.6.0
+    dev: true
+
+  /@mswjs/interceptors/0.17.9:
+    resolution: {integrity: sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@open-draft/until': 1.0.3
+      '@types/debug': 4.1.7
+      '@xmldom/xmldom': 0.8.6
+      debug: 4.3.4
+      headers-polyfill: 3.1.2
+      outvariant: 1.3.0
+      strict-event-emitter: 0.2.8
+      web-encoding: 1.1.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@namics/stylelint-bem/8.1.0_stylelint@14.16.1:
     resolution: {integrity: sha512-lVK6mqAD1WjKwtXW4pZ/V7T3TM3WFG+aqYtAxqYLp7et3Rm5Tu3JoXYhA63HE4t467XOJTK+K2foIzYz42j69w==}
     engines: {node: '>=14'}
@@ -2104,6 +2130,10 @@ packages:
     transitivePeerDependencies:
       - rollup
       - supports-color
+    dev: true
+
+  /@open-draft/until/1.0.3:
+    resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
     dev: true
 
   /@pinia/testing/0.0.15_pinia@2.0.32+vue@2.7.14:
@@ -2437,6 +2467,10 @@ packages:
     dependencies:
       '@types/node': 16.18.12
 
+  /@types/cookie/0.4.1:
+    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+    dev: true
+
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -2518,6 +2552,10 @@ packages:
 
   /@types/istanbul-lib-coverage/2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+    dev: true
+
+  /@types/js-levenshtein/1.1.1:
+    resolution: {integrity: sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==}
     dev: true
 
   /@types/json-schema/7.0.11:
@@ -2619,6 +2657,12 @@ packages:
     dependencies:
       '@types/mime': 3.0.1
       '@types/node': 16.18.12
+
+  /@types/set-cookie-parser/2.4.2:
+    resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
+    dependencies:
+      '@types/node': 16.18.12
+    dev: true
 
   /@types/sinonjs__fake-timers/8.1.1:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -3380,6 +3424,11 @@ packages:
     dev: false
     optional: true
 
+  /@xmldom/xmldom/0.8.6:
+    resolution: {integrity: sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==}
+    engines: {node: '>=10.0.0'}
+    dev: true
+
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
     dev: false
@@ -3388,6 +3437,12 @@ packages:
   /@xtuc/long/4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: false
+    optional: true
+
+  /@zxing/text-encoding/0.9.0:
+    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
+    requiresBuild: true
+    dev: true
     optional: true
 
   /abab/2.0.6:
@@ -3731,6 +3786,11 @@ packages:
     engines: {node: '>=10.12.0'}
     dev: true
 
+  /available-typed-arrays/1.0.5:
+    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /aws-sign2/0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
@@ -3834,6 +3894,14 @@ packages:
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /bl/4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
     dev: true
 
   /blob-util/2.0.2:
@@ -4125,6 +4193,14 @@ packages:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  /chalk/4.1.1:
+    resolution: {integrity: sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -4140,6 +4216,10 @@ packages:
 
   /character-reference-invalid/1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+
+  /chardet/0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+    dev: true
 
   /charenc/0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
@@ -4221,6 +4301,11 @@ packages:
     dependencies:
       restore-cursor: 3.1.0
 
+  /cli-spinners/2.7.0:
+    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
+    engines: {node: '>=6'}
+    dev: true
+
   /cli-table3/0.6.3:
     resolution: {integrity: sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==}
     engines: {node: 10.* || >= 12.*}
@@ -4242,6 +4327,11 @@ packages:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 5.1.2
+    dev: true
+
+  /cli-width/3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
     dev: true
 
   /cliui/6.0.0:
@@ -4274,6 +4364,11 @@ packages:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
     dependencies:
       mimic-response: 1.0.1
+    dev: true
+
+  /clone/1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
     dev: true
 
   /color-convert/1.9.3:
@@ -4411,6 +4506,11 @@ packages:
   /cookie-signature/1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: false
+
+  /cookie/0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /cookie/0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
@@ -4760,6 +4860,12 @@ packages:
       strip-bom: 4.0.0
     dev: false
     optional: true
+
+  /defaults/1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+    dependencies:
+      clone: 1.0.4
+    dev: true
 
   /defer-to-connect/2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
@@ -5947,8 +6053,6 @@ packages:
   /events/3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-    dev: false
-    optional: true
 
   /execa/4.1.0:
     resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
@@ -6033,6 +6137,15 @@ packages:
 
   /extend/3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  /external-editor/3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+    dev: true
 
   /extract-zip/2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -6216,6 +6329,12 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
+    dev: true
+
+  /for-each/0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+    dependencies:
+      is-callable: 1.2.7
     dev: true
 
   /foreground-child/2.0.0:
@@ -6571,6 +6690,11 @@ packages:
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
+  /graphql/16.6.0:
+    resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
   /hammerjs/2.0.8:
     resolution: {integrity: sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==}
     engines: {node: '>=0.8.0'}
@@ -6629,6 +6753,10 @@ packages:
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: true
+
+  /headers-polyfill/3.1.2:
+    resolution: {integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==}
     dev: true
 
   /hookable/5.4.2:
@@ -6773,7 +6901,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: false
 
   /iconv-lite/0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -6842,6 +6969,27 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
+  /inquirer/8.2.5:
+    resolution: {integrity: sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 7.0.0
+    dev: true
+
   /internal-slot/1.0.3:
     resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
     engines: {node: '>= 0.4'}
@@ -6863,6 +7011,14 @@ packages:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  /is-arguments/1.1.1:
+    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      has-tostringtag: 1.0.0
+    dev: true
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -6937,6 +7093,13 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /is-generator-function/1.0.10:
+    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.0
+    dev: true
+
   /is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -6953,6 +7116,11 @@ packages:
       global-dirs: 3.0.1
       is-path-inside: 3.0.3
 
+  /is-interactive/1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /is-language-code/3.1.0:
     resolution: {integrity: sha512-zJdQ3QTeLye+iphMeK3wks+vXSRFKh68/Pnlw7aOfApFSEIOhYa8P9vwwa6QrImNNBMJTiL1PpYF0f4BxDuEgA==}
     dependencies:
@@ -6966,6 +7134,10 @@ packages:
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
+
+  /is-node-process/1.0.1:
+    resolution: {integrity: sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==}
+    dev: true
 
   /is-number-object/1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -7042,6 +7214,17 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+
+  /is-typed-array/1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+    dev: true
 
   /is-typedarray/1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -7231,6 +7414,11 @@ packages:
       editorconfig: 0.15.3
       glob: 8.0.3
       nopt: 6.0.0
+    dev: true
+
+  /js-levenshtein/1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /js-sdsl/4.2.0:
@@ -7933,8 +8121,48 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msw/1.2.0_typescript@4.9.5:
+    resolution: {integrity: sha512-2nbGxmG8Zk/eCiWCAFtgz5kwPE5YnTlOcRBggFkykqkBSPQE+kvlHJElOzrTG21Tb0ZGXWgn0PI5kyANnOpgug==}
+    engines: {node: '>=14'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.4.x <= 5.0.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@mswjs/cookies': 0.2.2
+      '@mswjs/interceptors': 0.17.9
+      '@open-draft/until': 1.0.3
+      '@types/cookie': 0.4.1
+      '@types/js-levenshtein': 1.1.1
+      chalk: 4.1.1
+      chokidar: 3.5.3
+      cookie: 0.4.2
+      graphql: 16.6.0
+      headers-polyfill: 3.1.2
+      inquirer: 8.2.5
+      is-node-process: 1.0.1
+      js-levenshtein: 1.1.6
+      node-fetch: 2.6.9
+      outvariant: 1.3.0
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.4.6
+      type-fest: 2.19.0
+      typescript: 4.9.5
+      yargs: 17.6.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
   /muggle-string/0.2.2:
     resolution: {integrity: sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==}
+    dev: true
+
+  /mute-stream/0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: true
 
   /nanoid/3.3.4:
@@ -7964,6 +8192,18 @@ packages:
 
   /node-fetch-native/1.0.2:
     resolution: {integrity: sha512-KIkvH1jl6b3O7es/0ShyCgWLcfXxlBrLBbP3rOr23WArC66IMcU4DeZEeYEOwnopYhawLTn7/y+YtmASe8DFVQ==}
+    dev: true
+
+  /node-fetch/2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: true
 
   /node-preload/0.2.1:
@@ -8154,8 +8394,32 @@ packages:
       type-check: 0.4.0
       word-wrap: 1.2.3
 
+  /ora/5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.7.0
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+    dev: true
+
+  /os-tmpdir/1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /ospath/1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
+
+  /outvariant/1.3.0:
+    resolution: {integrity: sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==}
+    dev: true
 
   /p-cancelable/2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -8292,6 +8556,10 @@ packages:
   /path-to-regexp/0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: false
+
+  /path-to-regexp/6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
+    dev: true
 
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -8690,6 +8958,15 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /readable-stream/3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: true
+
   /readdirp/3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -8897,6 +9174,11 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /run-async/2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -9065,6 +9347,10 @@ packages:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: false
     optional: true
+
+  /set-cookie-parser/2.6.0:
+    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
+    dev: true
 
   /setimmediate/1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -9282,6 +9568,16 @@ packages:
 
   /stream-transform/3.2.2:
     resolution: {integrity: sha512-DHZQPNxvjU2qdQlGcpitn8pkJHQVTqdshtgXaLz6Vc5VCAognbGuuwGS5ugeqGVnyw8j4h89QcV8cwm0D1+V0A==}
+    dev: true
+
+  /strict-event-emitter/0.2.8:
+    resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
+    dependencies:
+      events: 3.3.0
+    dev: true
+
+  /strict-event-emitter/0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
     dev: true
 
   /string-width/4.2.3:
@@ -9701,6 +9997,13 @@ packages:
       tmp: 0.2.1
     dev: true
 
+  /tmp/0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: true
+
   /tmp/0.2.1:
     resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
     engines: {node: '>=8.17.0'}
@@ -9744,6 +10047,10 @@ packages:
       punycode: 2.1.1
       universalify: 0.2.0
       url-parse: 1.5.10
+    dev: true
+
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
 
   /tr46/1.0.1:
@@ -10165,6 +10472,16 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  /util/0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.1.1
+      is-generator-function: 1.0.10
+      is-typed-array: 1.1.10
+      which-typed-array: 1.1.9
+    dev: true
 
   /utils-merge/1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -10717,6 +11034,24 @@ packages:
     dev: false
     optional: true
 
+  /wcwidth/1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    dependencies:
+      defaults: 1.0.4
+    dev: true
+
+  /web-encoding/1.1.5:
+    resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
+    dependencies:
+      util: 0.12.5
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
+    dev: true
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
@@ -10801,6 +11136,13 @@ packages:
       webidl-conversions: 7.0.0
     dev: true
 
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: true
+
   /whatwg-url/7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
     dependencies:
@@ -10822,6 +11164,18 @@ packages:
     resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
     dev: false
     optional: true
+
+  /which-typed-array/1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
+    dev: true
 
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
       flush-promises: 1.0.2
       lodash: 4.17.21
       loglevel: 1.8.1
-      msw: ^1.2.0
+      msw: 1.2.1
       pinia: 2.0.32
       postcss: 8.4.21
       postcss-html: 1.5.0
@@ -183,7 +183,7 @@ importers:
       electron-store: 8.1.0
       eslint-plugin-cypress: 2.12.1_eslint@8.34.0
       flush-promises: 1.0.2
-      msw: 1.2.0_typescript@4.9.5
+      msw: 1.2.1_typescript@4.9.5
       postcss: 8.4.21
       postcss-html: 1.5.0
       postcss-scss: 4.0.6_postcss@8.4.21
@@ -2047,7 +2047,7 @@ packages:
       '@xmldom/xmldom': 0.8.6
       debug: 4.3.4
       headers-polyfill: 3.1.2
-      outvariant: 1.3.0
+      outvariant: 1.4.0
       strict-event-emitter: 0.2.8
       web-encoding: 1.1.5
     transitivePeerDependencies:
@@ -7135,8 +7135,8 @@ packages:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
 
-  /is-node-process/1.0.1:
-    resolution: {integrity: sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==}
+  /is-node-process/1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
     dev: true
 
   /is-number-object/1.0.7:
@@ -8121,8 +8121,8 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /msw/1.2.0_typescript@4.9.5:
-    resolution: {integrity: sha512-2nbGxmG8Zk/eCiWCAFtgz5kwPE5YnTlOcRBggFkykqkBSPQE+kvlHJElOzrTG21Tb0ZGXWgn0PI5kyANnOpgug==}
+  /msw/1.2.1_typescript@4.9.5:
+    resolution: {integrity: sha512-bF7qWJQSmKn6bwGYVPXOxhexTCGD5oJSZg8yt8IBClxvo3Dx/1W0zqE1nX9BSWmzRsCKWfeGWcB/vpqV6aclpw==}
     engines: {node: '>=14'}
     hasBin: true
     requiresBuild: true
@@ -8143,10 +8143,10 @@ packages:
       graphql: 16.6.0
       headers-polyfill: 3.1.2
       inquirer: 8.2.5
-      is-node-process: 1.0.1
+      is-node-process: 1.2.0
       js-levenshtein: 1.1.6
       node-fetch: 2.6.9
-      outvariant: 1.3.0
+      outvariant: 1.4.0
       path-to-regexp: 6.2.1
       strict-event-emitter: 0.4.6
       type-fest: 2.19.0
@@ -8417,8 +8417,8 @@ packages:
   /ospath/1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
 
-  /outvariant/1.3.0:
-    resolution: {integrity: sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==}
+  /outvariant/1.4.0:
+    resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
     dev: true
 
   /p-cancelable/2.1.1:


### PR DESCRIPTION
There exists common codes for components on the history pages, used in managing pagination and filtering, refactors these common code into a composable for reuse.

## Checklist

- [x] The PR modified the frontend, and updated the components on history pages, to create a composable from reusable code
- [x] replace parts of these components with the composable
- [x] contains unit test
- [x] requires dependency update
