### PR TITLE
Refactor pagination filters for binance savings

### DIFF
--- a/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
+++ b/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
@@ -1,16 +1,10 @@
 <script setup lang="ts">
 import { type PropType, type Ref } from 'vue';
 import { type DataTableHeader } from 'vuetify';
-import { type Collection } from '@/types/collection';
-import { defaultCollectionState } from '@/utils/collection';
-import { useEmptyFilter } from '@/composables/filters';
 import { type ActionStatus } from '@/types/action';
 import { type IgnoredAssetsHandlingType } from '@/types/asset';
 import { type Module } from '@/types/modules';
-import {
-  type NonFungibleBalance,
-  type NonFungibleBalancesRequestPayload
-} from '@/types/nfbalances';
+import { type NonFungibleBalance } from '@/types/nfbalances';
 import { type ManualPriceFormPayload } from '@/types/prices';
 import { Section } from '@/types/status';
 import { assert } from '@/utils/assertions';
@@ -187,17 +181,11 @@ const {
   options,
   setPage,
   setOptions
-} = useHistoryPaginationFilter<
-  NonFungibleBalance,
-  NonFungibleBalancesRequestPayload,
-  NonFungibleBalance,
-  Collection<NonFungibleBalance>
->(
+} = useHistoryPaginationFilter<NonFungibleBalance>(
   null,
   true,
   useEmptyFilter,
   fetchNonFungibleBalances,
-  defaultCollectionState,
   {
     onUpdateFilters(query) {
       set(ignoredAssetsHandling, query.ignoredAssetsHandling || 'exclude');

--- a/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
+++ b/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { type PropType, type Ref } from 'vue';
 import { type DataTableHeader } from 'vuetify';
+import { type Collection } from '@/types/collection';
+import { defaultCollectionState } from '@/utils/collection';
 import { useEmptyFilter } from '@/composables/filters';
 import { type ActionStatus } from '@/types/action';
 import { type IgnoredAssetsHandlingType } from '@/types/asset';
@@ -188,18 +190,26 @@ const {
 } = useHistoryPaginationFilter<
   NonFungibleBalance,
   NonFungibleBalancesRequestPayload,
-  NonFungibleBalance
->(null, true, useEmptyFilter, fetchNonFungibleBalances, {
-  onUpdateFilters(query) {
-    set(ignoredAssetsHandling, query.ignoredAssetsHandling || 'exclude');
-  },
-  extraParams,
-  defaultSortBy: {
-    pagination: 'name',
-    pageParams: ['name'],
-    pageParamsAsc: [true]
+  NonFungibleBalance,
+  Collection<NonFungibleBalance>
+>(
+  null,
+  true,
+  useEmptyFilter,
+  fetchNonFungibleBalances,
+  defaultCollectionState,
+  {
+    onUpdateFilters(query) {
+      set(ignoredAssetsHandling, query.ignoredAssetsHandling || 'exclude');
+    },
+    extraParams,
+    defaultSortBy: {
+      pagination: 'name',
+      pageParams: ['name'],
+      pageParamsAsc: [true]
+    }
   }
-});
+);
 
 onMounted(async () => {
   await fetchData();

--- a/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
+++ b/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { type DataTableHeader } from 'vuetify';
-import { useEmptyFilter } from '@/composables/filters';
 import { CURRENCY_USD } from '@/types/currencies';
 import {
   type ExchangeSavingsCollection,
@@ -47,19 +46,13 @@ const {
   ExchangeSavingsRequestPayload,
   ExchangeSavingsEvent,
   ExchangeSavingsCollection
->(
-  exchange,
-  true,
-  useEmptyFilter,
-  fetchExchangeSavings,
-  defaultCollectionState,
-  {
-    defaultSortBy: {
-      pageParamsAsc: [true]
-    },
-    extraParams
-  }
-);
+>(exchange, true, useEmptyFilter, fetchExchangeSavings, {
+  defaultCollection: defaultCollectionState,
+  defaultSortBy: {
+    pageParamsAsc: [true]
+  },
+  extraParams
+});
 
 watch(loading, async (isLoading, wasLoading) => {
   if (!isLoading && wasLoading) {

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { type DataTableHeader } from 'vuetify';
 import { type Collection } from '@/types/collection';
-import { defaultCollectionState } from '@/utils/collection';
 import { Routes } from '@/router/routes';
 import {
   type AssetMovement,
@@ -102,13 +101,7 @@ const {
   Collection<AssetMovementEntry>,
   Filters,
   Matcher
->(
-  locationOverview,
-  mainPage,
-  useAssetMovementFilters,
-  fetchAssetMovements,
-  defaultCollectionState
-);
+>(locationOverview, mainPage, useAssetMovementFilters, fetchAssetMovements);
 
 useHistoryAutoRefresh(fetchData);
 

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { type DataTableHeader } from 'vuetify';
+import { type Collection } from '@/types/collection';
+import { defaultCollectionState } from '@/utils/collection';
 import { Routes } from '@/router/routes';
 import {
   type AssetMovement,
@@ -97,9 +99,16 @@ const {
   AssetMovement,
   AssetMovementRequestPayload,
   AssetMovementEntry,
+  Collection<AssetMovementEntry>,
   Filters,
   Matcher
->(locationOverview, mainPage, useAssetMovementFilters, fetchAssetMovements);
+>(
+  locationOverview,
+  mainPage,
+  useAssetMovementFilters,
+  fetchAssetMovements,
+  defaultCollectionState
+);
 
 useHistoryAutoRefresh(fetchData);
 

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { type DataTableHeader } from 'vuetify';
+import { type Collection } from '@/types/collection';
+import { defaultCollectionState } from '@/utils/collection';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
 import { type TradeLocation } from '@/types/history/trade/location';
@@ -103,9 +105,16 @@ const {
   LedgerAction,
   LedgerActionRequestPayload,
   LedgerActionEntry,
+  Collection<LedgerActionEntry>,
   Filters,
   Matcher
->(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
+>(
+  locationOverview,
+  mainPage,
+  useLedgerActionsFilter,
+  fetchLedgerActions,
+  defaultCollectionState
+);
 
 const newLedgerAction = () => {
   set(editableItem, null);

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { type DataTableHeader } from 'vuetify';
 import { type Collection } from '@/types/collection';
-import { defaultCollectionState } from '@/utils/collection';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
 import { type TradeLocation } from '@/types/history/trade/location';
@@ -108,13 +107,7 @@ const {
   Collection<LedgerActionEntry>,
   Filters,
   Matcher
->(
-  locationOverview,
-  mainPage,
-  useLedgerActionsFilter,
-  fetchLedgerActions,
-  defaultCollectionState
-);
+>(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
 
 const newLedgerAction = () => {
   set(editableItem, null);

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -2,7 +2,6 @@
 import { type Ref } from 'vue';
 import { type DataTableHeader } from 'vuetify';
 import { type Collection } from '@/types/collection';
-import { defaultCollectionState } from '@/utils/collection';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
 import { type TradeLocation } from '@/types/history/trade/location';
@@ -142,19 +141,12 @@ const {
   Collection<TradeEntry>,
   Filters,
   Matcher
->(
-  locationOverview,
-  mainPage,
-  useTradeFilters,
-  fetchTrades,
-  defaultCollectionState,
-  {
-    onUpdateFilters(query) {
-      set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
-    },
-    extraParams
-  }
-);
+>(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+  onUpdateFilters(query) {
+    set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
+  },
+  extraParams
+});
 
 useHistoryAutoRefresh(fetchData);
 

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { type Ref } from 'vue';
 import { type DataTableHeader } from 'vuetify';
+import { type Collection } from '@/types/collection';
+import { defaultCollectionState } from '@/utils/collection';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
 import { type TradeLocation } from '@/types/history/trade/location';
@@ -137,14 +139,22 @@ const {
   Trade,
   TradeRequestPayload,
   TradeEntry,
+  Collection<TradeEntry>,
   Filters,
   Matcher
->(locationOverview, mainPage, useTradeFilters, fetchTrades, {
-  onUpdateFilters(query) {
-    set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
-  },
-  extraParams
-});
+>(
+  locationOverview,
+  mainPage,
+  useTradeFilters,
+  fetchTrades,
+  defaultCollectionState,
+  {
+    onUpdateFilters(query) {
+      set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
+    },
+    extraParams
+  }
+);
 
 useHistoryAutoRefresh(fetchData);
 

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -12,6 +12,7 @@ import {
 import isEqual from 'lodash/isEqual';
 import { type ComputedRef, type Ref } from 'vue';
 import { type DataTableHeader } from 'vuetify';
+import { type Collection } from '@/types/collection';
 import { SavedFilterLocation } from '@/types/filtering';
 import { IgnoreActionType } from '@/types/history/ignored';
 import {
@@ -24,7 +25,7 @@ import {
 import { RouterAccountsSchema } from '@/types/route';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
-import { getCollectionData } from '@/utils/collection';
+import { defaultCollectionState, getCollectionData } from '@/utils/collection';
 import type { Filters, Matcher } from '@/composables/filters/transactions';
 
 const props = withDefaults(
@@ -169,6 +170,7 @@ const {
   EthTransaction,
   TransactionRequestPayload,
   EthTransactionEntry,
+  Collection<EthTransactionEntry>,
   Filters,
   Matcher
 >(
@@ -176,6 +178,7 @@ const {
   mainPage,
   () => useTransactionFilter(get(protocols).length > 0),
   fetchTransactions,
+  defaultCollectionState,
   {
     onUpdateFilters(query) {
       const parsedAccounts = RouterAccountsSchema.parse(query);

--- a/frontend/app/src/components/history/transactions/TransactionContent.vue
+++ b/frontend/app/src/components/history/transactions/TransactionContent.vue
@@ -25,7 +25,7 @@ import {
 import { RouterAccountsSchema } from '@/types/route';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
-import { defaultCollectionState, getCollectionData } from '@/utils/collection';
+import { getCollectionData } from '@/utils/collection';
 import type { Filters, Matcher } from '@/composables/filters/transactions';
 
 const props = withDefaults(
@@ -178,7 +178,6 @@ const {
   mainPage,
   () => useTransactionFilter(get(protocols).length > 0),
   fetchTransactions,
-  defaultCollectionState,
   {
     onUpdateFilters(query) {
       const parsedAccounts = RouterAccountsSchema.parse(query);

--- a/frontend/app/tests/unit/fixtures/binance-savings.json
+++ b/frontend/app/tests/unit/fixtures/binance-savings.json
@@ -1,0 +1,97 @@
+{
+  "result": {
+    "entries": [
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670895975,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0012292140"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670809568,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0012807872"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670723131,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0013056020"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670636721,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0012947992"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670550371,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0013086304"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670463935,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0012825500"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670377528,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0013090372"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670291151,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.0013097152"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670204715,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.00133676740"
+      },
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "timestamp": 1670118314,
+        "location": "binance",
+        "amount": "0.00000452",
+        "usd_value": "0.00132013380"
+      }
+    ],
+    "entries_found": 260,
+    "entries_limit": -1,
+    "entries_total": 260,
+    "total_usd_value": "0.6206537810999999",
+    "assets": [
+      "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52"
+    ],
+    "received": [
+      {
+        "asset": "eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        "amount": "0.0010938400000000052",
+        "usd_value": "0.31907988540000004"
+      },
+      {
+        "asset": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        "amount": "0.301378",
+        "usd_value": "0.30157389570000004"
+      }
+    ]
+  },
+  "message": ""
+}

--- a/frontend/app/tests/unit/setup-files/handlers/binance-savings.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/binance-savings.ts
@@ -1,0 +1,10 @@
+import { rest } from 'msw';
+import binanceSavings from '../../fixtures/binance-savings.json';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+
+export default [
+  rest.post(`${backendUrl}/api/1/exchanges/binance/savings`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(binanceSavings))
+  )
+];

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -8,13 +8,15 @@ import assetMovementHandlers from './handlers/asset-movements';
 import ledgerActionHandlers from './handlers/ledger-actions';
 import transactionHandlers from './handlers/evm-transactions';
 import nfts from './handlers/nfts';
+import binanceSavings from './handlers/binance-savings';
 
 const server = setupServer(
   ...tradeHandlers,
   ...assetMovementHandlers,
   ...ledgerActionHandlers,
   ...transactionHandlers,
-  ...nfts
+  ...nfts,
+  ...binanceSavings
 );
 
 beforeAll(() => {

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -22,7 +22,9 @@ const server = setupServer(
 beforeAll(() => {
   Vue.use(Vuetify);
   Vue.use(PiniaVuePlugin);
-  server.listen();
+  server.listen({
+    onUnhandledRequest: 'bypass'
+  });
 
   vi.mock('@/composables/api/assets/info', () => ({
     useAssetInfoApi: vi.fn().mockReturnValue({

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
@@ -1,0 +1,198 @@
+import { type MaybeRef } from '@vueuse/shared';
+import flushPromises from 'flush-promises';
+import { type Ref } from 'vue';
+import { Zero } from '@/utils/bignumbers';
+import {
+  type ExchangeSavingsCollection,
+  type ExchangeSavingsEvent,
+  type ExchangeSavingsRequestPayload,
+  SupportedExchange
+} from '@/types/exchanges';
+import { useEmptyFilter } from '@/composables/filters';
+import type Vue from 'vue';
+
+vi.mock('vue-router/composables', () => ({
+  useRoute: vi.fn().mockReturnValue(
+    reactive({
+      query: {}
+    })
+  ),
+  useRouter: vi.fn().mockReturnValue({
+    push: vi.fn(({ query }) => {
+      useRoute().query = query;
+      return true;
+    })
+  })
+}));
+
+vi.mock('vue', async () => {
+  const mod = await vi.importActual<Vue>('vue');
+
+  return {
+    ...mod,
+    onBeforeMount: vi.fn()
+  };
+});
+
+describe('composables::history/filter-paginate', () => {
+  let fetchExchangeSavings: (
+    payload: MaybeRef<ExchangeSavingsRequestPayload>
+  ) => Promise<ExchangeSavingsCollection>;
+  const exchange: MaybeRef<SupportedExchange> = ref(SupportedExchange.BINANCE);
+  const mainPage: Ref<boolean> = ref(false);
+  const router = useRouter();
+  const route = useRoute();
+
+  beforeAll(() => {
+    setActivePinia(createPinia());
+    fetchExchangeSavings = useExchangeBalancesStore().fetchExchangeSavings;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('components::exchanges/BinanceSavingDetail.vue', () => {
+    const extraParams = computed(() => ({
+      location: get(exchange).toString()
+    }));
+
+    const defaultCollectionState = (): ExchangeSavingsCollection => ({
+      found: 0,
+      limit: 0,
+      data: [],
+      total: 0,
+      totalUsdValue: Zero,
+      assets: [],
+      received: []
+    });
+
+    beforeEach(() => {
+      set(mainPage, true);
+    });
+
+    test('initialize composable correctly', async () => {
+      const {
+        userAction,
+        filters,
+        options,
+        state,
+        fetchData,
+        applyRouteFilter,
+        isLoading
+      } = useHistoryPaginationFilter<
+        ExchangeSavingsEvent,
+        ExchangeSavingsRequestPayload,
+        ExchangeSavingsEvent,
+        ExchangeSavingsCollection
+      >(
+        exchange,
+        mainPage,
+        useEmptyFilter,
+        fetchExchangeSavings,
+        defaultCollectionState,
+        {
+          extraParams,
+          defaultSortBy: {
+            pageParamsAsc: [true]
+          }
+        }
+      );
+
+      expect(get(userAction)).toBe(false);
+      expect(get(isLoading)).toBe(false);
+      expect(get(filters)).to.toStrictEqual(undefined);
+      expect(get(options).sortBy[0]).toEqual('timestamp');
+      expect(get(options).sortDesc[0]).toEqual(true);
+      expect(get(options).sortBy).toHaveLength(1);
+      expect(get(options).sortDesc).toHaveLength(1);
+      expect(get(state).data).toHaveLength(0);
+      expect(get(state).assets).toHaveLength(0);
+      expect(get(state).received).toHaveLength(0);
+      expect(get(state).total).toEqual(0);
+
+      set(userAction, true);
+      applyRouteFilter();
+      fetchData().catch(() => {});
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(isLoading)).toBe(false);
+      expect(get(state).total).toEqual(260);
+    });
+
+    test('check the return types', async () => {
+      const { isLoading, state, filters, matchers } =
+        useHistoryPaginationFilter<
+          ExchangeSavingsEvent,
+          ExchangeSavingsRequestPayload,
+          ExchangeSavingsEvent,
+          ExchangeSavingsCollection
+        >(
+          exchange,
+          mainPage,
+          useEmptyFilter,
+          fetchExchangeSavings,
+          defaultCollectionState,
+          {
+            extraParams,
+            defaultSortBy: {
+              pageParamsAsc: [true]
+            }
+          }
+        );
+
+      expect(get(isLoading)).toBe(false);
+
+      expectTypeOf(get(state)).toEqualTypeOf<ExchangeSavingsCollection>();
+      expectTypeOf(get(state).data).toEqualTypeOf<ExchangeSavingsEvent[]>();
+      expectTypeOf(get(state).found).toEqualTypeOf<number>();
+      expectTypeOf(get(filters)).toEqualTypeOf<undefined>();
+      expectTypeOf(get(matchers)).toEqualTypeOf<undefined[]>();
+    });
+
+    test('modify filters and fetch data correctly', async () => {
+      const pushSpy = vi.spyOn(router, 'push');
+      const query = { sortDesc: ['false'] };
+
+      const { isLoading, state } = useHistoryPaginationFilter<
+        ExchangeSavingsEvent,
+        ExchangeSavingsRequestPayload,
+        ExchangeSavingsEvent,
+        ExchangeSavingsCollection
+      >(
+        exchange,
+        mainPage,
+        useEmptyFilter,
+        fetchExchangeSavings,
+        defaultCollectionState,
+        {
+          extraParams,
+          defaultSortBy: {
+            pageParamsAsc: [true]
+          }
+        }
+      );
+
+      await router.push({
+        query
+      });
+
+      expect(pushSpy).toHaveBeenCalledOnce();
+      expect(pushSpy).toHaveBeenCalledWith({ query });
+      expect(route.query).toEqual(query);
+      expect(get(isLoading)).toBe(true);
+      await flushPromises();
+      expect(get(isLoading)).toBe(false);
+
+      assertType<ExchangeSavingsCollection>(get(state));
+      assertType<ExchangeSavingsEvent[]>(get(state).data);
+      assertType<number>(get(state).found);
+
+      expect(get(state).data).toHaveLength(10);
+      expect(get(state).assets).toHaveLength(2);
+      expect(get(state).received).toHaveLength(2);
+      expect(get(state).found).toEqual(260);
+      expect(get(state).total).toEqual(260);
+    });
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
@@ -8,7 +8,6 @@ import {
   type ExchangeSavingsRequestPayload,
   SupportedExchange
 } from '@/types/exchanges';
-import { useEmptyFilter } from '@/composables/filters';
 import type Vue from 'vue';
 
 vi.mock('vue-router/composables', () => ({
@@ -85,19 +84,13 @@ describe('composables::history/filter-paginate', () => {
         ExchangeSavingsRequestPayload,
         ExchangeSavingsEvent,
         ExchangeSavingsCollection
-      >(
-        exchange,
-        mainPage,
-        useEmptyFilter,
-        fetchExchangeSavings,
-        defaultCollectionState,
-        {
-          extraParams,
-          defaultSortBy: {
-            pageParamsAsc: [true]
-          }
+      >(exchange, mainPage, useEmptyFilter, fetchExchangeSavings, {
+        defaultCollection: defaultCollectionState,
+        extraParams,
+        defaultSortBy: {
+          pageParamsAsc: [true]
         }
-      );
+      });
 
       expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
@@ -127,19 +120,13 @@ describe('composables::history/filter-paginate', () => {
           ExchangeSavingsRequestPayload,
           ExchangeSavingsEvent,
           ExchangeSavingsCollection
-        >(
-          exchange,
-          mainPage,
-          useEmptyFilter,
-          fetchExchangeSavings,
-          defaultCollectionState,
-          {
-            extraParams,
-            defaultSortBy: {
-              pageParamsAsc: [true]
-            }
+        >(exchange, mainPage, useEmptyFilter, fetchExchangeSavings, {
+          defaultCollection: defaultCollectionState,
+          extraParams,
+          defaultSortBy: {
+            pageParamsAsc: [true]
           }
-        );
+        });
 
       expect(get(isLoading)).toBe(false);
 
@@ -159,19 +146,13 @@ describe('composables::history/filter-paginate', () => {
         ExchangeSavingsRequestPayload,
         ExchangeSavingsEvent,
         ExchangeSavingsCollection
-      >(
-        exchange,
-        mainPage,
-        useEmptyFilter,
-        fetchExchangeSavings,
-        defaultCollectionState,
-        {
-          extraParams,
-          defaultSortBy: {
-            pageParamsAsc: [true]
-          }
+      >(exchange, mainPage, useEmptyFilter, fetchExchangeSavings, {
+        defaultCollection: defaultCollectionState,
+        extraParams,
+        defaultSortBy: {
+          pageParamsAsc: [true]
         }
-      );
+      });
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
@@ -1,6 +1,7 @@
 import { type MaybeRef } from '@vueuse/shared';
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
+import { defaultCollectionState } from '@/utils/collection';
 import { useEmptyFilter } from '@/composables/filters';
 import { type Collection } from '@/types/collection';
 import {
@@ -80,15 +81,22 @@ describe('composables::history/filter-paginate', () => {
         NonFungibleBalance,
         NonFungibleBalancesRequestPayload,
         NonFungibleBalance
-      >(locationOverview, mainPage, useEmptyFilter, fetchNonFungibleBalances, {
-        onUpdateFilters,
-        extraParams,
-        defaultSortBy: {
-          pagination: 'name',
-          pageParams: ['name'],
-          pageParamsAsc: [true]
+      >(
+        locationOverview,
+        mainPage,
+        useEmptyFilter,
+        fetchNonFungibleBalances,
+        defaultCollectionState,
+        {
+          onUpdateFilters,
+          extraParams,
+          defaultSortBy: {
+            pagination: 'name',
+            pageParams: ['name'],
+            pageParamsAsc: [true]
+          }
         }
-      });
+      );
 
       expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
@@ -119,6 +127,7 @@ describe('composables::history/filter-paginate', () => {
           mainPage,
           useEmptyFilter,
           fetchNonFungibleBalances,
+          defaultCollectionState,
           {
             onUpdateFilters,
             extraParams,
@@ -147,15 +156,22 @@ describe('composables::history/filter-paginate', () => {
         NonFungibleBalance,
         NonFungibleBalancesRequestPayload,
         NonFungibleBalance
-      >(locationOverview, mainPage, useEmptyFilter, fetchNonFungibleBalances, {
-        onUpdateFilters,
-        extraParams,
-        defaultSortBy: {
-          pagination: 'name',
-          pageParams: ['name'],
-          pageParamsAsc: [true]
+      >(
+        locationOverview,
+        mainPage,
+        useEmptyFilter,
+        fetchNonFungibleBalances,
+        defaultCollectionState,
+        {
+          onUpdateFilters,
+          extraParams,
+          defaultSortBy: {
+            pagination: 'name',
+            pageParams: ['name'],
+            pageParamsAsc: [true]
+          }
         }
-      });
+      );
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
@@ -1,8 +1,6 @@
 import { type MaybeRef } from '@vueuse/shared';
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
-import { defaultCollectionState } from '@/utils/collection';
-import { useEmptyFilter } from '@/composables/filters';
 import { type Collection } from '@/types/collection';
 import {
   type NonFungibleBalance,
@@ -77,16 +75,11 @@ describe('composables::history/filter-paginate', () => {
         fetchData,
         applyRouteFilter,
         isLoading
-      } = useHistoryPaginationFilter<
-        NonFungibleBalance,
-        NonFungibleBalancesRequestPayload,
-        NonFungibleBalance
-      >(
+      } = useHistoryPaginationFilter<NonFungibleBalance>(
         locationOverview,
         mainPage,
         useEmptyFilter,
         fetchNonFungibleBalances,
-        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,
@@ -118,16 +111,11 @@ describe('composables::history/filter-paginate', () => {
 
     test('check the return types', async () => {
       const { isLoading, state, filters, matchers } =
-        useHistoryPaginationFilter<
-          NonFungibleBalance,
-          NonFungibleBalancesRequestPayload,
-          NonFungibleBalance
-        >(
+        useHistoryPaginationFilter<NonFungibleBalance>(
           locationOverview,
           mainPage,
           useEmptyFilter,
           fetchNonFungibleBalances,
-          defaultCollectionState,
           {
             onUpdateFilters,
             extraParams,
@@ -152,26 +140,22 @@ describe('composables::history/filter-paginate', () => {
       const pushSpy = vi.spyOn(router, 'push');
       const query = { sortDesc: ['false'] };
 
-      const { isLoading, state } = useHistoryPaginationFilter<
-        NonFungibleBalance,
-        NonFungibleBalancesRequestPayload,
-        NonFungibleBalance
-      >(
-        locationOverview,
-        mainPage,
-        useEmptyFilter,
-        fetchNonFungibleBalances,
-        defaultCollectionState,
-        {
-          onUpdateFilters,
-          extraParams,
-          defaultSortBy: {
-            pagination: 'name',
-            pageParams: ['name'],
-            pageParamsAsc: [true]
+      const { isLoading, state } =
+        useHistoryPaginationFilter<NonFungibleBalance>(
+          locationOverview,
+          mainPage,
+          useEmptyFilter,
+          fetchNonFungibleBalances,
+          {
+            onUpdateFilters,
+            extraParams,
+            defaultSortBy: {
+              pagination: 'name',
+              pageParams: ['name'],
+              pageParamsAsc: [true]
+            }
           }
-        }
-      );
+        );
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
@@ -1,5 +1,6 @@
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
+import { defaultCollectionState } from '@/utils/collection';
 import type { Filters, Matcher } from '@/composables/filters/asset-movement';
 import type { Collection } from '@/types/collection';
 import type {
@@ -71,13 +72,15 @@ describe('composables::history/filter-paginate', () => {
         AssetMovement,
         AssetMovementRequestPayload,
         AssetMovementEntry,
+        Collection<AssetMovementEntry>,
         Filters,
         Matcher
       >(
         locationOverview,
         mainPage,
         useAssetMovementFilters,
-        fetchAssetMovements
+        fetchAssetMovements,
+        defaultCollectionState
       );
 
       expect(get(userAction)).toBe(false);
@@ -102,13 +105,15 @@ describe('composables::history/filter-paginate', () => {
           AssetMovement,
           AssetMovementRequestPayload,
           AssetMovementEntry,
+          Collection<AssetMovementEntry>,
           Filters,
           Matcher
         >(
           locationOverview,
           mainPage,
           useAssetMovementFilters,
-          fetchAssetMovements
+          fetchAssetMovements,
+          defaultCollectionState
         );
 
       expect(get(isLoading)).toBe(false);
@@ -128,13 +133,15 @@ describe('composables::history/filter-paginate', () => {
         AssetMovement,
         AssetMovementRequestPayload,
         AssetMovementEntry,
+        Collection<AssetMovementEntry>,
         Filters,
         Matcher
       >(
         locationOverview,
         mainPage,
         useAssetMovementFilters,
-        fetchAssetMovements
+        fetchAssetMovements,
+        defaultCollectionState
       );
 
       await router.push({

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-asset-movements.spec.ts
@@ -1,6 +1,5 @@
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
-import { defaultCollectionState } from '@/utils/collection';
 import type { Filters, Matcher } from '@/composables/filters/asset-movement';
 import type { Collection } from '@/types/collection';
 import type {
@@ -79,8 +78,7 @@ describe('composables::history/filter-paginate', () => {
         locationOverview,
         mainPage,
         useAssetMovementFilters,
-        fetchAssetMovements,
-        defaultCollectionState
+        fetchAssetMovements
       );
 
       expect(get(userAction)).toBe(false);
@@ -112,8 +110,7 @@ describe('composables::history/filter-paginate', () => {
           locationOverview,
           mainPage,
           useAssetMovementFilters,
-          fetchAssetMovements,
-          defaultCollectionState
+          fetchAssetMovements
         );
 
       expect(get(isLoading)).toBe(false);
@@ -140,8 +137,7 @@ describe('composables::history/filter-paginate', () => {
         locationOverview,
         mainPage,
         useAssetMovementFilters,
-        fetchAssetMovements,
-        defaultCollectionState
+        fetchAssetMovements
       );
 
       await router.push({

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
@@ -1,6 +1,5 @@
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
-import { defaultCollectionState } from '@/utils/collection';
 import type { Filters, Matcher } from '@/composables/filters/ledger-actions';
 import type { Collection } from '@/types/collection';
 import type {
@@ -75,13 +74,7 @@ describe('composables::history/filter-paginate', () => {
         Collection<LedgerActionEntry>,
         Filters,
         Matcher
-      >(
-        locationOverview,
-        mainPage,
-        useLedgerActionsFilter,
-        fetchLedgerActions,
-        defaultCollectionState
-      );
+      >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
 
       expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
@@ -112,8 +105,7 @@ describe('composables::history/filter-paginate', () => {
           locationOverview,
           mainPage,
           useLedgerActionsFilter,
-          fetchLedgerActions,
-          defaultCollectionState
+          fetchLedgerActions
         );
 
       expect(get(isLoading)).toBe(false);
@@ -136,13 +128,7 @@ describe('composables::history/filter-paginate', () => {
         Collection<LedgerActionEntry>,
         Filters,
         Matcher
-      >(
-        locationOverview,
-        mainPage,
-        useLedgerActionsFilter,
-        fetchLedgerActions,
-        defaultCollectionState
-      );
+      >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-ledger-actions.spec.ts
@@ -1,5 +1,6 @@
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
+import { defaultCollectionState } from '@/utils/collection';
 import type { Filters, Matcher } from '@/composables/filters/ledger-actions';
 import type { Collection } from '@/types/collection';
 import type {
@@ -71,9 +72,16 @@ describe('composables::history/filter-paginate', () => {
         LedgerAction,
         LedgerActionRequestPayload,
         LedgerActionEntry,
+        Collection<LedgerActionEntry>,
         Filters,
         Matcher
-      >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
+      >(
+        locationOverview,
+        mainPage,
+        useLedgerActionsFilter,
+        fetchLedgerActions,
+        defaultCollectionState
+      );
 
       expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
@@ -97,13 +105,15 @@ describe('composables::history/filter-paginate', () => {
           LedgerAction,
           LedgerActionRequestPayload,
           LedgerActionEntry,
+          Collection<LedgerActionEntry>,
           Filters,
           Matcher
         >(
           locationOverview,
           mainPage,
           useLedgerActionsFilter,
-          fetchLedgerActions
+          fetchLedgerActions,
+          defaultCollectionState
         );
 
       expect(get(isLoading)).toBe(false);
@@ -123,9 +133,16 @@ describe('composables::history/filter-paginate', () => {
         LedgerAction,
         LedgerActionRequestPayload,
         LedgerActionEntry,
+        Collection<LedgerActionEntry>,
         Filters,
         Matcher
-      >(locationOverview, mainPage, useLedgerActionsFilter, fetchLedgerActions);
+      >(
+        locationOverview,
+        mainPage,
+        useLedgerActionsFilter,
+        fetchLedgerActions,
+        defaultCollectionState
+      );
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
@@ -1,7 +1,6 @@
 import { type MaybeRef } from '@vueuse/shared';
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
-import { defaultCollectionState } from '@/utils/collection';
 import { type Collection } from '@/types/collection';
 import { type LocationQuery } from '@/types/route';
 import type { Filters, Matcher } from '@/composables/filters/trades';
@@ -84,17 +83,10 @@ describe('composables::history/filter-paginate', () => {
         Collection<TradeEntry>,
         Filters,
         Matcher
-      >(
-        locationOverview,
-        mainPage,
-        useTradeFilters,
-        fetchTrades,
-        defaultCollectionState,
-        {
-          onUpdateFilters,
-          extraParams
-        }
-      );
+      >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+        onUpdateFilters,
+        extraParams
+      });
 
       expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
@@ -121,17 +113,10 @@ describe('composables::history/filter-paginate', () => {
           Collection<TradeEntry>,
           Filters,
           Matcher
-        >(
-          locationOverview,
-          mainPage,
-          useTradeFilters,
-          fetchTrades,
-          defaultCollectionState,
-          {
-            onUpdateFilters,
-            extraParams
-          }
-        );
+        >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+          onUpdateFilters,
+          extraParams
+        });
 
       expect(get(isLoading)).toBe(false);
 
@@ -153,17 +138,10 @@ describe('composables::history/filter-paginate', () => {
         Collection<TradeEntry>,
         Filters,
         Matcher
-      >(
-        locationOverview,
-        mainPage,
-        useTradeFilters,
-        fetchTrades,
-        defaultCollectionState,
-        {
-          onUpdateFilters,
-          extraParams
-        }
-      );
+      >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
+        onUpdateFilters,
+        extraParams
+      });
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-trades.spec.ts
@@ -1,6 +1,7 @@
 import { type MaybeRef } from '@vueuse/shared';
 import flushPromises from 'flush-promises';
 import { type Ref } from 'vue';
+import { defaultCollectionState } from '@/utils/collection';
 import { type Collection } from '@/types/collection';
 import { type LocationQuery } from '@/types/route';
 import type { Filters, Matcher } from '@/composables/filters/trades';
@@ -80,12 +81,20 @@ describe('composables::history/filter-paginate', () => {
         Trade,
         TradeRequestPayload,
         TradeEntry,
+        Collection<TradeEntry>,
         Filters,
         Matcher
-      >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
-        onUpdateFilters,
-        extraParams
-      });
+      >(
+        locationOverview,
+        mainPage,
+        useTradeFilters,
+        fetchTrades,
+        defaultCollectionState,
+        {
+          onUpdateFilters,
+          extraParams
+        }
+      );
 
       expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
@@ -109,12 +118,20 @@ describe('composables::history/filter-paginate', () => {
           Trade,
           TradeRequestPayload,
           TradeEntry,
+          Collection<TradeEntry>,
           Filters,
           Matcher
-        >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
-          onUpdateFilters,
-          extraParams
-        });
+        >(
+          locationOverview,
+          mainPage,
+          useTradeFilters,
+          fetchTrades,
+          defaultCollectionState,
+          {
+            onUpdateFilters,
+            extraParams
+          }
+        );
 
       expect(get(isLoading)).toBe(false);
 
@@ -133,12 +150,20 @@ describe('composables::history/filter-paginate', () => {
         Trade,
         TradeRequestPayload,
         TradeEntry,
+        Collection<TradeEntry>,
         Filters,
         Matcher
-      >(locationOverview, mainPage, useTradeFilters, fetchTrades, {
-        onUpdateFilters,
-        extraParams
-      });
+      >(
+        locationOverview,
+        mainPage,
+        useTradeFilters,
+        fetchTrades,
+        defaultCollectionState,
+        {
+          onUpdateFilters,
+          extraParams
+        }
+      );
 
       await router.push({
         query

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
@@ -2,7 +2,6 @@ import { Blockchain } from '@rotki/common/lib/blockchain';
 import { TransactionEventProtocol } from '@rotki/common/lib/history/tx-events';
 import flushPromises from 'flush-promises';
 import { type ComputedRef, type Ref } from 'vue';
-import { defaultCollectionState } from '@/utils/collection';
 import { RouterAccountsSchema } from '@/types/route';
 import type { Filters, Matcher } from '@/composables/filters/transactions';
 import type { Collection } from '@/types/collection';
@@ -138,7 +137,6 @@ describe('composables::history/filter-paginate', () => {
         mainPage,
         () => useTransactionFilter(get(protocols).length > 0),
         fetchTransactions,
-        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,
@@ -176,7 +174,6 @@ describe('composables::history/filter-paginate', () => {
           mainPage,
           () => useTransactionFilter(get(protocols).length > 0),
           fetchTransactions,
-          defaultCollectionState,
           {
             onUpdateFilters,
             extraParams,
@@ -209,7 +206,6 @@ describe('composables::history/filter-paginate', () => {
         mainPage,
         () => useTransactionFilter(get(protocols).length > 0),
         fetchTransactions,
-        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,
@@ -263,7 +259,6 @@ describe('composables::history/filter-paginate', () => {
         mainPage,
         () => useTransactionFilter(get(protocols).length > 0),
         fetchTransactions,
-        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
@@ -2,6 +2,7 @@ import { Blockchain } from '@rotki/common/lib/blockchain';
 import { TransactionEventProtocol } from '@rotki/common/lib/history/tx-events';
 import flushPromises from 'flush-promises';
 import { type ComputedRef, type Ref } from 'vue';
+import { defaultCollectionState } from '@/utils/collection';
 import { RouterAccountsSchema } from '@/types/route';
 import type { Filters, Matcher } from '@/composables/filters/transactions';
 import type { Collection } from '@/types/collection';
@@ -129,6 +130,7 @@ describe('composables::history/filter-paginate', () => {
         EthTransaction,
         TransactionRequestPayload,
         EthTransactionEntry,
+        Collection<EthTransactionEntry>,
         Filters,
         Matcher
       >(
@@ -136,6 +138,7 @@ describe('composables::history/filter-paginate', () => {
         mainPage,
         () => useTransactionFilter(get(protocols).length > 0),
         fetchTransactions,
+        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,
@@ -165,6 +168,7 @@ describe('composables::history/filter-paginate', () => {
           EthTransaction,
           TransactionRequestPayload,
           EthTransactionEntry,
+          Collection<EthTransactionEntry>,
           Filters,
           Matcher
         >(
@@ -172,6 +176,7 @@ describe('composables::history/filter-paginate', () => {
           mainPage,
           () => useTransactionFilter(get(protocols).length > 0),
           fetchTransactions,
+          defaultCollectionState,
           {
             onUpdateFilters,
             extraParams,
@@ -196,6 +201,7 @@ describe('composables::history/filter-paginate', () => {
         EthTransaction,
         TransactionRequestPayload,
         EthTransactionEntry,
+        Collection<EthTransactionEntry>,
         Filters,
         Matcher
       >(
@@ -203,6 +209,7 @@ describe('composables::history/filter-paginate', () => {
         mainPage,
         () => useTransactionFilter(get(protocols).length > 0),
         fetchTransactions,
+        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,
@@ -248,6 +255,7 @@ describe('composables::history/filter-paginate', () => {
         EthTransaction,
         TransactionRequestPayload,
         EthTransactionEntry,
+        Collection<EthTransactionEntry>,
         Filters,
         Matcher
       >(
@@ -255,6 +263,7 @@ describe('composables::history/filter-paginate', () => {
         mainPage,
         () => useTransactionFilter(get(protocols).length > 0),
         fetchTransactions,
+        defaultCollectionState,
         {
           onUpdateFilters,
           extraParams,


### PR DESCRIPTION
## Checklist

- [x] extends the pagination/filter composable to allow passing default collection state function
- [x]  The PR modified the frontend, and updated the binance savings balance component to use pagination/filter composable
- [x]  adds unit test for the composable's use case with binance savings