### PR TITLE
Fix missing gitcoin donations in optimism

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Fix an issue where certain gitcoin donations were not detected in optimism and where the big transfer to the contract which later splits into the donations was mistakenly kept.
+
 * :release:`1.30.0 <2023-08-17>`
 * :feature:`6444` Users will now be able to see the asset graph in asset collection view.
 * :feature:`6274` Staking events from cointracking CSV can now be imported properly
@@ -14,15 +16,15 @@ Changelog
 * :feature:`-` Users will now be able to check their addresses able to claim the DIVA airdrop.
 * :feature:`-` DIVA token airdrop claim and delegations are now properly shown in the decoded history events.
 * :feature:`-` Transactions for adding, removing and changing owners threshold for a gnosis safe multisig will now be decoded properly.
-* :bug:`-` Fix and issue where MEV rewards could not be correctly accounted and exported in the CSV summary.
+* :bug:`-` Fix an issue where MEV rewards could not be correctly accounted and exported in the CSV summary.
 * :bug:`-` ENS names that use the new RegistrarController and are renewed will have their events properly detected.
 * :bug:`-` Fixed an error that prevented from exporting the PnL report with debug information.
 * :bug:`-` Fixed an error affecting compound decoders where having more than one asset with the same symbol made the decoding fail.
 * :bug:`-` Fix a bug where the ETH asset is not shown correctly in the location breakdown when the 'Treat ETH as ETH2' setting is activated.
 * :bug:`-` Improve date and hexadecimal address scrambling.
 * :bug:`-` Fix an error affecting the events pagination for non premium users.
-* :feature:`-` Arbitrum One support has been added. Balances will be shown, transactions pulled and decoded and taken into account in the PnL report.
-* :feature:`-` The balances snapshot csv file exported from rotki now contains an asset symbol column.
+* :feature:`3420` Arbitrum One support has been added. Balances will be shown, transactions pulled and decoded and taken into account in the PnL report.
+* :feature:`6454` The balances snapshot csv file exported from rotki now contains an asset symbol column.
 * :bug:`-` Remote errors should no longer affect the ethereum staking deposits decoded event view.
 * :bug:`-` Newer deposits to zksync lite should be decoded properly in the history events view.
 * :bug:`-` Using SVG icons for assets will now work.

--- a/rotkehlchen/chain/optimism/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/gitcoin/decoder.py
@@ -31,5 +31,13 @@ class GitcoinDecoder(GitcoinV2CommonDecoder):
             ],
             voting_impl_addresses=[
                 string_to_evm_address('0x99906Ea77C139000681254966b397a98E4bFdE21'),
+                string_to_evm_address('0x6526B0942E171A933Fd9aF90C993d9c547251042'),
+                string_to_evm_address('0x8dE199ec70057A324053E454741997F2A99FE771'),
+                string_to_evm_address('0x201bF28933bdbe7c7ddde85D26646b524D4830DD'),
+                string_to_evm_address('0xFc78164b7Ae88ae0F1394A94868E6172E84928D1'),
+                string_to_evm_address('0xeE14BFf31165D23422a989201Db4cF70a420B5F0'),
+                string_to_evm_address('0x390664d7951AD78B1dE1E733016B9A9b2F0007e9'),
+                string_to_evm_address('0xCf065AA4a2870f9D762FaF2f9d760fbB174C6449'),
+                string_to_evm_address('0x1444D2837BDFfc409B66bD6BEeb38784e82F57ff'),
             ],
         )


### PR DESCRIPTION
Taking this huge transaction as an example it was noticed that multiple donations were missing:
https://optimistic.etherscan.io/tx/0x5d85b436f5f177de6019baa9ecebae285e0def4924546307fac40556bece4cd7

This was due to not having many voting_impl addresses in the decoder. This is unfortunately a manual process which will need fixing often.

Also fixed a problem in the decoder where the original big transfer of the token to the contract for splitting was not removed.

Before:

https://github.com/rotki/rotki/assets/1658405/60821f04-c211-4977-bc23-87f7b6684987

Now:

https://github.com/rotki/rotki/assets/1658405/f6adf8f5-580c-4d3c-b1ab-30137e5f90e1

