### PR TITLE
Various changes centered around fixing 5432

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import traceback
 from collections import defaultdict
+from collections.abc import Sequence
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, get_args, overload
@@ -2698,7 +2699,7 @@ class RestAPI():
             module_name='liquity',
             method='get_positions',
             query_specific_balances_before=None,
-            addresses_list=self.rotkehlchen.chains_aggregator.queried_addresses_for_module('liquity'),  # noqa: E501
+            given_addresses=self.rotkehlchen.chains_aggregator.queried_addresses_for_module('liquity'),  # noqa: E501
         )
 
     @async_api_call()
@@ -3964,7 +3965,7 @@ class RestAPI():
     def detect_evm_tokens(
             self,
             only_cache: bool,
-            addresses: Optional[list[ChecksumEvmAddress]],
+            addresses: Optional[Sequence[ChecksumEvmAddress]],
             blockchain: SUPPORTED_EVM_CHAINS,
     ) -> dict[str, Any]:
         manager: EvmManager = self.rotkehlchen.chains_aggregator.get_chain_manager(blockchain)

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import Sequence
 from functools import wraps
 from http import HTTPStatus
 from pathlib import Path
@@ -2766,7 +2767,7 @@ class DetectTokensResource(BaseMethodView):
             blockchain: SUPPORTED_EVM_CHAINS,
             async_query: bool,
             only_cache: bool,
