### PR TITLE
Optimize withdrawals caching

### DIFF
--- a/rotkehlchen/chain/accounts.py
+++ b/rotkehlchen/chain/accounts.py
@@ -13,7 +13,7 @@ from rotkehlchen.types import (
 )
 
 
-@dataclass(init=True, repr=False, eq=True, order=False, unsafe_hash=False, frozen=False)
+@dataclass(init=True, repr=False, eq=True, order=False, unsafe_hash=False, frozen=True)
 class BlockchainAccounts:
     eth: list[ChecksumEvmAddress] = field(default_factory=list)
     optimism: list[ChecksumEvmAddress] = field(default_factory=list)

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -23,8 +23,8 @@ log = RotkehlchenLogsAdapter(logger)
 
 # How much time more than the last time a withdrawal happened to have allowed to pass
 # in order to recheck withdrawals for a given validator. In average at time of writing
-# withdrawals occur every 3-5 days for a single validator
-WITHDRAWALS_RECHECK_PERIOD = 3 * DAY_IN_SECONDS * 1000  # 3 days in milliseconds
+# withdrawals occur every 4-7 days for a single validator
+WITHDRAWALS_RECHECK_PERIOD = 4 * DAY_IN_SECONDS * 1000  # 4 days in milliseconds
 
 
 class DBEth2():


### PR DESCRIPTION
- Before runing the withdrawal query make sure it has not ran in last 3 hours. This is just a simple optimization which is probably temporary due to the nature of withdrawals having no api and us only being able to remember last withdrawal per validator (which can be up to 7-8 days in the past).
- Make the BlockchainAccounts dataclass immutable. (I think this should be immutable. Let's run the tests. This got prompted by the suspicions Alexey raised about the bug he looked into)