### PR TITLE
fix(frontend): hide history event header on non-mobile layouts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,8 @@ Changelog
 * :feature:`6275` Transaction events from bitstamp CSV can now be imported
 * :feature:`-` Properly decode optimism bridge 2 step withdrawal proving transactions
 * :feature:`2000` Users will now have the ability to filter between claimed and unclaimed airdrops.
-* :feature:`-` Transactions bridging from/to Base using the official bridge will be now decoded. 
+* :feature:`-` Transactions bridging from/to Base using the official bridge will be now decoded.
+* :bug:`-` History event header will now be visible only on mobile.
 
 * :release:`1.30.2 <2023-09-21>`
 * :feature:`-` Improved support for importing Binance CSV files.

--- a/frontend/app/src/components/history/events/HistoryEventsList.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsList.vue
@@ -129,7 +129,7 @@ watch(
   }
 );
 
-const { mdAndUp } = useDisplay();
+const { xs } = useDisplay();
 const blockEvent = isEthBlockEventRef(eventGroupHeader);
 </script>
 
@@ -177,7 +177,7 @@ const blockEvent = isEthBlockEventRef(eventGroupHeader);
                 :options="options"
                 hide-default-footer
                 disable-floating-header
-                :hide-default-header="mdAndUp"
+                :hide-default-header="!xs"
               >
                 <template #progress><span /></template>
                 <template #item.type="{ item }">


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
