### PR TITLE
Update spam assets in data migration

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migration_10.py
+++ b/rotkehlchen/data_migrations/migrations/migration_10.py
@@ -1,5 +1,6 @@
 import logging
 from typing import TYPE_CHECKING
+from rotkehlchen.db.updates import UpdateType
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ApiKey, ExternalService, ExternalServiceApiCredentials
@@ -21,6 +22,9 @@ def data_migration_10(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
     It also supersedes migration 8 which is removed since this one is added.
     """
     log.debug('Enter data_migration_10')
+    # Check updates for spam assets. This happens before accounts detection to avoid
+    # detecting accounts that only have spam assets.
+    rotki.data_updater.check_for_updates(updates=[UpdateType.SPAM_ASSETS])
     with rotki.data.db.conn.read_ctx() as cursor:
         accounts = rotki.data.db.get_blockchain_accounts(cursor)
 

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Literal, Union, overload
 
@@ -283,7 +284,7 @@ class RotkiDataUpdater:
                     entries=entries_to_add,
                 )
 
-    def check_for_updates(self) -> None:
+    def check_for_updates(self, updates: Sequence[UpdateType] = tuple(UpdateType)) -> None:
         """Retrieve the information about the latest available update"""
         try:
             remote_information = self._get_remote_info_json()
@@ -291,7 +292,7 @@ class RotkiDataUpdater:
             log.error(f'Could not retrieve json update information due to {e!s}')
             # skip updates, but write last date update to not spam periodic tasks
         else:
-            for update_type in UpdateType:
+            for update_type in updates:
                 # Get latest applied version
                 with self.user_db.conn.read_ctx() as cursor:
                     local_version = self._check_for_last_version(


### PR DESCRIPTION
Update the spam assets before detecting new addresses to avoid adding addresses without meaningful transactions
