### PR TITLE
fixed multiple typos inside docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3875,7 +3875,7 @@ Refreshing asset icons
 .. http:patch:: /api/(version)/assets/icon/modify
 
    Doing a PATCH on the asset icon endpoint will refresh the icon of the given asset.
-   First, the cache of the icon of the given asset is deleted and then required from CoinGecko and saved to the filesystem.
+   First, the cache of the icon of the given asset is deleted and then re-queried from CoinGecko and saved to the filesystem.
 
 
    **Example Request**:
@@ -3899,7 +3899,7 @@ Refreshing asset icons
 
       {"result": true, "message": ""}
 
-   :statuscode 200: Icon successfully deleted and required.
+   :statuscode 200: Icon successfully deleted and re-queried.
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 404: Unable to refresh icon at the moment.
    :statuscode 500: Internal rotki error

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -672,7 +672,7 @@ Getting or modifying settings
    :reqjson string[optional] dot_rpc_endpoint: A URL denoting the rpc endpoint for the Polkadot node to use when contacting the Polkadot blockchain. If it can not be reached or if it is invalid any default public node (e.g. Parity) is used instead.
    :reqjson string[optional] main_currency: The FIAT currency to use for all profit/loss calculation. USD by default.
    :reqjson string[optional] date_display_format: The format in which to display dates in the UI. Default is ``"%d/%m/%Y %H:%M:%S %Z"``.
-   :reqjson bool[optional] submit_usage_analytics: A boolean denoting wether or not to submit anonymous usage analytics to the rotki server.
+   :reqjson bool[optional] submit_usage_analytics: A boolean denoting whether or not to submit anonymous usage analytics to the rotki server.
    :reqjson list active_module: A list of strings denoting the active modules with which rotki should run.
    :reqjson list current_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting current prices.
    :reqjson list historical_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting historical prices.
@@ -2478,7 +2478,7 @@ Request transactions event decoding
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a PUT on the evm transactions endpoint will request a decoding of the given transactions and generation of decoded events. That basically entails querying the transaction receipts for each transaction hash and then decoding all events. If events are already queried and ignore_cache is true they will be deleted and requeried.
+   Doing a PUT on the evm transactions endpoint will request a decoding of the given transactions and generation of decoded events. That basically entails querying the transaction receipts for each transaction hash and then decoding all events. If events are already queried and ignore_cache is true they will be deleted and required.
 
    **Example Request**:
 
@@ -2502,7 +2502,7 @@ Request transactions event decoding
 
    :reqjson list data[optional]: A list of data to decode. Each data entry consists of an ``"evm_chain"`` key specifying the evm chain for which to decode tx_hashes and a ``"tx_hashes"`` key which is an optional list of transaction hashes to request decoding for in that chain. If the list of transaction hashes is not passed then all transactions for that chain are decoded. Passing an empty list is not allowed.
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
-   :reqjson bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not. This is always false by default. If true is given then the decoded events will be deleted and requeried.
+   :reqjson bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not. This is always false by default. If true is given then the decoded events will be deleted and required.
 
 
    **Example Response**:
@@ -3004,7 +3004,7 @@ Querying all supported assets
    :reqjson string evm_chain: The name for the evm chain to be used to filter the result data. Possible values are ``ethereum``, ``optimism``, ``gnosis``, ``celo``, etc. Optional.
    :reqjson string address: The address of the evm asset to be used to filter the result data. Optional.
    :reqjson bool show_user_owned_assets_only: A flag to specify if only user owned assets should be returned. Defaults to ``"false"``. Optional.
-   :reqjson string ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exlude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
+   :reqjson string ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exclude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
    :reqjson list[string] identifiers: A list of asset identifiers to filter by. Optional.
 
    **Example Response**:
@@ -3285,7 +3285,7 @@ Search for assets(Levenshtein)
    :reqjson list[string][optional] owner_addresses: A list of evm addresses. If provided, only nfts owned by these addresses will be returned.
    :reqjson string[optional] name: Optional nfts name to filter by.
    :reqjson string[optional] collection_name: Optional nfts collection_name to filter by.
