### PR TITLE
Use location asset mapping on generic csv import

### DIFF
--- a/rotkehlchen/assets/exchanges_mappings/ftx.py
+++ b/rotkehlchen/assets/exchanges_mappings/ftx.py
@@ -1,0 +1,125 @@
+from rotkehlchen.assets.exchanges_mappings.common import COMMON_ASSETS_MAPPINGS
+from rotkehlchen.constants.resolver import evm_address_to_identifier, strethaddress_to_identifier
+from rotkehlchen.types import ChainID, EvmTokenKind
+
+WORLD_TO_FTX = COMMON_ASSETS_MAPPINGS | {
+    strethaddress_to_identifier('0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9'): 'FTT',
+    strethaddress_to_identifier('0xcca0c9c383076649604eE31b20248BC04FdF61cA'): 'ASD',
+    'SOL-2': 'SOL',
+    'COIN': 'COIN',
+    # SLP is smooth love potion
+    strethaddress_to_identifier('0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25'): 'SLP',
+    'MER-2': 'MER',
+    strethaddress_to_identifier('0x476c5E26a75bd202a9683ffD34359C0CC15be0fF'): 'SRM',
+    strethaddress_to_identifier('0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF'): 'IMX',
+    'GENE': 'GENE',
+    strethaddress_to_identifier('0xC581b735A1688071A1746c968e0798D642EDE491'): 'EURT',
+    'LUNA-2': 'LUNA',
+    strethaddress_to_identifier('0x3392D8A60B77F8d3eAa4FB58F09d835bD31ADD29'): 'INDI',
+    strethaddress_to_identifier('0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6'): 'STG',
+    strethaddress_to_identifier('0x5c147e74D63B1D31AA3Fd78Eb229B65161983B2b'): 'WFLOW',
+    strethaddress_to_identifier('0x27702a26126e0B3702af63Ee09aC4d1A084EF628'): 'ALEPH',
+    evm_address_to_identifier('0x0f2D719407FdBeFF09D87557AbB7232601FD9F29', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'SYN',  # noqa: E501
+    evm_address_to_identifier('0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'LDO',  # noqa: E501
+    evm_address_to_identifier('0x08d967bb0134F2d07f7cfb6E246680c53927DD30', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'MATH',  # noqa: E501
+    evm_address_to_identifier('0xbC396689893D065F41bc2C6EcbeE5e0085233447', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'PERP',  # noqa: E501
+    evm_address_to_identifier('0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'SXP',  # noqa: E501
+    evm_address_to_identifier('0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'FXS',  # noqa: E501
+    evm_address_to_identifier('0x2ba592F78dB6436527729929AAf6c908497cB200', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'CREAM',  # noqa: E501
+    evm_address_to_identifier('0xa1faa113cbE53436Df28FF0aEe54275c13B40975', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'ALPHA',  # noqa: E501
+    evm_address_to_identifier('0xAC51066d7bEC65Dc4589368da368b212745d63E8', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'ALICE',  # noqa: E501
+    evm_address_to_identifier('0x3472A5A71965499acd81997a54BBA8D852C6E53d', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'BADGER',  # noqa: E501
+    evm_address_to_identifier('0x0D8775F648430679A709E98d2b0Cb6250d2887EF', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'BAT',  # noqa: E501
+    evm_address_to_identifier('0xAE12C5930881c53715B369ceC7606B70d8EB229f', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'C98',  # noqa: E501
+    evm_address_to_identifier('0x8e17ed70334C87eCE574C9d537BC153d8609e2a3', ChainID.BINANCE, EvmTokenKind.ERC20): 'WRX',  # noqa: E501
+    evm_address_to_identifier('0xD46bA6D942050d489DBd938a2C909A5d5039A161', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'AMPL',  # noqa: E501
+    evm_address_to_identifier('0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'MTA',  # noqa: E501
+    evm_address_to_identifier('0x43Dfc4159D86F3A37A5A4B3D4580b888ad7d4DDd', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'DODO',  # noqa: E501
+    evm_address_to_identifier('0xf8C3527CC04340b208C854E985240c02F7B7793f', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'FRONT',  # noqa: E501
+    evm_address_to_identifier('0xd1ba9BAC957322D6e8c07a160a3A8dA11A0d2867', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'HMT',  # noqa: E501
+    evm_address_to_identifier('0x3E9BC21C9b189C09dF3eF1B824798658d5011937', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'LINA',  # noqa: E501
+    evm_address_to_identifier('0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'MCB',  # noqa: E501
+    evm_address_to_identifier('0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'ORBS',  # noqa: E501
+    evm_address_to_identifier('0xfc82bb4ba86045Af6F327323a46E80412b91b27d', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'PROM',  # noqa: E501
+    evm_address_to_identifier('0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'REEF',  # noqa: E501
+    evm_address_to_identifier('0x0996bFb5D057faa237640E2506BE7B4f9C46de0B', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'RNDR',  # noqa: E501
+    evm_address_to_identifier('0x888888848B652B3E3a0f34c96E00EEC0F3a23F72', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'TLM',  # noqa: E501
+    evm_address_to_identifier('0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'TONCOIN',  # noqa: E501
+    evm_address_to_identifier('0x2C537E5624e4af88A7ae4060C022609376C8D0EB', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'TRYB',  # noqa: E501
+    evm_address_to_identifier('0x8564653879a18C560E7C0Ea0E084c516C62F5653', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'UBXT',  # noqa: E501
+    evm_address_to_identifier('0x915044526758533dfB918ecEb6e44bc21632060D', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'CHR',  # noqa: E501
+    evm_address_to_identifier('0x80C62FE4487E1351b47Ba49809EBD60ED085bf52', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'CLV',  # noqa: E501
+    evm_address_to_identifier('0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'CEL',  # noqa: E501
+    evm_address_to_identifier('0xB0c7a3Ba49C7a6EaBa6cD4a96C55a1391070Ac9A', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'MAGIC',  # noqa: E501
+    evm_address_to_identifier('0x4b13006980aCB09645131b91D259eaA111eaF5Ba', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'MYC',  # noqa: E501
+    evm_address_to_identifier('0x320623b8E4fF03373931769A31Fc52A4E78B5d70', ChainID.ETHEREUM, EvmTokenKind.ERC20): 'RSR',  # old token at 0x8762db106B2c2A0bccB3A80d1Ed41273552616E8  # noqa: E501
+}
+
+UNSUPPORTED_FTX_ASSETS = (
+    'AAPL',
+    'ABNB',
+    'ACB',
+    'AMC',
+    'AMD',
+    'AMZN',
+    'APHA',
+    'ASDBEAR',  # no cryptocompare/coingecko data
+    'ASDBULL',  # no cryptocompare/coingecko data
+    'ASDHALF',  # no cryptocompare/coingecko data
+    'ASDHEDGE',  # no cryptocompare/coingecko data
+    'ARKK',
+    'BABA',
+    'BB',
+    'BILI',
+    'BITO',  # no cryptocompare/coingecko data
+    'BITW',
+    'BNTX',
+    'DOGEBEAR2021',  # no cryptocompare/coingecko data
+    'MATICBEAR2021',  # no cryptocompare/coingecko data
+    'TOMOBEAR2021',  # no cryptocompare/coingecko data
+    'FB',
+    'GME',
+    'GOOGL',
+    'GRTBEAR',  # no cryptocompare/coingecko data
+    'GRTBULL',  # no cryptocompare/coingecko data
+    'KSHIB',  # kiloshiba no cryptocompare/coingecko data
+    'MSTR',
+    'NFLX',
+    'NOK',
+    'NVDA',
+    'PFE',
+    'PYPL',
+    'SLV',  # iShares Silver Trust
+    'SPY',
+    'SQ',
+    'TLRY',
+    'TSM',
+    'TSLA',
+    'TWTR',
+    'UBER',
+    'USO',
+    'ZM',
+    'DKNG',  # no cc/coingecko data https://twitter.com/FTX_Official/status/1404867122598072321
+    'ETHE',  # no cryptocompare/coingecko data
+    'GBTC',  # no cryptocompare/coingecko data
+    'GDX',  # no cryptocompare/coingecko data
+    'GDXJ',  # no cryptocompare/coingecko data
+    'GLD',  # no cryptocompare/coingecko data
+    'GLXY',  # no cryptocompare/coingecko data
+    'HOOD',  # no cryptocompare/coingecko data
+    'HUM'  # no cryptocompare/coingecko data
+    'MRNA',  # no cryptocompare/coingecko data
+    'PENN',  # no cryptocompare/coingecko data
+    'SECO',  # pool in bonfida
+    'ZECBULL',  # no cryptocompare/coingecko data
+    'ZECBEAR',  # no cryptocompare/coingecko data
+    'BYND',  # Beyond Meat Tokenized stock
+    'CGC',  # Trade Canopy Growth Corp Tokenized stock
+    'MRNA',  # Moderna Tokenized stock
+    'XRPMOON',  # no cryptocompare/coingecko data
+    'KBTT',  # no cryptocompare/coingecko data
+    'KSOS',  # no cryptocompare/coingecko data
+    'GALFAN',  # no cc/coingecko data
+    'APEAMC',  # no cc/coingecko data
+    'WAXL',  # no cc/coingecko data
+)

--- a/rotkehlchen/data_import/importers/rotki_trades.py
+++ b/rotkehlchen/data_import/importers/rotki_trades.py
@@ -5,15 +5,18 @@ from pathlib import Path
 from typing import Any
 
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
-from rotkehlchen.data_import.utils import BaseExchangeImporter
+from rotkehlchen.data_import.utils import (
+    BaseExchangeImporter,
+    process_rotki_generic_import_csv_fields,
+)
 from rotkehlchen.db.drivers.gevent import DBCursor
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_asset_amount, deserialize_timestamp
-from rotkehlchen.types import Fee, Location, Price, TimestampMS, TradeType
+from rotkehlchen.serialization.deserialize import deserialize_asset_amount
+from rotkehlchen.types import Price, TradeType
 from rotkehlchen.utils.misc import ts_ms_to_sec
 
 logger = logging.getLogger(__name__)
@@ -33,23 +36,16 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
         - KeyError
         - DivisionByZero if `amount_bought` is ZERO
         """
-        fee = Fee(deserialize_asset_amount(csv_row['Fee'])) if csv_row['Fee'] else None  # noqa: E501
-        fee_currency = (
-            symbol_to_asset_or_token(csv_row['Fee Currency'])
-            if csv_row['Fee Currency'] and fee is not None else None
-        )
         amount_sold = deserialize_asset_amount(csv_row['Sell Amount'])
         amount_bought = deserialize_asset_amount(csv_row['Buy Amount'])
-        location = Location.deserialize(csv_row['Location'])
+        asset, fee, fee_currency, location, timestamp = process_rotki_generic_import_csv_fields(csv_row, 'Base Currency')  # noqa: E501
         trade = Trade(
-            timestamp=ts_ms_to_sec(
-                TimestampMS(deserialize_timestamp(timestamp=csv_row['Timestamp'])),
-            ),
+            timestamp=ts_ms_to_sec(timestamp),
             location=location,
             fee=fee,
             fee_currency=fee_currency,
             rate=Price(amount_sold / amount_bought),
-            base_asset=symbol_to_asset_or_token(csv_row['Base Currency']),
+            base_asset=asset,
             quote_asset=symbol_to_asset_or_token(csv_row['Quote Currency']),
             trade_type=TradeType.SELL if csv_row['Type'] == 'Sell' else TradeType.BUY,
             amount=amount_bought,
@@ -71,18 +67,18 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
                         f'During rotki generic trades CSV import, found action with unknown '
                         f'asset {e.identifier}. Ignoring entry',
                     )
-                    continue
                 except DeserializationError as e:
                     self.db.msg_aggregator.add_warning(
                         f'Deserialization error during rotki generic trades CSV import. '
                         f'{e!s}. Ignoring entry',
                     )
-                    continue
                 except DivisionByZero:
                     self.db.msg_aggregator.add_warning(
                         f'During rotki generic trades import, csv row {row!s} has zero '
                         f'amount bought. Ignoring entry',
                     )
-                    continue
                 except KeyError as e:
                     raise InputError(f'Could not find key {e!s} in csv row {row!s}') from e
+
+                # if more logic is ever added here,
+                # `continue` must be placed at the end of all the exceptions handlers

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -1177,6 +1177,9 @@ class GlobalDBHandler:
                     log.error(f'Asset with identifier {entry[0]} has wrong asset type. {e!s}')
                     continue
 
+                if hasattr(asset, 'protocol') and asset.protocol == 'spam':
+                    continue
+
                 assets.append(asset)
 
         return assets


### PR DESCRIPTION
When doing a generic import of all of my trades, I get hundreds of unknown asset warnings for assets that Rotki does indeed support. This change improves the import by doing the following:
- If Location is one of the supported locations, use the asset mappings from that location
- Exclude spam tokens from list of results that might come from searching the DB for assets with the imported data symbol.

This change allows me to import my trades without skipping any rows due to unsupported asset warnings.

