### PR TITLE
Make the total lost amount always positive

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -226,7 +226,7 @@ class Aave(EthereumModule):
 
         for borrowed_asset, amount in historical_borrow_balances.items():
             borrow_balance = balances.borrowing.get(cast(CryptoAsset, borrowed_asset), None)
-            this_amount = amount
+            this_amount = abs(amount)  # the amount is always <= 0 as it represents a debt position that can get repaid but we need it positive for the calculations  # noqa: E501
             if borrow_balance is not None:
                 this_amount += borrow_balance.balance.amount
 

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -267,6 +267,10 @@ def test_events_aave_v2(rotkehlchen_api_server: 'APIServer') -> None:
                     'amount': '0.085033793839969583',
                     'usd_value': '0.1275506907599543745',
                 },
+                'ETH': {
+                    'amount': '0.2',
+                    'usd_value': '0.30',
+                },
             },
             'total_earned_liquidations': {},
         },

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -45,7 +45,7 @@ def test_asset_data(session_coingecko):
         identifier='yearn-finance',
         symbol='yfi',
         name='yearn.finance',
-        image_url='https://assets.coingecko.com/coins/images/11849/small/yearn-finance-yfi.png?1676174746',  # noqa: E501
+        image_url='https://assets.coingecko.com/coins/images/11849/small/yearn.jpg?1687142705',  # noqa: E501
     )
     data = session_coingecko.asset_data(A_YFI.resolve_to_asset_with_oracles().to_coingecko())
     assert_coin_data_same(data, expected_data, compare_description=False)


### PR DESCRIPTION
After 9189ce73c237dd14bce043e05f4fd7f14ab70752 the aave eth events got correctly decoded and this uncovered an issue in the aave stats.In the test the total lost amount was getting displayed as negative instead of positive.

It didn't appear before because it came from a liquidation event that was being correctly accounted and the debt event that existed before was getting cancelled.

