### PR TITLE
Deleting a tracked validator now also deletes its staking events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8839,7 +8839,7 @@ Deleting Eth2 validators
 
 .. http:delete:: /api/(version)/blockchains/ETH2/validators
 
-   Doing a DELETE on the eth2 validators endpoint will delete information and stop tracking an ETH2 validator.
+   Doing a DELETE on the eth2 validators endpoint will delete information and stop tracking a number of ETH2 validator/s.
 
 
    **Example Request**:
@@ -8851,17 +8851,10 @@ Deleting Eth2 validators
       Content-Type: application/json
 
       {
-        "validators": [
-          {
-            "validator_index": 1,
-            "public_key": "abcd"
-          }
-        ]
+        "validators": [1, 23423, 3233]
       }
 
-   :reqjson list[object] validators: A list of eth2 validators to delete.
-   :reqjsonarr int[optional] validator_index: An optional integer representing the validator index of the validator to track. If this is not given then the pulic key of the validator has to be given!
-   :reqjsonarr string[optional] public_key: An optional string representing the hexadecimal string of the public key of the validator to track. If this is not given the the validator index has to be given!
+   :reqjson list[int] validators: A list of indices of eth2 validators to delete
 
    **Example Response**:
 
@@ -8875,7 +8868,7 @@ Deleting Eth2 validators
         "message": ""
       }
 
-   :statuscode 200: Eth2 validator successfully delete.
+   :statuscode 200: Eth2 validator/s successfully delete.
    :statuscode 409: User is not logged in. Or eth2 module is not activated.
    :statuscode 500: Internal rotki error.
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2248,14 +2248,10 @@ class RestAPI():
 
     def delete_eth2_validator(
             self,
-            validators: list[dict],
+            validators: list[int],
     ) -> Response:
         try:
-            for validator in validators:
-                self.rotkehlchen.chains_aggregator.delete_eth2_validator(
-                    validator_index=validator.get('validator_index'),
-                    public_key=validator.get('public_key'),
-                )
+            self.rotkehlchen.chains_aggregator.delete_eth2_validators(validators)
             result = OK_RESULT
             status_code = HTTPStatus.OK
         except InputError as e:

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1802,7 +1802,7 @@ class Eth2ValidatorsResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(delete_schema, location='json')
-    def delete(self, validators: list[dict[str, Any]]) -> Response:
+    def delete(self, validators: list[int]) -> Response:
         return self.rest_api.delete_eth2_validator(validators=validators)
 
     @require_loggedin_user()

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2514,7 +2514,13 @@ class Eth2ValidatorPutSchema(AsyncQueryArgumentSchema, Eth2ValidatorSchema):
 
 
 class Eth2ValidatorDeleteSchema(Schema):
-    validators = fields.List(fields.Nested(Eth2ValidatorSchema), required=True)
+    validators = DelimitedOrNormalList(fields.Integer(
+        strict=True,
+        validate=webargs.validate.Range(
+            min=0,
+            error='Validator index must be an integer >= 0',
+        ),
+    ), required=True)
 
 
 class Eth2ValidatorPatchSchema(Schema):

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1218,11 +1218,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=False)  # noqa: E501
         self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=True)  # noqa: E501
 
-    def delete_eth2_validator(
-            self,
-            validator_index: Optional[int],
-            public_key: Optional[str],
-    ) -> None:
+    def delete_eth2_validators(self, validator_indices: list[int]) -> None:
         """May raise:
         - ModuleInactive if eth2 module is not activated
         - InputError if the validator is not found in the DB
@@ -1231,10 +1227,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         eth2 = self.get_module('eth2')
         if eth2 is None:
             raise ModuleInactive('Cant delete eth2 validator since eth2 module is not active')
-        return DBEth2(self.database).delete_validator(
-            validator_index=validator_index,
-            public_key=public_key,
-        )
+        return DBEth2(self.database).delete_validators(validator_indices)
 
     @cache_response_timewise()
     def get_loopring_balances(self) -> dict[CryptoAsset, Balance]:


### PR DESCRIPTION
This does two things.

1. As discussed with @kelsos, in the delete validator endpoint we now just accept a list of validator indices, and not either index or public key.
2. When deleting a validator, we delete it from:
    a. The validators table, which in turn deletes the daily stats references it has
    b. We find all events where that validator index is used and delete them ... unless it's a deposit event. As deposit events are 
        associated with the depositor EVM address and are EVM transactions so should stay.