### PR TITLE
passing submitUsageAnalytics in create account payload

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -120,7 +120,7 @@ Handling user creation, sign-in, log-out and querying
    :reqjson string[optional] premium_api_key: An optional api key if the user has a rotki premium account.
    :reqjson string[optional] premium_api_secret: An optional api secret if the user has a rotki premium account.
    :reqjson bool[optional] sync_database: If set to true rotki will try to download a remote database for premium users if there is any.
-   :reqjson object[optional] initial_settings: Optionally provide DB settings to set when creating the new user. If not provided, default settings are used.
+   :reqjson object[optional] initial_settings: Optionally provide DB settings to set when creating the new user. If not provided, default settings are used. The default value for `submit_usage_analytics` is `True`.
 
    **Example Response**:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`6307` Fix issue create account always saving submit_usage_analytics as true.
 * :feature:`2822` In the asset graph, users will see another setting `Infer zero timed balances` which when activated will show the periods when users weren't holding the asset.
 * :feature:`-` Transactions changing the content hash of an ENS name will now be properly decoded.
 * :feature:`5255` Pnl report assets now have an etherscan link to make it easier to identify pool assets.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`6307` Fix issue create account always saving submit_usage_analytics as true.
+* :bug:`-` Fix issue create account always saving submit_usage_analytics as true.
 * :feature:`2822` In the asset graph, users will see another setting `Infer zero timed balances` which when activated will show the periods when users weren't holding the asset.
 * :feature:`-` Transactions changing the content hash of an ENS name will now be properly decoded.
 * :feature:`5255` Pnl report assets now have an etherscan link to make it easier to identify pool assets.

--- a/frontend/app/src/components/account-management/CreateAccountForm.vue
+++ b/frontend/app/src/components/account-management/CreateAccountForm.vue
@@ -92,6 +92,9 @@ const confirm = () => {
     credentials: {
       username: get(username),
       password: get(password)
+    },
+    initialSettings: {
+      submitUsageAnalytics: get(submitUsageAnalytics)
     }
   };
 
@@ -99,7 +102,6 @@ const confirm = () => {
     payload.premiumSetup = {
       apiKey: get(apiKey),
       apiSecret: get(apiSecret),
-      submitUsageAnalytics: get(submitUsageAnalytics),
       syncDatabase: get(syncDatabase)
     };
   }

--- a/frontend/app/src/composables/api/session/users.ts
+++ b/frontend/app/src/composables/api/session/users.ts
@@ -62,7 +62,7 @@ export const useUsersApi = () => {
   const createAccount = async (
     payload: CreateAccountPayload
   ): Promise<PendingTask> => {
-    const { credentials, premiumSetup } = payload;
+    const { credentials, premiumSetup, initialSettings } = payload;
     const { username, password } = credentials;
 
     const response = await api.instance.put<ActionResult<PendingTask>>(
@@ -73,7 +73,7 @@ export const useUsersApi = () => {
         premiumApiKey: premiumSetup?.apiKey,
         premiumApiSecret: premiumSetup?.apiSecret,
         initialSettings: {
-          submitUsageAnalytics: premiumSetup?.submitUsageAnalytics
+          submitUsageAnalytics: initialSettings.submitUsageAnalytics
         },
         syncDatabase: premiumSetup?.syncDatabase,
         asyncQuery: true

--- a/frontend/app/src/composables/api/session/users.ts
+++ b/frontend/app/src/composables/api/session/users.ts
@@ -72,9 +72,7 @@ export const useUsersApi = () => {
         password,
         premiumApiKey: premiumSetup?.apiKey,
         premiumApiSecret: premiumSetup?.apiSecret,
-        initialSettings: {
-          submitUsageAnalytics: initialSettings.submitUsageAnalytics
-        },
+        initialSettings,
         syncDatabase: premiumSetup?.syncDatabase,
         asyncQuery: true
       }),

--- a/frontend/app/src/types/login.ts
+++ b/frontend/app/src/types/login.ts
@@ -14,8 +14,11 @@ export interface LoginCredentials {
 export interface PremiumSetup {
   readonly apiKey: string;
   readonly apiSecret: string;
-  readonly submitUsageAnalytics: boolean;
   readonly syncDatabase: boolean;
+}
+
+export interface initialSettings {
+  readonly submitUsageAnalytics: boolean;
 }
 
 export const AccountSession = z.record(
@@ -59,6 +62,7 @@ export class IncompleteUpgradeError extends Error {
 
 export interface CreateAccountPayload {
   readonly credentials: LoginCredentials;
+  readonly initialSettings: initialSettings;
   premiumSetup?: PremiumSetup;
 }
 

--- a/frontend/app/src/types/login.ts
+++ b/frontend/app/src/types/login.ts
@@ -17,7 +17,7 @@ export interface PremiumSetup {
   readonly syncDatabase: boolean;
 }
 
-export interface initialSettings {
+export interface InitialSettings {
   readonly submitUsageAnalytics: boolean;
 }
 
@@ -62,7 +62,7 @@ export class IncompleteUpgradeError extends Error {
 
 export interface CreateAccountPayload {
   readonly credentials: LoginCredentials;
-  readonly initialSettings: initialSettings;
+  readonly initialSettings: InitialSettings;
   premiumSetup?: PremiumSetup;
 }
 

--- a/frontend/app/tests/unit/specs/composables/user/account.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/user/account.spec.ts
@@ -82,7 +82,8 @@ describe('composables::user/account', () => {
       });
 
       await createNewAccount({
-        credentials: { username: 'test', password: '1234' }
+        credentials: { username: 'test', password: '1234' },
+        initialSettings: { submitUsageAnalytics: true }
       });
 
       expect(get(error)).toStrictEqual('errors');

--- a/frontend/app/tests/unit/specs/composables/user/account.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/user/account.spec.ts
@@ -88,5 +88,43 @@ describe('composables::user/account', () => {
 
       expect(get(error)).toStrictEqual('errors');
     });
+
+    test('create account with submitUsageAnalytics true', async () => {
+      const { createNewAccount } = useAccountManagement();
+      vi.clearAllMocks();
+      vi.mocked(createAccount).mockResolvedValue({
+        success: false,
+        message: 'errors'
+      });
+
+      await createNewAccount({
+        credentials: { username: 'test', password: '1234' },
+        initialSettings: { submitUsageAnalytics: true }
+      });
+
+      expect(createAccount).toHaveBeenCalledWith({
+        credentials: { username: 'test', password: '1234' },
+        initialSettings: { submitUsageAnalytics: true }
+      });
+    });
+
+    test('create account with submitUsageAnalytics false', async () => {
+      const { createNewAccount } = useAccountManagement();
+      vi.clearAllMocks();
+      vi.mocked(createAccount).mockResolvedValue({
+        success: false,
+        message: 'errors'
+      });
+
+      await createNewAccount({
+        credentials: { username: 'test', password: '1234' },
+        initialSettings: { submitUsageAnalytics: false }
+      });
+
+      expect(createAccount).toHaveBeenCalledWith({
+        credentials: { username: 'test', password: '1234' },
+        initialSettings: { submitUsageAnalytics: false }
+      });
+    });
   });
 });


### PR DESCRIPTION
## Fixes
- Fixes the issue while creating a new account on step 3 the system was not considering the `submit_usage_analytics` value selected by the user and was always saving it as true.

