### PR TITLE
fix(frontend): date-display not attaching classes to the proper element

### DIFF
--- a/frontend/app/src/components/display/DateDisplay.vue
+++ b/frontend/app/src/components/display/DateDisplay.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { displayDateFormatter } from '@/data/date_formatter';
 
+const css = useCssModule();
+
 const props = withDefaults(
   defineProps<{
     timestamp: number;
@@ -54,23 +56,25 @@ const showTooltip = computed(() => {
 </script>
 
 <template>
-  <v-tooltip top open-delay="400" :disabled="!showTooltip">
-    <template #activator="{ on, attrs }">
-      <span
-        class="date-display"
-        :class="{ 'blur-content': !shouldShowAmount }"
-        v-bind="attrs"
-        v-on="on"
-      >
-        {{ formattedDate }}
-      </span>
-    </template>
-    <span> {{ formattedDateWithTimezone }} </span>
-  </v-tooltip>
+  <span>
+    <v-tooltip top open-delay="400" :disabled="!showTooltip">
+      <template #activator="{ on, attrs }">
+        <span
+          class="date-display"
+          :class="{ [css.blur]: !shouldShowAmount }"
+          v-bind="attrs"
+          v-on="on"
+        >
+          {{ formattedDate }}
+        </span>
+      </template>
+      <span> {{ formattedDateWithTimezone }} </span>
+    </v-tooltip>
+  </span>
 </template>
 
-<style scoped lang="scss">
-.blur-content {
+<style module lang="scss">
+.blur {
   filter: blur(0.75em);
 }
 </style>


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

Classes were going to the tooltip instead of the activator.