### PR TITLE
Fix error key for messages from the rotki api

### DIFF
--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -83,7 +83,7 @@ def _process_dict_response(
         raise RemoteError('Could not decode rotki server response as json. Check logs') from e
 
     if response.status_code == HTTPStatus.UNAUTHORIZED:
-        raise PremiumAuthenticationError(result_dict.get('message', 'no message given'))
+        raise PremiumAuthenticationError(result_dict.get('error', 'no message given'))
 
     if 'error' in result_dict:
         raise RemoteError(result_dict['error'])


### PR DESCRIPTION
The API returns

```
    response = make_response((
        json.dumps({"error": error}),
        status_code,
        {'mimetype': 'application/json', 'Content-Type': 'application/json'},
    ))
```


