### PR TITLE
Smol rpc lama fix. Hopefully temporary

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -432,7 +432,10 @@ class EvmNodeInquirer(metaclass=ABCMeta):
                     'may be incorrect.',
                 )
 
-            is_pruned, is_archive = self.determine_capabilities(web3)
+            if node.endpoint.endswith('llamarpc.com'):  # temporary. Seems to sometimes switch
+                is_pruned, is_archive = True, False  # between pruned and non-pruned nodes
+            else:
+                is_pruned, is_archive = self.determine_capabilities(web3)
             log.info(f'Connected {self.chain_name} node {node} at {rpc_endpoint}')
             self.web3_mapping[node] = Web3Node(
                 web3_instance=web3,


### PR DESCRIPTION
It seems llama rpc is using some kind of load balancer and we sometimes hit a pruned node and sometimes a non-pruned one.

This can create problems as we expect a transaction hash to exist if we think rpc is non-pruned but next call we get an error.

With this, hopefully temporary, commit we always mark the llama rpc as pruned so we don't rely on them for anything historical.

