### PR TITLE
Periodically check for validator activation and update deposit event

### DIFF
--- a/rotkehlchen/accounting/structures/eth2.py
+++ b/rotkehlchen/accounting/structures/eth2.py
@@ -406,6 +406,12 @@ class EthDepositEvent(EvmEvent, EthStakingEvent):
     def __repr__(self) -> str:
         return f'EthDepositEvent({self.validator_index=}, {self.timestamp=}, {self.tx_hash=})'  # noqa: E501
 
+    def __eq__(self, other: Any) -> bool:
+        return (
+            EvmEvent.__eq__(self, other) is True and
+            EthStakingEvent.__eq__(self, other) is True
+        )
+
     def serialize_for_db(self) -> tuple[HISTORY_EVENT_DB_TUPLE_WRITE, EVM_EVENT_FIELDS, tuple[int, int]]:  # type: ignore  # does not match EvmEvent supertype, but yeah it would not make sense to  # noqa: E501
         base_tuple, evm_tuple = self._serialize_evm_event_tuple_for_db(HistoryBaseEntryType.ETH_DEPOSIT_EVENT)  # noqa: E501
         return (base_tuple, evm_tuple, (self.validator_index, 0))

--- a/rotkehlchen/chain/ethereum/modules/eth2/structures.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/structures.py
@@ -39,7 +39,7 @@ Eth2ValidatorDBTuple = tuple[int, str, str]
 class Eth2Validator:
     index: int
     public_key: Eth2PubKey
-    ownership_proportion: FVal
+    ownership_proportion: FVal = ONE
 
     def serialize_for_db(self) -> Eth2ValidatorDBTuple:
         return self.index, self.public_key, str(self.ownership_proportion)

--- a/rotkehlchen/tasks/events.py
+++ b/rotkehlchen/tasks/events.py
@@ -21,6 +21,7 @@ def process_events(
     eth2 = chains_aggregator.get_module('eth2')
     if eth2 is not None:
         eth2.combine_block_with_tx_events()
+        eth2.refresh_activated_validators_deposits()
 
     with database.user_write() as write_cursor:
         database.update_used_query_range(  # update last withdrawal query timestamp


### PR DESCRIPTION
It's possible that an ETH staking deposit event is decoded while the validator is waiting in the activation queue. In that case the validator has no validator index yet.

This commit is adding a periodic check (and tests for it) that if a deposit has no validator index and only a publickey, we ask beaconchain if it has been activated and if yes, the deposit data is updated and the full validator data (index + pubkey) is written in the DB.