### PR TITLE
Use packaged DB connection instead of attach/detach

### DIFF
--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1233,4 +1233,10 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
                 HistoryEventSubType.SPEND: EventCategory.SEND,
                 HistoryEventSubType.RECEIVE: EventCategory.RECEIVE,
             },
+            HistoryEventType.WITHDRAWAL: {
+                HistoryEventSubType.FEE: EventCategory.FEE,
+            },
+            HistoryEventType.DEPOSIT: {
+                HistoryEventSubType.FEE: EventCategory.FEE,
+            },
         }


### PR DESCRIPTION
Use packaged DB connection instead of attach/detach to get packaged DB contract data.

I only left the attach/detach in the hard/soft assets_reset functionality as there it combines queries in both DBs. It can probably be rewritten and we can then also get rid of the packaged db lock but I don't want to do such changes right before the release