### PR TITLE
Some Improvements

### DIFF
--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -272,7 +272,12 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
         new event or actions need to be propagated.
         """
         for rule in self.rules.event_rules:
-            decoding_output = rule(token=token, tx_log=tx_log, transaction=transaction, decoded_events=decoded_events, action_items=action_items, all_logs=all_logs)  # noqa: E501
+            try:
+                decoding_output = rule(token=token, tx_log=tx_log, transaction=transaction, decoded_events=decoded_events, action_items=action_items, all_logs=all_logs)  # noqa: E501
+            except (DeserializationError, IndexError) as e:
+                self.msg_aggregator.add_error(f'Decoding tx log with index {tx_log.log_index} of {transaction.tx_hash.hex()} through {rule} failed due to {e!s}. Skipping rule.')  # noqa: E501
+                continue
+
             if decoding_output.event is not None or len(decoding_output.action_items) > 0:
                 return decoding_output
 
@@ -312,7 +317,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
             else:
                 result = method(context, *mapping_result[1:])
         except (DeserializationError, ConversionError, UnknownAsset) as e:
-            log.debug(
+            self.msg_aggregator.add_error(
                 f'Decoding tx log with index {tx_log.log_index} of transaction '
                 f'{transaction.tx_hash.hex()} through {method.__name__} failed due to {e!s}')
             return DEFAULT_DECODING_OUTPUT
@@ -349,7 +354,10 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
         # Sort post decoding rules by priority (which is the first element of the tuple)
         rules.sort(key=lambda x: x[0])
         for _, rule in rules:
-            decoded_events = rule(transaction=transaction, decoded_events=decoded_events, all_logs=all_logs)  # noqa: E501
+            try:
+                decoded_events = rule(transaction=transaction, decoded_events=decoded_events, all_logs=all_logs)  # noqa: E501
+            except (DeserializationError, IndexError) as e:
+                self.msg_aggregator.add_error(f'Applying post-decoding rule {rule} for {transaction.tx_hash.hex()} failed due to {e!s}. Skipping rule.')  # noqa: E501
 
         assert self._check_correct_types(decoded_events)
         return decoded_events

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -1189,8 +1189,7 @@ class GlobalDBHandler():
             querylist.append(source.serialize_for_db())
 
         with GlobalDBHandler().conn.read_ctx() as cursor:
-            query = cursor.execute(querystr, tuple(querylist))
-            result = query.fetchone()
+            result = cursor.execute(querystr, tuple(querylist)).fetchone()
             if result[0] is None:
                 return None
 
@@ -1224,8 +1223,7 @@ class GlobalDBHandler():
         prices_results = []
         with GlobalDBHandler().conn.read_ctx() as cursor:
             for entry in querylist:
-                query = cursor.execute(querystr, entry)
-                result = query.fetchone()  # below last index of the result tuple is ignored in deserialize  # noqa: E501
+                result = cursor.execute(querystr, entry).fetchone()  # below last index of the result tuple is ignored in deserialize  # noqa: E501
                 prices_results.append(None if result[0] is None else HistoricalPrice.deserialize_from_db(result))  # noqa: E501
 
         return prices_results

--- a/rotkehlchen/tests/utils/args.py
+++ b/rotkehlchen/tests/utils/args.py
@@ -23,9 +23,10 @@ def default_args(
         data_dir: Optional[str] = None,
         ethrpc_endpoint: Optional[str] = None,
         max_size_in_mb_all_logs: int = DEFAULT_MAX_LOG_SIZE_IN_MB,
+        loglevel: str = 'debug',
 ):
     return ConfigurationArgs(
-        loglevel='debug',
+        loglevel=loglevel,
         logfromothermodules=False,
         data_dir=data_dir,
         ethrpc_endpoint=ethrpc_endpoint,


### PR DESCRIPTION
### [Improve price history query in sqlite](https://github.com/rotki/rotki/commit/b0869a21c0d04254021e2542ea0e48ef65a94ce3) 

1. Add a method to query multiple historical prices at the same
time.
2. Improve the query by using BETWEEN expr instead of the ABS and by
using MIN(ABS()) to select the closest value to the timestamp. The
biggest improvement comes from the usage of BETWEEN. For a query of
18k events over a DB of 4899694 price entries this improve speed by
13%. With the multiple historical prices query it took 73 seconds
while with the improvements it took 63.


### [Catch more potential errors in transaction decoding process](https://github.com/rotki/rotki/commit/fd20a094245f892bfee28b16d99068f0f890b49e)