### PR TITLE
Upgrade cryptography to 41.0.1 [CVE-2023-2650]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ beautifulsoup4==4.12.2
 maxminddb==2.2.0
 miniupnpc==2.0.2; sys_platform != 'win32'
 miniupnpc==2.2.3; sys_platform == 'win32'
-cryptography==40.0.2
+cryptography==41.0.1
 
 # For the rest api
 flask-cors==3.0.10


### PR DESCRIPTION
Upgrade cryptography library due to https://www.openssl.org/news/secadv/20230530.txt
