### PR TITLE
Add Decoder for The Graph staking

### DIFF
--- a/frontend/app/public/assets/images/protocols/thegraph.svg
+++ b/frontend/app/public/assets/images/protocols/thegraph.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="GRT" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 96 96" style="enable-background:new 0 0 96 96;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#6747ED;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+</style>
+<circle class="st0" cx="48" cy="48" r="48"/>
+<g id="Symbols">
+	<g transform="translate(-88.000000, -52.000000)">
+		<path id="Fill-19" class="st1" d="M135.3,106.2c-7.1,0-12.8-5.7-12.8-12.8c0-7.1,5.7-12.8,12.8-12.8c7.1,0,12.8,5.7,12.8,12.8
+			C148.1,100.5,142.4,106.2,135.3,106.2 M135.3,74.2c10.6,0,19.2,8.6,19.2,19.2s-8.6,19.2-19.2,19.2c-10.6,0-19.2-8.6-19.2-19.2
+			S124.7,74.2,135.3,74.2z M153.6,113.6c1.3,1.3,1.3,3.3,0,4.5l-12.8,12.8c-1.3,1.3-3.3,1.3-4.5,0c-1.3-1.3-1.3-3.3,0-4.5l12.8-12.8
+			C150.3,112.3,152.4,112.3,153.6,113.6z M161,77.4c0,1.8-1.4,3.2-3.2,3.2c-1.8,0-3.2-1.4-3.2-3.2s1.4-3.2,3.2-3.2
+			C159.5,74.2,161,75.6,161,77.4z"/>
+	</g>
+</g>
+</svg>

--- a/rotkehlchen/chain/ethereum/modules/thegraph/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/constants.py
@@ -1,0 +1,9 @@
+from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
+
+CPT_THEGRAPH = 'thegraph'
+
+THEGRAPH_CPT_DETAILS = CounterpartyDetails(
+    identifier=CPT_THEGRAPH,
+    label='The Graph',
+    image='thegraph.svg',
+)

