### PR TITLE
Add hidden flag to returned events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4923,6 +4923,7 @@ Dealing with History Events
 		      "product": null
                   },
                   "customized": false,
+		  "hidden": true,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 1
@@ -4967,6 +4968,7 @@ Dealing with History Events
 		      "is_exit": false
                   },
                   "customized": false,
+		  "hidden": true,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 1
@@ -5023,7 +5025,7 @@ Dealing with History Events
           "message": ""
       }
 
-   :resjson list decoded_events: A list of history events. Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry also has a `has_details` flag. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry has a `customized` flag denoting if the event has been customized/added by the user. Finally if `group_by_event_ids` is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the common event identifier. The consumer has to query this endpoint again with `group_by_event_ids` set to false and with the `event_identifiers` filter set to the identifier of the events having more than 1 event. Finally `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. Following are all possible entries depending on entry type.
+   :resjson list decoded_events: A list of history events. Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry may also have a `has_details` flag if true. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry may have a `customized` flag set to true. If it does, it means the event has been customized/added by the user. Each entry may also have a `hidden` flag if set to true. If it does then that means it should be hidden in the UI due to consolidation of events. Finally if `group_by_event_ids` exist and is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the common event identifier. The consumer has to query this endpoint again with `group_by_event_ids` set to false and with the `event_identifiers` filter set to the identifier of the events having more than 1 event. Finally `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. Following are all possible entries depending on entry type.
    :resjson string identifier: Common key. This is the identifier of a single event.
    :resjson string entry_type: Common key. This identifies the category of the event and determines the schema. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
    :resjson string event_identifier: Common key. An event identifier grouping multiple events under a common group. This is how we group transaction events under a transaction, staking related events under block production etc.
@@ -10588,7 +10590,7 @@ Data imports
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``.
-   
+
    .. note::
       If you want to provide a stream of data instead of a path, you can call POST on this endpoint and provide the stream in `filepath` variable.
 
@@ -12655,7 +12657,7 @@ Get all valid locations
         }
       }
 
-  :resjson list[string] locations: A mapping of locations to their details. Can contain `image` or `icon` depending on whether a known image should be used or an icon from the icon set. Can also contain `display_name` if a special name has to be used. 
+  :resjson list[string] locations: A mapping of locations to their details. Can contain `image` or `icon` depending on whether a known image should be used or an icon from the icon set. Can also contain `display_name` if a special name has to be used.
 
   :statuscode 200: Information was correctly returned
   :statuscode 500: Internal rotki error

--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -226,15 +226,17 @@ class HistoryBaseEntry(AccountingEventMixin, metaclass=ABCMeta):
             self,
             customized_event_ids: list[int],
             ignored_ids_mapping: dict[ActionType, set[str]],
+            hidden_event_ids: list[int],
             grouped_events_num: Optional[int] = None,
     ) -> dict[str, Any]:
         """Serialize event and extra flags for api"""
-        result = {
-            'entry': self.serialize(),
-            'has_details': False,
-            'customized': self.identifier in customized_event_ids,
-            'ignored_in_accounting': self.should_ignore(ignored_ids_mapping=ignored_ids_mapping),
-        }
+        result: dict[str, Any] = {'entry': self.serialize()}
+        if self.should_ignore(ignored_ids_mapping=ignored_ids_mapping):
+            result['ignored_in_accounting'] = True
+        if self.identifier in customized_event_ids:
+            result['customized'] = True
+        if self.identifier in hidden_event_ids:
+            result['hidden'] = True
         if grouped_events_num is not None:
             result['grouped_events_num'] = grouped_events_num
 

--- a/rotkehlchen/accounting/structures/evm_event.py
+++ b/rotkehlchen/accounting/structures/evm_event.py
@@ -162,14 +162,17 @@ class EvmEvent(HistoryBaseEntry):
             self,
             customized_event_ids: list[int],
             ignored_ids_mapping: dict[ActionType, set[str]],
+            hidden_event_ids: list[int],
             grouped_events_num: Optional[int] = None,
     ) -> dict[str, Any]:
         result = super().serialize_for_api(
             customized_event_ids=customized_event_ids,
             ignored_ids_mapping=ignored_ids_mapping,
+            hidden_event_ids=hidden_event_ids,
             grouped_events_num=grouped_events_num,
         )
-        result['has_details'] = self.has_details()
+        if self.has_details():
+            result['has_details'] = True
         return result
 
     @classmethod

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3602,6 +3602,7 @@ class RestAPI():
                 cursor=cursor,
                 chain_id=chain_id,  # type: ignore
             )
+            hidden_event_ids = dbevents.get_hidden_event_ids(cursor)
             ignored_ids_mapping = self.rotkehlchen.data.db.get_ignored_action_ids(
                 cursor=cursor,
                 action_type=ActionType.EVM_TRANSACTION,
@@ -3612,6 +3613,7 @@ class RestAPI():
                 x.serialize_for_api(
                     customized_event_ids=customized_event_ids,
                     ignored_ids_mapping=ignored_ids_mapping,
+                    hidden_event_ids=hidden_event_ids,
                     grouped_events_num=grouped_events_num,
                 ) for grouped_events_num, x in events_result
             ]
