### PR TITLE
Various ENS related bugfixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` ENS registrations that involve a refund to the user due to paying too much should reflect the proper amount in the decoded event.
 * :bug:`6597` Transactions involving ENS labelhashes with odd number of digits will now be decoded correctly and the entire decoding process should not halt if they are encountered.
 * :bug:`-` Substrate balances in the blockchain & accounts view will now display correctly.
 * :bug:`6587` All Kraken special & staking assets, like staking assets bonded for a specific time will now be handled properly.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`6597` Transactions involving ENS labelhashes with odd number of digits will now be decoded correctly and the entire decoding process should not halt if they are encountered.
 * :bug:`-` Substrate balances in the blockchain & accounts view will now display correctly.
 * :bug:`6587` All Kraken special & staking assets, like staking assets bonded for a specific time will now be handled properly.
 * :bug:`-` Pointed to the new yearn finance API domain.

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -127,6 +127,7 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
                 if event.balance.amount != expected_amount:
                     return DEFAULT_DECODING_OUTPUT  # registration amount did not match
 
+                event.balance.amount = amount  # adjust the spent amount too, after refund
                 event.event_type = HistoryEventType.TRADE
                 event.event_subtype = HistoryEventSubType.SPEND
                 event.counterparty = CPT_ENS

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -1,5 +1,4 @@
 import logging
-from multiprocessing.managers import RemoteError
 from typing import TYPE_CHECKING, Any, Optional
 
 import content_hash
@@ -23,6 +22,7 @@ from rotkehlchen.chain.evm.names import find_ens_mappings
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, DecoderEventMappingType, EvmTokenKind
@@ -198,7 +198,7 @@ class EnsDecoder(DecoderInterface, CustomizableDateMixin):
             log.error(f'Could not decode an ERC721 transfer for an ENS name transfer: {context.transaction.tx_hash.hex()}')  # noqa: E501
             return DEFAULT_DECODING_OUTPUT
 
-        label_hash = hex(transfer_event.extra_data['token_id'])  # type: ignore[index]  # noqa: E501  # ERC721 transfer always has extra data
+        label_hash = '0x{:064x}'.format(transfer_event.extra_data['token_id'])  # type: ignore[index]  # noqa: E501  # ERC721 transfer always has extra data
         try:
             result = self.graph.query(
                 querystr=f'query{{domains(first:1, where:{{labelhash:"{label_hash}"}}){{labelName}}}}')  # noqa: E501

--- a/rotkehlchen/tasks/utils.py
+++ b/rotkehlchen/tasks/utils.py
@@ -1,11 +1,11 @@
 import logging
-from multiprocessing.managers import RemoteError
 from typing import TYPE_CHECKING, Literal, Optional
+
 from rotkehlchen.constants.assets import A_USD
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
 from rotkehlchen.utils.misc import ts_now
 

--- a/rotkehlchen/tests/unit/decoders/test_ens.py
+++ b/rotkehlchen/tests/unit/decoders/test_ens.py
@@ -42,11 +42,13 @@ def test_mint_ens_name(database, ethereum_inquirer):
         tx_hash=tx_hash,
     )
     expires_timestamp = 2142055301
+    timestamp = TimestampMS(1637144069000)
+    register_fee_str = '0.019345192039577752'
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
             sequence_index=0,
-            timestamp=1637144069000,
+            timestamp=timestamp,
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -58,14 +60,14 @@ def test_mint_ens_name(database, ethereum_inquirer):
         ), EvmEvent(
             tx_hash=tx_hash,
             sequence_index=2,
-            timestamp=1637144069000,
+            timestamp=timestamp,
             location=Location.ETHEREUM,
             event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            balance=Balance(amount=FVal('0.021279711243535527')),
+            balance=Balance(amount=FVal(register_fee_str)),
             location_label=ADDY,
-            notes=f'Register ENS name hania.eth for 0.019345192039577752 ETH until {decoder.decoders["Ens"].timestamp_to_date(expires_timestamp)}',  # noqa: E501
+            notes=f'Register ENS name hania.eth for {register_fee_str} ETH until {decoder.decoders["Ens"].timestamp_to_date(expires_timestamp)}',  # noqa: E501
             counterparty=CPT_ENS,
             address=string_to_evm_address('0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5'),
         )]
@@ -658,7 +660,7 @@ def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts)
             event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            balance=Balance(amount=FVal('0.128749338636028262')),
+            balance=Balance(amount=FVal(register_fee_str)),
             location_label=user_address,
             notes=f'Register ENS name cantillon.eth for {register_fee_str} ETH until {decoder.decoders["Ens"].timestamp_to_date(expires_timestamp)}',  # noqa: E501
             counterparty=CPT_ENS,


### PR DESCRIPTION
### [Properly decode ENS labelhashes with odd number of digits](https://github.com/rotki/rotki/commit/be093b1cd0b0ec468efae7c3864e7a3c48d81445) 

Fix https://github.com/rotki/rotki/issues/6597

Also the wrong import of RemoteError from multiprocessing.managers in
two parts of the code is fixed here. That lead to the RemoteError not
being caught and as such the entire decoding process halting with the
graph error.

### [Fix event amount for ENS registrations with a refund](https://github.com/rotki/rotki/commit/d12caf11f7429ddd874cc7359f262cb93984d341)