### PR TITLE
Remove constraint in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ maxminddb==2.2.0
 miniupnpc==2.0.2; sys_platform != 'win32'
 miniupnpc==2.2.3; sys_platform == 'win32'
 cryptography==41.0.3
-jsonschema==4.17.3  # jsonchema 4.18 introduces a dependency that is missing wheels for macos in our CI. We have reported it but we will pin the version until is fixed https://github.com/crate-py/rpds/issues/11
 py-machineid==0.4.3
 
 # For the rest api


### PR DESCRIPTION
multiformats had a dependency on jsonchema but one dependency for jsonschema didn't provice wheels and it used rust to compile. Now we have wheels for our platforms and the app seems to work now
`