### PR TITLE
Handle some kraken event edge cases

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 * :bug:`6647` When PnL report generation is finished, users will not be redirected to the report page, but will get notified instead.
 * :bug:`6667` Wrong ENS name should no longer be reported for some edge case of ENS actions and the name should also appear in more events than before.
 * :bug:`-` Aave v2 accounting for deposit interest profit and borrow payback loss should now work correctly again.
+* :bug:`6169` Handle some kraken event categories better and show them in the UI. Categories like failed withdrawals, moving funds from/to staking and credits of forked assets or delisted asset trades.
 
 * :release:`1.30.2 <2023-09-21>`
 * :feature:`-` Improved support for importing Binance CSV files.

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1245,6 +1245,10 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
                         extra_data={'location_label': self.name},
                     )
                 continue
+            if event.event_type == HistoryEventType.TRADE and event.event_subtype == HistoryEventSubType.SPEND:  # noqa: E501
+                event.sequence_index = 0
+            elif event.event_type == HistoryEventType.TRADE and event.event_subtype == HistoryEventSubType.RECEIVE:  # noqa: E501
+                event.sequence_index = 1
 
             returned_events.append(event)
 

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -327,7 +327,7 @@ def get_random_kraken_asset() -> str:
 def generate_random_kraken_balance_response() -> dict[str, FVal]:
     kraken_assets = set(KRAKEN_TO_WORLD.keys()) - set(KRAKEN_DELISTED)
     number_of_assets = random.randrange(0, len(kraken_assets))
-    chosen_assets = random.sample(kraken_assets, number_of_assets)
+    chosen_assets = random.sample(list(kraken_assets), number_of_assets)
 
     balances = {}
     for asset in chosen_assets:


### PR DESCRIPTION
Fixes #6169 

### [Properly handle negative amounts for kraken staking](https://github.com/rotki/rotki/commit/8bc1afdbc29529e8addf53e47a23c49ee4e965ce) 

This handles part of https://github.com/rotki/rotki/issues/6169 where
negative amounts appeared in Kraken for:

- Moving from/to staking or earn program.
- Internal transfer events such as crediting forked coins, or trading
  away delisted assets
- OTC or private deals

### [Handle kraken failed withdrawals and other events properly](https://github.com/rotki/rotki/commit/01c0bbe23ba4abc480a4bfe95f0af3cae5096782)

Handle failed transactions such as withdrawals deposit that cancel each other out.