### PR TITLE
User approval to resume from user db backup

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1087,6 +1087,7 @@ class RestAPI():
                 premium_credentials=premium_credentials,
                 initial_settings=initial_settings,
                 sync_database=sync_database,
+                resume_from_backup=False,
             )
         # not catching RotkehlchenPermissionError here as for new account with premium
         # syncing there is no way that permission needs to be asked by the user
@@ -1117,6 +1118,7 @@ class RestAPI():
             name: str,
             password: str,
             sync_approval: Literal['yes', 'no', 'unknown'],
+            resume_from_backup: bool,
     ) -> dict[str, Any]:
         if self.rotkehlchen.user_is_logged_in:
             return wrap_in_fail_result(
@@ -1135,6 +1137,7 @@ class RestAPI():
                 create_new=False,
                 sync_approval=sync_approval,
                 premium_credentials=None,
+                resume_from_backup=resume_from_backup,
             )
         # We are not catching PremiumAuthenticationError here since it should not bubble
         # up until here. Even with non valid keys in the DB login should work fine
@@ -3146,7 +3149,7 @@ class RestAPI():
             return OK_RESULT
 
         return {
-            'result': result,
+            'result': result,  # returned conflicts
             'message': 'Found conflicts during assets upgrade',
             'status_code': HTTPStatus.CONFLICT,
         }

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1261,12 +1261,14 @@ class UsersByNameResource(BaseMethodView):
             name: str,
             password: str,
             sync_approval: Literal['yes', 'no', 'unknown'],
+            resume_from_backup: bool,
     ) -> Response:
         return self.rest_api.user_login(
             async_query=async_query,
             name=name,
             password=password,
             sync_approval=sync_approval,
+            resume_from_backup=resume_from_backup,
         )
 
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1314,6 +1314,7 @@ class UserActionLoginSchema(AsyncQueryArgumentSchema):
         load_default='unknown',
         validate=webargs.validate.OneOf(choices=('unknown', 'yes', 'no')),
     )
+    resume_from_backup = fields.Boolean(load_default=False)
 
 
 class UserPasswordChangeSchema(Schema):

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -54,6 +54,7 @@ class DataHandler():
             username: str,
             password: str,
             create_new: bool,
