### PR TITLE
Withdrawals remote error

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5233,6 +5233,7 @@ Querying online events
     :statuscode 400: Provided JSON is in some way malformed.
     :statuscode 409: Module for the given events is not active.
     :statuscode 500: Internal rotki error.
+    :statuscode 502: An external service used in the query such as beaconchain could not be reached or returned an unexpected response.
 
 Querying messages to show to the user
 =====================================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 * :feature:`5473` Block production rewards for your validators will now be properly detected, displayed and accounted for in the PnL report.
 * :feature:`4886` Staking MEV rewards for your validators will now be properly detected, displayed and accounted for in the PnL report.
 * :feature:`5933` FTX and FTX US support is removed since the exchanges no longer exist
-* :feature:`5824` Improved support for ENS allowing to decode the version of their contracts that added the name wrapper.
+* :feature:`5824` Improved support for ENS, allowing to decode the version of their contracts that added the name wrapper.
 * :feature:`-` Refunds in ENS renewal transactions will now be properly processed.
 * :feature:`5816` The NFT images will not be automatically rendered now. It is made so to prevent a known security issue, that may result in leakage of your privacy (read https://medium.com/@alxlpsc/critical-privacy-vulnerability-getting-exposed-by-metamask-693c63c2ce94 ). You can add domains you trust to the whitelisted domain in the NFT setting.
 * :feature:`5696` Transactions interacting with Curve Zap Deposit contracts are now decoded properly.

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -662,12 +662,17 @@ class HistoryEventSchema(DBPaginationSchema, DBOrderBySchema):
                     message='Filtering by counterparty ETH2 does not work in combination with other counterparties',  # noqa: E501
                     field_name='counterparties',
                 )
-
             if entry_types is not None:
                 raise ValidationError(
                     message='Filtering by counterparty ETH2 does not work in combination with entry type',  # noqa: E501
                     field_name='counterparties',
                 )
+            for x in ('products', 'tx_hashes'):
+                if data[x] is not None:
+                    raise ValidationError(
+                        message=f'Filtering by counterparty ETH2 does not work in combination with filtering by {x}',  # noqa: E501
+                        field_name='counterparties',
+                    )
 
             counterparties = None
             entry_types = [

--- a/rotkehlchen/chain/ethereum/modules/eth2/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/utils.py
@@ -69,7 +69,11 @@ def _parse_int(line: str, entry: str) -> int:
 
 
 def _query_page(url: str, event: Literal['stats', 'withdrawals']) -> requests.Response:
-    """Query a single page and return the response"""
+    """Query a single page and return the response
+
+    May raise:
+    - RemoteError if there is a request failure to beaconcha.in site
+    """
     tries = 1
     max_tries = 3
     backoff = 60

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1095,6 +1095,8 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
         If notify_events is True we send websocket messages to notify the current interval of
         time being queried. By default it is set to False to avoid sending unwanted message when
         this funtion is called internally and not directly from the UI by the user.
+        May raise:
+        - RemoteError if request to kraken fails for whatever reason
 
         Returns true if any query to the kraken API was not successful
         """

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -306,6 +306,11 @@ class ExchangeManager:
         return []
 
     def query_history_events(self) -> None:
+        """Queries all history events for exchanges that need it
+
+        May raise:
+        - RemoteError if any exchange's remote query fails
+        """
         for exchange in self.iterate_exchanges():
             exchange.query_history_events()
 


### PR DESCRIPTION
- When querying for withdrawals, exchange events or block production the API should now handle errors properly
- Do not silently ignore EVM filters if counterparty is eth2