### PR TITLE
Base fixes

### DIFF
--- a/rotkehlchen/chain/base/node_inquirer.py
+++ b/rotkehlchen/chain/base/node_inquirer.py
@@ -59,7 +59,7 @@ class BaseInquirer(OptimismSuperchainInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xeDF6D2a16e8081F777eB623EeB4411466556aF3d')),  # noqa: E501
-            contract_scan=contracts.contract(string_to_evm_address('0xFCa18B547623e2587e1842840B89f28f1d9d9643')),  # noqa: E501
+            contract_scan=contracts.contract(string_to_evm_address('0x2d26d6b698f6494efdB908A2A4f11ae5Fee86099')),  # noqa: E501
             native_token=A_ETH.resolve_to_crypto_asset(),
         )
         self.etherscan = cast(BaseEtherscan, self.etherscan)

--- a/rotkehlchen/chain/optimism_superchain/etherscan.py
+++ b/rotkehlchen/chain/optimism_superchain/etherscan.py
@@ -52,10 +52,13 @@ class OptimismSuperchainEtherscan(Etherscan, metaclass=ABCMeta):
             # TODO: write this tx_receipt to DB so it doesn't need to be queried again
             # https://github.com/rotki/rotki/pull/6359#discussion_r1252850465
             tx_receipt = self.get_transaction_receipt(tx.tx_hash)
+            l1_fee = 0
             if tx_receipt is not None:
-                l1_fee = int(tx_receipt['l1Fee'], 16)
+                if 'l1Fee' in tx_receipt:
+                    # system tx like deposits don't have the l1fee attribute
+                    # https://github.com/ethereum-optimism/optimism/blob/84ead32601fb825a060cde5a6635be2e8aea1a95/specs/deposits.md  # noqa: E501
+                    l1_fee = int(tx_receipt['l1Fee'], 16)
             else:
-                l1_fee = 0
                 log.error(f'Could not query receipt for {self.chain.name.lower()} transaction {tx.tx_hash.hex()}. Using 0 l1 fee')  # noqa: E501
 
             tx = OptimismTransaction(

--- a/rotkehlchen/tests/api/blockchain/test_evm.py
+++ b/rotkehlchen/tests/api/blockchain/test_evm.py
@@ -334,6 +334,7 @@ def test_detect_evm_accounts(
         {'evm_chain': ChainID.POLYGON_POS.to_name(), 'address': ethereum_accounts[0]},
         {'evm_chain': ChainID.OPTIMISM.to_name(), 'address': ethereum_accounts[0]},
         {'evm_chain': ChainID.ARBITRUM_ONE.to_name(), 'address': ethereum_accounts[0]},
+        {'evm_chain': ChainID.BASE.to_name(), 'address': ethereum_accounts[0]},
     ], key=operator.itemgetter('evm_chain', 'address'))
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     db = rotki.data.db


### PR DESCRIPTION
Fixes transaction query issue with l1 fee and balance detection

globaldb diff:

```
INSERT INTO contract_data(rowid,address,chain_id,abi,deployed_block) VALUES(145,'0x2d26d6b698f6494efdB908A2A4f11ae5Fee86099',8453,33,4769927);
```

the issue with the balance detection was the usage of a contracts with a different interface. The l1fee is not present in all the transactions