### PR TITLE
Remove pylint unsuscriptable object rule

### DIFF
--- a/.pylint.rc
+++ b/.pylint.rc
@@ -99,7 +99,6 @@ enable=
     unreachable,
     unnecessary-pass,
     broad-except,
-    unsubscriptable-object,
     unnecessary-lambda,
     isinstance-second-argument-not-valid-type,
     unsupported-membership-test,

--- a/rotkehlchen/accounting/structures/processed_event.py
+++ b/rotkehlchen/accounting/structures/processed_event.py
@@ -170,7 +170,7 @@ class ProcessedAccountingEvent:
         return string_data
 
     @classmethod
-    def deserialize_from_db(cls: builtins.type[T], timestamp: Timestamp, stringified_json: str) -> T:  # noqa: E501  # pylint: disable=unsubscriptable-object
+    def deserialize_from_db(cls: builtins.type[T], timestamp: Timestamp, stringified_json: str) -> T:  # noqa: E501
         """May raise:
         - DeserializationError if something is wrong with reading this from the DB
         """

--- a/rotkehlchen/chain/ethereum/modules/convex/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/balances.py
@@ -74,7 +74,7 @@ class ConvexBalances(ProtocolWithBalance):
 
         for idx, result in enumerate(call_output):
             address = addresses_with_stake[idx]
-            amount_raw = staking_contract.decode(result, 'balanceOf', arguments=[address])[0]  # pylint: disable=unsubscriptable-object  # noqa: E501
+            amount_raw = staking_contract.decode(result, 'balanceOf', arguments=[address])[0]
             amount = asset_normalized_value(amount_raw, self.cvx)
             if amount == ZERO:
                 continue

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -108,14 +108,14 @@ class Liquity(HasDSProxy):
             if status is True:
                 try:
                     trove_info = self.trove_manager_contract.decode(result, 'Troves', arguments=[addresses[idx]])  # noqa: E501
-                    trove_is_active = bool(trove_info[3])  # pylint: disable=unsubscriptable-object
+                    trove_is_active = bool(trove_info[3])
                     if not trove_is_active:
                         continue
                     collateral = deserialize_asset_amount(
-                        token_normalized_value_decimals(trove_info[1], 18),  # noqa: E501 pylint: disable=unsubscriptable-object
+                        token_normalized_value_decimals(trove_info[1], 18),
                     )
                     debt = deserialize_asset_amount(
-                        token_normalized_value_decimals(trove_info[0], 18),  # noqa: E501 pylint: disable=unsubscriptable-object
+                        token_normalized_value_decimals(trove_info[0], 18),
                     )
                     collateral_balance = AssetBalance(
                         asset=A_ETH,
@@ -152,7 +152,7 @@ class Liquity(HasDSProxy):
                         collateralization_ratio=collateralization_ratio,
                         liquidation_price=liquidation_price,
                         active=trove_is_active,
-                        trove_id=trove_info[4],  # pylint: disable=unsubscriptable-object
+                        trove_id=trove_info[4],
                     )
                 except DeserializationError as e:
                     self.msg_aggregator.add_warning(
@@ -222,7 +222,7 @@ class Liquity(HasDSProxy):
                 if idx % 3 == method_idx:
                     asset = _asset
                     key = _key
-                    gain_info = contract.decode(result, method, arguments=[current_address])[0]    # pylint: disable=unsubscriptable-object  # noqa: E501
+                    gain_info = contract.decode(result, method, arguments=[current_address])[0]
                     break
 
             # get price information for the asset and deserialize the amount

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -127,7 +127,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):
         )
         mapping = {}
         for result_encoded, method_name in zip(output, ('urns', 'owns')):
-            result = self.makerdao_cdp_manager.decode(    # pylint: disable=unsubscriptable-object
+            result = self.makerdao_cdp_manager.decode(
                 result_encoded,
                 method_name,
                 arguments=[cdp_id],

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
@@ -88,11 +88,11 @@ class PickleFinance(EthereumModule):
                         arguments=[address],
                     )
                     dill_rewards = token_normalized_value_decimals(
-                        token_amount=rewards[0],  # pylint: disable=unsubscriptable-object
+                        token_amount=rewards[0],
                         token_decimals=self.pickle.decimals,
                     )
                     dill_locked = token_normalized_value_decimals(
-                        token_amount=dill_amounts[0],  # pylint: disable=unsubscriptable-object
+                        token_amount=dill_amounts[0],
                         token_decimals=self.pickle.decimals,
                     )
                     balance = DillBalance(
@@ -110,7 +110,7 @@ class PickleFinance(EthereumModule):
                                 usd_value=pickle_price * dill_rewards,
                             ),
                         ),
