### PR TITLE
Fix error checking status of frontend settings for CSV exporter

### DIFF
--- a/rotkehlchen/accounting/export/csv.py
+++ b/rotkehlchen/accounting/export/csv.py
@@ -87,7 +87,7 @@ class CSVExporter(CustomizableDateMixin):
             self.reload_settings(cursor)
 
         frontend_settings = None
-        if self.settings.frontend_settings is not None:
+        if self.settings.frontend_settings != '':
             try:
                 frontend_settings = json.loads(self.settings.frontend_settings)
             except json.decoder.JSONDecodeError as e:


### PR DESCRIPTION
The check for no settings was being made against None but the setting data structure loads a empty string when there is no setting provided.