-   :reqjson string[optional] ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exlude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
+   :reqjson string[optional] ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exclude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
 
    **Example Response**:
 
@@ -3466,7 +3466,7 @@ Adding custom asset
    .. _custom_asset:
 
    :reqjson string name: The name of the asset. Required.
-   :reqjson string symbol: The symol of the asset. Required.
+   :reqjson string symbol: The symbol of the asset. Required.
    :reqjson integer started: The time the asset started existing. Optional
    :reqjson string forked: The identifier of an asset from which this asset got forked. For example ETC would have ETH as forked. Optional.
    :reqjson string swapped_for: The identifier of an asset for which this asset got swapped for. For example GNT got swapped for GLM. Optional.
@@ -3875,7 +3875,7 @@ Refreshing asset icons
 .. http:patch:: /api/(version)/assets/icon/modify
 
    Doing a PATCH on the asset icon endpoint will refresh the icon of the given asset.
-   First, the cache of the icon of the given asset is deleted and then requeried from CoinGecko and saved to the filesystem.
+   First, the cache of the icon of the given asset is deleted and then required from CoinGecko and saved to the filesystem.
 
 
    **Example Request**:
@@ -3899,7 +3899,7 @@ Refreshing asset icons
 
       {"result": true, "message": ""}
 
-   :statuscode 200: Icon successfully deleted and requeried.
+   :statuscode 200: Icon successfully deleted and required.
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 404: Unable to refresh icon at the moment.
    :statuscode 500: Internal rotki error
@@ -4682,7 +4682,7 @@ Dealing with History Events
    :resjson int entries_found: The number of entries found for the current filter. Ignores pagination.
    :resjson int entries_limit: The limit of entries if free version. -1 for premium.
    :resjson int entries_total: The number of total entries ignoring all filters.
-   :statuscode 200: Events succesfully queried
+   :statuscode 200: Events successfully queried
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 409: No user is logged in or failure at event addition.
    :statuscode 500: Internal rotki error
@@ -4992,7 +4992,7 @@ Exporting History Events
           "message" "",
       }
 
-   :statuscode 200: Events succesfully exported
+   :statuscode 200: Events successfully exported
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 409: No user is logged in or failure at event export.
    :statuscode 500: Internal rotki error
@@ -5042,7 +5042,7 @@ Exporting History Events
       HTTP/1.1 200 OK
       Content-Type: text/csv
 
-   :statuscode 200: Events succesfully downloaded
+   :statuscode 200: Events successfully downloaded
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 409: No user is logged in or failure at event download.
    :statuscode 500: Internal rotki error
@@ -5085,7 +5085,7 @@ Querying online events
 
    :resjson bool result: A boolean for success or failure
    :resjson str message: Error message if any errors occurred.
-   :statuscode 200: Events were queried succesfully
+   :statuscode 200: Events were queried successfully
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 409: Module for the given events is not active.
    :statuscode 500: Internal rotki error.
@@ -5321,7 +5321,7 @@ Export PnL report debug data
 
    :statuscode 200: Debugging history data returned successfully
    :statuscode 400: Provided JSON is in some way malformed.
-   :statuscode 409: No user is currently logged in. Error occured when creating history events for pnl debug data.
+   :statuscode 409: No user is currently logged in. Error occurred when creating history events for pnl debug data.
    :statuscode 500: Internal rotki error.
 
 
@@ -7060,7 +7060,7 @@ Getting compound statistics
    :resjson object liquidation_profit: A mapping of addresses to mappings of totals assets gained thanks to liquidation repayments over a given period.
    :resjson object rewards: A mapping of addresses to mappings of totals assets (only COMP atm) gained as a reward for using Compound over a given period.
 
-   :statuscode 200: Compound statistics succesfully queried.
+   :statuscode 200: Compound statistics successfully queried.
    :statuscode 400: Requested module is not allowed to query statistics.
    :statuscode 409: User is not logged in. Or compound module is not activated.
    :statuscode 500: Internal rotki error.
@@ -7212,7 +7212,7 @@ Getting Liquity staked amount
    :statuscode 502: An external service used in the query such as etherscan could not be reached or returned unexpected response.
 
 
