### PR TITLE
Fix for the too many files errors in the tests

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -17,7 +17,7 @@ jobs:
       TEST_ENVIRONMENT: ${{ inputs.test_environment }}
     runs-on: ${{ inputs.os }}
     name: 'Backend tests'
-    timeout-minutes: 90
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -216,6 +216,11 @@ class GlobalDBHandler():
         GlobalDBHandler.__instance.packaged_db_lock = Semaphore()
         return GlobalDBHandler.__instance
 
+    def cleanup(self) -> None:
+        self.conn.close()
+        if self._packaged_db_conn is not None:
+            self._packaged_db_conn.close()
+
     @staticmethod
     def packaged_db_conn() -> DBConnection:
         """Return a DBConnection instance for the packaged global db."""

--- a/rotkehlchen/tests/fixtures/__init__.py
+++ b/rotkehlchen/tests/fixtures/__init__.py
@@ -9,6 +9,7 @@ from rotkehlchen.tests.fixtures.google import *  # noqa: F403
 from rotkehlchen.tests.fixtures.greenlets import *  # noqa: F403
 from rotkehlchen.tests.fixtures.history import *  # noqa: F403
 from rotkehlchen.tests.fixtures.messages import *  # noqa: F403
+from rotkehlchen.tests.fixtures.networking import *  # noqa: F403
 from rotkehlchen.tests.fixtures.pylint import *  # noqa: F403
 from rotkehlchen.tests.fixtures.rotkehlchen import *  # noqa: F403
 from rotkehlchen.tests.fixtures.variables import *  # noqa: F403

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -137,7 +137,7 @@ def fixture_session_globaldb(
         tmpdir_factory,
         session_sql_vm_instructions_cb,
 ):
-    return _initialize_fixture_globaldb(
+    globaldb = _initialize_fixture_globaldb(
         custom_globaldb=None,
         tmpdir_factory=tmpdir_factory,
         sql_vm_instructions_cb=session_sql_vm_instructions_cb,
@@ -148,6 +148,9 @@ def fixture_session_globaldb(
         run_globaldb_migrations=True,
         empty_global_addressbook=False,
     )
+    yield globaldb
+
+    globaldb.cleanup()
 
 
 @pytest.fixture(name='globaldb')
@@ -162,7 +165,7 @@ def fixture_globaldb(
         run_globaldb_migrations,
         empty_global_addressbook,
 ):
-    return _initialize_fixture_globaldb(
+    globaldb = _initialize_fixture_globaldb(
         custom_globaldb=custom_globaldb,
         tmpdir_factory=tmpdir_factory,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
@@ -173,6 +176,9 @@ def fixture_globaldb(
         run_globaldb_migrations=run_globaldb_migrations,
         empty_global_addressbook=empty_global_addressbook,
     )
+    yield globaldb
+
+    globaldb.cleanup()
 
 
 @pytest.fixture(name='custom_globaldb')

--- a/rotkehlchen/tests/fixtures/networking.py
+++ b/rotkehlchen/tests/fixtures/networking.py
@@ -1,0 +1,82 @@
+import pytest
+import requests
+
+from rotkehlchen.constants.timing import DEFAULT_TIMEOUT_TUPLE
+
+
+class ConfigurableSession(requests.Session):
+    """A configurable requests Session that can be used anywhere"""
+
+    def __init__(self, timeout):
+        super().__init__()
+        self.timeout = timeout
+
+    def request(
+            self,
+            method,
+            url,
+            params=None,
+            data=None,
+            headers=None,
+            cookies=None,
+            files=None,
+            auth=None,
+            timeout=None,
+            allow_redirects=True,
+            proxies=None,
+            hooks=None,
+            stream=None,
+            verify=None,
+            cert=None,
+            json=None,
+    ):
+        if timeout is None:
+            timeout = self.timeout
+
+        return super().request(
+            method=method,
+            url=url,
+            params=params,
+            data=data,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            stream=stream,
+            verify=verify,
+            cert=cert,
+            json=json,
+        )
+
+
+@pytest.fixture(name='test_timeout')
+def fixture_test_timeout():
+    return DEFAULT_TIMEOUT_TUPLE
+
+
+@pytest.fixture(name='test_session_pool_maxsize')
+def fixture_test_session_pool_maxsize():
+    return 100
+
+
+@pytest.fixture(name='test_session')
+def fixture_test_session(test_timeout, test_session_pool_maxsize):
+    """This is a configurable session that can be used in tests instead of pure requests
+
+    What it adds over pure requests is that you get:
+    - Automatic and immediate cleanup of all session's connections
+    - Configurable connection pool size. Default setup is 10x the normal requests default.
+    - Configurable but also default timeout without specifying it in all requests.
+
+    The downside is that all that may slow the test this is used by a tiny bit and higher
+    pool size naturally uses more memory.
+    """
+    with ConfigurableSession(timeout=test_timeout) as session:
+        adapter = requests.adapters.HTTPAdapter(pool_maxsize=test_session_pool_maxsize)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        yield session


### PR DESCRIPTION
We noticed tests had started failing in the CI and then we even
reproduced this locally.

The pytest process was failing with "Too many open files"

Checking with `len(psutil.Process().open_files())` we noticed that
indeed there were ~1k open files, almost exclusively all ofthem user,
transient and global DB.

To address these we are now changing the user and global DB fixtures
to explicitly cleanup the DB once they are done.

--- 

Also cherry picking the 2 other test related commits from develop