### PR TITLE
fix: eth to eth2 setting is not used in asset breakdown

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Fix a bug where the ETH asset is not shown correctly in the location breakdown when the 'Treat ETH as ETH2' setting is activated.
 * :bug:`-` Improve date and hexadecimal address scrambling.
 
 * :release:`1.29.1 <2023-07-27>`

--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -698,6 +698,7 @@
     "LimitedParallelizationQueue": true,
     "truncateAddress": true,
     "truncationPoints": true,
-    "awaitParallelExecution": true
+    "awaitParallelExecution": true,
+    "groupAssetBreakdown": true
   }
 }

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -119,6 +119,7 @@ declare global {
   const getSortItems: typeof import('./utils/assets')['getSortItems']
   const getTags: typeof import('./utils/tags')['getTags']
   const getValidSelectorFromEvmAddress: typeof import('./utils/assets')['getValidSelectorFromEvmAddress']
+  const groupAssetBreakdown: typeof import('./utils/balances')['groupAssetBreakdown']
   const h: typeof import('vue')['h']
   const ignorableWatch: typeof import('@vueuse/core')['ignorableWatch']
   const indexedDb: typeof import('./utils/indexed-db')['default']
@@ -820,6 +821,7 @@ declare module 'vue' {
     readonly getSortItems: UnwrapRef<typeof import('./utils/assets')['getSortItems']>
     readonly getTags: UnwrapRef<typeof import('./utils/tags')['getTags']>
     readonly getValidSelectorFromEvmAddress: UnwrapRef<typeof import('./utils/assets')['getValidSelectorFromEvmAddress']>
+    readonly groupAssetBreakdown: UnwrapRef<typeof import('./utils/balances')['groupAssetBreakdown']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
     readonly ignorableWatch: UnwrapRef<typeof import('@vueuse/core')['ignorableWatch']>
     readonly indexedDb: UnwrapRef<typeof import('./utils/indexed-db')['default']>
@@ -1515,6 +1517,7 @@ declare module '@vue/runtime-core' {
     readonly getSortItems: UnwrapRef<typeof import('./utils/assets')['getSortItems']>
     readonly getTags: UnwrapRef<typeof import('./utils/tags')['getTags']>
     readonly getValidSelectorFromEvmAddress: UnwrapRef<typeof import('./utils/assets')['getValidSelectorFromEvmAddress']>
+    readonly groupAssetBreakdown: UnwrapRef<typeof import('./utils/balances')['groupAssetBreakdown']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
     readonly ignorableWatch: UnwrapRef<typeof import('@vueuse/core')['ignorableWatch']>
     readonly indexedDb: UnwrapRef<typeof import('./utils/indexed-db')['default']>

--- a/frontend/app/src/components/AssetBalances.vue
+++ b/frontend/app/src/components/AssetBalances.vue
@@ -134,7 +134,7 @@ const sortItems = getSortItems(asset => get(assetInfo(asset)));
     <template #expanded-item="{ item }">
       <table-expand-container visible :colspan="tableHeaders.length">
         <evm-native-token-breakdown
-          v-if="isEvmNativeToken(item.asset)"
+          v-if="!hideBreakdown && isEvmNativeToken(item.asset)"
           blockchain-only
           :identifier="item.asset"
         />
@@ -149,7 +149,7 @@ const sortItems = getSortItems(asset => get(assetInfo(asset)));
     <template #item.expand="{ item }">
       <row-expander
         v-if="
-          !hideBreakdown && (item.breakdown || isEvmNativeToken(item.asset))
+          item.breakdown || (!hideBreakdown && isEvmNativeToken(item.asset))
         "
         :expanded="expanded.includes(item)"
         @click="expanded = expanded.includes(item) ? [] : [item]"

--- a/frontend/app/src/components/EvmNativeTokenBreakdown.vue
+++ b/frontend/app/src/components/EvmNativeTokenBreakdown.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import groupBy from 'lodash/groupBy';
 import { type BigNumber } from '@rotki/common/lib';
 import { type DataTableHeader } from '@/types/vuetify';
-import { zeroBalance } from '@/utils/bignumbers';
-import { balanceSum, calculatePercentage } from '@/utils/calculation';
 import { CURRENCY_USD } from '@/types/currencies';
 
 const { t } = useI18n();
@@ -29,23 +26,9 @@ const { assetBreakdown } = useBalancesBreakdown();
 
 const breakdowns = computed(() => {
   const asset = get(identifier);
-  const data = get(blockchainOnly)
+  return get(blockchainOnly)
     ? get(getBlockchainBreakdown(asset))
     : get(assetBreakdown(asset));
-
-  const grouped = groupBy(data, 'location');
-
-  return Object.entries(grouped).map(([location, breakdown]) => {
-    const balance = zeroBalance();
-    return {
-      location,
-      balance: breakdown.reduce(
-        (previousValue, currentValue) =>
-          balanceSum(previousValue, currentValue.balance),
-        balance
-      )
-    };
-  });
 });
 
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -47,7 +47,7 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
     {
       text: t('deposits_withdrawals.headers.action'),
       value: 'category',
-      align: 'center',
+      align: overview ? 'start' : 'center',
       class: `text-no-wrap ${overview ? 'pl-0' : ''}`,
       cellClass: overview ? 'pl-0' : ''
     },
@@ -147,8 +147,8 @@ watch(loading, async (isLoading, wasLoading) => {
         {{ t('deposits_withdrawals.title') }}
       </navigator-link>
     </template>
-    <template #actions>
-      <v-row v-if="!locationOverview">
+    <template v-if="!locationOverview" #actions>
+      <v-row>
         <v-col cols="12" sm="6">
           <ignore-buttons
             :disabled="selected.length === 0 || loading"

--- a/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
+++ b/frontend/app/src/components/history/ledger-actions/LedgerActionContent.vue
@@ -250,8 +250,8 @@ watch(loading, async (isLoading, wasLoading) => {
           {{ t('ledger_actions.title') }}
         </navigator-link>
       </template>
-      <template #actions>
-        <v-row v-if="!locationOverview">
+      <template v-if="!locationOverview" #actions>
+        <v-row>
           <v-col cols="12" md="6">
             <v-row>
               <v-col cols="auto">

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -53,7 +53,7 @@ const tableHeaders = computed<DataTableHeader[]>(() => {
     {
       text: t('closed_trades.headers.action'),
       value: 'type',
-      align: 'center',
+      align: overview ? 'start' : 'center',
       class: `text-no-wrap ${overview ? 'pl-0' : ''}`,
       cellClass: overview ? 'pl-0' : ''
     },
@@ -305,8 +305,8 @@ watch(loading, async (isLoading, wasLoading) => {
           {{ t('closed_trades.title') }}
         </navigator-link>
       </template>
-      <template #actions>
-        <v-row v-if="!locationOverview">
+      <template v-if="!locationOverview" #actions>
+        <v-row>
           <v-col cols="12" md="6" class="d-flex">
             <div>
               <v-row>

--- a/frontend/app/src/components/locations/LocationAssets.vue
+++ b/frontend/app/src/components/locations/LocationAssets.vue
@@ -13,9 +13,8 @@ const { isTaskRunning } = useTaskStore();
 const { t } = useI18n();
 
 const { locationBreakdown: breakdown } = useBalancesBreakdown();
-const locationBreakdown: ComputedRef<AssetBalanceWithPrice[]> = computed(() =>
-  get(breakdown(get(identifier)))
-);
+const locationBreakdown: ComputedRef<AssetBalanceWithPrice[]> =
+  breakdown(identifier);
 
 const loadingData = computed<boolean>(
   () =>
@@ -28,6 +27,10 @@ const loadingData = computed<boolean>(
 <template>
   <card v-if="loadingData || locationBreakdown.length > 0" outlined-body>
     <template #title> {{ t('common.assets') }} </template>
-    <asset-balances :loading="loadingData" :balances="locationBreakdown" />
+    <asset-balances
+      :loading="loadingData"
+      :balances="locationBreakdown"
+      hide-breakdown
+    />
   </card>
 </template>

--- a/frontend/app/src/composables/balances/breakdown.ts
+++ b/frontend/app/src/composables/balances/breakdown.ts
@@ -1,4 +1,5 @@
 import { type AssetBalanceWithPrice, type BigNumber } from '@rotki/common';
+import { type MaybeRef } from '@vueuse/core';
 import { TRADE_LOCATION_BLOCKCHAIN } from '@/data/defaults';
 import { type AssetBreakdown } from '@/types/blockchain/accounts';
 
@@ -22,37 +23,36 @@ export const useBalancesBreakdown = () => {
 
   const assetBreakdown = (asset: string): ComputedRef<AssetBreakdown[]> =>
     computed(() =>
-      get(getBlockchainBreakdown(asset))
-        .concat(get(getManualBreakdown(asset)))
-        .concat(get(getExchangeBreakdown(asset)))
-        .sort((a, b) => sortDesc(a.balance.usdValue, b.balance.usdValue))
+      groupAssetBreakdown(
+        get(getBlockchainBreakdown(asset))
+          .concat(get(getManualBreakdown(asset)))
+          .concat(get(getExchangeBreakdown(asset)))
+      ).sort((a, b) => sortDesc(a.balance.usdValue, b.balance.usdValue))
     );
 
   const locationBreakdown = (
-    identifier: string
+    identifier: MaybeRef<string>
   ): ComputedRef<AssetBalanceWithPrice[]> =>
     computed(() => {
+      const id = get(identifier);
       let balances = mergeAssetBalances(
-        get(getManualLocationBreakdown(identifier)),
-        get(getExchangesLocationBreakdown(identifier))
+        get(getManualLocationBreakdown(id)),
+        get(getExchangesLocationBreakdown(id))
       );
 
-      if (identifier === TRADE_LOCATION_BLOCKCHAIN) {
+      if (id === TRADE_LOCATION_BLOCKCHAIN) {
         balances = mergeAssetBalances(
           balances,
           get(blockchainLocationBreakdown)
         );
       }
 
-      return Object.keys(balances)
-        .filter(asset => !get(isAssetIgnored(asset)))
-        .map(asset => ({
-          asset,
-          amount: balances[asset].amount,
-          usdValue: balances[asset].usdValue,
-          usdPrice: get(assetPrice(asset)) ?? NoPrice
-        }))
-        .sort((a, b) => sortDesc(a.usdValue, b.usdValue));
+      return toSortedAssetBalanceWithPrice(
+        balances,
+        asset => get(isAssetIgnored(asset)),
+        assetPrice,
+        true
+      );
     });
 
   const balancesByLocation: ComputedRef<Record<string, BigNumber>> = computed(

--- a/frontend/app/src/store/balances/exchanges.ts
+++ b/frontend/app/src/store/balances/exchanges.ts
@@ -61,16 +61,21 @@ export const useExchangeBalancesStore = defineStore(
         const cexBalances = get(exchangeBalances);
         for (const exchange in cexBalances) {
           const exchangeData = cexBalances[exchange];
-          if (!exchangeData[asset]) {
-            continue;
-          }
+          for (const exchangeDataAsset in exchangeData) {
+            const associatedAsset = get(
+              getAssociatedAssetIdentifier(exchangeDataAsset)
+            );
+            if (associatedAsset !== asset) {
+              continue;
+            }
 
-          breakdown.push({
-            address: '',
-            location: exchange,
-            balance: exchangeData[asset],
-            tags: []
-          });
+            breakdown.push({
+              address: '',
+              location: exchange,
+              balance: exchangeData[exchangeDataAsset],
+              tags: []
+            });
+          }
         }
         return breakdown;
       });

--- a/frontend/app/src/store/balances/manual.ts
+++ b/frontend/app/src/store/balances/manual.ts
@@ -113,7 +113,10 @@ export const useManualBalancesStore = defineStore('balances/manual', () => {
       const balances = get(manualBalances);
 
       for (const balance of balances) {
-        if (balance.asset !== asset) {
+        const associatedAsset = get(
+          getAssociatedAssetIdentifier(balance.asset)
+        );
+        if (associatedAsset !== asset) {
           continue;
         }
         breakdown.push({

--- a/frontend/app/src/utils/balances.ts
+++ b/frontend/app/src/utils/balances.ts
@@ -66,6 +66,30 @@ export const mergeAssetBalances = (
   return merged;
 };
 
+export const groupAssetBreakdown = (
+  breakdowns: AssetBreakdown[]
+): AssetBreakdown[] => {
+  const grouped = groupBy(breakdowns, 'location');
+
+  return Object.entries(grouped).map(
+    ([location, breakdown]: [
+      location: string,
+      breakdown: AssetBreakdown[]
+    ]) => {
+      const balance = zeroBalance();
+      return {
+        ...breakdown[0],
+        location,
+        balance: breakdown.reduce(
+          (previousValue, currentValue) =>
+            balanceSum(previousValue, currentValue.balance),
+          balance
+        )
+      };
+    }
+  );
+};
+
 export const appendAssetBalance = (
   value: AssetBalance,
   assets: AssetBalances,

--- a/frontend/app/tests/unit/specs/composables/balances/breakdown.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/balances/breakdown.spec.ts
@@ -1,0 +1,194 @@
+vi.mock('@/composables/assets/retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn().mockReturnValue({
+    assetInfo: vi.fn().mockImplementation(identifier => {
+      const collectionId = identifier.endsWith('USDC') ? 'USDC' : undefined;
+      return {
+        identifier,
+        evmChain: 'ethereum',
+        symbol: identifier,
+        isCustomAsset: false,
+        name: `Name ${identifier}`,
+        collectionId
+      };
+    })
+  })
+}));
+
+vi.mock('@/store/balances/manual', () => ({
+  useManualBalancesStore: vi.fn().mockReturnValue({
+    manualBalanceByLocation: ref([]),
+    getBreakdown: vi.fn().mockReturnValue(
+      computed(() => [
+        {
+          location: 'external',
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          },
+          address: '',
+          tags: null
+        },
+        {
+          location: 'kraken',
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          },
+          address: '',
+          tags: null
+        }
+      ])
+    ),
+    getLocationBreakdown: vi.fn().mockReturnValue(
+      computed(() => ({
+        ETH: {
+          amount: bigNumberify(1000),
+          usdValue: bigNumberify(1000)
+        },
+        aUSDC: {
+          amount: bigNumberify(2000),
+          usdValue: bigNumberify(2000)
+        },
+        bUSDC: {
+          amount: bigNumberify(1000),
+          usdValue: bigNumberify(1000)
+        }
+      }))
+    )
+  })
+}));
+
+vi.mock('@/store/balances/exchanges', () => ({
+  useExchangeBalancesStore: vi.fn().mockReturnValue({
+    getBreakdown: vi.fn().mockReturnValue(
+      computed(() => [
+        {
+          location: 'kraken',
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          },
+          address: '',
+          tags: null
+        }
+      ])
+    ),
+    getLocationBreakdown: vi.fn().mockReturnValue(
+      computed(() => ({
+        ETH: {
+          amount: bigNumberify(1000),
+          usdValue: bigNumberify(1000)
+        },
+        aUSDC: {
+          amount: bigNumberify(2000),
+          usdValue: bigNumberify(2000)
+        },
+        cUSDC: {
+          amount: bigNumberify(1000),
+          usdValue: bigNumberify(1000)
+        }
+      }))
+    ),
+    getByLocationBalances: vi.fn()
+  })
+}));
+
+vi.mock('@/composables/blockchain/account-balances/index', () => ({
+  useAccountBalances: vi.fn().mockReturnValue({
+    getBreakdown: vi.fn().mockReturnValue(
+      computed(() => [
+        {
+          location: 'ethereum',
+          address: '0xaddres',
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          },
+          tags: null
+        }
+      ])
+    )
+  })
+}));
+
+describe('composables::balances/breakdown', () => {
+  setActivePinia(createPinia());
+  let balancesBreakdown: ReturnType<typeof useBalancesBreakdown> =
+    useBalancesBreakdown();
+
+  beforeEach(() => {
+    balancesBreakdown = useBalancesBreakdown();
+  });
+
+  it('assetBreakdown', () => {
+    const assetBreakdown = balancesBreakdown.assetBreakdown('ETH');
+    const expectedResult = [
+      {
+        location: 'kraken',
+        balance: { amount: bigNumberify(2000), usdValue: bigNumberify(2000) },
+        address: '',
+        tags: null
+      },
+      {
+        location: 'ethereum',
+        address: '0xaddres',
+        balance: { amount: bigNumberify(1000), usdValue: bigNumberify(1000) },
+        tags: null
+      },
+      {
+        location: 'external',
+        balance: { amount: bigNumberify(1000), usdValue: bigNumberify(1000) },
+        address: '',
+        tags: null
+      }
+    ];
+
+    expect(get(assetBreakdown)).toMatchObject(expectedResult);
+  });
+
+  it('locationBreakdown', () => {
+    const { fetchedAssetCollections } = storeToRefs(useAssetCacheStore());
+    set(fetchedAssetCollections, {
+      USDC: {
+        name: 'USDC',
+        symbol: 'USDC'
+      }
+    });
+    const locationBreakdown = balancesBreakdown.locationBreakdown('kraken');
+    const expectedResult = [
+      {
+        asset: 'aUSDC',
+        amount: bigNumberify(6000),
+        usdValue: bigNumberify(6000),
+        usdPrice: bigNumberify(-1),
+        breakdown: [
+          {
+            asset: 'aUSDC',
+            amount: bigNumberify(4000),
+            usdValue: bigNumberify(4000),
+            usdPrice: bigNumberify(-1)
+          },
+          {
+            asset: 'bUSDC',
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000),
+            usdPrice: bigNumberify(-1)
+          },
+          {
+            asset: 'cUSDC',
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000),
+            usdPrice: bigNumberify(-1)
+          }
+        ]
+      },
+      {
+        asset: 'ETH',
+        amount: bigNumberify(2000),
+        usdValue: bigNumberify(2000),
+        usdPrice: bigNumberify(-1)
+      }
+    ];
+    expect(get(locationBreakdown)).toMatchObject(expectedResult);
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/blockchains/balances/index.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/blockchains/balances/index.spec.ts
@@ -44,7 +44,7 @@ vi.mock('@/store/tasks', () => ({
   })
 }));
 
-describe('store::blockchain/balances/index', () => {
+describe('composables::blockchain/balances/index', () => {
   setActivePinia(createPinia());
   let api: ReturnType<typeof useBlockchainBalancesApi> =
     useBlockchainBalancesApi();

--- a/frontend/app/tests/unit/specs/store/balances/exchanges.spec.ts
+++ b/frontend/app/tests/unit/specs/store/balances/exchanges.spec.ts
@@ -1,0 +1,201 @@
+import { SupportedExchange } from '@/types/exchanges';
+import { updateGeneralSettings } from '../../../utils/general-settings';
+
+describe('store::balances/manual', () => {
+  setActivePinia(createPinia());
+  const store: ReturnType<typeof useExchangeBalancesStore> =
+    useExchangeBalancesStore();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockBalances = {
+    kraken: {
+      ETH: {
+        amount: bigNumberify(1000),
+        usdValue: bigNumberify(1000)
+      },
+      ETH2: {
+        amount: bigNumberify(1000),
+        usdValue: bigNumberify(1000)
+      }
+    },
+    coinbase: {
+      ETH: {
+        amount: bigNumberify(2000),
+        usdValue: bigNumberify(2000)
+      },
+      ETH2: {
+        amount: bigNumberify(2000),
+        usdValue: bigNumberify(2000)
+      }
+    }
+  };
+
+  describe('computed', () => {
+    const { exchangeBalances } = storeToRefs(store);
+    set(exchangeBalances, mockBalances);
+
+    it('exchanges', () => {
+      const { exchanges } = storeToRefs(store);
+      const expectedResult = [
+        {
+          location: SupportedExchange.COINBASE,
+          balances: mockBalances.coinbase,
+          total: bigNumberify(4000)
+        },
+        {
+          location: SupportedExchange.KRAKEN,
+          balances: mockBalances.kraken,
+          total: bigNumberify(2000)
+        }
+      ];
+
+      expect(get(exchanges)).toMatchObject(expectedResult);
+    });
+
+    it('balances', () => {
+      const { balances } = storeToRefs(store);
+
+      const expectedResult = {
+        ETH: {
+          amount: bigNumberify(3000),
+          usdValue: bigNumberify(3000)
+        },
+        ETH2: {
+          amount: bigNumberify(3000),
+          usdValue: bigNumberify(3000)
+        }
+      };
+      expect(get(balances)).toMatchObject(expectedResult);
+    });
+
+    it('getBreakdown', () => {
+      const breakdown = store.getBreakdown('ETH');
+
+      updateGeneralSettings({
+        treatEth2AsEth: false
+      });
+
+      expect(get(breakdown)).toMatchObject([
+        {
+          address: '',
+          location: SupportedExchange.KRAKEN,
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          }
+        },
+        {
+          address: '',
+          location: SupportedExchange.COINBASE,
+          balance: {
+            amount: bigNumberify(2000),
+            usdValue: bigNumberify(2000)
+          }
+        }
+      ]);
+
+      updateGeneralSettings({
+        treatEth2AsEth: true
+      });
+
+      expect(get(breakdown)).toMatchObject([
+        {
+          address: '',
+          location: SupportedExchange.KRAKEN,
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          }
+        },
+        {
+          address: '',
+          location: SupportedExchange.KRAKEN,
+          balance: {
+            amount: bigNumberify(1000),
+            usdValue: bigNumberify(1000)
+          }
+        },
+        {
+          address: '',
+          location: SupportedExchange.COINBASE,
+          balance: {
+            amount: bigNumberify(2000),
+            usdValue: bigNumberify(2000)
+          }
+        },
+        {
+          address: '',
+          location: SupportedExchange.COINBASE,
+          balance: {
+            amount: bigNumberify(2000),
+            usdValue: bigNumberify(2000)
+          }
+        }
+      ]);
+    });
+
+    it('getLocationBreakdown', () => {
+      const sessionSettingsStore = useSessionSettingsStore();
+      const { connectedExchanges } = storeToRefs(sessionSettingsStore);
+
+      set(connectedExchanges, [
+        {
+          name: 'Kraken',
+          location: SupportedExchange.KRAKEN
+        },
+        {
+          name: 'Coinbase',
+          location: SupportedExchange.COINBASE
+        }
+      ]);
+
+      updateGeneralSettings({
+        treatEth2AsEth: false
+      });
+
+      const locationBreakdown = store.getLocationBreakdown(
+        SupportedExchange.KRAKEN
+      );
+
+      expect(get(locationBreakdown)).toMatchObject({
+        ETH: {
+          asset: 'ETH',
+          amount: bigNumberify(1000),
+          usdValue: bigNumberify(1000),
+          usdPrice: bigNumberify(-1)
+        },
+        ETH2: {
+          asset: 'ETH2',
+          amount: bigNumberify(1000),
+          usdValue: bigNumberify(1000),
+          usdPrice: bigNumberify(-1)
+        }
+      });
+
+      updateGeneralSettings({
+        treatEth2AsEth: true
+      });
+
+      expect(get(locationBreakdown)).toMatchObject({
+        ETH: {
+          asset: 'ETH',
+          amount: bigNumberify(2000),
+          usdValue: bigNumberify(2000),
+          usdPrice: bigNumberify(-1)
+        }
+      });
+    });
+
+    it('getByLocationBalances', () => {
+      const byLocationBalances = store.getByLocationBalances(bn => bn);
+
+      expect(get(byLocationBalances)).toMatchObject({
+        [SupportedExchange.COINBASE]: bigNumberify(4000),
+        [SupportedExchange.KRAKEN]: bigNumberify(2000)
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
