### PR TITLE
Modify decoding arguments

### DIFF
--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -161,8 +161,8 @@ class EthereumTransactionDecoder(EVMTransactionDecoder):
                 # Don't try other rules since all of them will fail to resolve the asset
                 return None
 
-            if transfer_enrich.counterparty is not None:
-                return transfer_enrich.counterparty
+            if transfer_enrich.matched_counterparty is not None:
+                return transfer_enrich.matched_counterparty
 
         return None
 

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -149,29 +149,14 @@ class EthereumTransactionDecoder(EVMTransactionDecoder):
 
     # -- methods that need to be implemented by child classes --
 
-    def _enrich_protocol_tranfers(
-            self,
-            token: EvmToken,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,
-            event: 'EvmEvent',
-            action_items: list[ActionItem],
-            all_logs: list[EvmTxReceiptLog],
-    ) -> Optional[str]:
-        context = EnricherContext(
-            tx_log=tx_log,
-            transaction=transaction,
-            action_items=action_items,
-            all_logs=all_logs,
-            token=token,
-            event=event,
-        )
+    def _enrich_protocol_tranfers(self, context: EnricherContext) -> Optional[str]:
         for enrich_call in self.rules.token_enricher_rules:
             try:
                 transfer_enrich: TransferEnrichmentOutput = enrich_call(context)
             except (UnknownAsset, WrongAssetType) as e:
                 log.error(
-                    f'Failed to enrich transfer due to unknown asset {event.asset}. {str(e)}',
+                    f'Failed to enrich transfer due to unknown asset '
+                    f'{context.event.asset}. {str(e)}',
                 )
                 # Don't try other rules since all of them will fail to resolve the asset
                 return None

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -11,6 +11,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
     DecodingOutput,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -157,16 +158,17 @@ class EthereumTransactionDecoder(EVMTransactionDecoder):
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
     ) -> Optional[str]:
+        context = EnricherContext(
+            tx_log=tx_log,
+            transaction=transaction,
+            action_items=action_items,
+            all_logs=all_logs,
+            token=token,
+            event=event,
+        )
         for enrich_call in self.rules.token_enricher_rules:
             try:
-                transfer_enrich: TransferEnrichmentOutput = enrich_call(
-                    token=token,
-                    tx_log=tx_log,
-                    transaction=transaction,
-                    event=event,
-                    action_items=action_items,
-                    all_logs=all_logs,
-                )
+                transfer_enrich: TransferEnrichmentOutput = enrich_call(context)
             except (UnknownAsset, WrongAssetType) as e:
                 log.error(
                     f'Failed to enrich transfer due to unknown asset {event.asset}. {str(e)}',

--- a/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
@@ -5,7 +5,11 @@ from rotkehlchen.chain.ethereum.modules.aave.common import asset_to_atoken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
@@ -14,7 +18,6 @@ from ..constants import CPT_AAVE_V1
 
 DEPOSIT = b'\xc1,W\xb1\xc7:,:.\xa4a>\x94v\xab\xb3\xd8\xd1F\x85z\xabs)\xe2BC\xfbYq\x0c\x82'
 REDEEM_UNDERLYING = b'\x9cN\xd5\x99\xcd\x85U\xb9\xc1\xe8\xcdvC$\r}q\xebv\xb7\x92\x94\x8cI\xfc\xb4\xd4\x11\xf7\xb6\xb3\xc6'  # noqa: E501
-DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_AAVE_V1)
 
 
 class Aavev1Decoder(DecoderInterface):

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
@@ -7,7 +7,11 @@ from rotkehlchen.chain.ethereum.constants import RAY
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.fval import FVal
@@ -29,7 +33,6 @@ DEPOSIT = b'\xdehW!\x95D\xbb[wF\xf4\x8e\xd3\x0b\xe68o\xef\xc6\x1b/\x86L\xac\xf5Y
 WITHDRAW = b'1\x15\xd1D\x9a{s,\x98l\xba\x18$N\x89zE\x0fa\xe1\xbb\x8dX\x9c\xd2\xe6\x9el\x89$\xf9\xf7'  # noqa: E501
 BORROW = b'\xc6\xa8\x980\x9e\x82>\xe5\x0b\xacd\xe4\\\xa8\xad\xbaf\x90\xe9\x9exA\xc4]uN*8\xe9\x01\x9d\x9b'  # noqa: E501
 REPAY = b'L\xdd\xe6\xe0\x9b\xb7U\xc9\xa5X\x9e\xba\xecd\x0b\xbf\xed\xff\x13b\xd4\xb2U\xeb\xf83\x97\x82\xb9\x94/\xaa'  # noqa: E501
-DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_AAVE_V2)
 
 
 class Aavev2Decoder(DecoderInterface):
@@ -213,29 +216,28 @@ class Aavev2Decoder(DecoderInterface):
 
     def _decode_lending_pool_events(self, context: DecoderContext) -> DecodingOutput:
         """Decodes AAVE V2 Lending Pool events"""
-        tx_log = context.tx_log
         decoded_events = context.decoded_events
-        event_signature = tx_log.topics[0]
+        event_signature = context.tx_log.topics[0]
         if event_signature not in (ENABLE_COLLATERAL, DISABLE_COLLATERAL, DEPOSIT, WITHDRAW, BORROW, REPAY):  # noqa: E501
             return DEFAULT_DECODING_OUTPUT
 
         token = EvmToken(evm_address_to_identifier(
-            address=hex_or_bytes_to_address(tx_log.topics[1]),
+            address=hex_or_bytes_to_address(context.tx_log.topics[1]),
             token_type=EvmTokenKind.ERC20,
             chain_id=self.evm_inquirer.chain_id,
         ))
 
-        if tx_log.topics[0] in (ENABLE_COLLATERAL, DISABLE_COLLATERAL):
-            event = self._decode_collateral_events(token, context.transaction, tx_log)
+        if context.tx_log.topics[0] in (ENABLE_COLLATERAL, DISABLE_COLLATERAL):
+            event = self._decode_collateral_events(token, context.transaction, context.tx_log)
             return DecodingOutput(event=event)
-        if tx_log.topics[0] == DEPOSIT:
-            self._decode_deposit(token, tx_log, decoded_events)
-        elif tx_log.topics[0] == WITHDRAW:
-            self._decode_withdrawal(token, tx_log, decoded_events)
-        elif tx_log.topics[0] == BORROW:
-            self._decode_borrow(token, tx_log, decoded_events)
+        if context.tx_log.topics[0] == DEPOSIT:
+            self._decode_deposit(token, context.tx_log, decoded_events)
+        elif context.tx_log.topics[0] == WITHDRAW:
+            self._decode_withdrawal(token, context.tx_log, decoded_events)
+        elif context.tx_log.topics[0] == BORROW:
+            self._decode_borrow(token, context.tx_log, decoded_events)
         else:  # Repay
-            self._decode_repay(token, tx_log, decoded_events)
+            self._decode_repay(token, context.tx_log, decoded_events)
 
         return DEFAULT_DECODING_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
@@ -216,9 +216,7 @@ class Aavev2Decoder(DecoderInterface):
 
     def _decode_lending_pool_events(self, context: DecoderContext) -> DecodingOutput:
         """Decodes AAVE V2 Lending Pool events"""
