### PR TITLE
Adjust nfts logic

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/nft/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nft/nfts.py
@@ -209,7 +209,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
         with self.db.conn.read_ctx() as cursor:
             accounts = self.db.get_blockchain_accounts(cursor=cursor)
         # Be sure that the only addresses queried already exist in the database. Fix for #4456
-        queried_addresses = list(set(accounts.eth) & set(addresses))
+        queried_addresses = sorted(set(accounts.eth) & set(addresses))  # Sorting for consistency in tests  # noqa: E501
         nft_results, _ = self._get_all_nft_data(queried_addresses, ignore_cache=True)
         db_data: list[NFT_DB_TUPLE] = []
         # get uniswap v3 lp balances and update nfts that are LPs with their worth.

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -161,8 +161,8 @@ def test_nft_ids_are_unique(rotkehlchen_api_server):
     assert len(all_ids) == len(set_of_ids)
 
 
-@requires_env([TestEnvironment.NIGHTLY, TestEnvironment.NFTS])
-@pytest.mark.vcr()
+@requires_env([TestEnvironment.STANDARD, TestEnvironment.NIGHTLY, TestEnvironment.NFTS])
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ACC4, TEST_ACC5, TEST_ACC6]])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('ethereum_modules', [['nfts', 'uniswap']])


### PR DESCRIPTION
There was a problem that the order of addresses to query in nfts module was randomized, which led to different remote queries from test to test, and this led to a vcr issue since not all queries were covered in the cassette.