### PR TITLE
fix: asset breakdown in account balance table

### DIFF
--- a/frontend/app/src/composables/balances/account-details.ts
+++ b/frontend/app/src/composables/balances/account-details.ts
@@ -82,7 +82,7 @@ export const useAccountDetails = (
       totalLoopringBalances = Object.entries(loopringBalance).length;
     }
 
-    return totalAssets + totalLiabilities + totalLoopringBalances > 1;
+    return totalAssets + totalLiabilities + totalLoopringBalances > 0;
   };
 
   const getLoopringBalances = (


### PR DESCRIPTION
Fix this issue
<img width="1133" alt="image" src="https://github.com/rotki/rotki/assets/26648140/b045151a-cac8-4db5-90e2-1470a3cc56fe">

So for exampe in arbitrum table, this address only has 1 token (ARB), and 0 balance in ETH.