+            resume_from_backup: bool,
             initial_settings: Optional[ModifiableDBSettings] = None,
     ) -> Path:
         """Unlocks a user, either logging them in or creating a new user
@@ -114,6 +115,7 @@ class DataHandler():
             msg_aggregator=self.msg_aggregator,
             initial_settings=initial_settings,
             sql_vm_instructions_cb=self.sql_vm_instructions_cb,
+            resume_from_backup=resume_from_backup,
         )
         self.user_data_dir = user_data_dir
         self.logged_in = True

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -241,6 +241,7 @@ class Rotkehlchen():
             create_new: bool,
             sync_approval: Literal['yes', 'no', 'unknown'],
             premium_credentials: Optional[PremiumCredentials],
+            resume_from_backup: bool,
             initial_settings: Optional[ModifiableDBSettings] = None,
             sync_database: bool = True,
     ) -> None:
@@ -265,10 +266,17 @@ class Rotkehlchen():
             sync_approval=sync_approval,
             sync_database=sync_database,
             initial_settings=initial_settings,
+            resume_from_backup=resume_from_backup,
         )
 
         # unlock or create the DB
-        self.user_directory = self.data.unlock(user, password, create_new, initial_settings)
+        self.user_directory = self.data.unlock(
+            username=user,
+            password=password,
+            create_new=create_new,
+            initial_settings=initial_settings,
+            resume_from_backup=resume_from_backup,
+        )
         # Run the DB integrity check due to https://github.com/rotki/rotki/issues/3010
         # TODO: Hopefully once 3010 is handled this can go away
         self.greenlet_manager.spawn_and_track(

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -99,6 +99,7 @@ def _init_db_with_target_version(
         target_version: int,
         user_data_dir: Path,
         msg_aggregator: MessagesAggregator,
+        resume_from_backup: bool,
 ) -> DBHandler:
     no_tables_created_after_init = patch(
         'rotkehlchen.db.dbhandler.DB_SCRIPT_CREATE_TABLES',
@@ -117,6 +118,7 @@ def _init_db_with_target_version(
             msg_aggregator=msg_aggregator,
             initial_settings=None,
             sql_vm_instructions_cb=DEFAULT_SQL_VM_INSTRUCTIONS_CB,
+            resume_from_backup=resume_from_backup,
         )
     return db
 
@@ -133,6 +135,7 @@ def test_upgrade_db_26_to_27(user_data_dir):  # pylint: disable=unused-argument
         target_version=26,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     # Checks before migration
     cursor = db_v26.conn.cursor()
@@ -153,6 +156,7 @@ def test_upgrade_db_26_to_27(user_data_dir):  # pylint: disable=unused-argument
         target_version=27,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
     assert cursor.execute('SELECT COUNT(*) from used_query_ranges;').fetchone()[0] == 2
@@ -177,6 +181,7 @@ def test_upgrade_db_27_to_28(user_data_dir):  # pylint: disable=unused-argument
         target_version=27,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v27.conn.cursor()
 
@@ -190,6 +195,7 @@ def test_upgrade_db_27_to_28(user_data_dir):  # pylint: disable=unused-argument
         target_version=28,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
 
@@ -226,6 +232,7 @@ def test_upgrade_db_28_to_29(user_data_dir):  # pylint: disable=unused-argument
         target_version=28,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v28.conn.cursor()
 
@@ -282,6 +289,7 @@ def test_upgrade_db_28_to_29(user_data_dir):  # pylint: disable=unused-argument
         target_version=29,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
 
@@ -343,6 +351,7 @@ def test_upgrade_db_29_to_30(user_data_dir):  # pylint: disable=unused-argument
         target_version=30,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     # Finally also make sure that we have updated to the target version
     with db.conn.read_ctx() as cursor:
@@ -373,6 +382,7 @@ def test_upgrade_db_30_to_31(user_data_dir):  # pylint: disable=unused-argument
         target_version=30,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v30.conn.cursor()
     result = cursor.execute('SELECT COUNT(*) FROM eth2_deposits;')
@@ -399,6 +409,7 @@ def test_upgrade_db_30_to_31(user_data_dir):  # pylint: disable=unused-argument
         target_version=31,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
 
     cursor = db.conn.cursor()
@@ -439,6 +450,7 @@ def test_upgrade_db_31_to_32(user_data_dir):  # pylint: disable=unused-argument
         target_version=31,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v31.conn.cursor()
     result = cursor.execute('SELECT rowid from history_events')
@@ -528,6 +540,7 @@ def test_upgrade_db_31_to_32(user_data_dir):  # pylint: disable=unused-argument
         target_version=32,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
     cursor.execute('SELECT subtype FROM history_events')
@@ -623,6 +636,7 @@ def test_upgrade_db_32_to_33(user_data_dir):  # pylint: disable=unused-argument
         target_version=32,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v32.conn.cursor()
     # check that you cannot add blockchain column in xpub_mappings
@@ -674,6 +688,7 @@ def test_upgrade_db_32_to_33(user_data_dir):  # pylint: disable=unused-argument
         target_version=33,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
     # check that xpubs mappings were not altered.
@@ -738,6 +753,7 @@ def test_upgrade_db_33_to_34(user_data_dir):  # pylint: disable=unused-argument
         target_version=33,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     with db_v33.conn.read_ctx() as cursor:
         cursor.execute('SELECT * FROM combined_trades_view ORDER BY time ASC')
@@ -750,6 +766,7 @@ def test_upgrade_db_33_to_34(user_data_dir):  # pylint: disable=unused-argument
         target_version=34,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     with db.conn.read_ctx() as cursor:
         cursor.execute('SELECT * FROM combined_trades_view ORDER BY time ASC')
@@ -773,6 +790,7 @@ def test_upgrade_db_34_to_35(user_data_dir):  # pylint: disable=unused-argument
             target_version=34,
             user_data_dir=user_data_dir,
             msg_aggregator=msg_aggregator,
+            resume_from_backup=False,
         )
 
     upgraded_tables = (
@@ -899,6 +917,7 @@ def test_upgrade_db_34_to_35(user_data_dir):  # pylint: disable=unused-argument
         target_version=35,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     # it should not fail after upgrade since we added `blockchain` to primary key
     with db_v35.conn.write_ctx() as write_cursor:
@@ -1012,6 +1031,7 @@ def test_upgrade_db_35_to_36(user_data_dir):  # pylint: disable=unused-argument
         target_version=35,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v35.conn.cursor()
 
@@ -1127,6 +1147,7 @@ def test_upgrade_db_35_to_36(user_data_dir):  # pylint: disable=unused-argument
         target_version=36,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
 
@@ -1309,6 +1330,7 @@ def test_upgrade_db_36_to_37(user_data_dir):  # pylint: disable=unused-argument
         target_version=36,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db_v36.conn.cursor()
     # Test state of DB before upgrade is as expected
@@ -1412,6 +1434,7 @@ def test_upgrade_db_36_to_37(user_data_dir):  # pylint: disable=unused-argument
         target_version=37,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
 
@@ -1516,6 +1539,7 @@ def test_latest_upgrade_adds_remove_tables(user_data_dir):
         target_version=35,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = last_db.conn.cursor()
     result = cursor.execute('SELECT name FROM sqlite_master WHERE type="table"')
@@ -1530,6 +1554,7 @@ def test_latest_upgrade_adds_remove_tables(user_data_dir):
         target_version=36,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     cursor = db.conn.cursor()
     result = cursor.execute('SELECT name FROM sqlite_master WHERE type="table"')
@@ -1588,6 +1613,7 @@ def test_steps_counted_properly_in_upgrades(user_data_dir):
         target_version=MIN_SUPPORTED_USER_DB_VERSION,
         user_data_dir=user_data_dir,
         msg_aggregator=msessages_aggregator,
+        resume_from_backup=False,
     )
     progress_handler = DBUpgradeProgressHandler(
         messages_aggregator=msessages_aggregator,
@@ -1613,7 +1639,7 @@ def test_db_newer_than_software_raises_error(data_dir, username, sql_vm_instruct
     """
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
-    data.unlock(username, '123', create_new=True)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
     # Manually set a bigger version than the current known one
     cursor = data.db.conn.cursor()
     cursor.execute(
@@ -1626,7 +1652,7 @@ def test_db_newer_than_software_raises_error(data_dir, username, sql_vm_instruct
     del data
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
     with pytest.raises(DBUpgradeError):
-        data.unlock(username, '123', create_new=False)
+        data.unlock(username, '123', create_new=False, resume_from_backup=False)
 
 
 def test_upgrades_list_is_sane():
@@ -1649,6 +1675,7 @@ def test_old_versions_raise_error(user_data_dir):  # pylint: disable=unused-argu
             target_version=34,
             user_data_dir=user_data_dir,
             msg_aggregator=msg_aggregator,
+            resume_from_backup=False,
         )
     assert 'Your account was last opened by a very old version of rotki' in str(upgrade_exception)
 
@@ -1660,6 +1687,7 @@ def test_unfinished_upgrades(user_data_dir):
         target_version=33,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=False,
     )
     with db.user_write() as write_cursor:
         db.set_setting(  # Pretend that an upgrade was started
@@ -1674,6 +1702,7 @@ def test_unfinished_upgrades(user_data_dir):
             target_version=34,
             user_data_dir=user_data_dir,
             msg_aggregator=msg_aggregator,
+            resume_from_backup=True,
         )
 
     # Add a backup