--- a/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
@@ -1,0 +1,187 @@
+import logging
+from typing import TYPE_CHECKING, Any
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.chain.ethereum.modules.thegraph.constants import (
+    CPT_THEGRAPH,
+    THEGRAPH_CPT_DETAILS,
+)
+from rotkehlchen.chain.ethereum.utils import token_normalized_value
+from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    ActionItem,
+    DecoderContext,
+    DecodingOutput,
+)
+from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails, EventCategory
+from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_GRT
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.types import ChecksumEvmAddress, DecoderEventMappingType
+from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.user_messages import MessagesAggregator
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+CONTRACT_THEGRAPH_STAKING = string_to_evm_address('0xF55041E37E12cD407ad00CE2910B8269B01263b9')
+TOPIC_TRANSFER = b'\xdd\xf2R\xad\x1b\xe2\xc8\x9bi\xc2\xb0h\xfc7\x8d\xaa\x95+\xa7\xf1c\xc4\xa1\x16(\xf5ZM\xf5#\xb3\xef'  # noqa: E501
+# example delegate() call: https://etherscan.io/tx/0x6ed3377db652151fb8e4794dd994a921a2d029ad317bd3f2a2916af239490fec
+TOPIC_STAKE_DELEGATED = b'\xcd\x03f\xdc\xe5$}\x87O\xfc`\xa7b\xaaz\xbb\xb8,\x16\x95\xbb\xb1q`\x9c\x1b\x88a\xe2y\xebs'  # noqa: E501
+# example undelegate() call: https://etherscan.io/tx/0x5ca5244868d9c0d8c30a1cad0feaf137bd28acd9c3f669a09a3a199fd75ad25a
+TOPIC_STAKE_DELEGATED_LOCKED = b'\x040\x18?\x84\xd9\xc4P#\x86\xd4\x99\xda\x80eC\xde\xe1\xd9\xde\x83\xc0\x8b\x01\xe3\x9am!\x16\xc4;%'  # noqa: E501
+# example withdrawDelegated() call: https://etherscan.io/tx/0x49307751de5ba4cf98fccbdd1ab8387fd60a7ce120800212c216bf0a6a04acfa
+TOPIC_STAKE_DELEGATED_WITHDRAWN = b'\x1b.w7\xe0C\xc5\xcf\x1bX|\xebM\xae\xb7\xae\x00\x14\x8b\x9b\xda\x8fy\xf1\t>\xea\xd0\x8f\x14\x19R'  # noqa: E501
+
+
+class ThegraphDecoder(DecoderInterface):
+    def __init__(
+            self,
+            ethereum_inquirer: 'EthereumInquirer',
+            base_tools: 'BaseDecoderTools',
+            msg_aggregator: 'MessagesAggregator',
+    ) -> None:
+        super().__init__(
+            evm_inquirer=ethereum_inquirer,
+            base_tools=base_tools,
+            msg_aggregator=msg_aggregator,
+        )
+        self.token = A_GRT.resolve_to_evm_token()
+
+    def counterparties(self) -> list[CounterpartyDetails]:
+        return [THEGRAPH_CPT_DETAILS]
+
+    def possible_events(self) -> DecoderEventMappingType:
+        return {CPT_THEGRAPH: {
+            HistoryEventType.STAKING: {
+                HistoryEventSubType.DEPOSIT_ASSET: EventCategory.DEPOSIT,
+                HistoryEventSubType.REMOVE_ASSET: EventCategory.WITHDRAW,
+            },
+            HistoryEventType.INFORMATIONAL: {
+                HistoryEventSubType.NONE: EventCategory.INFORMATIONAL,
+            },
+        }}
+
+    def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
+        return {
+            CONTRACT_THEGRAPH_STAKING: (self._decode_delegator_staking,),
+        }
+
+    def _decode_delegator_staking(self, context: DecoderContext) -> DecodingOutput:
+        if context.tx_log.topics[0] == TOPIC_STAKE_DELEGATED:
+            return self._decode_stake_delegated(context)
+        elif context.tx_log.topics[0] == TOPIC_STAKE_DELEGATED_LOCKED:
+            return self._decode_stake_locked(context)
+        elif context.tx_log.topics[0] == TOPIC_STAKE_DELEGATED_WITHDRAWN:
+            return self._decode_stake_withdrawn(context)
+        return DEFAULT_DECODING_OUTPUT
+
+    def _decode_stake_delegated(self, context: DecoderContext) -> DecodingOutput:
+        deposit_event, burn_event = None, None
+        delegator = hex_or_bytes_to_address(context.tx_log.topics[2])
+        if delegator is None or self.base.is_tracked(delegator) is False:
+            return DEFAULT_DECODING_OUTPUT
+        indexer = hex_or_bytes_to_address(context.tx_log.topics[1])
+        stake_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        stake_amount_norm = token_normalized_value(
+            token_amount=stake_amount,
+            token=self.token,
+        )
+        # identify and override the original stake Transfer event
+        for event in context.decoded_events:
+            if (
+                event.location_label == delegator and
+                event.address == CONTRACT_THEGRAPH_STAKING and
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE
+            ):
+                initial_amount_norm = event.balance.amount
+                event.event_type = HistoryEventType.STAKING
+                event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                event.balance = Balance(amount=stake_amount_norm)
+                event.notes = f'Delegate {stake_amount_norm} GRT to indexer {indexer}'
+                event.counterparty = CPT_THEGRAPH
+                deposit_event = event
+
+                # also account for the GRT burnt due to delegation tax
+                tokens_burnt = initial_amount_norm - stake_amount_norm
+                if tokens_burnt > 0:
+                    burn_event = self.base.make_event_from_transaction(
+                        transaction=context.transaction,
+                        tx_log=context.tx_log,
+                        event_type=HistoryEventType.SPEND,
+                        event_subtype=HistoryEventSubType.FEE,
+                        asset=A_GRT,
+                        balance=Balance(amount=tokens_burnt),
+                        location_label=delegator,
+                        notes=f'Burn {tokens_burnt} GRT as delegation tax',
+                        counterparty=CPT_THEGRAPH,
+                        address=context.tx_log.address,
+                    )
+                    maybe_reshuffle_events(
+                        ordered_events=[deposit_event, burn_event],
+                        events_list=context.decoded_events,
+                    )
+                    return DecodingOutput(event=burn_event)
+                break
+
+        return DEFAULT_DECODING_OUTPUT
+
+    def _decode_stake_locked(self, context: DecoderContext) -> DecodingOutput:
+        delegator = hex_or_bytes_to_address(context.tx_log.topics[2])
+        if delegator is None or self.base.is_tracked(delegator) is False:
+            return DEFAULT_DECODING_OUTPUT
+        indexer = hex_or_bytes_to_address(context.tx_log.topics[1])
+        tokens_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        lock_timeout_secs = hex_or_bytes_to_int(context.tx_log.data[64:128])
+        tokens_amount_norm = token_normalized_value(
+            token_amount=tokens_amount,
+            token=self.token,
+        )
+        # create a new informational event about undelegation and the expiring lock on tokens
+        event = self.base.make_event_from_transaction(
+            transaction=context.transaction,
+            tx_log=context.tx_log,
+            event_type=HistoryEventType.INFORMATIONAL,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_GRT,
+            balance=Balance(),
+            location_label=delegator,
+            notes=(
+                f'Undelegate {tokens_amount_norm} GRT from indexer {indexer}.'
+                f' Lock expires in {lock_timeout_secs} seconds'
+            ),
+            counterparty=CPT_THEGRAPH,
+            address=context.tx_log.address,
+        )
+        return DecodingOutput(event=event)
+
+    def _decode_stake_withdrawn(self, context: DecoderContext) -> DecodingOutput:
+        delegator = hex_or_bytes_to_address(context.tx_log.topics[2])
+        if delegator is None or self.base.is_tracked(delegator) is False:
+            return DEFAULT_DECODING_OUTPUT
+        indexer = hex_or_bytes_to_address(context.tx_log.topics[1])
+        tokens_amount_norm = token_normalized_value(
+            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token=self.token,
+        )
+        # create action item that will modify the relevant Transfer event that will appear later
+        action_item = ActionItem(
+            action='transform',
+            from_event_type=HistoryEventType.RECEIVE,
+            from_event_subtype=HistoryEventSubType.NONE,
+            asset=A_GRT,
+            amount=tokens_amount_norm,
+            to_event_type=HistoryEventType.STAKING,
+            to_event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            to_notes=f'Withdraw {tokens_amount_norm} GRT from indexer {indexer}',
+            to_counterparty=CPT_THEGRAPH,
+        )
+        return DecodingOutput(action_items=[action_item])

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -75,6 +75,7 @@ def test_decoders_initialization(ethereum_transaction_decoder: 'EthereumTransact
         'Safemultisig',
         'Stakedao',
         'Sushiswap',
+        'Thegraph',
         'Uniswapv1',
         'Uniswapv2',
         'Uniswapv3',
@@ -138,6 +139,7 @@ def test_decoders_initialization(ethereum_transaction_decoder: 'EthereumTransact
         'arbitrum_one',
         'base',
         'sDAI',
+        'thegraph',
     }
 
 

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -1,0 +1,174 @@
+import pytest
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.evm_event import EvmEvent
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.chain.ethereum.modules.thegraph.constants import CPT_THEGRAPH
+from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_ETH, A_GRT
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
+from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+
+ADDY_USER = string_to_evm_address('0xd200aeEC7Cd9dD27CAB5a85083953a734D4e84f0')
+ADDY_THEGRAPH = string_to_evm_address('0xF55041E37E12cD407ad00CE2910B8269B01263b9')
+
+
+@pytest.mark.vcr()
+@pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
+def test_thegraph_delegate(database, ethereum_inquirer):
+    tx_hash = deserialize_evm_tx_hash('0x6ed3377db652151fb8e4794dd994a921a2d029ad317bd3f2a2916af239490fec')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        database=database,
+        tx_hash=tx_hash,
+    )
+    timestamp = TimestampMS(1690731467000)
+    expected_events = [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            balance=Balance(amount=FVal('0.002150596408306665')),
+            location_label=ADDY_USER,
+            notes='Burned 0.002150596408306665 ETH for gas',
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=358,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.INFORMATIONAL,
+            event_subtype=HistoryEventSubType.APPROVE,
+            asset=A_GRT,
+            balance=Balance(amount=FVal('1.157920892373161954235709850E+59')),
+            location_label=ADDY_USER,
+            notes=(
+                f'Set GRT spending approval of {ADDY_USER} by {ADDY_THEGRAPH}'
+                f' to 115792089237316195423570985000000000000000000000000000000000'
+            ),
+            counterparty=None,
+            address=ADDY_THEGRAPH,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=359,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.STAKING,
+            event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+            asset=A_GRT,
+            balance=Balance(amount=FVal('998.98')),
+            location_label=ADDY_USER,
+            notes='Delegate 998.98 GRT to indexer 0x6125eA331851367716beE301ECDe7F38A7E429e7',
+            counterparty=CPT_THEGRAPH,
+            address=ADDY_THEGRAPH,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=360,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_GRT,
+            balance=Balance(amount=FVal('5.02')),
+            location_label=ADDY_USER,
+            notes='Burn 5.02 GRT as delegation tax',
+            counterparty=CPT_THEGRAPH,
+            address=ADDY_THEGRAPH,
+        ),
+    ]
+    assert expected_events == events
+
+
+@pytest.mark.vcr()
+@pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
+def test_thegraph_undelegate(database, ethereum_inquirer):
+    tx_hash = deserialize_evm_tx_hash('0x5ca5244868d9c0d8c30a1cad0feaf137bd28acd9c3f669a09a3a199fd75ad25a')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        database=database,
+        tx_hash=tx_hash,
+    )
+    timestamp = TimestampMS(1691771855000)
+    expected_events = [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            balance=Balance(amount=FVal('0.00307607001551556')),
+            location_label=ADDY_USER,
+            notes='Burned 0.00307607001551556 ETH for gas',
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=297,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.INFORMATIONAL,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_GRT,
+            balance=Balance(),
+            location_label=ADDY_USER,
+            notes=(
+                'Undelegate 1003.70342593701668535 GRT from'
+                ' indexer 0x6125eA331851367716beE301ECDe7F38A7E429e7. Lock expires in 983 seconds'
+            ),
+            counterparty=CPT_THEGRAPH,
+            address=ADDY_THEGRAPH,
+        ),
+    ]
+    assert expected_events == events
+
+
+@pytest.mark.vcr()
+@pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
+def test_thegraph_delegated_withdrawn(database, ethereum_inquirer):
+    tx_hash = deserialize_evm_tx_hash('0x49307751de5ba4cf98fccbdd1ab8387fd60a7ce120800212c216bf0a6a04acfa')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        database=database,
+        tx_hash=tx_hash,
+    )
+    timestamp = TimestampMS(1694577371000)
+    expected_events = [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            balance=Balance(amount=FVal('0.000651667321615926')),
+            location_label=ADDY_USER,
+            notes='Burned 0.000651667321615926 ETH for gas',
+            counterparty=CPT_GAS,
+        ),
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=208,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.STAKING,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_GRT,
+            balance=Balance(amount=FVal('1003.70342593701668535')),
+            location_label=ADDY_USER,
+            notes=(
+                'Withdraw 1003.70342593701668535 GRT'
+                ' from indexer 0x6125eA331851367716beE301ECDe7F38A7E429e7'
+            ),
+            counterparty=CPT_THEGRAPH,
+            address=ADDY_THEGRAPH,
+        ),
+    ]
+    assert expected_events == events


### PR DESCRIPTION
Related to #(2044)

For Delegator staking the typical scenario is:
- call `delegate()` (emits `StakeDelegated` event)
- call `undelegate()` (emits `StakeDelegatedLocked` event)
- call `withdrawDelegated()` (emits `StakeDelegatedWithdrawn` event)