### PR TITLE
Third time is the charm

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Changelog
 * :feature:`-` The balances snapshot csv file exported from rotki now contains an asset symbol column.
 * :bug:`-` Remote errors should no longer affect the ethereum staking deposits decoded event view.
 * :bug:`-` Newer deposits to zksync lite should be decoded properly in the history events view.
+* :bug:`5038` The rare error some premium users got: "Plaintext DB is locked" should no longer happen.
+
 
 * :release:`1.29.1 <2023-07-27>`
 * :bug:`-` Fix a bug where some images indicating the location of the assets are not loaded.

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -16,6 +16,7 @@ from rotkehlchen.errors.api import (
 )
 from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.tests.utils.constants import A_GBP, DEFAULT_TESTS_MAIN_CURRENCY
+from rotkehlchen.tests.utils.factories import make_ethereum_event, make_ethereum_transaction
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.premium import (
     VALID_PREMIUM_KEY,
@@ -481,9 +482,13 @@ def test_premium_toggle_chains_aggregator(blockchain, rotki_premium_credentials)
 
 @pytest.mark.parametrize('sql_vm_instructions_cb', [10])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-def test_upload_data_to_server_big_db(rotkehlchen_instance):
+def test_upload_data_to_server_db_already_in_use(rotkehlchen_instance):
     """Test that if the server has bigger DB size and context switch happens it
     all works out. Essentially a test for https://github.com/rotki/rotki/issues/5038
+    where the DB is already in use error occurs.
+
+    This can happen if we get into maybe_upload_data_to_server from 2 different greenlets and reach the export code from both. The solution was to add a lock in the
+    entire maybe_upload_data_to_server.
 
     We emulate bigger size by just lowering sql_vm_instructions_cb to force a context switch
     """
@@ -513,6 +518,68 @@ def test_upload_data_to_server_big_db(rotkehlchen_instance):
         a = gevent.spawn(rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server)
         b = gevent.spawn(rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server)
         greenlets = [a, b]
+        gevent.joinall(greenlets)
+        for g in greenlets:
+            assert g.exception is None, f'One of the greenlets had an exception: {g.exception}'
+        # The upload mock should not have been called since the hash is the same
+        assert not put_mock.called
+
+
+@pytest.mark.parametrize('sql_vm_instructions_cb', [20])
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_upload_data_to_server_db_locked(rotkehlchen_instance):
+    """Test that if the server has big DB size and context switch happens it
+    all works out. Essentially a test for https://github.com/rotki/rotki/issues/5038
+    where the DB is locked part occurs.
+
+    This can occur when there is a context switch between ATTACH/DETACH of the
+    exported plaintext DB and a transaction is somehow open and stays open in
+    another greenlet.
+
+    We emulate bigger size by just lowering sql_vm_instructions_cb to force a context switch
+    """
+
+    db = rotkehlchen_instance.data.db
+
+    def function_to_context_switch_to():
+        """This is the function that export_unencrypted should context switch to.
+        When the error occured any detach or other operation here would result
+        in database is locked.
+
+        So to check this does not happen we make sure that when we come here
+        the plaintext DB is not attached. Which is also the fix. To make that
+        export occur under a critical section
+        """
+        result = db.conn.execute('SELECT * FROM pragma_database_list;')
+        assert len(result.fetchall()) == 1, 'the plaintext DB should not be attached here'
+
+    with db.user_write() as cursor:
+        last_ts = rotkehlchen_instance.data.db.get_setting(cursor, name='last_data_upload_ts')
+        assert last_ts == 0
+        # Write anything in the DB to set a non-zero last_write_ts
+        rotkehlchen_instance.data.db.set_settings(cursor, ModifiableDBSettings(main_currency=A_EUR))  # noqa:
+
+    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db()
+    remote_hash = get_different_hash(our_hash)
+
+    patched_put = patch.object(
+        rotkehlchen_instance.premium.session,
+        'put',
+        return_value=None,
+    )
+    patched_get = create_patched_requests_get_for_premium(
+        session=rotkehlchen_instance.premium.session,
+        metadata_last_modify_ts=0,
+        metadata_data_hash=remote_hash,
+        # larger DB than ours
+        metadata_data_size=9999999999,
+        saved_data='foo',
+    )
+
+    greenlets = []
+    with patched_get, patched_put as put_mock:
+        greenlets.append(gevent.spawn(rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server))
+        greenlets.append(gevent.spawn(function_to_context_switch_to))
         gevent.joinall(greenlets)
         for g in greenlets:
             assert g.exception is None, f'One of the greenlets had an exception: {g.exception}'

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -16,7 +16,6 @@ from rotkehlchen.errors.api import (
 )
 from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.tests.utils.constants import A_GBP, DEFAULT_TESTS_MAIN_CURRENCY
-from rotkehlchen.tests.utils.factories import make_ethereum_event, make_ethereum_transaction
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.premium import (
     VALID_PREMIUM_KEY,
@@ -487,8 +486,9 @@ def test_upload_data_to_server_db_already_in_use(rotkehlchen_instance):
     all works out. Essentially a test for https://github.com/rotki/rotki/issues/5038
     where the DB is already in use error occurs.
 
-    This can happen if we get into maybe_upload_data_to_server from 2 different greenlets and reach the export code from both. The solution was to add a lock in the
-    entire maybe_upload_data_to_server.
+    This can happen if we get into maybe_upload_data_to_server from 2 different greenlets
+    and reach the export code from both.
+    The solution was to add a lock in the entire maybe_upload_data_to_server.
 
     We emulate bigger size by just lowering sql_vm_instructions_cb to force a context switch
     """
@@ -557,7 +557,7 @@ def test_upload_data_to_server_db_locked(rotkehlchen_instance):
         last_ts = rotkehlchen_instance.data.db.get_setting(cursor, name='last_data_upload_ts')
         assert last_ts == 0
         # Write anything in the DB to set a non-zero last_write_ts
-        rotkehlchen_instance.data.db.set_settings(cursor, ModifiableDBSettings(main_currency=A_EUR))  # noqa:
+        rotkehlchen_instance.data.db.set_settings(cursor, ModifiableDBSettings(main_currency=A_EUR))  # noqa: E501
 
     _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db()
     remote_hash = get_different_hash(our_hash)


### PR DESCRIPTION

### [Fix DB plaintext locked -- third try](https://github.com/rotki/rotki/commit/5dece5ffa9bb148506154869dad5f85727e5675b) 

Fix https://github.com/rotki/rotki/issues/5038 ... for the third time.

The idea is to put the entire export unencrypted DB under a critical
DB section.

It's needed because a context switch
from inside this execute script can result in:
1. coming into this code again from another greenlet which can result
to DB plaintext already in use
2. Having a DB transaction open between the attach and detach and not
closed when we detach which will result in DB plaintext locked.

### [Remove the upload_lock from maybe_upload_data_to_server](https://github.com/rotki/rotki/commit/ea0689def6c37979fc32edc9e69481609d28d498)

### [Do not constantly retry uploads. Only try an upload per hour](https://github.com/rotki/rotki/commit/9819996bd76600f4259b616c82d6e3894aa52070) 

Forcing an upload via the UI will still work.