-Getting Liquity stability pool infomration
+Getting Liquity stability pool information
 ==========================================
 
 .. http:get:: /api/(version)/blockchains/eth/modules/liquity/pool
@@ -8264,7 +8264,7 @@ Getting Eth2 Staking details
    :resjson eth_depositor [optional]string: The eth1 address that made the deposit for the validator. Can be missing if we can't find it yet.
    :resjson index int: The Eth2 validator index.
    :resjson has_exited bool: A boolean indicating if the validator has exited.
-   :resjson public_key str: The Eth2 validator pulic key.
+   :resjson public_key str: The Eth2 validator public key.
    :resjson balance object: The balance in ETH of the validator and its usd value
    :resjson performance_1d object: How much has the validator earned in ETH (and USD equivalent value) in the past day.
    :resjson performance_1w object: How much has the validator earned in ETH (and USD equivalent value) in the past week.
@@ -8483,7 +8483,7 @@ Editing an Eth2 validator
 
 .. http:patch:: /api/(version)/blockchains/eth2/validators
 
-   Doing a PATCH on the eth2 validators endpoint will allow to edit the ownership percentage of a validator indentified by its index.
+   Doing a PATCH on the eth2 validators endpoint will allow to edit the ownership percentage of a validator identified by its index.
 
 
    **Example Request**:
@@ -8811,7 +8811,7 @@ Adding EVM accounts to all EVM chains
 
 .. http:put:: /api/(version)/blockchains/evm/accounts
 
-   Doing a PUT on the EVM accounts endpoint functions just like the add blockchain accounts endpoint but adds the addresses for all evm chains. It will follow the folowing logic. Take ethereum mainnet as the parent chain. If it's a contract there, it will only add it to the mainnet. If it's an EoA it will try all chains one by one and see if they have any transactions/activity and add it to the ones that do.
+   Doing a PUT on the EVM accounts endpoint functions just like the add blockchain accounts endpoint but adds the addresses for all evm chains. It will follow the following logic. Take ethereum mainnet as the parent chain. If it's a contract there, it will only add it to the mainnet. If it's an EoA it will try all chains one by one and see if they have any transactions/activity and add it to the ones that do.
 
    .. note::
      This endpoint can also be queried asynchronously by using ``"async_query": true``
@@ -8859,7 +8859,7 @@ Adding EVM accounts to all EVM chains
    :statuscode 400: Provided JSON or data is in some way malformed. The accounts to add contained invalid addresses or were an empty list.
    :statuscode 409: User is not logged in. Provided tags do not exist. Check message for details.
    :statuscode 500: Internal rotki error
-   :statuscode 502: Remote error occured when attempted to connect to an Avalanche or Polkadot node and only if it's the first account added. Check message for details.
+   :statuscode 502: Remote error occurred when attempted to connect to an Avalanche or Polkadot node and only if it's the first account added. Check message for details.
 
 
 .. http:post:: /api/(version)/blockchains/evm/accounts
@@ -8895,7 +8895,7 @@ Adding EVM accounts to all EVM chains
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 409: User is not logged in. Node that was queried is not synchronized.
    :statuscode 500: Internal rotki error
-   :statuscode 502: Remote error occured.
+   :statuscode 502: Remote error occurred.
 
 
 Adding blockchain accounts
@@ -8958,7 +8958,7 @@ Adding blockchain accounts
    :statuscode 400: Provided JSON or data is in some way malformed. The accounts to add contained invalid addresses or were an empty list.
    :statuscode 409: User is not logged in. Provided tags do not exist. Check message for details.
    :statuscode 500: Internal rotki error
-   :statuscode 502: Remote error occured when attempted to connect to an Avalanche or Polkadot node and only if it's the first account added. Check message for details.
+   :statuscode 502: Remote error occurred when attempted to connect to an Avalanche or Polkadot node and only if it's the first account added. Check message for details.
 
 Adding BTC/BCH xpubs
 ========================
@@ -10398,7 +10398,7 @@ Show NFT Balances
    :reqjson list[string][optional] owner_addresses: A list of evm addresses. If provided, only nfts owned by these addresses will be returned.
    :reqjson string[optional] name: Optional nfts name to filter by.
    :reqjson string[optional] collection_name: Optional nfts collection_name to filter by.
