### PR TITLE
Keep old passphrase if new credentials are invalid

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,7 @@ Changelog
 * :bug:`-` If a premium user changes their rotki password they will now be able to pull remote data without restarting the app.
 * :bug:`-` Now there won't be errors querying balances when an address owning a Makerdao vault is deleted.
 * :bug:`-` Fixed an issue where reports couldn't be exported if there was special characters in notes or assets and the user locale was not compatible.
+* :bug:`-` When users edit exchange credentials, if new credentials are invalid, the old passphrase will now be kept.
 
 * :release:`1.27.1 <2023-02-24>`
 * :feature:`-` Transactions involving Sai CDP migration to Dai CDP are now properly decoded.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -575,7 +575,10 @@ class RestAPI():
 
     def remove_exchange(self, name: str, location: Location) -> Response:
         result: Optional[bool]
-        result, message = self.rotkehlchen.remove_exchange(name=name, location=location)
+        result, message = self.rotkehlchen.exchange_manager.delete_exchange(
+            name=name,
+            location=location,
+        )
         status_code = HTTPStatus.OK
         if not result:
             result = None

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -548,25 +548,19 @@ class RestAPI():
             binance_markets: Optional[list[str]],
             ftx_subaccount: Optional[str],
     ) -> Response:
+        edited, msg = self.rotkehlchen.exchange_manager.edit_exchange(
+            name=name,
+            location=location,
+            new_name=new_name,
+            api_key=api_key,
+            api_secret=api_secret,
+            passphrase=passphrase,
+            kraken_account_type=kraken_account_type,
+            binance_selected_trade_pairs=binance_markets,
+            ftx_subaccount=ftx_subaccount,
+        )
         result: Optional[bool] = True
         status_code = HTTPStatus.OK
-        msg = ''
-        try:
-            edited, msg = self.rotkehlchen.exchange_manager.edit_exchange(
-                name=name,
-                location=location,
-                new_name=new_name,
-                api_key=api_key,
-                api_secret=api_secret,
-                passphrase=passphrase,
-                kraken_account_type=kraken_account_type,
-                binance_selected_trade_pairs=binance_markets,
-                ftx_subaccount=ftx_subaccount,
-            )
-        except InputError as e:
-            edited = False
-            msg = str(e)
-
         if not edited:
             result = None
             status_code = HTTPStatus.CONFLICT

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -35,7 +35,11 @@ from rotkehlchen.exchanges.data_structures import (
     Trade,
     TradeType,
 )
