### PR TITLE
Improve account detection

### DIFF
--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1324,14 +1324,13 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                         continue
                 else:
                     etherscan_activity = chain_manager.node_inquirer.etherscan.has_activity(address)  # noqa: E501
-                    if (
-                        (
-                            etherscan_activity == EtherscanHasChainActivity.TOKENS and
-                            chain_manager.transactions.address_has_been_spammed(address=address)
-                        ) or
-                        etherscan_activity == EtherscanHasChainActivity.NONE
-                    ):  # in the case of tokens we check if the transactions were spam tokens
-                        continue
+                    only_token_spam = (
+                        etherscan_activity == EtherscanHasChainActivity.TOKENS and
+                        chain_manager.transactions.address_has_been_spammed(address=address)
+                    )
+                    if only_token_spam or etherscan_activity == EtherscanHasChainActivity.NONE:
+                        continue  # do not add the address for the chain
+
                     # else we add the chain
             except RemoteError as e:
                 log.error(f'{e!s} when checking if {address} is active at {chain}')

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1330,8 +1330,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                     )
                     if only_token_spam or etherscan_activity == EtherscanHasChainActivity.NONE:
                         continue  # do not add the address for the chain
-
-                    # else we add the chain
             except RemoteError as e:
                 log.error(f'{e!s} when checking if {address} is active at {chain}')
                 continue

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -55,6 +55,11 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class EtherscanHasChainActivity(Enum):
+    """
+    Classify the type of transaction first found in etherscan. TRANSACTIONS means that the endpoint
+    for transactions/internal transactions had entries, TOKENS means that the tokens endpoint had
+    entries and NONE means that no entry has been found in the different endpoints.
+    """
     TRANSACTIONS = auto()
     TOKENS = auto()
     NONE = auto()
@@ -483,7 +488,11 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
 
     def has_activity(self, account: ChecksumEvmAddress) -> EtherscanHasChainActivity:
         """Queries transactions, internal_txs and tokentx for an address with limit=1
-        just to quickly determine if the account has had any activity in the chain"""
+        just to quickly determine if the account has had any activity in the chain.
+        We make a distinction between transactions and ERC20 transfers since ERC20
+        are often spammed. If there was no activity at all we return the enum value
+        NONE.
+        """
         options = {'address': str(account), 'page': 1, 'offset': 1}
         result = self._query(module='account', action='txlist', options=options)
         if len(result) != 0:

--- a/rotkehlchen/tests/unit/test_chains_aggregator.py
+++ b/rotkehlchen/tests/unit/test_chains_aggregator.py
@@ -171,8 +171,9 @@ def test_detect_evm_accounts(blockchain: 'ChainsAggregator') -> None:
 @pytest.mark.parametrize('polygon_pos_accounts', [[make_evm_address()]])  # to connect to nodes
 def test_detect_evm_accounts_spam_tx(polygon_pos_manager: 'PolygonPOSManager') -> None:
     """
-    Test correctly that an account with only erc20 transfers of spam tokens get correctly
-    marked as spammed.
+    Test that an account with only erc20 transfers of spam tokens gets marked as spam
+    and does not get detected as a tracked account in the EVM chain.
+
     The tested address has received the following spam tokens
     eip155:137/erc20:0x91bD4023A21bc12814905f251eb348e298DBC0F0
     eip155:137/erc20:0xD6198855979714255d711A4bB8BF1763d28A473B
@@ -190,7 +191,7 @@ def test_detect_evm_accounts_spam_tx(polygon_pos_manager: 'PolygonPOSManager') -
     - adding the second as spam asset
     - third is unknown so the address is marked as not spammed
 
-    to verify that the transaction has been spamemd all the remaining assets are ignored
+    to verify that the address has been spammed all the remaining assets are ignored
     """
     evm_address = string_to_evm_address('0xc1C736F2Ac0e0019A188982c7c8C063976A4d8d9')
     db = polygon_pos_manager.node_inquirer.database

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -14,7 +14,7 @@ from rotkehlchen.constants.resolver import strethaddress_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.beaconchain import BeaconChain
-from rotkehlchen.externalapis.etherscan import Etherscan
+from rotkehlchen.externalapis.etherscan import Etherscan, EtherscanHasChainActivity
 from rotkehlchen.fval import FVal
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
@@ -624,18 +624,18 @@ def setup_evm_addresses_activity_mock(
 
     def mock_optimism_has_activity(account):
         if account in optimism_addresses:
-            return True
-        return False
+            return EtherscanHasChainActivity.TRANSACTIONS
+        return EtherscanHasChainActivity.NONE
 
     def mock_polygon_pos_has_activity(account):
         if account in polygon_pos_addresses:
-            return True
-        return False
+            return EtherscanHasChainActivity.TRANSACTIONS
+        return EtherscanHasChainActivity.NONE
 
     def mock_ethereum_has_activity(account):
         if account in ethereum_addresses:
-            return True
-        return False
+            return EtherscanHasChainActivity.TRANSACTIONS
+        return EtherscanHasChainActivity.NONE
 
     stack.enter_context(patch.object(
         chains_aggregator.ethereum.node_inquirer,

--- a/rotkehlchen/tests/utils/polygon_pos.py
+++ b/rotkehlchen/tests/utils/polygon_pos.py
@@ -2,6 +2,7 @@ from rotkehlchen.chain.evm.types import NodeName, WeightedNode
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import SupportedBlockchain
 
+ALCHEMY_RPC_ENDPOINT = 'https://polygon-mainnet.g.alchemy.com/v2/uNdnI7_6XXc7ayswOxtd_RuTBGojJhIf'
 POLYGON_POS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED: tuple[str, list[tuple]] = (
     'polygon_pos_manager_connect_at_start',
     [(
@@ -26,7 +27,7 @@ POLYGON_POS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED: tuple[str, list[tuple
         ), WeightedNode(
             node_info=NodeName(
                 name='alchemy',
-                endpoint='https://polygon-mainnet.g.alchemy.com/v2/uNdnI7_6XXc7ayswOxtd_RuTBGojJhIf',
+                endpoint=ALCHEMY_RPC_ENDPOINT,
                 owned=False,
                 blockchain=SupportedBlockchain.POLYGON_POS,
             ),


### PR DESCRIPTION
This PR changes how accounts get automatically detected:

1. If the account had any transaction or internal transaction as categorized in etherscan it is added
2. if it had only erc20 transfers we iterate over the logs filtering the transactions. If any token is uknown the account is marked as not spammed but if all of them are ignored or marked as spam the account gets marked as spammed