-   :reqjson string[optional] ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exlude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
+   :reqjson string[optional] ignored_assets_handling: A flag to specify how to handle ignored assets. Possible values are `'none'`, `'exclude'` and `'show_only'`. You can write 'none' in order to not handle them in any special way (meaning to show them too). This is the default. You can write 'exclude' if you want to exclude them from the result. And you can write 'show_only' if you want to only see the ignored assets in the result.
    :reqjson int limit: This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson int offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
    :reqjson list[string][optional] order_by_attributes: This is the list of attributes of the nft by which to order the results. By default we sort using ``name``.
@@ -12318,7 +12318,7 @@ Refresh general cache
   :resjson bool result: Is true if all the caches were refreshed successfully.
 
   :statuscode 200: Caches were correctly updated
-  :statuscode 409: An issue during refreshing caches occured
+  :statuscode 409: An issue during refreshing caches occurred
   :statuscode 500: Internal rotki error
 
 Getting Metadata For Airdrops
@@ -12512,10 +12512,10 @@ Dealing with skipped external events
       }
 
   :resjson int total: The total number of skipped events that we tried to reprocess
-  :resjson int succesfull: The number of skipped events that we reprocessed succesfully and were thus deleted from the skipped events table.
+  :resjson int succesfull: The number of skipped events that we reprocessed successfully and were thus deleted from the skipped events table.
 
   :statuscode 200: Reprocessing went fine.
-  :statuscode 409: An issue ocurred during reprocessing
+  :statuscode 409: An issue occurred during reprocessing
   :statuscode 500: Internal rotki error
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2478,7 +2478,7 @@ Request transactions event decoding
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a PUT on the evm transactions endpoint will request a decoding of the given transactions and generation of decoded events. That basically entails querying the transaction receipts for each transaction hash and then decoding all events. If events are already queried and ignore_cache is true they will be deleted and required.
+   Doing a PUT on the evm transactions endpoint will request a decoding of the given transactions and generation of decoded events. That basically entails querying the transaction receipts for each transaction hash and then decoding all events. If events are already queried and ignore_cache is true they will be deleted and re-queried.
 
    **Example Request**:
 
@@ -2502,7 +2502,7 @@ Request transactions event decoding
 
    :reqjson list data[optional]: A list of data to decode. Each data entry consists of an ``"evm_chain"`` key specifying the evm chain for which to decode tx_hashes and a ``"tx_hashes"`` key which is an optional list of transaction hashes to request decoding for in that chain. If the list of transaction hashes is not passed then all transactions for that chain are decoded. Passing an empty list is not allowed.
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
-   :reqjson bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not. This is always false by default. If true is given then the decoded events will be deleted and required.
+   :reqjson bool ignore_cache: Boolean denoting whether to ignore the cache for this query or not. This is always false by default. If true is given then the decoded events will be deleted and re-queried.
 
 
    **Example Response**:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -697,7 +697,7 @@ Changelog
 * :bug:`2835` Eth2 users with a very big number of validators should no longer get a 429 error.
 * :bug:`2846` Premium users who create a new account with premium api credentials that have no saved DB in the server to sync with will have these credentials properly saved in the DB right after creation. At re-login the premium subscription should be properly recognized and the credentials should not need to be input again.
 * :bug:`2821` Users will now be able to properly scroll through the asset when conflicts appear during the asset database upgrade.
-* :bug:`2837` Binance US users will now be able to see the correct location for their trades and deposits/withdrawals. It should no longer be Binance. To reflect those changes Binance US data should be purged and then required. To see how to purge data for an exchange look here: https://rotki.readthedocs.io/en/latest/usage_guide.html#purging-data
+* :bug:`2837` Binance US users will now be able to see the correct location for their trades and deposits/withdrawals. It should no longer be Binance. To reflect those changes Binance US data should be purged and then re-queried. To see how to purge data for an exchange look here: https://rotki.readthedocs.io/en/latest/usage_guide.html#purging-data
 * :bug:`2819` Users using macOS will no longer be stuck at "connecting to backend".
 * :bug:`865` Users will now be given an option to retry or terminate the application when communication with the backend fails.
 * :bug:`2791` Updating assets database which adds customs assets already owned as officially supported should no longer get the DB in an inconsistent state.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,7 +37,7 @@ Changelog
 * :bug:`-` Last premium DB upload will now show the last known DB upload time from the remote and not the time the local app did its last upload. This is important for people using multiple machines.
 * :bug:`6528` Spam assets will be synced across accounts sharing the same globaldb and won't be queried during token detection.
 * :bug:`-` Removed deprecated "Reset DB button" from the aave/yearn view.
