### PR TITLE
Fix pyinstaller build loading jsonschema metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ maxminddb==2.2.0
 miniupnpc==2.0.2; sys_platform != 'win32'
 miniupnpc==2.2.3; sys_platform == 'win32'
 cryptography==41.0.1
+jsonschema==4.17.3  # jsonchema 4.18 introduces a dependency that is missing wheels for macos in our CI. We have reported it but we will pin the version until is fixed https://github.com/crate-py/rpds/issues/11
 
 # For the rest api
 flask-cors==3.0.10


### PR DESCRIPTION
After jsonschema 4.18 metadata files have been moved to jsonschema_specifications and pyinstaller-hooks doesn't provide a hook to load them at version 2023.5.

edit: rpds-py is a dep of jsonschema 4.18 that doesn't provide a wheel for arch64 macos11 that is one of the steps in our CI so we are pinning jsonschema to 4.17.3 until a wheel file is provided

