### PR TITLE
Fix curve inquirer

### DIFF
--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -75,7 +75,7 @@ from rotkehlchen.externalapis.xratescom import (
     get_historical_xratescom_exchange_rates,
 )
 from rotkehlchen.fval import FVal
-from rotkehlchen.globaldb.cache import globaldb_get_general_cache_values
+from rotkehlchen.globaldb.cache import globaldb_get_general_cache_values, read_curve_data
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
 from rotkehlchen.interfaces import CurrentPriceOracleInterface
@@ -789,10 +789,7 @@ class Inquirer():
                 return None
             # pool address is guaranteed to be checksumed due to how we save it
             pool_address = string_to_evm_address(pool_addresses_in_cache[0])
-            pool_tokens_addresses = globaldb_get_general_cache_values(
-                cursor=cursor,
-                key_parts=[GeneralCacheType.CURVE_POOL_TOKENS, pool_address],
-            )
+            pool_tokens_addresses = read_curve_data(cursor=cursor, pool_address=pool_address)
 
         tokens: list[EvmToken] = []
         # Translate addresses to tokens

--- a/rotkehlchen/tests/unit/test_general_cache.py
+++ b/rotkehlchen/tests/unit/test_general_cache.py
@@ -4,13 +4,13 @@ from unittest.mock import patch
 
 import pytest
 from freezegun import freeze_time
-from rotkehlchen.chain.ethereum.modules.curve.curve_cache import read_curve_data
 
 from rotkehlchen.constants.timing import WEEK_IN_SECONDS
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.globaldb.cache import (
     globaldb_get_general_cache_values,
     globaldb_set_general_cache_values,
+    read_curve_data,
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.types import ChainID, GeneralCacheType

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -360,11 +360,13 @@ def test_find_curve_lp_token_price(inquirer_defi, ethereum_manager):
         )
         globaldb_set_general_cache_values(
             write_cursor=write_cursor,
-            key_parts=[GeneralCacheType.CURVE_POOL_TOKENS, pool_address],
-            values=[
-                '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-                '0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb',
-            ],
+            key_parts=[GeneralCacheType.CURVE_POOL_TOKENS, pool_address, '0'],
+            values=['0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'],
+        )
+        globaldb_set_general_cache_values(
+            write_cursor=write_cursor,
+            key_parts=[GeneralCacheType.CURVE_POOL_TOKENS, pool_address, '1'],
+            values=['0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb'],
         )
     price = inquirer_defi.find_curve_pool_price(EvmToken(identifier))
     assert price is not None


### PR DESCRIPTION
The issue that this PR fixes was that method in our Inquirer that queries price for a curve lp token used old curve pool tokens schema (so unindexed/unordered tokens). This was not working.

Also to solve circular import that popped up after the fix I moved `read_curve_data` function to globaldb/cache.py