-from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
+from rotkehlchen.exchanges.exchange import (
+    ExchangeInterface,
+    ExchangeQueryBalances,
+    ExchangeWithExtras,
+)
 from rotkehlchen.exchanges.utils import (
     deserialize_asset_movement_address,
     get_key_if_has_val,
@@ -181,7 +185,7 @@ def trade_from_binance(
     )
 
 
-class Binance(ExchangeInterface):
+class Binance(ExchangeInterface, ExchangeWithExtras):
     """This class supports:
       - Binance: when instantiated with default uri, equals BINANCE_BASE_URL.
       - Binance US: when instantiated with uri equals BINANCEUS_BASE_URL.

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -251,27 +251,12 @@ class Binance(ExchangeInterface):
             self.session.headers.update({'X-MBX-APIKEY': credentials.api_key})
         return changed
 
-    def edit_exchange(
-            self,
-            name: Optional[str],
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            **kwargs: Any,
-    ) -> tuple[bool, str]:
-        success, msg = super().edit_exchange(
-            name=name,
-            api_key=api_key,
-            api_secret=api_secret,
-            **kwargs,
-        )
-        if success is False:
-            return success, msg
-
-        binance_markets = kwargs.get(BINANCE_MARKETS_KEY)
+    def edit_exchange_extras(self, extras: dict) -> tuple[bool, str]:
+        binance_markets = extras.get(BINANCE_MARKETS_KEY)
         if binance_markets is None:
-            return success, msg
+            return False, 'No binance markets provided'
 
-        # here we can finally update the account type
+        # now we can update the account type
         self.selected_pairs = binance_markets
         return True, ''
 

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -57,6 +57,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Timestamp,
@@ -244,15 +245,10 @@ class Binance(ExchangeInterface):
 
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
-            self.session.headers.update({'X-MBX-APIKEY': api_key})
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
+            self.session.headers.update({'X-MBX-APIKEY': credentials.api_key})
         return changed
 
     def edit_exchange(

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -32,7 +32,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, Timestamp, TradeType
+from rotkehlchen.types import ApiKey, ApiSecret, ExchangeAuthCredentials, Timestamp, TradeType
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import iso8601ts_to_timestamp
 
@@ -152,15 +152,10 @@ class Bitcoinde(ExchangeInterface):
         self.session.headers.update({'x-api-key': api_key})
         self.msg_aggregator = msg_aggregator
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
-            self.session.headers.update({'x-api-key': api_key})
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
+            self.session.headers.update({'x-api-key': credentials.api_key})
         return changed
 
     def _generate_signature(self, request_type: str, url: str, nonce: str) -> str:

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -47,6 +47,7 @@ from rotkehlchen.types import (
     ApiSecret,
     AssetAmount,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Timestamp,
@@ -139,14 +140,9 @@ class Bitfinex(ExchangeInterface):
         self.msg_aggregator = msg_aggregator
         self.nonce_lock = Semaphore()
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'bfx-apikey': self.api_key})
         return changed
 

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -26,7 +26,15 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount_force_positive,
     deserialize_fee,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, AssetAmount, AssetMovementCategory, Fee, Timestamp
+from rotkehlchen.types import (
+    ApiKey,
+    ApiSecret,
+    AssetAmount,
+    AssetMovementCategory,
+    ExchangeAuthCredentials,
+    Fee,
+    Timestamp,
+)
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import iso8601ts_to_timestamp, satoshis_to_btc
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
@@ -111,15 +119,10 @@ class Bitmex(ExchangeInterface):
         self.msg_aggregator = msg_aggregator
         self.btc = A_BTC.resolve_to_crypto_asset()
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
-            self.session.headers.update({'api-key': api_key})
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
+            self.session.headers.update({'api-key': credentials.api_key})
         return changed
 
     def first_connection(self) -> None:

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -29,7 +29,15 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_int_from_str,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, Fee, Location, Timestamp, TradeType
+from rotkehlchen.types import (
+    ApiKey,
+    ApiSecret,
+    ExchangeAuthCredentials,
+    Fee,
+    Location,
+    Timestamp,
+    TradeType,
+)
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
@@ -121,14 +129,9 @@ class Bitpanda(ExchangeInterface):
 
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'X-API-KEY': self.api_key})
 
         return changed

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -36,7 +36,14 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_int_from_str,
     deserialize_timestamp_from_bitstamp_date,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, AssetAmount, Location, Timestamp
+from rotkehlchen.types import (
+    ApiKey,
+    ApiSecret,
+    AssetAmount,
+    ExchangeAuthCredentials,
+    Location,
+    Timestamp,
+)
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now_in_ms
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
@@ -129,15 +136,10 @@ class Bitstamp(ExchangeInterface):
     def first_connection(self) -> None:
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
-            self.session.headers.update({'X-Auth': f'BITSTAMP {api_key}'})
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
+            self.session.headers.update({'X-Auth': f'BITSTAMP {credentials.api_key}'})
         return changed
 
     @protect_with_lock()

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -36,6 +36,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Price,
@@ -173,14 +174,9 @@ class Bittrex(ExchangeInterface):
     def first_connection(self) -> None:
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'Api-Key': self.api_key})
         return changed
 

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -35,6 +35,7 @@ from rotkehlchen.types import (
     ApiSecret,
     AssetAmount,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Price,
@@ -207,14 +208,9 @@ class Coinbase(ExchangeInterface):
     def first_connection(self) -> None:
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'CB-ACCESS-KEY': self.api_key})
         return changed
 

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -43,6 +43,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Timestamp,
@@ -129,17 +130,12 @@ class Coinbasepro(ExchangeInterface):
     def update_passphrase(self, new_passphrase: str) -> None:
         self.session.headers.update({'CB-ACCESS-PASSPHRASE': new_passphrase})
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'CB-ACCESS-KEY': self.api_key})
-        if passphrase is not None:
-            self.update_passphrase(passphrase)
+        if credentials.passphrase is not None:
+            self.update_passphrase(credentials.passphrase)
 
         return changed
 

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -19,6 +19,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    ExchangeAuthCredentials,
     ExchangeLocationID,
     Location,
     T_ApiKey,

--- a/rotkehlchen/exchanges/ftx.py
+++ b/rotkehlchen/exchanges/ftx.py
@@ -34,6 +34,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Timestamp,
@@ -131,21 +132,15 @@ class Ftx(ExchangeInterface):
     def first_connection(self) -> None:
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({f'{self.base_header_string}-KEY': self.api_key})
-            subaccount = self.db.get_ftx_subaccount(self.name)
-            if subaccount is not None:
+            if credentials.ftx_subaccount is not None:
                 self.session.headers.update(
-                    {f'{self.base_header_string}-SUBACCOUNT': quote(subaccount)},
+                    {f'{self.base_header_string}-SUBACCOUNT': quote(credentials.ftx_subaccount)},
                 )
-                self.subaccount = subaccount
+                self.subaccount = credentials.ftx_subaccount
             else:
                 self.session.headers.pop(f'{self.base_header_string}-SUBACCOUNT', None)
 

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -33,7 +33,15 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, Fee, Location, Timestamp, TradeType
+from rotkehlchen.types import (
+    ApiKey,
+    ApiSecret,
+    ExchangeAuthCredentials,
+    Fee,
+    Location,
+    Timestamp,
+    TradeType,
+)
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now_in_ms
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
@@ -121,14 +129,9 @@ class Gemini(ExchangeInterface):
         self._symbols = self._public_api_query('symbols')
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'X-GEMINI-APIKEY': self.api_key})
 
         return changed

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -108,15 +108,6 @@ class Iconomi(ExchangeInterface):
         self.msg_aggregator = msg_aggregator
         self.aust = A_AUST.resolve_to_asset_with_oracles()
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        return changed
-
     def _generate_signature(self, request_type: str, request_path: str, timestamp: str) -> str:
         signed_data = ''.join([timestamp, request_type.upper(), request_path, '']).encode()
         signature = hmac.new(

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -75,6 +75,7 @@ from rotkehlchen.types import (
     ApiSecret,
     AssetAmount,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Timestamp,
     TradeType,
@@ -247,15 +248,10 @@ class Independentreserve(ExchangeInterface):
         self.session.headers.update({'Content-Type': 'application/json'})
         self.account_guids: Optional[list] = None
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
-            self.session.headers.update({'x-api-key': api_key})
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
+            self.session.headers.update({'x-api-key': credentials.api_key})
         return changed
 
     def _api_query(

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -49,6 +49,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetAmount,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Price,
@@ -311,39 +312,19 @@ class Kraken(ExchangeInterface):
             self.call_limit = 20
             self.reduction_every_secs = 1
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'API-Key': self.api_key})
 
         return changed
 
-    def edit_exchange(
-            self,
-            name: Optional[str],
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            **kwargs: Any,
-    ) -> tuple[bool, str]:
-        success, msg = super().edit_exchange(
-            name=name,
-            api_key=api_key,
-            api_secret=api_secret,
-            **kwargs,
-        )
-        if success is False:
-            return success, msg
-
-        account_type = kwargs.get(KRAKEN_ACCOUNT_TYPE_KEY)
+    def edit_exchange_extras(self, extras: dict) -> tuple[bool, str]:
+        account_type = extras.get(KRAKEN_ACCOUNT_TYPE_KEY)
         if account_type is None:
-            return success, msg
+            return False, 'No account type provided'
 
-        # here we can finally update the account type
+        # now we can update the account type
         self.set_account_type(account_type)
         return True, ''
 

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -37,7 +37,11 @@ from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import AssetMovement, MarginPosition, Trade
-from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
+from rotkehlchen.exchanges.exchange import (
+    ExchangeInterface,
+    ExchangeQueryBalances,
+    ExchangeWithExtras,
+)
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
@@ -273,7 +277,7 @@ class KrakenAccountType(SerializableEnumMixin):
 DEFAULT_KRAKEN_ACCOUNT_TYPE = KrakenAccountType.STARTER
 
 
-class Kraken(ExchangeInterface):
+class Kraken(ExchangeInterface, ExchangeWithExtras):
     def __init__(
             self,
             name: str,

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -38,6 +38,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Location,
     Timestamp,
     TradeType,
@@ -165,17 +166,12 @@ class Kucoin(ExchangeInterface):
     def update_passphrase(self, new_passphrase: str) -> None:
         self.api_passphrase = new_passphrase
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'KC-API-KEY': self.api_key})
-        if passphrase is not None:
-            self.update_passphrase(passphrase)
+        if credentials.passphrase is not None:
+            self.update_passphrase(credentials.passphrase)
 
         return changed
 

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -28,6 +28,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Timestamp,
@@ -76,16 +77,11 @@ class Okx(ExchangeInterface):
             'OK-ACCESS-PASSPHRASE': self.passphrase,
         })
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'OK-ACCESS-KEY': self.api_key})
-        if passphrase is not None:
+        if credentials.passphrase is not None:
             self.session.headers.update({'OK-ACCESS-PASSPHRASE': self.passphrase})
         return changed
 

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -38,6 +38,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetMovementCategory,
+    ExchangeAuthCredentials,
     Fee,
     Location,
     Timestamp,
@@ -139,14 +140,9 @@ class Poloniex(ExchangeInterface):
 
         self.first_connection_made = True
 
-    def edit_exchange_credentials(
-            self,
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
-    ) -> bool:
-        changed = super().edit_exchange_credentials(api_key, api_secret, passphrase)
-        if api_key is not None:
+    def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        changed = super().edit_exchange_credentials(credentials)
+        if credentials.api_key is not None:
             self.session.headers.update({'key': self.api_key})
 
         return changed

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -1069,19 +1069,6 @@ class Rotkehlchen():
             )
         return is_success, msg
 
-    def remove_exchange(self, name: str, location: Location) -> tuple[bool, str]:
-        if self.exchange_manager.get_exchange(name=name, location=location) is None:
-            return False, f'{str(location)} exchange {name} is not registered'
-
-        self.exchange_manager.delete_exchange(name=name, location=location)
-        # Success, remove it also from the DB
-        with self.data.db.user_write() as write_cursor:
-            self.data.db.remove_exchange(write_cursor=write_cursor, name=name, location=location)
-            if self.exchange_manager.connected_exchanges.get(location) is None:
-                # was last exchange of the location type. Delete used query ranges
-                self.data.db.delete_used_query_range_for_exchange(write_cursor=write_cursor, location=location)  # noqa: E501
-        return True, ''
-
     def query_periodic_data(self) -> dict[str, Union[bool, list[str], Timestamp]]:
         """Query for frequently changing data"""
         result: dict[str, Union[bool, list[str], Timestamp]] = {}

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -1054,7 +1054,12 @@ def test_edit_exchange_account(rotkehlchen_api_server_with_exchanges: 'APIServer
         db.update_used_query_range(cursor, name='uniswap_trades', start_ts=start_ts, end_ts=end_ts)
         test_event_id = event_db.add_history_event(write_cursor=cursor, event=test_event)
 
-    data = {'name': 'mockkraken', 'location': 'kraken', 'new_name': 'my_kraken'}
+    data = {
+        'name': 'mockkraken',
+        'location': 'kraken',
+        'new_name': 'my_kraken',
+        'kraken_account_type': KrakenAccountType.STARTER.serialize(),
+    }
     response = requests.patch(api_url_for(server, 'exchangesresource'), json=data)
     result = assert_proper_response_with_result(response)
     assert result is True
@@ -1218,6 +1223,10 @@ def test_edit_exchange_credentials(rotkehlchen_api_server_with_exchanges):
             'api_key': new_key,
             'api_secret': new_secret,
         }
+        if location in (Location.BINANCE, Location.BINANCEUS):
+            data['binance_markets'] = ['ETHBTC']
+        elif location == Location.KRAKEN:
+            data['kraken_account_type'] = KrakenAccountType.STARTER.serialize()
         with mock_validate_api_key_success(location):
             response = requests.patch(api_url_for(server, 'exchangesresource'), json=data)
             assert_simple_ok_response(response)

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -16,6 +16,7 @@ from rotkehlchen.assets.converters import UNSUPPORTED_BINANCE_ASSETS, asset_from
 from rotkehlchen.assets.exchanges_mappings.binance import WORLD_TO_BINANCE
 from rotkehlchen.constants.assets import A_ADA, A_BNB, A_BTC, A_DOT, A_ETH, A_EUR, A_USDT, A_WBTC
 from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
+from rotkehlchen.db.constants import BINANCE_MARKETS_KEY
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.binance import (
@@ -876,12 +877,7 @@ def test_binance_query_trade_history_custom_markets(function_scope_binance):
     binance = function_scope_binance
 
     markets = ['ETHBTC', 'BNBBTC', 'BTCUSDC']
-    binance.edit_exchange(
-        name=None,
-        api_key=None,
-        api_secret=None,
-        binance_selected_trade_pairs=markets,
-    )
+    binance.edit_exchange_extras({BINANCE_MARKETS_KEY: markets})
     count = 0
     p = re.compile(r'symbol=[A-Z]*')
     seen = set()

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -537,6 +537,8 @@ def rotkehlchen_api_server_with_exchanges(
             kwargs['api_key'] = okx_api_key
             kwargs['secret'] = okx_api_secret
             kwargs['passphrase'] = okx_passphrase
+        if exchange_location == Location.BINANCEUS:
+            kwargs['location'] = Location.BINANCEUS
         exchangeobj = create_fn(
             database=rotki.data.db,
             msg_aggregator=rotki.msg_aggregator,

--- a/rotkehlchen/tests/unit/accounting/test_exchanges.py
+++ b/rotkehlchen/tests/unit/accounting/test_exchanges.py
@@ -114,7 +114,7 @@ def test_exchanges_removed_api_keys(rotkehlchen_api_server_with_exchanges):
             )],
         )
 
-    rotki.remove_exchange(name='coinbase', location=Location.COINBASE)
+    rotki.exchange_manager.delete_exchange(name='coinbase', location=Location.COINBASE)
     _, events = accounting_create_and_process_history(rotki=rotki, start_ts=0, end_ts=1611426233)
     assert len(events) == 7
     event1 = events[0]

--- a/rotkehlchen/tests/unit/test_exchanges.py
+++ b/rotkehlchen/tests/unit/test_exchanges.py
@@ -1,8 +1,10 @@
+from unittest.mock import patch
+
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.exchanges.ftx import Ftx
 from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
 from rotkehlchen.tests.utils.kraken import MockKraken
-from rotkehlchen.types import Location
+from rotkehlchen.types import ApiKey, ApiSecret, ExchangeApiCredentials, Location
 
 
 def test_exchanges_filtering(database, exchange_manager, function_scope_messages_aggregator):
@@ -54,3 +56,111 @@ def test_exchanges_filtering(database, exchange_manager, function_scope_messages
             non_syncing_exchanges=[ftx1.location_id()],
         ))
         assert set(exchange_manager.iterate_exchanges()) == {ftx2, kraken1, kraken2}
+
+
+TEST_CREDENTIALS_1 = ExchangeApiCredentials(
+    name='KuCoin',
+    location=Location.KUCOIN,
+    api_key=ApiKey('api-key-1'),
+    api_secret=ApiSecret(b'api-secret-1'),
+    passphrase='passphrase-1',
+)
+
+TEST_CREDENTIALS_2 = ExchangeApiCredentials(
+    name='KuCoin',
+    location=Location.KUCOIN,
+    api_key=ApiKey('api-key-2'),
+    api_secret=ApiSecret(b'api-secret-2'),
+    passphrase='passphrase-2',
+)
+
+TEST_CREDENTIALS_3 = ExchangeApiCredentials(
+    name='KuCoin',
+    location=Location.KUCOIN,
+    api_key=ApiKey('api-key-3'),
+    api_secret=ApiSecret(b'api-secret-3'),
+    passphrase='passphrase-3',
+)
+
+
+def test_change_credentials(rotkehlchen_api_server) -> None:
+    """
+    Test that chaning exchange credentials works as expected and if incorrect credentials
+    were provided then the old credentials are restored.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+
+    def mock_kucoin_validate_api_key(kucoin):
+        if kucoin.api_passphrase in (TEST_CREDENTIALS_1.passphrase, TEST_CREDENTIALS_3.passphrase):
+            return True, ''
+
+        return False, 'Invalid passphrase'  # For TEST_KUCOIN_PASSPHRASE_2
+
+    def get_current_credentials(kucoin) -> ExchangeApiCredentials:
+        return ExchangeApiCredentials(
+            name=kucoin.name,
+            location=Location.KUCOIN,
+            api_key=kucoin.api_key,
+            api_secret=kucoin.secret,
+            passphrase=kucoin.api_passphrase,
+        )
+
+    with patch('rotkehlchen.exchanges.kucoin.Kucoin.validate_api_key', mock_kucoin_validate_api_key):  # noqa: E501
+        # Setup with correct credentials
+        rotki.setup_exchange(
+            name='KuCoin',
+            location=Location.KUCOIN,
+            api_key=TEST_CREDENTIALS_1.api_key,
+            api_secret=TEST_CREDENTIALS_1.api_secret,
+            passphrase=TEST_CREDENTIALS_1.passphrase,
+        )
+        kucoin = rotki.exchange_manager.connected_exchanges[Location.KUCOIN][0]
+        with rotki.data.db.conn.read_ctx() as cursor:
+            credentials_in_db = rotki.data.db.get_exchange_credentials(
+                cursor=cursor,
+                location=Location.KUCOIN,
+                name='KuCoin',
+            )[Location.KUCOIN][0]
+            assert credentials_in_db == get_current_credentials(kucoin) == TEST_CREDENTIALS_1
+
+        # Try to change credentials to incorrect ones
+        success, _ = rotki.exchange_manager.edit_exchange(
+            name='KuCoin',
+            location=Location.KUCOIN,
+            new_name=None,
+            api_key=TEST_CREDENTIALS_2.api_key,
+            api_secret=TEST_CREDENTIALS_2.api_secret,
+            passphrase=TEST_CREDENTIALS_2.passphrase,
+            kraken_account_type=None,
+            binance_selected_trade_pairs=None,
+            ftx_subaccount=None,
+        )
+        assert success is False, 'Should not have been able to change credentials'
+        with rotki.data.db.conn.read_ctx() as cursor:
+            credentials_in_db = rotki.data.db.get_exchange_credentials(
+                cursor=cursor,
+                location=Location.KUCOIN,
+                name='KuCoin',
+            )[Location.KUCOIN][0]
+            assert credentials_in_db == get_current_credentials(kucoin) == TEST_CREDENTIALS_1, 'Credentials should not have changed'  # noqa: E501
+
+        # Change credentials to correct ones
+        success, _ = rotki.exchange_manager.edit_exchange(
+            name='KuCoin',
+            location=Location.KUCOIN,
+            new_name=None,
+            api_key=TEST_CREDENTIALS_3.api_key,
+            api_secret=TEST_CREDENTIALS_3.api_secret,
+            passphrase=TEST_CREDENTIALS_3.passphrase,
+            kraken_account_type=None,
+            binance_selected_trade_pairs=None,
+            ftx_subaccount=None,
+        )
+        assert success is True, 'Should have been able to change credentials'
+        with rotki.data.db.conn.read_ctx() as cursor:
+            credentials_in_db = rotki.data.db.get_exchange_credentials(
+                cursor=cursor,
+                location=Location.KUCOIN,
+                name='KuCoin',
+            )[Location.KUCOIN][0]
+            assert credentials_in_db == get_current_credentials(kucoin) == TEST_CREDENTIALS_3

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -623,6 +623,18 @@ class AssetMovementCategory(DBEnumMixIn):
     WITHDRAWAL = 2
 
 
+class ExchangeAuthCredentials(NamedTuple):
+    """
+    Data structure that is used for editing credentials of exchanges.
+    If a certain field is not None, it is modified in the exchange, otherwise
+    the current value is kept.
+    """
+    api_key: Optional[ApiKey]
+    api_secret: Optional[ApiSecret]
+    passphrase: Optional[str]
+    ftx_subaccount: Optional[str]
+
+
 class ExchangeApiCredentials(NamedTuple):
     """Represents Credentials for Exchanges
 


### PR DESCRIPTION
This PR does 2 things:
1. Previously when editing an exchange there was a remote call (to validate new api credentials) under an open write cursor (which is bad because it blocks write access for a long time). This PR fixes it.
2. Previously when editing an exchange if there was a change in passphrase and new api credentials were incorrect then an inconsistency occurred. In database old passphrase was kept (which is what has to happen), but in the exchange object new (invalid) passphrase was set. This PR fixes it.