-                        lock_time=deserialize_timestamp(dill_amounts[1]),  # noqa: E501 pylint: disable=unsubscriptable-object
+                        lock_time=deserialize_timestamp(dill_amounts[1]),
                     )
                     api_output[address] = balance
                 except (DeserializationError, IndexError) as e:

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -204,7 +204,7 @@ def find_uniswap_v2_lp_price(
             decoded_method = contract.decode(call_result, method_name)
             if len(decoded_method) == 1:
                 # https://github.com/PyCQA/pylint/issues/4739
-                decoded.append(decoded_method[0])  # pylint: disable=unsubscriptable-object
+                decoded.append(decoded_method[0])
             else:
                 decoded.append(decoded_method)
         else:

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
@@ -134,7 +134,7 @@ def uniswap_v3_lp_token_balances(
             continue
 
         tokens_ids = [
-            uniswap_v3_nft_manager.decode(   # pylint: disable=unsubscriptable-object
+            uniswap_v3_nft_manager.decode(
                 result=data[1],
                 method_name='tokenOfOwnerByIndex',
                 arguments=[address, index],

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -608,7 +608,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
 
         if len(output_data) == 1:
             # due to https://github.com/PyCQA/pylint/issues/4114
-            return output_data[0]  # pylint: disable=unsubscriptable-object
+            return output_data[0]
         return output_data
 
     def call_contract(

--- a/rotkehlchen/chain/evm/proxies_inquirer.py
+++ b/rotkehlchen/chain/evm/proxies_inquirer.py
@@ -78,7 +78,7 @@ class EvmProxiesInquirer():
         mapping = {}
         for idx, result_encoded in enumerate(output):
             address = addresses[idx]
-            result = self.dsproxy_registry.decode(    # pylint: disable=unsubscriptable-object
+            result = self.dsproxy_registry.decode(
                 result_encoded,
                 'proxies',
                 arguments=[address],

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -189,7 +189,7 @@ class EvmTokens(metaclass=ABCMeta):
         )
         balances: dict[ChecksumEvmAddress, dict[EvmToken, FVal]] = defaultdict(lambda: defaultdict(FVal))  # noqa: E501
         for (address, tokens), result in zip(chunk, results):
-            decoded_result = self.evm_inquirer.contract_scan.decode(  # pylint: disable=unsubscriptable-object  # noqa: E501
+            decoded_result = self.evm_inquirer.contract_scan.decode(
                 result=result,
                 method_name='tokensBalance',
                 arguments=[address, [token.evm_address for token in tokens]],

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -399,7 +399,7 @@ class Gemini(ExchangeInterface):
             # Use millisecond timestamp as pagination mechanism for lack of better option
             # Most recent entry is first
             # https://github.com/PyCQA/pylint/issues/4739
-            last_ts_ms = single_result[0]['timestampms']  # pylint: disable=unsubscriptable-object
+            last_ts_ms = single_result[0]['timestampms']
             # also if we are already over the end timestamp stop
             if int(last_ts_ms / 1000) > end_ts:
                 break

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -534,9 +534,9 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
         try:
             parsed_data = CoingeckoAssetData(
                 identifier=asset_coingecko_id,
-                symbol=data['symbol'],  # pylint: disable=unsubscriptable-object
-                name=data['name'],  # pylint: disable=unsubscriptable-object
-                image_url=data['image']['small'],  # pylint: disable=unsubscriptable-object
+                symbol=data['symbol'],
+                name=data['name'],
+                image_url=data['image']['small'],
             )
         except KeyError as e:
             raise RemoteError(
@@ -625,7 +625,7 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
 
         # https://github.com/PyCQA/pylint/issues/4739
         try:
-            return Price(FVal(result[from_coingecko_id][vs_currency])), False  # pylint: disable=unsubscriptable-object  # noqa: E501
+            return Price(FVal(result[from_coingecko_id][vs_currency])), False
         except KeyError as e:
             log.warning(
                 f'Queried coingecko simple price from {from_asset.identifier} '
@@ -716,7 +716,7 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
 
         # https://github.com/PyCQA/pylint/issues/4739
         try:
-            price = Price(FVal(result['market_data']['current_price'][vs_currency]))  # pylint: disable=unsubscriptable-object  # noqa: E501
+            price = Price(FVal(result['market_data']['current_price'][vs_currency]))
         except KeyError as e:
             log.warning(
                 f'Queried coingecko historical price from {from_asset.identifier} '

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
 import gevent
 import requests
-from rotkehlchen.api.websockets.typedefs import WSMessageType
 
+from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.structures import TimestampOrBlockRange
 from rotkehlchen.constants.timing import (
@@ -361,7 +361,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         chain_id = self.chain.to_chain_id()
         while True:
             result = self._query(module='account', action=action, options=options)
-            last_ts = deserialize_timestamp(result[0]['timeStamp']) if len(result) != 0 else None  # noqa: E501 pylint: disable=unsubscriptable-object
+            last_ts = deserialize_timestamp(result[0]['timeStamp']) if len(result) != 0 else None
             for entry in result:
                 try:  # Handle normal transactions. Internal dict does not contain a hash sometimes
                     if is_internal or entry['hash'].startswith('GENESIS') is False:
@@ -424,7 +424,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             # block we got. There may be duplicate entries if there are more than one
             # transactions for that last block but they should be filtered
             # out when we input all of these in the DB
-            last_block = result[-1]['blockNumber']  # pylint: disable=unsubscriptable-object
+            last_block = result[-1]['blockNumber']
             options['startBlock'] = last_block
 
         yield transactions
@@ -446,7 +446,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         hashes: set[tuple[str, Timestamp]] = set()
         while True:
             result = self._query(module='account', action='tokentx', options=options)
-            last_ts = deserialize_timestamp(result[0]['timeStamp']) if len(result) != 0 else None  # noqa: E501 pylint: disable=unsubscriptable-object
+            last_ts = deserialize_timestamp(result[0]['timeStamp']) if len(result) != 0 else None
             for entry in result:
                 timestamp = deserialize_timestamp(entry['timeStamp'])
                 if timestamp > last_ts and len(hashes) >= TRANSACTIONS_BATCH_NUM:  # type: ignore
@@ -461,7 +461,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             # block we got. There may be duplicate entries if there are more than one
             # transactions for that last block but they should be filtered
             # out when we input all of these in the DB
-            last_block = result[-1]['blockNumber']  # pylint: disable=unsubscriptable-object
+            last_block = result[-1]['blockNumber']
             options['startBlock'] = last_block
 
         yield _hashes_tuple_to_list(hashes)
@@ -504,7 +504,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         block_data = self._query(module='proxy', action='eth_getBlockByNumber', options=options)
         # We need to convert some data from hex here
         # https://github.com/PyCQA/pylint/issues/4739
-        block_data['timestamp'] = hex_or_bytes_to_int(block_data['timestamp'])  # pylint: disable=unsubscriptable-object  # noqa: E501
+        block_data['timestamp'] = hex_or_bytes_to_int(block_data['timestamp'])
         block_data['number'] = hex_or_bytes_to_int(block_data['number'])
 
         return block_data

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -323,7 +323,7 @@ class Opensea(ExternalServiceWithApiKey):
             # https://github.com/rotki/rotki/issues/3676
             stats_result = self._query(endpoint='collectionstats', options={'name': entry['slug']})
             floor_price = deserialize_optional_to_optional_fval(
-                value=stats_result['stats']['floor_price'],  # pylint: disable=unsubscriptable-object  # noqa: E501
+                value=stats_result['stats']['floor_price'],
                 name='floor price',
                 location='opensea',
             )
@@ -344,8 +344,8 @@ class Opensea(ExternalServiceWithApiKey):
         raw_result = []
         while True:
             result = self._query(endpoint='assets', options=options)
-            raw_result.extend(result['assets'])  # pylint: disable=unsubscriptable-object
-            if len(result['assets']) != ASSETS_MAX_LIMIT:  # pylint: disable=unsubscriptable-object
+            raw_result.extend(result['assets'])
+            if len(result['assets']) != ASSETS_MAX_LIMIT:
                 break
 
             # else continue by paginating

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -467,7 +467,7 @@ class AssetsUpdater:
 
             # else can't resolve. Mark it for the user to resolve.
             # TODO: When assets refactor is finished, remove the usage of AssetData here
-            local_data = GlobalDBHandler().get_all_asset_data(  # pylint: disable=unsubscriptable-object  # noqa: E501
+            local_data = GlobalDBHandler().get_all_asset_data(
                 mapping=False,
                 serialized=False,
                 specific_ids=[local_asset.identifier],

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -846,18 +846,18 @@ class Inquirer():
         # Deserialize information obtained in the multicall execution
         data = []
         # https://github.com/PyCQA/pylint/issues/4739
-        virtual_price_decoded = contract.decode(output[0][1], 'get_virtual_price')  # pylint: disable=unsubscriptable-object  # noqa: E501
+        virtual_price_decoded = contract.decode(output[0][1], 'get_virtual_price')
         if not _check_curve_contract_call(virtual_price_decoded):
             log.debug(f'Failed to decode get_virtual_price while finding curve price. {output}')
             return None
-        data.append(FVal(virtual_price_decoded[0]))  # pylint: disable=unsubscriptable-object
+        data.append(FVal(virtual_price_decoded[0]))
         for i, token in enumerate(tokens):
             amount_decoded = contract.decode(output[i + 1][1], 'balances', arguments=[i])
             if not _check_curve_contract_call(amount_decoded):
                 log.debug(f'Failed to decode balances {i} while finding curve price. {output}')
                 return None
             # https://github.com/PyCQA/pylint/issues/4739
-            amount = amount_decoded[0]  # pylint: disable=unsubscriptable-object
+            amount = amount_decoded[0]
             normalized_amount = token_normalized_value_decimals(amount, token.decimals)
             data.append(normalized_amount)
 

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -406,9 +406,9 @@ def test_query_transactions(rotkehlchen_api_server):
                 ),
                 has_premium=True,  # for this function we don't limit. We only limit txs.
             )
-            event_ids.add(events[0].identifier)  # pylint: disable=unsubscriptable-object
+            event_ids.add(events[0].identifier)
             assert len(events) == 1
-            assert events[0].balance.usd_value == events[0].balance.amount * FVal(1.5)  # pylint: disable=unsubscriptable-object  # noqa: E501
+            assert events[0].balance.usd_value == events[0].balance.amount * FVal(1.5)
 
     # see that if same transaction hash is requested for decoding events are not re-decoded
     response = requests.put(
@@ -437,7 +437,7 @@ def test_query_transactions(rotkehlchen_api_server):
                 has_premium=True,  # for this function we don't limit. We only limit txs.
             )
             assert len(events) == 1
-            assert events[0].identifier in event_ids  # pylint: disable=unsubscriptable-object
+            assert events[0].identifier in event_ids
 
     # Check that force re-requesting the events works
     assert_force_redecode_txns_works(rotkehlchen_api_server, hashes)
@@ -1292,8 +1292,8 @@ def test_query_transactions_check_decoded_events(
             assert cursor.execute(f'SELECT COUNT(*) from {name}').fetchone()[0] == count
         customized_events = dbevents.get_history_events(cursor, EvmEventFilterQuery.make(), True)  # noqa: E501
 
-    assert customized_events[0].serialize() == tx4_events[0]['entry']  # pylint: disable=unsubscriptable-object  # noqa: E501
-    assert customized_events[1].serialize() == tx2_events[1]['entry']  # pylint: disable=unsubscriptable-object  # noqa: E501
+    assert customized_events[0].serialize() == tx4_events[0]['entry']
+    assert customized_events[1].serialize() == tx2_events[1]['entry']
     # requery all transactions and events. Assert they are the same (different event id though)
     result = query_transactions(rotki)
     entries = result['entries']

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -141,8 +141,8 @@ def mock_etherscan_for_dsr(
     account2_join1_move_event = f"""{{"address": "{makerdao_vat.address}", "topics": ["0xbb35783b00000000000000000000000000000000000000000000000000000000", "{address_to_32byteshexstr(proxy2)}", "{makerdao_pot.address}", "{int_to_32byteshexstr(account2_join1_deposit // 10 ** 27)}"], "data": "0x1", "blockNumber": "{hex(params.account2_join1_blocknumber)}", "timeStamp": "{hex(blocknumber_to_timestamp(params.account2_join1_blocknumber))}", "gasPrice": "0x1", "gasUsed": "0x1", "logIndex": "0x6c", "transactionHash": "0xd81bddb97599cfab91b9ee52b5c505ffa730b71f1e484dc46d0f4ecb57893d2f", "transactionIndex": "0x79"}}"""  # noqa: E501
 
     # Not sure how to convince pylint that this ChecksumEvmAddress IS a subscriptable object
-    proxy1_contents = proxy1[2:].lower()  # pylint: disable=unsubscriptable-object
-    proxy2_contents = proxy2[2:].lower()  # pylint: disable=unsubscriptable-object
+    proxy1_contents = proxy1[2:].lower()
+    proxy2_contents = proxy2[2:].lower()
 
     def mock_requests_get(url, *args, **kwargs):
         if 'etherscan.io/api?module=proxy&action=eth_blockNumber' in url:

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -76,7 +76,7 @@ def test_convex_pools(ethereum_inquirer):
     queried_convex_pools_info = {}
     for convex_reward_addr, single_lp_token_result in zip(convex_rewards_addrs, lp_tokens_result):
         decoded_lp_token_result = lp_tokens_contract.decode(single_lp_token_result, 'symbol')
-        queried_convex_pools_info[convex_reward_addr] = decoded_lp_token_result[0]  # pylint: disable=unsubscriptable-object  # noqa: E501
+        queried_convex_pools_info[convex_reward_addr] = decoded_lp_token_result[0]
 
     if queried_convex_pools_info != CONVEX_POOLS:
         added_pools_addrs = queried_convex_pools_info.keys() - CONVEX_POOLS.keys()

--- a/rotkehlchen/tests/unit/events/test_eth_deposit.py
+++ b/rotkehlchen/tests/unit/events/test_eth_deposit.py
@@ -34,7 +34,7 @@ def test_db_read_write(database):
             filter_query=EthDepositEventFilterQuery.make(),
             has_premium=True,
         )
-    assert event == events[0]  # pylint: disable=unsubscriptable-object
+    assert event == events[0]
 
 
 def test_serialization():

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -736,7 +736,7 @@ def test_combine_block_with_tx_events(eth2, database):
         notes=f'Received {mev_reward} ETH from {mev_builder_address} as mev reward for block {block_number}',  # noqa: E501
         event_identifier=EthBlockEvent.form_event_identifier(block_number),
     )
-    assert modified_event == events[2]  # pylint: disable=unsubscriptable-object
+    assert modified_event == events[2]
 
 
 @pytest.mark.vcr()
@@ -800,17 +800,17 @@ def test_refresh_activated_validators_deposits(eth2, database):
     # make sure validator indices have been detected for the deposits
     assert isinstance(new_events, list)
     assert len(starting_events) == len(new_events)
-    assert starting_events[0] == new_events[0], 'first event should not have been modified'  # pylint: disable=unsubscriptable-object  # noqa: E501
+    assert starting_events[0] == new_events[0], 'first event should not have been modified'
     edited_event_2 = starting_events[1]
     edited_event_2.extra_data = None
     edited_event_2.validator_index = validator2.index
     edited_event_2.notes = f'Deposit 32 ETH to validator {validator2.index}'
-    assert edited_event_2 == new_events[1]  # pylint: disable=unsubscriptable-object
+    assert edited_event_2 == new_events[1]
     edited_event_3 = starting_events[2]
     edited_event_3.extra_data = None
     edited_event_3.validator_index = validator3.index
     edited_event_3.notes = f'Deposit 32 ETH to validator {validator3.index}'
-    assert edited_event_3 == new_events[2]  # pylint: disable=unsubscriptable-object
+    assert edited_event_3 == new_events[2]
 
     # finally make sure validators are also added
     with database.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -257,7 +257,7 @@ def test_genesis_remove_address(
     assert get_genesis_events() == all_events, 'Events should have not been modified'
 
     delete_transactions_for_address(genesis_address_1)
-    assert get_genesis_events() == [all_events[1]], 'One of the events should have been deleted'  # pylint: disable=unsubscriptable-object  # noqa: E501
+    assert get_genesis_events() == [all_events[1]], 'One of the events should have been deleted'
 
     delete_transactions_for_address(genesis_address_2)
     assert get_genesis_events() == [], 'There should be no events at this point'

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -363,14 +363,14 @@ def mock_etherscan_query(
                     scan_input_types = get_abi_input_types(scan_fn_abi)
                     scan_output_types = get_abi_output_types(scan_fn_abi)
                     result_bytes = []
-                    for call_entry in decoded_input[0]:  # pylint: disable=unsubscriptable-object
+                    for call_entry in decoded_input[0]:
                         call_contract_address = deserialize_evm_address(call_entry[0])
                         assert call_contract_address == contract.address, 'balances multicall should only contain calls to scan contract'  # noqa: E501
                         call_data = call_entry[1]
                         scan_decoded_input = web3.codec.decode_abi(scan_input_types, call_data[4:])
-                        account_address = deserialize_evm_address(scan_decoded_input[0])  # pylint: disable=unsubscriptable-object  # noqa: E501
+                        account_address = deserialize_evm_address(scan_decoded_input[0])
                         token_values = []
-                        for token_addy_str in scan_decoded_input[1]:  # pylint: disable=unsubscriptable-object # noqa: E501
+                        for token_addy_str in scan_decoded_input[1]:
                             token_address = deserialize_evm_address(token_addy_str)
                             token = _get_token(token_address)
                             if token is None:
@@ -389,7 +389,7 @@ def mock_etherscan_query(
                     # else has to be the 32 bytes for multicall balance
                     # of both veCRV and others. Return empty response
                     # all pylint ignores below due to https://github.com/PyCQA/pylint/issues/4114
-                    args = [1, [b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' for x in decoded_input[0]]]  # pylint: disable=unsubscriptable-object  # noqa: E501
+                    args = [1, [b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' for x in decoded_input[0]]]  # noqa: E501
                     result = '0x' + web3.codec.encode_abi(output_types, args).hex()
                     response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
 
@@ -416,7 +416,7 @@ def mock_etherscan_query(
                 output_types = get_abi_output_types(fn_abi)
                 decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
                 args = []
-                for raw_account_address in decoded_input[0]:  # pylint: disable=unsubscriptable-object  # noqa: E501
+                for raw_account_address in decoded_input[0]:
                     account_address = deserialize_evm_address(raw_account_address)
                     args.append(int(eth_map[account_address]['ETH']))
                 result = '0x' + web3.codec.encode_abi(output_types, [args]).hex()
@@ -435,10 +435,10 @@ def mock_etherscan_query(
                 output_types = get_abi_output_types(fn_abi)
                 decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
                 args = []
-                for raw_account_address in decoded_input[0]:  # pylint: disable=unsubscriptable-object  # noqa: E501
+                for raw_account_address in decoded_input[0]:
                     account_address = deserialize_evm_address(raw_account_address)
                     x = []
-                    for raw_token_address in decoded_input[1]:  # pylint: disable=unsubscriptable-object  # noqa: E501
+                    for raw_token_address in decoded_input[1]:
                         token_address = deserialize_evm_address(raw_token_address)
                         value_to_add = 0
                         for given_asset, value in eth_map[account_address].items():
@@ -470,9 +470,9 @@ def mock_etherscan_query(
                 output_types = get_abi_output_types(fn_abi)
                 decoded_input = web3.codec.decode_abi(input_types, bytes.fromhex(data[10:]))
                 args = []
-                account_address = deserialize_evm_address(decoded_input[0])  # pylint: disable=unsubscriptable-object  # noqa: E501
+                account_address = deserialize_evm_address(decoded_input[0])
                 x = []
-                for raw_token_address in decoded_input[1]:  # pylint: disable=unsubscriptable-object  # noqa: E501
+                for raw_token_address in decoded_input[1]:
                     token_address = deserialize_evm_address(raw_token_address)
                     value_to_add = 0
                     for given_asset, value in eth_map[account_address].items():


### PR DESCRIPTION
This rule is useless.

**every single** case it found was a false positive. And other tools, like mypy if done correctly also detect the problem.

This PR saves us a lot of pylint disable comments
