### PR TITLE
ci: moves permissions to upper level

### DIFF
--- a/.github/workflows/rotki_cassette_merge.yml
+++ b/.github/workflows/rotki_cassette_merge.yml
@@ -5,12 +5,13 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   merge:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - uses: rotki/action-cassette-deck@v1
         with:


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
