### PR TITLE
Handle lp tokens protocol for uniswap like protocols

### DIFF
--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -270,6 +270,19 @@ def get_or_create_evm_token(
     return evm_token
 
 
+def set_token_protocol_if_missing(evm_token: EvmToken, protocol: str) -> None:
+    """
+    Check if the provided token has the expected protocol and if the protocol is not the expected
+    update the token and update it in the database.
+    """
+    if evm_token.protocol == protocol:
+        return
+
+    object.__setattr__(evm_token, 'protocol', protocol)  # since is a frozen dataclass
+    AssetResolver.clean_memory_cache(evm_token.identifier)
+    GlobalDBHandler().edit_evm_token(evm_token)
+
+
 def get_crypto_asset_by_symbol(
         symbol: str,
         asset_type: Optional[AssetType] = None,

--- a/rotkehlchen/chain/ethereum/modules/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/constants.py
@@ -5,7 +5,6 @@ from rotkehlchen.chain.ethereum.modules.uniswap.constants import (
     CPT_UNISWAP_V3,
 )
 
-
 AMM_POSSIBLE_COUNTERPARTIES = {
     CPT_UNISWAP_V1,
     CPT_UNISWAP_V2,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
@@ -6,7 +6,11 @@ from web3 import Web3
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken, UnderlyingToken
-from rotkehlchen.assets.utils import TokenSeenAt, get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    TokenSeenAt,
+    get_or_create_evm_token,
+    set_token_protocol_if_missing,
+)
 from rotkehlchen.chain.ethereum.modules.constants import AMM_ASSETS_SYMBOLS
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, generate_address_via_create2
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -31,7 +35,14 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, EvmTransaction, EVMTxHash
+from rotkehlchen.types import (
+    SUSHISWAP_PROTOCOL,
+    UNISWAP_PROTOCOL,
+    ChecksumEvmAddress,
+    EvmTokenKind,
+    EvmTransaction,
+    EVMTxHash,
+)
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 if TYPE_CHECKING:
@@ -348,6 +359,7 @@ def enrich_uniswap_v2_like_lp_tokens_transfers(
         context.event.counterparty = counterparty
         context.event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
         context.event.notes = f'Receive {context.event.balance.amount} {resolved_asset.symbol} from {counterparty} pool'  # noqa: E501
+        set_token_protocol_if_missing(context.event.asset.resolve_to_evm_token(), UNISWAP_PROTOCOL if lp_token_symbol == 'UNI-V2' else SUSHISWAP_PROTOCOL)  # noqa: E501
         return TransferEnrichmentOutput(matched_counterparty=counterparty)
 
     if (

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -82,6 +82,7 @@ SUSHISWAP_PROTOCOL: Final = 'SLP'
 YEARN_VAULTS_V1_PROTOCOL = 'yearn_vaults_v1'
 YEARN_VAULTS_V2_PROTOCOL = 'yearn_vaults_v2'
 CURVE_POOL_PROTOCOL = 'curve_pool'
+VELODROME_POOL_PROTOCOL = 'velodrome_pool'
 PICKLE_JAR_PROTOCOL = 'pickle_jar'
 SPAM_PROTOCOL = 'spam'
 


### PR DESCRIPTION
When calculating prices of LP tokens in uniswap like protocols is needed to properly populate the protocol field. To achive this during the decoding of events (the moment when we are sure of working with one of the protocol LP tokens) we ensure that the protocol is correctly set for the token in the db