-            addresses: Optional[list[ChecksumEvmAddress]],
+            addresses: Optional[Sequence[ChecksumEvmAddress]],
     ) -> Response:
         return self.rest_api.detect_evm_tokens(
             async_query=async_query,

--- a/rotkehlchen/chain/avalanche/manager.py
+++ b/rotkehlchen/chain/avalanche/manager.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from typing import Any, Optional
 
 from eth_utils import to_checksum_address
@@ -70,7 +71,7 @@ class AvalancheManager():
 
     def get_multiavax_balance(
             self,
-            accounts: list[ChecksumEvmAddress],
+            accounts: Sequence[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, FVal]:
         """Returns a dict with keys being accounts and balances in AVAX
 

--- a/rotkehlchen/chain/bitcoin/__init__.py
+++ b/rotkehlchen/chain/bitcoin/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import requests
 
 from rotkehlchen.errors.misc import RemoteError, UnableToDecryptRemoteData
@@ -9,12 +11,12 @@ from rotkehlchen.utils.misc import satoshis_to_btc
 from rotkehlchen.utils.network import request_get_dict
 
 
-def _have_bc1_accounts(accounts: list[BTCAddress]) -> bool:
+def _have_bc1_accounts(accounts: Sequence[BTCAddress]) -> bool:
     return any(account.lower()[0:3] == 'bc1' for account in accounts)
 
 
 def _query_blockstream_or_mempool(
-        accounts: list[BTCAddress],
+        accounts: Sequence[BTCAddress],
         base_url: str,
 ) -> dict[BTCAddress, FVal]:
     """Queries balances from blockstream.info
@@ -47,21 +49,21 @@ def _query_blockstream_or_mempool(
     return balances
 
 
-def _query_blockstream_info(accounts: list[BTCAddress]) -> dict[BTCAddress, FVal]:
+def _query_blockstream_info(accounts: Sequence[BTCAddress]) -> dict[BTCAddress, FVal]:
     return _query_blockstream_or_mempool(
         accounts=accounts,
         base_url='https://blockstream.info/api/address/',
     )
 
 
-def _query_mempool_space(accounts: list[BTCAddress]) -> dict[BTCAddress, FVal]:
+def _query_mempool_space(accounts: Sequence[BTCAddress]) -> dict[BTCAddress, FVal]:
     return _query_blockstream_or_mempool(
         accounts=accounts,
         base_url='https://mempool.space/api/address/',
     )
 
 
-def _query_blockchain_info(accounts: list[BTCAddress]) -> dict[BTCAddress, FVal]:
+def _query_blockchain_info(accounts: Sequence[BTCAddress]) -> dict[BTCAddress, FVal]:
     """Queries balances from blockchain.info
     May raise:
     - RemoteError if got problems with querying the API
@@ -91,7 +93,7 @@ def _query_blockchain_info(accounts: list[BTCAddress]) -> dict[BTCAddress, FVal]
 
 
 def get_bitcoin_addresses_balances(
-        accounts: list[BTCAddress],
+        accounts: Sequence[BTCAddress],
 ) -> dict[BTCAddress, FVal]:
     """Queries bitcoin balance APIs for the balances of accounts
 

--- a/rotkehlchen/chain/bitcoin/bch/__init__.py
+++ b/rotkehlchen/chain/bitcoin/bch/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import requests
 
 from rotkehlchen.chain.bitcoin.bch.utils import cash_to_legacy_address
@@ -12,7 +14,7 @@ from rotkehlchen.utils.network import request_get, request_get_dict
 HASKOIN_BASE_URL = 'https://api.haskoin.com'
 
 
-def get_bitcoin_cash_addresses_balances(accounts: list[BTCAddress]) -> dict[BTCAddress, FVal]:
+def get_bitcoin_cash_addresses_balances(accounts: Sequence[BTCAddress]) -> dict[BTCAddress, FVal]:
     """Queries api.haskoin.com for the balances of BCH accounts.
 
     May raise:
@@ -65,7 +67,7 @@ def get_bitcoin_cash_addresses_balances(accounts: list[BTCAddress]) -> dict[BTCA
 
 
 def _check_haskoin_for_transactions(
-        accounts: list[BTCAddress],
+        accounts: Sequence[BTCAddress],
 ) -> dict[BTCAddress, tuple[bool, FVal]]:
     """Checks if the BCH addresses have at least a transaction.
     May raise RemoteError or KeyError or DeserializationError"""
@@ -92,7 +94,7 @@ def _check_haskoin_for_transactions(
     return have_transactions
 
 
-def have_bch_transactions(accounts: list[BTCAddress]) -> dict[BTCAddress, tuple[bool, FVal]]:
+def have_bch_transactions(accounts: Sequence[BTCAddress]) -> dict[BTCAddress, tuple[bool, FVal]]:
     """
     Takes a list of BCH addresses and returns a mapping of which addresses have had transactions
     and also their current balance

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -1,7 +1,7 @@
 import csv
 import logging
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any
@@ -277,7 +277,7 @@ def get_poap_airdrop_data(name: str, data_dir: Path) -> dict[str, Any]:
 
 
 def check_airdrops(
-        addresses: list[ChecksumEvmAddress],
+        addresses: Sequence[ChecksumEvmAddress],
         data_dir: Path,
 ) -> dict[ChecksumEvmAddress, dict]:
     """Checks airdrop data for the given list of ethereum addresses

--- a/rotkehlchen/chain/ethereum/defi/chad.py
+++ b/rotkehlchen/chain/ethereum/defi/chad.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.ethereum.defi.structures import DefiProtocolBalances
@@ -28,7 +29,7 @@ class DefiChad():
 
     def query_defi_balances(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, list[DefiProtocolBalances]]:
         defi_balances = defaultdict(list)
         for account in addresses:

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import gevent
@@ -82,7 +83,7 @@ class Eth2(EthereumModule):
 
     def fetch_and_update_eth1_validator_data(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> list[ValidatorID]:
         """Query all eth1 addresses for their validators and any newly detected validators
         are added to the DB.
@@ -128,7 +129,7 @@ class Eth2(EthereumModule):
 
     def get_balances(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
             fetch_validators_for_eth1: bool,
     ) -> dict[Eth2PubKey, Balance]:
         """
@@ -177,7 +178,7 @@ class Eth2(EthereumModule):
 
         return balance_mapping
 
-    def get_details(self, addresses: list[ChecksumEvmAddress]) -> list[ValidatorDetails]:
+    def get_details(self, addresses: Sequence[ChecksumEvmAddress]) -> list[ValidatorDetails]:
         """Go through the list of eth1 addresses and find all eth2 validators associated
         with them along with their details.
 

--- a/rotkehlchen/chain/ethereum/modules/liquity/statistics.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/statistics.py
@@ -1,4 +1,6 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
+
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
 from rotkehlchen.constants.assets import A_LQTY, A_LUSD
@@ -103,7 +105,7 @@ def _get_stats(
     }
 
 
-def get_stats(database: 'DBHandler', addresses: list[ChecksumEvmAddress]) -> dict[str, Any]:
+def get_stats(database: 'DBHandler', addresses: Sequence[ChecksumEvmAddress]) -> dict[str, Any]:
     """
     Query staking information for the liquity module related to both the LQTY staking
     and the stability pool. It returns a dictionary combining the information from all

--- a/rotkehlchen/chain/ethereum/modules/nft/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nft/nfts.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
 from pysqlcipher3 import dbapi2 as sqlcipher
@@ -202,7 +203,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
 
     def query_balances(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
             uniswap_nfts: Optional[AddressToUniswapV3LPBalances],
     ) -> None:
         """Queries NFT balances for the specified addresses and saves them to the db.
@@ -239,7 +240,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
                 f'DELETE FROM nfts WHERE owner_address IN '
                 f'({",".join("?"*len(addresses))}) AND identifier NOT IN '
                 f'({",".join("?"*len(fresh_nfts_identifiers))})',
-                addresses + fresh_nfts_identifiers,
+                tuple(addresses) + tuple(fresh_nfts_identifiers),
             )
 
             # Add new NFTs to the DB cache

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from rotkehlchen.accounting.structures.balance import AssetBalance, Balance
@@ -50,7 +51,7 @@ class PickleFinance(EthereumModule):
 
     def get_dill_balances(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, DillBalance]:
         """
         Query information for amount locked, pending rewards and time until unlock
@@ -122,7 +123,7 @@ class PickleFinance(EthereumModule):
 
     def balances_in_protocol(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, list['AssetBalance']]:
         """Queries all the pickles deposited and available to claim in the protocol"""
         dill_balances = self.get_dill_balances(addresses)

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -315,7 +315,7 @@ def decode_basic_uniswap_info(
             # If what described in the comment above is not met then it is an error.
             log.debug(
                 f'Found unexpected event {event.serialize()} during decoding a uniswap swap in '
-                f'transaction {event.tx_hash.hex()}. Either uniswap router or an aggregator was'
+                f'transaction {event.tx_hash.hex()}. Either uniswap router or an aggregator was '
                 f'used and decoding needs to happen in the aggregator-specific decoder.',
             )
             break

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import EvmToken
@@ -73,7 +74,7 @@ class EthereumTokens(EvmTokens):
 
         return exceptions
 
-    def maybe_detect_proxies_tokens(self, addresses: list[ChecksumEvmAddress]) -> None:
+    def maybe_detect_proxies_tokens(self, addresses: Sequence[ChecksumEvmAddress]) -> None:
         """Detect tokens for proxies that are owned by the given addresses"""
         # Add Makerdao vault collateral tokens
         with GlobalDBHandler().conn.read_ctx() as cursor:

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -284,7 +284,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
 
     def get_multi_balance(
             self,
-            accounts: list[ChecksumEvmAddress],
+            accounts: Sequence[ChecksumEvmAddress],
             call_order: Optional[Sequence[WeightedNode]] = None,
     ) -> dict[ChecksumEvmAddress, FVal]:
         """Returns a dict with keys being accounts and balances in ETH

--- a/rotkehlchen/chain/evm/proxies_inquirer.py
+++ b/rotkehlchen/chain/evm/proxies_inquirer.py
@@ -1,5 +1,6 @@
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional
 
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -60,7 +61,7 @@ class EvmProxiesInquirer():
 
     def get_accounts_proxy(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, ChecksumEvmAddress]:
         """
         Returns DSProxy if it exists for a list of addresses using only one call
@@ -110,8 +111,7 @@ class EvmProxiesInquirer():
 
         with self.node_inquirer.database.conn.read_ctx() as cursor:
             accounts = self.node_inquirer.database.get_blockchain_accounts(cursor)
-        eth_accounts = accounts.eth
-        mapping = self.get_accounts_proxy(eth_accounts)
+        mapping = self.get_accounts_proxy(accounts.get(self.node_inquirer.blockchain))
 
         self.last_proxy_mapping_query_ts = ts_now()
         self.address_to_proxy = mapping

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -224,7 +224,7 @@ class EvmTokens(metaclass=ABCMeta):
             total_token_balances = combine_dicts(total_token_balances, new_token_balances)
         return total_token_balances
 
-    def _compute_detected_tokens_info(self, addresses: list[ChecksumEvmAddress]) -> DetectedTokensType:  # noqa: E501
+    def _compute_detected_tokens_info(self, addresses: Sequence[ChecksumEvmAddress]) -> DetectedTokensType:  # noqa: E501
         """
         Generate a structure that contains information about the addresses that tokens
         were requested for.
@@ -265,7 +265,7 @@ class EvmTokens(metaclass=ABCMeta):
     def detect_tokens(
             self,
             only_cache: bool,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> DetectedTokensType:
         """
         Detect tokens for the given addresses.
@@ -294,7 +294,7 @@ class EvmTokens(metaclass=ABCMeta):
 
     def _detect_tokens(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
             tokens_to_check: list[EvmToken],
     ) -> None:
         """
@@ -325,7 +325,7 @@ class EvmTokens(metaclass=ABCMeta):
 
     def query_tokens_for_addresses(
             self,
-            addresses: list[ChecksumEvmAddress],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> TokenBalancesType:
         """Queries token balances for a list of addresses
         Returns the token balances of each address and the usd prices of the tokens.
@@ -381,6 +381,6 @@ class EvmTokens(metaclass=ABCMeta):
         Each chain needs to implement any chain-specific exceptions here.
         """
 
-    def maybe_detect_proxies_tokens(self, addresses: list[ChecksumEvmAddress]) -> None:  # pylint: disable=unused-argument  # noqa: E501
+    def maybe_detect_proxies_tokens(self, addresses: Sequence[ChecksumEvmAddress]) -> None:  # pylint: disable=unused-argument  # noqa: E501
         """Subclasses may implement this method to detect tokens for proxies"""
         return None

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -124,7 +124,7 @@ class EvmTransactions(metaclass=ABCMeta):  # noqa: B024
         """
         query_accounts = filter_query.accounts
         if query_accounts is not None:
-            accounts = [x.address for x in query_accounts if x.chain_id == self.evm_inquirer.chain_id]  # noqa: E501
+            accounts = tuple(x.address for x in query_accounts if x.chain_id == self.evm_inquirer.chain_id)  # noqa: E501
         else:
             with self.database.conn.read_ctx() as cursor:
                 accounts = self.database.get_blockchain_accounts(cursor).get(

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -557,7 +557,7 @@ class SubstrateManager():
 
     def get_accounts_balance(
             self,
-            accounts: list[SubstrateAddress],
+            accounts: Sequence[SubstrateAddress],
     ) -> dict[SubstrateAddress, FVal]:
         """Given a list of accounts get their amount of chain native token.
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1244,10 +1244,10 @@ class DBHandler:
 
     def get_blockchain_accounts(self, cursor: 'DBCursor') -> BlockchainAccounts:
         """Returns a Blockchain accounts instance containing all blockchain account addresses"""
-        accounts = BlockchainAccounts()
         cursor.execute(
             'SELECT blockchain, account FROM blockchain_accounts;',
         )
+        accounts_lists = defaultdict(list)
         for entry in cursor:
             try:
                 blockchain = SupportedBlockchain.deserialize(entry[0])
@@ -1264,10 +1264,9 @@ class DBHandler:
                 )
                 continue
 
-            accounts_list = getattr(accounts, blockchain.get_key())
-            accounts_list.append(entry[1])
+            accounts_lists[blockchain.get_key()].append(entry[1])
 
-        return accounts
+        return BlockchainAccounts(**{x: tuple(y) for x, y in accounts_lists.items()})
 
     def get_blockchain_account_data(
             self,

--- a/rotkehlchen/db/queried_addresses.py
+++ b/rotkehlchen/db/queried_addresses.py
@@ -52,19 +52,19 @@ class QueriedAddresses():
             self,
             cursor: 'DBCursor',
             module: ModuleName,
-    ) -> Optional[list[ChecksumAddress]]:
+    ) -> Optional[tuple[ChecksumAddress, ...]]:
         """Get a List of addresses to query for module or None if none is set"""
         cursor = self.db.conn.cursor()
         query = cursor.execute(
             'SELECT value FROM multisettings WHERE name=?;',
             (f'queried_address_{module}',),
         )
-        result = [entry[0] for entry in query]
+        result = tuple(entry[0] for entry in query)
         return None if len(result) == 0 else result
 
-    def get_queried_addresses_per_module(self) -> dict[ModuleName, list[ChecksumAddress]]:
+    def get_queried_addresses_per_module(self) -> dict[ModuleName, tuple[ChecksumAddress, ...]]:
         """Get a mapping of modules to addresses to query for that module"""
-        mapping: dict[ModuleName, list[ChecksumAddress]] = {}
+        mapping: dict[ModuleName, tuple[ChecksumAddress, ...]] = {}
         with self.db.conn.read_ctx() as cursor:
             for module in AVAILABLE_MODULES_MAP:
                 result = self.get_queried_addresses_for_module(cursor, module)  # type: ignore

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast, overload
 
+from gevent.lock import Semaphore
+
 from rotkehlchen.assets.asset import (
     Asset,
     AssetWithNameAndType,
@@ -189,6 +191,7 @@ class GlobalDBHandler():
     _packaged_db_conn: Optional[DBConnection] = None
     conn: DBConnection
     used_backup: bool  # specifies if the global DB was restored from a backup
+    packaged_db_lock: Semaphore
 
     def __new__(
             cls,
@@ -210,6 +213,7 @@ class GlobalDBHandler():
         GlobalDBHandler.__instance = object.__new__(cls)
         GlobalDBHandler.__instance._data_directory = data_dir
         GlobalDBHandler.__instance.conn, GlobalDBHandler.__instance.used_backup = _initialize_global_db_directory(data_dir, sql_vm_instructions_cb)  # noqa: E501
+        GlobalDBHandler.__instance.packaged_db_lock = Semaphore()
         return GlobalDBHandler.__instance
 
     @staticmethod
@@ -1570,53 +1574,54 @@ class GlobalDBHandler():
                     msg = 'There are assets that can not be deleted. Check logs for more details.'  # noqa: E501
                     return False, msg
 
-            read_cursor.execute(f'ATTACH DATABASE "{builtin_database}" AS clean_db;')
-            try:
-                # Check that versions match
-                query = read_cursor.execute('SELECT value from clean_db.settings WHERE name="version";')  # noqa: E501
-                version = query.fetchone()
-                if version is None or int(version[0]) != globaldb_get_setting_value(read_cursor, 'version', GLOBAL_DB_VERSION):  # noqa: E501
-                    msg = (
-                        'Failed to restore assets. Global database is not '
-                        'updated to the latest version'
-                    )
-                    return False, msg
+            with self.packaged_db_lock:
+                read_cursor.execute(f'ATTACH DATABASE "{builtin_database}" AS clean_db;')
+                try:
+                    # Check that versions match
+                    query = read_cursor.execute('SELECT value from clean_db.settings WHERE name="version";')  # noqa: E501
+                    version = query.fetchone()
+                    if version is None or int(version[0]) != globaldb_get_setting_value(read_cursor, 'version', GLOBAL_DB_VERSION):  # noqa: E501
+                        msg = (
+                            'Failed to restore assets. Global database is not '
+                            'updated to the latest version'
+                        )
+                        return False, msg
 
-                with self.conn.write_ctx() as write_cursor:
-                    # If versions match drop tables
-                    write_cursor.execute('DELETE FROM assets')
-                    write_cursor.execute('DELETE FROM asset_collections')
-                    # Copy assets
-                    write_cursor.switch_foreign_keys('OFF')
-                    write_cursor.execute('INSERT INTO assets SELECT * FROM clean_db.assets;')
-                    write_cursor.execute('INSERT INTO evm_tokens SELECT * FROM clean_db.evm_tokens;')  # noqa: E501
-                    write_cursor.execute('INSERT INTO underlying_tokens_list SELECT * FROM clean_db.underlying_tokens_list;')  # noqa: E501
-                    write_cursor.execute('INSERT INTO common_asset_details SELECT * FROM clean_db.common_asset_details;')  # noqa: E501
-                    write_cursor.execute('INSERT INTO asset_collections SELECT * FROM clean_db.asset_collections')  # noqa: E501
-                    write_cursor.execute('INSERT INTO multiasset_mappings SELECT * FROM clean_db.multiasset_mappings')  # noqa: E501
-                    # Don't copy custom_assets since there are no custom assets in clean_db
-                    write_cursor.switch_foreign_keys('ON')
+                    with self.conn.write_ctx() as write_cursor:
+                        # If versions match drop tables
+                        write_cursor.execute('DELETE FROM assets')
+                        write_cursor.execute('DELETE FROM asset_collections')
+                        # Copy assets
+                        write_cursor.switch_foreign_keys('OFF')
+                        write_cursor.execute('INSERT INTO assets SELECT * FROM clean_db.assets;')
+                        write_cursor.execute('INSERT INTO evm_tokens SELECT * FROM clean_db.evm_tokens;')  # noqa: E501
+                        write_cursor.execute('INSERT INTO underlying_tokens_list SELECT * FROM clean_db.underlying_tokens_list;')  # noqa: E501
+                        write_cursor.execute('INSERT INTO common_asset_details SELECT * FROM clean_db.common_asset_details;')  # noqa: E501
+                        write_cursor.execute('INSERT INTO asset_collections SELECT * FROM clean_db.asset_collections')  # noqa: E501
+                        write_cursor.execute('INSERT INTO multiasset_mappings SELECT * FROM clean_db.multiasset_mappings')  # noqa: E501
+                        # Don't copy custom_assets since there are no custom assets in clean_db
+                        write_cursor.switch_foreign_keys('ON')
 
-                    with user_db.user_write() as user_db_cursor:
-                        user_db_cursor.switch_foreign_keys('OFF')
-                        user_db_cursor.execute('DELETE FROM assets;')
-                        # Get ids for assets to insert them in the user db
-                        write_cursor.execute('SELECT identifier from assets')
-                        ids = write_cursor.fetchall()
-                        ids_proccesed = ', '.join([f'("{id[0]}")' for id in ids])
-                        user_db_cursor.execute(f'INSERT INTO assets(identifier) VALUES {ids_proccesed};')  # noqa: E501
-                        user_db_cursor.switch_foreign_keys('ON')
+                        with user_db.user_write() as user_db_cursor:
+                            user_db_cursor.switch_foreign_keys('OFF')
+                            user_db_cursor.execute('DELETE FROM assets;')
+                            # Get ids for assets to insert them in the user db
+                            write_cursor.execute('SELECT identifier from assets')
+                            ids = write_cursor.fetchall()
+                            ids_proccesed = ', '.join([f'("{id[0]}")' for id in ids])
+                            user_db_cursor.execute(f'INSERT INTO assets(identifier) VALUES {ids_proccesed};')  # noqa: E501
+                            user_db_cursor.switch_foreign_keys('ON')
 
-                with user_db.conn.read_ctx() as cursor:
-                    # Update the owned assets table
-                    user_db.update_owned_assets_in_globaldb(cursor)
+                    with user_db.conn.read_ctx() as cursor:
+                        # Update the owned assets table
+                        user_db.update_owned_assets_in_globaldb(cursor)
 
-            except sqlite3.Error as e:
-                log.error(f'Failed to restore assets in globaldb due to {e!s}')
-                return False, 'Failed to restore assets. Read logs to get more information.'
-            finally:  # on the way out always detach the DB. Make sure no transaction is active
-                with self.conn.critical_section_and_transaction_lock():
-                    read_cursor.execute('DETACH DATABASE "clean_db";')
+                except sqlite3.Error as e:
+                    log.error(f'Failed to restore assets in globaldb due to {e!s}')
+                    return False, 'Failed to restore assets. Read logs to get more information.'
+                finally:  # on the way out always detach the DB. Make sure no transaction is active
+                    with self.conn.critical_section_and_transaction_lock():
+                        read_cursor.execute('DETACH DATABASE "clean_db";')
 
         return True, ''
 
@@ -1628,51 +1633,52 @@ class GlobalDBHandler():
         root_dir = Path(__file__).resolve().parent.parent
         builtin_database = root_dir / 'data' / 'global.db'
 
-        try:
-            with self.conn.read_ctx() as read_cursor:
-                read_cursor.execute(f'ATTACH DATABASE "{builtin_database}" AS clean_db;')
-                # Check that versions match
-                query = read_cursor.execute('SELECT value from clean_db.settings WHERE name="version";')  # noqa: E501
-                version = query.fetchone()
-                if version is None or int(version[0]) != globaldb_get_setting_value(read_cursor, 'version', GLOBAL_DB_VERSION):  # noqa: E501
-                    msg = (
-                        'Failed to restore assets. Global database is not '
-                        'updated to the latest version'
-                    )
-                    return False, msg
+        with self.packaged_db_lock:
+            try:
+                with self.conn.read_ctx() as read_cursor:
+                    read_cursor.execute(f'ATTACH DATABASE "{builtin_database}" AS clean_db;')
+                    # Check that versions match
+                    query = read_cursor.execute('SELECT value from clean_db.settings WHERE name="version";')  # noqa: E501
+                    version = query.fetchone()
+                    if version is None or int(version[0]) != globaldb_get_setting_value(read_cursor, 'version', GLOBAL_DB_VERSION):  # noqa: E501
+                        msg = (
+                            'Failed to restore assets. Global database is not '
+                            'updated to the latest version'
+                        )
+                        return False, msg
 
-                # Get the list of ids that we will restore
-                query = read_cursor.execute('SELECT identifier from clean_db.assets;')
-                shipped_asset_ids = set(query.fetchall())
-                asset_ids = ', '.join([f'"{id[0]}"' for id in shipped_asset_ids])
-                query = read_cursor.execute('SELECT id FROM clean_db.asset_collections')
-                shipped_collection_ids = set(query.fetchall())
-                collection_ids = ', '.join([f'"{id[0]}"' for id in shipped_collection_ids])
+                    # Get the list of ids that we will restore
+                    query = read_cursor.execute('SELECT identifier from clean_db.assets;')
+                    shipped_asset_ids = set(query.fetchall())
+                    asset_ids = ', '.join([f'"{id[0]}"' for id in shipped_asset_ids])
+                    query = read_cursor.execute('SELECT id FROM clean_db.asset_collections')
+                    shipped_collection_ids = set(query.fetchall())
+                    collection_ids = ', '.join([f'"{id[0]}"' for id in shipped_collection_ids])
 
-            with self.conn.write_ctx() as write_cursor:
-                # If versions match drop tables
-                write_cursor.switch_foreign_keys('OFF')
-                write_cursor.execute(f'DELETE FROM assets WHERE identifier IN ({asset_ids});')
-                write_cursor.execute(f'DELETE FROM evm_tokens WHERE identifier IN ({asset_ids});')  # noqa: E501
-                write_cursor.execute(f'DELETE FROM underlying_tokens_list WHERE parent_token_entry IN ({asset_ids});')  # noqa: E501
-                write_cursor.execute(f'DELETE FROM common_asset_details WHERE identifier IN ({asset_ids});')  # noqa: E501
-                write_cursor.execute(f'DELETE FROM asset_collections WHERE id IN ({collection_ids})')  # noqa: E501
-                write_cursor.execute(f'DELETE FROM multiasset_mappings WHERE collection_id IN ({collection_ids})')  # noqa: E501
-                # Copy assets
-                write_cursor.execute('INSERT INTO assets SELECT * FROM clean_db.assets;')
-                write_cursor.execute('INSERT INTO evm_tokens SELECT * FROM clean_db.evm_tokens;')  # noqa: E501
-                write_cursor.execute('INSERT INTO underlying_tokens_list SELECT * FROM clean_db.underlying_tokens_list;')  # noqa: E501
-                write_cursor.execute('INSERT INTO common_asset_details SELECT * FROM clean_db.common_asset_details;')  # noqa: E501
-                write_cursor.execute('INSERT INTO asset_collections SELECT * FROM clean_db.asset_collections')  # noqa: E501
-                write_cursor.execute('INSERT INTO multiasset_mappings SELECT * FROM clean_db.multiasset_mappings')  # noqa: E501
-                # TODO: think about how to implement multiassets insertion
-                write_cursor.switch_foreign_keys('ON')
-        except sqlite3.Error as e:
-            log.error(f'Failed to restore assets in globaldb due to {e!s}')
-            return False, 'Failed to restore assets. Read logs to get more information.'
-        finally:  # on the way out always detach the DB. Make sure no transaction is active
-            with self.conn.transaction_lock, self.conn.read_ctx() as read_cursor:
-                read_cursor.execute('DETACH DATABASE "clean_db";')
+                with self.conn.write_ctx() as write_cursor:
+                    # If versions match drop tables
+                    write_cursor.switch_foreign_keys('OFF')
+                    write_cursor.execute(f'DELETE FROM assets WHERE identifier IN ({asset_ids});')
+                    write_cursor.execute(f'DELETE FROM evm_tokens WHERE identifier IN ({asset_ids});')  # noqa: E501
+                    write_cursor.execute(f'DELETE FROM underlying_tokens_list WHERE parent_token_entry IN ({asset_ids});')  # noqa: E501
+                    write_cursor.execute(f'DELETE FROM common_asset_details WHERE identifier IN ({asset_ids});')  # noqa: E501
+                    write_cursor.execute(f'DELETE FROM asset_collections WHERE id IN ({collection_ids})')  # noqa: E501
+                    write_cursor.execute(f'DELETE FROM multiasset_mappings WHERE collection_id IN ({collection_ids})')  # noqa: E501
+                    # Copy assets
+                    write_cursor.execute('INSERT INTO assets SELECT * FROM clean_db.assets;')
+                    write_cursor.execute('INSERT INTO evm_tokens SELECT * FROM clean_db.evm_tokens;')  # noqa: E501
+                    write_cursor.execute('INSERT INTO underlying_tokens_list SELECT * FROM clean_db.underlying_tokens_list;')  # noqa: E501
+                    write_cursor.execute('INSERT INTO common_asset_details SELECT * FROM clean_db.common_asset_details;')  # noqa: E501
+                    write_cursor.execute('INSERT INTO asset_collections SELECT * FROM clean_db.asset_collections')  # noqa: E501
+                    write_cursor.execute('INSERT INTO multiasset_mappings SELECT * FROM clean_db.multiasset_mappings')  # noqa: E501
+                    # TODO: think about how to implement multiassets insertion
+                    write_cursor.switch_foreign_keys('ON')
+            except sqlite3.Error as e:
+                log.error(f'Failed to restore assets in globaldb due to {e!s}')
+                return False, 'Failed to restore assets. Read logs to get more information.'
+            finally:  # on the way out always detach the DB. Make sure no transaction is active
+                with self.conn.transaction_lock, self.conn.read_ctx() as read_cursor:
+                    read_cursor.execute('DETACH DATABASE "clean_db";')
 
         return True, ''
 
@@ -1702,12 +1708,13 @@ class GlobalDBHandler():
             query = cursor.execute('SELECT identifier from assets;')
         user_ids = {tup[0] for tup in query}
         # Attach to the clean db packaged with rotki
-        cursor.execute(f'ATTACH DATABASE "{builtin_database}" AS clean_db;')
-        # Get built in identifiers
-        query = cursor.execute('SELECT identifier from clean_db.assets;')
-        shipped_ids = {tup[0] for tup in query}
-        with GlobalDBHandler().conn.critical_section_and_transaction_lock():
-            cursor.execute('DETACH DATABASE clean_db;')
+        with GlobalDBHandler().packaged_db_lock:
+            cursor.execute(f'ATTACH DATABASE "{builtin_database}" AS clean_db;')
+            # Get built in identifiers
+            query = cursor.execute('SELECT identifier from clean_db.assets;')
+            shipped_ids = {tup[0] for tup in query}
+            with GlobalDBHandler().conn.critical_section_and_transaction_lock():
+                cursor.execute('DETACH DATABASE clean_db;')
         return user_ids - shipped_ids
 
     @staticmethod

--- a/rotkehlchen/tests/api/blockchain/test_base.py
+++ b/rotkehlchen/tests/api/blockchain/test_base.py
@@ -530,12 +530,12 @@ def test_add_blockchain_accounts(
         {'address': '12tkqA9xSoowkzoERHMWNKsTey55YEBqkv'},
         {'address': 'pp8skudq3x5hzw8ew7vzsw8tn4k8wxsqsv0lt0mf3g'},
     ]})
-    expected_bch_accounts = [
+    expected_bch_accounts = {
         '1H9EndxvYSibvnDSsxZRYvuqZaCcRXdRcB',
         '12tkqA9xSoowkzoERHMWNKsTey55YEBqkv',
         'pp8skudq3x5hzw8ew7vzsw8tn4k8wxsqsv0lt0mf3g',
-    ]
-    assert rotki.chains_aggregator.accounts.bch == expected_bch_accounts
+    }
+    assert set(rotki.chains_aggregator.accounts.bch) == expected_bch_accounts
     assert_proper_response(response)
 
     # Check that the BCH accounts are present in the DB
@@ -1744,7 +1744,7 @@ def test_remove_blockchain_account_with_tags_removes_mapping(rotkehlchen_api_ser
     ), json={'accounts': [UNIT_BTC_ADDRESS1]})
     assert_proper_response(response)
 
-    assert rotki.chains_aggregator.accounts.btc == [UNIT_BTC_ADDRESS2]
+    assert set(rotki.chains_aggregator.accounts.btc) == {UNIT_BTC_ADDRESS2}
 
     # Now check the DB directly and see that tag mappings of the deleted account are gone
     cursor = rotki.data.db.conn.cursor()

--- a/rotkehlchen/tests/api/blockchain/test_bitcoin.py
+++ b/rotkehlchen/tests/api/blockchain/test_bitcoin.py
@@ -38,4 +38,4 @@ def test_add_btc_blockchain_account_ens_domain(rotkehlchen_api_server):
         result = assert_proper_response_with_result(response)
 
     assert result == [ENS_BRUNO_BTC_ADDR]
-    assert rotki.chains_aggregator.accounts.btc == [ENS_BRUNO_BTC_ADDR]
+    assert set(rotki.chains_aggregator.accounts.btc) == {ENS_BRUNO_BTC_ADDR}

--- a/rotkehlchen/tests/api/blockchain/test_evm.py
+++ b/rotkehlchen/tests/api/blockchain/test_evm.py
@@ -101,7 +101,7 @@ def test_deleting_ens_account_works(rotkehlchen_api_server):
         blockchain='ETH',
     ), json=request_data)
     assert_proper_response(response)
