### PR TITLE
Do not run background tasks until first snapshot is taken

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2798,6 +2798,9 @@ Querying all balances
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
    .. note::
+      This endpoint also serves as a hacky way of notifying the backend that the user has logged in the dashboard and background task scheduling or other heavy tasks can commence.
+
+   .. note::
       This endpoint also accepts parameters as query arguments.
 
    .. note::

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -1010,6 +1010,11 @@ class Rotkehlchen:
                     save_despite_errors=save_despite_errors,
                 )
 
+        # Once the first snapshot is taken the task manager should now be able to
+        # start scheduling tasks. This means that the user has logged in and seen
+        # the dashboard. This is to avoid scheduling tasks during DB upgrade,
+        # migrations and asset updates.
+        self.task_manager.should_schedule = True  # type: ignore[union-attr]  # should exist here
         return result_dict
 
     def set_settings(self, settings: ModifiableDBSettings) -> tuple[bool, str]:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -110,6 +110,7 @@ class TaskManager:
             msg_aggregator: 'MessagesAggregator',
             data_updater: 'RotkiDataUpdater',
     ) -> None:
+        self.should_schedule = False
         self.max_tasks_num = max_tasks_num
         self.greenlet_manager = greenlet_manager
         self.api_task_greenlets = api_task_greenlets
@@ -731,8 +732,15 @@ class TaskManager:
     def schedule(self) -> None:
         """Schedules background task while holding the scheduling lock
 
+        Only if should_schedule has been set to True, which happpens after the first
+        time the user loads up the dashboard. This is to avoid any background tasks running
+        during user migrations, db upgrades and asset upgrades.
+
         Used during logout to make sure no task is being scheduled at the same time
         as logging out
         """
+        if self.should_schedule is False:
+            return
+
         with self.schedule_lock:
             self._schedule()

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -316,6 +316,7 @@ def initialize_mock_rotkehlchen_instance(
             resume_from_backup=False,
         )
 
+    rotki.task_manager.should_schedule = True
     inquirer_inject_ethereum_set_order(
         inquirer=Inquirer(),
         add_defi_oracles=False,

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -78,6 +78,7 @@ def fixture_task_manager(
         msg_aggregator=messages_aggregator,
         data_updater=RotkiDataUpdater(msg_aggregator=messages_aggregator, user_db=database),
     )
+    task_manager.should_schedule = True
     return task_manager
 
 


### PR DESCRIPTION
This is so that we can keep the login process lean and not start any background tasks while we are still in DB upgrades, migration or asset updates which will end up killin them and restarting the app.

