### PR TITLE
Include multiformats_config datafiles

### DIFF
--- a/tools/pyinstaller_hooks/hook-multiformats_config.py
+++ b/tools/pyinstaller_hooks/hook-multiformats_config.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('multiformats_config')


### PR DESCRIPTION
This avoids errors where the multiformats_config data files were not found at the packaged binary.