-    assert rotki.chains_aggregator.accounts.eth == []
+    assert rotki.chains_aggregator.accounts.eth == ()
 
     request_data = {'accounts': ['ishouldnotexistforrealz.eth']}
     response = requests.delete(api_url_for(
@@ -375,4 +375,4 @@ def test_evm_account_deletion_does_not_wait_for_pending_txn_queries(
     # retrieve ethereum accounts from the DB and see they are deleted
     with rotki.data.db.conn.read_ctx() as cursor:
         accounts = rotki.data.db.get_blockchain_accounts(cursor)
-        assert accounts.eth == [api_addies[1]]
+        assert set(accounts.eth) == {api_addies[1]}

--- a/rotkehlchen/tests/api/blockchain/test_optimism.py
+++ b/rotkehlchen/tests/api/blockchain/test_optimism.py
@@ -96,7 +96,6 @@ def test_add_optimism_blockchain_account(rotkehlchen_api_server):
             token_type=EvmTokenKind.ERC20,
         ) for x in [
             '0x4200000000000000000000000000000000000042',  # OP token
-            '0x625E7708f30cA75bfd92586e17077590C60eb4cD',  # aOPTUSDC
             '0x026B623Eb4AaDa7de37EF25256854f9235207178',  # spam token
             '0x15992f382D8c46d667B10DC8456dc36651Af1452',  # spam token
         ]

--- a/rotkehlchen/tests/api/blockchain/test_substrate.py
+++ b/rotkehlchen/tests/api/blockchain/test_substrate.py
@@ -196,7 +196,7 @@ def test_add_ksm_blockchain_account_ens_domain(rotkehlchen_api_server):
         result = assert_proper_response_with_result(response)
 
     assert result == [ENS_BRUNO_KSM_ADDR]
-    assert rotki.chains_aggregator.accounts.ksm == [ENS_BRUNO_KSM_ADDR]
+    assert set(rotki.chains_aggregator.accounts.ksm) == {ENS_BRUNO_KSM_ADDR}
     # check that we did connect to the nodes after account addition
     assert rotki.chains_aggregator.kusama.available_nodes_call_order != []
 
@@ -227,7 +227,7 @@ def test_remove_ksm_blockchain_account_ens_domain(rotkehlchen_api_server):
     else:
         assert_proper_response(response)
 
-    assert rotki.chains_aggregator.accounts.ksm == [SUBSTRATE_ACC1_KSM_ADDR]
+    assert set(rotki.chains_aggregator.accounts.ksm) == {SUBSTRATE_ACC1_KSM_ADDR}
 
     # Also make sure it's removed from the DB
     with rotki.data.db.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/api/test_bitcoin.py
+++ b/rotkehlchen/tests/api/test_bitcoin.py
@@ -247,8 +247,8 @@ def test_add_delete_xpub(rotkehlchen_api_server):
     else:
         assert_proper_response(response)
 
-    assert rotki.chains_aggregator.accounts.btc[:2] == [UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2]
-    assert rotki.chains_aggregator.accounts.btc == [UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2]
+    assert set(rotki.chains_aggregator.accounts.btc[:2]) == {UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2}
+    assert set(rotki.chains_aggregator.accounts.btc) == {UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2}
 
     # Also make sure all mappings are gone from the DB
     cursor = rotki.data.db.conn.cursor()
@@ -293,8 +293,8 @@ def test_add_delete_xpub_multiple_chains(rotkehlchen_api_server):
             gevent.sleep(1)
 
     # Check that bch accounts were detected while btc accounts were not affected
-    assert rotki.chains_aggregator.accounts.bch != []
-    assert rotki.chains_aggregator.accounts.btc == []
+    assert len(rotki.chains_aggregator.accounts.bch) != 0
+    assert len(rotki.chains_aggregator.accounts.btc) == 0
     with rotki.data.db.conn.read_ctx() as cursor:
         result = rotki.data.db.get_addresses_to_xpub_mapping(
             cursor=cursor,
@@ -404,7 +404,7 @@ def test_add_delete_xpub_multiple_chains(rotkehlchen_api_server):
     result = cursor.execute('SELECT object_reference from tag_mappings;').fetchall()
     assert len(result) == 0, 'all tag mappings should have been deleted'
     result = cursor.execute('SELECT * from xpub_mappings WHERE xpub=?', (xpub,)).fetchall()
-    assert rotki.chains_aggregator.accounts.bch == []
+    assert len(rotki.chains_aggregator.accounts.bch) == 0
     # Check that we still have derived BTC addresses
     assert len(result) >= 23
     for address, xpub_result, _, _, _, blockchain in result:

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -294,7 +294,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
     with data.db.conn.read_ctx() as cursor:
         accounts = data.db.get_blockchain_accounts(cursor)
         assert isinstance(accounts, BlockchainAccounts)
-        assert accounts.btc == ['1CB7Pbji3tquDtMRp8mBkerimkFzWRkovS']
+        assert accounts.btc == ('1CB7Pbji3tquDtMRp8mBkerimkFzWRkovS',)
         # See that after addition the address has been checksummed
         assert set(accounts.eth) == {
             '0xd36029d76af6fE4A356528e4Dc66B2C18123597D',
@@ -322,7 +322,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
             ['0xd36029d76af6fE4A356528e4Dc66B2C18123597D'],
         )
         accounts = data.db.get_blockchain_accounts(write_cursor)
-        assert accounts.eth == ['0x80B369799104a47e98A553f3329812a44A7FaCDc']
+        assert accounts.eth == ('0x80B369799104a47e98A553f3329812a44A7FaCDc',)
 
     result, _ = data.add_ignored_assets([A_DAO])
     assert result
@@ -1390,7 +1390,7 @@ def test_remove_queried_address_on_account_remove(data_dir, username, sql_vm_ins
 
     with data.db.conn.read_ctx() as cursor:
         addresses = queried_addresses.get_queried_addresses_for_module(cursor, 'makerdao_vaults')
-    assert not addresses
+    assert addresses is None
 
 
 def test_int_overflow_at_tuple_insertion(database, caplog):

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -143,13 +143,13 @@ def fixture_blockchain_accounts(
         dot_accounts: list[SubstrateAddress],
 ) -> BlockchainAccounts:
     return BlockchainAccounts(
-        eth=ethereum_accounts,
-        optimism=optimism_accounts.copy(),
-        avax=avax_accounts.copy(),
-        btc=btc_accounts.copy(),
-        bch=bch_accounts.copy(),
-        ksm=ksm_accounts.copy(),
-        dot=dot_accounts.copy(),
+        eth=tuple(ethereum_accounts),
+        optimism=tuple(optimism_accounts),
+        avax=tuple(avax_accounts),
+        btc=tuple(btc_accounts),
+        bch=tuple(bch_accounts),
+        ksm=tuple(ksm_accounts),
+        dot=tuple(dot_accounts),
     )
 
 

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -233,7 +233,7 @@ def session_database(
         return None
 
     # No sessions blockchain accounts given
-    blockchain_accounts = BlockchainAccounts([], [], [], [], [], [])
+    blockchain_accounts = BlockchainAccounts()
     return _init_database(
         data_dir=session_user_data_dir,
         msg_aggregator=messages_aggregator,

--- a/rotkehlchen/tests/utils/rotkehlchen.py
+++ b/rotkehlchen/tests/utils/rotkehlchen.py
@@ -164,7 +164,7 @@ def setup_balances(
                     if balance == ZERO:
                         continue
 
-                    account = ethereum_accounts[idx]
+                    account = rotki.chains_aggregator.accounts.eth[idx]
                     rotki.chains_aggregator.balances.eth[account].liabilities[token] = Balance(balance)  # noqa: E501
 
             # need this to not get randomized behaviour when defi balances are added or not

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -181,6 +181,11 @@ ListOfBlockchainAddresses = Union[
     list[ChecksumEvmAddress],
     list[SubstrateAddress],
 ]
+TuplesOfBlockchainAddresses = Union[
+    tuple[BTCAddress, ...],
+    tuple[ChecksumEvmAddress, ...],
+    tuple[SubstrateAddress, ...],
+]
 
 
 T_Fee = FVal


### PR DESCRIPTION
### BlockchainAccounts lists are now tuples -- immutable

Also using Sequence as type in all relevant functions, which is an
immutable sequence. Matches either tuple or list or any other sequence
used immutably. As these should not be modified at any point apart from when reading from the DB or adding/removing an address to/from the DB.

This was all done in order to try and reproduce and find the root cause for this: https://github.com/rotki/rotki/issues/5432
But apart from liquity module where there was addresses being added, but on a carefully made copy I did not see anything else where mypy had warnings.

### Evm chain bug

[Fix bug where eth_accounts were always used irrespective of chain id](https://github.com/rotki/rotki/commit/c623743df9e4254ff3a234a58e26af0004f6f927)

### Reproduce and "fix"

Finally reproduced 5432 reliably in a test and provided a bad fix. For more info read the issue.