### PR TITLE
Fix newer deposits of optimism bridge

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -1349,7 +1349,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
     def _get_pruned_check_tx_hash(self) -> EVMTxHash:
         """Returns a transaction hash that can used for checking whether a node is pruned."""
 
-    def _additional_receipt_processing(self, tx_receipt: Optional[dict[str, Any]]) -> None:  # noqa: B027 E501
+    def _additional_receipt_processing(self, tx_receipt: dict[str, Any]) -> None:  # noqa: B027 E501
         """Performs additional tx_receipt processing where necessary"""
 
 

--- a/rotkehlchen/chain/optimism/node_inquirer.py
+++ b/rotkehlchen/chain/optimism/node_inquirer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from eth_typing import BlockNumber
 
@@ -8,6 +8,7 @@ from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirerWithDSProxy
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.externalapis.utils import maybe_read_integer
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -18,7 +19,7 @@ from rotkehlchen.types import (
     SupportedBlockchain,
     Timestamp,
 )
-from rotkehlchen.utils.misc import hexstr_to_int
+
 from .constants import (
     ARCHIVE_NODE_CHECK_ADDRESS,
     ARCHIVE_NODE_CHECK_BLOCK,
@@ -65,7 +66,7 @@ class OptimismInquirer(EvmNodeInquirerWithDSProxy):
         )
         self.etherscan = cast(OptimismEtherscan, self.etherscan)
 
-    def _additional_receipt_processing(self, tx_receipt: Optional[dict[str, Any]]) -> None:
+    def _additional_receipt_processing(self, tx_receipt: dict[str, Any]) -> None:
         """Performs additional tx_receipt processing where necessary
 
         May raise:
@@ -73,7 +74,7 @@ class OptimismInquirer(EvmNodeInquirerWithDSProxy):
             type is given.
             - KeyError if tx_receipt has no l1Fee entry
         """
-        tx_receipt['l1Fee'] = hexstr_to_int(tx_receipt['l1Fee'])  # type: ignore[index]
+        tx_receipt['l1Fee'] = maybe_read_integer(data=tx_receipt, key='l1Fee', api='web3 optimism')
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/externalapis/utils.py
+++ b/rotkehlchen/externalapis/utils.py
@@ -31,3 +31,12 @@ def read_integer(data: dict[str, Any], key: str, api: str = DEFAULT_API) -> int:
             f'Failed to read {key} as an integer during {api} transaction query',
         ) from e
     return result
+
+
+def maybe_read_integer(data: dict[str, Any], key: str, api: str = DEFAULT_API, default_value: int = 0) -> int:  # noqa: E501
+    try:
+        result = read_integer(data=data, key=key, api=api)
+    except KeyError:
+        result = default_value
+
+    return result

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.optimism.types import OptimismTransaction
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.errors.serialization import ConversionError, DeserializationError
-from rotkehlchen.externalapis.utils import read_hash, read_integer
+from rotkehlchen.externalapis.utils import maybe_read_integer, read_hash, read_integer
 from rotkehlchen.fval import AcceptableFValInitInput, FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import (
@@ -608,7 +608,7 @@ def deserialize_evm_transaction(
         if chain_id == ChainID.OPTIMISM and evm_inquirer is not None:
             if not raw_receipt_data:
                 raw_receipt_data = evm_inquirer.get_transaction_receipt(tx_hash)
-            l1_fee = read_integer(raw_receipt_data, 'l1Fee', source)
+            l1_fee = maybe_read_integer(raw_receipt_data, 'l1Fee', source)
             return OptimismTransaction(
                 timestamp=timestamp,
                 chain_id=chain_id,


### PR DESCRIPTION
For those ones l1Fee was missing from the receipt, since it was 0. But the code always assumed l1Fee would be there. This commit fixes this.
