### PR TITLE
fix(frontend): removes en-US as a default local for date formatter

### DIFF
--- a/frontend/app/src/components/display/DateDisplay.vue
+++ b/frontend/app/src/components/display/DateDisplay.vue
@@ -1,22 +1,28 @@
 <script setup lang="ts">
 import { displayDateFormatter } from '@/data/date_formatter';
 
-const props = defineProps({
-  timestamp: { required: true, type: Number },
-  noTimezone: { required: false, type: Boolean, default: false },
-  noTime: { required: false, type: Boolean, default: false }
-});
+const props = withDefaults(
+  defineProps<{
+    timestamp: number;
+    showTimezone?: boolean;
+    noTime?: boolean;
+  }>(),
+  {
+    showTimezone: false,
+    noTime: false
+  }
+);
 
-const { timestamp, noTimezone, noTime } = toRefs(props);
+const { timestamp, showTimezone, noTime } = toRefs(props);
 const { dateDisplayFormat } = storeToRefs(useGeneralSettingsStore());
 const { scrambleData, shouldShowAmount } = storeToRefs(
   useSessionSettingsStore()
 );
 
 const dateFormat = computed<string>(() => {
-  const display = get(noTimezone)
-    ? get(dateDisplayFormat).replace('%z', '').replace('%Z', '')
-    : get(dateDisplayFormat);
+  const display = get(showTimezone)
+    ? get(dateDisplayFormat)
+    : get(dateDisplayFormat).replace('%z', '').replace('%Z', '');
 
   if (get(noTime)) {
     return display.split(' ')[0];
@@ -33,18 +39,34 @@ const displayTimestamp = computed<number>(() => {
   return new Date(start + Math.random() * (now - start)).getTime() / 1000;
 });
 
-const formattedDate = computed<string>(() =>
-  displayDateFormatter.format(
-    new Date(get(displayTimestamp) * 1000),
-    get(dateFormat)
-  )
-);
+const date = computed(() => new Date(get(displayTimestamp) * 1000));
+const format = (date: Ref<Date>, format: Ref<string>) =>
+  computed(() => displayDateFormatter.format(get(date), get(format)));
+
+const formattedDate = format(date, dateFormat);
+const formattedDateWithTimezone = format(date, dateDisplayFormat);
+
+const showTooltip = computed(() => {
+  const timezone = get(showTimezone);
+  const format = get(dateDisplayFormat);
+  return !timezone && (format.includes('%z') || format.includes('%Z'));
+});
 </script>
 
 <template>
-  <span class="date-display" :class="{ 'blur-content': !shouldShowAmount }">
-    {{ formattedDate }}
-  </span>
+  <v-tooltip top open-delay="400" :disabled="!showTooltip">
+    <template #activator="{ on, attrs }">
+      <span
+        class="date-display"
+        :class="{ 'blur-content': !shouldShowAmount }"
+        v-bind="attrs"
+        v-on="on"
+      >
+        {{ formattedDate }}
+      </span>
+    </template>
+    <span> {{ formattedDateWithTimezone }} </span>
+  </v-tooltip>
 </template>
 
 <style scoped lang="scss">

--- a/frontend/app/src/components/profitloss/ReportHeader.vue
+++ b/frontend/app/src/components/profitloss/ReportHeader.vue
@@ -19,18 +19,10 @@ defineProps({
         class="text-h5 mt-6"
       >
         <template #start>
-          <date-display
-            no-timezone
-            :timestamp="period.start"
-            class="font-weight-medium"
-          />
+          <date-display :timestamp="period.start" class="font-weight-medium" />
         </template>
         <template #end>
-          <date-display
-            no-timezone
-            :timestamp="period.end"
-            class="font-weight-medium"
-          />
+          <date-display :timestamp="period.end" class="font-weight-medium" />
         </template>
       </i18n>
     </v-col>

--- a/frontend/app/src/components/status/update/ConflictRow.vue
+++ b/frontend/app/src/components/status/update/ConflictRow.vue
@@ -16,7 +16,7 @@ const isAddress = computed(() => get(field) === 'address');
     <v-col cols="auto" class="font-weight-medium"> {{ field }}: </v-col>
     <v-col class="ms-4" :class="diff ? 'red--text font-weight-bold' : null">
       <span v-if="isStarted">
-        <date-display v-if="value" :timestamp="value" no-timezone />
+        <date-display v-if="value" :timestamp="value" />
         <span v-else>-</span>
       </span>
       <span v-else-if="isAddress">

--- a/frontend/app/src/data/date_formatter.ts
+++ b/frontend/app/src/data/date_formatter.ts
@@ -1,47 +1,40 @@
 export class DateFormatter {
   private regex = /%-?[A-Za-z]/gm;
-  private translations: Record<string, (date: Date, locale: string) => string> =
-    {
-      a: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { weekday: 'short' }),
-      A: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { weekday: 'long' }),
-      w: (date: Date) => date.getDay().toString(),
-      y: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { year: '2-digit' }),
-      Y: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { year: 'numeric' }),
-      b: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { month: 'short' }),
-      B: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { month: 'long' }),
-      m: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { month: '2-digit' }),
-      '-m': (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { month: 'numeric' }),
-      d: (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { day: '2-digit' }),
-      '-d': (date: Date, locale: string) =>
-        date.toLocaleDateString(locale, { day: 'numeric' }),
-      H: (date: Date) => DateFormatter.leftPad(date.getHours().toString()),
-      '-H': (date: Date) => date.getHours().toString(),
-      I: (date: Date) => DateFormatter.leftPad(DateFormatter.twelveHours(date)),
-      '-I': (date: Date) => DateFormatter.twelveHours(date),
-      M: (date: Date) => DateFormatter.leftPad(date.getMinutes().toString()),
-      '-M': (date: Date) => date.getMinutes().toString(),
-      S: (date: Date) => DateFormatter.leftPad(date.getSeconds().toString()),
-      '-S': (date: Date) => date.getSeconds().toString(),
-      p: (date, locale) => DateFormatter.amPm(date, locale),
-      z: (date: Date) => DateFormatter.timezoneOffset(date),
-      Z: (date: Date, locale: string) => DateFormatter.timezone(date, locale),
-      j: (date: Date) =>
-        DateFormatter.leftPad(DateFormatter.dayOfTheYear(date).toString(), 3),
-      '-j': (date: Date) => DateFormatter.dayOfTheYear(date).toString(),
-      c: (date: Date, locale: string) => date.toLocaleString(locale),
-      x: (date: Date, locale: string) => date.toLocaleDateString(locale),
-      X: (date: Date, locale: string) => date.toLocaleTimeString(locale),
-      '%': () => '%'
-    };
+  private translations: Record<
+    string,
+    (date: Date, locale?: string) => string
+  > = {
+    a: (date, locale) => date.toLocaleDateString(locale, { weekday: 'short' }),
+    A: (date, locale) => date.toLocaleDateString(locale, { weekday: 'long' }),
+    w: date => date.getDay().toString(),
+    y: (date, locale) => date.toLocaleDateString(locale, { year: '2-digit' }),
+    Y: (date, locale) => date.toLocaleDateString(locale, { year: 'numeric' }),
+    b: (date, locale) => date.toLocaleDateString(locale, { month: 'short' }),
+    B: (date, locale) => date.toLocaleDateString(locale, { month: 'long' }),
+    m: (date, locale) => date.toLocaleDateString(locale, { month: '2-digit' }),
+    '-m': (date, locale) =>
+      date.toLocaleDateString(locale, { month: 'numeric' }),
+    d: (date, locale) => date.toLocaleDateString(locale, { day: '2-digit' }),
+    '-d': (date, locale) => date.toLocaleDateString(locale, { day: 'numeric' }),
+    H: date => DateFormatter.leftPad(date.getHours().toString()),
+    '-H': date => date.getHours().toString(),
+    I: date => DateFormatter.leftPad(DateFormatter.twelveHours(date)),
+    '-I': date => DateFormatter.twelveHours(date),
+    M: date => DateFormatter.leftPad(date.getMinutes().toString()),
+    '-M': date => date.getMinutes().toString(),
+    S: date => DateFormatter.leftPad(date.getSeconds().toString()),
+    '-S': date => date.getSeconds().toString(),
+    p: (date, locale) => DateFormatter.amPm(date, locale),
+    z: date => DateFormatter.timezoneOffset(date),
+    Z: (date, locale) => DateFormatter.timezone(date, locale),
+    j: date =>
+      DateFormatter.leftPad(DateFormatter.dayOfTheYear(date).toString(), 3),
+    '-j': date => DateFormatter.dayOfTheYear(date).toString(),
+    c: (date, locale) => date.toLocaleString(locale),
+    x: (date, locale) => date.toLocaleDateString(locale),
+    X: (date, locale) => date.toLocaleTimeString(locale),
+    '%': () => '%'
+  };
 
   private static leftPad(text: string, length = 2, padString = '0'): string {
     let paddedText = text;
@@ -69,12 +62,12 @@ export class DateFormatter {
     return Math.floor(diff / oneDay);
   }
 
-  private static amPm(date: Date, locale: string): string {
+  private static amPm(date: Date, locale?: string): string {
     const timeString = date.toLocaleTimeString(locale, { hour12: true });
     return timeString.slice(-2);
   }
 
-  private static timezone(date: Date, locale: string): string {
+  private static timezone(date: Date, locale?: string): string {
     const withTimezone = date.toLocaleString(locale, { timeZoneName: 'short' });
     const withoutTimezone = date.toLocaleString(locale);
     return withTimezone.replace(withoutTimezone, '').trim();
@@ -90,7 +83,7 @@ export class DateFormatter {
     )}`;
   }
 
-  constructor(private readonly locale: string = 'en-US') {}
+  constructor(private readonly locale?: string) {}
 
   get directives(): string[] {
     return Object.keys(this.translations)

--- a/frontend/app/src/pages/reports/[id].vue
+++ b/frontend/app/src/pages/reports/[id].vue
@@ -104,7 +104,6 @@ const regenerateReport = async () => {
           <date-display
             :timestamp="report.firstProcessedTimestamp"
             class="font-weight-medium"
-            no-timezone
           />
         </template>
       </i18n>


### PR DESCRIPTION
It causes CET to render as GMT+1

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