@@ -3620,6 +3622,7 @@ class RestAPI():
                 x.serialize_for_api(  # type: ignore
                     customized_event_ids=customized_event_ids,
                     ignored_ids_mapping=ignored_ids_mapping,
+                    hidden_event_ids=hidden_event_ids,
                 ) for x in events_result
             ]
         result = {

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -618,3 +618,19 @@ class DBHistoryEvents():
             except DeserializationError as e:
                 log.debug(f'Failed to deserialize amount {row[1]}. {str(e)}')
         return usd_value, assets_amounts
+
+    def get_hidden_event_ids(self, cursor: 'DBCursor') -> list[int]:
+        """Returns all event identifiers that should be hidden in the UI
+
+        These are, at the moment, special cases where due to grouping different event
+        types with similar info they all appear together but the UI should just show one.
+        """
+        # Only 1 type of hidden event for now
+        cursor.execute(
+            'SELECT E.identifier FROM history_events E LEFT JOIN eth_staking_events_info S '
+            'ON E.identifier=S.identifier WHERE E.sequence_index=1 AND S.identifier IS NOT NULL '
+            'AND 3=(SELECT COUNT(*) FROM history_events E2 WHERE '
+            'E2.event_identifier=E.event_identifier)',
+        )
+        result = [x[0] for x in cursor]
+        return result

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1101,9 +1101,6 @@ def test_query_transactions_check_decoded_events(
             'timestamp': 1642802807,
             'tx_hash': '0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f',
         },
-        'customized': False,
-        'has_details': False,
-        'ignored_in_accounting': False,
     }, {
         'entry': {
             'identifier': 5,
@@ -1123,9 +1120,6 @@ def test_query_transactions_check_decoded_events(
             'timestamp': 1642802807,
             'tx_hash': '0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f',
         },
-        'customized': False,
-        'has_details': False,
-        'ignored_in_accounting': False,
     }]
     assert returned_events[:2] == tx1_events
     tx2_events = [{
@@ -1147,9 +1141,6 @@ def test_query_transactions_check_decoded_events(
             'timestamp': 1642802735,
             'tx_hash': '0x38ed9c2d4f0855f2d88823d502f8794b993d28741da48724b7dfb559de520602',
         },
-        'customized': False,
-        'has_details': False,
-        'ignored_in_accounting': False,
     }, {
         'entry': {
             'identifier': 2,
@@ -1169,9 +1160,6 @@ def test_query_transactions_check_decoded_events(
             'timestamp': 1642802735,
             'tx_hash': '0x38ed9c2d4f0855f2d88823d502f8794b993d28741da48724b7dfb559de520602',
         },
-        'customized': False,
-        'has_details': False,
-        'ignored_in_accounting': False,
     }]
     assert returned_events[2:4] == tx2_events
     tx3_events = [{
@@ -1193,9 +1181,6 @@ def test_query_transactions_check_decoded_events(
             'timestamp': 1642802651,
             'tx_hash': '0x6c27ea39e5046646aaf24e1bb451caf466058278685102d89979197fdb89d007',
         },
-        'customized': False,
-        'has_details': False,
-        'ignored_in_accounting': False,
     }]
     assert returned_events[4:5] == tx3_events
     tx4_events = [{
@@ -1217,9 +1202,6 @@ def test_query_transactions_check_decoded_events(
             'timestamp': 1642802286,
             'tx_hash': '0xccb6a445e136492b242d1c2c0221dc4afd4447c96601e88c156ec4d52e993b8f',
         },
-        'customized': False,
-        'has_details': False,
-        'ignored_in_accounting': False,
     }]
     assert returned_events[5:6] == tx4_events
 
@@ -1256,8 +1238,6 @@ def test_query_transactions_check_decoded_events(
             'tx_hash': '0xccb6a445e136492b242d1c2c0221dc4afd4447c96601e88c156ec4d52e993b8f',
         },
         'customized': True,
-        'has_details': False,
-        'ignored_in_accounting': False,
     })
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -393,7 +393,6 @@ def test_event_with_details(rotkehlchen_api_server: 'APIServer'):
     )
     result = assert_proper_response_with_result(response)
     events = result['entries']
-    assert events[0]['has_details'] is False
     assert events[1]['has_details'] is True
 
     # Check that if an event is not in the db, an error is returned
@@ -460,14 +459,12 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
     assert result['entries_total'] == 6
     for event in result['entries']:
         assert event['entry'] in expected_entries
-        assert event['customized'] is False
-        assert event['has_details'] is False
 
         # check that the only ignored event is the one that we have set
         if event['entry']['event_identifier'] == entries[0].event_identifier:
             assert event['ignored_in_accounting'] is True
         else:
-            assert event['ignored_in_accounting'] is False
+            assert 'ignored_in_accounting' not in event
 
     # now try with grouping
     response = requests.post(

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -852,6 +852,10 @@ def test_combine_block_with_tx_events(eth2, database):
     )
     assert modified_event == events[2]
 
+    with database.conn.read_ctx() as cursor:
+        hidden_ids = dbevents.get_hidden_event_ids(cursor)
+        assert [2] == hidden_ids
+
 
 @pytest.mark.vcr()
 @pytest.mark.parametrize('network_mocking', [False])

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -154,9 +154,6 @@ def generate_events_response(
     for event in data:
         result.append({
             'entry': event.serialize(),
-            'has_details': False,
-            'customized': False,
-            'ignored_in_accounting': False,
         })
     return result
 


### PR DESCRIPTION
- Potentially adds a hidden key to each returned event if it should be hidden by the frontend's UI
- All flags for the history events are now optional. Since they were all booleans if they exist, they are set to true. If missing they are false and as such we reduce amount of data moving between backend and frontend.