### PR TITLE
Add hook for content_hash

### DIFF
--- a/tools/pyinstaller_hooks/hook-content_hash.py
+++ b/tools/pyinstaller_hooks/hook-content_hash.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('content_hash')


### PR DESCRIPTION
ENS decoder was failing to load because `content_hash` was not properly picked up by pyinstaller. There are several submodules that need to be imported and they were not automatically imported.

The reason this got unnoticed is because we suppress the module not found error when loading the decoders and this is the same error that was appearing due to the missing lib