@@ -1692,6 +1721,7 @@ def test_unfinished_upgrades(user_data_dir):
         target_version=34,
         user_data_dir=user_data_dir,
         msg_aggregator=msg_aggregator,
+        resume_from_backup=True,
     )
     # Check that there is no setting left
     with db.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/db/test_defi_events.py
+++ b/rotkehlchen/tests/db/test_defi_events.py
@@ -26,7 +26,7 @@ def test_add_and_get_aave_events(data_dir, username, sql_vm_instructions_cb):
     """Test that get aave events works fine and returns only events for what we need"""
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
-    data.unlock(username, '123', create_new=True)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
 
     addr1 = make_evm_address()
     addr1_events = [AaveDepositWithdrawalEvent(
@@ -185,7 +185,7 @@ def test_add_and_get_yearn_vault_events(
     """Test that get yearn vault events works fine and returns only events for what we need"""
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
-    data.unlock(username, '123', create_new=True)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
 
     addr1 = make_evm_address()
     addr1_events = [YearnVaultEvent(

--- a/rotkehlchen/tests/db/test_evmtx.py
+++ b/rotkehlchen/tests/db/test_evmtx.py
@@ -29,7 +29,7 @@ def test_add_get_evm_transactions(data_dir, username, sql_vm_instructions_cb):
     """
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
-    data.unlock(username, '123', create_new=True)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
     tx2_hash = deserialize_evm_tx_hash(b'.h\xdd\x82\x85\x94\xeaq\xfe\n\xfc\xcf\xadwH\xc9\x0f\xfc\xd0\xf1\xad\xd4M\r$\x9b\xf7\x98\x87\xda\x93\x18')  # noqa: E501
     with data.db.user_write() as cursor:
         data.db.add_blockchain_accounts(
@@ -134,7 +134,7 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
     """
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
-    data.unlock(username, '123', create_new=True)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
     address_4 = make_evm_address()
 
     with data.db.user_write() as cursor:

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -36,6 +36,7 @@ def fixture_temp_etherscan(function_scope_messages_aggregator, tmpdir_factory, s
         msg_aggregator=function_scope_messages_aggregator,
         initial_settings=None,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
+        resume_from_backup=False,
     )
 
     # Test with etherscan API key

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -155,6 +155,7 @@ def _init_database(
             msg_aggregator=msg_aggregator,
             initial_settings=None,
             sql_vm_instructions_cb=sql_vm_instructions_cb,
+            resume_from_backup=False,
         )
     # Make sure that the fixture provided data are included in the DB
     add_settings_to_test_db(db, db_settings, ignored_assets, data_migration_version)

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -110,7 +110,12 @@ def test_upload_data_to_server(rotkehlchen_instance, username, db_password, db_s
 
     # and now logout and login again and make sure that the last_data_upload_ts is correct
     rotkehlchen_instance.logout()
-    rotkehlchen_instance.data.unlock(username, db_password, create_new=False)
+    rotkehlchen_instance.data.unlock(
+        username=username,
+        password=db_password,
+        create_new=False,
+        resume_from_backup=False,
+    )
     assert last_ts == rotkehlchen_instance.premium_sync_manager.last_data_upload_ts
     with rotkehlchen_instance.data.db.conn.read_ctx() as cursor:
         assert last_ts == rotkehlchen_instance.data.db.get_setting(cursor, name='last_data_upload_ts')  # noqa: E501

--- a/rotkehlchen/tests/test_users.py
+++ b/rotkehlchen/tests/test_users.py
@@ -14,11 +14,21 @@ def _user_creation_and_login(username, password, data_dir, msg_aggregator, sql_v
         msg_aggregator=msg_aggregator,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
     )
-    filepath = handler.unlock(username=username, password=password, create_new=True)
+    filepath = handler.unlock(
+        username=username,
+        password=password,
+        create_new=True,
+        resume_from_backup=False,
+    )
     assert filepath is not None
     # Also login as non-new user with same password
     handler.logout()
-    filepath = handler.unlock(username=username, password=password, create_new=False)
+    filepath = handler.unlock(
+        username=username,
+        password=password,
+        create_new=False,
+        resume_from_backup=False,
+    )
     assert filepath is not None
 
 
@@ -92,6 +102,11 @@ def test_new_user_permission_error(data_dir, function_scope_messages_aggregator,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
     )
     with pytest.raises(SystemPermissionError):
-        handler.unlock(username='someuser', password='123', create_new=True)
+        handler.unlock(
+            username='someuser',
+            password='123',
+            create_new=True,
+            resume_from_backup=False,
+        )
     # Change permissions back to that pytest cleanup can clean it
     os.chmod(not_allowed_dir, 0o777)

--- a/rotkehlchen/tests/unit/test_app.py
+++ b/rotkehlchen/tests/unit/test_app.py
@@ -18,7 +18,7 @@ def test_initializing_exchanges(uninitialized_rotkehlchen):
     rotki = uninitialized_rotkehlchen
     username = 'someusername'
     db_password = '123'
-    rotki.data.unlock(username, db_password, create_new=True)
+    rotki.data.unlock(username, db_password, create_new=True, resume_from_backup=False)
     database = rotki.data.db
     # Mock having user_credentials for all exchanges and for premium
     cmd = (

--- a/rotkehlchen/tests/utils/xpubs.py
+++ b/rotkehlchen/tests/utils/xpubs.py
@@ -12,7 +12,7 @@ def setup_db_for_xpub_tests_impl(data_dir, username, sql_vm_instructions_cb):
     """Setups a test database with xpub data"""
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
-    data.unlock(username, '123', create_new=True)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
 
     with data.db.user_write() as cursor:
         data.db.add_tag(cursor, 'public', 'foooo', 'ffffff', '000000')

--- a/tools/assets_database/main.py
+++ b/tools/assets_database/main.py
@@ -108,6 +108,7 @@ def main() -> None:
             msg_aggregator=msg_aggregator,
             initial_settings=None,
             sql_vm_instructions_cb=0,
+            resume_from_backup=False,
         )
         GlobalDBHandler(data_dir=target_directory, sql_vm_instructions_cb=0)
         assets_updater = AssetsUpdater(msg_aggregator=msg_aggregator, user_db=db)

--- a/tools/uniswapv2/detect.py
+++ b/tools/uniswapv2/detect.py
@@ -211,6 +211,7 @@ if __name__ == '__main__':
             msg_aggregator=msg_aggregator,
             initial_settings=None,
             sql_vm_instructions_cb=5000,
+            resume_from_backup=False,
         )
         ethereum = init_ethereum(
             rpc_endpoint=args.eth_rpc_endpoint,


### PR DESCRIPTION
Addresses issue #5221 

* If there is an ongoing upgrade and the user tries to login he is prompted to resume from the latest user db backup. In that case, the frontend should show two options to the user: 1. Resume from backup  2. Abort login.
* a resume_from_backup argument was added to user login endpoint
* a test case was added

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
