### PR TITLE
Add dependency needed for builds

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -128,6 +128,8 @@ jobs:
           make install
           echo "::endgroup::"
         working-directory: libffi
+      - name: Add rust target for building deps
+        run: rustup target add aarch64-apple-darwin
       - name: Cache python pkg
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
When building `rpds-py` in mac arm we need to build it from source and it uses rust so we need the mac arm target for rust in order to being able to build it