### PR TITLE
Fix debug export of PnL report

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 * :feature:`-` Transactions for adding, removing and changing owners threshold for a gnosis safe multisig will now be decoded properly.
 * :feature:`6033` Fix gas fee calculation for Optimism transactions to include L1 fees.
 * :bug:`-` ENS names that use the new RegistrarController and are renewed will have their events properly detected.
+* :bug:`-` Fixed an error that prevented from exporting the PnL report with debug information.
 * :bug:`-` Improve date and hexadecimal address scrambling.
 * :feature:`-` Arbitrum One support has been added. Balances will be shown, transactions pulled and decoded and taken into account in the PnL report.
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1565,7 +1565,7 @@ class RestAPI:
         debug_info = {
             'events': [entry.serialize_for_debug_import() for entry in events],
             'settings': settings.serialize(),
-            'ignored_events_ids': {k.serialize(): v for k, v in ignored_ids.items()},
+            'ignored_events_ids': {k.serialize(): list(v) for k, v in ignored_ids.items()},
             'pnl_settings': {
                 'from_timestamp': int(from_timestamp),
                 'to_timestamp': int(to_timestamp),

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -2,6 +2,7 @@ import random
 from contextlib import ExitStack
 from http import HTTPStatus
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ import requests
 from rotkehlchen.accounting.constants import FREE_PNL_EVENTS_LIMIT, FREE_REPORTS_LOOKUP_LIMIT
 from rotkehlchen.accounting.ledger_actions import LedgerAction, LedgerActionType
 from rotkehlchen.accounting.mixins.event import AccountingEventType
+from rotkehlchen.accounting.structures.types import ActionType
 from rotkehlchen.constants.assets import A_BTC, A_DAI, A_EUR
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.ledger_actions import DBLedgerActions
@@ -27,6 +29,7 @@ from rotkehlchen.tests.utils.api import (
     wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.constants import ETH_ADDRESS1, ETH_ADDRESS2, ETH_ADDRESS3
+from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.tests.utils.history import (
     assert_pnl_debug_import,
     prepare_rotki_for_history_processing_test,
@@ -36,6 +39,10 @@ from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.pnl_report import query_api_create_and_get_report
 from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TradeType
 from rotkehlchen.utils.misc import ts_now
+
+
+if TYPE_CHECKING:
+    from rotkehlchen.api.server import APIServer
 
 
 @pytest.mark.parametrize('have_decoders', [True])
@@ -337,9 +344,19 @@ def test_query_pnl_report_events_pagination_filtering(
             assert x['timestamp'] >= events[idx + 1]['timestamp']
 
 
-@pytest.mark.parametrize('ethereum_accounts', [])
-def test_history_debug_export(rotkehlchen_api_server):
+@pytest.mark.parametrize('ethereum_accounts', [[]])
+@pytest.mark.parametrize('have_decoders', [[True]])
+def test_history_debug_export(rotkehlchen_api_server: 'APIServer') -> None:
     """Check that the format of the data exported matches the expected type."""
+    tx_id = '10' + str(make_evm_tx_hash())
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    with rotki.data.db.user_write() as write_cursor:
+        rotki.data.db.add_to_ignored_action_ids(
+            write_cursor=write_cursor,
+            action_type=ActionType.EVM_TRANSACTION,
+            identifiers=[tx_id],
+        )
+
     expected_keys = ('events', 'settings', 'ignored_events_ids', 'pnl_settings')
     now = ts_now()
     response = requests.post(
@@ -353,8 +370,9 @@ def test_history_debug_export(rotkehlchen_api_server):
         },
     )
     result = assert_proper_response_with_result(response)
-    assert result.keys() == expected_keys
+    assert tuple(result.keys()) == expected_keys
     assert result['pnl_settings'] == {'from_timestamp': Timestamp(0), 'to_timestamp': now}
+    assert result['ignored_events_ids'] == {'evm_transaction': [tx_id]}
 
 
 @pytest.mark.parametrize('mocked_price_queries', [prices])


### PR DESCRIPTION
For the debug export we were retrieving the ignored events that is a mapping of str to set and set is not json serializable. Since we weren't converting to a serializable object the report couldn't be exported.
