### PR TITLE
Simplify and improve balance aggregation for liquity

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7427,8 +7427,8 @@ Getting Liquity staked amount
           "message": ""
       }
 
-   :resjson object balances: A mapping of the category to the amount & value of assets staked in the protocol.
-   :resjson object proxies: A mapping of proxy addresses to the amount and value of assets staked in the protocol.
+   :resjson object optional[balances]: A mapping of the category to the amount & value of assets staked in the protocol.
+   :resjson object optional[proxies]: A mapping of proxy addresses to the amount and value of assets staked in the protocol.
 
    :statuscode 200: Liquity staking information successfully queried.
    :statuscode 409: User is not logged in or Liquity module is not activated.

--- a/rotkehlchen/tests/api/test_liquity.py
+++ b/rotkehlchen/tests/api/test_liquity.py
@@ -131,7 +131,7 @@ def test_trove_staking(rotkehlchen_api_server, inquirer):  # pylint: disable=unu
                 'usd_value': '0.0000000345435577215',
             },
         },
-        'proxies': {},
+        'proxies': None,
     }
 
 


### PR DESCRIPTION
To improve consistency in the API and performance in the frontend we agreed to change the returned value for the staking endpoints in liquity to use `null` instead of `{}` for the empty case.

This PR:

- Makes nullable the API response for staked amounts in liquity
- Makes a little refactor in the aggregator to avoid duplicated code
