### PR TITLE
Move etherscan missing api key to websockets

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -181,3 +181,23 @@ This also contains two optional, mutually excluse keys. If one exists the other 
 
 - ``seen_tx_hash``: A transaction hash in the same chain as the token in which the token was first seen.
 - ``seen_description``: A description of the action in which the token was first seen and added to the DB. For example, querying curve pools, querying yearn pools etc.
+
+
+Missing API Key
+=======================
+
+Having API keys for some services (such as etherscan) is crucial for rotki to work. So sometimes we might specifically prompt the user to add an API key for a service. In that case we send a websocket message to the frontend.
+
+::
+
+    {
+        "type": "missing_api_key",
+        "data": {
+            "service": "etherscan",
+            "location": "optimism"
+        }
+    }
+
+
+- ``service``: Service for which an API key is needed.
+- ``location``: For services like etherscan that require different API keys for different locations this is the location for which the API key is needed. If a service does not require a location then this key will be missing.

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -19,6 +19,7 @@ class WSMessageType(Enum):
     # Used for when a new token is found and saved via processing evm transactions
     NEW_EVM_TOKEN_DETECTED = auto()
     DATA_MIGRATION_STATUS = auto()
+    MISSING_API_KEY = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
 import gevent
 import requests
+from rotkehlchen.api.websockets.typedefs import WSMessageType
 
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.structures import TimestampOrBlockRange
@@ -187,12 +188,12 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         api_key = self._get_api_key()
         if api_key is None:
             if not self.warning_given:
-                self.msg_aggregator.add_warning(
-                    f'You do not have an {self.chain} Etherscan API key configured. rotki '
-                    f'etherscan queries will still work but will be very slow. '
-                    f'If you are not using your own ethereum node, it is recommended '
-                    f'to go to https://{self.base_url}/register, create an API '
-                    f'key and then input it in the external service credentials setting of rotki',
+                self.msg_aggregator.add_message(
+                    message_type=WSMessageType.MISSING_API_KEY,
+                    data={
+                        'service': ExternalService.ETHERSCAN.serialize(),
+                        'location': self.chain.to_chain_id().to_name(),
+                    },
                 )
                 self.warning_given = True
         else:


### PR DESCRIPTION
Backend aspect of #5611

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
