### PR TITLE
Fix wrong name in some ENS events. Use name/labelhash mapping cache

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 * :feature:`-` Transactions bridging from/to Base using the official bridge will be now decoded.
 * :bug:`-` History event header will now be visible only on mobile.
 * :bug:`6647` When PnL report generation is finished, users will not be redirected to the report page, but will get notified instead.
+* :bug:`6667` Wrong ENS name should no longer be reported for some edge case of ENS actions and the name should also appear in more events than before.
 
 * :release:`1.30.2 <2023-09-21>`
 * :feature:`-` Improved support for importing Binance CSV files.

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -19,13 +19,12 @@ from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import (
-    UNIQUE_CACHE_KEYS,
     globaldb_get_general_cache_last_queried_ts_by_key,
     globaldb_get_unique_cache_last_queried_ts_by_key,
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import CacheType, ChecksumEvmAddress
+from rotkehlchen.types import UNIQUE_CACHE_KEYS, CacheType, ChecksumEvmAddress
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 from rotkehlchen.utils.misc import ts_now
 

--- a/rotkehlchen/globaldb/cache.py
+++ b/rotkehlchen/globaldb/cache.py
@@ -14,13 +14,6 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.misc import ts_now
 
-UNIQUE_CACHE_KEYS: set[CacheType] = {
-    CacheType.CURVE_POOL_ADDRESS,
-    CacheType.MAKERDAO_VAULT_ILK,
-    CacheType.CURVE_GAUGE_ADDRESS,
-    CacheType.YEARN_VAULTS,
-}
-
 
 def compute_cache_key(key_parts: Iterable[Union[str, CacheType]]) -> str:
     """Function that computes the cache key for accessing the globaldb general or unique cache

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -932,6 +932,8 @@ class CacheType(Enum):
     CURVE_POOL_UNDERLYING_TOKENS = auto()  # get underlying tokens by pool address
     VELODROME_POOL_ADDRESS = auto()  # get pool address information
     VELODROME_GAUGE_ADDRESS = auto()  # get gauge address by pool address
+    ENS_NAMEHASH = auto()  # map ENS namehash -> ens name
+    ENS_LABELHASH = auto()  # map ENS labelhash -> ens name
 
     def serialize(self) -> str:
         # Using custom serialize method instead of SerializableEnumMixin since mixin replaces
@@ -948,7 +950,11 @@ UniqueCacheType = Literal[
     CacheType.MAKERDAO_VAULT_ILK,
     CacheType.CURVE_GAUGE_ADDRESS,
     CacheType.YEARN_VAULTS,
+    CacheType.ENS_NAMEHASH,
+    CacheType.ENS_LABELHASH,
 ]
+
+UNIQUE_CACHE_KEYS: tuple[UniqueCacheType, ...] = typing.get_args(UniqueCacheType)
 
 GeneralCacheType = Literal[
     CacheType.CURVE_LP_TOKENS,


### PR DESCRIPTION
Fix #6667

- Save namehash and labelhash to ENS name mapping in the DB whenever possible.
- When finding an ENS node/namehash ask DB if we know it. If not ask the subgraph, to get the final ens name
- Adjust the ENS decoder to fix inconsistencies with the ENS name and utilize this new namehash/labelhash querying logic

