### PR TITLE
Fix premium account creation bug on Windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Errors creating a premium account with an invalid premium key in Windows are now handled gracefully
 * :bug:`-` Doing multiple simultaneous filter asset searches no longer results in Global DB locked error.
 * :bug:`-` Removing an evm address will no longer affect metadata such as detected tokens of the address if it is also tracked for another evm chain.
 * :bug:`-` DSR balances that are held via a proxy contract will no longer appear duplicated under some specific circumstances.

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -242,8 +242,10 @@ class PremiumSyncManager:
         premium API keys and we failed. But a directory was created. Remove it.
         But create a backup of it in case something went really wrong
         and the directory contained data we did not want to lose"""
+        user_data_dir = self.data.user_data_dir
+        self.data.logout()  # wipes self.data.user_data_dir, so store it
         shutil.move(
-            self.data.user_data_dir,  # type: ignore
+            user_data_dir,  # type: ignore
             self.data.data_directory / f'auto_backup_{username}_{ts_now()}',
         )
         raise PremiumAuthenticationError(


### PR DESCRIPTION
## Problem
On Windows, when trying to create a new premium account with a random base64 string for the API secret, the backend throws an unexpected error
![image](https://github.com/rotki/rotki/assets/28752776/3c052aa1-8e73-4de2-99fb-3ae817796786)
## Cause
On windows the database connection is not properly closed before trying to back it up for the new user.
## Solution
Close the DB connection before backing up the new user's DB.
## Tests
After the fix I performed the same steps I did to re-produce the bug, and now we get the expected error message: `Could not verify keys for the new account. rotki API key was rejected by server`.

Also logged in as a non-premium user and navigated around... added a bitcoin address to check balances... things seem to work fine.

`test_try_premium_at_start_new_account_different_password_than_remote_db` and `test_user_creation_with_invalid_premium_credentials` now pass with this change.