-* :bug:`6524` Premium users will be able to explicity request to force push their local DB to the server backup properly again.
+* :bug:`6524` Premium users will be able to explicitly request to force push their local DB to the server backup properly again.
 * :bug:`-` Fix an issue where certain gitcoin donations were not detected in optimism and where the big transfer to the contract which later splits into the donations was mistakenly kept.
 
 * :release:`1.30.0 <2023-08-17>`
@@ -186,7 +186,7 @@ Changelog
 * :feature:`1793` The PnL report can now be generated with the average cost basis accounting method.
 * :feature:`5148` Users will now see tokens detected for accounts having a DSProxy.
 * :feature:`5526` Users will now be able to read the name of the profit currency when moving the mouse over the currency symbol.
-* :feature:`4912` Users can now ignore invidual NFTs and they will not appear in the dashboard balances or snapshots.
+* :feature:`4912` Users can now ignore individual NFTs and they will not appear in the dashboard balances or snapshots.
 * :feature:`5050` Users can now add a custom image/icon for each custom asset they own.
 * :bug:`4332` Price oracles are now temporarily penalized after repeated failures.
 * :bug:`5402` Fix issue where the wrong filepath is used when deleting user DB backup in Windows.
@@ -418,7 +418,7 @@ Changelog
 * :bug:`-` AVAX balances should now be always correctly queried.
 * :bug:`-` PnL report will correctly detect asset cost basis when the fee of a trade is nominated in the received asset.
 * :bug:`3903` The application should now run on macOS 10.14 (Mojave) without errors.
-* :bug:`3901` Coinbase accounts with intenal subaccount movements will now display the Coinbase withdrawals properly.
+* :bug:`3901` Coinbase accounts with internal subaccount movements will now display the Coinbase withdrawals properly.
 
 * :release:`1.23.0 <2021-12-31>`
 * :feature:`3324` Users will be able to set the percentage of ownership for jointly held eth2 validators.
@@ -668,7 +668,7 @@ Changelog
 * :bug:`2986` Users won't be affected by a login error at the moment of querying FTX when the keys are correct.
 
 * :release:`1.17.0 <2021-05-25>`
-* :feature:`2898` Users are now able to see the asset identifiers in the asset management view and replace one asset and all its occurences with another.
+* :feature:`2898` Users are now able to see the asset identifiers in the asset management view and replace one asset and all its occurrences with another.
 * :feature:`2820` Users will now be able to select if they want to view graphs based at a 0 y-axis start instead of the minimum in the selected period.
 * :feature:`2725` Users will now be able to view a small help dialog with the supported options for the date display format.
 * :feature:`1902` Users can now modify the backend settings (e.g. data directory, log directory) through the application.
@@ -697,10 +697,10 @@ Changelog
 * :bug:`2835` Eth2 users with a very big number of validators should no longer get a 429 error.
 * :bug:`2846` Premium users who create a new account with premium api credentials that have no saved DB in the server to sync with will have these credentials properly saved in the DB right after creation. At re-login the premium subscription should be properly recognized and the credentials should not need to be input again.
 * :bug:`2821` Users will now be able to properly scroll through the asset when conflicts appear during the asset database upgrade.
-* :bug:`2837` Binance US users will now be able to see the correct location for their trades and deposits/withdrawals. It should no longer be Binance. To reflect those changes Binance US data should be purged and then requeried. To see how to purge data for an exchange look here: https://rotki.readthedocs.io/en/latest/usage_guide.html#purging-data
+* :bug:`2837` Binance US users will now be able to see the correct location for their trades and deposits/withdrawals. It should no longer be Binance. To reflect those changes Binance US data should be purged and then required. To see how to purge data for an exchange look here: https://rotki.readthedocs.io/en/latest/usage_guide.html#purging-data
 * :bug:`2819` Users using macOS will no longer be stuck at "connecting to backend".
 * :bug:`865` Users will now be given an option to retry or terminate the application when communication with the backend fails.
