### PR TITLE
Fix balances not working if address has only locked cvx

### DIFF
--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -190,7 +190,7 @@ class ProtocolWithGauges(ProtocolWithBalance):
         """
         Query gauge balances for the addresses that have interacted with known gauges.
         """
-        balances: BalancesType = {}
+        balances: BalancesType = defaultdict(lambda: defaultdict(Balance))
         gauges_to_token: dict[ChecksumEvmAddress, EvmToken] = {}
         # query addresses and gauges where they interacted
         addresses_with_deposits = self.addresses_with_deposits(

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -126,8 +126,8 @@ def test_convex_staking_balances_without_gauges(
 ) -> None:
     """
     Check that convex balances are correctly propagated if one account doesn't have gauges
-    deposits but has staked CVX since staked/locked CVX is added to the balances returned from
-    gauges.
+    deposits but has staked CVX. The reason for this test is that staked/locked CVX is added to the balances 
+    returned from the gauges and those balances before this commit were not a defaultdict and could lead to a failure.
     """
     database = ethereum_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0x38bd199803e7cb065c809ce07957afc0647a41da4c0610d1209a843d9b045cd6')  # noqa: E501


### PR DESCRIPTION
If the address doesn't have convex deposits and only locked cvx the address is not present in the balances mapping and therefore it fails when adding the CVX balances