### PR TITLE
Gitcoin allo protocol payout events will be properly decoded

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoinv2/decoder.py
@@ -28,6 +28,11 @@ class Gitcoinv2Decoder(GitcoinV2CommonDecoder):
             project_registry=string_to_evm_address('0x03506eD3f57892C85DB20C36846e9c808aFe9ef4'),
             round_impl_addresses=[
                 string_to_evm_address('0xe575282b376E3c9886779A841A2510F1Dd8C2CE4'),
+                string_to_evm_address('0xdf22a2C8F6BA9376fF17EE13E6154B784ee92094'),
+            ],
+            payout_strategy_addresses=[  # they match to the above round_impl addresses. Can be found by roundimpl.payoutStrategy()  # noqa: E501
+                string_to_evm_address('0xc41bBa19D78242C141D229e5Fe9078def93f304f'),
+                string_to_evm_address('0xebaF311F318b5426815727101fB82f0Af3525d7b'),
             ],
             voting_impl_addresses=[
                 string_to_evm_address('0xDA2F26B30e8f5aa9cbE9c5B7Ed58E1cA81D0EbF2'),

--- a/rotkehlchen/chain/optimism/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/gitcoin/decoder.py
@@ -29,6 +29,9 @@ class GitcoinDecoder(GitcoinV2CommonDecoder):
             round_impl_addresses=[
                 string_to_evm_address('0x8de918F0163b2021839A8D84954dD7E8e151326D'),
             ],
+            payout_strategy_addresses=[  # they match to the above round_impl addresses. Can be found by roundimpl.payoutStrategy()  # noqa: E501
+                string_to_evm_address('0xEb33BB3705135e99F7975cDC931648942cB2A96f'),
+            ],
             voting_impl_addresses=[
                 string_to_evm_address('0x99906Ea77C139000681254966b397a98E4bFdE21'),
                 string_to_evm_address('0x6526B0942E171A933Fd9aF90C993d9c547251042'),


### PR DESCRIPTION
This unfortunately requires, just like with the rounds, maintaining a list of payout_strategy implementations (which can be derived from the round implementation contracts themselves)

Looks like this

![2023-10-14_19-47](https://github.com/rotki/rotki/assets/1658405/e99247cc-4de2-40d2-bb00-2d5683edd41c)
