### PR TITLE
Add windows nightly tests to discord notifier

### DIFF
--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -45,7 +45,7 @@ jobs:
   notify:
     name: 'Success check'
     if: ${{ always() }}
-    needs: [ 'linux', 'macos' ]
+    needs: [ 'linux', 'macos', 'windows' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Since #5168 was closed and all the windows tests were fixed, there have been no windows-specific failures in the windows nightly tests the last 4 nights, so I think it's safe to re-add them to the notifier bot.