### PR TITLE
Fix slow windows tests and re-enable windows nightly tests

### DIFF
--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -24,6 +24,14 @@ jobs:
       test_environment: nightly
     secrets: inherit
 
+  windows:
+    uses: ./.github/workflows/task_backend_tests.yml
+    if: ${{ always() }}
+    with:
+      os: windows-latest
+      test_environment: nightly
+    secrets: inherit
+
   e2e:
     uses: ./.github/workflows/task_e2e_tests.yml
     if: ${{ always() }}

--- a/rotkehlchen/tests/api/test_statistics.py
+++ b/rotkehlchen/tests/api/test_statistics.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from rotkehlchen.accounting.structures.balance import BalanceType
+from rotkehlchen.api.server import APIServer
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_ETH2, A_EUR
 from rotkehlchen.fval import FVal
@@ -158,12 +159,17 @@ def test_query_statistics_asset_balance(
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-def test_query_statistics_asset_balance_errors(rotkehlchen_api_server, rest_api_port):
+def test_query_statistics_asset_balance_errors(rotkehlchen_api_server: APIServer):
     """Test that errors at the statistics asset balance over time endpoint are hanled properly"""
     start_time = ts_now()
 
     # Check that no asset given is an error
-    response = requests.post(f'http://localhost:{rest_api_port}/api/1/statistics/balance')
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'statisticsassetbalanceresource',
+        ),
+    )
     assert_error_response(
         response=response,
         status_code=HTTPStatus.BAD_REQUEST,

--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -40,7 +40,7 @@ def create_api_server(
 ) -> APIServer:
     api_server = APIServer(RestAPI(rotkehlchen=rotki), rotki.rotki_notifier)
 
-    api_server.flask_app.config['SERVER_NAME'] = f'localhost:{rest_port_number}'
+    api_server.flask_app.config['SERVER_NAME'] = f'127.0.0.1:{rest_port_number}'
     api_server.start(
         host='127.0.0.1',
         rest_port=rest_port_number,


### PR DESCRIPTION
Work on #5168 together with https://github.com/rotki/rotki/pull/6398 and https://github.com/rotki/test-caching/pull/35

## Problem
After profiling the tests it became clear that `requests` calls were the culprit. `requests` calls took 4 seconds longer on windows than it did on linux. 

## Solution
Turns out this is a DNS issue as `requests` use DNS in the case when it's not given an IP Address. Changing `localhost` to `127.0.0.1` when creating the api server for the tests fixes the issue.

It appears that the slow connections on Windows were not directly due to name resolution, but were caused by `urllib3` (the transport library used by `requests`) attempting an IPv6 connection first, which is refused since the server is listening on IPv4 only. For Windows only, however, there is an unavoidable 1 second timeout on `socket.connect` for refused TCP connections, while the OS 'helpfully' retries the connection up to 3 times. This explains the 4 second time difference I saw when I profiled the tests.

A local run on my windows 11 machine confirms the tests runs in almost the same time as linux or macos with this change, therefore I've re-enabled the windows nightly. 