### PR TITLE
Fix Aave-v2 accounting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Aave v2 accounting for deposit interest profit and borrow payback loss should now work correctly again.
+
 * :release:`1.30.2 <2023-09-21>`
 * :feature:`-` Improved support for importing Binance CSV files.
 * :bug:`6625` Error text when merging assets will now appear properly.

--- a/rotkehlchen/accounting/structures/processed_event.py
+++ b/rotkehlchen/accounting/structures/processed_event.py
@@ -42,7 +42,7 @@ class ProcessedAccountingEvent:
     taxable_amount: FVal
     price: Price
     pnl: PNL
-    cost_basis: Optional['CostBasisInfo']
+    cost_basis: Optional[CostBasisInfo]
     index: int
     # This is set only for some events to remember extra data that can be used later
     # such as the transaction hash of an event

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/accountant.py
@@ -82,9 +82,9 @@ class Aavev2Accountant(ModuleAccountantInterface):
         key = (string_to_evm_address(event.location_label), event.asset)  # type: ignore[arg-type]  # location_label can't be None here  # noqa: E501
         self.assets_supplied[key] -= event.balance.amount
         if self.assets_supplied[key] < ZERO:
-            gain = -1 * self.assets_borrowed[key]
+            gain = -1 * self.assets_supplied[key]
             resolved_asset = event.asset.resolve_to_asset_with_symbol()
-            pot.add_spend(
+            pot.add_acquisition(
                 event_type=AccountingEventType.TRANSACTION_EVENT,
                 notes=f'Gained {gain} {resolved_asset.symbol} on Aave v2 as interest rate for {event.location_label}',  # noqa: E501
                 location=event.location,
@@ -94,7 +94,7 @@ class Aavev2Accountant(ModuleAccountantInterface):
                 taxable=True,
                 extra_data={'tx_hash': event.tx_hash.hex()},
             )
-            self.assets_borrowed[key] = ZERO
+            self.assets_supplied[key] = ZERO
 
     def event_settings(self, pot: 'AccountingPot') -> dict[str, TxEventSettings]:  # pylint: disable=unused-argument  # noqa: E501
         """Being defined at function call time is fine since this function is called only once"""

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -2,7 +2,7 @@ from rotkehlchen.assets.types import AssetType
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import Price
 
-CURRENCYCONVERTER_API_KEY = '950873c204f11268e253'
+CURRENCYCONVERTER_API_KEY = '0529ead07a5a12d2db0e'
 
 ZERO = FVal(0)
 ONE = FVal(1)

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -36,7 +36,7 @@ def test_asset_data(session_coingecko):
         identifier='bitcoin',
         symbol='btc',
         name='Bitcoin',
-        image_url='https://assets.coingecko.com/coins/images/1/small/bitcoin.png?1547033579',
+        image_url='https://assets.coingecko.com/coins/images/1/small/bitcoin.png?1696501400',
     )
     data = session_coingecko.asset_data(A_BTC.resolve_to_asset_with_oracles().to_coingecko())
     assert_coin_data_same(data, expected_data)
@@ -45,7 +45,7 @@ def test_asset_data(session_coingecko):
         identifier='yearn-finance',
         symbol='yfi',
         name='yearn.finance',
-        image_url='https://assets.coingecko.com/coins/images/11849/small/yearn.jpg?1687142705',  # noqa: E501
+        image_url='https://assets.coingecko.com/coins/images/11849/small/yearn.jpg?1696511720',  # noqa: E501
     )
     data = session_coingecko.asset_data(A_YFI.resolve_to_asset_with_oracles().to_coingecko())
     assert_coin_data_same(data, expected_data, compare_description=False)

