### PR TITLE
Add geth_poa middleware also for Polygon

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -358,7 +358,8 @@ class EvmNodeInquirer(metaclass=ABCMeta):
             web3.middleware_onion.remove('gas_estimate')
             # we do our own handling for ens names
             web3.middleware_onion.remove('name_to_address')
-        if self.chain_id == ChainID.OPTIMISM:  # for now only optimism needs this
+        if self.chain_id in (ChainID.OPTIMISM, ChainID.POLYGON_POS):
+            # TODO: Is it needed for all non-mainet EVM chains?
             # https://web3py.readthedocs.io/en/stable/middleware.html#why-is-geth-poa-middleware-necessary
             web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 


### PR DESCRIPTION
If not then we get the same errors we used to get in optimism:

```
[25/05/2023 13:16:32 CEST] WARNING rotkehlchen.chain.evm.node_inquirer
Main Greenlet: Failed to query NodeName(name='public node',
endpoint='https://polygon-bor.publicnode.com', owned=False,
blockchain=<SupportedBlockchain.POLYGON_POS: 'POLYGON_POS'>) for
<bound method EvmNodeInquirer._get_block_by_number of
<rotkehlchen.chain.polygon_pos.node_inquirer.PolygonPOSInquirer object
at 0x7f913fd34f40>> due to Could not format value
'0xd682020c83626f7288676f312e31372e34856c696e7578000000000000000000a0526a5439b5e336714b0bbc5599da246aad484c58c3702d046362d3d421b99948dce151269270973291eb635838abcac08d43c7bc444335b5084a6a86b6871801'
as field 'extraData'
```

Open question: Does this mean the middleware is needed in all non-mainnet evm chains?