### PR TITLE
Notify on adding empty EVM accounts

### DIFF
--- a/frontend/app/src/components/accounts/management/AccountForm.vue
+++ b/frontend/app/src/components/accounts/management/AccountForm.vue
@@ -20,6 +20,8 @@ onMounted(() => {
     if ('xpub' in account) {
       set(inputMode, InputMode.XPUB_ADD);
     }
+  } else {
+    set(blockchain, get(context));
   }
 });
 

--- a/frontend/app/src/composables/blockchain/index.ts
+++ b/frontend/app/src/composables/blockchain/index.ts
@@ -1,6 +1,7 @@
 import { Blockchain } from '@rotki/common/lib/blockchain';
 import { Severity } from '@rotki/common/lib/messages';
 import { type MaybeRef } from '@vueuse/core';
+import isEmpty from 'lodash/isEmpty';
 import { TaskType } from '@/types/task-type';
 import { isBlockchain, isTokenChain } from '@/types/blockchain/chains';
 import {
@@ -111,8 +112,23 @@ export const useBlockchains = () => {
     };
 
     const promiseResult = await Promise.allSettled(
-      payload.payload.map(async p => {
-        const addresses = await addEvmAccount(p);
+      payload.payload.map(async account => {
+        const addresses = await addEvmAccount(account);
+        if (isEmpty(addresses)) {
+          return notify({
+            title: tc(
+              'actions.balances.blockchain_accounts_add.error.title',
+              0,
+              { blockchain: 'EVM' }
+            ),
+            message: tc(
+              'actions.balances.blockchain_accounts_add.error.empty_addresses_description',
+              0,
+              { address: account.address }
+            ),
+            display: true
+          });
+        }
         for (const chain in addresses) {
           if (!isBlockchain(chain)) {
             logger.error(`${chain} was not a valid blockchain`);

--- a/frontend/app/src/locales/cn.json
+++ b/frontend/app/src/locales/cn.json
@@ -245,6 +245,7 @@
         "error": {
           "description": "无法添加 {addresses} 个新的 {blockchain} 账户： {error}",
           "failed_list_description": "无法添加 {addresses} 个新的 {blockchain} 账户。请再次检查这些账户是否有效：\n {list}",
+          "empty_addresses_description": "地址 {address} 未添加，因为它是合约或在任何受支持的 EVM 链中没有任何活动",
           "title": "添加 {blockchain} 账户"
         },
         "no_new": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -245,6 +245,7 @@
         "error": {
           "description": "Failed to add {addresses} new {blockchain} accounts: {error}",
           "failed_list_description": "Failed to add {addresses} new {blockchain} accounts. Please check again if these account(s) are valid:\n {list}",
+          "empty_addresses_description": "Address {address} was not added because it is either a contract or doesn't have any activity in any of the supported EVM chains",
           "title": "Adding {blockchain} accounts"
         },
         "no_new": {

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -238,6 +238,7 @@
       "blockchain_accounts_add": {
         "error": {
           "description": "Failed to add {addresses} new {blockchain} accounts: {error}",
+          "empty_addresses_description": "La dirección {address} no se agregó porque es un contrato o no tiene ninguna actividad en ninguna de las cadenas EVM admitidas",
           "title": "Adding {blockchain} accounts"
         },
         "no_new": {

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -234,6 +234,7 @@
         "error": {
           "description": "Failed to add {addresses} new {blockchain} accounts: {error}",
           "failed_list_description": "Failed to add {addresses} new {blockchain} accounts. Please check again if these account(s) are valid:\n {list}",
+          "empty_addresses_description": "Η διεύθυνση {address} δεν προστέθηκε επειδή είτε είναι contract είτε δεν έχει καμία δραστηριότητα σε καμία από τις υποστηριζόμενες EVM chains",
           "title": "Adding {blockchain} accounts"
         },
         "no_new": {

--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -58,17 +58,14 @@ const { btcAccounts, bchAccounts } = useBtcAccountBalances();
 const { blockchainAssets } = useBlockchainAggregatedBalances();
 
 const context: ComputedRef<Blockchain> = computed(() => {
-  const intersect = get(intersections);
-  let currentContext = Blockchain.ETH;
   // pick only intersections that are visible (at least 50%)
-  const activeObservers = pickBy(intersect, e => e);
+  const activeObservers = Object.keys(pickBy(get(intersections), e => e));
 
-  for (const current in activeObservers) {
-    if (activeObservers[current]) {
-      currentContext = current as Blockchain;
-    }
+  if (activeObservers.length > 0) {
+    return activeObservers[activeObservers.length - 1] as Blockchain;
   }
-  return currentContext;
+
+  return Blockchain.ETH;
 });
 
 const observers: Observers = {

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       'lodash/isEmpty',
       'lodash/dropRight',
       'lodash/omitBy',
+      'lodash/pickBy',
       'lodash/pick',
       'lodash/keys',
       '@vueuse/math'


### PR DESCRIPTION
## Checklist

- [x] The PR modified the frontend, and updated the add evm callback to notify users when they have entered an address with no activity
- [x] Fixes issue when a user is viewing a specific blockchain account and clicks on add, should set the default blockchain to the currently visible one.