### PR TITLE
Timezone and datetime fixes

### DIFF
--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -2,7 +2,7 @@ from rotkehlchen.assets.types import AssetType
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import Price
 
-CURRENCYCONVERTER_API_KEY = 'da602d71f11712a25137'
+CURRENCYCONVERTER_API_KEY = 'b3e8cb5a5fa441d38adc'
 
 ZERO = FVal(0)
 ONE = FVal(1)

--- a/rotkehlchen/tests/unit/test_nfts.py
+++ b/rotkehlchen/tests/unit/test_nfts.py
@@ -1,4 +1,5 @@
 import pytest
+
 from rotkehlchen.db.filtering import NFTFilterQuery
 
 TEST_ACC1 = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65'  # yabir.eth
@@ -11,6 +12,8 @@ TEST_ACC2 = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'  # lefteris.eth
 def test_addresses_queried_for_nfts(blockchain):
     """Tests that nfts are only queried for addresses stored in the database preventing the
     IntegrityError described in https://github.com/rotki/rotki/issues/4456
+
+    TODO: May make sense to VCR this as it makes multiple opensea queries.
     """
     nft_module = blockchain.get_module('nfts')
     nft_module.query_balances(
@@ -18,4 +21,4 @@ def test_addresses_queried_for_nfts(blockchain):
         uniswap_nfts=None,
     )
     balances = nft_module.get_db_nft_balances(filter_query=NFTFilterQuery.make())['entries']
-    assert len(balances) == 1 and balances[0]['name'] == 'yabir.eth'
+    assert any(x['name'] == 'yabir.eth' for x in balances)

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -113,13 +113,13 @@ def timestamp_to_date(
         formatstr: str = '%d/%m/%Y %H:%M:%S',
         treat_as_local: bool = False,
 ) -> str:
-    """Transforms a timestamp to a datesring depending on given formatstr and UTC/local choice"""
+    """Transforms a timestamp to a datestring depending on given formatstr and UTC/local choice"""
     if treat_as_local is False:
         date = datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc).strftime(formatstr)
     else:  # localtime
         date = datetime.datetime.fromtimestamp(
-            ts,
-            tz=datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo,
+            ts,  # ignore below is due to: https://github.com/pjknkda/flake8-datetimez/issues/11
+            tz=datetime.datetime.fromtimestamp(ts).astimezone().tzinfo,  # noqa: DTZ006
         ).strftime(formatstr)
 
     # Depending on the formatstr we could have empty strings at the end. Strip them.


### PR DESCRIPTION
Before it was always using the now() timezone. Which would be correct in most
cases except for cases when DST or similar is activated.

So it would show CEST all year round for people in Germany. Now it
will show CEST for dates with DST on and CET for dates when DST is off.

```
>>> formatstr='%d/%m/%Y %H:%M:%S %Z'
>>> datetime.datetime.fromtimestamp(now, tz=datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo).strftime(formatstr)
'06/06/2023 13:20:29 CEST'
>>> datetime.datetime.fromtimestamp(before, tz=datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo).strftime(formatstr)
'01/02/2023 12:20:29 CEST'
>>> datetime.datetime.fromtimestamp(now).strftime(formatstr)
'06/06/2023 13:20:29 '
>>> datetime.datetime.fromtimestamp(before).strftime(formatstr)
'01/02/2023 11:20:29 '
>>> ts = now
>>> datetime.datetime.fromtimestamp(ts, tz=datetime.datetime.fromtimestamp(ts).astimezone().tzinfo).strftime(formatstr)
'06/06/2023 13:20:29 CEST'
>>> ts = before
>>> datetime.datetime.fromtimestamp(ts, tz=datetime.datetime.fromtimestamp(ts).astimezone().tzinfo).strftime(formatstr)
'01/02/2023 11:20:29 CET'
>>> 
```

Backend part of #6215 