### PR TITLE
feat: group evm chain for statistic to false

### DIFF
--- a/frontend/app/src/premium/premium-apis.ts
+++ b/frontend/app/src/premium/premium-apis.ts
@@ -110,7 +110,9 @@ export const balancesApi = (): BalancesApi => {
   const { balances } = useAggregatedBalances();
   return {
     byLocation: balancesByLocation as ComputedRef<Record<string, BigNumber>>,
-    aggregatedBalances: balances() as ComputedRef<AssetBalanceWithPrice[]>,
+    aggregatedBalances: balances(false, false) as ComputedRef<
+      AssetBalanceWithPrice[]
+    >,
     exchangeRate: (currency: string) =>
       computed(() => get(exchangeRate(currency)) ?? One)
   };


### PR DESCRIPTION
Closes #(issue_number)

Fix this issue where current value is not used for the graph (only happen for asset that have multiple chains)
<img width="1059" alt="image" src="https://github.com/rotki/rotki/assets/26648140/62789f8d-be9b-43b9-959a-b26a803dacca">

