### PR TITLE
Easier opensea api key handling

### DIFF
--- a/frontend/app/src/pages/settings/api-keys/external/index.vue
+++ b/frontend/app/src/pages/settings/api-keys/external/index.vue
@@ -345,7 +345,7 @@ onMounted(async () => {
         <i18n tag="div" path="external_services.opensea.link">
           <template #link>
             <ExternalLink
-              url="https://docs.opensea.io/reference/request-an-api-key"
+              url="https://docs.opensea.io/reference/api-keys#how-do-i-get-an-api-key"
             >
               {{ t('common.here') }}
             </ExternalLink>

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -30,6 +30,7 @@ from rotkehlchen.tests.utils.constants import A_DAO, A_SNGLS, A_XMR
 from rotkehlchen.types import Price, Timestamp
 
 
+@pytest.mark.skip('They are updating their systems & cleaning inactive pairs. Check again soon')
 def test_cryptocompare_query_pricehistorical(cryptocompare):
     """Test that cryptocompare price historical query works fine"""
     price = cryptocompare.query_endpoint_pricehistorical(
@@ -95,6 +96,7 @@ def check_cc_result(result: list, forward: bool):
             raise AssertionError(f'Unexpected time entry {entry.time}')
 
 
+@pytest.mark.skip('They are updating their systems & cleaning inactive pairs. Check again soon')
 @pytest.mark.freeze_time()
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_cryptocompare_histohour_data_going_forward(data_dir, database, freezer):
@@ -138,6 +140,7 @@ def test_cryptocompare_histohour_data_going_forward(data_dir, database, freezer)
     assert data_range[1] == 1301544000  # that's the closest ts to now_ts cc returns
 
 
+@pytest.mark.skip('They are updating their systems & cleaning inactive pairs. Check again soon')
 @pytest.mark.freeze_time()
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_cryptocompare_histohour_data_going_backward(data_dir, database, freezer):
@@ -313,6 +316,7 @@ def test_cryptocompare_query_compound_tokens(
     assert price is not None
 
 
+@pytest.mark.skip('They are updating their systems & cleaning inactive pairs. Check again soon')
 @pytest.mark.parametrize('include_cryptocompare_key', [True])
 def test_cryptocompare_query_with_api_key(cryptocompare):
     """Just try to query cryptocompare endpoints with an api key


### PR DESCRIPTION
Now that opensea api key is possible to be made by end users we can stop querying our server for it, and let users use their own, with a local backup of ours that is a last resort choice.

