### PR TITLE
Handle an EVM rpc node potentially returning non-int blocknumber

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 =========
 Changelog
 =========
+* :bug:`6350` Graceful handling of EVM rpc node returning non-int block number
 
 * :release:`1.29.0 <2023-06-28>`
 * :feature:`-` ENS name transfers will now be shown properly and not just as generic ERC721 transfers.

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -440,6 +440,8 @@ class EvmNodeInquirer(metaclass=ABCMeta):
 
                     try:
                         current_block = web3.eth.block_number  # pylint: disable=no-member
+                        if isinstance(current_block, int) is False:  # Check for https://github.com/rotki/rotki/issues/6350  # TODO: Check if web3.py v6 has a check for this # noqa: E501
+                            raise RemoteError(f'Found non-int current block:{current_block}')
                         latest_block = self.query_highest_block()
                     except (requests.exceptions.RequestException, RemoteError) as e:
                         msg = f'Could not query latest block due to {e!s}'


### PR DESCRIPTION
Fix #6350

Not so much a fix, as a more graceful handling.

But we also need to check if when we upgrade to web3.py v6 they can handle this in the library itself.

Perhaps would make sense to report it and they can also provide a fix already,