### PR TITLE
Account for MEV rewards in the accounting process

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 * :feature:`-` DIVA token airdrop claim and delegations are now properly shown in the decoded history events.
 * :feature:`-` Transactions for adding, removing and changing owners threshold for a gnosis safe multisig will now be decoded properly.
 * :feature:`6033` Fix gas fee calculation for Optimism transactions to include L1 fees.
+* :bug:`-` Fix and issue where MEV rewards could not be correctly accounted and exported in the CSV summary.
 * :bug:`-` ENS names that use the new RegistrarController and are renewed will have their events properly detected.
 * :bug:`-` Fixed an error that prevented from exporting the PnL report with debug information.
 * :bug:`-` Improve date and hexadecimal address scrambling.

--- a/rotkehlchen/accounting/structures/eth2.py
+++ b/rotkehlchen/accounting/structures/eth2.py
@@ -322,11 +322,10 @@ class EthBlockEvent(EthStakingEvent):
             accounting: 'AccountingPot',
             events_iterator: Iterator['AccountingEventMixin'],  # pylint: disable=unused-argument
     ) -> int:
-        """For block production events we should consume all 3 possible events directly here
-        so that we do not double count anything"""
-        if self.sequence_index == 1:
-            return 1  # this is always the block production mev reward, so ignore
-
+        """
+        For block production events we should consume all 3 possible events directly here
+        so that we do not double count anything
+        """
         with accounting.database.conn.read_ctx() as cursor:
             accounts = accounting.database.get_blockchain_accounts(cursor)
 
@@ -347,28 +346,7 @@ class EthBlockEvent(EthStakingEvent):
             amount=self.balance.amount,
             taxable=True,
         )
-
-        consumed = 1
-        if self.sequence_index == 0:  # the first event drives what else is consumed
-            event_seq1 = next(events_iterator, None)
-            if event_seq1 is None:
-                return consumed
-            if not isinstance(event_seq1, HistoryBaseEntry):  # not a base event. Just consume
-                consumed += event_seq1.process(accounting, events_iterator)
-                return consumed
-
-            if event_seq1.event_identifier == self.event_identifier:
-                # this is the block production mev reward so there is probably transaction receive after it  # noqa: E501
-                consumed += 1  # we skip it
-                event_seq2 = next(events_iterator, None)
-                if event_seq2 is None:
-                    return consumed  # mev block production event without transaction receive
-                # consume it no matter if it's block production or other kind of event
-                consumed += event_seq2.process(accounting, events_iterator)
-            else:  # just consume it -- is another event
-                consumed += event_seq1.process(accounting, events_iterator)
-
-        return consumed
+        return 1
 
 
 class EthDepositEvent(EvmEvent, EthStakingEvent):

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -439,6 +439,8 @@ class EventsHistorian:
                 self.msg_aggregator.add_error(
                     f'Eth2 events are not included in the PnL report due to {e!s}',
                 )
+            # make sure that eth2 events and history events are combined
+            eth2.combine_block_with_tx_events()
 
         step = self._increase_progress(step, total_steps)
         self.processing_state_name = 'Querying base history events'

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -348,7 +348,7 @@ def test_query_pnl_report_events_pagination_filtering(
 @pytest.mark.parametrize('have_decoders', [[True]])
 def test_history_debug_export(rotkehlchen_api_server: 'APIServer') -> None:
     """Check that the format of the data exported matches the expected type."""
-    tx_id = '10' + str(make_evm_tx_hash())
+    tx_id = '10' + str(make_evm_tx_hash())  # add a random tx id to the ignore list to ensure that at least one kind of event is ignored and is not empty  # noqa: E501
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     with rotki.data.db.user_write() as write_cursor:
         rotki.data.db.add_to_ignored_action_ids(


### PR DESCRIPTION
A user reported in discord that MEV rewards didn't appear correctly in the CSV summary. What I found is that we assumed in the code that there was a evm event with a receive of the MEV from the builder but in ae358d2956ed121ae53eb54580fefc48279d41be we changed this and now events are combined.

What I did was:
1. Make sure that events are combined before running the PnL report
2. Allow to process evm events normally

Now block events appear correctly in the report:

```
history event,Withdrawal of 0.013652776 ETH from validator 611330. Only 0.013652776 is profit,ethereum,14/06/2023 04:49:59 CEST,ETH,0,0.013652776,1650.7,0,0,,
history event,Block reward of 0.044215575898091043 for block 17478946,ethereum,14/06/2023 17:03:47 CEST,ETH,0,0.044215575898091043,1650.7,0,0,,
history event,Mev reward of 0.10266515239310775 for block 17479280,ethereum,14/06/2023 18:11:11 CEST,ETH,0,0.10266515239310775,1650.7,0,0,,
history event,Mev reward of 0.051410693634587231 for block 17479558,ethereum,14/06/2023 19:07:23 CEST,ETH,0,0.051410693634587231,1650.7,0,0,,
```

(these are 4 different events related to block production)