### PR TITLE
fix: shorten alias name

### DIFF
--- a/frontend/app/src/components/display/AccountDisplay.vue
+++ b/frontend/app/src/components/display/AccountDisplay.vue
@@ -31,7 +31,10 @@ const aliasName = computed<string | null>(() => {
   if (!get(scrambleData) && get(useAliasName)) {
     const { address, chain } = get(account);
     const chainId = chain === 'ALL' ? Blockchain.ETH : chain;
-    return get(addressNameSelector(address, chainId));
+    const name = get(addressNameSelector(address, chainId));
+    if (name) {
+      return truncateAddress(name, 10);
+    }
   }
 
   return null;

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -20,7 +20,13 @@ const aliasName = computed<string | null>(() => {
   }
 
   const { address, chain } = get(account);
-  return get(addressNameSelector(address, chain));
+  const name = get(addressNameSelector(address, chain));
+
+  if (!name) {
+    return null;
+  }
+
+  return truncateAddress(name, get(truncationLength));
 });
 
 const xsOnly = computed(() => get(currentBreakpoint).xsOnly);

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -52,7 +52,12 @@ const aliasName = computed<string | null>(() => {
     return null;
   }
 
-  return get(addressNameSelector(text, chain));
+  const name = get(addressNameSelector(text, chain));
+  if (!name) {
+    return null;
+  }
+
+  return truncateAddress(name, 10);
 });
 
 const displayText = computed<string>(() => {


### PR DESCRIPTION
Shorten alias name for very long ENS name, for example `0x65aac64335bcae4573254794682f6bbd596ecaa3.eth`