-* :bug:`2791` Updating assets database which adds customs assets already owned as officially supported should no longer get the DB in an incosistent state.
+* :bug:`2791` Updating assets database which adds customs assets already owned as officially supported should no longer get the DB in an inconsistent state.
 
 * :release:`1.16.1 <2021-04-30>`
 * :bug:`2811` ETH and WETH are now considered equivalent for cost basis and accounting purposes.
@@ -1603,7 +1603,7 @@ Changelog
 * :bug:`1072` Tax report progress report percentage should now work properly and negative numbers should no longer appear.
 * :feature:`921` A new DeFi overview component is added. There the user can get an overview of all their balances across all DeFi protocols. For protocols that are supported further the user can click and be taken to the protocol specific page to see more details and historical accounting for that protocol.
 * :feature:`1160` The Accounts & Balances page layout has been updated to increase usability. It is now split across three sub-pages: Blockchain Balances, Exchange Balances, Manual Balances (includes Fiat Balances). Exchange Balances is a new page where you will be able to see all of your asset balances for each connected exchange (previously this was only accessible from the Dashboard by clicking on an exchange).
-* :bug:`1140` The Accounts column in "Blockhain Balances" is now correctly sorted by label (if it exists) or the account address.
+* :bug:`1140` The Accounts column in "Blockchain Balances" is now correctly sorted by label (if it exists) or the account address.
 * :bug:`1154` Tag filtering in "Manual Balances" within Accounts & Balances now works correctly if any balances do not have any tags assigned.
 * :bug:`1155` Fix the cryptocompate price queries of LUNA Terra
 * :bug:`1151` Fix for bittrex users so that if bittrex returns dates without a millisecond component rotki can still parse them properly.
@@ -1819,7 +1819,7 @@ Changelog
 * :bug:`698` rotki should now also display the version in the UI for Windows and OSX.
 * :bug:`709` rotki no longer crashes after second time of opening the application in Windows.
 * :bug:`716` The rotki logs for linux now go into a proper directory: ``~/.config/rotki/logs``
-* :feature:`461` You can now label your blockchain accounts and tag them with any numer of custom tags to group them into categories. Tags can be customized.
+* :feature:`461` You can now label your blockchain accounts and tag them with any number of custom tags to group them into categories. Tags can be customized.
 * :bug:`739` If there is an error during DBUpgrade or if the user uses old software to run a new DB we don't crash and burn with a 500 error but instead show a proper message.
 * :bug:`731` Fixed cointracking file import.
 * :bug:`726` Fail gracefully and don't throw a 500 server error if blockchain balance query fails.
@@ -1835,7 +1835,7 @@ Changelog
   - `WaykiChain (WICC) <https://coinmarketcap.com/currencies/waykichain/>`__
 
 * :release:`1.1.1 <2020-02-06>`
-* :bug:`693` Fix crash in OSX .dmg package version that occured with v1.1.0
+* :bug:`693` Fix crash in OSX .dmg package version that occurred with v1.1.0
 
 * :release:`1.1.0 <2020-02-05>`
 * :feature:`626` rotki now accepts addition of API keys for external services such as etherscan or cryptocompare.
@@ -1907,7 +1907,7 @@ Changelog
   - `Morpheus Network (MRPH) <https://coinmarketcap.com/currencies/morpheus-network/>`__
   - `Chiliz (CHZ) <https://coinmarketcap.com/currencies/chiliz/>`__
   - `Binance USD (BUSD) <https://coinmarketcap.com/currencies/binance-usd/>`__
-  - `Band Protcol (BAND) <https://coinmarketcap.com/currencies/band-protocol/>`__
+  - `Band Protocol (BAND) <https://coinmarketcap.com/currencies/band-protocol/>`__
   - `Beam Token (BEAM) <https://coinmarketcap.com/currencies/beam/>`__
 
 * :release:`1.0.3 <2019-08-30>`
