### PR TITLE
Deleting EVM address won't remove metadata for all chains

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Removing an evm address will no longer affect metadata such as detected tokens of the address if it is also tracked for another evm chain.
 * :bug:`-` DSR balances that are held via a proxy contract will no longer appear duplicated under some specific circumstances.
 * :bug:`-` Fix issue where users cannot add non EVM asset.
 * :bug:`-` Fix bug on the `<date-time-picker />` component, where the validation for future dates was broken when selecting a different timezone. This also fixes the issue with the cursor, while the user is editing the number in the middle.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1798,19 +1798,24 @@ class DBHandler:
             blockchain: SUPPORTED_EVM_CHAINS,
     ) -> None:
         """Deletes all evm related data from the DB for a single evm address"""
-        write_cursor.execute('DELETE FROM used_query_ranges WHERE name = ?', (f'aave_events_{address}',))  # noqa: E501
+        if blockchain == SupportedBlockchain.ETHEREUM:  # mainnet only behaviour
+            write_cursor.execute('DELETE FROM used_query_ranges WHERE name = ?', (f'aave_events_{address}',))  # noqa: E501
+            write_cursor.execute(
+                'DELETE FROM used_query_ranges WHERE name = ?',
+                (f'{BALANCER_EVENTS_PREFIX}_{address}',),
+            )
+            write_cursor.execute('DELETE FROM balancer_events WHERE address=?;', (address,))
+            write_cursor.execute(  # queried addresses per module
+                'DELETE FROM multisettings WHERE name LIKE "queried_address_%" AND value = ?',
+                (address,),
+            )
+            loopring = DBLoopring(self)
+            loopring.remove_accountid_mapping(write_cursor, address)
+
         write_cursor.execute(
-            'DELETE FROM used_query_ranges WHERE name = ?',
-            (f'{BALANCER_EVENTS_PREFIX}_{address}',),
+            'DELETE FROM evm_accounts_details WHERE account=? AND chain_id=?',
+            (address, blockchain.to_chain_id().serialize_for_db()),
         )
-        write_cursor.execute('DELETE FROM evm_accounts_details WHERE account = ?', (address,))
-        write_cursor.execute('DELETE FROM balancer_events WHERE address=?;', (address,))
-        write_cursor.execute(
-            'DELETE FROM multisettings WHERE name LIKE "queried_address_%" AND value = ?',
-            (address,),
-        )
-        loopring = DBLoopring(self)
-        loopring.remove_accountid_mapping(write_cursor, address)
 
         dbtx = DBEvmTx(self)
         dbtx.delete_transactions(write_cursor=write_cursor, address=address, chain=blockchain)  # noqa: E501

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -15,7 +15,16 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccountData, BlockchainAccounts
 from rotkehlchen.constants import ONE, YEAR_IN_SECONDS
-from rotkehlchen.constants.assets import A_1INCH, A_BTC, A_DAI, A_ETH, A_ETH2, A_USD
+from rotkehlchen.constants.assets import (
+    A_1INCH,
+    A_BTC,
+    A_DAI,
+    A_ETH,
+    A_ETH2,
+    A_POLYGON_POS_MATIC,
+    A_USD,
+    A_USDC,
+)
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.db.dbhandler import DBHandler
@@ -295,7 +304,30 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
             [
                 BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address='0xd36029d76af6fE4A356528e4Dc66B2C18123597D'),  # noqa: E501
                 BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address='0x80B369799104a47e98A553f3329812a44A7FaCDc'),  # noqa: E501
+                # Add this to 2 evm chains
+                BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'),  # noqa: E501
+                BlockchainAccountData(chain=SupportedBlockchain.POLYGON_POS, address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'),  # noqa: E501
             ],
+        )
+
+    # add some metadata for only the eth mainnet address
+    queried_addresses = QueriedAddresses(data.db)
+    queried_addresses.add_queried_address_for_module(
+        'makerdao_vaults',
+        '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+    )  # now some for both
+    with data.db.user_write() as write_cursor:
+        data.db.save_tokens_for_address(
+            write_cursor=write_cursor,
+            address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+            blockchain=SupportedBlockchain.ETHEREUM,
+            tokens=[A_DAI, A_USDC],
+        )
+        data.db.save_tokens_for_address(
+            write_cursor=write_cursor,
+            address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+            blockchain=SupportedBlockchain.POLYGON_POS,
+            tokens=[A_POLYGON_POS_MATIC],
         )
 
     with data.db.conn.read_ctx() as cursor:
@@ -306,7 +338,9 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         assert set(accounts.eth) == {
             '0xd36029d76af6fE4A356528e4Dc66B2C18123597D',
             '0x80B369799104a47e98A553f3329812a44A7FaCDc',
+            '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
         }
+        assert set(accounts.polygon_pos) == {'0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'}
 
     with data.db.user_write() as write_cursor:
         # Add existing account should fail
@@ -329,7 +363,35 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
             ['0xd36029d76af6fE4A356528e4Dc66B2C18123597D'],
         )
         accounts = data.db.get_blockchain_accounts(write_cursor)
-        assert accounts.eth == ('0x80B369799104a47e98A553f3329812a44A7FaCDc',)
+        assert set(accounts.eth) == {
+            '0x80B369799104a47e98A553f3329812a44A7FaCDc',
+            '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+        }
+        # Remove only the polygon account
+        data.db.remove_single_blockchain_accounts(
+            write_cursor,
+            SupportedBlockchain.POLYGON_POS,
+            ['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'],
+        )
+        accounts = data.db.get_blockchain_accounts(write_cursor)
+        assert set(accounts.eth) == {
+            '0x80B369799104a47e98A553f3329812a44A7FaCDc',
+            '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+        }
+        assert accounts.polygon_pos == ()
+        # and also make sure that the relevant meta data of the mainnet account are still there
+        assert queried_addresses.get_queried_addresses_for_module(write_cursor, 'makerdao_vaults') == ('0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',)  # noqa: E501
+        assert data.db.get_tokens_for_address(
+            cursor=write_cursor,
+            address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+            blockchain=SupportedBlockchain.POLYGON_POS,
+        ) == (None, None)
+        eth_tokens, _ = data.db.get_tokens_for_address(
+            cursor=write_cursor,
+            address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
+            blockchain=SupportedBlockchain.ETHEREUM,
+        )
+        assert set(eth_tokens) == {A_DAI, A_USDC}
 
     result, _ = data.add_ignored_assets([A_DAO])
     assert result


### PR DESCRIPTION
Removing an evm address will no longer affect metadata such as detected tokens of the address if it is also tracked for another evm chain