--- a/rotkehlchen/tests/unit/accounting/evm/test_aave.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_aave.py
@@ -1,0 +1,262 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rotkehlchen.accounting.cost_basis.base import (
+    AssetAcquisitionEvent,
+    CostBasisInfo,
+    MatchedAcquisition,
+)
+from rotkehlchen.accounting.mixins.event import AccountingEventType
+from rotkehlchen.accounting.pnl import PNL
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.evm_event import EvmEvent
+from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.ethereum.modules.aave.constants import CPT_AAVE_V2
+from rotkehlchen.chain.ethereum.modules.aave.v2.accountant import Aavev2Accountant
+from rotkehlchen.constants.assets import A_DAI, A_REN
+from rotkehlchen.constants.misc import ONE, ZERO
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
+from rotkehlchen.types import Location, Price, Timestamp
+from rotkehlchen.utils.misc import ts_sec_to_ms
+
+if TYPE_CHECKING:
+    from rotkehlchen.accounting.accountant import Accountant
+    from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+
+TS1, TS2 = Timestamp(1), Timestamp(2)
+TSMS1, TSMS2 = ts_sec_to_ms(TS1), ts_sec_to_ms(TS2)
+USER_ADDRESS = make_evm_address()
+HASH1, HASH2 = make_evm_tx_hash(), make_evm_tx_hash()
+
+
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+def test_v2_withdraw(accountant: 'Accountant', ethereum_inquirer: 'EvmNodeInquirer'):
+    pot = accountant.pots[0]
+    events_accountant = pot.events_accountant
+    aave_accountant = Aavev2Accountant(
+        node_inquirer=ethereum_inquirer,
+        msg_aggregator=ethereum_inquirer.database.msg_aggregator,
+    )
+    aave_settings = aave_accountant.event_settings(pot)
+    events_accountant.event_settings.update(aave_settings)
+    events_iterator = iter([EvmEvent(
+        tx_hash=HASH1,
+        sequence_index=0,
+        timestamp=TSMS1,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+        asset=A_DAI,
+        balance=Balance(amount=FVal('1000')),
+        location_label=USER_ADDRESS,
+        notes='Deposit 1000 DAI into AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    ), EvmEvent(
+        tx_hash=HASH1,
+        sequence_index=2,
+        timestamp=TSMS1,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+        asset=Asset('eip155:1/erc20:0x028171bCA77440897B824Ca71D1c56caC55b68A3'),
+        balance=Balance(amount=FVal('1000')),
+        location_label=USER_ADDRESS,
+        notes='Receive 1000 aDAI from AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    ), EvmEvent(
+        tx_hash=HASH2,
+        sequence_index=0,
+        timestamp=TSMS2,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        asset=Asset('eip155:1/erc20:0x028171bCA77440897B824Ca71D1c56caC55b68A3'),
+        balance=Balance(amount=FVal('1050')),
+        location_label=USER_ADDRESS,
+        notes='Return 1050 aDAI to AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    ), EvmEvent(
+        tx_hash=HASH2,
+        sequence_index=2,
+        timestamp=TSMS2,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REMOVE_ASSET,
+        asset=A_DAI,
+        balance=Balance(amount=FVal('1050')),
+        location_label=USER_ADDRESS,
+        notes='Withdraw 1050 DAI from AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    )])
+    for event in events_iterator:
+        pot.events_accountant.process(event=event, events_iterator=events_iterator)
+
+    expected_events = [
+        ProcessedAccountingEvent(
+            type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Deposit 1000 DAI into AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS1,
+            asset=A_DAI,
+            free_amount=ZERO,
+            taxable_amount=FVal(1000),
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),  # Deposits are not taxable
+            cost_basis=None,
+            index=0,
+            extra_data={'tx_hash': HASH1.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            type=AccountingEventType.TRANSACTION_EVENT,
+            notes=f'Gained 50 DAI on Aave v2 as interest rate for {USER_ADDRESS}',
+            location=Location.ETHEREUM,
+            timestamp=TS2,
+            asset=A_DAI,
+            free_amount=ZERO,
+            taxable_amount=FVal(50),
+            price=Price(ONE),
+            pnl=PNL(taxable=FVal(50), free=ZERO),  # $50 interest gained
+            cost_basis=None,
+            index=1,
+            extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Withdraw 1050 DAI from AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS2,
+            asset=A_DAI,
+            free_amount=FVal(1050),
+            taxable_amount=ZERO,
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),
+            cost_basis=None,
+            index=2,
+            extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
+        ),
+    ]
+    expected_events[1].count_cost_basis_pnl = True  # can't be set by init()
+    assert pot.processed_events == expected_events
+
+
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+def test_v2_payback(accountant: 'Accountant', ethereum_inquirer: 'EvmNodeInquirer'):
+    pot = accountant.pots[0]
+    events_accountant = pot.events_accountant
+    aave_accountant = Aavev2Accountant(
+        node_inquirer=ethereum_inquirer,
+        msg_aggregator=ethereum_inquirer.database.msg_aggregator,
+    )
+    aave_settings = aave_accountant.event_settings(pot)
+    events_accountant.event_settings.update(aave_settings)
+    events_iterator = iter([EvmEvent(
+        tx_hash=HASH1,
+        sequence_index=0,
+        timestamp=TSMS1,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+        asset=Asset('eip155:1/erc20:0xcd9D82d33bd737De215cDac57FE2F7f04DF77FE0'),
+        balance=Balance(amount=FVal('1000')),
+        location_label=USER_ADDRESS,
+        notes='Receive 1000 variableDebtREN from AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    ), EvmEvent(
+        tx_hash=HASH1,
+        sequence_index=2,
+        timestamp=TSMS1,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.GENERATE_DEBT,
+        asset=A_REN,
+        balance=Balance(amount=FVal('1000')),
+        location_label=USER_ADDRESS,
+        notes='Borrow 1000 REN from AAVE v2 with variable APY 0.80%',
+        counterparty=CPT_AAVE_V2,
+    ), EvmEvent(
+        tx_hash=HASH2,
+        sequence_index=0,
+        timestamp=TSMS2,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        asset=Asset('eip155:1/erc20:0xcd9D82d33bd737De215cDac57FE2F7f04DF77FE0'),
+        balance=Balance(amount=FVal('1050')),
+        location_label=USER_ADDRESS,
+        notes='Return 1050 variableDebtREN to AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    ), EvmEvent(
+        tx_hash=HASH2,
+        sequence_index=2,
+        timestamp=TSMS2,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.PAYBACK_DEBT,
+        asset=A_REN,
+        balance=Balance(amount=FVal('1050')),
+        location_label=USER_ADDRESS,
+        notes='Repay 1050 REN on AAVE v2',
+        counterparty=CPT_AAVE_V2,
+    )])
+    for event in events_iterator:
+        pot.events_accountant.process(event=event, events_iterator=events_iterator)
+
+    matched_acquisitions = [MatchedAcquisition(
+        amount=FVal(50),
+        event=AssetAcquisitionEvent(amount=FVal(1000), timestamp=TS1, rate=Price(ONE), index=0),
+        taxable=True,
+    )]
+    matched_acquisitions[0].event.remaining_amount = FVal(950)  # can't be set by init
+    expected_events = [
+        ProcessedAccountingEvent(
+            type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Borrow 1000 REN from AAVE v2 with variable APY 0.80%',
+            location=Location.ETHEREUM,
+            timestamp=TS1,
+            asset=A_REN,
+            free_amount=FVal(1000),
+            taxable_amount=ZERO,
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),  # Deposits are not taxable
+            cost_basis=None,
+            index=0,
+            extra_data={'tx_hash': HASH1.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            type=AccountingEventType.TRANSACTION_EVENT,
+            notes=f'Lost 50 REN as debt during payback to Aave v2 loan for {USER_ADDRESS}',
+            location=Location.ETHEREUM,
+            timestamp=TS2,
+            asset=A_REN,
+            free_amount=ZERO,
+            taxable_amount=FVal(50),
+            price=Price(ONE),
+            pnl=PNL(taxable=FVal(-50), free=ZERO),  # $50 loss in interest for payback
+            cost_basis=CostBasisInfo(
+                taxable_amount=FVal(50),
+                taxable_bought_cost=FVal(50),
+                taxfree_bought_cost=ZERO,
+                matched_acquisitions=matched_acquisitions,
+                is_complete=True,
+            ),
+            index=1,
+            extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Repay 1050 REN on AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS2,
+            asset=A_REN,
+            free_amount=ZERO,
+            taxable_amount=FVal(1050),
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),
+            cost_basis=None,
+            index=2,
+            extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
+        ),
+    ]
+    expected_events[1].count_cost_basis_pnl = True  # can't be set by init()
+    expected_events[1].count_entire_amount_spend = True  # can't be set by init()
+    assert pot.processed_events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_aave.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave.py
@@ -640,22 +640,7 @@ def test_aave_v2_withdraw(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ), EvmEvent(
             tx_hash=evmhash,
-            sequence_index=26,
-            timestamp=0,
-            location=Location.ETHEREUM,
-            event_type=HistoryEventType.WITHDRAWAL,
-            event_subtype=HistoryEventSubType.REMOVE_ASSET,
-            asset=A_WETH,
-            balance=Balance(amount=FVal('5504.540904812179621204')),
-            location_label=user_address,
-            notes='Withdraw 5504.540904812179621204 WETH from AAVE v2 to 0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44',  # noqa: E501
-            counterparty=CPT_AAVE_V2,
-            identifier=None,
-            extra_data=None,
-            address=string_to_evm_address('0x030bA81f1c18d280636F32af80b9AAd02Cf0854e'),
-        ), EvmEvent(
-            tx_hash=evmhash,
-            sequence_index=27,
+            sequence_index=1,
             timestamp=0,
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
@@ -668,6 +653,21 @@ def test_aave_v2_withdraw(database, ethereum_inquirer, eth_transactions):
             identifier=None,
             extra_data=None,
             address=ZERO_ADDRESS,
+        ), EvmEvent(
+            tx_hash=evmhash,
+            sequence_index=2,
+            timestamp=0,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_WETH,
+            balance=Balance(amount=FVal('5504.540904812179621204')),
+            location_label=user_address,
+            notes='Withdraw 5504.540904812179621204 WETH from AAVE v2 to 0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44',  # noqa: E501
+            counterparty=CPT_AAVE_V2,
+            identifier=None,
+            extra_data=None,
+            address=string_to_evm_address('0x030bA81f1c18d280636F32af80b9AAd02Cf0854e'),
         ),
     ]
     assert events == expected_events


### PR DESCRIPTION
## [Aave v2 accounting should now work correctly again](https://github.com/rotki/rotki/commit/41d6fe61250286056d0f0f87b7254c825c50a51d)

Fixed some bugs and wrote some much needed tests for the accounting
part of aave v2

## [Enforce proper event order (out first) for aave v2 withdrawal](https://github.com/rotki/rotki/commit/54bb70d154085ef5159adfe85d3c22814fd3311a)

Noticed the test for aave v2 withdrawal was spitting out the withdrawal (in event) first which was wrong and fixed it

----

We need to be writing tests for these type of Decoding Accountants. Otherwise it's so easy to make such silly errors as these and not have them noticed for a long time.

On the other hand the tests as you can see from this PR need a bit more tooling around them and to abstract some setup in fixtures ... and due to lack of some fields being in the data class init .. a bit of ugly code in testing.

The worse thing is that with all our plans to revamp accounting (https://github.com/rotki/rotki/issues/6427) this may also change a lot so not much sense to invest a lot of time into it.