### PR TITLE
Fix substrate tests and subscan bug

### DIFF
--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -406,6 +406,7 @@ class SubstrateManager:
                 SubstrateRequestException,
                 WebSocketException,
                 ValueError,
+                AttributeError,
         ) as e:
             message = (
                 f'{self.chain} failed to request last block '
@@ -460,7 +461,7 @@ class SubstrateManager:
         """Subscan API metadata documentation:
         https://docs.api.subscan.io/#metadata
         """
-        url = f'https://{self.chain.get_key()}.api.subscan.io/api/scan/metadata'
+        url = f'https://{self.chain.name.lower()}.api.subscan.io/api/scan/metadata'
         log.debug(f'{self.chain} subscan API request', request_url=url)
         try:
             response = requests.post(url=url, timeout=CachedSettings().get_timeout_tuple())

--- a/rotkehlchen/tests/api/test_substrate_manager.py
+++ b/rotkehlchen/tests/api/test_substrate_manager.py
@@ -1,15 +1,15 @@
 import pytest
 import requests
-from flaky import flaky
 
 from rotkehlchen.chain.substrate.types import KusamaNodeName
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
-from rotkehlchen.tests.utils.substrate import KUSAMA_TEST_NODES, SUBSTRATE_ACC1_KSM_ADDR
+from rotkehlchen.tests.utils.substrate import KUSAMA_TEST_RPC_ENDPOINT
 
 
-@flaky(max_runs=3, min_passes=1)  # Kusama open nodes some times time out
-def test_set_own_rpc_endpoint(rotkehlchen_api_server):
-    """Test that successfully setting an own node (via `ksm_rpc_endpoint` setting)
+@pytest.mark.vcr()
+@pytest.mark.freeze_time('2023-10-12 09:00:00 GMT')
+def test_set_unset_own_rpc_endpoint(rotkehlchen_api_server):
+    """Test that successfully setting/unsetting an own node (via `ksm_rpc_endpoint` setting)
     updates the `available_node_attributes_map`, sorts `available_nodes_call_order`,
     and sets the `own_rpc_endpoint` property.
 
@@ -24,40 +24,17 @@ def test_set_own_rpc_endpoint(rotkehlchen_api_server):
     assert len(kusama_manager.available_nodes_call_order) == 0
 
     # Set ksm_rpc_endpoint with a reliable endpoint (e.g. NOT Parity)
-    test_node_endpoint = KUSAMA_TEST_NODES[1].endpoint()
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'settingsresource'),
-        json={'settings': {'ksm_rpc_endpoint': test_node_endpoint}},
+        json={'settings': {'ksm_rpc_endpoint': KUSAMA_TEST_RPC_ENDPOINT}},
     )
 
     # Check settings response
     result = assert_proper_response_with_result(response)
-    assert result['ksm_rpc_endpoint'] == test_node_endpoint
+    assert result['ksm_rpc_endpoint'] == KUSAMA_TEST_RPC_ENDPOINT
 
     # Check SubstrateManager instance
-    assert kusama_manager.own_rpc_endpoint == test_node_endpoint
-    assert len(kusama_manager.available_node_attributes_map) == 1
-    assert len(kusama_manager.available_nodes_call_order) == 1
-    assert KusamaNodeName.OWN in kusama_manager.available_node_attributes_map
-    assert kusama_manager.available_nodes_call_order[0][0] == KusamaNodeName.OWN
-
-
-@flaky(max_runs=3, min_passes=1)  # Kusama open nodes some times time out
-@pytest.mark.parametrize('ksm_accounts', [[SUBSTRATE_ACC1_KSM_ADDR]])
-@pytest.mark.parametrize('ksm_rpc_endpoint', [KUSAMA_TEST_NODES[1].endpoint()])
-@pytest.mark.parametrize('kusama_manager_connect_at_start', [[KusamaNodeName.OWN]])
-def test_unset_own_rpc_endpoint(ksm_rpc_endpoint, rotkehlchen_api_server):
-    """Test that unsetting the own node (via `ksm_rpc_endpoint` setting) removes
-    it from `available_node_attributes_map` and `available_nodes_call_order`,
-    and sets the `own_rpc_endpoint` property to empty string.
-
-    NB: `set_rpc_endpoint()` is synchronous therefore no need to sleep/wait.
-    """
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    kusama_manager = rotki.chains_aggregator.kusama
-
-    # Property exists (own node connected)
-    assert kusama_manager.own_rpc_endpoint == ksm_rpc_endpoint
+    assert kusama_manager.own_rpc_endpoint == KUSAMA_TEST_RPC_ENDPOINT
     assert len(kusama_manager.available_node_attributes_map) == 1
     assert len(kusama_manager.available_nodes_call_order) == 1
     assert KusamaNodeName.OWN in kusama_manager.available_node_attributes_map

