### PR TITLE
Bump VCR version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ pytest-freezer==0.4.8
 git+https://github.com/rotki/pytest-deadfixtures@87d2be8#egg=pytest-deadfixtures # temporarily due to false positive
 pytest-socket==0.6.0
 pytest-vcr==1.0.2
-vcrpy==4.3.1
+vcrpy==5.1.0
 freezegun==1.2.2
 flaky==3.7.0
 


### PR DESCRIPTION
In the old version there seems to be a bug that was leaking requests to the urllib module instead of using the mocked version

