### PR TITLE
Vault owner deletion

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,7 @@ Changelog
 * :bug:`5749` Phishing zero token transfer transactions will now be hidden and ignored.
 * :bug:`5717` Swaps will now be processed in accounting correctly even if set manually.
 * :bug:`-` If a premium user changes their rotki password they will now be able to pull remote data without restarting the app.
+* :bug:`-` Now there won't be errors querying balances when an address owning a Makerdao vault is deleted.
 
 * :release:`1.27.1 <2023-02-24>`
 * :feature:`-` Transactions involving Sai CDP migration to Dai CDP are now properly decoded.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,6 @@
 Changelog
 =========
 
-
 * :feature:`5824` Improved support for ENS allowing to decode the version of their contracts that added the name wrapper.
 * :feature:`-` Refunds in ENS renewal transactions will now be properly processed.
 * :feature:`5816` The NFT images will not be automatically rendered now. It is made so to prevent a known security issue, that may result in leakage of your privacy (read https://medium.com/@alxlpsc/critical-privacy-vulnerability-getting-exposed-by-metamask-693c63c2ce94 ). You can add domains you trust to the whitelisted domain in the NFT setting.

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -151,7 +151,7 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
 
             # Find the transfer event which should be before the name renewed event
             if event.event_type == HistoryEventType.SPEND and event.asset == A_ETH and event.balance.amount - refund_amount == name_cost and event.address == context.tx_log.address:  # noqa: E501
-                event.balance.amount -= refund_amount
+                event.balance.amount -= refund_amount  # is now equal to name_cost
                 event.event_type = HistoryEventType.RENEW
                 event.event_subtype = HistoryEventSubType.NFT
                 event.counterparty = CPT_ENS

--- a/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
@@ -729,3 +729,7 @@ class MakerdaoVaults(HasDSProxy):
         if proxy_address:
             # get any vaults the proxy owns
             self._get_vaults_of_address(user_address=address, proxy_address=proxy_address)
+
+    def on_account_removal(self, address: ChecksumEvmAddress) -> None:
+        super().on_account_removal(address)
+        self.vault_mappings.pop(address, None)

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -77,7 +77,7 @@ def _initialize_and_yield_evm_inquirer_fixture(
         mock_data=mock_data,
     )
     if mocked_proxies is not None:
-        parent_stack.enter_context(mock_proxies(mocked_proxies))
+        mock_proxies(parent_stack, mocked_proxies)
     return inquirer
 
 

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -420,7 +420,7 @@ def fixture_rotkehlchen_api_server(
                     )
 
             if mocked_proxies is not None:
-                stack.enter_context(mock_proxies(mocked_proxies))
+                mock_proxies(stack, mocked_proxies)
 
             stack.enter_context(patch_decoder_reload_data())
 

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -311,11 +311,19 @@ def patch_avalanche_request(avalanche_manager, mock_data):
     )
 
 
-def mock_proxies(mocked_proxies):
-    return patch(
-        'rotkehlchen.chain.evm.proxies_inquirer.EvmProxiesInquirer.get_accounts_having_proxy',
-        return_value=mocked_proxies,
-    )
+def mock_proxies(stack, mocked_proxies):
+    stack.enter_context(patch(
+        'rotkehlchen.chain.evm.proxies_inquirer.EvmProxiesInquirer.get_account_proxy',
+        lambda _, address: mocked_proxies.get(address),
+    ))
+    stack.enter_context(patch(
+        'rotkehlchen.chain.evm.proxies_inquirer.EvmProxiesInquirer.get_accounts_proxy',
+        lambda _, addresses: {
+            address: mocked_proxies.get(address)
+            for address in addresses
+            if mocked_proxies.get(address) is not None
+        },
+    ))
 
 
 def mock_evm_chains_with_transactions():


### PR DESCRIPTION
There was a bug that when an address that owns a makerdao vault is deleted, mappings in the module are not updated properly, and then later during balances query the module's `get_balances` method returns balances for addresses that is no longer tracked, and this results in an error.

This PR fixes it.