### PR TITLE
Add force_delete for history event deletion

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4950,7 +4950,7 @@ Dealing with History Events
 
 .. http:delete:: /api/(version)/history/events
 
-   Doing a DELETE on this endpoint deletes a set of history entry events from the DB for the currently logged in user. If any of the identifiers is not found in the DB the entire call fails. If any of the identifiers are the last for their transaction hash the call fails.
+   Doing a DELETE on this endpoint deletes a set of history entry events from the DB for the currently logged in user. If any of the identifiers is not found in the DB the entire call fails. If any of the identifiers are the last for their transaction hash the call fails, unless the ``force_delete`` argument is given.
 
    **Example Request**:
 
@@ -4963,6 +4963,7 @@ Dealing with History Events
       {"identifiers" : [55, 65, 124]}
 
    :reqjson list<integer> identifiers: A list of the identifiers of the history entries to delete.
+   :reqjson bool force_delete: If true, then even if an event is the last event of a transaction it will be deleted. False by default.
 
    **Example Response**:
 
@@ -4978,7 +4979,7 @@ Dealing with History Events
 
    :statuscode 200: Event was successfully removed.
    :statuscode 400: Provided JSON is in some way malformed
-   :statuscode 409: No user is logged in or one of the identifiers to delete did not correspond to an event in the DB or one of the identifiers was for the last event in the corresponding transaction hash.
+   :statuscode 409: No user is logged in or one of the identifiers to delete did not correspond to an event in the DB or one of the identifiers was for the last event in the corresponding transaction hash and force_delete was false..
    :statuscode 500: Internal rotki error
 
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -951,9 +951,12 @@ class RestAPI():
 
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
-    def delete_history_events(self, identifiers: list[int]) -> Response:
+    def delete_history_events(self, identifiers: list[int], force_delete: bool) -> Response:
         db = DBHistoryEvents(self.rotkehlchen.data.db)
-        error_msg = db.delete_history_events_by_identifier(identifiers=identifiers)
+        error_msg = db.delete_history_events_by_identifier(
+            identifiers=identifiers,
+            force_delete=force_delete,
+        )
         if error_msg is not None:
             return api_response(wrap_in_fail_result(error_msg), status_code=HTTPStatus.CONFLICT)
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -87,11 +87,11 @@ from rotkehlchen.api.v1.schemas import (
     FileListSchema,
     HistoricalAssetsPriceSchema,
     HistoryEventSchema,
+    HistoryEventsDeletionSchema,
     HistoryExportingSchema,
     HistoryProcessingDebugImportSchema,
     HistoryProcessingExportSchema,
     HistoryProcessingSchema,
-    IdentifiersListSchema,
     IgnoredActionsModifySchema,
     IgnoredAssetsSchema,
     IntegerIdentifierListSchema,
@@ -1141,7 +1141,7 @@ class HistoryEventResource(BaseMethodView):
     put_schema = EvmEventSchema()
     post_schema = HistoryEventSchema()
     patch_schema = EditEvmEventSchema()
-    delete_schema = IdentifiersListSchema()
+    delete_schema = HistoryEventsDeletionSchema()
 
     @require_loggedin_user()
     @use_kwargs(post_schema, location='json')
@@ -1160,8 +1160,11 @@ class HistoryEventResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(delete_schema, location='json')
-    def delete(self, identifiers: list[int]) -> Response:
-        return self.rest_api.delete_history_events(identifiers=identifiers)
+    def delete(self, identifiers: list[int], force_delete: bool) -> Response:
+        return self.rest_api.delete_history_events(
+            identifiers=identifiers,
+            force_delete=force_delete,
+        )
 
 
 class UsersResource(BaseMethodView):

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2440,6 +2440,10 @@ class IdentifiersListSchema(Schema):
     identifiers = fields.List(fields.Integer(), required=True)
 
 
+class HistoryEventsDeletionSchema(IdentifiersListSchema):
+    force_delete = fields.Boolean(load_default=False)
+
+
 class AssetsImportingSchema(Schema):
     file = FileField(allowed_extensions=['.zip', '.json'], load_default=None)
     destination = DirectoryField(load_default=None)


### PR DESCRIPTION
Backend part of https://github.com/rotki/rotki/issues/6243. To enable that we create a special flag in history event deletion where we ignore the check for the last history event in a transaction.
