### PR TITLE
Cleanup identifiers usage in /assets/all

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2912,6 +2912,7 @@ Querying all supported assets
    :reqjson string address: The address of the evm asset to be used to filter the result data. Optional.
    :reqjson bool show_user_owned_assets_only: A flag to specify if only user owned assets should be returned. Defaults to ``"false"``. Optional.
    :reqjson string ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exlude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
+   :reqjson list[string] identifiers: A list of asset identifiers to filter by. Optional.
 
    **Example Response**:
 
@@ -3009,7 +3010,6 @@ Querying all supported assets
    :resjson string notes: If the type is ``custom_asset`` this is a string field with notes added by the user.
    :resjson string custom_asset_type: If the type is ``custom_asset`` this field contains the custom type set by the user for the asset.
    :statuscode 200: Assets successfully queried.
-   :statuscode 409: One or more of the requested identifiers don't exist in the database.
    :statuscode 500: Internal rotki error
 
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1254,30 +1254,14 @@ class RestAPI():
         # else
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
-    def query_list_of_all_assets(
-            self,
-            filter_query: AssetsFilterQuery,
-            identifiers: Optional[list[str]],
-    ) -> Response:
-        """
-        If a set of identifiers is provided returns the information for those identifiers otherwise
-        returns all supported assets with pagination.
-        """
+    def query_list_of_all_assets(self, filter_query: AssetsFilterQuery) -> Response:
+        """Query assets using the provided filter_query and return them in a paginated format"""
         assets, assets_found = GlobalDBHandler().retrieve_assets(filter_query=filter_query)
         with GlobalDBHandler().conn.read_ctx() as cursor:
             assets_total = self.rotkehlchen.data.db.get_entries_count(
                 cursor=cursor,
                 entries_table='assets',
             )
-
-        if identifiers is not None and len(identifiers) != assets_found:
-            not_found = []
-            found_assets = {asset['identifier'] for asset in assets}
-            for asset in identifiers:
-                if asset not in found_assets:
-                    not_found.append(asset)
-            msg = f"Queried identifiers {','.join(not_found)} are not present in the database"
-            return api_response(wrap_in_fail_result(msg), status_code=HTTPStatus.CONFLICT)
 
         result = {
             'entries': assets,

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -745,11 +745,8 @@ class AllAssetsResource(BaseMethodView):
         )
 
     @resource_parser.use_kwargs(make_post_schema, location='json')
-    def post(self, filter_query: AssetsFilterQuery, identifiers: Optional[list[str]]) -> Response:
-        return self.rest_api.query_list_of_all_assets(
-            filter_query=filter_query,
-            identifiers=identifiers,
-        )
+    def post(self, filter_query: AssetsFilterQuery) -> Response:
+        return self.rest_api.query_list_of_all_assets(filter_query=filter_query)
 
     @require_loggedin_user()
     @resource_parser.use_kwargs(make_add_schema, location='json')

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -470,22 +470,6 @@ def test_get_all_assets(rotkehlchen_api_server):
     assert result['entries'][1]['identifier'] == custom_asset_id
     assert result['entries'][2]['identifier'] == A_BTC
 
-    # ask for a non existent asset
-    response = requests.post(
-        api_url_for(
-            rotkehlchen_api_server,
-            'allassetsresource',
-        ),
-        json={
-            'identifiers': ['my_life'],
-        },
-    )
-    assert_error_response(
-        response=response,
-        contained_in_msg='Queried identifiers my_life are not present in the database',
-        status_code=HTTPStatus.CONFLICT,
-    )
-
     # check that evm tokens with underlying tokens are shown
     response = requests.post(
         api_url_for(


### PR DESCRIPTION
Updates the docs, removes unneeded code and makes sure that if `identifiers` list is provided, it has the highest priority in `POST /assets/all` enpoint