### PR TITLE
Decode transactions that change the content hash of an ENS name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Transactions changing the content hash of an ENS name will now be properly decoded.
 * :feature:`5255` Pnl report assets now have an etherscan link to make it easier to identify pool assets.
 * :feature:`6179` Users will now be able to import their trades, income and spending from BitcoinTaxes.
 * :feature:`-` Ethereum transactions involing bribe claim payouts from StakeDAO will now be decoded properly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ greenlet==2.0.2
 gevent-websocket==0.10.1
 wsaccel==0.6.3  # recommended for acceleration of gevent-websocket. But abandoned.
 web3==5.31.3
-content-hash==1.1.1  # to decode ens content hashes
+rotki-content-hash==0.0.3  # fork of content-hash due to https://github.com/filips123/ContentHashPy/issues/1
 rotki-pysqlcipher3==2022.8.1
 requests==2.31.0
 urllib3==1.26.14
@@ -37,7 +37,7 @@ polyleven==0.8
 
 bip-utils==2.7.0
 
-typing-extensions==4.6.3 # used for typing.ParamSpec and typing.Concatenate (in stdlib since python 3.10)
+typing-extensions==4.5.0 # used for typing.ParamSpec and typing.Concatenate (in stdlib since python 3.10). Also limiting temporarily to 4.5.0 due to a bug in multiformats which is used by rotki-content-hash: https://github.com/hashberg-io/multiformats/issues/10
 
 #constraints
 pycparser<=2.17 # ugly -- to avoid https://github.com/eliben/pycparser/pull/198

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ greenlet==2.0.2
 gevent-websocket==0.10.1
 wsaccel==0.6.3  # recommended for acceleration of gevent-websocket. But abandoned.
 web3==5.31.3
+content-hash==1.1.1  # to decode ens content hashes
 rotki-pysqlcipher3==2022.8.1
 requests==2.31.0
 urllib3==1.26.14

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -255,9 +255,6 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
         try:
             codec = content_hash.get_codec(new_hash)
             value_hash = content_hash.decode(new_hash)
-            if codec == 'ipns-ns':
-                codec = 'ipns'
-
             value = f'{codec}://{value_hash}'
         except (TypeError, KeyError, ValueError) as e:
             msg = str(e)

--- a/rotkehlchen/chain/evm/contracts.py
+++ b/rotkehlchen/chain/evm/contracts.py
@@ -115,7 +115,7 @@ class EvmContract(NamedTuple):
             self,
             tx_log: 'EvmTxReceiptLog',
             event_name: str,
-            argument_names: Sequence[str],
+            argument_names: Optional[Sequence[str]],
     ) -> tuple[list, list]:
         """Decodes an event by finding the event ABI in the given contract's abi
 


### PR DESCRIPTION
Quickly implemented thanks to the prompt by @kelsos that rotki does not decode it yet properly and the python package hint by @decanus and @pcaversaccio


Decoded transaction
![2023-06-15_13-27](https://github.com/rotki/rotki/assets/1658405/9e03d035-d3bc-426a-9f10-61217f88d80a)
Decoded content hash
![2023-06-15_13-20](https://github.com/rotki/rotki/assets/1658405/4cf97854-21e3-4e1b-bdbd-fb5e353a24d0)
