### PR TITLE
Use a requirements file for packaging 

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           echo "::group::packaging dependencies"
           pip3 install --upgrade pip==${{ env.PIP_VERSION }}
-          pip3 install packaging wheel setuptools-scm
+          pip3 install -r requirements_packaging.txt
           echo "::endgroup::"
           ./package.py --build full
       - name: Upload files
@@ -173,7 +173,7 @@ jobs:
           pip3 install virtualenv
           python3 -m virtualenv ~/venv
           source ~/venv/bin/activate
-          pip3 install packaging wheel setuptools-scm
+          pip3 install -r requirements_packaging.txt
           echo "::endgroup::"
           ./package.py --build full
         env:
@@ -256,7 +256,7 @@ jobs:
         run: |
           echo ::group::"packaging dependencies"          
           pip3 install --upgrade pip==${{ env.PIP_VERSION }}
-          pip3 install packaging wheel setuptools-scm
+          pip3 install -r requirements_packaging.txt
           echo ::endgroup::
           python .\package.py --build full
         shell: powershell

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -146,7 +146,7 @@ jobs:
         run: |
           echo "::group::packaging dependencies"
           pip3 install --upgrade pip==${{ env.PIP_VERSION }}
-          pip3 install packaging wheel setuptools-scm
+          pip3 install -r requirements_packaging.txt
           echo "::endgroup::"
           ./package.py --build full
       - name: Upload to release
@@ -261,7 +261,7 @@ jobs:
           pip3 install virtualenv
           python3 -m virtualenv ~/venv
           source ~/venv/bin/activate
-          pip3 install packaging wheel setuptools-scm
+          pip3 install -r requirements_packaging.txt
           echo "::endgroup::"
           ./package.py --build full
         env:
@@ -341,7 +341,7 @@ jobs:
         run: |
           echo ::group::"packaging dependencies"
           pip3 install --upgrade pip==${{ env.PIP_VERSION }}
-          pip3 install packaging wheel setuptools-scm
+          pip3 install -r requirements_packaging.txt
           echo ::endgroup::
           python .\package.py --build full
         shell: powershell

--- a/requirements_packaging.txt
+++ b/requirements_packaging.txt
@@ -1,0 +1,3 @@
+packaging==23.1
+setuptools-scm==7.1.0
+wheel==0.40.0


### PR DESCRIPTION
Puts the required list packages for packaging (by `package.py`):
- packaging
- setuptools-scm
- wheel

in a `requirements_packaging.txt` file.

