### PR TITLE
Remove query of size for past PnL reports

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5750,7 +5750,6 @@ Query saved PnL Reports
               "end_ts":1637928988,
               "first_processed_timestamp":null,
               "last_processed_timestamp": 1602042717,
-              "size_on_disk":14793,
               "settings": {
                   "profit_currency": "USD",
                   "taxfree_after_period": 365,
@@ -5774,7 +5773,6 @@ Query saved PnL Reports
               "end_ts":1637928988,
               "first_processed_timestamp":null,
               "last_processed_timestamp": 1602042717,
-              "size_on_disk":6793,
               "settings": {
                   "profit_currency": "USD",
                   "taxfree_after_period": 365,
@@ -5797,7 +5795,6 @@ Query saved PnL Reports
               "end_ts":1637928988,
               "first_processed_timestamp":null,
               "last_processed_timestamp": 1602042717,
-              "size_on_disk":23493,
               "settings": {
                   "profit_currency": "USD",
                   "taxfree_after_period": 365,
@@ -5824,8 +5821,6 @@ Query saved PnL Reports
    :resjson int start_ts: The end unix timestamp of the PnL report
    :resjson int end_ts: The end unix timestamp of the PnL report
    :resjson int first_processed_timestamp: The timestamp of the first even we processed in the PnL report or 0 for empty report.
-   :resjson int size_on_disk: An approximation of the size of the PnL report on disk.
-
 
    :resjson object overview: The overview contains an entry for totals per event type. Each entry contains pnl breakdown (free/taxable for now).
    :resjson int last_processed_timestamp: The timestamp of the last processed action. This helps us figure out when was the last action the backend processed and if it was before the start of the PnL period to warn the user WHY the PnL is empty.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`-` ENS avatar fetching for each name's avatar should now work for all name resolvers. Even older or custom ones.
 * :bug:`-` Users will now be able to decode compounding transactions for Convex gauges.
+* :feature:`-` The PnL report page will load faster if there is many old reports in the DB.
 * :feature:`-` Convex staking and Curve gauge balances will no longer need a manual balances referesh to be detected.
 
 * :release:`1.28.0 <2023-05-17>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 * :bug:`-` ENS avatar fetching for each name's avatar should now work for all name resolvers. Even older or custom ones.
 * :bug:`-` Users will now be able to decode compounding transactions for Convex gauges.
-* :bug:`-` Convex staking and Curve gauge balances will no longer need a manual balances referesh to be detected.
+* :feature:`-` Convex staking and Curve gauge balances will no longer need a manual balances referesh to be detected.
 
 * :release:`1.28.0 <2023-05-17>`
 * :feature:`2469` History events have now been unified under a common history events section. At the moment it features all kraken exchange events, evm events, custom imported events, block productions, staking withdrawals. Missing events retain their own sections and will be merged into the unified history in subsequent releases.

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -75,11 +75,10 @@ def test_query_history(rotkehlchen_api_server_with_exchanges, start_ts, end_ts):
     assert report_result['entries_found'] == 1
     assert report_result['entries_limit'] == FREE_REPORTS_LOOKUP_LIMIT
     report = report_result['entries'][0]
-    assert len(report) == 11  # 11 entries in the report api endpoint
+    assert len(report) == 10  # 10 entries in the report api endpoint
     assert report['first_processed_timestamp'] == 1428994442
     assert report['last_processed_timestamp'] == end_ts if end_ts == 1539713238 else 1566572401
     assert report['identifier'] == report_id
-    assert report['size_on_disk'] > 0
 
     overview = report['overview']
     if start_ts == 0:


### PR DESCRIPTION
Remove query of size for past PnL reports

A user reported to us that the app was freezing for him after loading a huge pnl report.
By reading the logs it took around 4 mins for the endpoint to return a value. The reasons for
the issue where:

1. The reports endpoint is called sync and not async
2. It was performing a heavy sql query fetching the size of the reports

This was blocking the backend from receiving any other request and also making as if no report
was getting generated since it was not being displayed on the frontend.

We discussed in discord and didn't see any meaningful reason to have it so we are removing the size
on disk info for now.
