### PR TITLE
Upgrade sphinx to 7.2.5 now that rtd theme has new release

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -181,7 +181,7 @@ This also contains two optional, mutually excluded keys. If one exists the other
 
 - ``seen_tx_hash``: A transaction hash in the same chain as the token in which the token was first seen.
 - ``seen_description``: A description of the action in which the token was first seen and added to the DB. For example, querying curve pools, querying yearn pools etc.
-- ``is_ignored``(Optional): If it is set the backend has marked automatically the asset as ignored for the user.
+- ``is_ignored`` (Optional): If it is set the backend has marked automatically the asset as ignored for the user.
 
 
 Missing API Key

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
-sphinx==5.3.0
+sphinx==7.2.5
 sphinx-autobuild==2021.3.14
-sphinx_rtd_theme==1.2.2
+sphinx_rtd_theme==1.3.0
 sphinxcontrib-httpdomain==1.8.1
 sphinxcontrib-httpexample==1.1
 # This is our fork of releases in order to handle https://github.com/rotki/rotki/issues/704


### PR DESCRIPTION
Now that sphinx rtd theme 1.3.0 is out we can upgrade sphinx to 7.2.5

