### PR TITLE
Allow to trigger a remote query of history events for exchanges

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5111,12 +5111,12 @@ Querying online events
 
       {
           "async_query": true,
-          "name": "eth_withdrawals"
+          "query_type": "eth_withdrawals"
       }
 
 
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
-   :reqjson string name: The name of the type of events to query for. Valid values are: ``"eth_withdrawals"``, ``"block_productions"``
+   :reqjson string query_type: The name of the type of events to query for. Valid values are: ``"eth_withdrawals"``, ``"block_productions"``, ``"exchanges"``
 
     **Example Response**
 
@@ -12540,4 +12540,3 @@ Get all valid locations
 
   :statuscode 200: Information was correctly returned
   :statuscode 500: Internal rotki error
-

--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -201,3 +201,43 @@ Having API keys for some services (such as etherscan) is crucial for rotki to wo
 
 - ``service``: Service for which an API key is needed.
 - ``location``: For services like etherscan that require different API keys for different locations this is the location for which the API key is needed. If a service does not require a location then this key will be missing.
+
+
+Query new history events
+=========================
+
+In addition to history from evm transactions we need to query events from exchanges that support this kind of events. The backend will emit a ws message as the following when a query start for such exchange.
+
+::
+
+    {
+        "type": "querying_events_status",
+        "data": {
+            "status": "querying_events_started",
+            "location": "kraken",
+            "name": "My kraken exchange"
+        }
+    }
+
+
+- ``status``: Can be either `querying_events_started`, `querying_events_finished`, `querying_events_status_update`. Each pair of events is triggered per exchange instance.
+- ``location``: Exchange location triggering the event.
+- ``name``: Name of the exchange instance that is being queried.
+
+Finally the backend provides more granular information to know what interval of time is getting queried.
+
+::
+
+    {
+        "type": "querying_events_status",
+        "data": {
+            "status": "history_event_status",
+            "location": "kraken",
+            "name": "My kraken exchange",
+            'period': [0, 1682100570]
+        }
+    }
+
+- ``location``: Exchange location triggering the event.
+- ``name``: Name of the exchange instance that is being queried.
+- ``period``: Time range that is being queried.

--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -206,7 +206,7 @@ Having API keys for some services (such as etherscan) is crucial for rotki to wo
 Query new history events
 =========================
 
-In addition to history from evm transactions we need to query events from exchanges that support this kind of events. The backend will emit a ws message as the following when a query start for such exchange.
+In addition to history from evm transactions we need to query events from exchanges, eth staking events etc. The backend will emit a ws message as the following when such a query starts.
 
 ::
 
@@ -215,16 +215,18 @@ In addition to history from evm transactions we need to query events from exchan
         "data": {
             "status": "querying_events_started",
             "location": "kraken",
+            "event_type": "history_query",
             "name": "My kraken exchange"
         }
     }
 
 
-- ``status``: Can be either `querying_events_started`, `querying_events_finished`, `querying_events_status_update`. Each pair of events is triggered per exchange instance.
-- ``location``: Exchange location triggering the event.
-- ``name``: Name of the exchange instance that is being queried.
+- ``status``: Can be either `querying_events_started`, `querying_events_finished`, `querying_events_status_update`. Each pair of events is triggered per exchange instance if the location is an exchange.
+- ``event_type``: Labels the type of events being queried. Valid values are: ``history_query``.
+- ``location``(Optional): When the same ``event_type`` can be queried in multiple locations this helps to differentiate them.
+- ``name``(Optional): If multiple appearences of the same location are possible it will differentiate each one of them.
 
-Finally the backend provides more granular information to know what interval of time is getting queried.
+Finally the backend provides more granular information to know what interval of time is getting queried for certain locations.
 
 ::
 
@@ -233,11 +235,14 @@ Finally the backend provides more granular information to know what interval of 
         "data": {
             "status": "history_event_status",
             "location": "kraken",
+            "event_type": "history_query",
             "name": "My kraken exchange",
             'period': [0, 1682100570]
         }
     }
 
-- ``location``: Exchange location triggering the event.
-- ``name``: Name of the exchange instance that is being queried.
+
+- ``event_type``: Labels the type of events being queried. Valid values are: ``history_query``.
+- ``location``(Optional): When the same ``event_type`` can be queried in multiple locations this helps to differentiate them.
+- ``name``(Optional): If multiple appearences of the same location are possible it will differentiate each one of them.
 - ``period``: Time range that is being queried.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3533,7 +3533,7 @@ class RestAPI():
             self.rotkehlchen.exchange_manager.query_history_events()
             return OK_RESULT
 
