### PR TITLE
Fix kyber decoder for trades

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 * :feature:`5250` Ethereum transactions involving AAVE v1 and v2 liquidations will now be decoded properly.
 * :bug:`-` Fix issue for ledger actions with zero rate, where the rate isn't used in the PnL report.
 * :bug:`-` ENS avatar fetching for each name's avatar should now work for all name resolvers. Even older or custom ones.
+* :bug:`-` Users will now see correctly decoded Kyber legacy trades.
 * :bug:`-` Users will now be able to decode compounding transactions for Convex gauges.
 * :bug:`-` Events depositing tokens in Yearn V2 vaults where the full owned amount is deposited should be now correctly decoded.
 * :bug:`-` Users will no longer see double counting of balances in curve gauges.

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -3,93 +3,30 @@ import pytest
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.evm_event import EvmEvent
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.kyber.constants import CPT_KYBER
 from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
-from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_CRV, A_ETH, A_USDC
-from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import (
-    ChainID,
-    EvmInternalTransaction,
-    EvmTransaction,
-    Location,
-    deserialize_evm_tx_hash,
-)
-from rotkehlchen.utils.hexbytes import hexstring_to_bytes
+from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
+from rotkehlchen.types import Location, deserialize_evm_tx_hash
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b']])  # noqa: E501
-def test_kyber_legacy_old_contract(database, ethereum_inquirer, eth_transactions):
-    """Data for trade taken from
+def test_kyber_legacy_old_contract(database, ethereum_inquirer, ethereum_accounts):
+    """
+    Data for trade taken from
     https://etherscan.io/tx/0xe9cc9f27ef2a09fe23abc886a0a0f7ae19d9e2eb73663e1e41e07a3e0c011b87
     """
-    tx_hex = '0xe9cc9f27ef2a09fe23abc886a0a0f7ae19d9e2eb73663e1e41e07a3e0c011b87'
+    tx_hex = deserialize_evm_tx_hash('0xe9cc9f27ef2a09fe23abc886a0a0f7ae19d9e2eb73663e1e41e07a3e0c011b87')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EvmTransaction(
-        tx_hash=evmhash,
-        chain_id=ChainID.ETHEREUM,
-        timestamp=1591043988,
-        block_number=10182160,
-        from_address=string_to_evm_address('0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b'),
-        to_address=string_to_evm_address('0x818E6FECD516Ecc3849DAf6845e3EC868087B755'),
-        value=0,
-        gas=600000,
-        gas_price=22990000000,
-        gas_used=527612,
-        input_data=hexstring_to_bytes('0xcb3c28c7000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000002aea540000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0000000000000000000000006d379cb5ba04c09293b21bf314e7aba3ffeaaf5b8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e5f611df3b9ac000000000000000000000000f1aa99c69715f423086008eb9d06dc1e35cc504d'),  # noqa: E501
-        nonce=1,
-    )
-    receipt = EvmTxReceipt(
-        tx_hash=evmhash,
-        chain_id=ChainID.ETHEREUM,
-        contract_address=None,
-        status=True,
-        type=0,
-        logs=[
-            EvmTxReceiptLog(
-                log_index=87,
-                data=hexstring_to_bytes('0x0000000000000000000000000000000000000000000000000000000002aea540'),  # noqa: E501
-                address=string_to_evm_address('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
-                removed=False,
-                topics=[
-                    hexstring_to_bytes('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000006d379cb5ba04c09293b21bf314e7aba3ffeaaf5b'),  # noqa: E501
-                    hexstring_to_bytes('0x00000000000000000000000065bf64ff5f51272f729bdcd7acfb00677ced86cd'),  # noqa: E501
-                ],
-            ), EvmTxReceiptLog(
-                log_index=93,
-                data=hexstring_to_bytes('0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0000000000000000000000000000000000000000000000000000000002aea540000000000000000000000000000000000000000000000000029a80338e28df730000000000000000000000006d379cb5ba04c09293b21bf314e7aba3ffeaaf5b000000000000000000000000000000000000000000000000029a80338e28df730000000000000000000000001670dfb52806de7789d5cf7d5c005cf7083f9a5d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000'),  # noqa: E501
-                address=string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd'),
-                removed=False,
-                topics=[
-                    hexstring_to_bytes('0xd30ca399cb43507ecec6a629a35cf45eb98cda550c27696dcb0d8c4a3873ce6c'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000006d379cb5ba04c09293b21bf314e7aba3ffeaaf5b'),  # noqa: E501
-                ],
-            ),
-        ],
-    )
-    internal_tx = EvmInternalTransaction(
-        parent_tx_hash=evmhash,
-        chain_id=ChainID.ETHEREUM,
-        trace_id=27,
-        from_address=string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd'),
-        to_address=string_to_evm_address('0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b'),
-        value=187603293406027635,
-    )
-    dbevmtx = DBEvmTx(database)
-    with database.user_write() as cursor:
-        dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-        dbevmtx.add_evm_internal_transactions(cursor, [internal_tx], relevant_address=string_to_evm_address('0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b'))  # noqa: E501
-    decoder = EthereumTransactionDecoder(
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
         database=database,
-        ethereum_inquirer=ethereum_inquirer,
-        transactions=eth_transactions,
+        tx_hash=tx_hex,
     )
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
 
     assert len(events) == 3
     expected_events = [
@@ -105,7 +42,7 @@ def test_kyber_legacy_old_contract(database, ethereum_inquirer, eth_transactions
                 amount=FVal(0.01212979988),
                 usd_value=ZERO,
             ),
-            location_label='0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b',
+            location_label=ethereum_accounts[0],
             notes='Burned 0.01212979988 ETH for gas',
             counterparty=CPT_GAS,
         ), EvmEvent(
@@ -117,7 +54,7 @@ def test_kyber_legacy_old_contract(database, ethereum_inquirer, eth_transactions
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_USDC,
             balance=Balance(amount=FVal(45), usd_value=ZERO),
-            location_label='0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b',
+            location_label=ethereum_accounts[0],
             notes='Swap 45 USDC in kyber',
             counterparty=CPT_KYBER,
             address=string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd'),
@@ -133,7 +70,7 @@ def test_kyber_legacy_old_contract(database, ethereum_inquirer, eth_transactions
                 amount=FVal('0.187603293406027635'),
                 usd_value=ZERO,
             ),
-            location_label='0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b',
+            location_label=ethereum_accounts[0],
             notes='Receive 0.187603293406027635 ETH from kyber swap',
             counterparty=CPT_KYBER,
             address=string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd'),
@@ -141,78 +78,19 @@ def test_kyber_legacy_old_contract(database, ethereum_inquirer, eth_transactions
     assert events == expected_events
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x5340F6faff9BF55F66C16Db6Bf9E020d987F87D0']])  # noqa: E501
-def test_kyber_legacy_new_contract(database, ethereum_inquirer, eth_transactions):
+def test_kyber_legacy_new_contract(database, ethereum_inquirer):
     """Data for trade taken from
     https://etherscan.io/tx/0xe80928d5e21f9628c047af1f8b191cbffbb6b8b9945adb502cfb3af152552f22
     """
-    tx_hex = '0xe80928d5e21f9628c047af1f8b191cbffbb6b8b9945adb502cfb3af152552f22'
+    tx_hex = deserialize_evm_tx_hash('0xe80928d5e21f9628c047af1f8b191cbffbb6b8b9945adb502cfb3af152552f22')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    transaction = EvmTransaction(
-        tx_hash=evmhash,
-        chain_id=ChainID.ETHEREUM,
-        timestamp=1644182638,
-        block_number=14154915,
-        from_address=string_to_evm_address('0x5340F6faff9BF55F66C16Db6Bf9E020d987F87D0'),
-        to_address=string_to_evm_address('0x9AAb3f75489902f3a48495025729a0AF77d4b11e'),
-        value=0,
-        gas=2784000,
-        gas_price=71000000000,
-        gas_used=938231,
-        input_data=hexstring_to_bytes('0xae591d54000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000001e52b2aa0000000000000000000000000d533a949740bb3306d119cc777fa900ba034cd520000000000000000000000005340f6faff9bf55f66c16db6bf9e020d987f87d0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000003ef569a751d10e0000000000000000000000000de63aef60307655405835da74ba02ce4db1a42fb000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000'),  # noqa: E501
-        nonce=41,
-    )
-    receipt = EvmTxReceipt(
-        tx_hash=evmhash,
-        chain_id=ChainID.ETHEREUM,
-        contract_address=None,
-        status=True,
-        type=0,
-        logs=[
-            EvmTxReceiptLog(
-                log_index=349,
-                data=hexstring_to_bytes('0x00000000000000000000000000000000000000000000000000000001e52b2aa0'),  # noqa: E501
-                address=string_to_evm_address('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
-                removed=False,
-                topics=[
-                    hexstring_to_bytes('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000005340f6faff9bf55f66c16db6bf9e020d987f87d0'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000007c66550c9c730b6fdd4c03bc2e73c5462c5f7acc'),  # noqa: E501
-                ],
-            ),
-            EvmTxReceiptLog(
-                log_index=369,
-                data=hexstring_to_bytes('0x000000000000000000000000000000000000000000000083a3ee0140f345d2d8'),  # noqa: E501
-                address=string_to_evm_address('0xD533a949740bb3306d119CC777fa900bA034cd52'),
-                removed=False,
-                topics=[
-                    hexstring_to_bytes('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000007c66550c9c730b6fdd4c03bc2e73c5462c5f7acc'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000005340f6faff9bf55f66c16db6bf9e020d987f87d0'),  # noqa: E501
-                ],
-            ),
-            EvmTxReceiptLog(
-                log_index=372,
-                data=hexstring_to_bytes('0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000d533a949740bb3306d119cc777fa900ba034cd520000000000000000000000005340f6faff9bf55f66c16db6bf9e020d987f87d000000000000000000000000000000000000000000000000000000001e52b2aa0000000000000000000000000000000000000000000000083a3ee0140f345d2d8000000000000000000000000de63aef60307655405835da74ba02ce4db1a42fb0000000000000000000000000000000000000000000000000000000000000012'),  # noqa: E501
-                address=string_to_evm_address('0x9AAb3f75489902f3a48495025729a0AF77d4b11e'),
-                removed=False,
-                topics=[
-                    hexstring_to_bytes('0xf724b4df6617473612b53d7f88ecc6ea983074b30960a049fcd0657ffe808083'),  # noqa: E501
-                    hexstring_to_bytes('0x0000000000000000000000005340f6faff9bf55f66c16db6bf9e020d987f87d0'),  # noqa: E501
-                ],
-            ),
-        ],
-    )
-
-    dbevmtx = DBEvmTx(database)
-    with database.user_write() as cursor:
-        dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    decoder = EthereumTransactionDecoder(
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
         database=database,
-        ethereum_inquirer=ethereum_inquirer,
-        transactions=eth_transactions,
+        tx_hash=tx_hex,
     )
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
 
     assert len(events) == 3
     expected_events = [


### PR DESCRIPTION
The decoder was using the wrong tx log topic to filter trandes and it was failing to decode the transaction because it matched againt an event that didn't have the expected fields.

This was not noticed in tests because I didn't use all the logs and just some of them. By mocking the two tests it is now properly tested.

Also fixed an issue with uniswap front running the kyber decoder

