### PR TITLE
fix: typos inside docs/installation_guide.rst

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -621,7 +621,7 @@ Python
 ^^^^^^^^^^^^^^^^^^^^
 
 1. Get `python 3.10 <https://www.python.org/downloads/release/python-31011/>`_ (3.10 is required due to some rotki dependencies). Make sure to download the 64-bit version of python if your version of Windows is 64-bit! If you're unsure of what Windows version you have, you can check in Control Panel -> System and Security -> System.
-2. For some reason python does not always install to the Path variable in Windows. To ensure you have the necessary python directories referenced, go to Control Panel -> System -> Advanced system settings -> Advanced (tab) -> Environment Variables... In the Environment Variables... dialog under "System Varaiables" open the "Path" variable and ensure that both the root python directory as well as the ``\Scripts\`` subdirectory are included. If they are not, add them one by one by clicking "New" and then "Browse" and locating the correct directories. NOTE: By default the Windows MSI installer place python in the ``C:\Users\<username>\AppData\Local\Programs\`` directory.
+2. For some reason python does not always install to the Path variable in Windows. To ensure you have the necessary python directories referenced, go to Control Panel -> System -> Advanced system settings -> Advanced (tab) -> Environment Variables... In the Environment Variables... dialog under "System Variables" open the "Path" variable and ensure that both the root python directory as well as the ``\Scripts\`` subdirectory are included. If they are not, add them one by one by clicking "New" and then "Browse" and locating the correct directories. NOTE: By default the Windows MSI installer place python in the ``C:\Users\<username>\AppData\Local\Programs\`` directory.
 3. To test if you have entered python correctly into the Path variable, open a command prompt and type in ``python`` then hit Enter. The python cli should run and you should see the python version you installed depicted above the prompt. Press CTRL+Z, then Enter to exit.
 
     .. NOTE::
@@ -664,7 +664,7 @@ Going back to your open terminal, it's time to set up your python virtual enviro
 
     setprojectdir .
 
-If at any time you want to dissasociate with the virtual env, you can use the command ``deactivate``. Whenever you open a new terminal you can now use ``workon rotki-develop`` (if you named your virtualenv something else then use that instead of ``rotki-develop``) and it should establish the link to the python virtualenv you created and set your working directory to the directory you were in in Step 5. Following the example above, if you open a brand new terminal and type in ``workon rotki-develop`` your terminal prompt should look something like::
+If at any time you want to disassociate with the virtual env, you can use the command ``deactivate``. Whenever you open a new terminal you can now use ``workon rotki-develop`` (if you named your virtualenv something else then use that instead of ``rotki-develop``) and it should establish the link to the python virtualenv you created and set your working directory to the directory you were in in Step 5. Following the example above, if you open a brand new terminal and type in ``workon rotki-develop`` your terminal prompt should look something like::
 
     (rotki-develop) c:\dev\rotki-develop>
 


### PR DESCRIPTION
This PR fixes a couple of typos inside of docs/installation_guide.rst.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
