### PR TITLE
feat: update usePaginationFilters to use the defaultSortBy.ascending

### DIFF
--- a/frontend/app/src/components/accounts/ModuleActivator.vue
+++ b/frontend/app/src/components/accounts/ModuleActivator.vue
@@ -33,6 +33,8 @@ const visibleModules = computed(() =>
 onMounted(async () => await queriedAddressesStore.fetchQueriedAddresses());
 
 const { t } = useI18n();
+const { isAccountOperationRunning } = useAccountLoading();
+const loading = isAccountOperationRunning();
 </script>
 
 <template>
@@ -45,6 +47,7 @@ const { t } = useI18n();
       <v-btn-toggle
         v-model="enabledModules"
         multiple
+        :disabled="loading"
         class="mt-2"
         @change="updateSelection($event)"
       >
@@ -52,6 +55,7 @@ const { t } = useI18n();
           v-for="module in visibleModules"
           :key="module.identifier"
           icon
+          :disabled="loading"
           :value="module.identifier"
           color="primary"
           depressed

--- a/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
+++ b/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
@@ -30,6 +30,8 @@ const copyPageUrl = async () => {
 
 const { t } = useI18n();
 const { isPackaged } = useInterop();
+const { isAccountOperationRunning } = useAccountLoading();
+const loading = isAccountOperationRunning();
 </script>
 
 <template>
@@ -40,7 +42,11 @@ const { isPackaged } = useInterop();
       mandatory
       @change="update($event)"
     >
-      <v-btn :value="InputMode.MANUAL_ADD" data-cy="input-mode-manual">
+      <v-btn
+        :value="InputMode.MANUAL_ADD"
+        data-cy="input-mode-manual"
+        :disabled="loading"
+      >
         <v-icon>mdi-pencil-plus</v-icon>
         <span class="hidden-sm-and-down ml-1">
           {{ t('input_mode_select.manual_add.label') }}
@@ -49,7 +55,7 @@ const { isPackaged } = useInterop();
       <v-btn
         v-if="isEth"
         :value="InputMode.METAMASK_IMPORT"
-        :disabled="!isMetaMaskSupported()"
+        :disabled="!isMetaMaskSupported() || loading"
       >
         <v-img
           contain

--- a/frontend/app/src/components/asset-manager/ManagedAssetContent.vue
+++ b/frontend/app/src/components/asset-manager/ManagedAssetContent.vue
@@ -158,7 +158,7 @@ const {
   extraParams,
   defaultSortBy: {
     key: 'symbol',
-    ascending: [false]
+    ascending: [true]
   }
 });
 

--- a/frontend/app/src/composables/filter-paginate.ts
+++ b/frontend/app/src/composables/filter-paginate.ts
@@ -57,7 +57,7 @@ export const usePaginationFilters = <
   const router = useRouter();
   const route = useRoute();
   const paginationOptions: Ref<TablePagination<T>> = ref(
-    defaultOptions<T>(options.defaultSortBy?.key)
+    defaultOptions<T>(options.defaultSortBy)
   );
   const selected: Ref<V[]> = ref([]);
   const openDialog: Ref<boolean> = ref(false);
@@ -139,7 +139,7 @@ export const usePaginationFilters = <
       // for empty query, we reset the filters, and pagination to defaults
       onUpdateFilters?.(query);
       updateFilter(RouteFilterSchema.parse({}));
-      return setOptions(defaultOptions<T>(options.defaultSortBy?.key));
+      return setOptions(defaultOptions<T>(options.defaultSortBy));
     }
 
     const parsedOptions = RouterPaginationOptionsSchema.parse(query);

--- a/frontend/app/src/utils/collection.ts
+++ b/frontend/app/src/utils/collection.ts
@@ -86,14 +86,19 @@ export const setupEntryLimit = (
   };
 };
 
-export const defaultOptions = <T extends Object>(
-  orderBy?: keyof T
-): TablePagination<T> => {
+export const defaultOptions = <T extends Object>(defaultSortBy?: {
+  key?: keyof T;
+  ascending?: boolean[];
+}): TablePagination<T> => {
   const { itemsPerPage } = useFrontendSettingsStore();
   return {
     page: 1,
     itemsPerPage,
-    sortBy: orderBy ? [orderBy] : ['timestamp' as keyof T],
-    sortDesc: [true]
+    sortBy: defaultSortBy?.key
+      ? [defaultSortBy?.key]
+      : ['timestamp' as keyof T],
+    sortDesc: defaultSortBy?.ascending
+      ? defaultSortBy?.ascending.map(bool => !bool)
+      : [true]
   };
 };

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
@@ -96,7 +96,7 @@ describe('composables::history/filter-paginate', () => {
       expect(get(isLoading)).toBe(false);
       expect(get(filters)).to.toStrictEqual(undefined);
       expect(get(options).sortBy[0]).toEqual('timestamp');
-      expect(get(options).sortDesc[0]).toEqual(true);
+      expect(get(options).sortDesc[0]).toEqual(false);
       expect(get(options).sortBy).toHaveLength(1);
       expect(get(options).sortDesc).toHaveLength(1);
       expect(get(state).data).toHaveLength(0);
@@ -149,7 +149,7 @@ describe('composables::history/filter-paginate', () => {
         defaultCollection: defaultCollectionState,
         extraParams,
         defaultSortBy: {
-          ascending: [true]
+          ascending: [false]
         }
       });
 

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
@@ -94,7 +94,7 @@ describe('composables::history/filter-paginate', () => {
       expect(get(isLoading)).toBe(false);
       expect(get(filters)).to.toStrictEqual(undefined);
       expect(get(options).sortBy[0]).toEqual('name');
-      expect(get(options).sortDesc[0]).toEqual(true);
+      expect(get(options).sortDesc[0]).toEqual(false);
       expect(get(options).sortBy).toHaveLength(1);
       expect(get(options).sortDesc).toHaveLength(1);
       expect(get(state).data).toHaveLength(0);
@@ -148,7 +148,7 @@ describe('composables::history/filter-paginate', () => {
           extraParams,
           defaultSortBy: {
             key: 'name',
-            ascending: [true]
+            ascending: [false]
           }
         }
       );


### PR DESCRIPTION
update usePaginationFilters to use the defaultSortBy.ascending
and also set the default sort for `ManagedAsset` = sort by name, ascending