### PR TITLE
fix: downgrades vite from 4.3 to 4.2

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -113,7 +113,7 @@
     "unplugin-auto-import": "0.15.3",
     "unplugin-vue-components": "0.24.1",
     "unplugin-vue-define-options": "1.3.3",
-    "vite": "4.3.1",
+    "vite": "4.2.2",
     "vite-plugin-checker": "0.5.6",
     "vite-plugin-istanbul": "4.0.1",
     "vite-plugin-pwa": "0.14.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
         version: 16.18.24
       '@vitejs/plugin-vue2':
         specifier: 2.2.0
-        version: 2.2.0(vite@4.3.1)(vue@2.7.14)
+        version: 2.2.0(vite@4.2.2)(vue@2.7.14)
       '@vitest/coverage-c8':
         specifier: 0.30.1
         version: 0.30.1(vitest@0.30.1)
@@ -276,20 +276,20 @@ importers:
         specifier: 1.3.3
         version: 1.3.3(rollup@2.79.1)(vue@2.7.14)
       vite:
-        specifier: 4.3.1
-        version: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+        specifier: 4.2.2
+        version: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
       vite-plugin-checker:
         specifier: 0.5.6
-        version: 0.5.6(eslint@8.39.0)(stylelint@15.6.0)(typescript@4.9.5)(vite@4.3.1)(vue-tsc@1.5.2)
+        version: 0.5.6(eslint@8.39.0)(stylelint@15.6.0)(typescript@4.9.5)(vite@4.2.2)(vue-tsc@1.5.2)
       vite-plugin-istanbul:
         specifier: 4.0.1
-        version: 4.0.1(vite@4.3.1)
+        version: 4.0.1(vite@4.2.2)
       vite-plugin-pwa:
         specifier: 0.14.7
-        version: 0.14.7(vite@4.3.1)(workbox-build@6.5.4)(workbox-window@6.5.4)
+        version: 0.14.7(vite@4.2.2)(workbox-build@6.5.4)(workbox-window@6.5.4)
       vite-plugin-vue-layouts:
         specifier: 0.8.0
-        version: 0.8.0(vite@4.3.1)(vue-router@3.6.5)(vue@2.7.14)
+        version: 0.8.0(vite@4.2.2)(vue-router@3.6.5)(vue@2.7.14)
       vitest:
         specifier: 0.30.1
         version: 0.30.1(jsdom@20.0.3)(sass@1.32.13)
@@ -2832,14 +2832,14 @@ packages:
       '@typescript-eslint/types': 5.59.1
       eslint-visitor-keys: 3.4.0
 
-  /@vitejs/plugin-vue2@2.2.0(vite@4.3.1)(vue@2.7.14):
+  /@vitejs/plugin-vue2@2.2.0(vite@4.2.2)(vue@2.7.14):
     resolution: {integrity: sha512-1km7zEuZ/9QRPvzXSjikbTYGQPG86Mq1baktpC4sXqsXlb02HQKfi+fl8qVS703JM7cgm24Ga9j+RwKmvFn90A==}
     engines: {node: ^14.18.0 || >= 16.0.0}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
       vue: ^2.7.0-0
     dependencies:
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
       vue: 2.7.14
     dev: true
 
@@ -10025,7 +10025,7 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10036,7 +10036,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker@0.5.6(eslint@8.39.0)(stylelint@15.6.0)(typescript@4.9.5)(vite@4.3.1)(vue-tsc@1.5.2):
+  /vite-plugin-checker@0.5.6(eslint@8.39.0)(stylelint@15.6.0)(typescript@4.9.5)(vite@4.2.2)(vue-tsc@1.5.2):
     resolution: {integrity: sha512-ftRyON0gORUHDxcDt2BErmsikKSkfvl1i2DoP6Jt2zDO9InfvM6tqO1RkXhSjkaXEhKPea6YOnhFaZxW3BzudQ==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -10082,7 +10082,7 @@ packages:
       stylelint: 15.6.0
       tiny-invariant: 1.3.1
       typescript: 4.9.5
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.7
@@ -10090,7 +10090,7 @@ packages:
       vue-tsc: 1.5.2(typescript@4.9.5)
     dev: true
 
-  /vite-plugin-istanbul@4.0.1(vite@4.3.1):
+  /vite-plugin-istanbul@4.0.1(vite@4.2.2):
     resolution: {integrity: sha512-1fUCJyYvt/vkDQWR/15knwCk+nWmNbVbmZTXf/X4XD0dcdmJsYrZF5JQo7ttYxFyflGH2SVu+XRlpN06CakKPQ==}
     peerDependencies:
       vite: '>=2.9.1 <= 5'
@@ -10099,12 +10099,12 @@ packages:
       istanbul-lib-instrument: 5.2.1
       picocolors: 1.0.0
       test-exclude: 6.0.0
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa@0.14.7(vite@4.3.1)(workbox-build@6.5.4)(workbox-window@6.5.4):
+  /vite-plugin-pwa@0.14.7(vite@4.2.2)(workbox-build@6.5.4)(workbox-window@6.5.4):
     resolution: {integrity: sha512-dNJaf0fYOWncmjxv9HiSa2xrSjipjff7IkYE5oIUJ2x5HKu3cXgA8LRgzOwTc5MhwyFYRSU0xyN0Phbx3NsQYw==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
@@ -10116,14 +10116,14 @@ packages:
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.17.2
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-vue-layouts@0.8.0(vite@4.3.1)(vue-router@3.6.5)(vue@2.7.14):
+  /vite-plugin-vue-layouts@0.8.0(vite@4.2.2)(vue-router@3.6.5)(vue@2.7.14):
     resolution: {integrity: sha512-UZW2nSV2LraTSe7gsAL46hfdi7a0X1RvkGGoJVtA2O8beu7anzpXFwQLou8+kHy31CzVycT4gIPySBsHhtBN5g==}
     peerDependencies:
       vite: ^2.5.0 || ^3.0.0-0 || ^4.0.0
@@ -10133,15 +10133,15 @@ packages:
       '@vue/compiler-sfc': 3.2.45
       debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.2.12
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
       vue: 2.7.14
       vue-router: 3.6.5(vue@2.7.14)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@4.3.1(@types/node@16.18.24)(sass@1.32.13):
-    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
+  /vite@4.2.2(@types/node@16.18.24)(sass@1.32.13):
+    resolution: {integrity: sha512-PcNtT5HeDxb3QaSqFYkEum8f5sCVe0R3WK20qxgIvNBZPXU/Obxs/+ubBMeE7nLWeCo2LDzv+8hRYSlcaSehig==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -10168,6 +10168,7 @@ packages:
       '@types/node': 16.18.24
       esbuild: 0.17.14
       postcss: 8.4.23
+      resolve: 1.22.1
       rollup: 3.20.2
       sass: 1.32.13
     optionalDependencies:
@@ -10229,7 +10230,7 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.4.0
       tinypool: 0.4.0
-      vite: 4.3.1(@types/node@16.18.24)(sass@1.32.13)
+      vite: 4.2.2(@types/node@16.18.24)(sass@1.32.13)
       vite-node: 0.30.1(@types/node@16.18.24)(sass@1.32.13)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

### Notes 

@rotki/frontend anyone that is up before me please check that this doesn't give the error posted in Discord. 

If you also don't get the error, if @LefterisJP checks it and it is ok we can merge to unblock the release.

Then I want someone to figure out what changes we need to make for vite 4.3 builds to work on develop.
