### PR TITLE
Add a websocket message that provides DB upload result info

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -267,3 +267,26 @@ If at some point backend detects that balances need to be refreshed, it will sen
 
 - ``type``: Balances section that needs a refresh. Valid values are: ``blockchain_balances``.
 - ``blockchain``: Returned only for section: ``blockchain_balances``. The blockchain for which balances need to be refreshed. Valid values are: ``optimism``, ``eth``.
+
+
+Premium Database Upload result
+========================================
+
+Whenever the backend attempts to upload a premium user DB there can be various reasons it did not upload. Either errors (non-actionable) or safety limits (actionable -- can be force pushed).  We use this websocket message to communicate to the frontend.
+
+::
+
+    {
+        "type": "database_upload_result",
+        "data": {
+            "uploaded": False,
+	    "actionable": True,
+            "message": "Remote database bigger than the local one"
+        }
+    }
+
+
+- ``uploaded``: A boolean, denoting if the premium database upload happened or not.
+- ``actionable``: If ``uploaded`` is false, then this explains if the reason it did not upload is something actionable that could be solved by force pushing. If True, then
+  that means it failed to upload for something like remote database being more recent than local or bigger than local etc. If false it's a bad error like "could not contact the server" in which case force pushing won't help.
+- ``message``: If ``uploaded`` is false, then this is a user facing message to explain why. IF ``uploaded`` is true this will be ``null``.

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -22,6 +22,7 @@ class WSMessageType(Enum):
     MISSING_API_KEY = auto()
     HISTORY_EVENTS_STATUS = auto()
     REFRESH_BALANCES = auto()
+    DATABASE_UPLOAD_RESULT = auto()
 
     def __str__(self) -> str:
         return self.name.lower()  # pylint: disable=no-member

--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -80,16 +80,10 @@ def update_spam_assets(db: 'DBHandler', assets_info: list[dict[str, Any]]) -> in
     with db.conn.read_ctx() as cursor:
         ignored_asset_ids = db.get_ignored_asset_ids(cursor)
 
-    write_data = []
-    for token in spam_tokens:
-        if token.identifier in ignored_asset_ids:
-            continue
-
-        write_data.append(('ignored_asset', token.identifier))
-
     with db.user_write() as write_cursor:
         write_cursor.executemany(
-            'INSERT OR IGNORE INTO multisettings(name, value) VALUES(?, ?)', write_data,
+            'INSERT OR IGNORE INTO multisettings(name, value) VALUES(?, ?)',
+            [('ignored_asset', x.identifier) for x in spam_tokens if x.identifier not in ignored_asset_ids],  # noqa: E501
         )
         assets_added = write_cursor.rowcount
 

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -91,7 +91,7 @@ class RotkiDataUpdater:
                 updates = query_file(file_url, True)
             except RemoteError as e:
                 log.warning(f'Failed to update {update_type.value} due to {e!s}')
-                continue  # perhaps broken file? Skipping
+                continue  # perhaps broken link? Skipping
 
             updated_data = updates.get(update_type.value)
             if updated_data is None:


### PR DESCRIPTION
We now have a way to provide information to the user for the periodic DB upload task and let the know if something went wrong or if they can do something to force push (if they are absolutely sure).

Backend part of #6533
