### PR TITLE
chore: fixes failure to resolve alias with volar

### DIFF
--- a/frontend/app/tests/e2e/tsconfig.json
+++ b/frontend/app/tests/e2e/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "types": ["cypress", "node"],
     "target": "ES5",
     "sourceMap": false,
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "paths": {
+      "@/*": ["../../src/*"]
+    }
   },
-  "include": ["**/*.ts"],
+  "include": ["../../src/**/*.ts", "**/*.ts", "../../src/auto-imports.d.ts"],
   "exclude": ["node_modules/**", "**/.*"],
   "compileOnSave": false
 }

--- a/frontend/app/tsconfig.json
+++ b/frontend/app/tsconfig.json
@@ -13,7 +13,13 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "components.d.ts"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "components.d.ts"
+  ],
   "exclude": ["node_modules/**", "**/.*"],
   "vueCompilerOptions": {
     "target": 2.7

--- a/frontend/app/tsconfig.json
+++ b/frontend/app/tsconfig.json
@@ -1,15 +1,19 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "types": [
       "vuetify",
       "vue-i18n",
       "vite/client",
       "vite-plugin-vue-layouts/client",
       "unplugin-vue-define-options/macros-global"
-    ]
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "components.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "components.d.ts"],
   "exclude": ["node_modules/**", "**/.*"],
   "vueCompilerOptions": {
     "target": 2.7

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "es2020",
     "module": "esnext",
     "strict": true,
@@ -17,16 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "isolatedModules": true,
-    "paths": {
-      "@/*": ["app/src/*"]
-    },
     "lib": ["es2020", "dom", "dom.iterable", "scripthost"]
   },
-  "references": [
-    {
-      "path": "app"
-    }
-  ],
-  "include": [".eslintrc.js"],
   "exclude": ["node_modules/**", "**/.*", "cypress"]
 }


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Notes

The problem was that the wrong root file was used and the alias didn't resolve to the correct path. With this, it should work fine now.

I had to nuke my `.idea` in `WS 2023.2 EAP` but it seems that now things are not highlighted as errors anymore. 

The issue was visible when I also opened vscode with volar 1.4.0.