### PR TITLE
Fix remaining windows nightly tests

### DIFF
--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -115,6 +115,8 @@ class PremiumSyncManager:
         try:
             self.data.decompress_and_decrypt_db(result['data'])
         except UnableToDecryptRemoteData as e:
+            self.data.db.disconnect()
+            self.data.db.disconnect(conn_attribute='conn_transient')
             raise PremiumAuthenticationError(
                 'The given password can not unlock the database that was retrieved  from '
                 'the server. Make sure to use the same password as when the account was created.',
@@ -254,8 +256,10 @@ class PremiumSyncManager:
         premium API keys and we failed. But a directory was created. Remove it.
         But create a backup of it in case something went really wrong
         and the directory contained data we did not want to lose"""
+        user_data_dir = self.data.user_data_dir
+        self.data.db.logout()  # wipes self.data.user_data_dir
         shutil.move(
-            self.data.user_data_dir,  # type: ignore
+            user_data_dir,  # type: ignore
             self.data.data_directory / f'auto_backup_{username}_{ts_now()}',
         )
         raise PremiumAuthenticationError(

--- a/rotkehlchen/tests/unit/test_cost_basis.py
+++ b/rotkehlchen/tests/unit/test_cost_basis.py
@@ -532,16 +532,17 @@ def test_accounting_lifo_order(accountant):
     cost_basis = accountant.pots[0].cost_basis
     cost_basis.reset(DBSettings(cost_basis_method=CostBasisMethod.LIFO))
     asset_events = cost_basis.get_events(asset)
+    base_ts = 1614556800  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846 # noqa: E501
     # first we do a simple test that from 2 events the second is used
     event1 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
     event2 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556810,  # 01/03/2021, changed from 2 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts + 10,
         rate=ONE,
         index=2,
     )
@@ -556,13 +557,13 @@ def test_accounting_lifo_order(accountant):
     # checking what happens if one of the events has non-zero remaining_amount
     event3 = AssetAcquisitionEvent(
         amount=FVal(2),
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
     event4 = AssetAcquisitionEvent(
         amount=FVal(5),
-        timestamp=1614556810,  # 01/03/2021, changed from 2 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts + 10,
         rate=ONE,
         index=2,
     )
@@ -583,7 +584,7 @@ def test_accounting_lifo_order(accountant):
     # checking that new event after processing previous is added properly
     event5 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
@@ -603,7 +604,7 @@ def test_accounting_lifo_order(accountant):
     # check what happens if we use all remaining events
     event6 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
@@ -623,7 +624,7 @@ def test_accounting_lifo_order(accountant):
     # check what happens if we try to use more than available
     event7 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
@@ -678,16 +679,17 @@ def test_accounting_hifo_order(accountant):
     cost_basis = accountant.pots[0].cost_basis
     cost_basis.reset(DBSettings(cost_basis_method=CostBasisMethod.HIFO))
     asset_events = cost_basis.get_events(asset)
+    base_ts = 1614556800  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846 # noqa: E501
     # checking that cost basis is correct if one of the events has non-zero remaining_amount
     event3 = AssetAcquisitionEvent(
         amount=FVal(2),
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=FVal(3),
         index=1,
     )
     event4 = AssetAcquisitionEvent(
         amount=FVal(5),
-        timestamp=1614556810,  # 01/03/2021, changed from 2 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts + 10,
         rate=ONE,
         index=2,
     )
@@ -708,7 +710,7 @@ def test_accounting_hifo_order(accountant):
     # check that adding a new event after processing the previous one is added properly
     event5 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=FVal(2),
         index=1,
     )
@@ -728,7 +730,7 @@ def test_accounting_hifo_order(accountant):
     # check that using all remaining events uses up all acquisitions
     event6 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
@@ -748,7 +750,7 @@ def test_accounting_hifo_order(accountant):
     # check that using more than available creates MissingAcquisition
     event7 = AssetAcquisitionEvent(
         amount=ONE,
-        timestamp=1614556800,  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts,
         rate=ONE,
         index=1,
     )
@@ -780,6 +782,7 @@ def test_missing_acquisitions(accountant):
     expected_missing_acquisitions = []
     cost_basis = accountant.pots[0].cost_basis
     all_events = cost_basis.get_events(A_ETH)
+    base_ts = 1614556800  # 01/03/2021, changed from 1 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846 # noqa: E501
     # Test when there are no documented acquisitions
     cost_basis.reduce_asset_amount(
         asset=A_ETH,
@@ -809,7 +812,7 @@ def test_missing_acquisitions(accountant):
         amount=2,
         rate=1,
         index=1,
-        timestamp=1614556810,  # 01/03/2021, changed from 2 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts + 10,
     ))
     cost_basis.reduce_asset_amount(
         asset=A_ETH,
@@ -827,7 +830,7 @@ def test_missing_acquisitions(accountant):
         amount=2,
         rate=1,
         index=2,
-        timestamp=1614556820,  # 01/03/2021, changed from 3 for windows. See https://github.com/rotki/rotki/pull/6398#discussion_r1271323846  # noqa: E501
+        timestamp=base_ts + 20,
     ))
     all_events.acquisitions_manager.calculate_spend_cost_basis(
         spending_amount=3,


### PR DESCRIPTION
## Problem
`test_try_premium_at_start_new_account_different_password_than_remote_db` and `test_user_creation_with_invalid_premium_credentials` fail on windows with the following error:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_data_dir604\\testuser\\rotkehlchen.db'
``` 
## Solution
In both cases `shutil.move()` was trying to create a backup of the DB but the pre-existing connection did not appear to get closed. Therefore I've added lines to explicitly close the connection before making the backup.