### PR TITLE
Hide zero balance on asset breakdown

### DIFF
--- a/frontend/app/src/composables/balances/breakdown.ts
+++ b/frontend/app/src/composables/balances/breakdown.ts
@@ -27,6 +27,7 @@ export const useBalancesBreakdown = () => {
         get(getBlockchainBreakdown(asset))
           .concat(get(getManualBreakdown(asset)))
           .concat(get(getExchangeBreakdown(asset)))
+          .filter(item => !item.balance.amount.isZero())
       )
     );
 

--- a/frontend/app/src/composables/blockchain/account-balances/index.ts
+++ b/frontend/app/src/composables/blockchain/account-balances/index.ts
@@ -90,6 +90,7 @@ export const useAccountBalances = () => {
       get(ethStore.getBreakdown(asset))
         .concat(get(btcStore.getBreakdown(asset)))
         .concat(get(chainStore.getBreakdown(asset)))
+        .filter(item => !item.balance.amount.isZero())
     );
 
   return {


### PR DESCRIPTION
Fix this issue:
![image](https://github.com/rotki/rotki/assets/26648140/5c1890be-ca26-43c0-9dd0-ef8993799370)
