### PR TITLE
fix: some small things on history events

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventForm.vue
+++ b/frontend/app/src/components/history/events/HistoryEventForm.vue
@@ -15,6 +15,7 @@ import {
 import { TaskType } from '@/types/task-type';
 import { toMessages } from '@/utils/validation-errors';
 import { type ActionDataEntry } from '@/types/action';
+import { type HistoricalPriceFormPayload } from '@/types/prices';
 
 const props = withDefaults(
   defineProps<{
@@ -198,6 +199,12 @@ const setEditMode = async () => {
 const { setMessage } = useMessageStore();
 
 const { editTransactionEvent, addTransactionEvent } = useHistoryTransactions();
+const { resetHistoricalPricesData } = useHistoricCachePriceStore();
+
+const savePrice = async (payload: HistoricalPriceFormPayload) => {
+  await addHistoricalPrice(payload);
+  await resetHistoricalPricesData([payload]);
+};
 
 const save = async (): Promise<boolean> => {
   const timestamp = convertToTimestamp(get(datetime));
@@ -225,7 +232,7 @@ const save = async (): Promise<boolean> => {
 
   if (get(isCurrentCurrencyUsd)) {
     if (get(assetToUsdPrice) !== get(fetchedAssetToUsdPrice)) {
-      await addHistoricalPrice({
+      await savePrice({
         fromAsset: assetVal,
         toAsset: CURRENCY_USD,
         timestamp,
@@ -233,7 +240,7 @@ const save = async (): Promise<boolean> => {
       });
     }
   } else if (get(assetToFiatPrice) !== get(fetchedAssetToFiatPrice)) {
-    await addHistoricalPrice({
+    await savePrice({
       fromAsset: assetVal,
       toAsset: get(currencySymbol),
       timestamp,

--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -508,19 +508,28 @@ const { locationData } = useLocations();
       </template>
       <template #actions>
         <v-row>
-          <v-col cols="12" md="7">
+          <v-col cols="12" md="5">
             <v-row>
               <v-col v-if="includeEvmEvents" cols="auto">
-                <v-btn
-                  color="primary"
-                  depressed
-                  height="40px"
-                  small
-                  :disabled="refreshing"
-                  @click="redecodeAllEvmEvents()"
-                >
-                  {{ t('transactions.redecode_events.title') }}
-                </v-btn>
+                <v-tooltip top>
+                  <template #activator="{ on }">
+                    <v-btn
+                      color="primary"
+                      depressed
+                      height="40px"
+                      small
+                      :loading="eventTaskLoading"
+                      :disabled="refreshing"
+                      v-on="on"
+                      @click="redecodeAllEvmEvents()"
+                    >
+                      <v-icon> mdi-select-compare </v-icon>
+                    </v-btn>
+                  </template>
+                  <span>
+                    {{ t('transactions.redecode_events.title') }}
+                  </span>
+                </v-tooltip>
               </v-col>
               <v-col v-if="!useExternalAccountFilter">
                 <div>
@@ -539,7 +548,7 @@ const { locationData } = useLocations();
               </v-col>
             </v-row>
           </v-col>
-          <v-col cols="12" md="5">
+          <v-col cols="12" md="7">
             <div>
               <table-filter
                 :matches="filters"

--- a/frontend/app/src/components/inputs/ComboboxWithCustomInput.vue
+++ b/frontend/app/src/components/inputs/ComboboxWithCustomInput.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import { type ComputedRef, type Ref, useListeners } from 'vue';
 
-const props = defineProps<{
-  value: string;
-  items: any[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    value?: string | null;
+    items: any[];
+  }>(),
+  {
+    value: ''
+  }
+);
 
 const emit = defineEmits<{
   (e: 'input', value: string): void;

--- a/frontend/app/src/components/table-filter/TableFilter.vue
+++ b/frontend/app/src/components/table-filter/TableFilter.vue
@@ -313,6 +313,7 @@ watch(matches, matches => {
 
 const css = useCssModule();
 const slots = useSlots();
+const { t } = useI18n();
 </script>
 
 <template>
@@ -334,6 +335,9 @@ const slots = useSlots();
             chips
             small-chips
             deletable-chips
+            :label="t('table_filter.label')"
+            solo
+            flat
             multiple
             clearable
             hide-details

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3910,6 +3910,7 @@
       "description": "Use operator `!=` to filter out option, e.g.",
       "example": "type != evm event"
     },
+    "label": "Combined filters",
     "no_suggestions": "No suggestions found for {search}",
     "saved_filters": {
       "actions": {

--- a/frontend/app/src/store/prices/historic.ts
+++ b/frontend/app/src/store/prices/historic.ts
@@ -1,6 +1,6 @@
 import { type BigNumber } from '@rotki/common';
 import { type ComputedRef } from 'vue';
-import { HistoricPrices, type HistoricalPrice } from '@/types/prices';
+import { HistoricPrices } from '@/types/prices';
 import { TaskType } from '@/types/task-type';
 import { type TaskMeta } from '@/types/task';
 import { NoPrice } from '@/utils/bignumbers';
@@ -79,7 +79,9 @@ export const useHistoricCachePriceStore = defineStore(
       reset();
     });
 
-    const resetHistoricalPricesData = (items: HistoricalPrice[]) => {
+    const resetHistoricalPricesData = (
+      items: { fromAsset: string; timestamp: number }[]
+    ) => {
       items.forEach(item => {
         const key = createKey(item.fromAsset, item.timestamp);
         deleteCacheKey(key);


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] Refetch historic price when editing the price on the history event form.
- [ ] Change `Redecode EVM Events` button to use icon only, to save some space.
- [ ] Add placeholder to `Combined filters input`
- [ ] Remove errror from `<ComboboxWIthCustomInput />` component, when null value passed.