### PR TITLE
fix: updates docker builder stage to node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM node:16-buster as frontend-build-stage
+FROM --platform=$BUILDPLATFORM node:18-buster as frontend-build-stage
 
 ARG BUILDARCH
 WORKDIR /app


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
