### PR TITLE
Bump cryptography to 41.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ beautifulsoup4==4.12.2
 maxminddb==2.2.0
 miniupnpc==2.0.2; sys_platform != 'win32'
 miniupnpc==2.2.3; sys_platform == 'win32'
-cryptography==41.0.1
+cryptography==41.0.2
 jsonschema==4.17.3  # jsonchema 4.18 introduces a dependency that is missing wheels for macos in our CI. We have reported it but we will pin the version until is fixed https://github.com/crate-py/rpds/issues/11
 
 # For the rest api


### PR DESCRIPTION
Fixes CVE-2023-38325

Checked that builds binaries fine here: https://github.com/rotki/rotki/actions/runs/5593186483

Replaces: https://github.com/rotki/rotki/pull/6395