### PR TITLE
Add kraken as location for event search

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4886,10 +4886,10 @@ Dealing with History Events
    :reqjson list[string] event_identifiers: An optional list of event identifiers to filter for.
    :reqjson list[string] event_types: An optional list of event types by which to filter the decoded events.
    :reqjson list[string] event_subtypes: An optional list of event subtypes by which to filter the decoded events.
+   :reqjson list location: An optional location name to filter events only for that location.
    :reqjson list[string] location_labels: A list of location labels to optionally filter by. Location label is a string field that allows to provide more information about the location. When we use this structure in blockchains, it is used to specify the user address. For exchange events it's the exchange name assigned by the user.
    :reqjson string asset: The asset to optionally filter by.
    :reqjson list counterparties: An optional list of counterparties to filter by. List of strings.
-   :reqjson list evm_chain: An optional evm_chain name to filter events only for that chain. This makes it an EVMEVent query.
    :reqjson list products: An optional list of product type to filter by. List of strings. This makes it an EVMEVent query.
 
    **Example Response**:

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1082,7 +1082,7 @@ def test_query_transactions_check_decoded_events(
 
     tx_result = query_transactions(rotki)
     assert len(tx_result['entries']) == 4
-    returned_events = query_events(rotkehlchen_api_server, json={'evm_chain': 'ethereum'}, expected_num_with_grouping=4, expected_totals_with_grouping=4)  # noqa: E501
+    returned_events = query_events(rotkehlchen_api_server, json={'location': 'ethereum'}, expected_num_with_grouping=4, expected_totals_with_grouping=4)  # noqa: E501
 
     tx1_events = [{
         'entry': {
@@ -1286,7 +1286,7 @@ def test_query_transactions_check_decoded_events(
     result = query_transactions(rotki)
     entries = result['entries']
     assert len(entries) == 4
-    returned_events = query_events(rotkehlchen_api_server, json={'evm_chain': 'ethereum'}, expected_num_with_grouping=4, expected_totals_with_grouping=4)  # noqa: E501
+    returned_events = query_events(rotkehlchen_api_server, json={'location': 'ethereum'}, expected_num_with_grouping=4, expected_totals_with_grouping=4)  # noqa: E501
 
     assert len(returned_events) == 7
     assert_serialized_lists_equal(returned_events[0:2], tx1_events, ignore_keys='identifier')  # noqa: E501
@@ -1358,7 +1358,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
                 'historyeventresource',
             ),
             json={
-                'evm_chain': 'ethereum',
+                'location': 'ethereum',
                 'asset': A_WETH.serialize(),
                 attribute: [],
             },
@@ -1371,7 +1371,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
     returned_events = query_events(
         rotkehlchen_api_server,
         json={
-            'evm_chain': 'ethereum',
+            'location': 'ethereum',
             'asset': A_WETH.serialize(),
             'location_labels': [ethereum_accounts[0]],
         },
@@ -1384,7 +1384,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
 
     returned_events = query_events(
         rotkehlchen_api_server,
-        json={'asset': A_ETH.serialize(), 'evm_chain': 'ethereum'},
+        json={'asset': A_ETH.serialize(), 'location': 'ethereum'},
         expected_num_with_grouping=1,
         expected_totals_with_grouping=3,
         entries_limit=100,
@@ -1394,7 +1394,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
 
     returned_events = query_events(
         rotkehlchen_api_server,
-        json={'asset': A_WETH.serialize(), 'evm_chain': 'ethereum'},
+        json={'asset': A_WETH.serialize(), 'location': 'ethereum'},
         expected_num_with_grouping=2,
         expected_totals_with_grouping=3,
         entries_limit=100,
@@ -1404,7 +1404,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
 
     returned_events = query_events(
         rotkehlchen_api_server,
-        json={'counterparties': ['EXAMPLE_PROTOCOL'], 'evm_chain': 'ethereum'},
+        json={'counterparties': ['EXAMPLE_PROTOCOL'], 'location': 'ethereum'},
         expected_num_with_grouping=1,
         expected_totals_with_grouping=3,
         entries_limit=100,
@@ -1415,7 +1415,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
     returned_events = query_events(
         rotkehlchen_api_server,
         json={
-            'evm_chain': 'ethereum',
+            'location': 'ethereum',
             'asset': A_WETH.serialize(),
             'counterparties': ['EXAMPLE_PROTOCOL'],
         },
@@ -1430,7 +1430,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
     returned_events = query_events(
         rotkehlchen_api_server,
         json={
-            'evm_chain': 'ethereum',
+            'location': 'ethereum',
             'event_types': ['staking'],
         },
         expected_num_with_grouping=1,
@@ -1444,7 +1444,7 @@ def test_events_filter_params(rotkehlchen_api_server, ethereum_accounts):
     returned_events = query_events(
         rotkehlchen_api_server,
         json={
-            'evm_chain': 'ethereum',
+            'location': 'ethereum',
             'event_types': ['staking'],
             'event_subtypes': ['deposit_asset'],
         },
@@ -1481,7 +1481,7 @@ def test_ignored_assets(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         json={
             'exclude_ignored_assets': False,
-            'evm_chain': 'ethereum',
+            'location': 'ethereum',
         },
         expected_num_with_grouping=2,
         expected_totals_with_grouping=2,
@@ -1492,7 +1492,7 @@ def test_ignored_assets(rotkehlchen_api_server, ethereum_accounts):
 
     returned_events = query_events(
         rotkehlchen_api_server,  # test that default exclude_ignored_assets is True
-        json={'evm_chain': 'ethereum'},
+        json={'location': 'ethereum'},
         expected_num_with_grouping=1,
         expected_totals_with_grouping=2,
         entries_limit=100,


### PR DESCRIPTION
We needed to filter by location to allow searching kraken events (and in the future others) in the history events tab.