### PR TITLE
Add decoder for compunding CRV in convex

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Users will now be able to decode compounding transactions for Convex gauges.
+
 * :release:`1.28.0 <2023-05-17>`
 * :feature:`2469` History events have now been unified under a common history events section. At the moment it features all kraken exchange events, evm events, custom imported events, block productions, staking withdrawals. Missing events retain their own sections and will be merged into the unified history in subsequent releases.
 * :feature:`3973` Users will now be able to track their profit in Liquity staking and stability pool.


### PR DESCRIPTION
The current decoded didn't support compunding events and was raising a key error. This PR covers the correct decoding of the event

