### PR TITLE
Removes the update curve cache task

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -455,7 +455,6 @@ class Rotkehlchen:
             deactivate_premium=self.deactivate_premium_status,
             activate_premium=self.activate_premium_status,
             query_balances=self.query_balances,
-            update_curve_pools_cache=self.chains_aggregator.ethereum.assure_curve_cache_is_queried_and_decoder_updated,  # noqa: E501
             msg_aggregator=self.msg_aggregator,
             data_updater=self.data_updater,
             username=user,


### PR DESCRIPTION
* The cache is updated on demand by the reload_data method of the ReloadableDecoderMixin decoders (decoders that need data from the cache) whenever an undecoded event needs to be decoded. Curve's decoder is one of them so there is no need for an additional task that updates the curve related cache tables.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
