### PR TITLE
Fix deposits/withdrawals events for yearn V2 (full amount)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 * :bug:`-` Fix issue for ledger actions with zero rate, where the rate isn't used in the PnL report.
 * :bug:`-` ENS avatar fetching for each name's avatar should now work for all name resolvers. Even older or custom ones.
 * :bug:`-` Users will now be able to decode compounding transactions for Convex gauges.
+* :bug:`-` Events depositing tokens in Yearn V2 vaults where the full owned amount is deposited should be now correctly decoded.
 * :bug:`-` Users will no longer see double counting of balances in curve gauges.
 * :bug:`-` Events that were imported via a csv file will now be properly accounted for in PnL reports.
 * :bug:`-` Notes in exported CSV reports will contain the correct url for transactions in different EVM chains.

--- a/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
@@ -32,8 +32,10 @@ if TYPE_CHECKING:
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
 
+YEARN_DEPOSIT_AMOUNT_4_BYTES = b'\xd0\xe3\r\xb0'
 YEARN_DEPOSIT_4_BYTES = b'\xb6\xb5_%'
-YEARN_WITHDRAW_4_BYTES = b'.\x1a}M'
+YEARN_WITHDRAW_AMOUNT_4_BYTES = b'.\x1a}M'
+YEARN_WITHDRAW_4_BYTES = b'<\xcf\xd6\x0b'
 
 
 def _get_vault_token_name(vault_address: 'ChecksumEvmAddress') -> str:
@@ -83,9 +85,15 @@ class YearnDecoder(DecoderInterface):
             return FAILED_ENRICHMENT_OUTPUT
 
         is_deposit = False
-        if context.transaction.input_data.startswith(YEARN_DEPOSIT_4_BYTES):
+        if (
+            context.transaction.input_data.startswith(YEARN_DEPOSIT_4_BYTES) or
+            context.transaction.input_data.startswith(YEARN_DEPOSIT_AMOUNT_4_BYTES)
+        ):
             is_deposit = True
-        elif not context.transaction.input_data.startswith(YEARN_WITHDRAW_4_BYTES):
+        elif not (
+            context.transaction.input_data.startswith(YEARN_WITHDRAW_4_BYTES) or
+            context.transaction.input_data.startswith(YEARN_WITHDRAW_AMOUNT_4_BYTES)
+        ):
             # a yearn contract method that we don't need to handle
             return FAILED_ENRICHMENT_OUTPUT
 

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -463,6 +463,10 @@ class EvmNodeInquirer(metaclass=ABCMeta):
 
             if node.endpoint.endswith('llamarpc.com'):  # temporary. Seems to sometimes switch
                 is_pruned, is_archive = True, False  # between pruned and non-pruned nodes
+            elif node.endpoint.endswith('blastapi.io'):  # temporary
+                # After the bedrock update blastapi.io switches from archive to non archive nodes
+                # It has never reported pruned nodes.
+                is_pruned, is_archive = False, False
             else:
                 is_pruned, is_archive = self.determine_capabilities(web3)
             log.info(f'Connected {self.chain_name} node {node} at {rpc_endpoint}')

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -19,9 +19,12 @@ def test_optimism_nodes_prune_and_archive_status(
         if node_name.endpoint in ('https://rpc.ankr.com/optimism', 'https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4'):  # noqa: E501
             assert not web3_node.is_pruned
             assert not web3_node.is_archive
-        elif node_name.endpoint in ('https://mainnet.optimism.io', 'https://optimism-mainnet.public.blastapi.io'):  # noqa: E501
+        elif node_name.endpoint == 'https://mainnet.optimism.io':
             assert not web3_node.is_pruned
             assert web3_node.is_archive
+        elif node_name.endpoint == 'https://optimism-mainnet.public.blastapi.io':
+            assert not web3_node.is_pruned
+            assert not web3_node.is_archive
         else:
             raise AssertionError(f'Unknown node {node_name} encountered.')
 


### PR DESCRIPTION
In yearn contracts the signature when depositing/withdrawing all the available amount was different than the one used when deposit/withdrawing any other amount and this was making the decoding process fail.

