### PR TITLE
add balances detection for The Graph

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 
+* :feature:`6733` Added support for detection of GRT tokens delegated to indexers in The Graph protocol (amounts including rewards).
 * :feature:`-` Binance CSV importing will now recognize more entry types.
 * :feature:`6712` The Graph protocol support has been added. The events related to delegator staking now will be properly displayed and accounted for.
 * :feature:`5843` Velodrome is now supported in Optimism. Related transactions should be decoded properly and shown in human readable format and any balances in Velodrome auto-detected.

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -45,6 +45,7 @@ from rotkehlchen.chain.ethereum.modules import (
 from rotkehlchen.chain.ethereum.modules.convex.balances import ConvexBalances
 from rotkehlchen.chain.ethereum.modules.curve.balances import CurveBalances
 from rotkehlchen.chain.ethereum.modules.eth2.structures import Eth2Validator
+from rotkehlchen.chain.ethereum.modules.thegraph.balances import ThegraphBalances
 from rotkehlchen.chain.optimism.modules.velodrome.balances import VelodromeBalances
 from rotkehlchen.chain.substrate.manager import wait_until_a_node_is_available
 from rotkehlchen.chain.substrate.utils import SUBSTRATE_NODE_CONNECTION_TIMEOUT
@@ -177,7 +178,7 @@ DEFI_PROTOCOLS_TO_SKIP_LIABILITIES = {
     'Compound': True,
 }
 CHAIN_TO_BALANCE_PROTOCOLS = {
-    ChainID.ETHEREUM: (CurveBalances, ConvexBalances),
+    ChainID.ETHEREUM: (CurveBalances, ConvexBalances, ThegraphBalances),
     ChainID.OPTIMISM: (VelodromeBalances,),
 }
 

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
-PROTOCOLS_WITH_BALANCES = Literal['curve', 'convex', 'velodrome']
+PROTOCOLS_WITH_BALANCES = Literal['curve', 'convex', 'velodrome', 'thegraph']
 BalancesType = dict[ChecksumEvmAddress, dict[EvmToken, Balance]]
 
 

--- a/rotkehlchen/chain/ethereum/modules/thegraph/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/balances.py
@@ -1,0 +1,140 @@
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.evm_event import EvmProduct
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithBalance
+from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_GRT
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+
+from .constants import CONTRACT_STAKING, CPT_THEGRAPH
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.interfaces.balances import BalancesType
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.types import CHAIN_IDS_WITH_BALANCE_PROTOCOLS
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class ThegraphBalances(ProtocolWithBalance):
+    def __init__(
+            self,
+            database: DBHandler,
+            evm_inquirer: 'EthereumInquirer',
+            chain_id: 'CHAIN_IDS_WITH_BALANCE_PROTOCOLS',
+    ):
+        super().__init__(
+            database=database,
+            evm_inquirer=evm_inquirer,
+            chain_id=chain_id,
+            counterparty=CPT_THEGRAPH,
+        )
+        self.grt = A_GRT.resolve_to_evm_token()
+
+    def get_deposit_events(self) -> set[tuple[HistoryEventType, HistoryEventSubType]]:
+        return {(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)}
+
+    def query_balances(self) -> 'BalancesType':
+        """
+        Query balances of GRT tokens delegated to indexers if deposit events are found.
+        First, the current shares amounts are fetched from the contract,
+        then shares are converted into GRT balances according to the current pool ratio.
+        The results include delegation rewards earned over time.
+        """
+        balances: BalancesType = defaultdict(lambda: defaultdict(Balance))
+
+        # fetch deposit events
+        addresses_with_deposits = self.addresses_with_deposits(
+            product=EvmProduct.STAKING,
+            deposit_events=self.get_deposit_events(),
+        )
+        # remap all events into a list that will contain all pairs (delegator, indexer)
+        delegations_unique = set()
+        for delegator, event_list in addresses_with_deposits.items():
+            for event in event_list:
+                if event.extra_data is None:
+                    continue
+                if (indexer := event.extra_data.get('indexer')) is not None:
+                    delegations_unique.add((delegator, indexer))
+        delegations = list(delegations_unique)
+
+        # user had no delegation events
+        if len(delegations) == 0:
+            return balances
+
+        staking_contract = self.evm_inquirer.contracts.contract(string_to_evm_address(CONTRACT_STAKING))  # noqa: E501
+        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+
+        # query how many shares delegator currently have at the indexers/pools
+        delegation_balances = self.evm_inquirer.multicall(
+            calls=[(
+                staking_contract.address,
+                staking_contract.encode(
+                    method_name='getDelegation',
+                    arguments=[indexer, delegator],
+                ),
+            ) for delegator, indexer in delegations],
+            call_order=call_order,
+            calls_chunk_size=chunk_size,
+        )
+
+        # process all current delegation balances
+        delegations_active = []
+        for idx, delegation in enumerate(delegations):
+            shares, _, _ = staking_contract.decode(
+                delegation_balances[idx],
+                'getDelegation',
+                arguments=[delegation[1], delegation[0]],
+            )[0]
+            if shares > 0:
+                delegations_active.append((delegation[0], delegation[1], shares))
+
+        # user has already undelegated everything and has no active stakes
+        if len(delegations_active) == 0:
+            return balances
+
+        # query current total amount of shares and tokens in all pools that currently have stake
+        pools = self.evm_inquirer.multicall(
+            calls=[(
+                staking_contract.address,
+                staking_contract.encode(
+                    method_name='delegationPools',
+                    arguments=[indexer],
+                ),
+            ) for _, indexer, _ in delegations_active],
+            call_order=call_order,
+            calls_chunk_size=chunk_size,
+        )
+
+        grt_price = Inquirer().find_usd_price(A_GRT)
+        for idx, stake in enumerate(delegations_active):
+            delegator, indexer, shares_amount = stake[0], stake[1], stake[2]
+
+            # each calculation is for one pool
+            _, _, _, _, pool_total_tokens, pool_total_shares = staking_contract.decode(
+                result=pools[idx],
+                method_name='delegationPools',
+                arguments=[indexer],
+            )[0]
+
+            # calculate current tokens balance relative to the pool state and shares distribution
+            if pool_total_shares == 0:
+                continue
+            balance = FVal(shares_amount * pool_total_tokens / pool_total_shares)
+            balance_norm = asset_normalized_value(balance.to_int(exact=False), self.grt)
+            balances[delegator][self.grt] += Balance(
+                amount=balance_norm,
+                usd_value=grt_price * balance_norm,
+            )
+
+        return balances

--- a/rotkehlchen/chain/ethereum/modules/thegraph/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/constants.py
@@ -1,9 +1,12 @@
+from typing import Final
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 
-CPT_THEGRAPH = 'thegraph'
+CPT_THEGRAPH: Final = 'thegraph'
 
 THEGRAPH_CPT_DETAILS = CounterpartyDetails(
     identifier=CPT_THEGRAPH,
     label='The Graph',
     image='thegraph.svg',
 )
+
+CONTRACT_STAKING = '0xF55041E37E12cD407ad00CE2910B8269B01263b9'

--- a/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
@@ -2,8 +2,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.evm_event import EvmProduct
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.modules.thegraph.constants import (
+    CONTRACT_STAKING,
     CPT_THEGRAPH,
     THEGRAPH_CPT_DETAILS,
 )
@@ -31,7 +33,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
-CONTRACT_THEGRAPH_STAKING = string_to_evm_address('0xF55041E37E12cD407ad00CE2910B8269B01263b9')
+CONTRACT_THEGRAPH_STAKING = string_to_evm_address(CONTRACT_STAKING)
 TOPIC_TRANSFER = b'\xdd\xf2R\xad\x1b\xe2\xc8\x9bi\xc2\xb0h\xfc7\x8d\xaa\x95+\xa7\xf1c\xc4\xa1\x16(\xf5ZM\xf5#\xb3\xef'  # noqa: E501
 # example delegate() call: https://etherscan.io/tx/0x6ed3377db652151fb8e4794dd994a921a2d029ad317bd3f2a2916af239490fec
 TOPIC_STAKE_DELEGATED = b'\xcd\x03f\xdc\xe5$}\x87O\xfc`\xa7b\xaaz\xbb\xb8,\x16\x95\xbb\xb1q`\x9c\x1b\x88a\xe2y\xebs'  # noqa: E501
@@ -108,6 +110,8 @@ class ThegraphDecoder(DecoderInterface):
                 event.balance = Balance(amount=stake_amount_norm)
                 event.notes = f'Delegate {stake_amount_norm} GRT to indexer {indexer}'
                 event.counterparty = CPT_THEGRAPH
+                event.extra_data = {'indexer': indexer}
+                event.product = EvmProduct.STAKING
                 deposit_event = event
 
                 # also account for the GRT burnt due to delegation tax

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -1,9 +1,9 @@
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
-from rotkehlchen.accounting.structures.evm_event import EvmEvent
+from rotkehlchen.accounting.structures.evm_event import EvmEvent, EvmProduct
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.chain.ethereum.modules.thegraph.constants import CPT_THEGRAPH
+from rotkehlchen.chain.ethereum.modules.thegraph.constants import CONTRACT_STAKING, CPT_THEGRAPH
 from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_GRT
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 ADDY_USER = string_to_evm_address('0xd200aeEC7Cd9dD27CAB5a85083953a734D4e84f0')
-ADDY_THEGRAPH = string_to_evm_address('0xF55041E37E12cD407ad00CE2910B8269B01263b9')
+ADDY_THEGRAPH = string_to_evm_address(CONTRACT_STAKING)
 
 
 @pytest.mark.vcr()
@@ -67,6 +67,8 @@ def test_thegraph_delegate(database, ethereum_inquirer):
             notes='Delegate 998.98 GRT to indexer 0x6125eA331851367716beE301ECDe7F38A7E429e7',
             counterparty=CPT_THEGRAPH,
             address=ADDY_THEGRAPH,
+            extra_data={'indexer': '0x6125eA331851367716beE301ECDe7F38A7E429e7'},
+            product=EvmProduct.STAKING,
         ), EvmEvent(
             tx_hash=tx_hash,
             sequence_index=360,


### PR DESCRIPTION
Related to [#2044](https://github.com/rotki/rotki/issues/2044)

To detect GRT balances we fetch all `StakeDelegated` events, pick all relevant delegator-indexer pairs and query The Graph staking contract to get data on delegator shares within all pools. With this data we then can calculate shares back to the relevant amount of GRT tokens.