### PR TITLE
chore: update vuetify 2.7

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -68,7 +68,7 @@
     "vue-i18n": "8.28.2",
     "vue-i18n-composable": "2.0.0",
     "vue-router": "3.6.5",
-    "vuetify": "2.6.15",
+    "vuetify": "2.7.0",
     "zod": "3.21.4"
   },
   "devDependencies": {

--- a/frontend/app/src/components/helper/TabNavigation.vue
+++ b/frontend/app/src/components/helper/TabNavigation.vue
@@ -87,6 +87,7 @@ const isRouterVisible = (route: string, tab: TabContent) =>
     }
 
     &__tab {
+      text-transform: uppercase;
       background-color: white;
       border: var(--v-rotki-light-grey-darken1) solid thin;
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         version: 9.14.1(eslint@8.41.0)
       eslint-plugin-vuetify:
         specifier: 1.1.0
-        version: 1.1.0(eslint@8.41.0)(vuetify@2.6.15)
+        version: 1.1.0(eslint@8.41.0)(vuetify@2.7.0)
       imask:
         specifier: 6.6.2
         version: 6.6.2
@@ -137,8 +137,8 @@ importers:
         specifier: 3.6.5
         version: 3.6.5(vue@2.7.14)
       vuetify:
-        specifier: 2.6.15
-        version: 2.6.15(vue@2.7.14)
+        specifier: 2.7.0
+        version: 2.7.0(vue@2.7.14)
       zod:
         specifier: 3.21.4
         version: 3.21.4
@@ -5532,7 +5532,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-vuetify@1.1.0(eslint@8.41.0)(vuetify@2.6.15):
+  /eslint-plugin-vuetify@1.1.0(eslint@8.41.0)(vuetify@2.7.0):
     resolution: {integrity: sha512-I1YRUCGkDqe8F7O0tdf63UZVKtk4734+8fzbZ24YIZKTTyQp/FIR0nSZYG8mPFhTWerzPta7oXNzliBOwP2XeQ==}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
@@ -5541,7 +5541,7 @@ packages:
       eslint: 8.41.0
       eslint-plugin-vue: 7.20.0(eslint@8.41.0)
       requireindex: 1.2.0
-      vuetify: 2.6.15(vue@2.7.14)
+      vuetify: 2.7.0(vue@2.7.14)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10832,8 +10832,8 @@ packages:
       '@vue/compiler-sfc': 2.7.14
       csstype: 3.1.1
 
-  /vuetify@2.6.15(vue@2.7.14):
-    resolution: {integrity: sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA==}
+  /vuetify@2.7.0(vue@2.7.14):
+    resolution: {integrity: sha512-eDb+lbtB9e+FRbOPIIyXwgwgc2M6gvhHkhSgggzM0hmKh1XM34YStZbM865viH0AfpxGZIOsRcs0S+OtdyOB+Q==}
     peerDependencies:
       vue: ^2.6.4
     dependencies:


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