--- a/rotkehlchen/tests/data/pnl_debug.json
+++ b/rotkehlchen/tests/data/pnl_debug.json
@@ -4,7 +4,7 @@
       "identifier": 1,
       "event_identifier": "0xb626d9d9e3a5b9ecbe0c2194cf96ab7561063c6d31e0e6799d56a589b8094609",
       "sequence_index": 0,
-      "timestamp": 1651258550,
+      "timestamp": 1651258550000,
       "location": "blockchain",
       "asset": "ETH",
       "balance": {
@@ -22,7 +22,7 @@
       "identifier": 2,
       "event_identifier": "0xa9905f5eaa664a53e6513f7ba2147dcebc3e54d4062df9df1925116b6a220014",
       "sequence_index": 0,
-      "timestamp": 1651259834,
+      "timestamp": 1651259834000,
       "location": "blockchain",
       "asset": "ETH",
       "balance": {

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -391,10 +391,11 @@ def initialize_mock_rotkehlchen_instance(
         for evm_inquirer, connect_at_start in evm_nodes_wait:
             wait_until_all_nodes_connected(connect_at_start=connect_at_start, evm_inquirer=evm_inquirer)  # noqa: E501
 
-    wait_until_all_substrate_nodes_connected(
-        substrate_manager_connect_at_start=kusama_manager_connect_at_start,
-        substrate_manager=rotki.chains_aggregator.kusama,
-    )
+    if len(rotki.chains_aggregator.accounts.ksm) != 0:
+        wait_until_all_substrate_nodes_connected(  # no connection would have been attempted if there are no accounts  # noqa: E501
+            substrate_manager_connect_at_start=kusama_manager_connect_at_start,
+            substrate_manager=rotki.chains_aggregator.kusama,
+        )
 
 
 @pytest.fixture(name='uninitialized_rotkehlchen')

--- a/rotkehlchen/tests/utils/substrate.py
+++ b/rotkehlchen/tests/utils/substrate.py
@@ -43,6 +43,7 @@ KUSAMA_SS58_FORMAT = 2
 POLKADOT_SS58_FORMAT = 2
 KUSAMA_MAIN_ASSET_DECIMALS = FVal(12)
 KUSAMA_DEFAULT_OWN_RPC_ENDPOINT = 'http://localhost:9933'
+KUSAMA_TEST_RPC_ENDPOINT = 'https://ksm.getblock.io/ae78eb1d-2643-4e22-b691-0ecb9d9c5e08/mainnet/'  # made by lef for testing # noqa: E501
 
 
 def attempt_connect_test_nodes(
@@ -109,8 +110,7 @@ def wait_until_all_substrate_nodes_connected(
         substrate_manager: SubstrateManager,
         timeout: int = NODE_CONNECTION_TIMEOUT,
 ) -> None:
-    """Wait until all substrate nodes are connected or until a timeout is hit.
-    """
+    """Wait until all substrate nodes are connected or until a timeout is hit"""
     all_nodes: set[NodeName] = set(substrate_manager_connect_at_start)
     connected: set[NodeName] = set()
     try:


### PR DESCRIPTION
### [Fix bug with substrate manager subscan query](https://github.com/rotki/rotki/commit/cb55fdad64ce05681d3f391fdd8e83f95e0cb640) 

Also catch AttributeError as potential error from the underlying
library. They really do no error handling ...

### [Fix substrate tests and fixtures. VCR them too.](https://github.com/rotki/rotki/commit/f83ffce9f7fa6062277e2a8224b1e1d45c7ba1a4) 

- Due to the way the tests were written the
wait_until_all_substrate_nodes_connected always timed out. Since at
the point of the fixture there was no kusama accounts for some tests.
- It also tried to connect to all kusama nodes, of which onfinality is
being bad right now and 409s almost everything. On top of that they
ran with the flaky modifier which means they did not fail but retry up
to 3 times
- VCRed them and adjusted fixtures so all these problems go away