### PR TITLE
Protect with a lock contract query in packaged db

### DIFF
--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1091,9 +1091,10 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
         of history events. Internally we look for the query range that needs to be queried in the
         range (start_ts, end_ts) to avoid double quering the kraken API when this method is called
         for deposits/withdrawals and trades. The events queried are then stored in the database.
+
         If notify_events is True we send websocket messages to notify the current interval of
-        time being queried. By default is set to False to avoid sending unwanted message when this
-        funtion is called internally and not directly from the UI by the user.
+        time being queried. By default it is set to False to avoid sending unwanted message when
+        this funtion is called internally and not directly from the UI by the user.
 
         Returns true if any query to the kraken API was not successful
         """


### PR DESCRIPTION
It could happen that two different requests tried to access at the same time the packaged db to copy a contract and then the task would fail because the packaged db would be already attached by one of them.

This was easily seen while visiting a page with multiple ens avatars when the contract was still not copied.

Notes:

1. I didn't use a lock at funtion level to avoid blocking contracts queries since the problem was only when querying from the packaged db
2. In the case of two greenlets executing the copy it will be a no-op for the second since we do `get_or_write_abi`
and a `INSERT OR IGNORE`