### PR TITLE
ci: sets e2e test task timeout to 30 minutes

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -67,6 +67,7 @@ jobs:
         working-directory: ./frontend
         run: pnpm install --frozen-lockfile
       - name: Run e2e tests
+        timeout-minutes: 30
         env:
           CYPRESS_ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: pnpm run --filter rotki test:integration-ci --browser chrome


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Note

Tests should run between 7-15 minutes