@@ -1990,7 +1990,7 @@ Changelog
 * :bug:`206` Fixes an error when adding a bitcoin account for the first time.
 * :bug:`209` Fixes error during login due to invalid date being saved.
 * :bug:`223` Fix error in profit/loss calculation due to bugs in the search of the FIFO queue of buy events.
-* :feature:`221` Rotkehlchen is now shielded against incosistencies of cryptocompare FIAT data.
+* :feature:`221` Rotkehlchen is now shielded against inconsistencies of cryptocompare FIAT data.
 * :bug:`219` Poloniex BTC settlement loss calculation is now correct.
 * :bug:`217` Tax report CSV exports should now agree with the app report.
 * :bug:`211` Handle the BCHSV fork in Kraken properly.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -341,7 +341,7 @@ So essentially determining whether:
 Multiple submodules
 --------------------
 
-The modules system is hierachical and one module may contain multiple submodules. For example uniswap having both v1 and v3 each in their own subdirectories as seen `here <https://github.com/rotki/rotki/tree/develop/rotkehlchen/chain/ethereum/modules/uniswap>`__.
+The modules system is hierarchical and one module may contain multiple submodules. For example uniswap having both v1 and v3 each in their own subdirectories as seen `here <https://github.com/rotki/rotki/tree/develop/rotkehlchen/chain/ethereum/modules/uniswap>`__.
 
 Add a new language or translation
 ===================================
@@ -723,7 +723,7 @@ Exchanges
 
 - Add an invalid exchange API key and see it's handled properly
 - Add a valid exchange API key and see it works. See that dashboard balances are also updated.
-- Remove an exchange and see that it works and that the dasboard balances are updated.
+- Remove an exchange and see that it works and that the dashboard balances are updated.
 
 External Services
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ THE SERVICE IS NOT INTENDED FOR CONTINUOUS MONITORING OF TRANSACTION DATA OR FOR
 Where to start?
 ---------------
 
-If this is the first time looking at rotki you will probably want to visit the :doc:`Installation Guide<installation_guide>`. Once you have succesfully managed to install rotki you can proceed to the :doc:`Usage Guide<usage_guide>`. If you wish to contribute to Rotkehlhen please check the :doc:`Contribution Guide<contribute>`.
+If this is the first time looking at rotki you will probably want to visit the :doc:`Installation Guide<installation_guide>`. Once you have successfully managed to install rotki you can proceed to the :doc:`Usage Guide<usage_guide>`. If you wish to contribute to Rotkehlhen please check the :doc:`Contribution Guide<contribute>`.
 
 
 Contents

--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -621,7 +621,7 @@ Python
 ^^^^^^^^^^^^^^^^^^^^
 
 1. Get `python 3.10 <https://www.python.org/downloads/release/python-31011/>`_ (3.10 is required due to some rotki dependencies). Make sure to download the 64-bit version of python if your version of Windows is 64-bit! If you're unsure of what Windows version you have, you can check in Control Panel -> System and Security -> System.
-2. For some reason python does not always install to the Path variable in Windows. To ensure you have the necessary python directories referenced, go to Control Panel -> System -> Advanced system settings -> Advanced (tab) -> Environment Variables... In the Environment Variables... dialog under "System Varaiables" open the "Path" variable and ensure that both the root python directory as well as the ``\Scripts\`` subdirectory are included. If they are not, add them one by one by clicking "New" and then "Browse" and locating the correct directories. NOTE: By default the Windows MSI installer place python in the ``C:\Users\<username>\AppData\Local\Programs\`` directory.
+2. For some reason python does not always install to the Path variable in Windows. To ensure you have the necessary python directories referenced, go to Control Panel -> System -> Advanced system settings -> Advanced (tab) -> Environment Variables... In the Environment Variables... dialog under "System Variables" open the "Path" variable and ensure that both the root python directory as well as the ``\Scripts\`` subdirectory are included. If they are not, add them one by one by clicking "New" and then "Browse" and locating the correct directories. NOTE: By default the Windows MSI installer place python in the ``C:\Users\<username>\AppData\Local\Programs\`` directory.
 3. To test if you have entered python correctly into the Path variable, open a command prompt and type in ``python`` then hit Enter. The python cli should run and you should see the python version you installed depicted above the prompt. Press CTRL+Z, then Enter to exit.
 
     .. NOTE::
