### PR TITLE
Querying asset existence with case insensitive ID now normalizes it

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3722,7 +3722,7 @@ Replacing an asset
 Querying asset icons
 ======================
 
-.. http:post:: /api/(version)/assets/icon
+.. http:get:: /api/(version)/assets/icon
 
    Doing a GET on the asset icon endpoint will return the icon of the given asset. If we have no icon for an asset a 404 is returned
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -53,6 +53,7 @@ from rotkehlchen.assets.asset import (
     CustomAsset,
     EvmToken,
     FiatAsset,
+    ResolvedAsset,
 )
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.types import AssetType
@@ -2792,7 +2793,7 @@ class RestAPI:
 
     def get_asset_icon(
             self,
-            asset: Asset,
+            asset: ResolvedAsset,
             match_header: Optional[str],
     ) -> Response:
         icon_path = self.rotkehlchen.icon_manager.asset_icon_path(asset)
@@ -4177,7 +4178,7 @@ class RestAPI:
 
         return maybe_create_image_response(image_path=avatar_path)
 
-    def clear_icons_cache(self, icons: Optional[list[Asset]]) -> Response:
+    def clear_icons_cache(self, icons: Optional[list[ResolvedAsset]]) -> Response:
         """Clears cache entries for the specified icons.
 
         If no icons are provided, the icons cache is cleared entirely.

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -153,7 +153,13 @@ from rotkehlchen.api.v1.schemas import (
     XpubAddSchema,
     XpubPatchSchema,
 )
-from rotkehlchen.assets.asset import Asset, AssetWithNameAndType, AssetWithOracles, CustomAsset
+from rotkehlchen.assets.asset import (
+    Asset,
+    AssetWithNameAndType,
+    AssetWithOracles,
+    CustomAsset,
+    ResolvedAsset,
+)
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import SingleBlockchainAccountData
@@ -2195,7 +2201,7 @@ class AssetIconFileResource(BaseMethodView):
     get_schema = SingleAssetIdentifierSchema()
 
     @use_kwargs(get_schema, location='query')
-    def get(self, asset: Asset) -> Response:
+    def get(self, asset: ResolvedAsset) -> Response:
         return self.rest_api.get_asset_icon(asset=asset, match_header=get_match_header())
 
 

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -1859,6 +1859,30 @@ class GlobalDBHandler:
         return AssetType.deserialize_from_db(type_in_db[0])
 
     @staticmethod
+    def asset_id_exists(identifier: str, use_packaged_db: bool = False) -> str:
+        """
+        For a given identifier return the normalized identifier if it exists.
+        If `use_packaged_db` is True, it checks the packaged global db.
+
+        May raise:
+        - UnknownAsset: if the asset is not present in the database
+        """
+        if identifier.startswith(NFT_DIRECTIVE):
+            return identifier
+
+        connection = GlobalDBHandler().packaged_db_conn() if use_packaged_db is True else GlobalDBHandler().conn  # noqa: E501
+        with connection.read_ctx() as cursor:
+            normalized_id = cursor.execute(
+                'SELECT identifier FROM assets WHERE identifier=?',
+                (identifier,),
+            ).fetchone()
+
+        if normalized_id is None:  # should not happen
+            raise UnknownAsset(identifier)
+
+        return normalized_id[0]
+
+    @staticmethod
     def get_collection_main_asset(identifier: str) -> Optional[str]:
         """
         Given an asset identifier return id of the asset in the collection with the lowest

--- a/rotkehlchen/tests/api/test_icons.py
+++ b/rotkehlchen/tests/api/test_icons.py
@@ -131,3 +131,24 @@ def test_refresh_icon(rotkehlchen_api_server):
     )
     assert_simple_ok_response(response)
     assert icon_filepath.stat().st_ctime > now
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_case_insensitive_icon(rotkehlchen_api_server):
+    """
+    Test that providing asset identifier in a case insensitive way still maps to the correct asset
+    """
+    icon_manager = rotkehlchen_api_server.rest_api.rotkehlchen.icon_manager
+    with open(icon_manager.icons_dir / 'ETH_small.png', 'wb') as f:
+        f.write(b'123')
+
+    for identifier in ('ETH', 'eth', 'eTh'):
+        response = requests.get(
+            api_url_for(
+                rotkehlchen_api_server,
+                'asseticonfileresource',
+                asset=identifier,
+            ),
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.text == '123'

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -1,8 +1,8 @@
 from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import patch
-import gevent
 
+import gevent
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
@@ -75,11 +75,13 @@ def test_asset_icons_for_collections(icon_manager: IconManager) -> None:
     Test that for assets in the same collection only one file is saved and
     is later used by all the assets in the same collection
     """
-    dai_op = Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1')
+    dai_op = Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1').resolve()
+    dai_main = A_DAI.resolve()
+    eth = A_ETH.resolve()
     times_api_was_queried = 0
 
-    # make sure that the icon asset doesn't exists
-    icon_path = icon_manager.iconfile_path(A_DAI)
+    # make sure that the icon asset doesn't exist
+    icon_path = icon_manager.iconfile_path(dai_main)
     assert icon_path.exists() is False
 
     # mock coingecko response
@@ -121,7 +123,7 @@ def test_asset_icons_for_collections(icon_manager: IconManager) -> None:
 
     # Try to get the icon for an asset in the same collection
     with patch.object(icon_manager.coingecko.session, 'get', wraps=mock_coingecko):
-        icon_dai_eth, processed = icon_manager.get_icon(A_DAI)
+        icon_dai_eth, processed = icon_manager.get_icon(dai_main)
         gevent.joinall(icon_manager.greenlet_manager.greenlets)
 
     # check that the api was not queried again and the fail returned is the same
@@ -131,8 +133,8 @@ def test_asset_icons_for_collections(icon_manager: IconManager) -> None:
 
     # try to get an asset without collection
     with patch.object(icon_manager.coingecko.session, 'get', wraps=mock_coingecko):
-        icon_manager.get_icon(A_ETH)
+        icon_manager.get_icon(eth)
         gevent.joinall(icon_manager.greenlet_manager.greenlets)
 
-    assert icon_manager.iconfile_path(A_ETH).exists()
+    assert icon_manager.iconfile_path(eth).exists()
     assert times_api_was_queried == 4


### PR DESCRIPTION
When resolving an asset via `resolve()` the returned resolved asset, has the normalized identifier. But when checking for asset existence with `check_existence()` the asset can be seen to be in the DB but its identifier will not be normalized.

This can result to all the following assets moving around in our codebase: Asset('ETH'), Asset('eth'), Asset('eTh'), Asset ('etH') etc. While the normalized identifier is 'ETH'.

This hit us recently in the icons query, where the frontend was sending us 'eth' instead of 'ETH', and this was seen as a valid asset, but its icon filepath was not found in Linux since it expected "$ICON_DIR/eth_small.png" but did not find it. What's interesting is that this works fine for Mac and Windows since filepaths there are case insensitive.

To solve it:

- Added a new type `ResolvedType` which is just used for typing in functions to signify we know an asset that has been checked to be in the DB.
- Modified the existence check of an asset to check for the identifier in the DB and return the normalized one. Then set it to the returned `Asset` instance
- Wrote test for the case that hit us with the icons and case insensitive identifiers

