### PR TITLE
refactor: adds wrapper to ease migration to vue-i18n v9

### DIFF
--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -445,7 +445,7 @@ declare global {
   const useHistoryIgnoringApi: typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']
   const useHistoryStore: typeof import('./store/history/index')['useHistoryStore']
   const useHistoryTransactions: typeof import('./composables/history/events/tx')['useHistoryTransactions']
-  const useI18n: typeof import('vue-i18n-composable')['useI18n']
+  const useI18n: typeof import('./composables/usei18n')['useI18n']
   const useIdle: typeof import('@vueuse/core')['useIdle']
   const useIgnore: typeof import('./composables/history/index')['useIgnore']
   const useIgnoredAssetsStore: typeof import('./store/assets/ignored')['useIgnoredAssetsStore']
@@ -1119,7 +1119,7 @@ declare module 'vue' {
     readonly useHistoryIgnoringApi: UnwrapRef<typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']>
     readonly useHistoryStore: UnwrapRef<typeof import('./store/history/index')['useHistoryStore']>
     readonly useHistoryTransactions: UnwrapRef<typeof import('./composables/history/events/tx')['useHistoryTransactions']>
-    readonly useI18n: UnwrapRef<typeof import('vue-i18n-composable')['useI18n']>
+    readonly useI18n: UnwrapRef<typeof import('./composables/usei18n')['useI18n']>
     readonly useIdle: UnwrapRef<typeof import('@vueuse/core')['useIdle']>
     readonly useIgnore: UnwrapRef<typeof import('./composables/history/index')['useIgnore']>
     readonly useIgnoredAssetsStore: UnwrapRef<typeof import('./store/assets/ignored')['useIgnoredAssetsStore']>
@@ -1787,7 +1787,7 @@ declare module '@vue/runtime-core' {
     readonly useHistoryIgnoringApi: UnwrapRef<typeof import('./composables/api/history/ignore')['useHistoryIgnoringApi']>
     readonly useHistoryStore: UnwrapRef<typeof import('./store/history/index')['useHistoryStore']>
     readonly useHistoryTransactions: UnwrapRef<typeof import('./composables/history/events/tx')['useHistoryTransactions']>
-    readonly useI18n: UnwrapRef<typeof import('vue-i18n-composable')['useI18n']>
+    readonly useI18n: UnwrapRef<typeof import('./composables/usei18n')['useI18n']>
     readonly useIdle: UnwrapRef<typeof import('@vueuse/core')['useIdle']>
     readonly useIgnore: UnwrapRef<typeof import('./composables/history/index')['useIgnore']>
     readonly useIgnoredAssetsStore: UnwrapRef<typeof import('./store/assets/ignored')['useIgnoredAssetsStore']>

--- a/frontend/app/src/components/account-management/upgrade/DbActivityProgress.vue
+++ b/frontend/app/src/components/account-management/upgrade/DbActivityProgress.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { type CurrentDbUpgradeProgress } from '@/types/login';
 
+const { t } = useI18n();
+
 const props = withDefaults(
   defineProps<{
     progress: CurrentDbUpgradeProgress | null;
@@ -12,8 +14,6 @@ const props = withDefaults(
 );
 
 const { progress } = toRefs(props);
-
-const { tc } = useI18n();
 
 const multipleUpgrades = computed(() => {
   if (isDefined(progress)) {
@@ -27,8 +27,8 @@ const multipleUpgrades = computed(() => {
 <template>
   <card v-if="progress" flat>
     <template #title>
-      <span v-if="dataMigration">{{ tc('login.migrating_data.title') }} </span>
-      <span v-else> {{ tc('login.upgrading_db.title') }}</span>
+      <span v-if="dataMigration">{{ t('login.migrating_data.title') }} </span>
+      <span v-else> {{ t('login.upgrading_db.title') }}</span>
     </template>
     <v-row class="my-2">
       <v-col cols="auto">
@@ -52,20 +52,20 @@ const multipleUpgrades = computed(() => {
       <v-col class="text-body-1">
         <div v-if="!dataMigration">
           <div>
-            {{ tc('login.upgrading_db.warning', 0, progress) }}
+            {{ t('login.upgrading_db.warning', { ...progress }) }}
           </div>
           <v-divider class="my-2" />
           <div>
-            {{ tc('login.upgrading_db.current', 0, progress) }}
+            {{ t('login.upgrading_db.current', { ...progress }) }}
           </div>
         </div>
         <div v-else>
           <div>
-            {{ tc('login.migrating_data.warning', 0, progress) }}
+            {{ t('login.migrating_data.warning', { ...progress }) }}
           </div>
           <v-divider class="my-2" />
           <div>
-            {{ tc('login.migrating_data.current', 0, progress) }}
+            {{ t('login.migrating_data.current', { ...progress }) }}
           </div>
           <ul v-if="progress.description" class="ml-n2">
             <li>{{ progress.description }}</li>

--- a/frontend/app/src/components/settings/data-security/backups/DatabaseBackups.vue
+++ b/frontend/app/src/components/settings/data-security/backups/DatabaseBackups.vue
@@ -6,6 +6,8 @@ import { displayDateFormatter } from '@/data/date_formatter';
 import { type UserDbBackup } from '@/types/backup';
 import { size } from '@/utils/data';
 
+const { t } = useI18n();
+
 const props = defineProps({
   items: { required: true, type: Array as PropType<UserDbBackup[]> },
   selected: { required: true, type: Array as PropType<UserDbBackup[]> },
@@ -18,21 +20,19 @@ const emit = defineEmits<{
   (e: 'remove', backup: UserDbBackup): void;
 }>();
 
-const { tc } = useI18n();
-
 const tableHeaders = computed<DataTableHeader[]>(() => [
   {
     value: 'version',
-    text: tc('database_backups.column.version')
+    text: t('database_backups.column.version')
   },
   {
     value: 'time',
-    text: tc('common.datetime')
+    text: t('common.datetime')
   },
   {
     value: 'size',
     align: 'end',
-    text: tc('database_backups.column.size')
+    text: t('database_backups.column.size')
   },
   { value: 'actions', align: 'end', sortable: false, text: '' }
 ]);
@@ -86,8 +86,8 @@ const showDeleteConfirmation = (item: UserDbBackup & { index: number }) => {
 
   show(
     {
-      title: tc('database_backups.confirm.title'),
-      message: tc('database_backups.confirm.message', 0, messageInfo)
+      title: t('database_backups.confirm.title'),
+      message: t('database_backups.confirm.message', { ...messageInfo })
     },
     () => remove(item)
   );
@@ -126,7 +126,7 @@ const showDeleteConfirmation = (item: UserDbBackup & { index: number }) => {
               <v-icon small> mdi-delete-outline </v-icon>
             </v-btn>
           </template>
-          <span>{{ tc('database_backups.action.delete') }}</span>
+          <span>{{ t('database_backups.action.delete') }}</span>
         </v-tooltip>
         <v-tooltip top>
           <template #activator="{ on, attrs }">
@@ -141,13 +141,13 @@ const showDeleteConfirmation = (item: UserDbBackup & { index: number }) => {
               <v-icon small> mdi-download </v-icon>
             </v-btn>
           </template>
-          <span>{{ tc('database_backups.action.download') }}</span>
+          <span>{{ t('database_backups.action.download') }}</span>
         </v-tooltip>
       </template>
       <template #body.append="{ isMobile }">
         <row-append
           label-colspan="3"
-          :label="tc('common.total')"
+          :label="t('common.total')"
           :right-patch-colspan="1"
           :is-mobile="isMobile"
         >

--- a/frontend/app/src/composables/usei18n.ts
+++ b/frontend/app/src/composables/usei18n.ts
@@ -1,0 +1,31 @@
+import { useI18n as i18n } from 'vue-i18n-composable';
+
+export const useI18n = () => {
+  const { t: originalT, tc: originalTc, locale } = i18n();
+
+  const t = (
+    key: string,
+    values?: Record<string, unknown>,
+    choice?: number
+  ): string => {
+    if (choice) {
+      return originalTc(key, choice, values);
+    }
+    return originalT(key, values).toString();
+  };
+
+  /**
+   * @deprecated use {@link t} as a replacement.
+   */
+  const tc = (
+    key: string,
+    choice?: number,
+    values?: Record<string, unknown>
+  ): string => t(key, values, choice);
+
+  return {
+    t,
+    tc,
+    locale
+  };
+};

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -84,7 +84,6 @@ export default defineConfig({
         '@vueuse/core',
         '@vueuse/math',
         'pinia',
-        { 'vue-i18n-composable': ['useI18n'] },
         { '@vueuse/shared': ['get', 'set'] },
         {
           'vue-router/composables': [

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -19,8 +19,7 @@
   },
   "peerDependencies": {
     "@vueuse/core": "9.6.0",
-    "vue": "2.7.14",
-    "vue-i18n": "8.28.2"
+    "vue": "2.7.14"
   },
   "dependencies": {
     "bignumber.js": "9.1.1",
@@ -31,7 +30,6 @@
     "core-js": "3.30.2",
     "rimraf": "5.0.1",
     "typescript": "5.0.4",
-    "vue": "2.7.14",
-    "vue-i18n": "8.28.2"
+    "vue": "2.7.14"
   }
 }

--- a/frontend/common/src/premium/index.ts
+++ b/frontend/common/src/premium/index.ts
@@ -26,7 +26,6 @@ import {
   type TimedAssetBalances,
   type TimedBalances
 } from '../statistics';
-import type VueI18n from 'vue-i18n';
 
 export interface PremiumInterface {
   readonly useHostComponents: boolean;
@@ -131,8 +130,19 @@ export interface SettingsApi {
   themes(): Themes;
   user: UserSettingsApi;
   i18n: {
-    t: typeof VueI18n.prototype.t;
-    tc: typeof VueI18n.prototype.tc;
+    t: (
+      key: string,
+      values?: Record<string, unknown>,
+      choice?: number
+    ) => string;
+    /**
+     * @deprecated
+     */
+    tc: (
+      key: string,
+      choice?: number,
+      values?: Record<string, unknown>
+    ) => string;
   };
 }
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -330,9 +330,6 @@ importers:
       vue:
         specifier: 2.7.14
         version: 2.7.14
-      vue-i18n:
-        specifier: 8.28.2
-        version: 8.28.2(vue@2.7.14)
 
   dev-proxy:
     dependencies:
@@ -10253,6 +10250,7 @@ packages:
       vue: ^2
     dependencies:
       vue: 2.7.14
+    dev: false
 
   /vue-router@3.6.5(vue@2.7.14):
     resolution: {integrity: sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==}


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