@@ -664,7 +664,7 @@ Going back to your open terminal, it's time to set up your python virtual enviro
 
     setprojectdir .
 
-If at any time you want to dissasociate with the virtual env, you can use the command ``deactivate``. Whenever you open a new terminal you can now use ``workon rotki-develop`` (if you named your virtualenv something else then use that instead of ``rotki-develop``) and it should establish the link to the python virtualenv you created and set your working directory to the directory you were in in Step 5. Following the example above, if you open a brand new terminal and type in ``workon rotki-develop`` your terminal prompt should look something like::
+If at any time you want to disassociate with the virtual env, you can use the command ``deactivate``. Whenever you open a new terminal you can now use ``workon rotki-develop`` (if you named your virtualenv something else then use that instead of ``rotki-develop``) and it should establish the link to the python virtualenv you created and set your working directory to the directory you were in in Step 5. Following the example above, if you open a brand new terminal and type in ``workon rotki-develop`` your terminal prompt should look something like::
 
     (rotki-develop) c:\dev\rotki-develop>
 

--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -971,7 +971,7 @@ Examples of customization. You can set:
 - ``Event Type`` to ``Spend`` / ``Receive`` and ``Event Subtype`` to ``None`` if it is a plain expenditure / receipt.
 - ``Event Type`` to ``Receive`` and ``Event Subtype`` to ``Reward`` if you got a reward for something.
 - ``Event Type`` to ``Receive`` and ``Event Subtype`` to ``Airdrop`` if you received an airdrop.
-- ``Event Type`` to ``Receive`` / ``Spend`` and ``Event Subtype`` to ``Recieve Wrapped`` / ``Return Wrapped`` accordingly if you interacted with a protocol (e.g. Curve, Yearn, Aave, etc.) and received wrapped / returned some wrapped tokens.
+- ``Event Type`` to ``Receive`` / ``Spend`` and ``Event Subtype`` to ``Receive Wrapped`` / ``Return Wrapped`` accordingly if you interacted with a protocol (e.g. Curve, Yearn, Aave, etc.) and received wrapped / returned some wrapped tokens.
 - ``Event Type`` to ``Spend`` and ``Event Subtype`` to ``Fee`` if you are paying a fee for some of your actions.
 - ``Event Type`` to ``Migration`` if it is a migration of assets from one protocol to another and you don't lose / gain anything from this event. For example when migrating from SAI to DAI.
 - ``Event Type`` to ``Staking`` and ``Event Subtype`` to ``Deposit Asset`` if it is a staking event. For example staking in eth2 or in liquity.
@@ -1269,7 +1269,7 @@ You can filter using the following keys:
 * **action:** it can be buy or sell [2]_.
 * **start:** will only filter any trades from that date onwards [2]_.
 * **end:** will only filter any trades that happened before the selected date [2]_.
-* **location:** the location of tha trade, e.g. kraken, uniswap etc [1]_.
+* **location:** the location of the trade, e.g. kraken, uniswap etc [1]_.
 
 .. image:: images/sc_history_trades_filter_suggestions.png
    :alt: Trade filter suggestions
@@ -1306,7 +1306,7 @@ For deposits you can use the following filters:
 * **action:** the actions (withdrawal or deposit) [1]_.
 * **start:** will only filter any trades from that date onwards [2]_.
 * **end:** will only filter any trades that happened before the selected date [2]_.
-* **location:** the location of tha trade, e.g. kraken, uniswap etc [1]_.
+* **location:** the location of the trade, e.g. kraken, uniswap etc [1]_.
 
 .. [1] Suggestions will appear for this field based on the available data.
 .. [2] The date filter has to be in the DD/MM/YYYY HH:mm:ss format. You can completely skip the time part or just the seconds part, thus making DD/MM/YYYY or DD/MM/YYYY HH:mm acceptable.


### PR DESCRIPTION
Multiple typos on 6 different files have been fixed inside /docs

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
