### PR TITLE
Change order of things during logout

### DIFF
--- a/frontend/app/src/components/UserDropdown.vue
+++ b/frontend/app/src/components/UserDropdown.vue
@@ -26,8 +26,7 @@ const showConfirmation = () =>
         await clearPassword();
       }
 
-      await logout();
-      await navigateToUserLogin();
+      await Promise.all([logout(), navigateToUserLogin()]);
     }
   );
 

--- a/frontend/app/src/composables/item-cache.ts
+++ b/frontend/app/src/composables/item-cache.ts
@@ -71,6 +71,9 @@ export const useItemCache = <T>(
 
   const fetchBatch = useDebounceFn(async () => {
     const currentBatch = get(batch);
+    if (currentBatch.length === 0) {
+      return;
+    }
     set(batch, []);
     await processBatch(currentBatch);
   }, 800);

--- a/frontend/app/src/store/plugins.ts
+++ b/frontend/app/src/store/plugins.ts
@@ -13,6 +13,11 @@ export const StoreResetPlugin = ({ store }: PiniaPluginContext): void => {
       state = cloneDeep(initialState);
     }
     store.$patch(toReactive(state));
+    // If a store has its own reset function (e.g. to cancel actions)
+    // Then we will also call this to properly cleanup.
+    if (typeof store.reset === 'function') {
+      store.reset();
+    }
   };
 };
 

--- a/frontend/app/src/store/session/index.ts
+++ b/frontend/app/src/store/session/index.ts
@@ -162,11 +162,12 @@ export const useSessionStore = defineStore('session', () => {
   };
 
   const logout = async (): Promise<void> => {
+    set(logged, false);
     resetTray();
     try {
       await usersApi.logout(get(username));
-      set(logged, false);
     } catch (e: any) {
+      logger.error(e);
       setMessage({
         title: 'Logout failed',
         description: e.message


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Notes
What as happening is that during logout the state was cleared first and then the navigation happened. 

Because some of the elements where still visible they would trigger a refresh of state after the logout. (e.g. fetching assets mappings)