### PR TITLE
Fix bug with simultaneous filter asset searches

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Doing multiple simultaneous filter asset searches no longer results in Global DB locked error.
 * :bug:`-` Removing an evm address will no longer affect metadata such as detected tokens of the address if it is also tracked for another evm chain.
 * :bug:`-` DSR balances that are held via a proxy contract will no longer appear duplicated under some specific circumstances.
 * :bug:`-` Fix issue where users cannot add non EVM asset.

--- a/rotkehlchen/db/search_assets.py
+++ b/rotkehlchen/db/search_assets.py
@@ -52,51 +52,53 @@ def _search_only_assets_levenstein(
     resolved_eth = A_ETH.resolve_to_crypto_asset()
     globaldb = GlobalDBHandler()
     treat_eth2_as_eth = db.get_settings(cursor).treat_eth2_as_eth
-    cursor.execute(
-        f'ATTACH DATABASE "{globaldb.filepath()!s}" AS globaldb KEY "";',
-    )
-    try:
-        query, bindings = filter_query.prepare('assets')
-        query = ALL_ASSETS_TABLES_QUERY.format(dbprefix='globaldb.') + query
-        cursor.execute(query, bindings)
-        found_eth = False
-        for entry in cursor:
-            lev_dist_min = 100
-            if entry[1] is not None:
-                lev_dist_min = min(
-                    lev_dist_min,
-                    levenshtein(filter_query.substring_search, entry[1].casefold()),
-                )
-            if entry[2] is not None:
-                lev_dist_min = min(
-                    lev_dist_min,
-                    levenshtein(filter_query.substring_search, entry[2].casefold()),
-                )
-            if treat_eth2_as_eth is True and entry[0] in (A_ETH.identifier, A_ETH2.identifier):  # noqa: E501
-                if found_eth is False:
-                    search_result.append((lev_dist_min, {
-                        'identifier': resolved_eth.identifier,
-                        'name': resolved_eth.name,
-                        'symbol': resolved_eth.symbol,
-                        'asset_type': AssetType.OWN_CHAIN.serialize(),
-                    }))
-                    found_eth = True
-                continue
+    with db.conn.critical_section():  # needed due to ATTACH. Must not context switch out of this
+        cursor.execute(
+            f'ATTACH DATABASE "{globaldb.filepath()!s}" AS globaldb KEY "";',
+        )
+        try:
+            query, bindings = filter_query.prepare('assets')
+            query = ALL_ASSETS_TABLES_QUERY.format(dbprefix='globaldb.') + query
+            cursor.execute(query, bindings)
+            found_eth = False
+            for entry in cursor:
+                lev_dist_min = 100
+                if entry[1] is not None:
+                    lev_dist_min = min(
+                        lev_dist_min,
+                        levenshtein(filter_query.substring_search, entry[1].casefold()),
+                    )
+                if entry[2] is not None:
+                    lev_dist_min = min(
+                        lev_dist_min,
+                        levenshtein(filter_query.substring_search, entry[2].casefold()),
+                    )
+                if treat_eth2_as_eth is True and entry[0] in (A_ETH.identifier, A_ETH2.identifier):  # noqa: E501
+                    if found_eth is False:
+                        search_result.append((lev_dist_min, {
+                            'identifier': resolved_eth.identifier,
+                            'name': resolved_eth.name,
+                            'symbol': resolved_eth.symbol,
+                            'asset_type': AssetType.OWN_CHAIN.serialize(),
+                        }))
+                        found_eth = True
+                    continue
 
-            entry_info = {
-                'identifier': entry[0],
-                'name': entry[1],
-                'symbol': entry[2],
-                'asset_type': AssetType.deserialize_from_db(entry[4]).serialize(),
-            }
-            if entry[3] is not None:
-                entry_info['evm_chain'] = ChainID.deserialize_from_db(entry[3]).to_name()
-            if entry[5] is not None:
-                entry_info['custom_asset_type'] = entry[5]
+                entry_info = {
+                    'identifier': entry[0],
+                    'name': entry[1],
+                    'symbol': entry[2],
+                    'asset_type': AssetType.deserialize_from_db(entry[4]).serialize(),
+                }
+                if entry[3] is not None:
+                    entry_info['evm_chain'] = ChainID.deserialize_from_db(entry[3]).to_name()
+                if entry[5] is not None:
+                    entry_info['custom_asset_type'] = entry[5]
 
-            search_result.append((lev_dist_min, entry_info))
-    finally:
-        cursor.execute('DETACH globaldb;')
+                search_result.append((lev_dist_min, entry_info))
+        finally:
+            cursor.execute('DETACH globaldb;')
+
     return search_result
 
 

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -16,10 +16,10 @@ def test_optimism_nodes_prune_and_archive_status(
     to the nodes not being able to be replicated in a reproducible way in the cassetes.
     """  # noqa: E501
     for node_name, web3_node in optimism_inquirer.web3_mapping.items():
-        if node_name.endpoint in ('https://rpc.ankr.com/optimism', 'https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4'):  # noqa: E501
+        if node_name.endpoint == 'https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4':  # noqa: E501
             assert not web3_node.is_pruned
             assert not web3_node.is_archive
-        elif node_name.endpoint == 'https://mainnet.optimism.io':
+        elif node_name.endpoint in ('https://mainnet.optimism.io', 'https://rpc.ankr.com/optimism'):
             assert not web3_node.is_pruned
             assert web3_node.is_archive
         elif node_name.endpoint == 'https://optimism-mainnet.public.blastapi.io':

--- a/rotkehlchen/tests/unit/test_search.py
+++ b/rotkehlchen/tests/unit/test_search.py
@@ -1,0 +1,25 @@
+import gevent
+
+from rotkehlchen.db.filtering import LevenshteinFilterQuery
+from rotkehlchen.db.search_assets import search_assets_levenshtein
+
+
+def test_search_assets_levensthein_multiple(globaldb, database):  # pylint: disable=unused-argument
+    """Test that parallel access to levensthein search does not raise any errors"""
+    filter_query = LevenshteinFilterQuery.make(substring_search='ETH')
+
+    def do_search():
+        search_assets_levenshtein(
+            db=database,
+            filter_query=filter_query,
+            limit=None,
+            search_nfts=False,
+        )
+
+    greenlets = []
+    greenlets.append(gevent.spawn(do_search))
+    greenlets.append(gevent.spawn(do_search))
+    greenlets.append(gevent.spawn(do_search))
+
+    gevent.joinall(greenlets)
+    assert all(x.exception is None for x in greenlets)


### PR DESCRIPTION
Doing multiple simultaneous filter asset searches no longer results in Global DB locked error.