-        # else we query eth2 events
+        # else we query eth staking events
         eth2 = self.rotkehlchen.chains_aggregator.get_module('eth2')
         if eth2 is None:
             return wrap_in_fail_result(

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -203,6 +203,7 @@ from rotkehlchen.types import (
     ExternalServiceApiCredentials,
     Fee,
     HexColorCode,
+    HistoryEventQueryType,
     ListOfBlockchainAddresses,
     Location,
     ModuleName,
@@ -1160,8 +1161,11 @@ class EventsOnlineQueryResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(post_schema, location='json')
-    def post(self, name: Literal['eth_withdrawals', 'block_productions']) -> Response:
-        return self.rest_api.query_online_events(name=name)
+    def post(self, async_query: bool, query_type: HistoryEventQueryType) -> Response:
+        return self.rest_api.query_online_events(
+            async_query=async_query,
+            query_type=query_type,
+        )
 
 
 class HistoryEventResource(BaseMethodView):

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -89,6 +89,7 @@ from rotkehlchen.types import (
     ExchangeLocationID,
     ExternalService,
     ExternalServiceApiCredentials,
+    HistoryEventQueryType,
     Location,
     OptionalChainAddress,
     SupportedBlockchain,
@@ -334,9 +335,7 @@ class SingleEVMTransactionDecodingSchema(Schema):
 
 
 class EventsOnlineQuerySchema(AsyncQueryArgumentSchema):
-    name = fields.String(
-        validate=webargs.validate.OneOf(choices=('eth_withdrawals', 'block_productions')),
-    )
+    query_type = SerializableEnumField(enum_class=HistoryEventQueryType, required=True)
 
 
 class EvmTransactionDecodingSchema(AsyncIgnoreCacheQueryArgumentSchema):

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -20,6 +20,7 @@ class WSMessageType(Enum):
     NEW_EVM_TOKEN_DETECTED = auto()
     DATA_MIGRATION_STATUS = auto()
     MISSING_API_KEY = auto()
+    HISTORY_EVENTS_STATUS = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member
@@ -31,6 +32,15 @@ class TransactionStatusStep(Enum):
     QUERYING_INTERNAL_TRANSACTIONS = auto()
     QUERYING_EVM_TOKENS_TRANSACTIONS = auto()
     QUERYING_TRANSACTIONS_FINISHED = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()  # pylint: disable=no-member
+
+
+class HistoryEventsStep(Enum):
+    QUERYING_EVENTS_STARTED = auto()
+    QUERYING_EVENTS_STATUS_UPDATE = auto()
+    QUERYING_EVENTS_FINISHED = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -44,3 +44,10 @@ class HistoryEventsStep(Enum):
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member
+
+
+class HistoryEventsQueryType(Enum):
+    HISTORY_QUERY = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -245,7 +245,9 @@ class ExchangeInterface(CacheableMixIn, LockableQueryMixIn):
         )
 
     def query_history_events(self) -> None:
-        """Query and store in the database history events from the current exchange instance"""
+        """Query history events from the current exchange
+        instance and store them in the database
+        """
         return None
 
     @protect_with_lock()

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -244,6 +244,10 @@ class ExchangeInterface(CacheableMixIn, LockableQueryMixIn):
             'query_online_income_loss_expense should only be implemented by subclasses',
         )
 
+    def query_history_events(self) -> None:
+        """Query and store in the database history events from the current exchange instance"""
+        return None
+
     @protect_with_lock()
     def query_trade_history(
             self,

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -277,3 +277,7 @@ class ExchangeManager():
         if is_connected:
             return self.database.get_binance_pairs(name, location)
         return []
+
+    def query_history_events(self) -> None:
+        for exchange in self.iterate_exchanges():
+            exchange.query_history_events()

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -832,7 +832,7 @@ DecoderEventMappingType = dict[
 
 
 class HistoryEventQueryType(SerializableEnumMixin):
-    """Locations to """
+    """Locations to query for history events"""
     ETH_WITHDRAWALS = auto()
     BLOCK_PRODUCTIONS = auto()
     EXCHANGES = auto()

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -829,3 +829,10 @@ DecoderEventMappingType = dict[
         dict['HistoryEventSubType', 'EventCategory'],
     ],
 ]
+
+
+class HistoryEventQueryType(SerializableEnumMixin):
+    """Locations to """
+    ETH_WITHDRAWALS = auto()
+    BLOCK_PRODUCTIONS = auto()
+    EXCHANGES = auto()


### PR DESCRIPTION
Currently the only way to query kraken history events is by navigating to trades/deposits or do a report. This PR introduces a new endpoint and ws messages to allow querying kraken remote events and present them to the user
