### PR TITLE
Properly decode ENS name transfers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` ENS name transfers will now be shown properly and not just as generic ERC721 transfers.
 * :bug:`-` Fix issue create account always saving submit_usage_analytics as true.
 * :feature:`2822` In the asset graph, users will see another setting `Infer zero timed balances` which when activated will show the periods when users weren't holding the asset.
 * :feature:`-` Transactions changing the content hash of an ENS name will now be properly decoded.

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -469,7 +469,7 @@ class CurveDecoder(DecoderInterface, ReloadableDecoderMixin):
         else:
             log.debug(
                 f'Did not find spend and receive events for a curve swap. '
-                f'{context.transaction.tx_hash.hex}. Probably some aggregator was used and '
+                f'{context.transaction.tx_hash.hex()}. Probably some aggregator was used and '
                 f'decoding needs to happen in the aggregator-specific decoder.',
             )
 

--- a/rotkehlchen/chain/evm/decoding/base.py
+++ b/rotkehlchen/chain/evm/decoding/base.py
@@ -178,9 +178,9 @@ class BaseDecoderTools:
             name = 'ERC721 token' if token.name == '' else token.name
             extra_data = {'token_id': token_id, 'token_name': name}
             if event_type in {HistoryEventType.SPEND, HistoryEventType.TRANSFER}:
-                notes = f'{verb} {name} with id {token_id} from {location_label} to {counterparty}'  # noqa: E501
+                notes = f'{verb} {name} with id {token_id} from {location_label} to {counterparty_or_address}'  # noqa: E501
             else:
-                notes = f'{verb} {name} with id {token_id} from {counterparty} to {location_label}'  # noqa: E501
+                notes = f'{verb} {name} with id {token_id} from {counterparty_or_address} to {location_label}'  # noqa: E501
         else:
             return None  # unknown kind
 


### PR DESCRIPTION
This adds a small optional dependency in a subgraph for turning ENS token ID (which is the hash of the name) to the name. If there is any problem or if subgraph goes down we just don't show the specific name.

