### PR TITLE
refactor(frontend): updates interfacing with vuetify to ease migration

### DIFF
--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -678,6 +678,7 @@
     "useCustomAssetForm": true,
     "useForm": true,
     "useManualBalancesForm": true,
-    "useTradesForm": true
+    "useTradesForm": true,
+    "useDisplay": true
   }
 }

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -395,6 +395,7 @@ declare global {
   const useDeviceOrientation: typeof import('@vueuse/core')['useDeviceOrientation']
   const useDevicePixelRatio: typeof import('@vueuse/core')['useDevicePixelRatio']
   const useDevicesList: typeof import('@vueuse/core')['useDevicesList']
+  const useDisplay: typeof import('./composables/common')['useDisplay']
   const useDisplayMedia: typeof import('@vueuse/core')['useDisplayMedia']
   const useDocumentVisibility: typeof import('@vueuse/core')['useDocumentVisibility']
   const useDraggable: typeof import('@vueuse/core')['useDraggable']
@@ -1077,6 +1078,7 @@ declare module 'vue' {
     readonly useDeviceOrientation: UnwrapRef<typeof import('@vueuse/core')['useDeviceOrientation']>
     readonly useDevicePixelRatio: UnwrapRef<typeof import('@vueuse/core')['useDevicePixelRatio']>
     readonly useDevicesList: UnwrapRef<typeof import('@vueuse/core')['useDevicesList']>
+    readonly useDisplay: UnwrapRef<typeof import('./composables/common')['useDisplay']>
     readonly useDisplayMedia: UnwrapRef<typeof import('@vueuse/core')['useDisplayMedia']>
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>
@@ -1753,6 +1755,7 @@ declare module '@vue/runtime-core' {
     readonly useDeviceOrientation: UnwrapRef<typeof import('@vueuse/core')['useDeviceOrientation']>
     readonly useDevicePixelRatio: UnwrapRef<typeof import('@vueuse/core')['useDevicePixelRatio']>
     readonly useDevicesList: UnwrapRef<typeof import('@vueuse/core')['useDevicesList']>
+    readonly useDisplay: UnwrapRef<typeof import('./composables/common')['useDisplay']>
     readonly useDisplayMedia: UnwrapRef<typeof import('@vueuse/core')['useDisplayMedia']>
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>

--- a/frontend/app/src/components/AssetBalances.vue
+++ b/frontend/app/src/components/AssetBalances.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { type AssetBalanceWithPrice } from '@rotki/common';
 import { type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { isEvmNativeToken } from '@/types/asset';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -21,7 +23,6 @@ const props = withDefaults(
 const { balances } = toRefs(props);
 const expanded: Ref<AssetBalanceWithPrice[]> = ref([]);
 
-const { t } = useI18n();
 const total = computed(() =>
   bigNumberSum(balances.value.map(({ usdValue }) => usdValue))
 );

--- a/frontend/app/src/components/EvmNativeTokenBreakdown.vue
+++ b/frontend/app/src/components/EvmNativeTokenBreakdown.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import groupBy from 'lodash/groupBy';
-import { type DataTableHeader } from 'vuetify';
 import { type BigNumber } from '@rotki/common/lib';
+import { type DataTableHeader } from '@/types/vuetify';
 import { zeroBalance } from '@/utils/bignumbers';
 import { balanceSum, calculatePercentage } from '@/utils/calculation';
 import { CURRENCY_USD } from '@/types/currencies';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -46,7 +48,6 @@ const breakdowns = computed(() => {
   });
 });
 
-const { t } = useI18n();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 
 const tableHeaders = computed<DataTableHeader[]>(() => {

--- a/frontend/app/src/components/UserDropdown.vue
+++ b/frontend/app/src/components/UserDropdown.vue
@@ -7,9 +7,8 @@ const { logout } = useSessionStore();
 const { username } = storeToRefs(useSessionAuthStore());
 const { isPackaged, clearPassword } = useInterop();
 const { privacyModeIcon, togglePrivacyMode } = usePrivacyMode();
-const { currentBreakpoint } = useTheme();
+const { xs } = useDisplay();
 const { navigateToUserLogin } = useAppNavigation();
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
 
 const savedRememberPassword = useLocalStorage(KEY_REMEMBER_PASSWORD, null);
 
@@ -74,11 +73,7 @@ const { darkModeEnabled } = useDarkMode();
           </v-list-item-title>
         </v-list-item>
 
-        <v-list-item
-          v-if="xsOnly"
-          key="privacy-mode"
-          @click="togglePrivacyMode()"
-        >
+        <v-list-item v-if="xs" key="privacy-mode" @click="togglePrivacyMode()">
           <v-list-item-avatar>
             <v-icon color="primary"> {{ privacyModeIcon }}</v-icon>
           </v-list-item-avatar>
@@ -87,7 +82,7 @@ const { darkModeEnabled } = useDarkMode();
           </v-list-item-title>
         </v-list-item>
 
-        <theme-control v-if="xsOnly" :dark-mode-enabled="darkModeEnabled" menu>
+        <theme-control v-if="xs" :dark-mode-enabled="darkModeEnabled" menu>
           {{ t('user_dropdown.switch_theme') }}
         </theme-control>
 

--- a/frontend/app/src/components/accounts/AccountBalanceTable.vue
+++ b/frontend/app/src/components/accounts/AccountBalanceTable.vue
@@ -4,7 +4,7 @@ import { Blockchain } from '@rotki/common/lib/blockchain';
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 import { type ComputedRef, type Ref, useListeners } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Properties } from '@/types';
 import { chainSection } from '@/types/blockchain';
 import { Section } from '@/types/status';
@@ -15,6 +15,8 @@ import {
   type XpubAccountWithBalance,
   type XpubPayload
 } from '@/types/blockchain/accounts';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -48,8 +50,6 @@ const { hasDetails, getLoopringBalances } = useAccountDetails(blockchain);
 const { getEthDetectedTokensInfo, detectingTokens } =
   useTokenDetection(blockchain);
 
-const { t } = useI18n();
-
 const editClick = (account: BlockchainAccountWithBalance) => {
   emit('edit-click', account);
 };
@@ -67,10 +67,10 @@ const addressesSelected = (selected: string[]) => {
   emit('addresses-selected', selected);
 };
 
-const { currentBreakpoint } = useTheme();
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
+const { xs } = useDisplay();
+
 const mobileClass = computed<string | null>(() =>
-  get(xsOnly) ? 'v-data-table__mobile-row' : null
+  get(xs) ? 'v-data-table__mobile-row' : null
 );
 
 const section = computed<Section>(() =>
@@ -493,7 +493,7 @@ defineExpose({
               <amount-display
                 :loading="loading"
                 :value="total.amount"
-                :asset="$vuetify.breakpoint.xsOnly ? blockchain : null"
+                :asset="xs ? blockchain : null"
               />
             </td>
             <td class="text-end" :class="mobileClass">

--- a/frontend/app/src/components/accounts/AccountGroupHeader.vue
+++ b/frontend/app/src/components/accounts/AccountGroupHeader.vue
@@ -5,6 +5,8 @@ import Fragment from '@/components/helper/Fragment';
 import { truncateAddress, truncationPoints } from '@/filters';
 import { type XpubAccountWithBalance } from '@/types/blockchain/accounts';
 
+const { t } = useI18n();
+
 const props = defineProps({
   group: { required: true, type: String },
   items: {
@@ -18,12 +20,11 @@ const props = defineProps({
 const emit = defineEmits(['delete-clicked', 'expand-clicked', 'edit-clicked']);
 
 const { items } = toRefs(props);
-const { breakpoint, currentBreakpoint } = useTheme();
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
+const { name: breakpoint, xs } = useDisplay();
 const { shouldShowAmount } = storeToRefs(useSessionSettingsStore());
 
 const mobileClass = computed<string | null>(() =>
-  get(xsOnly) ? 'v-data-table__mobile-row' : null
+  get(xs) ? 'v-data-table__mobile-row' : null
 );
 
 const xpub: ComputedRef<XpubAccountWithBalance> = computed(() => {
@@ -59,8 +60,6 @@ const expandClicked = (_payload: XpubAccountWithBalance) =>
 
 const editClicked = (_payload: XpubAccountWithBalance) =>
   emit('edit-clicked', _payload);
-
-const { t } = useI18n();
 </script>
 
 <template>
@@ -69,10 +68,10 @@ const { t } = useI18n();
   </td>
   <fragment v-else>
     <td
-      :colspan="xsOnly ? 1 : 2"
+      :colspan="xs ? 1 : 2"
       :class="{
-        'v-data-table__mobile-row': xsOnly,
-        'pa-2': !xsOnly
+        'v-data-table__mobile-row': xs,
+        'pa-2': !xs
       }"
     >
       <div class="ps-8">
@@ -124,7 +123,7 @@ const { t } = useI18n();
       <amount-display
         :value="sum"
         :loading="loading"
-        :asset="xsOnly ? 'BTC' : null"
+        :asset="xs ? 'BTC' : null"
       />
     </td>
     <td class="text-end" :class="mobileClass">

--- a/frontend/app/src/components/accounts/balances/AccountAssetBalances.vue
+++ b/frontend/app/src/components/accounts/balances/AccountAssetBalances.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import { type AssetBalance } from '@rotki/common';
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
+
+const { t } = useI18n();
 
 defineProps({
   assets: { required: true, type: Array as PropType<AssetBalance[]> },
   title: { required: true, type: String }
 });
 
-const { t } = useI18n();
 const { assetPrice } = useBalancePricesStore();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 

--- a/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
+++ b/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type PropType, type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type ActionStatus } from '@/types/action';
 import { type IgnoredAssetsHandlingType } from '@/types/asset';
 import { type Module } from '@/types/modules';

--- a/frontend/app/src/components/address-book-manager/AddressBookTable.vue
+++ b/frontend/app/src/components/address-book-manager/AddressBookTable.vue
@@ -5,22 +5,20 @@ import {
   Severity
 } from '@rotki/common/lib/messages';
 import { type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
 import { type Blockchain } from '@rotki/common/lib/blockchain';
+import { type DataTableHeader } from '@/types/vuetify';
 import {
   type AddressBookEntries,
   type AddressBookEntry,
   type AddressBookLocation
 } from '@/types/eth-names';
 
+const { t } = useI18n();
 const addressBookDeletion = (location: Ref<AddressBookLocation>) => {
   const { show } = useConfirmStore();
-
-  const { t } = useI18n();
   const { notify } = useNotificationsStore();
   const { deleteAddressBook: deleteAddressBookCaller } =
     useAddressesNamesStore();
-
   const deleteAddressBook = async (
     address: string,
     blockchain: Blockchain | null
@@ -81,8 +79,6 @@ const loading = ref<boolean>(false);
 const addressesNamesStore = useAddressesNamesStore();
 const { fetchAddressBook } = addressesNamesStore;
 const { addressBookEntries } = toRefs(addressesNamesStore);
-
-const { t } = useI18n();
 
 const data = computed<AddressBookEntries>(
   () => get(addressBookEntries)[get(location)]

--- a/frontend/app/src/components/app/AppCore.vue
+++ b/frontend/app/src/components/app/AppCore.vue
@@ -5,11 +5,12 @@ import zoomPlugin from 'chartjs-plugin-zoom';
 const visibilityStore = useAreaVisibilityStore();
 const { showDrawer, isMini } = storeToRefs(visibilityStore);
 
-const { isMobile, appBarColor } = useTheme();
+const { appBarColor } = useTheme();
+const { mobile } = useDisplay();
 
 const small = computed(() => get(showDrawer) && get(isMini));
 const expanded = computed(
-  () => get(showDrawer) && !get(isMini) && !get(isMobile)
+  () => get(showDrawer) && !get(isMini) && !get(mobile)
 );
 const { overall } = storeToRefs(useStatisticsStore());
 
@@ -18,7 +19,7 @@ const { updateTray } = useInterop();
 const toggleDrawer = visibilityStore.toggleDrawer;
 
 onMounted(() => {
-  set(showDrawer, !get(isMobile));
+  set(showDrawer, !get(mobile));
 });
 
 watch(overall, overall => {

--- a/frontend/app/src/components/app/AppIndicators.vue
+++ b/frontend/app/src/components/app/AppIndicators.vue
@@ -3,8 +3,7 @@ import Fragment from '@/components/helper/Fragment';
 
 const isDevelopment = checkIfDevelopment();
 
-const { currentBreakpoint } = useTheme();
-const smAndUp = computed(() => get(currentBreakpoint).smAndUp);
+const { smAndUp } = useDisplay();
 
 const { darkModeEnabled } = useDarkMode();
 const { showPinned, showNotesSidebar, showNotificationBar, showHelpBar } =

--- a/frontend/app/src/components/asset-manager/CustomAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/CustomAssetTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type TablePagination } from '@/types/pagination';
 import {
   type CustomAsset,
@@ -9,6 +9,8 @@ import {
   type Filters,
   type Matcher
 } from '@/composables/filters/custom-assets';
+
+const { t } = useI18n();
 
 withDefaults(
   defineProps<{
@@ -31,8 +33,6 @@ const emit = defineEmits<{
   (e: 'update:filters', filters: Filters): void;
   (e: 'update:expanded', expandedAssets: CustomAsset[]): void;
 }>();
-
-const { t } = useI18n();
 
 const tableHeaders = computed<DataTableHeader[]>(() => [
   {

--- a/frontend/app/src/components/asset-manager/ManagedAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/ManagedAssetTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type SupportedAsset } from '@rotki/common/lib/data';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type TablePagination } from '@/types/pagination';
 import { type Filters, type Matcher } from '@/composables/filters/assets';
 import {

--- a/frontend/app/src/components/asset-manager/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/NewlyDetectedAssetTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
 import { type ComputedRef, type Ref } from 'vue';
 import { Blockchain } from '@rotki/common/lib/blockchain';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type NewDetectedToken } from '@/types/websocket-messages';
 
 const { t } = useI18n();

--- a/frontend/app/src/components/assets/AssetLocations.vue
+++ b/frontend/app/src/components/assets/AssetLocations.vue
@@ -3,9 +3,11 @@ import { type BigNumber } from '@rotki/common';
 import { type GeneralAccount } from '@rotki/common/lib/account';
 import { Blockchain } from '@rotki/common/lib/blockchain';
 import { type ComputedRef } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { CURRENCY_USD } from '@/types/currencies';
 import { type AssetBreakdown } from '@/types/blockchain/accounts';
+
+const { t } = useI18n();
 
 interface AssetLocation extends AssetBreakdown {
   readonly account?: GeneralAccount;
@@ -23,7 +25,6 @@ const { getEth2Account } = useEthAccountsStore();
 const { detailsLoading } = storeToRefs(useStatusStore());
 const { assetPriceInfo } = useAggregatedBalances();
 const { assetBreakdown } = useBalancesBreakdown();
-const { t } = useI18n();
 
 const onlyTags = ref<string[]>([]);
 

--- a/frontend/app/src/components/common/FullSizeContent.vue
+++ b/frontend/app/src/components/common/FullSizeContent.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
 const top = ref(0);
 const proxy = useProxy();
+
 onMounted(() => {
   const { top: topBound } = proxy.$el.getBoundingClientRect();
   set(top, topBound);
 });
+
+const { xs } = useDisplay();
+const css = useCssModule();
 </script>
 
 <template>
   <div
     class="d-flex flex-column align-center"
     :class="{
-      [$style.empty]: true,
-      'pa-2 mt-2': $vuetify.breakpoint.xsOnly
+      [css.empty]: true,
+      'pa-2 mt-2': xs
     }"
     :style="`height: calc(100vh - ${top + 64}px);`"
   >

--- a/frontend/app/src/components/common/NoDataScreen.vue
+++ b/frontend/app/src/components/common/NoDataScreen.vue
@@ -3,13 +3,11 @@ const FullSizeContent = defineAsyncComponent(
   () => import('@/components/common/FullSizeContent.vue')
 );
 
-defineProps({
-  full: { required: false, type: Boolean, default: true }
-});
+withDefaults(defineProps<{ full?: boolean }>(), { full: true });
 
 const slots = useSlots();
 const css = useCssModule();
-const { isMobile } = useTheme();
+const { mobile } = useDisplay();
 const remoteEmptyScreenLogo =
   'https://raw.githubusercontent.com/rotki/data/main/assets/icons/empty_screen_logo.png';
 </script>
@@ -20,7 +18,7 @@ const remoteEmptyScreenLogo =
       <v-col cols="auto" :class="css.logo">
         <slot name="logo">
           <rotki-logo
-            :width="isMobile ? '100px' : '200px'"
+            :width="mobile ? '100px' : '200px'"
             :url="remoteEmptyScreenLogo"
           />
         </slot>

--- a/frontend/app/src/components/common/PaginatedCards.vue
+++ b/frontend/app/src/components/common/PaginatedCards.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 });
 
 const { items } = toRefs(props);
-const { breakpoint } = useTheme();
+const { name: breakpoint } = useDisplay();
 const page = ref(1);
 const itemsPerPage = computed(() => {
   if (get(breakpoint) === 'xs') {

--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -5,12 +5,14 @@ import {
   type BigNumber
 } from '@rotki/common';
 import { type PropType, type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Nullable } from '@/types';
 import { CURRENCY_USD } from '@/types/currencies';
 import { type DashboardTableType } from '@/types/frontend-settings';
 import { TableColumn } from '@/types/table-column';
 import { isEvmNativeToken } from '@/types/asset';
+
+const { t } = useI18n();
 
 const props = defineProps({
   loading: { required: false, type: Boolean, default: false },
@@ -28,8 +30,6 @@ const search = ref('');
 const expanded: Ref<AssetBalanceWithPrice[]> = ref([]);
 
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-
-const { t } = useI18n();
 
 const { exchangeRate } = useBalancePricesStore();
 const totalInUsd = computed(() =>

--- a/frontend/app/src/components/dashboard/EditBalancesSnapshotTable.vue
+++ b/frontend/app/src/components/dashboard/EditBalancesSnapshotTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type BigNumber } from '@rotki/common';
 import { type ComputedRef, type PropType, type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { CURRENCY_USD } from '@/types/currencies';
 import {
   type BalanceSnapshot,
@@ -11,6 +11,8 @@ import {
 import { isNft } from '@/utils/nft';
 import { toSentenceCase } from '@/utils/text';
 import { BalanceType } from '@/types/balances';
+
+const { t } = useI18n();
 
 type IndexedBalanceSnapshot = BalanceSnapshot & { index: number };
 
@@ -40,7 +42,6 @@ const valid = ref<boolean>(false);
 const loading = ref<boolean>(false);
 
 const { exchangeRate } = useBalancePricesStore();
-const { t } = useI18n();
 const fiatExchangeRate = computed<BigNumber>(
   () => get(exchangeRate(get(currencySymbol))) ?? One
 );

--- a/frontend/app/src/components/dashboard/EditLocationDataSnapshotTable.vue
+++ b/frontend/app/src/components/dashboard/EditLocationDataSnapshotTable.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { type BigNumber } from '@rotki/common';
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { CURRENCY_USD } from '@/types/currencies';
 import {
   type LocationDataSnapshot,
   type LocationDataSnapshotPayload
 } from '@/types/snapshots';
+
+const { t } = useI18n();
 
 type IndexedLocationDataSnapshot = LocationDataSnapshot & { index: number };
 
@@ -34,8 +36,6 @@ const form = ref<LocationDataSnapshotPayload | null>(null);
 const valid = ref<boolean>(false);
 const loading = ref<boolean>(false);
 const excludedLocations = ref<string[]>([]);
-
-const { t } = useI18n();
 
 const tableHeaders = computed<DataTableHeader[]>(() => [
   {

--- a/frontend/app/src/components/dashboard/LiquidityProviderBalanceDetails.vue
+++ b/frontend/app/src/components/dashboard/LiquidityProviderBalanceDetails.vue
@@ -2,7 +2,7 @@
 import { type AssetBalanceWithPrice } from '@rotki/common';
 import { type XswapAsset } from '@rotki/common/lib/defi/xswap';
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 
 defineProps({
   span: {

--- a/frontend/app/src/components/dashboard/LiquidityProviderBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/LiquidityProviderBalanceTable.vue
@@ -6,7 +6,7 @@ import {
 } from '@rotki/common/lib/defi/xswap';
 import isEqual from 'lodash/isEqual';
 import { type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { Routes } from '@/router/routes';
 import {
   DashboardTableType,

--- a/frontend/app/src/components/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/NftBalanceTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type BigNumber } from '@rotki/common';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type IgnoredAssetsHandlingType } from '@/types/asset';
 import { Routes } from '@/router/routes';
 import { DashboardTableType } from '@/types/frontend-settings';

--- a/frontend/app/src/components/defi/airdrops/PoapDeliveryAirdrops.vue
+++ b/frontend/app/src/components/defi/airdrops/PoapDeliveryAirdrops.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type PoapDeliveryDetails } from '@/types/airdrops';
 import { default as images } from './poap.json';
 

--- a/frontend/app/src/components/defi/display/LendingAssetTable.vue
+++ b/frontend/app/src/components/defi/display/LendingAssetTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type BaseDefiBalance } from '@/types/defi/lending';
 
 defineProps({

--- a/frontend/app/src/components/defi/yearn/YearnAssetsTable.vue
+++ b/frontend/app/src/components/defi/yearn/YearnAssetsTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type YearnVaultAsset } from '@/types/defi/yearn';
 import { ProtocolVersion } from '@/types/defi';
 

--- a/frontend/app/src/components/display/AssetMovementDisplay.vue
+++ b/frontend/app/src/components/display/AssetMovementDisplay.vue
@@ -1,15 +1,19 @@
 <script setup lang="ts">
-import { type PropType } from 'vue';
 import { type AssetMovement } from '@/types/defi';
 
-defineProps({
-  movement: { required: true, type: Object as PropType<AssetMovement> },
-  gainLoss: { required: false, type: Boolean, default: false }
-});
+withDefaults(
+  defineProps<{
+    movement: AssetMovement;
+    gainLoss?: boolean;
+  }>(),
+  {
+    gainLoss: false
+  }
+);
 
-const { breakpoint, isMobile } = useTheme();
+const { name: breakpoint, mobile } = useDisplay();
 const small = computed(
-  () => !(['xs', 'sm'].includes(get(breakpoint)) || get(isMobile))
+  () => !(['xs', 'sm'].includes(get(breakpoint)) || get(mobile))
 );
 </script>
 
@@ -32,7 +36,7 @@ const small = computed(
     <v-col
       v-if="!gainLoss"
       sm="12"
-      :md="isMobile ? '12' : 'auto'"
+      :md="mobile ? '12' : 'auto'"
       cols="12"
       :class="small ? 'mr-6' : null"
     >

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -9,7 +9,6 @@ const props = defineProps<{
 }>();
 
 const { account } = toRefs(props);
-const { currentBreakpoint } = useTheme();
 const { scrambleData, shouldShowAmount, scrambleHex, scrambleIdentifier } =
   useScramble();
 const { addressNameSelector } = useAddressesNamesStore();
@@ -29,8 +28,7 @@ const aliasName = computed<string | null>(() => {
   return truncateAddress(name, get(truncationLength));
 });
 
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
-const smAndDown = computed(() => get(currentBreakpoint).smAndDown);
+const { xs, sm, md, lg, xl, smAndDown, mdAndDown, name } = useDisplay();
 
 const address = computed<string>(() => {
   const address = get(account).address;
@@ -38,9 +36,7 @@ const address = computed<string>(() => {
 });
 
 const breakpoint = computed<string>(() =>
-  get(account).label.length > 0 && get(currentBreakpoint).mdAndDown
-    ? 'sm'
-    : get(currentBreakpoint).name
+  get(account).label.length > 0 && get(mdAndDown) ? 'sm' : get(name)
 );
 
 const truncationLength = computed<number>(() => {
@@ -73,7 +69,6 @@ const truncated = computed<boolean>(() => {
 });
 
 const label = computed<string>(() => {
-  const bp = get(currentBreakpoint);
   const label = get(account).label;
 
   if (consistOfNumbers(label)) {
@@ -82,13 +77,13 @@ const label = computed<string>(() => {
 
   let length = -1;
 
-  if (bp.xlOnly && label.length > 50) {
+  if (get(xl) && label.length > 50) {
     length = 47;
-  } else if (bp.lgOnly && label.length > 38) {
+  } else if (get(lg) && label.length > 38) {
     length = 35;
-  } else if (bp.md && label.length > 27) {
+  } else if (get(md) && label.length > 27) {
     length = 24;
-  } else if (bp.smOnly && label.length > 19) {
+  } else if (get(sm) && label.length > 19) {
     length = 16;
   }
 
@@ -107,7 +102,7 @@ const label = computed<string>(() => {
         <span
           data-cy="labeled-address-display"
           class="labeled-address-display__address"
-          :class="xsOnly ? 'labeled-address-display__address--mobile' : null"
+          :class="xs ? 'labeled-address-display__address--mobile' : null"
           v-on="on"
         >
           <v-chip label outlined class="labeled-address-display__chip">

--- a/frontend/app/src/components/display/StatCard.vue
+++ b/frontend/app/src/components/display/StatCard.vue
@@ -6,6 +6,7 @@ defineProps({
   protocolIcon: { required: false, type: String, default: '' },
   bordered: { required: false, type: Boolean, default: false }
 });
+const { dark } = useTheme();
 </script>
 
 <template>
@@ -24,7 +25,7 @@ defineProps({
       <div
         class="stat-card__border__gradient"
         :class="
-          $vuetify.theme.dark
+          dark
             ? 'stat-card__border__gradient--dark'
             : 'stat-card__border__gradient--light'
         "

--- a/frontend/app/src/components/display/StatCardWide.vue
+++ b/frontend/app/src/components/display/StatCardWide.vue
@@ -12,7 +12,7 @@ const colsSize = {
   4: 3
 };
 
-const { currentBreakpoint } = useTheme();
+const { smAndUp } = useDisplay();
 
 const size = computed(() => {
   const colNum = get(cols);
@@ -30,16 +30,16 @@ const size = computed(() => {
       <v-col
         class="stat-card-wide__second-col d-flex"
         :class="{
-          'stat-card-wide__second-col--horizontal': currentBreakpoint.smAndUp
+          'stat-card-wide__second-col--horizontal': smAndUp
         }"
         cols="12"
         :sm="size"
       >
-        <v-divider :vertical="currentBreakpoint.smAndUp" />
+        <v-divider :vertical="smAndUp" />
         <div class="stat-card-wide__second-col__content pa-6 flex-grow-1">
           <slot name="second-col" />
         </div>
-        <v-divider v-if="cols > 2" :vertical="currentBreakpoint.smAndUp" />
+        <v-divider v-if="cols > 2" :vertical="smAndUp" />
       </v-col>
       <v-col
         v-if="cols > 2"

--- a/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
+++ b/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { CURRENCY_USD } from '@/types/currencies';
 import {
   type ExchangeSavingsCollection,
@@ -8,6 +8,8 @@ import {
   type SupportedExchange
 } from '@/types/exchanges';
 import { Section } from '@/types/status';
+
+const { t } = useI18n();
 
 const props = defineProps<{
   exchange: SupportedExchange.BINANCE | SupportedExchange.BINANCEUS;
@@ -62,8 +64,6 @@ watch(loading, async (isLoading, wasLoading) => {
 onMounted(async () => {
   await fetchData();
 });
-
-const { t } = useI18n();
 
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const tableHeaders = computed<DataTableHeader[]>(() => [

--- a/frontend/app/src/components/help/HelpSidebar.vue
+++ b/frontend/app/src/components/help/HelpSidebar.vue
@@ -80,13 +80,15 @@ const downloadBrowserLog = async () => {
     );
   });
 };
+
+const { smAndDown } = useDisplay();
 </script>
 
 <template>
   <v-navigation-drawer
     width="400px"
     class="help-sidebar"
-    :class="$vuetify.breakpoint.smAndDown ? 'help-sidebar--mobile' : null"
+    :class="smAndDown ? 'help-sidebar--mobile' : null"
     absolute
     clipped
     :value="visible"

--- a/frontend/app/src/components/helper/DataTable.vue
+++ b/frontend/app/src/components/helper/DataTable.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useListeners } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type TablePagination } from '@/types/pagination';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -125,8 +127,6 @@ const pageSelectorData = (props: {
     )}`
   }));
 };
-
-const { t } = useI18n();
 
 onMounted(() => {
   const optionsVal = get(options);

--- a/frontend/app/src/components/helper/ListItem.vue
+++ b/frontend/app/src/components/helper/ListItem.vue
@@ -20,17 +20,17 @@ const props = withDefaults(
 
 const emit = defineEmits(['click']);
 const { subtitle } = toRefs(props);
-const { currentBreakpoint } = useTheme();
 const css = useCssModule();
 const rootAttrs = useAttrs();
-const large = computed(() => get(currentBreakpoint).lgAndUp);
+const { lgAndUp: large, mdAndDown } = useDisplay();
+
 const visibleSubtitle = computed(() => {
   const sub = get(subtitle);
   if (!sub) {
     return '';
   }
   const truncLength = 7;
-  const small = get(currentBreakpoint).mdAndDown;
+  const small = get(mdAndDown);
   const length = sub.length;
 
   if (!small || (length <= truncLength * 2 && small)) {

--- a/frontend/app/src/components/helper/TabNavigation.vue
+++ b/frontend/app/src/components/helper/TabNavigation.vue
@@ -11,14 +11,12 @@ const { tabContents } = toRefs(props);
 const selectedTab = ref('');
 
 const route = useRoute();
-const { currentBreakpoint } = useTheme();
+const { xs } = useDisplay();
 const isDev = checkIfDevelopment();
 
 const visibleTabs = computed(() =>
   get(tabContents).filter(({ hidden }) => !hidden)
 );
-
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
 
 const isRouterVisible = (route: string, tab: TabContent) =>
   route.includes(tab.route) && tab.route === get(selectedTab);
@@ -31,7 +29,7 @@ const isRouterVisible = (route: string, tab: TabContent) =>
       fixed-tabs
       height="36px"
       hide-slider
-      :show-arrows="xsOnly"
+      :show-arrows="xs"
       active-class="tab-navigation__tabs__tab--active"
       class="tab-navigation__tabs"
     >

--- a/frontend/app/src/components/history/UpgradeRow.vue
+++ b/frontend/app/src/components/history/UpgradeRow.vue
@@ -11,15 +11,12 @@ defineProps({
 
 const { t } = useI18n();
 const { premiumURL } = useInterop();
-const { currentBreakpoint } = useTheme();
+const { xs } = useDisplay();
 </script>
 
 <template>
   <tr class="tr">
-    <td
-      :colspan="currentBreakpoint.xsOnly ? 2 : colspan"
-      class="upgrade-row font-weight-medium"
-    >
+    <td :colspan="xs ? 2 : colspan" class="upgrade-row font-weight-medium">
       <i18n
         v-if="events"
         tag="span"

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Collection } from '@/types/collection';
 import { Routes } from '@/router/routes';
 import {
@@ -13,6 +13,8 @@ import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
 import type { Filters, Matcher } from '@/composables/filters/asset-movement';
 
+const { t } = useI18n();
+
 const props = withDefaults(
   defineProps<{
     locationOverview?: TradeLocation;
@@ -25,8 +27,6 @@ const props = withDefaults(
 );
 
 const { locationOverview, mainPage } = toRefs(props);
-
-const { t } = useI18n();
 
 const tableHeaders = computed<DataTableHeader[]>(() => {
   const overview = get(locationOverview);

--- a/frontend/app/src/components/history/events/HistoryEventForm.vue
+++ b/frontend/app/src/components/history/events/HistoryEventForm.vue
@@ -17,6 +17,8 @@ import { toMessages } from '@/utils/validation';
 import { type ActionDataEntry } from '@/types/action';
 import { type HistoricalPriceFormPayload } from '@/types/prices';
 
+const { t } = useI18n();
+
 const props = withDefaults(
   defineProps<{
     value?: boolean;
@@ -30,7 +32,6 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{ (e: 'input', valid: boolean): void }>();
-const { t } = useI18n();
 const { edit, transaction } = toRefs(props);
 
 const { isTaskRunning } = useTaskStore();
@@ -498,6 +499,7 @@ watch(historyEventLimitedProducts, products => {
 });
 
 const evmEvent = isEvmEventRef(transaction);
+const { mdAndUp } = useDisplay();
 </script>
 
 <template>
@@ -534,13 +536,7 @@ const evmEvent = isEvmEventRef(transaction);
         />
       </v-col>
     </v-row>
-    <v-row
-      :class="
-        $vuetify.breakpoint.mdAndUp
-          ? 'transaction-event-form__amount-wrapper'
-          : null
-      "
-    >
+    <v-row :class="mdAndUp ? 'transaction-event-form__amount-wrapper' : null">
       <v-col cols="12" md="6">
         <asset-select
           v-model="asset"

--- a/frontend/app/src/components/history/events/HistoryEventsIdentifier.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsIdentifier.vue
@@ -22,8 +22,8 @@ const evmOrDepositEvent = computed(
 const blockEvent = isEthBlockEventRef(event);
 const withdrawEvent = isWithdrawalEventRef(event);
 
-const { currentBreakpoint } = useTheme();
 const css = useCssModule();
+const { xl } = useDisplay();
 </script>
 
 <template>
@@ -65,7 +65,7 @@ const css = useCssModule();
             type="transaction"
             :chain="getChain(evmOrDepositEvent.location)"
             :truncate-length="8"
-            :full-address="currentBreakpoint.xlOnly"
+            :full-address="xl"
           />
         </span>
       </template>

--- a/frontend/app/src/components/history/events/HistoryEventsList.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsList.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
 import { HistoryEventEntryType } from '@rotki/common/lib/history/events';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type HistoryEventEntry } from '@/types/history/events';
 import { isEvmEvent } from '@/utils/history/events';
 import { type TablePagination } from '@/types/pagination';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -34,7 +36,6 @@ const emit = defineEmits<{
 const { eventGroupHeader, allEvents } = toRefs(props);
 
 const css = useCssModule();
-const { t } = useI18n();
 
 const { getChain } = useSupportedChains();
 
@@ -128,6 +129,8 @@ watch(
     }
   }
 );
+
+const { mdAndUp } = useDisplay();
 </script>
 
 <template>
@@ -174,7 +177,7 @@ watch(
                 class="transparent"
                 :options="options"
                 hide-default-footer
-                :hide-default-header="$vuetify.breakpoint.mdAndUp"
+                :hide-default-header="mdAndUp"
               >
                 <template #progress><span /></template>
                 <template #item.type="{ item }">

--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -5,10 +5,10 @@ import {
   type BlockchainSelection
 } from '@rotki/common/lib/blockchain';
 import isEqual from 'lodash/isEqual';
-import { type DataTableHeader } from 'vuetify';
 import { type ComputedRef, type Ref } from 'vue';
 import { not } from '@vueuse/math';
 import { type HistoryEventEntryType } from '@rotki/common/lib/history/events';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Collection } from '@/types/collection';
 import { SavedFilterLocation } from '@/types/filtering';
 import { IgnoreActionType } from '@/types/history/ignored';
@@ -25,6 +25,8 @@ import { TaskType } from '@/types/task-type';
 import { type Writeable } from '@/types';
 import HistoryEventsAction from '@/components/history/events/HistoryEventsAction.vue';
 import type { Filters, Matcher } from '@/composables/filters/events';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -56,8 +58,6 @@ const props = withDefaults(
     onlyChains: () => []
   }
 );
-
-const { t } = useI18n();
 
 const {
   location,

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Collection } from '@/types/collection';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionForm.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionForm.vue
@@ -214,6 +214,8 @@ onMounted(() => {
   setEditMode();
 });
 
+const { mdAndUp } = useDisplay();
+
 defineExpose({
   reset,
   save
@@ -252,11 +254,7 @@ defineExpose({
 
     <v-row
       align="center"
-      :class="
-        $vuetify.breakpoint.mdAndUp
-          ? 'ledger-action-form__amount-wrapper'
-          : null
-      "
+      :class="mdAndUp ? 'ledger-action-form__amount-wrapper' : null"
     >
       <v-col cols="12" md="4">
         <asset-select
@@ -299,11 +297,7 @@ defineExpose({
 
     <v-divider class="mb-6 mt-2" />
 
-    <v-row
-      :class="
-        $vuetify.breakpoint.mdAndUp ? 'ledger-action-form__rate-wrapper' : null
-      "
-    >
+    <v-row :class="mdAndUp ? 'ledger-action-form__rate-wrapper' : null">
       <v-col cols="12" md="8">
         <amount-input
           v-model="rate"

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Collection } from '@/types/collection';
 import Fragment from '@/components/helper/Fragment';
 import { Routes } from '@/router/routes';
@@ -13,6 +13,8 @@ import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
 import type { Filters, Matcher } from '@/composables/filters/trades';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -29,7 +31,6 @@ const { locationOverview, mainPage } = toRefs(props);
 
 const hideIgnoredTrades: Ref<boolean> = ref(false);
 
-const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 

--- a/frontend/app/src/components/nft/NftGallery.vue
+++ b/frontend/app/src/components/nft/NftGallery.vue
@@ -2,17 +2,14 @@
 import { BigNumber } from '@rotki/common';
 import { type GeneralAccount } from '@rotki/common/lib/account';
 import { Blockchain } from '@rotki/common/lib/blockchain';
-import { type PropType, type Ref } from 'vue';
+import { type Ref } from 'vue';
 import { type Module } from '@/types/modules';
 import { type GalleryNft, type Nft, type Nfts } from '@/types/nfts';
 import { type NftPriceArray } from '@/types/prices';
 
-defineProps({
-  modules: {
-    required: true,
-    type: Array as PropType<Module[]>
-  }
-});
+const { t } = useI18n();
+
+defineProps<{ modules: Module[] }>();
 
 const prices: Ref<NftPriceArray> = ref([]);
 const priceError = ref('');
@@ -24,7 +21,6 @@ const perAccount: Ref<Nfts | null> = ref(null);
 const sortBy = ref<'name' | 'priceUsd' | 'collection'>('name');
 const sortDescending = ref(false);
 
-const { t } = useI18n();
 const { premiumURL } = useInterop();
 const css = useCssModule();
 const sortProperties = [
@@ -44,7 +40,7 @@ const sortProperties = [
 
 const chains = [Blockchain.ETH];
 
-const { isMobile, breakpoint, width } = useTheme();
+const { mobile, name: breakpoint, width } = useDisplay();
 const page = ref(1);
 
 const itemsPerPage = computed(() => {
@@ -227,7 +223,7 @@ const sortNfts = (
     <v-row justify="space-between">
       <v-col>
         <v-row align="center">
-          <v-col :cols="isMobile ? '12' : '6'">
+          <v-col :cols="mobile ? '12' : '6'">
             <blockchain-account-selector
               v-model="selectedAccounts"
               :label="t('nft_gallery.select_account')"
@@ -239,7 +235,7 @@ const sortNfts = (
               :usable-addresses="availableAddresses"
             />
           </v-col>
-          <v-col :cols="isMobile ? '12' : '6'">
+          <v-col :cols="mobile ? '12' : '6'">
             <v-card flat>
               <div>
                 <v-autocomplete
@@ -257,7 +253,7 @@ const sortNfts = (
               </div>
             </v-card>
           </v-col>
-          <v-col :cols="isMobile ? '12' : '6'">
+          <v-col :cols="mobile ? '12' : '6'">
             <sorting-selector
               :sort-by="sortBy"
               :sort-properties="sortProperties"
@@ -266,7 +262,7 @@ const sortNfts = (
               @update:sort-desc="sortDescending = $event"
             />
           </v-col>
-          <v-col :cols="isMobile ? '12' : '6'">
+          <v-col :cols="mobile ? '12' : '6'">
             <pagination v-if="pages > 0" v-model="page" :length="pages" />
           </v-col>
         </v-row>

--- a/frontend/app/src/components/notes/UserNotesSidebar.vue
+++ b/frontend/app/src/components/notes/UserNotesSidebar.vue
@@ -44,13 +44,15 @@ watch(locationName, locationName => {
     set(tab, 0);
   }
 });
+
+const { smAndDown } = useDisplay();
 </script>
 
 <template>
   <v-navigation-drawer
     width="400px"
     class="user-notes-sidebar"
-    :class="$vuetify.breakpoint.smAndDown ? 'user-notes-sidebar--mobile' : null"
+    :class="smAndDown ? 'user-notes-sidebar--mobile' : null"
     absolute
     clipped
     :value="visible"

--- a/frontend/app/src/components/premium/NoPremiumPlaceholder.vue
+++ b/frontend/app/src/components/premium/NoPremiumPlaceholder.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
-defineProps({
-  text: {
-    type: String,
-    required: true
-  }
-});
-
 const { t } = useI18n();
+
+defineProps<{ text: string }>();
+
 const { premiumURL } = useInterop();
-const { isMobile } = useTheme();
+const { mobile } = useDisplay();
 const css = useCssModule();
 const remoteEmptyScreenLogo =
   'https://raw.githubusercontent.com/rotki/data/main/assets/icons/empty_screen_logo.png';
@@ -22,7 +18,7 @@ const remoteEmptyScreenLogo =
           <v-col cols="auto">
             <div :class="css.logo" class="d-flex justify-center align-center">
               <rotki-logo
-                :width="isMobile ? '100px' : '200px'"
+                :width="mobile ? '100px' : '200px'"
                 :url="remoteEmptyScreenLogo"
               />
             </div>

--- a/frontend/app/src/components/price-manager/historic/HistoricPriceTable.vue
+++ b/frontend/app/src/components/price-manager/historic/HistoricPriceTable.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type HistoricalPrice } from '@/types/prices';
+
+const { t } = useI18n();
 
 const props = withDefaults(
   defineProps<{
@@ -19,8 +21,6 @@ const emit = defineEmits<{
 }>();
 
 const { items } = toRefs(props);
-
-const { t } = useI18n();
 
 const headers = computed<DataTableHeader[]>(() => [
   {

--- a/frontend/app/src/components/price-manager/latest/LatestPriceTable.vue
+++ b/frontend/app/src/components/price-manager/latest/LatestPriceTable.vue
@@ -5,7 +5,7 @@ import {
   Severity
 } from '@rotki/common/lib/messages';
 import { type ComputedRef, type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { CURRENCY_USD } from '@/types/currencies';
 import { isNft } from '@/utils/nft';
 import { type ManualPrice } from '@/types/prices';

--- a/frontend/app/src/components/profitloss/CostBasisTable.vue
+++ b/frontend/app/src/components/profitloss/CostBasisTable.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type CostBasis } from '@/types/reports';
+
+const { t } = useI18n();
 
 const props = defineProps({
   costBasis: { required: true, type: Object as PropType<CostBasis> },
@@ -17,7 +19,6 @@ const props = defineProps({
 const { costBasis, currency } = toRefs(props);
 
 const panel = ref<number[]>([]);
-const { t } = useI18n();
 
 const css = useCssModule();
 

--- a/frontend/app/src/components/profitloss/ProfitLossEvents.vue
+++ b/frontend/app/src/components/profitloss/ProfitLossEvents.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type ProfitLossEvents, type SelectedReport } from '@/types/reports';
 import { isTransactionEvent } from '@/utils/report';
 

--- a/frontend/app/src/components/profitloss/ReportActionableCard.vue
+++ b/frontend/app/src/components/profitloss/ReportActionableCard.vue
@@ -153,6 +153,8 @@ const close = () => {
     setDialog(false);
   }
 };
+
+const { mdAndUp } = useDisplay();
 </script>
 
 <template>
@@ -221,12 +223,7 @@ const close = () => {
                 :complete="step > index + 1"
                 :class="{ [$style['pinned__stepper-step']]: isPinned }"
               >
-                <span
-                  v-if="
-                    ($vuetify.breakpoint.mdAndUp && !isPinned) ||
-                    step === index + 1
-                  "
-                >
+                <span v-if="(mdAndUp && !isPinned) || step === index + 1">
                   {{ content.title }}
                 </span>
               </v-stepper-step>

--- a/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type PropType, type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type MissingAcquisition, type SelectedReport } from '@/types/reports';
 import { type LedgerAction } from '@/types/history/ledger-action/ledger-actions';
 

--- a/frontend/app/src/components/profitloss/ReportMissingPrices.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingPrices.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type BigNumber } from '@rotki/common';
 import { type PropType, type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type EditableMissingPrice, type MissingPrice } from '@/types/reports';
 import {
   type HistoricalPrice,

--- a/frontend/app/src/components/profitloss/ReportsTable.vue
+++ b/frontend/app/src/components/profitloss/ReportsTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type ComputedRef, type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { Routes } from '@/router/routes';
 import { type Report } from '@/types/reports';
 import { calculateTotalProfitLoss } from '@/utils/report';

--- a/frontend/app/src/components/settings/data-security/OracleCacheManagement.vue
+++ b/frontend/app/src/components/settings/data-security/OracleCacheManagement.vue
@@ -1,6 +1,6 @@
 ﻿<script setup lang="ts">
 import { Severity } from '@rotki/common/lib/messages';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import Fragment from '@/components/helper/Fragment';
 import { PriceOracle } from '@/types/price-oracle';
 import { type PrioritizedListItemData } from '@/types/prioritized-list-data';

--- a/frontend/app/src/components/settings/data-security/backups/DatabaseBackups.vue
+++ b/frontend/app/src/components/settings/data-security/backups/DatabaseBackups.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type ComputedRef, type PropType } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import Fragment from '@/components/helper/Fragment';
 import { displayDateFormatter } from '@/data/date_formatter';
 import { type UserDbBackup } from '@/types/backup';

--- a/frontend/app/src/components/status/notifications/NotificationPopup.vue
+++ b/frontend/app/src/components/status/notifications/NotificationPopup.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+const { t } = useI18n();
+
 const visibleNotification = ref(createNotification());
 const notificationStore = useNotificationsStore();
 const { queue } = storeToRefs(notificationStore);
@@ -34,7 +36,7 @@ onMounted(() => {
   checkQueue();
 });
 
-const { t } = useI18n();
+const { dark } = useTheme();
 </script>
 
 <template>
@@ -44,7 +46,7 @@ const { t } = useI18n();
     :timeout="visibleNotification.duration"
     top
     right
-    :light="!$vuetify.theme.dark"
+    :light="!dark"
     app
     rounded
     width="400px"

--- a/frontend/app/src/components/status/notifications/NotificationSidebar.vue
+++ b/frontend/app/src/components/status/notifications/NotificationSidebar.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+const { t } = useI18n();
+
 defineProps<{ visible: boolean }>();
 
-const { t } = useI18n();
 const css = useCssModule();
 
 const emit = defineEmits(['close']);
@@ -40,13 +41,13 @@ const showConfirmation = () => {
   );
 };
 
-const { isMobile } = useTheme();
+const { mobile } = useDisplay();
 const { hasRunningTasks } = storeToRefs(useTaskStore());
 </script>
 
 <template>
   <v-navigation-drawer
-    :class="{ [css.mobile]: isMobile, [css.sidebar]: true }"
+    :class="{ [css.mobile]: mobile, [css.sidebar]: true }"
     width="400px"
     absolute
     clipped

--- a/frontend/app/src/components/status/sync/SyncIndicator.vue
+++ b/frontend/app/src/components/status/sync/SyncIndicator.vue
@@ -16,7 +16,6 @@ const { upgradeVisible, canRequestData } = storeToRefs(useSessionAuthStore());
 const { forceSync } = useSync();
 
 const { fetchBalances } = useBalances();
-const { currentBreakpoint } = useTheme();
 const premium = usePremium();
 const { appSession } = useInterop();
 
@@ -33,7 +32,7 @@ const locationDataSnapshotFile = ref<File | null>(null);
 const importSnapshotLoading = ref<boolean>(false);
 const importSnapshotDialog = ref<boolean>(false);
 
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
+const { xs } = useDisplay();
 
 const isDownload = computed<boolean>(() => get(syncAction) === SYNC_DOWNLOAD);
 const textChoice = computed<number>(() =>
@@ -173,7 +172,7 @@ const importSnapshot = async () => {
       transition="slide-y-transition"
       offset-y
       :close-on-content-click="false"
-      :max-width="xsOnly ? '97%' : '350px'"
+      :max-width="xs ? '97%' : '350px'"
       z-index="215"
     >
       <template #activator="{ on }">

--- a/frontend/app/src/components/status/update/ConflictDialog.vue
+++ b/frontend/app/src/components/status/update/ConflictDialog.vue
@@ -1,13 +1,15 @@
 ﻿<script setup lang="ts">
 import { type SupportedAsset } from '@rotki/common/lib/data';
 import { type PropType, type Ref, useListeners } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Writeable } from '@/types';
 import {
   type AssetUpdateConflictResult,
   type ConflictResolution,
   type ConflictResolutionStrategy
 } from '@/types/asset';
+
+const { t } = useI18n();
 
 const props = defineProps({
   conflicts: {
@@ -25,8 +27,6 @@ const { conflicts } = toRefs(props);
 
 const rootAttrs = useAttrs();
 const rootListeners = useListeners();
-
-const { t } = useI18n();
 
 const tableHeaders = computed<DataTableHeader[]>(() => [
   {

--- a/frontend/app/src/components/tags/TagManager.vue
+++ b/frontend/app/src/components/tags/TagManager.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Tag, defaultTag } from '@/types/tags';
 
 withDefaults(

--- a/frontend/app/src/components/user/LoginOverlay.vue
+++ b/frontend/app/src/components/user/LoginOverlay.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 const isTest = !!import.meta.env.VITE_TEST;
 const css = useCssModule();
-const { currentBreakpoint } = useTheme();
 const { animationEnabled } = useAnimation();
-
-const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
+const { xs } = useDisplay();
 </script>
 
 <template>
@@ -12,7 +10,7 @@ const xsOnly = computed(() => get(currentBreakpoint).xsOnly);
     <div
       class="animate"
       :class="{
-        [css.loading]: !xsOnly && !isTest,
+        [css.loading]: !xs && !isTest,
         [css['loading--paused']]: !animationEnabled
       }"
       data-cy="account-management__loading"

--- a/frontend/app/src/composables/common.ts
+++ b/frontend/app/src/composables/common.ts
@@ -6,15 +6,13 @@ export const useProxy = () => {
 
 export const useTheme = () => {
   const { $vuetify } = useProxy();
-  const isMobile = computed(() => $vuetify.breakpoint.mobile);
   const theme = computed(() => $vuetify.theme);
   const dark = computed(() => $vuetify.theme.dark);
-  const breakpoint = computed(() => $vuetify.breakpoint.name);
-  const currentBreakpoint = computed(() => $vuetify.breakpoint);
-  const width = computed(() => $vuetify.breakpoint.width);
+
   const fontStyle = computed(() => ({
     color: get(dark) ? 'rgba(255,255,255,0.87)' : 'rgba(0,0,0,0.87)'
   }));
+
   const appBarColor = computed(() => {
     if (!get(dark)) {
       return 'white';
@@ -24,13 +22,45 @@ export const useTheme = () => {
 
   return {
     $vuetify,
-    isMobile,
     theme,
     dark,
-    breakpoint,
-    currentBreakpoint,
-    width,
     fontStyle,
     appBarColor
+  };
+};
+
+export const useDisplay = () => {
+  const { $vuetify } = useProxy();
+  const mobile = computed(() => $vuetify.breakpoint.mobile);
+  const name = computed(() => $vuetify.breakpoint.name);
+  const width = computed(() => $vuetify.breakpoint.width);
+
+  const xs = computed(() => $vuetify.breakpoint.xs);
+  const sm = computed(() => $vuetify.breakpoint.sm);
+  const md = computed(() => $vuetify.breakpoint.md);
+  const lg = computed(() => $vuetify.breakpoint.lg);
+  const xl = computed(() => $vuetify.breakpoint.xl);
+  const smAndDown = computed(() => $vuetify.breakpoint.smAndDown);
+  const smAndUp = computed(() => $vuetify.breakpoint.smAndUp);
+  const mdAndDown = computed(() => $vuetify.breakpoint.mdAndDown);
+  const mdAndUp = computed(() => $vuetify.breakpoint.mdAndUp);
+  const lgAndDown = computed(() => $vuetify.breakpoint.lgAndDown);
+  const lgAndUp = computed(() => $vuetify.breakpoint.lgAndUp);
+
+  return {
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+    smAndDown,
+    smAndUp,
+    mdAndDown,
+    mdAndUp,
+    lgAndDown,
+    lgAndUp,
+    mobile,
+    name,
+    width
   };
 };

--- a/frontend/app/src/main.ts
+++ b/frontend/app/src/main.ts
@@ -5,7 +5,7 @@ import '@/filters';
 import '@/main.scss';
 import 'roboto-fontface/css/roboto/roboto-fontface.css';
 import 'typeface-roboto-mono';
-import vuetify from '@/plugins/vuetify';
+import { vuetify } from '@/plugins/vuetify';
 import { usePremiumApi } from '@/premium/setup-interface';
 import i18n from './i18n';
 import router from './router';

--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -3,6 +3,8 @@ import { Blockchain } from '@rotki/common/lib/blockchain';
 import pickBy from 'lodash/pickBy';
 import { type ComputedRef, type Ref } from 'vue';
 
+const { t } = useI18n();
+
 type Intersections = {
   [key in Blockchain]: boolean;
 };
@@ -14,8 +16,6 @@ type Observers = {
 type Busy = {
   [key in Blockchain]: ComputedRef<boolean>;
 };
-
-const { t } = useI18n();
 
 const router = useRouter();
 const route = useRoute();
@@ -119,6 +119,8 @@ const showDetectEvmAccountsButton: Readonly<Ref<boolean>> = computedEager(
     get(optimismAccounts).length > 0 ||
     get(avaxAccounts).length > 0
 );
+
+const { xl } = useDisplay();
 </script>
 
 <template>
@@ -138,14 +140,14 @@ const showDetectEvmAccountsButton: Readonly<Ref<boolean>> = computedEager(
         fixed
         bottom
         right
-        :fab="!$vuetify.breakpoint.xl"
-        :rounded="$vuetify.breakpoint.xl"
-        :x-large="$vuetify.breakpoint.xl"
+        :fab="!xl"
+        :rounded="xl"
+        :x-large="xl"
         color="primary"
         @click="createAccount()"
       >
         <v-icon> mdi-plus </v-icon>
-        <div v-if="$vuetify.breakpoint.xl" class="ml-2">
+        <div v-if="xl" class="ml-2">
           {{ t('blockchain_balances.add_account') }}
         </div>
       </v-btn>

--- a/frontend/app/src/pages/balances/exchange/index.vue
+++ b/frontend/app/src/pages/balances/exchange/index.vue
@@ -5,6 +5,8 @@ import { SupportedExchange } from '@/types/exchanges';
 import { TaskType } from '@/types/task-type';
 import { type Nullable } from '@/types';
 
+const { t } = useI18n();
+
 const props = withDefaults(
   defineProps<{
     exchange?: Nullable<SupportedExchange>;
@@ -76,8 +78,6 @@ watch(exchange, () => {
   set(exchangeDetailTabs, 0);
 });
 
-const { t } = useI18n();
-
 onMounted(() => {
   refreshExchangeSavings();
 });
@@ -91,6 +91,8 @@ const isBinance = computed(() => {
     exchangeVal
   );
 });
+
+const { xl, mdAndUp } = useDisplay();
 </script>
 
 <template>
@@ -109,14 +111,14 @@ const isBinance = computed(() => {
       fixed
       bottom
       right
-      :fab="!$vuetify.breakpoint.xl"
-      :rounded="$vuetify.breakpoint.xl"
-      :x-large="$vuetify.breakpoint.xl"
+      :fab="!xl"
+      :rounded="xl"
+      :x-large="xl"
       color="primary"
       to="/settings/api-keys/exchanges?add=true"
     >
       <v-icon> mdi-plus </v-icon>
-      <div v-if="$vuetify.breakpoint.xl" class="ml-2">
+      <div v-if="xl" class="ml-2">
         {{ t('exchange_balances.add_exchange') }}
       </div>
     </v-btn>
@@ -176,11 +178,7 @@ const isBinance = computed(() => {
           </v-tab>
         </v-tabs>
       </v-col>
-      <v-col
-        :class="
-          $vuetify.breakpoint.mdAndUp ? 'exchange-balances__balances' : null
-        "
-      >
+      <v-col :class="mdAndUp ? 'exchange-balances__balances' : null">
         <div>
           <div v-if="exchange">
             <v-tabs v-model="exchangeDetailTabs">

--- a/frontend/app/src/pages/balances/manual/index.vue
+++ b/frontend/app/src/pages/balances/manual/index.vue
@@ -94,6 +94,8 @@ const context = computed(() => {
 });
 
 const threshold = [1];
+
+const { xl } = useDisplay();
 </script>
 
 <template>
@@ -108,15 +110,15 @@ const threshold = [1];
       fixed
       bottom
       right
-      :fab="!$vuetify.breakpoint.xl"
-      :rounded="$vuetify.breakpoint.xl"
-      :x-large="$vuetify.breakpoint.xl"
+      :fab="!xl"
+      :rounded="xl"
+      :x-large="xl"
       color="primary"
       class="manual-balances__add-balance"
       @click="add()"
     >
       <v-icon> mdi-plus </v-icon>
-      <div v-if="$vuetify.breakpoint.xl" class="ml-2">
+      <div v-if="xl" class="ml-2">
         {{ t('manual_balances.add_manual_balance') }}
       </div>
     </v-btn>

--- a/frontend/app/src/pages/defi/airdrops/index.vue
+++ b/frontend/app/src/pages/defi/airdrops/index.vue
@@ -2,7 +2,7 @@
 import { type GeneralAccount } from '@rotki/common/lib/account';
 import { Blockchain } from '@rotki/common/lib/blockchain';
 import { type Ref } from 'vue';
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import {
   AIRDROP_1INCH,
   AIRDROP_CONVEX,

--- a/frontend/app/src/pages/settings/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/settings/api-keys/exchanges/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DataTableHeader } from 'vuetify';
+import { type DataTableHeader } from '@/types/vuetify';
 import { type Writeable } from '@/types';
 import {
   type Exchange,

--- a/frontend/app/src/plugins/vuetify.ts
+++ b/frontend/app/src/plugins/vuetify.ts
@@ -65,7 +65,7 @@ VNavigationDrawer.options.mixins[2].options.methods.shouldScroll =
 
 const DARK_GREY = '#1e1e1e';
 
-export default new Vuetify({
+const vuetify = new Vuetify({
   icons: {
     iconfont: 'mdi',
     values: {
@@ -111,3 +111,4 @@ export default new Vuetify({
     }
   }
 });
+export { vuetify };

--- a/frontend/app/src/types/vuetify.ts
+++ b/frontend/app/src/types/vuetify.ts
@@ -1,0 +1,2 @@
+import { type DataTableHeader } from 'vuetify';
+export { type DataTableHeader };


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [x] Introduces `useDisplay` composable to make it similar to [vuetify 3](https://vuetifyjs.com/en/features/display-and-platform/)
- [x] Uses a local re-export of the DataTableHeader class (to make it easier to migrate)  
- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