-        decoded_events = context.decoded_events
-        event_signature = context.tx_log.topics[0]
-        if event_signature not in (ENABLE_COLLATERAL, DISABLE_COLLATERAL, DEPOSIT, WITHDRAW, BORROW, REPAY):  # noqa: E501
+        if context.tx_log.topics[0] not in (ENABLE_COLLATERAL, DISABLE_COLLATERAL, DEPOSIT, WITHDRAW, BORROW, REPAY):  # noqa: E501
             return DEFAULT_DECODING_OUTPUT
 
         token = EvmToken(evm_address_to_identifier(
@@ -231,13 +229,13 @@ class Aavev2Decoder(DecoderInterface):
             event = self._decode_collateral_events(token, context.transaction, context.tx_log)
             return DecodingOutput(event=event)
         if context.tx_log.topics[0] == DEPOSIT:
-            self._decode_deposit(token, context.tx_log, decoded_events)
+            self._decode_deposit(token, context.tx_log, context.decoded_events)
         elif context.tx_log.topics[0] == WITHDRAW:
-            self._decode_withdrawal(token, context.tx_log, decoded_events)
+            self._decode_withdrawal(token, context.tx_log, context.decoded_events)
         elif context.tx_log.topics[0] == BORROW:
-            self._decode_borrow(token, context.tx_log, decoded_events)
+            self._decode_borrow(token, context.tx_log, context.decoded_events)
         else:  # Repay
-            self._decode_repay(token, context.tx_log, decoded_events)
+            self._decode_repay(token, context.tx_log, context.decoded_events)
 
         return DEFAULT_DECODING_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.constants import RAY
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.fval import FVal
@@ -211,15 +211,10 @@ class Aavev2Decoder(DecoderInterface):
                 # Set protocol for both events
                 event.counterparty = CPT_AAVE_V2
 
-    def _decode_lending_pool_events(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_lending_pool_events(self, context: DecoderContext) -> DecodingOutput:
         """Decodes AAVE V2 Lending Pool events"""
+        tx_log = context.tx_log
+        decoded_events = context.decoded_events
         event_signature = tx_log.topics[0]
         if event_signature not in (ENABLE_COLLATERAL, DISABLE_COLLATERAL, DEPOSIT, WITHDRAW, BORROW, REPAY):  # noqa: E501
             return DEFAULT_DECODING_OUTPUT
@@ -231,7 +226,7 @@ class Aavev2Decoder(DecoderInterface):
         ))
 
         if tx_log.topics[0] in (ENABLE_COLLATERAL, DISABLE_COLLATERAL):
-            event = self._decode_collateral_events(token, transaction, tx_log)
+            event = self._decode_collateral_events(token, context.transaction, tx_log)
             return DecodingOutput(event=event)
         if tx_log.topics[0] == DEPOSIT:
             self._decode_deposit(token, tx_log, decoded_events)

--- a/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
@@ -7,7 +7,12 @@ from rotkehlchen.accounting.structures.types import HistoryEventSubType, History
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    ActionItem,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_1INCH, A_BADGER, A_CVX, A_ELFI, A_FOX, A_FPIS, A_UNI
@@ -79,7 +84,7 @@ class AirdropsDecoder(DecoderInterface):
 
     def _decode_uniswap_claim(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != UNISWAP_TOKEN_CLAIMED:
-            return DecodingOutput(counterparty=CPT_UNISWAP)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(context.tx_log.data[32:64])
         raw_amount = hex_or_bytes_to_int(context.tx_log.data[64:96])
@@ -93,7 +98,7 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claim {amount} UNI from uniswap airdrop'
                 break
 
-        return DecodingOutput(counterparty=CPT_UNISWAP)
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_fox_claim(
             self,
@@ -104,7 +109,7 @@ class AirdropsDecoder(DecoderInterface):
             action_items: list[ActionItem],  # pylint: disable=unused-argument
     ) -> DecodingOutput:
         if tx_log.topics[0] != FOX_CLAIMED:
-            return DecodingOutput(counterparty=CPT_SHAPESHIFT)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(tx_log.topics[1])
         raw_amount = hex_or_bytes_to_int(tx_log.data[64:96])
@@ -118,11 +123,11 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claim {amount} FOX from shapeshift airdrop'
                 break
 
-        return DecodingOutput(counterparty=CPT_SHAPESHIFT)
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_badger_claim(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != BADGER_HUNT_EVENT:
-            return DecodingOutput(counterparty=CPT_BADGER)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(context.tx_log.topics[1])
         raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
@@ -139,11 +144,11 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claim {amount} BADGER from badger airdrop'
                 break
 
-        return DecodingOutput(counterparty=CPT_BADGER)
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_oneinch_claim(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != ONEINCH_CLAIMED:
-            return DecodingOutput(counterparty=CPT_ONEINCH)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(context.tx_log.data[32:64])
         raw_amount = hex_or_bytes_to_int(context.tx_log.data[64:96])
@@ -157,7 +162,7 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claim {amount} 1INCH from 1inch airdrop'
                 break
 
-        return DecodingOutput(counterparty=CPT_ONEINCH)
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_fpis_claim(
             self,
@@ -165,7 +170,7 @@ class AirdropsDecoder(DecoderInterface):
             airdrop: Literal['convex', 'fpis'],
     ) -> DecodingOutput:
         if context.tx_log.topics[0] != FPIS_CONVEX_CLAIM:
-            return DecodingOutput(counterparty=CPT_FRAX)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(context.tx_log.data[0:32])
         raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
@@ -197,14 +202,14 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claim {amount} {crypto_asset.symbol} {note_location}'
                 break
 
-        return DecodingOutput(counterparty=counterparty)
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_elfi_claim(self, context: DecoderContext) -> DecodingOutput:
         """Example:
         https://etherscan.io/tx/0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b
         """
         if context.tx_log.topics[0] != ELFI_VOTE_CHANGE:
-            return DecodingOutput(counterparty=CPT_ELEMENT_FINANCE)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(context.tx_log.topics[1])
         delegate_address = hex_or_bytes_to_address(context.tx_log.topics[2])
@@ -240,7 +245,7 @@ class AirdropsDecoder(DecoderInterface):
                 )
                 return DecodingOutput(event=event)
 
-        return DecodingOutput(counterparty=CPT_ELEMENT_FINANCE)
+        return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
@@ -89,50 +89,49 @@ class Balancerv1Decoder(DecoderInterface):
         In balancer v1 pools are managed using a DSProxy so the account doesn't interact
         directly with the pools.
         """
-        event, token = context.event, context.token
         events_information = self._decode_v1_pool_event(all_logs=context.all_logs)
         if events_information is None:
             return DEFAULT_ENRICHMENT_OUTPUT
 
         for proxied_event in events_information:
-            if proxied_event['ds_address'] != event.address:
+            if proxied_event['ds_address'] != context.event.address:
                 continue
 
             if proxied_event['type'] == BalancerV1EventTypes.JOIN:
                 if (
-                    event.event_type == HistoryEventType.RECEIVE and
-                    event.event_subtype == HistoryEventSubType.NONE
+                    context.event.event_type == HistoryEventType.RECEIVE and
+                    context.event.event_subtype == HistoryEventSubType.NONE
                 ):
-                    event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
-                    event.counterparty = CPT_BALANCER_V1
-                    event.notes = f'Receive {event.balance.amount} {token.symbol} from a Balancer v1 pool'  # noqa: E501
+                    context.event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
+                    context.event.counterparty = CPT_BALANCER_V1
+                    context.event.notes = f'Receive {context.event.balance.amount} {context.token.symbol} from a Balancer v1 pool'  # noqa: E501
                     return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
                 if (
-                    event.event_type == HistoryEventType.SPEND and
-                    event.event_subtype == HistoryEventSubType.NONE
+                    context.event.event_type == HistoryEventType.SPEND and
+                    context.event.event_subtype == HistoryEventSubType.NONE
                 ):
-                    event.event_type = HistoryEventType.DEPOSIT
-                    event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
-                    event.counterparty = CPT_BALANCER_V1
-                    event.notes = f'Deposit {event.balance.amount} {token.symbol} to a Balancer v1 pool'  # noqa: E501
+                    context.event.event_type = HistoryEventType.DEPOSIT
+                    context.event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                    context.event.counterparty = CPT_BALANCER_V1
+                    context.event.notes = f'Deposit {context.event.balance.amount} {context.token.symbol} to a Balancer v1 pool'  # noqa: E501
                     return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
             elif proxied_event['type'] == BalancerV1EventTypes.EXIT:
                 if (
-                    event.event_type == HistoryEventType.RECEIVE and
-                    event.event_subtype == HistoryEventSubType.NONE
+                    context.event.event_type == HistoryEventType.RECEIVE and
+                    context.event.event_subtype == HistoryEventSubType.NONE
                 ):
-                    event.event_type = HistoryEventType.WITHDRAWAL
-                    event.event_subtype = HistoryEventSubType.REMOVE_ASSET
-                    event.counterparty = CPT_BALANCER_V1
-                    event.notes = f'Receive {event.balance.amount} {token.symbol} after removing liquidity from a Balancer v1 pool'  # noqa: E501
+                    context.event.event_type = HistoryEventType.WITHDRAWAL
+                    context.event.event_subtype = HistoryEventSubType.REMOVE_ASSET
+                    context.event.counterparty = CPT_BALANCER_V1
+                    context.event.notes = f'Receive {context.event.balance.amount} {context.token.symbol} after removing liquidity from a Balancer v1 pool'  # noqa: E501
                     return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
                 if (
-                    event.event_type == HistoryEventType.SPEND and
-                    event.event_subtype == HistoryEventSubType.NONE
+                    context.event.event_type == HistoryEventType.SPEND and
+                    context.event.event_subtype == HistoryEventSubType.NONE
                 ):
-                    event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
-                    event.counterparty = CPT_BALANCER_V1
-                    event.notes = f'Return {event.balance.amount} {token.symbol} to a Balancer v1 pool'  # noqa: E501
+                    context.event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
+                    context.event.counterparty = CPT_BALANCER_V1
+                    context.event.notes = f'Return {context.event.balance.amount} {context.token.symbol} to a Balancer v1 pool'  # noqa: E501
                     return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
 
         return DEFAULT_ENRICHMENT_OUTPUT

--- a/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
@@ -2,13 +2,12 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.modules.balancer.constants import CPT_BALANCER_V1
 from rotkehlchen.chain.ethereum.modules.balancer.types import BalancerV1EventTypes
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_ENRICHMENT_OUTPUT,
-    ActionItem,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
@@ -80,12 +79,7 @@ class Balancerv1Decoder(DecoderInterface):
 
     def _maybe_enrich_balancer_v1_events(
             self,
-            token: 'EvmToken',
-            tx_log: EvmTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],
+            context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """
         Enrich balancer v1 transfer to read pool events of:
@@ -95,7 +89,8 @@ class Balancerv1Decoder(DecoderInterface):
         In balancer v1 pools are managed using a DSProxy so the account doesn't interact
         directly with the pools.
         """
-        events_information = self._decode_v1_pool_event(all_logs=all_logs)
+        event, token = context.event, context.token
+        events_information = self._decode_v1_pool_event(all_logs=context.all_logs)
         if events_information is None:
             return DEFAULT_ENRICHMENT_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
@@ -106,7 +106,7 @@ class Balancerv1Decoder(DecoderInterface):
                     event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
                     event.counterparty = CPT_BALANCER_V1
                     event.notes = f'Receive {event.balance.amount} {token.symbol} from a Balancer v1 pool'  # noqa: E501
-                    return TransferEnrichmentOutput(counterparty=CPT_BALANCER_V1)
+                    return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
                 if (
                     event.event_type == HistoryEventType.SPEND and
                     event.event_subtype == HistoryEventSubType.NONE
@@ -115,7 +115,7 @@ class Balancerv1Decoder(DecoderInterface):
                     event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
                     event.counterparty = CPT_BALANCER_V1
                     event.notes = f'Deposit {event.balance.amount} {token.symbol} to a Balancer v1 pool'  # noqa: E501
-                    return TransferEnrichmentOutput(counterparty=CPT_BALANCER_V1)
+                    return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
             elif proxied_event['type'] == BalancerV1EventTypes.EXIT:
                 if (
                     event.event_type == HistoryEventType.RECEIVE and
@@ -125,7 +125,7 @@ class Balancerv1Decoder(DecoderInterface):
                     event.event_subtype = HistoryEventSubType.REMOVE_ASSET
                     event.counterparty = CPT_BALANCER_V1
                     event.notes = f'Receive {event.balance.amount} {token.symbol} after removing liquidity from a Balancer v1 pool'  # noqa: E501
-                    return TransferEnrichmentOutput(counterparty=CPT_BALANCER_V1)
+                    return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
                 if (
                     event.event_type == HistoryEventType.SPEND and
                     event.event_subtype == HistoryEventSubType.NONE
@@ -133,7 +133,7 @@ class Balancerv1Decoder(DecoderInterface):
                     event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
                     event.counterparty = CPT_BALANCER_V1
                     event.notes = f'Return {event.balance.amount} {token.symbol} to a Balancer v1 pool'  # noqa: E501
-                    return TransferEnrichmentOutput(counterparty=CPT_BALANCER_V1)
+                    return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V1)
 
         return DEFAULT_ENRICHMENT_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
@@ -146,7 +146,7 @@ class Balancerv2Decoder(DecoderInterface):
         else:
             event.event_subtype = HistoryEventSubType.SPEND
 
-        return TransferEnrichmentOutput(counterparty=CPT_BALANCER_V2)
+        return DEFAULT_ENRICHMENT_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
@@ -123,28 +123,27 @@ class Balancerv2Decoder(DecoderInterface):
         - UnknownAsset
         - WrongAssetType
         """
-        event, action_items = context.event, context.action_items
-        if action_items is None or len(action_items) == 0 or context.transaction.to_address != VAULT_ADDRESS:  # noqa: E501
+        if context.action_items is None or len(context.action_items) == 0 or context.transaction.to_address != VAULT_ADDRESS:  # noqa: E501
             return DEFAULT_ENRICHMENT_OUTPUT
 
-        if action_items[-1].extra_data is None:
+        if context.action_items[-1].extra_data is None:
             return DEFAULT_ENRICHMENT_OUTPUT
 
-        asset = event.asset.resolve_to_evm_token()
+        asset = context.event.asset.resolve_to_evm_token()
         if (
-            isinstance(action_items[-1].asset, EvmToken) is False or
-            action_items[-1].asset.evm_address != context.tx_log.address or  # type: ignore[attr-defined]  # noqa: E501 mypy fails to understand that due the previous statmenet in the or this check won't be evaluated if the asset isn't a token
-            action_items[-1].amount != event.balance.amount
+            isinstance(context.action_items[-1].asset, EvmToken) is False or
+            context.action_items[-1].asset.evm_address != context.tx_log.address or  # type: ignore[attr-defined]  # noqa: E501 mypy fails to understand that due the previous statmenet in the or this check won't be evaluated if the asset isn't a token
+            context.action_items[-1].amount != context.event.balance.amount
         ):
             return DEFAULT_ENRICHMENT_OUTPUT
 
-        event.counterparty = CPT_BALANCER_V2
-        event.event_type = HistoryEventType.TRADE
-        if asset == event.asset:
-            event.event_subtype = HistoryEventSubType.RECEIVE
-            event.notes = f'Receive {event.balance.amount} {asset.symbol} from Balancer v2'
+        context.event.counterparty = CPT_BALANCER_V2
+        context.event.event_type = HistoryEventType.TRADE
+        if asset == context.event.asset:
+            context.event.event_subtype = HistoryEventSubType.RECEIVE
+            context.event.notes = f'Receive {context.event.balance.amount} {asset.symbol} from Balancer v2'  # noqa: E501
         else:
-            event.event_subtype = HistoryEventSubType.SPEND
+            context.event.event_subtype = HistoryEventSubType.SPEND
 
         return DEFAULT_ENRICHMENT_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/compound/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/decoder.py
@@ -212,17 +212,15 @@ class CompoundDecoder(DecoderInterface):
             context: DecoderContext,
             compound_token: EvmToken,
     ) -> DecodingOutput:
-        transaction = context.transaction
-        decoded_events = context.decoded_events
         if context.tx_log.topics[0] == MINT_COMPOUND_TOKEN:
             log.debug(f'Hash: {context.transaction.tx_hash.hex()}')
-            return self._decode_mint(transaction=transaction, tx_log=context.tx_log, decoded_events=decoded_events, compound_token=compound_token)  # noqa: E501
+            return self._decode_mint(transaction=context.transaction, tx_log=context.tx_log, decoded_events=context.decoded_events, compound_token=compound_token)  # noqa: E501
 
         if context.tx_log.topics[0] in (BORROW_COMPOUND, REPAY_COMPOUND):
-            return self._decode_borrow_and_repay(tx_log=context.tx_log, decoded_events=decoded_events, compound_token=compound_token)  # noqa: E501
+            return self._decode_borrow_and_repay(tx_log=context.tx_log, decoded_events=context.decoded_events, compound_token=compound_token)  # noqa: E501
 
         if context.tx_log.topics[0] == REDEEM_COMPOUND_TOKEN:
-            return self._decode_redeem(tx_log=context.tx_log, decoded_events=decoded_events, compound_token=compound_token)  # noqa: E501
+            return self._decode_redeem(tx_log=context.tx_log, decoded_events=context.decoded_events, compound_token=compound_token)  # noqa: E501
 
         return DEFAULT_DECODING_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/cowswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/cowswap/decoder.py
@@ -9,7 +9,7 @@ from rotkehlchen.chain.ethereum.modules.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog, SwapData
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -52,15 +52,10 @@ class CowswapDecoder(DecoderInterface):
         )
         self.eth = A_ETH.resolve_to_crypto_asset()
 
-    def _decode_eth_orders(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_eth_orders(self, context: DecoderContext) -> DecodingOutput:
         counterparty = None
+        tx_log = context.tx_log
+        decoded_events = context.decoded_events
         if tx_log.topics[0] == PLACE_ETH_ORDER_SIGNATURE:
             target_token_address = hex_or_bytes_to_address(tx_log.data[32:64])
             target_token = EvmToken(evm_address_to_identifier(

--- a/rotkehlchen/chain/ethereum/modules/cowswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/cowswap/decoder.py
@@ -250,4 +250,7 @@ class CowswapDecoder(DecoderInterface):
         return {ETH_FLOW_ADDRESS: (self._decode_eth_orders,)}
 
     def post_decoding_rules(self) -> dict[str, list[tuple[int, Callable]]]:
-        return {GPV2_SETTLEMENT_ADDRESS: [(0, self._aggregator_post_decoding)]}
+        return {CPT_COWSWAP: [(0, self._aggregator_post_decoding)]}
+
+    def addresses_to_counterparties(self) -> dict[ChecksumEvmAddress, str]:
+        return {GPV2_SETTLEMENT_ADDRESS: CPT_COWSWAP}

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -8,6 +8,7 @@ from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface, Reloadab
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_ENRICHMENT_OUTPUT,
     ActionItem,
+    DecoderContext,
     DecodingOutput,
     TransferEnrichmentOutput,
 )
@@ -227,14 +228,8 @@ class CurveDecoder(DecoderInterface, ReloadableDecoderMixin):
             previous_event = event
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_curve_events(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_curve_events(self, context: DecoderContext) -> DecodingOutput:
+        tx_log = context.tx_log
         if tx_log.topics[0] in (
             REMOVE_LIQUIDITY,
             REMOVE_ONE,
@@ -245,8 +240,8 @@ class CurveDecoder(DecoderInterface, ReloadableDecoderMixin):
             user_address = hex_or_bytes_to_address(tx_log.topics[1])
             return self._decode_curve_remove_events(
                 tx_log=tx_log,
-                transaction=transaction,
-                decoded_events=decoded_events,
+                transaction=context.transaction,
+                decoded_events=context.decoded_events,
                 user_address=user_address,
             )
         if tx_log.topics[0] in (
@@ -256,9 +251,9 @@ class CurveDecoder(DecoderInterface, ReloadableDecoderMixin):
         ):
             user_address = hex_or_bytes_to_address(tx_log.topics[1])
             return self._decode_curve_deposit_events(
-                transaction=transaction,
+                transaction=context.transaction,
                 tx_log=tx_log,
-                decoded_events=decoded_events,
+                decoded_events=context.decoded_events,
                 user_address=user_address,
             )
 

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -7,7 +7,11 @@ from rotkehlchen.accounting.structures.types import HistoryEventSubType, History
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.types import ChecksumEvmAddress
 
 from .constants import CPT_DXDAO_MESA
@@ -21,7 +25,6 @@ DEPOSIT = b'\xc1\x1c\xc3N\x93\xc6z\x938+\x99\xf2I\x8e\x997\x19\x87\x98\xf3\xc1\x
 ORDER_PLACEMENT = b'\xde\xcfo\xde\x82C\x98\x12\x99\xf7\xb7\xa7v\xf2\x9a\x9f\xc6z,\x98H\xe2]w\xc5\x0e\xb1\x1f\xa5\x8a~!'  # noqa: E501
 WITHDRAW_REQUEST = b',bE\xafPo\x0f\xc1\x08\x99\x18\xc0,\x1d\x01\xbd\xe9\xcc\x80v\t\xb34\xb3\xe7dMm\xfbZl^'  # noqa: E501
 WITHDRAW = b'\x9b\x1b\xfa\x7f\xa9\xeeB\n\x16\xe1$\xf7\x94\xc3Z\xc9\xf9\x04r\xac\xc9\x91@\xeb/dG\xc7\x14\xca\xd8\xeb'  # noqa: E501
-DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_DXDAO_MESA)
 
 
 class DxdaomesaDecoder(DecoderInterface):
@@ -48,14 +51,13 @@ class DxdaomesaDecoder(DecoderInterface):
         )
 
     def _decode_events(self, context: DecoderContext) -> DecodingOutput:
-        tx_log = context.tx_log
-        if tx_log.topics[0] == DEPOSIT:
+        if context.tx_log.topics[0] == DEPOSIT:
             return self._decode_deposit(context=context)
-        if tx_log.topics[0] == ORDER_PLACEMENT:
+        if context.tx_log.topics[0] == ORDER_PLACEMENT:
             return self._decode_order_placement(context=context)
-        if tx_log.topics[0] == WITHDRAW_REQUEST:
+        if context.tx_log.topics[0] == WITHDRAW_REQUEST:
             return self._decode_withdraw_request(context=context)
-        if tx_log.topics[0] == WITHDRAW:
+        if context.tx_log.topics[0] == WITHDRAW:
             return self._decode_withdraw(context=context)
 
         return DEFAULT_DECODING_OUTPUT

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -7,14 +7,12 @@ from rotkehlchen.accounting.structures.types import HistoryEventSubType, History
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
-from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
-from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.types import ChecksumEvmAddress
 
 from .constants import CPT_DXDAO_MESA
 
 if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
@@ -49,35 +47,22 @@ class DxdaomesaDecoder(DecoderInterface):
             deployed_block=contracts['DXDAOMESA']['deployed_block'],
         )
 
-    def _decode_events(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],
-            action_items: list[ActionItem],
-    ) -> DecodingOutput:
+    def _decode_events(self, context: DecoderContext) -> DecodingOutput:
+        tx_log = context.tx_log
         if tx_log.topics[0] == DEPOSIT:
-            return self._decode_deposit(tx_log, transaction, decoded_events, all_logs, action_items)  # noqa: E501
+            return self._decode_deposit(context=context)
         if tx_log.topics[0] == ORDER_PLACEMENT:
-            return self._decode_order_placement(tx_log, transaction, decoded_events, all_logs, action_items)  # noqa: E501
+            return self._decode_order_placement(context=context)
         if tx_log.topics[0] == WITHDRAW_REQUEST:
-            return self._decode_withdraw_request(tx_log, transaction, decoded_events, all_logs, action_items)  # noqa: E501
+            return self._decode_withdraw_request(context=context)
         if tx_log.topics[0] == WITHDRAW:
-            return self._decode_withdraw(tx_log, transaction, decoded_events, all_logs, action_items)  # noqa: E501
+            return self._decode_withdraw(context=context)
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_deposit(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_deposit(self, context: DecoderContext) -> DecodingOutput:
         topic_data, log_data = self.contract.decode_event(
-            tx_log=tx_log,
+            tx_log=context.tx_log,
             event_name='Deposit',
             argument_names=('user', 'token', 'amount', 'batchId'),
         )
@@ -86,7 +71,7 @@ class DxdaomesaDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
         amount = asset_normalized_value(amount=log_data[0], asset=deposited_asset)
 
-        for event in decoded_events:
+        for event in context.decoded_events:
             # Find the transfer event which should come before the deposit
             if event.event_type == HistoryEventType.SPEND and event.asset == deposited_asset and event.balance.amount == amount and event.address == self.contract.address:  # noqa: E501
                 event.event_type = HistoryEventType.DEPOSIT
@@ -97,16 +82,9 @@ class DxdaomesaDecoder(DecoderInterface):
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_withdraw(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_withdraw(self, context: DecoderContext) -> DecodingOutput:
         topic_data, log_data = self.contract.decode_event(
-            tx_log=tx_log,
+            tx_log=context.tx_log,
             event_name='Withdraw',
             argument_names=('user', 'token', 'amount'),
         )
@@ -115,7 +93,7 @@ class DxdaomesaDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
         amount = asset_normalized_value(amount=log_data[0], asset=withdraw_asset)
 
-        for event in decoded_events:
+        for event in context.decoded_events:
             # Find the transfer event which should come before the withdraw
             if event.event_type == HistoryEventType.RECEIVE and event.asset == withdraw_asset and event.balance.amount == amount and event.address == self.contract.address:  # noqa: E501
                 event.event_type = HistoryEventType.WITHDRAWAL
@@ -126,16 +104,9 @@ class DxdaomesaDecoder(DecoderInterface):
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_withdraw_request(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_withdraw_request(self, context: DecoderContext) -> DecodingOutput:
         topic_data, log_data = self.contract.decode_event(
-            tx_log=tx_log,
+            tx_log=context.tx_log,
             event_name='WithdrawRequest',
             argument_names=('user', 'token', 'amount', 'batchId'),
         )
@@ -149,8 +120,8 @@ class DxdaomesaDecoder(DecoderInterface):
         amount = asset_normalized_value(amount=log_data[0], asset=token)
 
         event = self.base.make_event_from_transaction(
-            transaction=transaction,
-            tx_log=tx_log,
+            transaction=context.transaction,
+            tx_log=context.tx_log,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             location_label=user,
@@ -158,21 +129,14 @@ class DxdaomesaDecoder(DecoderInterface):
             balance=Balance(amount=amount),
             notes=f'Request a withdrawal of {amount} {token.symbol} from DXDao Mesa',
             counterparty=CPT_DXDAO_MESA,
-            address=transaction.to_address,
+            address=context.transaction.to_address,
         )
         return DecodingOutput(event=event)
 
-    def _decode_order_placement(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_order_placement(self, context: DecoderContext) -> DecodingOutput:
         """Some docs: https://docs.gnosis.io/protocol/docs/tutorial-limit-orders/"""
         topic_data, log_data = self.contract.decode_event(
-            tx_log=tx_log,
+            tx_log=context.tx_log,
             event_name='OrderPlacement',
             argument_names=('owner', 'index', 'buyToken', 'sellToken', 'validFrom', 'validUntil', 'priceNumerator', 'priceDenominator'),  # noqa: E501
         )
@@ -195,8 +159,8 @@ class DxdaomesaDecoder(DecoderInterface):
         buy_amount = asset_normalized_value(amount=log_data[3], asset=buy_token)
         sell_amount = asset_normalized_value(amount=log_data[4], asset=sell_token)
         event = self.base.make_event_from_transaction(
-            transaction=transaction,
-            tx_log=tx_log,
+            transaction=context.transaction,
+            tx_log=context.tx_log,
             location_label=owner,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.PLACE_ORDER,
@@ -204,7 +168,7 @@ class DxdaomesaDecoder(DecoderInterface):
             balance=Balance(amount=sell_amount),
             notes=f'Place an order in DXDao Mesa to sell {sell_amount} {sell_token.symbol} for {buy_amount} {buy_token.symbol}',  # noqa: E501
             counterparty=CPT_DXDAO_MESA,
-            address=transaction.to_address,
+            address=context.transaction.to_address,
         )
         return DecodingOutput(event=event)
 

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -1,6 +1,6 @@
 import logging
 from multiprocessing.managers import RemoteError
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from eth_utils import to_checksum_address
 
@@ -8,21 +8,19 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.names import find_ens_mappings
-from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
+from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import from_wei
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 from .constants import CPT_ENS
 
 if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
@@ -58,44 +56,18 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
         CustomizableDateMixin.__init__(self, base_tools.database)
         self.eth = A_ETH.resolve_to_crypto_asset()
 
-    def _decode_ens_registrar_event(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],
-            action_items: Optional[list[ActionItem]],
-    ) -> DecodingOutput:
-        if tx_log.topics[0] == NAME_REGISTERED:
-            return self._decode_name_registered(
-                tx_log=tx_log,
-                transaction=transaction,
-                decoded_events=decoded_events,
-                all_logs=all_logs,
-                action_items=action_items,
-            )
+    def _decode_ens_registrar_event(self, context: DecoderContext) -> DecodingOutput:
+        if context.tx_log.topics[0] == NAME_REGISTERED:
+            return self._decode_name_registered(context=context)
 
-        if tx_log.topics[0] == NAME_RENEWED:
-            return self._decode_name_renewed(
-                tx_log=tx_log,
-                transaction=transaction,
-                decoded_events=decoded_events,
-                all_logs=all_logs,
-                action_items=action_items,
-            )
+        if context.tx_log.topics[0] == NAME_RENEWED:
+            return self._decode_name_renewed(context=context)
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_name_registered(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_name_registered(self, context: DecoderContext) -> DecodingOutput:
         try:
-            _, decoded_data = decode_event_data_abi_str(tx_log, NAME_REGISTERED_ABI)
+            _, decoded_data = decode_event_data_abi_str(context.tx_log, NAME_REGISTERED_ABI)
         except DeserializationError as e:
             log.debug(f'Failed to decode ENS name registered event due to {str(e)}')
             return DEFAULT_DECODING_OUTPUT
@@ -106,14 +78,14 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
 
         refund_from_registrar = None
         to_remove_indices = []
-        for event_idx, event in enumerate(decoded_events):
+        for event_idx, event in enumerate(context.decoded_events):
             if event.event_type == HistoryEventType.RECEIVE and event.asset == A_ETH and event.address == ENS_REGISTRAR_CONTROLLER:  # noqa: E501
                 # remove ETH refund event
                 refund_from_registrar = event.balance.amount
                 to_remove_indices.append(event_idx)
 
             # Find the ETH transfer event which should be before the registered event
-            if event.event_type == HistoryEventType.SPEND and event.asset == A_ETH and event.address == tx_log.address:  # noqa: E501
+            if event.event_type == HistoryEventType.SPEND and event.asset == A_ETH and event.address == context.tx_log.address:  # noqa: E501
                 expected_amount = amount
                 if refund_from_registrar:
                     expected_amount = amount + refund_from_registrar
@@ -134,20 +106,13 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
                 event.notes = f'Receive ENS name ERC721 token for {name}.eth with id {event.extra_data["token_id"]}'  # noqa: E501
 
         for index in to_remove_indices:
-            del decoded_events[index]
+            del context.decoded_events[index]
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_name_renewed(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_name_renewed(self, context: DecoderContext) -> DecodingOutput:
         try:
-            _, decoded_data = decode_event_data_abi_str(tx_log, NAME_RENEWED_ABI)
+            _, decoded_data = decode_event_data_abi_str(context.tx_log, NAME_RENEWED_ABI)
         except DeserializationError as e:
             log.debug(f'Failed to decode ENS name renewed event due to {str(e)}')
             return DEFAULT_DECODING_OUTPUT
@@ -156,9 +121,9 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
         amount = from_wei(decoded_data[1])
         expires = decoded_data[2]
 
-        for event in decoded_events:
+        for event in context.decoded_events:
             # Find the transfer event which should be before the name renewed event
-            if event.event_type == HistoryEventType.SPEND and event.asset == A_ETH and event.balance.amount == amount and event.address == tx_log.address:  # noqa: E501
+            if event.event_type == HistoryEventType.SPEND and event.asset == A_ETH and event.balance.amount == amount and event.address == context.tx_log.address:  # noqa: E501
                 event.event_type = HistoryEventType.RENEW
                 event.event_subtype = HistoryEventSubType.NFT
                 event.counterparty = CPT_ENS
@@ -166,17 +131,10 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_ens_registry_with_fallback_event(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_ens_registry_with_fallback_event(self, context: DecoderContext) -> DecodingOutput:
         """Decode event where address is set for an ENS name."""
-        if tx_log.topics[0] == NEW_RESOLVER:
-            node = tx_log.topics[1]
+        if context.tx_log.topics[0] == NEW_RESOLVER:
+            node = context.tx_log.topics[1]
             try:
                 ens_name = self.ethereum.contracts.contract('ENS_REVERSE_RESOLVER').call(
                     node_inquirer=self.ethereum,
@@ -194,32 +152,25 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
             # Not able to give more info to the user such as address that was set since
             # we don't have historical info and event doesn't provide it
             notes = f'Set ENS address for {ens_name}'
-            decoded_events.append(self.base.make_event_from_transaction(
-                transaction=transaction,
-                tx_log=tx_log,
+            context.decoded_events.append(self.base.make_event_from_transaction(
+                transaction=context.transaction,
+                tx_log=context.tx_log,
                 event_type=HistoryEventType.INFORMATIONAL,
                 event_subtype=HistoryEventSubType.NONE,
                 asset=A_ETH,
                 balance=Balance(),
-                location_label=transaction.from_address,
+                location_label=context.transaction.from_address,
                 notes=notes,
                 counterparty=CPT_ENS,
-                address=transaction.to_address,
+                address=context.transaction.to_address,
             ))
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_ens_public_resolver_2_events(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_ens_public_resolver_2_events(self, context: DecoderContext) -> DecodingOutput:
         """Decode event where a text property (discord, telegram, etc.) is set for an ENS name."""
-        if tx_log.topics[0] == TEXT_CHANGED:
+        if context.tx_log.topics[0] == TEXT_CHANGED:
             try:
-                _, decoded_data = decode_event_data_abi_str(tx_log, TEXT_CHANGED_ABI)
+                _, decoded_data = decode_event_data_abi_str(context.tx_log, TEXT_CHANGED_ABI)
                 changed_key = decoded_data[0]
             except (DeserializationError, KeyError) as e:
                 msg = str(e)
@@ -229,7 +180,7 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
                 log.debug(f'Failed to decode ENS set-text event due to {msg}')
                 return DEFAULT_DECODING_OUTPUT
 
-            node = tx_log.topics[1]
+            node = context.tx_log.topics[1]
             try:
                 address = self.ethereum.contracts.contract('ENS_PUBLIC_RESOLVER_2').call(
                     node_inquirer=self.ethereum,
@@ -249,17 +200,17 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
             name_to_show = ens_mapping.get(address, address)
 
             notes = f'Set ENS {changed_key} attribute for {name_to_show}'
-            decoded_events.append(self.base.make_event_from_transaction(
-                transaction=transaction,
-                tx_log=tx_log,
+            context.decoded_events.append(self.base.make_event_from_transaction(
+                transaction=context.transaction,
+                tx_log=context.tx_log,
                 event_type=HistoryEventType.INFORMATIONAL,
                 event_subtype=HistoryEventSubType.NONE,
                 asset=A_ETH,
                 balance=Balance(),
-                location_label=transaction.from_address,
+                location_label=context.transaction.from_address,
                 notes=notes,
                 counterparty=CPT_ENS,
-                address=transaction.to_address,
+                address=context.transaction.to_address,
             ))
         return DEFAULT_DECODING_OUTPUT
 

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -8,7 +8,11 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.names import find_ens_mappings
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
@@ -41,7 +45,6 @@ NAME_RENEWED_ABI = '{"anonymous":false,"inputs":[{"indexed":false,"internalType"
 NEW_RESOLVER = b'3W!\xb0\x18f\xdc#\xfb\xee\x8bk,{\x1e\x14\xd6\xf0\\(\xcd5\xa2\xc94#\x9f\x94\tV\x02\xa0'  # noqa: E501
 TEXT_CHANGED = b'\xd8\xc93K\x1a\x9c/\x9d\xa3B\xa0\xa2\xb3&)\xc1\xa2)\xb6D]\xadx\x94\x7fgKDDJuP'
 TEXT_CHANGED_ABI = '{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"node","type":"bytes32"},{"indexed":true,"internalType":"string","name":"indexedKey","type":"string"},{"indexed":false,"internalType":"string","name":"key","type":"string"}],"name":"TextChanged","type":"event"}'  # noqa: E501
-DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_ENS)
 
 
 class EnsDecoder(DecoderInterface, CustomizableDateMixin):

--- a/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
@@ -6,7 +6,7 @@ from eth_utils import encode_hex
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.constants import ETH2_DEPOSIT_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -33,9 +33,9 @@ class Eth2Decoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] != DEPOSIT_EVENT:
-            return None, []
+            return DecodingOutput(counterparty=CPT_ETH2)
 
         pubkey = encode_hex(tx_log.data[192:240])
         withdrawal_credentials = encode_hex(tx_log.data[288:320])
@@ -54,7 +54,7 @@ class Eth2Decoder(DecoderInterface):
                 event.notes = f'Deposit {amount} ETH to validator with pubkey {pubkey}. Deposit index: {deposit_index}. Withdrawal credentials: {withdrawal_credentials}'  # noqa: E501
                 event.extra_data = {'withdrawal_credentials': withdrawal_credentials}
 
-        return None, []
+        return DecodingOutput(counterparty=CPT_ETH2)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
@@ -1,22 +1,19 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any
 
 from eth_utils import encode_hex
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.constants import ETH2_DEPOSIT_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
-from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
+from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import from_gwei, hex_or_bytes_to_int
 
 from .constants import CPT_ETH2
 
-if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
 
 DEPOSIT_EVENT = b'd\x9b\xbcb\xd0\xe3\x13B\xaf\xeaN\\\xd8-@I\xe7\xe1\xee\x91/\xc0\x88\x9a\xa7\x90\x80;\xe3\x908\xc5'  # noqa: E501
 
@@ -26,14 +23,8 @@ log = RotkehlchenLogsAdapter(logger)
 
 class Eth2Decoder(DecoderInterface):
 
-    def _decode_eth2_deposit_event(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_eth2_deposit_event(self, context: DecoderContext) -> DecodingOutput:
+        tx_log = context.tx_log
         if tx_log.topics[0] != DEPOSIT_EVENT:
             return DecodingOutput(counterparty=CPT_ETH2)
 
@@ -41,7 +32,7 @@ class Eth2Decoder(DecoderInterface):
         withdrawal_credentials = encode_hex(tx_log.data[288:320])
         amount = from_gwei(hex_or_bytes_to_int(tx_log.data[352:360], byteorder='little'))
         deposit_index = hex_or_bytes_to_int(tx_log.data[544:552 + 8], byteorder='little')  # is not same as validator index  # noqa: E501
-        for event in decoded_events:
+        for event in context.decoded_events:
             if (
                 event.event_type == HistoryEventType.SPEND and
                 event.event_subtype == HistoryEventSubType.NONE and

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -28,23 +28,22 @@ class GitcoinDecoder(DecoderInterface):
         - UnknownAsset
         - WrongAssetType
         """
-        event = context.event
         if context.transaction.to_address not in (
                 '0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
                 '0x7d655c57f71464B6f83811C55D84009Cd9f5221C',
         ):
             return DEFAULT_ENRICHMENT_OUTPUT
-        crypto_asset = event.asset.resolve_to_crypto_asset()
-        if event.event_type == HistoryEventType.SPEND:
-            to_address = event.address
-            event.notes = f'Donate {event.balance.amount} {crypto_asset.symbol} to {to_address} via gitcoin'  # noqa: E501
+        crypto_asset = context.event.asset.resolve_to_crypto_asset()
+        if context.event.event_type == HistoryEventType.SPEND:
+            to_address = context.event.address
+            context.event.notes = f'Donate {context.event.balance.amount} {crypto_asset.symbol} to {to_address} via gitcoin'  # noqa: E501
         else:  # can only be RECEIVE
-            from_address = event.address
-            event.notes = f'Receive donation of {event.balance.amount} {crypto_asset.symbol} from {from_address} via gitcoin'  # noqa: E501
+            from_address = context.event.address
+            context.event.notes = f'Receive donation of {context.event.balance.amount} {crypto_asset.symbol} from {from_address} via gitcoin'  # noqa: E501
 
-        event.event_subtype = HistoryEventSubType.DONATE
-        event.counterparty = CPT_GITCOIN
-        return TransferEnrichmentOutput(counterparty=CPT_GITCOIN)
+        context.event.event_subtype = HistoryEventSubType.DONATE
+        context.event.counterparty = CPT_GITCOIN
+        return DEFAULT_ENRICHMENT_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -4,7 +4,11 @@ from typing import TYPE_CHECKING, Callable
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_ENRICHMENT_OUTPUT,
+    ActionItem,
+    TransferEnrichmentOutput,
+)
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import EvmTransaction
@@ -28,7 +32,7 @@ class GitcoinDecoder(DecoderInterface):
             event: 'EvmEvent',
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> bool:
+    ) -> TransferEnrichmentOutput:
         """
         May raise:
         - UnknownAsset
@@ -38,7 +42,7 @@ class GitcoinDecoder(DecoderInterface):
                 '0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
                 '0x7d655c57f71464B6f83811C55D84009Cd9f5221C',
         ):
-            return False
+            return DEFAULT_ENRICHMENT_OUTPUT
         crypto_asset = event.asset.resolve_to_crypto_asset()
         if event.event_type == HistoryEventType.SPEND:
             to_address = event.address
@@ -49,7 +53,7 @@ class GitcoinDecoder(DecoderInterface):
 
         event.event_subtype = HistoryEventSubType.DONATE
         event.counterparty = CPT_GITCOIN
-        return True
+        return TransferEnrichmentOutput(counterparty=CPT_GITCOIN)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -1,22 +1,17 @@
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import Callable
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_ENRICHMENT_OUTPUT,
-    ActionItem,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
-from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import EvmTransaction
 
 from .constants import CPT_GITCOIN
 
-if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -26,19 +21,15 @@ class GitcoinDecoder(DecoderInterface):
 
     def _maybe_enrich_gitcoin_transfers(
             self,
-            token: EvmToken,  # pylint: disable=unused-argument
-            tx_log: EvmTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EvmTransaction,
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """
         May raise:
         - UnknownAsset
         - WrongAssetType
         """
-        if transaction.to_address not in (
+        event = context.event
+        if context.transaction.to_address not in (
                 '0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
                 '0x7d655c57f71464B6f83811C55D84009Cd9f5221C',
         ):

--- a/rotkehlchen/chain/ethereum/modules/hop/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hop/decoder.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.evm.decoding.constants import CPT_HOP
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
@@ -40,9 +40,9 @@ class HopDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] != TRANSFER_TO_L2:
-            return None, []
+            return DecodingOutput(counterparty=CPT_HOP)
 
         chain_id = hex_or_bytes_to_int(tx_log.topics[1])
         recipient = hex_or_bytes_to_address(tx_log.topics[2])
@@ -63,7 +63,7 @@ class HopDecoder(DecoderInterface):
                 event.notes = f'Bridge {amount} ETH to {name} {target_str} via Hop protocol'
                 break
 
-        return None, []
+        return DecodingOutput(counterparty=CPT_HOP)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.accounting.structures.types import HistoryEventSubType, History
 from rotkehlchen.assets.asset import CryptoAsset
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -24,6 +24,7 @@ KYBER_TRADE_LEGACY = b'\xf7$\xb4\xdff\x17G6\x12\xb5=\x7f\x88\xec\xc6\xea\x980t\x
 KYBER_LEGACY_CONTRACT = string_to_evm_address('0x9ae49C0d7F8F9EF4B864e004FE86Ac8294E20950')
 KYBER_LEGACY_CONTRACT_MIGRATED = string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd')  # noqa: E501
 KYBER_LEGACY_CONTRACT_UPGRADED = string_to_evm_address('0x9AAb3f75489902f3a48495025729a0AF77d4b11e')  # noqa: E501
+DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_KYBER)
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -92,13 +93,13 @@ class KyberDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] == KYBER_TRADE_LEGACY:
-            return None, []
+            return DEFAULT_DECODING_OUTPUT
 
         sender, source_asset, destination_asset = _legacy_contracts_basic_info(tx_log)
         if source_asset is None or destination_asset is None:
-            return None, []
+            return DEFAULT_DECODING_OUTPUT
 
         spent_amount_raw = hex_or_bytes_to_int(tx_log.data[64:96])
         return_amount_raw = hex_or_bytes_to_int(tx_log.data[96:128])
@@ -114,7 +115,7 @@ class KyberDecoder(DecoderInterface):
             notify_user=self.notify_user,
         )
 
-        return None, []
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_legacy_upgraded_trade(
             self,
@@ -123,13 +124,13 @@ class KyberDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] != KYBER_TRADE_LEGACY:
-            return None, []
+            return DEFAULT_DECODING_OUTPUT
 
         sender, source_asset, destination_asset = _legacy_contracts_basic_info(tx_log)
         if source_asset is None or destination_asset is None:
-            return None, []
+            return DEFAULT_DECODING_OUTPUT
 
         spent_amount_raw = hex_or_bytes_to_int(tx_log.data[96:128])
         return_amount_raw = hex_or_bytes_to_int(tx_log.data[128:160])
@@ -145,7 +146,7 @@ class KyberDecoder(DecoderInterface):
             notify_user=self.notify_user,
         )
 
-        return None, []
+        return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -5,7 +5,11 @@ from rotkehlchen.accounting.structures.types import HistoryEventSubType, History
 from rotkehlchen.assets.asset import CryptoAsset
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -24,7 +28,6 @@ KYBER_TRADE_LEGACY = b'\xf7$\xb4\xdff\x17G6\x12\xb5=\x7f\x88\xec\xc6\xea\x980t\x
 KYBER_LEGACY_CONTRACT = string_to_evm_address('0x9ae49C0d7F8F9EF4B864e004FE86Ac8294E20950')
 KYBER_LEGACY_CONTRACT_MIGRATED = string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd')  # noqa: E501
 KYBER_LEGACY_CONTRACT_UPGRADED = string_to_evm_address('0x9AAb3f75489902f3a48495025729a0AF77d4b11e')  # noqa: E501
-DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_KYBER)
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -13,6 +13,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
     ActionItem,
     DecoderContext,
     DecodingOutput,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
@@ -383,14 +384,10 @@ class MakerdaosaiDecoder(DecoderInterface):
 
     def _maybe_enrich_sai_tub_transfers(
             self,
-            token: EvmToken,  # pylint: disable=unused-argument
-            tx_log: EvmTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """This method enriches relevant asset transfers to and from the SaiTub contract."""
+        event = context.event
         if (
             event.event_type == HistoryEventType.SPEND and
             event.event_subtype == HistoryEventSubType.NONE and

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -385,43 +385,42 @@ class MakerdaosaiDecoder(DecoderInterface):
             context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """This method enriches relevant asset transfers to and from the SaiTub contract."""
-        event = context.event
         if (
-            event.event_type == HistoryEventType.SPEND and
-            event.event_subtype == HistoryEventSubType.NONE and
-            event.address in (MAKERDAO_SAITUB_CONTRACT, MAKERDAO_SAI_PROXY_CONTRACT)
+            context.event.event_type == HistoryEventType.SPEND and
+            context.event.event_subtype == HistoryEventSubType.NONE and
+            context.event.address in (MAKERDAO_SAITUB_CONTRACT, MAKERDAO_SAI_PROXY_CONTRACT)
         ):
-            if event.asset == self.weth:
-                event.event_type = HistoryEventType.DEPOSIT
-                event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
-                event.notes = f'Supply {event.balance.amount} {self.weth.symbol} to Sai vault'
-                event.counterparty = CPT_SAI
+            if context.event.asset == self.weth:
+                context.event.event_type = HistoryEventType.DEPOSIT
+                context.event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                context.event.notes = f'Supply {context.event.balance.amount} {self.weth.symbol} to Sai vault'  # noqa: E501
+                context.event.counterparty = CPT_SAI
                 return DEFAULT_ENRICHMENT_OUTPUT
 
-            if event.asset == self.peth:
-                event.event_type = HistoryEventType.DEPOSIT
-                event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
-                event.notes = f'Increase CDP collateral by {event.balance.amount} {self.peth.symbol}'  # noqa: E501
-                event.counterparty = CPT_SAI
+            if context.event.asset == self.peth:
+                context.event.event_type = HistoryEventType.DEPOSIT
+                context.event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                context.event.notes = f'Increase CDP collateral by {context.event.balance.amount} {self.peth.symbol}'  # noqa: E501
+                context.event.counterparty = CPT_SAI
                 return DEFAULT_ENRICHMENT_OUTPUT
 
         if (
-            event.event_type == HistoryEventType.RECEIVE and
-            event.event_subtype == HistoryEventSubType.NONE and
-            event.address == MAKERDAO_SAITUB_CONTRACT
+            context.event.event_type == HistoryEventType.RECEIVE and
+            context.event.event_subtype == HistoryEventSubType.NONE and
+            context.event.address == MAKERDAO_SAITUB_CONTRACT
         ):
-            if event.asset == self.weth:
-                event.event_type = HistoryEventType.WITHDRAWAL
-                event.event_subtype = HistoryEventSubType.REMOVE_ASSET
-                event.notes = f'Withdraw {event.balance.amount} {self.weth.symbol} from Sai vault'
-                event.counterparty = CPT_SAI
+            if context.event.asset == self.weth:
+                context.event.event_type = HistoryEventType.WITHDRAWAL
+                context.event.event_subtype = HistoryEventSubType.REMOVE_ASSET
+                context.event.notes = f'Withdraw {context.event.balance.amount} {self.weth.symbol} from Sai vault'  # noqa: E501
+                context.event.counterparty = CPT_SAI
                 return DEFAULT_ENRICHMENT_OUTPUT
 
-            if event.asset == self.peth:
-                event.event_type = HistoryEventType.WITHDRAWAL
-                event.event_subtype = HistoryEventSubType.REMOVE_ASSET
-                event.notes = f'Decrease CDP collateral by {event.balance.amount} {self.peth.symbol}'  # noqa: E501
-                event.counterparty = CPT_SAI
+            if context.event.asset == self.peth:
+                context.event.event_type = HistoryEventType.WITHDRAWAL
+                context.event.event_subtype = HistoryEventSubType.REMOVE_ASSET
+                context.event.notes = f'Decrease CDP collateral by {context.event.balance.amount} {self.peth.symbol}'  # noqa: E501
+                context.event.counterparty = CPT_SAI
                 return DEFAULT_ENRICHMENT_OUTPUT
 
         return DEFAULT_ENRICHMENT_OUTPUT

--- a/rotkehlchen/chain/ethereum/modules/optimism_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/optimism_bridge/decoder.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
@@ -33,7 +33,7 @@ class OptimismBridgeDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         """Decodes a bridging event. Either a deposit or a withdrawal."""
         if tx_log.topics[0] not in {
             ETH_DEPOSIT_INITIATED,
@@ -41,7 +41,8 @@ class OptimismBridgeDecoder(DecoderInterface):
             ERC20_DEPOSIT_INITIATED,
             ERC20_WITHDRAWAL_FINALIZED,
         }:
-            return None, []  # Make sure that we are decoding a supported event.
+            # Make sure that we are decoding a supported event.
+            return DecodingOutput(counterparty=CPT_OPTIMISM)
 
         # Read information from event's topics & data
         if tx_log.topics[0] in {ETH_DEPOSIT_INITIATED, ETH_WITHDRAWAL_FINALIZED}:
@@ -91,7 +92,7 @@ class OptimismBridgeDecoder(DecoderInterface):
                     f'{to_chain} address {to_address} via optimism bridge'
                 )
 
-        return None, []
+        return DecodingOutput(counterparty=CPT_OPTIMISM)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -10,6 +10,7 @@ from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import (
 )
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
     ActionItem,
     DecodingOutput,
     EnricherContext,
@@ -29,7 +30,6 @@ BURN_SIGNATURE = b'\xdc\xcdA/\x0b\x12R\x81\x9c\xb1\xfd3\x0b\x93"L\xa4&\x12\x89+\
 
 SUSHISWAP_V2_FACTORY = string_to_evm_address('0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac')
 SUSHISWAP_V2_INIT_CODE_HASH = '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303'  # noqa: E501
-DEFAULT_DECODING_OUTPUT = DecodingOutput(counterparty=CPT_SUSHISWAP_V2)
 
 
 class SushiswapDecoder(DecoderInterface):

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -12,6 +12,7 @@ from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     ActionItem,
     DecodingOutput,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -92,21 +93,9 @@ class SushiswapDecoder(DecoderInterface):
         return DEFAULT_DECODING_OUTPUT
 
     @staticmethod
-    def _maybe_enrich_lp_tokens_transfers(
-            token: EvmToken,  # pylint: disable=unused-argument
-            tx_log: EvmTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> TransferEnrichmentOutput:
+    def _maybe_enrich_lp_tokens_transfers(context: EnricherContext) -> TransferEnrichmentOutput:
         return enrich_uniswap_v2_like_lp_tokens_transfers(
-            token=token,
-            tx_log=tx_log,
-            transaction=transaction,
-            event=event,
-            action_items=action_items,
-            all_logs=all_logs,
+            context=context,
             counterparty=CPT_SUSHISWAP_V2,
             lp_token_symbol=SUSHISWAP_PROTOCOL,
         )

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import _decode_result
 from rotkehlchen.chain.ethereum.modules.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.types import WeightedNode
 from rotkehlchen.constants import ZERO
@@ -250,7 +250,7 @@ def decode_basic_uniswap_info(
         decoded_events: list['EvmEvent'],
         counterparty: str,
         notify_user: Callable[['EvmEvent', str], None],
-) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+) -> DecodingOutput:
     """
     Check last three events and if they are related to the swap, label them as such.
     We check three events because potential events are: spend, (optionally) approval, receive.
@@ -262,7 +262,7 @@ def decode_basic_uniswap_info(
             crypto_asset = event.asset.resolve_to_crypto_asset()
         except (UnknownAsset, WrongAssetType):
             notify_user(event, counterparty)
-            return None, []
+            return DecodingOutput(counterparty=counterparty)
 
         if (
             event.event_type == HistoryEventType.INFORMATIONAL and
@@ -325,4 +325,4 @@ def decode_basic_uniswap_info(
     if spend_event is not None and receive_event is not None:
         maybe_reshuffle_events(out_event=spend_event, in_event=receive_event)
 
-    return None, []
+    return DecodingOutput(counterparty=counterparty)

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.ethereum.interfaces.ammswap.utils import _decode_result
 from rotkehlchen.chain.ethereum.modules.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
-from rotkehlchen.chain.evm.decoding.structures import DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT, DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.types import WeightedNode
 from rotkehlchen.constants import ZERO
@@ -262,7 +262,7 @@ def decode_basic_uniswap_info(
             crypto_asset = event.asset.resolve_to_crypto_asset()
         except (UnknownAsset, WrongAssetType):
             notify_user(event, counterparty)
-            return DecodingOutput(counterparty=counterparty)
+            return DEFAULT_DECODING_OUTPUT
 
         if (
             event.event_type == HistoryEventType.INFORMATIONAL and
@@ -325,4 +325,4 @@ def decode_basic_uniswap_info(
     if spend_event is not None and receive_event is not None:
         maybe_reshuffle_events(out_event=spend_event, in_event=receive_event)
 
-    return DecodingOutput(counterparty=counterparty)
+    return DEFAULT_DECODING_OUTPUT

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.ethereum.modules.aave.v1.decoder import DEFAULT_DECODING_OUTPUT
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
@@ -37,7 +38,7 @@ class Uniswapv1Decoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         """Search for both events. Since the order is not guaranteed try reshuffle in both cases"""
         out_event = in_event = None
         if tx_log.topics[0] == TOKEN_PURCHASE:
@@ -77,7 +78,7 @@ class Uniswapv1Decoder(DecoderInterface):
                     out_event = event
 
         maybe_reshuffle_events(out_event=out_event, in_event=in_event)
-        return None, []
+        return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
@@ -301,28 +301,27 @@ def enrich_uniswap_v2_like_lp_tokens_transfers(
         lp_token_symbol: Literal['UNI-V2', 'SLP'],
 ) -> TransferEnrichmentOutput:
     """This function enriches LP tokens transfers of Uniswap V2 like AMMs."""
-    event = context.event
-    resolved_asset = event.asset.resolve_to_crypto_asset()
+    resolved_asset = context.event.asset.resolve_to_crypto_asset()
     if (
         resolved_asset.symbol == lp_token_symbol and
-        event.event_type == HistoryEventType.RECEIVE and
-        event.event_subtype == HistoryEventSubType.NONE and
-        event.address == ZERO_ADDRESS
+        context.event.event_type == HistoryEventType.RECEIVE and
+        context.event.event_subtype == HistoryEventSubType.NONE and
+        context.event.address == ZERO_ADDRESS
     ):
-        event.counterparty = counterparty
-        event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
-        event.notes = f'Receive {event.balance.amount} {resolved_asset.symbol} from {counterparty} pool'  # noqa: E501
+        context.event.counterparty = counterparty
+        context.event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
+        context.event.notes = f'Receive {context.event.balance.amount} {resolved_asset.symbol} from {counterparty} pool'  # noqa: E501
         return DEFAULT_ENRICHMENT_OUTPUT
 
     if (
         resolved_asset.symbol == lp_token_symbol and
-        event.event_type == HistoryEventType.SPEND and
-        event.event_subtype == HistoryEventSubType.NONE and
-        event.address == context.tx_log.address  # the recipient of the transfer is the pool
+        context.event.event_type == HistoryEventType.SPEND and
+        context.event.event_subtype == HistoryEventSubType.NONE and
+        context.event.address == context.tx_log.address  # the recipient of the transfer is the pool  # noqa: E501
     ):
-        event.counterparty = counterparty
-        event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
-        event.notes = f'Send {event.balance.amount} {resolved_asset.symbol} to {counterparty} pool'
+        context.event.counterparty = counterparty
+        context.event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
+        context.event.notes = f'Send {context.event.balance.amount} {resolved_asset.symbol} to {counterparty} pool'  # noqa: E501
         return DEFAULT_ENRICHMENT_OUTPUT
 
     return DEFAULT_ENRICHMENT_OUTPUT

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -14,6 +14,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
     DecodingOutput,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -133,21 +134,9 @@ class Uniswapv2Decoder(DecoderInterface):
         return DEFAULT_DECODING_OUTPUT
 
     @staticmethod
-    def _maybe_enrich_lp_tokens_transfers(
-            token: EvmToken,  # pylint: disable=unused-argument
-            tx_log: EvmTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> TransferEnrichmentOutput:
+    def _maybe_enrich_lp_tokens_transfers(context: EnricherContext) -> TransferEnrichmentOutput:
         return enrich_uniswap_v2_like_lp_tokens_transfers(
-            token=token,
-            tx_log=tx_log,
-            transaction=transaction,
-            event=event,
-            action_items=action_items,
-            all_logs=all_logs,
+            context=context,
             counterparty=CPT_UNISWAP_V2,
             lp_token_symbol=UNISWAP_PROTOCOL,
         )

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -538,4 +538,7 @@ class Uniswapv3Decoder(DecoderInterface):
         return [CPT_UNISWAP_V3]
 
     def post_decoding_rules(self) -> dict[str, list[tuple[int, Callable]]]:
-        return {router_address: [(0, self._routers_post_decoding)] for router_address in UNISWAP_ROUTERS}  # noqa: E501
+        return {CPT_UNISWAP_V3: [(0, self._routers_post_decoding)]}
+
+    def addresses_to_counterparties(self) -> dict[ChecksumEvmAddress, str]:
+        return {router_address: CPT_UNISWAP_V3 for router_address in UNISWAP_ROUTERS}

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -514,7 +514,7 @@ class Uniswapv3Decoder(DecoderInterface):
             event.event_subtype = HistoryEventSubType.NFT
             event.notes = f'Create {CPT_UNISWAP_V3} LP with id {hex_or_bytes_to_int(context.tx_log.topics[3])}'  # noqa: E501
             event.counterparty = CPT_UNISWAP_V3
-            return TransferEnrichmentOutput(counterparty=CPT_UNISWAP_V3)
+            return DEFAULT_ENRICHMENT_OUTPUT
 
         return DEFAULT_ENRICHMENT_OUTPUT
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -503,17 +503,16 @@ class Uniswapv3Decoder(DecoderInterface):
             context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """This method enriches Uniswap V3 LP creation transactions."""
-        event = context.event
         if (
-            event.asset == self.uniswap_v3_nft and
-            event.balance.amount == ONE and
-            event.address == ZERO_ADDRESS and
-            event.event_type == HistoryEventType.RECEIVE and
-            event.event_subtype == HistoryEventSubType.NONE
+            context.event.asset == self.uniswap_v3_nft and
+            context.event.balance.amount == ONE and
+            context.event.address == ZERO_ADDRESS and
+            context.event.event_type == HistoryEventType.RECEIVE and
+            context.event.event_subtype == HistoryEventSubType.NONE
         ):
-            event.event_subtype = HistoryEventSubType.NFT
-            event.notes = f'Create {CPT_UNISWAP_V3} LP with id {hex_or_bytes_to_int(context.tx_log.topics[3])}'  # noqa: E501
-            event.counterparty = CPT_UNISWAP_V3
+            context.event.event_subtype = HistoryEventSubType.NFT
+            context.event.notes = f'Create {CPT_UNISWAP_V3} LP with id {hex_or_bytes_to_int(context.tx_log.topics[3])}'  # noqa: E501
+            context.event.counterparty = CPT_UNISWAP_V3
             return DEFAULT_ENRICHMENT_OUTPUT
 
         return DEFAULT_ENRICHMENT_OUTPUT

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -16,6 +16,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
     ActionItem,
     DecoderContext,
     DecodingOutput,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog, SwapData
@@ -499,14 +500,10 @@ class Uniswapv3Decoder(DecoderInterface):
 
     def _maybe_enrich_liquidity_pool_creation(
             self,
-            token: EvmToken,  # pylint: disable=unused-argument
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """This method enriches Uniswap V3 LP creation transactions."""
+        event = context.event
         if (
             event.asset == self.uniswap_v3_nft and
             event.balance.amount == ONE and
@@ -515,7 +512,7 @@ class Uniswapv3Decoder(DecoderInterface):
             event.event_subtype == HistoryEventSubType.NONE
         ):
             event.event_subtype = HistoryEventSubType.NFT
-            event.notes = f'Create {CPT_UNISWAP_V3} LP with id {hex_or_bytes_to_int(tx_log.topics[3])}'  # noqa: E501
+            event.notes = f'Create {CPT_UNISWAP_V3} LP with id {hex_or_bytes_to_int(context.tx_log.topics[3])}'  # noqa: E501
             event.counterparty = CPT_UNISWAP_V3
             return TransferEnrichmentOutput(counterparty=CPT_UNISWAP_V3)
 

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -4,7 +4,11 @@ from typing import TYPE_CHECKING, Any, Optional
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, ethaddress_to_asset
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    ActionItem,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
@@ -34,14 +38,14 @@ class VotiumDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: Optional[list[ActionItem]],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] != VOTIUM_CLAIM:
-            return None, []
+            return DEFAULT_DECODING_OUTPUT
 
         claimed_token_address = hex_or_bytes_to_address(tx_log.topics[1])
         claimed_token = ethaddress_to_asset(claimed_token_address)
         if claimed_token is None:
-            return None, []
+            return DEFAULT_DECODING_OUTPUT
 
         receiver = hex_or_bytes_to_address(tx_log.topics[2])
         claimed_amount_raw = hex_or_bytes_to_int(tx_log.data[32:64])
@@ -58,7 +62,7 @@ class VotiumDecoder(DecoderInterface):
                 event.counterparty = CPT_VOTIUM
                 event.notes = f'Receive {event.balance.amount} {crypto_asset.symbol} from votium bribe'  # noqa: E501
 
-        return None, []
+        return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
@@ -7,22 +7,15 @@ from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_ENRICHMENT_OUTPUT,
-    ActionItem,
+    EnricherContext,
     TransferEnrichmentOutput,
 )
-from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.types import (
-    YEARN_VAULTS_V1_PROTOCOL,
-    YEARN_VAULTS_V2_PROTOCOL,
-    ChainID,
-    EvmTransaction,
-)
+from rotkehlchen.types import YEARN_VAULTS_V1_PROTOCOL, YEARN_VAULTS_V2_PROTOCOL, ChainID
 
 if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
     from rotkehlchen.chain.ethereum.manager import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
     from rotkehlchen.types import ChecksumEvmAddress
@@ -61,12 +54,7 @@ class YearnDecoder(DecoderInterface):
 
     def _maybe_enrich_yearn_transfers(
             self,
-            token: 'EvmToken',
-            tx_log: EvmTxReceiptLog,  # pylint: disable=unused-argument
-            transaction: EvmTransaction,
-            event: 'EvmEvent',
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            context: EnricherContext,
     ) -> TransferEnrichmentOutput:
         """
         Enrich ethereum transfers made during the execution of yearn contracts.
@@ -77,6 +65,7 @@ class YearnDecoder(DecoderInterface):
         First we make sure that the contract is a yearn v1 or v2 contract and that the method
         executed in the contract is one of the expected.
         """
+        event, transaction, token = context.event, context.transaction, context.token
         protocol = CPT_YEARN_V2
         if transaction.to_address in self.vaults_v1:
             protocol = CPT_YEARN_V1

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.utils import asset_raw_value
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
@@ -29,11 +29,11 @@ class ZksyncDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             all_logs: list[EvmTxReceiptLog],
             action_items: list[ActionItem],
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] == DEPOSIT:
             return self._decode_deposit(tx_log, transaction, decoded_events, all_logs, action_items)  # noqa: E501
 
-        return None, []
+        return DecodingOutput(counterparty=CPT_ZKSYNC)
 
     def _decode_deposit(
             self,
@@ -42,7 +42,7 @@ class ZksyncDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         """Match a zksync deposit with the transfer to decode it
 
         TODO: This is now quite bad. We don't use the token id of zksync as we should.
@@ -72,7 +72,7 @@ class ZksyncDecoder(DecoderInterface):
                 event.notes = f'Deposit {event.balance.amount} {crypto_asset.symbol} to zksync'  # noqa: E501
                 break
 
-        return None, []
+        return DecodingOutput(counterparty=CPT_ZKSYNC)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -3,13 +3,16 @@ from typing import Any
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.utils import asset_raw_value
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 from .constants import CPT_ZKSYNC
-
 
 DEPOSIT = b'\xb6\x86k\x02\x9f:\xa2\x9c\xd9\xe2\xbf\xf8\x15\x9a\x8c\xca\xa48\x9fz\x08|q\th\xe0\xb2\x00\xc0\xc7;\x08'  # noqa: E501
 
@@ -22,7 +25,7 @@ class ZksyncDecoder(DecoderInterface):
         if context.tx_log.topics[0] == DEPOSIT:
             return self._decode_deposit(context)
 
-        return DecodingOutput(counterparty=CPT_ZKSYNC)
+        return DEFAULT_DECODING_OUTPUT
 
     def _decode_deposit(self, context: DecoderContext) -> DecodingOutput:
         """Match a zksync deposit with the transfer to decode it
@@ -54,7 +57,7 @@ class ZksyncDecoder(DecoderInterface):
                 event.notes = f'Deposit {event.balance.amount} {crypto_asset.symbol} to zksync'  # noqa: E501
                 break
 
-        return DecodingOutput(counterparty=CPT_ZKSYNC)
+        return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/constants.py
+++ b/rotkehlchen/chain/evm/decoding/constants.py
@@ -2,6 +2,7 @@ from rotkehlchen.accounting.structures.types import HistoryEventType
 
 CPT_GAS = 'gas'
 CPT_HOP = 'hop-protocol'
+CPT_ALL = 'all'
 
 OUTGOING_EVENT_TYPES = {
     HistoryEventType.SPEND,

--- a/rotkehlchen/chain/evm/decoding/constants.py
+++ b/rotkehlchen/chain/evm/decoding/constants.py
@@ -2,7 +2,6 @@ from rotkehlchen.accounting.structures.types import HistoryEventType
 
 CPT_GAS = 'gas'
 CPT_HOP = 'hop-protocol'
-CPT_ALL = 'all'
 
 OUTGOING_EVENT_TYPES = {
     HistoryEventType.SPEND,

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -49,7 +49,7 @@ class DecoderInterface(metaclass=ABCMeta):
         """
         return []
 
-    def post_decoding_rules(self) -> list[tuple[int, Callable]]:
+    def post_decoding_rules(self) -> dict[str, list[tuple[int, Callable]]]:
         """
         Subclasses may implement this to add post processing of the decoded events.
         This will run after the normal decoding step and will only process decoded history events.
@@ -58,7 +58,7 @@ class DecoderInterface(metaclass=ABCMeta):
         a function and the second element is the function to run. The higher the priority number
         the later the function will be run.
         """
-        return []
+        return {}
 
     def notify_user(self, event: 'EvmEvent', counterparty: str) -> None:
         """

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -54,9 +54,17 @@ class DecoderInterface(metaclass=ABCMeta):
         Subclasses may implement this to add post processing of the decoded events.
         This will run after the normal decoding step and will only process decoded history events.
 
-        This function should return a list of tuples where the first element is the priority of
-        a function and the second element is the function to run. The higher the priority number
-        the later the function will be run.
+        This function should return a dict where values are tuples where the first element is the
+        priority of a function and the second element is the function to run. The higher the
+        priority number the later the function will be run.
+        The keys of the dictionary are counterparties.
+        """
+        return {}
+
+    def addresses_to_counterparties(self) -> dict[ChecksumEvmAddress, str]:
+        """
+        Map addresses to counterparties so they can be filtered in the post
+        decoding step.
         """
         return {}
 

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -30,6 +30,7 @@ class ActionItem(NamedTuple):
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class BasicContext:
+    """Common elements between different contexts in the decoding logic"""
     tx_log: 'EvmTxReceiptLog'
     transaction: 'EvmTransaction'
     action_items: list[ActionItem]
@@ -38,19 +39,22 @@ class BasicContext:
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DecoderContext(BasicContext):
-    """
-    Context given to decoding rules
-    """
+    """Context given to decoding rules"""
     decoded_events: list['EvmEvent']
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class EnricherContext(BasicContext):
+    """Context for enrichment rules"""
     token: 'EvmToken'
     event: 'EvmEvent'
 
 
 class DecodingOutput(NamedTuple):
+    """
+    Output of decoding functions
+    Counterparty is set to the counterparty that modified the transaction
+    """
     event: Optional['EvmEvent'] = None
     action_items: list[ActionItem] = []
     counterparty: Optional[str] = None

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -1,26 +1,56 @@
-from typing import TYPE_CHECKING, Literal, NamedTuple, Optional
-
-from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.assets.asset import Asset
-from rotkehlchen.fval import FVal
+from typing import TYPE_CHECKING, Final, Literal, NamedTuple, Optional
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.structures.evm_event import EvmEvent
+    from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+    from rotkehlchen.assets.asset import Asset
+    from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+    from rotkehlchen.fval import FVal
+    from rotkehlchen.types import EvmTransaction
 
 
 class ActionItem(NamedTuple):
     """Action items to propagate to other decoders during decoding"""
     action: Literal['transform', 'skip', 'skip & keep']
     sequence_index: int
-    from_event_type: HistoryEventType
-    from_event_subtype: HistoryEventSubType
-    asset: Asset
-    amount: FVal
-    to_event_type: Optional[HistoryEventType] = None
-    to_event_subtype: Optional[HistoryEventSubType] = None
+    from_event_type: 'HistoryEventType'
+    from_event_subtype: 'HistoryEventSubType'
+    asset: 'Asset'
+    amount: 'FVal'
+    to_event_type: Optional['HistoryEventType'] = None
+    to_event_subtype: Optional['HistoryEventSubType'] = None
     to_notes: Optional[str] = None
     to_counterparty: Optional[str] = None
     extra_data: Optional[dict] = None
     # Optional event data that pairs it with the event of the action item
     # Contains a tuple with the paired event and whether it's an out event (True) or in event
     paired_event_data: Optional[tuple['EvmEvent', bool]] = None
+
+
+class DecoderContext(NamedTuple):
+    """
+    Context given to decoding rules
+    """
+    tx_log: 'EvmTxReceiptLog'
+    transaction: 'EvmTransaction'
+    decoded_events: list['EvmEvent']
+    all_logs: list['EvmTxReceiptLog']
+    action_items: list[ActionItem]
+
+
+class DecodingOutput(NamedTuple):
+    event: Optional['EvmEvent'] = None
+    action_items: list[ActionItem] = []
+    counterparty: Optional[str] = None
+
+
+class TransferEnrichmentOutput(NamedTuple):
+    """
+    Return structure for the enrichment functions.
+    Counterparty is set to the counterparty that modified the transaction
+    """
+    counterparty: Optional[str] = None
+
+
+DEFAULT_DECODING_OUTPUT: Final = DecodingOutput()
+DEFAULT_ENRICHMENT_OUTPUT: Final = TransferEnrichmentOutput()

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -29,7 +29,7 @@ class ActionItem(NamedTuple):
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
-class BasicContext:
+class DecoderBasicContext:
     """Common elements between different contexts in the decoding logic"""
     tx_log: 'EvmTxReceiptLog'
     transaction: 'EvmTransaction'
@@ -38,14 +38,14 @@ class BasicContext:
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
-class DecoderContext(BasicContext):
-    """Context given to decoding rules"""
+class DecoderContext(DecoderBasicContext):
+    """Arguments context for decoding rules"""
     decoded_events: list['EvmEvent']
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
-class EnricherContext(BasicContext):
-    """Context for enrichment rules"""
+class EnricherContext(DecoderBasicContext):
+    """Arguments context for enrichment rules"""
     token: 'EvmToken'
     event: 'EvmEvent'
 
@@ -53,19 +53,21 @@ class EnricherContext(BasicContext):
 class DecodingOutput(NamedTuple):
     """
     Output of decoding functions
-    Counterparty is set to the counterparty that modified the transaction
+    matched_counterparty is optionally set if needed for decoder rules that matched
+    and is used in post-decoding rules like in the case of balancer
     """
     event: Optional['EvmEvent'] = None
     action_items: list[ActionItem] = []
-    counterparty: Optional[str] = None
+    matched_counterparty: Optional[str] = None
 
 
 class TransferEnrichmentOutput(NamedTuple):
     """
     Return structure for the enrichment functions.
-    Counterparty is set to the counterparty that modified the transaction
+    matched_counterparty is optionally set if needed for enrichment rules
+    and is used in post-decoding rules like in the case of balancer
     """
-    counterparty: Optional[str] = None
+    matched_counterparty: Optional[str] = None
 
 
 DEFAULT_DECODING_OUTPUT: Final = DecodingOutput()

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -1,9 +1,10 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple, Optional
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.structures.evm_event import EvmEvent
     from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-    from rotkehlchen.assets.asset import Asset
+    from rotkehlchen.assets.asset import Asset, EvmToken
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.fval import FVal
     from rotkehlchen.types import EvmTransaction
@@ -27,15 +28,26 @@ class ActionItem(NamedTuple):
     paired_event_data: Optional[tuple['EvmEvent', bool]] = None
 
 
-class DecoderContext(NamedTuple):
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
+class BasicContext:
+    tx_log: 'EvmTxReceiptLog'
+    transaction: 'EvmTransaction'
+    action_items: list[ActionItem]
+    all_logs: list['EvmTxReceiptLog']
+
+
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
+class DecoderContext(BasicContext):
     """
     Context given to decoding rules
     """
-    tx_log: 'EvmTxReceiptLog'
-    transaction: 'EvmTransaction'
     decoded_events: list['EvmEvent']
-    all_logs: list['EvmTxReceiptLog']
-    action_items: list[ActionItem]
+
+
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
+class EnricherContext(BasicContext):
+    token: 'EvmToken'
+    event: 'EvmEvent'
 
 
 class DecodingOutput(NamedTuple):

--- a/rotkehlchen/chain/optimism/decoding/decoder.py
+++ b/rotkehlchen/chain/optimism/decoding/decoder.py
@@ -50,7 +50,7 @@ class OptimismTransactionDecoder(EVMTransactionDecoder):
             event: 'EvmEvent',
             action_items: list['ActionItem'],
             all_logs: list['EvmTxReceiptLog'],
-    ) -> None:
+    ) -> Optional[str]:
         return None
 
     @staticmethod

--- a/rotkehlchen/chain/optimism/decoding/decoder.py
+++ b/rotkehlchen/chain/optimism/decoding/decoder.py
@@ -4,23 +4,16 @@ from typing import TYPE_CHECKING, Optional
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
+from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
-    from rotkehlchen.assets.asset import EvmToken
-    from rotkehlchen.chain.evm.decoding.structures import ActionItem
-    from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.chain.optimism.transactions import OptimismTransactions
     from rotkehlchen.db.dbhandler import DBHandler
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
-
-
-def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:  # pylint: disable=unused-argument # noqa: E501
-    return None
 
 
 class OptimismTransactionDecoder(EVMTransactionDecoder):
@@ -42,15 +35,7 @@ class OptimismTransactionDecoder(EVMTransactionDecoder):
 
     # -- methods that need to be implemented by child classes --
 
-    def _enrich_protocol_tranfers(
-            self,
-            token: 'EvmToken',
-            tx_log: 'EvmTxReceiptLog',
-            transaction: EvmTransaction,
-            event: 'EvmEvent',
-            action_items: list['ActionItem'],
-            all_logs: list['EvmTxReceiptLog'],
-    ) -> Optional[str]:
+    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> Optional[str]:  # pylint: disable=unused-argument # noqa: E501
         return None
 
     @staticmethod

--- a/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
@@ -44,9 +44,9 @@ class AirdropsDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] != OP_CLAIMED:
-            return None, []
+            return DecodingOutput(counterparty=CPT_OPTIMISM)
 
         user_address = hex_or_bytes_to_address(tx_log.data[32:64])
         raw_amount = hex_or_bytes_to_int(tx_log.data[64:96])
@@ -60,7 +60,7 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claimed {amount} OP from optimism airdrop'
                 break
 
-        return None, []
+        return DecodingOutput(counterparty=CPT_OPTIMISM)
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {

--- a/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
 from rotkehlchen.constants.assets import A_OP
@@ -37,7 +41,7 @@ class AirdropsDecoder(DecoderInterface):
 
     def _decode_optimism_airdrop_claim(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != OP_CLAIMED:
-            return DecodingOutput(counterparty=CPT_OPTIMISM)
+            return DEFAULT_DECODING_OUTPUT
 
         user_address = hex_or_bytes_to_address(context.tx_log.data[32:64])
         raw_amount = hex_or_bytes_to_int(context.tx_log.data[64:96])
@@ -51,7 +55,7 @@ class AirdropsDecoder(DecoderInterface):
                 event.notes = f'Claimed {amount} OP from optimism airdrop'
                 break
 
-        return DecodingOutput(counterparty=CPT_OPTIMISM)
+        return DEFAULT_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {

--- a/rotkehlchen/chain/optimism/modules/hop/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/hop/decoder.py
@@ -4,7 +4,11 @@ from rotkehlchen.accounting.structures.types import HistoryEventSubType, History
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.constants import CPT_HOP
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_HETH_OPT, A_WETH_OPT
 from rotkehlchen.types import ChecksumEvmAddress
@@ -38,11 +42,11 @@ class HopDecoder(DecoderInterface):
 
     def _decode_receive_eth(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != TRANSFER_FROM_L1_COMPLETED:
-            return DecodingOutput(counterparty=CPT_HOP)
+            return DEFAULT_DECODING_OUTPUT
 
         recipient = hex_or_bytes_to_address(context.tx_log.topics[1])
         if not self.base.is_tracked(recipient):
-            return DecodingOutput(counterparty=CPT_HOP)
+            return DEFAULT_DECODING_OUTPUT
 
         amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
         heth_amount = token_normalized_value_decimals(amount_raw, 18)
@@ -56,7 +60,7 @@ class HopDecoder(DecoderInterface):
                 event.extra_data = {'sent_amount': str(heth_amount)}
                 break
 
-        return DecodingOutput(counterparty=CPT_HOP)
+        return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/optimism/modules/optimism/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/optimism/decoder.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
@@ -29,13 +29,13 @@ class OptimismDecoder(DecoderInterface):
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> tuple[Optional['EvmEvent'], list[ActionItem]]:
+    ) -> DecodingOutput:
         if tx_log.topics[0] != DELEGATE_CHANGED:
-            return None, []
+            return DecodingOutput(counterparty=CPT_OPTIMISM)
 
         delegator = hex_or_bytes_to_address(tx_log.topics[1])
         if not self.base.is_tracked(delegator):
-            return None, []
+            return DecodingOutput(counterparty=CPT_OPTIMISM)
 
         from_delegate = hex_or_bytes_to_address(tx_log.topics[2])
         to_delegate = hex_or_bytes_to_address(tx_log.topics[3])
@@ -51,7 +51,7 @@ class OptimismDecoder(DecoderInterface):
             counterparty=CPT_OPTIMISM,
             address=transaction.to_address,
         )
-        return event, []
+        return DecodingOutput(event=event, counterparty=CPT_OPTIMISM)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/optimism/modules/optimism_bridge/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/optimism_bridge/decoder.py
@@ -1,24 +1,20 @@
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
-from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
 from rotkehlchen.constants.assets import A_OPTIMISM_ETH
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind, EvmTransaction
+from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
-
-if TYPE_CHECKING:
-    from rotkehlchen.accounting.structures.evm_event import EvmEvent
 
 
 BRIDGE_ADDRESS = string_to_evm_address('0x4200000000000000000000000000000000000010')
@@ -32,15 +28,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class OptimismBridgeDecoder(DecoderInterface):
-    def _decode_receive_deposit(
-            self,
-            tx_log: EvmTxReceiptLog,
-            transaction: EvmTransaction,  # pylint: disable=unused-argument
-            decoded_events: list['EvmEvent'],
-            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-            action_items: list[ActionItem],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    def _decode_receive_deposit(self, context: DecoderContext) -> DecodingOutput:
         """Decodes a bridging event. Either a deposit or a withdrawal"""
+        tx_log = context.tx_log
         if tx_log.topics[0] not in {DEPOSIT_FINALIZED, WITHDRAWAL_INITIATED}:
             return DEFAULT_DECODING_OUTPUT
 
@@ -82,7 +72,7 @@ class OptimismBridgeDecoder(DecoderInterface):
             from_chain, to_chain = 'optimism', 'ethereum'
 
         # Find the corresponding transfer event and update it
-        for event in decoded_events:
+        for event in context.decoded_events:
             if (
                 event.event_type == expected_event_type and
                 event.location_label == expected_location_label and


### PR DESCRIPTION
This PR does:

- Modify post decoding rules so they are triggered by protocol/address instead for all addresses
- Use a single argument for all the context in decoding rules, decode enriches and transfer enriches
- Use a single return argument for enrichers and decoders

The reason for this changes are:
- Now we can target post decoding rules by protocol/address
- Anytime we need to change arguments/return type for decoders we don't have to modify every function