### PR TITLE
fix: scramble issue in trove liquity section

### DIFF
--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -287,6 +287,8 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
         <table-expand-container visible :colspan="tableHeaders.length">
           <evm-native-token-breakdown
             v-if="isEvmNativeToken(item.asset)"
+            show-percentage
+            :total="item.usdValue"
             :identifier="item.asset"
           />
           <asset-balances

--- a/frontend/app/src/components/defi/DefiAsset.vue
+++ b/frontend/app/src/components/defi/DefiAsset.vue
@@ -1,35 +1,26 @@
 <script setup lang="ts">
-import { type PropType } from 'vue';
-import AmountDisplay from '@/components/display/AmountDisplay.vue';
+import { type ComputedRef, type PropType } from 'vue';
 import AssetIcon from '@/components/helper/display/icons/AssetIcon.vue';
 import { type DefiAsset } from '@/types/defi/overview';
 import { createEvmIdentifierFromAddress } from '@/utils/assets';
 
-defineProps({
+const props = defineProps({
   asset: { required: true, type: Object as PropType<DefiAsset> }
 });
 
-const assetPadding = 1;
+const { asset } = toRefs(props);
+
+const evmIdentifier: ComputedRef<string> = computed(() =>
+  createEvmIdentifierFromAddress(get(asset).tokenAddress)
+);
 </script>
 <template>
-  <div class="defi-asset d-flex flex-row align-center">
-    <asset-icon
-      size="32px"
-      :identifier="createEvmIdentifierFromAddress(asset.tokenAddress)"
-    />
+  <div class="defi-asset d-flex flex-row align-center py-4">
+    <asset-icon size="32px" :identifier="evmIdentifier" />
     <span class="ml-3">{{ asset.tokenSymbol }}</span>
     <v-spacer />
     <div class="d-flex flex-column align-end">
-      <amount-display
-        :asset-padding="assetPadding"
-        :value="asset.balance.amount"
-        class="defi-asset__amount font-weight-medium"
-      />
-      <amount-display
-        :asset-padding="assetPadding"
-        :value="asset.balance.usdValue"
-        fiat-currency="USD"
-      />
+      <balance-display no-icon :asset="evmIdentifier" :value="asset.balance" />
     </div>
   </div>
 </template>

--- a/frontend/app/src/components/defi/DefiSelectorItem.vue
+++ b/frontend/app/src/components/defi/DefiSelectorItem.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { type DefiProtocol } from '@rotki/common/lib/blockchain';
 import { type PropType } from 'vue';
-import { useSessionSettingsStore } from '@/store/settings/session';
 
 interface DefiProtocolInfo {
   readonly identifier: string;
+  readonly label?: string;
   readonly protocol: DefiProtocol;
 }
 
@@ -12,25 +12,9 @@ const props = defineProps({
   item: { required: true, type: Object as PropType<DefiProtocolInfo> }
 });
 const { item } = toRefs(props);
-const { scrambleData } = storeToRefs(useSessionSettingsStore());
 
-const getIcon = ({ protocol }: DefiProtocolInfo): string => {
-  return protocol.startsWith('makerdao') ? 'makerdao' : protocol;
-};
-
-const { t } = useI18n();
-
-const identifier = computed<string>(() => {
-  const { identifier } = get(item);
-  if (get(scrambleData)) {
-    if (Number.parseInt(identifier)) {
-      return t('defi_selector_item.vault').toString();
-    } else if (identifier.includes('-')) {
-      return identifier.split('-')[0];
-    }
-  }
-  return identifier;
-});
+const getIcon = ({ protocol }: DefiProtocolInfo): string =>
+  protocol.startsWith('makerdao') ? 'makerdao' : protocol;
 </script>
 <template>
   <div class="d-flex flex-row align-center">
@@ -42,6 +26,6 @@ const identifier = computed<string>(() => {
       max-height="24px"
       :src="`./assets/images/defi/${getIcon(item)}.svg`"
     />
-    <span class="ml-2">{{ identifier }}</span>
+    <span class="ml-2">{{ item.label ?? item.identifier }}</span>
   </div>
 </template>

--- a/frontend/app/src/components/defi/loan/loans/LiquityLending.vue
+++ b/frontend/app/src/components/defi/loan/loans/LiquityLending.vue
@@ -7,7 +7,6 @@ import LoanHeader from '@/components/defi/loan/LoanHeader.vue';
 import LiquityCollateral from '@/components/defi/loan/loans/liquity/LiquityCollateral.vue';
 import LiquityLiquidation from '@/components/defi/loan/loans/liquity/LiquityLiquidation.vue';
 import PremiumCard from '@/components/display/PremiumCard.vue';
-
 import { type LiquityLoan } from '@/store/defi/liquity/types';
 import {
   HistoryEventType,
@@ -34,13 +33,19 @@ const liquidationPrice: ComputedRef<BigNumber | null> = computed(
 );
 const premium = usePremium();
 const { tc } = useI18n();
+
+const { scrambleIdentifier } = useScramble();
 </script>
 
 <template>
   <v-row>
     <v-col cols="12">
       <loan-header class="mt-8 mb-6" :owner="loan.owner">
-        {{ tc('liquity_lending.header', 0, { troveId: loan.balance.troveId }) }}
+        {{
+          tc('liquity_lending.header', 0, {
+            troveId: scrambleIdentifier(loan.balance.troveId)
+          })
+        }}
       </loan-header>
       <v-row no-gutters>
         <v-col cols="12" md="6" class="pe-md-4">

--- a/frontend/app/src/components/defi/loan/loans/MakerDaoVaultLoan.vue
+++ b/frontend/app/src/components/defi/loan/loans/MakerDaoVaultLoan.vue
@@ -7,10 +7,8 @@ import MakerDaoVaultCollateral from '@/components/defi/loan/loans/makerdao/Maker
 import MakerDaoVaultDebtDetails from '@/components/defi/loan/loans/makerdao/MakerDaoVaultDebtDetails.vue';
 import MakerDaoVaultLiquidation from '@/components/defi/loan/loans/makerdao/MakerDaoVaultLiquidation.vue';
 import PremiumCard from '@/components/display/PremiumCard.vue';
-
 import { VaultEventsList } from '@/premium/premium';
 import { usePremiumStore } from '@/store/session/premium';
-import { useSessionSettingsStore } from '@/store/settings/session';
 import {
   type MakerDAOVaultEvent,
   type MakerDAOVaultModel
@@ -25,7 +23,6 @@ const props = defineProps({
 });
 
 const { vault } = toRefs(props);
-const { scrambleData } = storeToRefs(useSessionSettingsStore());
 const { premium } = storeToRefs(usePremiumStore());
 const { openUrl } = useInterop();
 const { tc } = useI18n();
@@ -58,10 +55,12 @@ const creation = computed(() => {
   return undefined;
 });
 
+const { scrambleIdentifier } = useScramble();
+
 const header = computed(() => {
   const makerVault = get(vault);
   return {
-    identifier: get(scrambleData) ? '-' : makerVault.identifier,
+    identifier: scrambleIdentifier(makerVault.identifier),
     collateralType: makerVault.collateralType
   };
 });

--- a/frontend/app/src/components/display/AccountDisplay.vue
+++ b/frontend/app/src/components/display/AccountDisplay.vue
@@ -29,9 +29,6 @@ const { addressNameSelector } = useAddressesNamesStore();
 
 const address = computed<string>(() => {
   const address = get(account).address;
-  if (!get(scrambleData)) {
-    return address;
-  }
   return scrambleHex(address);
 });
 

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -28,9 +28,6 @@ const smAndDown = computed(() => get(currentBreakpoint).smAndDown);
 
 const address = computed<string>(() => {
   const address = get(account).address;
-  if (!get(scrambleData)) {
-    return address;
-  }
   return scrambleHex(address);
 });
 

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -56,10 +56,6 @@ const aliasName = computed<string | null>(() => {
 
 const displayText = computed<string>(() => {
   const textVal = get(text);
-  if (!get(scrambleData)) {
-    return textVal;
-  }
-
   return scrambleHex(textVal);
 });
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1698,9 +1698,6 @@
     "filter_specific": "Showing results for selected protocol",
     "label": "Filter protocol(s)"
   },
-  "defi_selector_item": {
-    "vault": "Maker Vault"
-  },
   "defi_wizard": {
     "steps": {
       "select_accounts": {

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -1634,9 +1634,6 @@
     "filter_specific": "Showing results for selected protocol",
     "label": "Filter protocol(s)"
   },
-  "defi_selector_item": {
-    "vault": "Maker Vault"
-  },
   "defi_wizard": {
     "steps": {
       "select_accounts": {

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -1640,9 +1640,6 @@
     "filter_specific": "Showing results for selected protocol",
     "label": "Filter protocol(s)"
   },
-  "defi_selector_item": {
-    "vault": "Maker Vault"
-  },
   "defi_wizard": {
     "steps": {
       "select_accounts": {

--- a/frontend/app/src/types/defi/index.ts
+++ b/frontend/app/src/types/defi/index.ts
@@ -12,6 +12,7 @@ export interface CollateralizedLoan<C extends Collateral | Collateral[]>
 
 export interface DefiLoan {
   readonly identifier: string;
+  readonly label?: string;
   readonly protocol: DefiProtocol;
   readonly asset?: string;
   readonly owner?: string;


### PR DESCRIPTION
Closes #5813 

## Checklist

- [x] Fix address not scrambled in trove liquity section
- [x] Also scramble the trove id
- [x] Show percentage in ETH breakdown in dashboard asset table


Use this to test `0xDdFE74f671F6546F49A6D20909999cFE5F09Ad78`
