### PR TITLE
Fix asset resolution problems

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -1767,9 +1767,14 @@ class GlobalDBHandler:
         Resolve asset in only one query to the database
 
         If `use_packaged_db` is True, it checks the packaged global db.
+
+        The functions called here could also potentially raise WrongAssetType
+        but due to the way they are called they should not. The expected type
+        is always based on what type the asset already has in DB when called
+        from this function.
+
         May raise:
         - UnknownAsset if the asset is not found in the database
-        - WrongAssetType
         """
         if identifier.startswith(NFT_DIRECTIVE):
             return Nft(identifier)
@@ -1817,7 +1822,8 @@ class GlobalDBHandler:
     def resolve_asset_from_packaged_and_store(self, identifier: str) -> AssetWithNameAndType:
         """
         Reads an asset from the packaged globaldb and adds it to the database if missing or edits
-        the local version of the asset.
+        the local version of the asset overwriting it with that of the packaged DB.
+
         May raise:
         - UnknownAsset
         """


### PR DESCRIPTION
### [Fix resolve_asset_to_class. If type in DB is not what we ask bail.](https://github.com/rotki/rotki/commit/aa6673236fe1db34c06586749a013875a9d88d5c) 

And by bailing earlier we don't end up overwriting the user's global
DB with the packaged global DB.

What was happening was that at some point all assets were attempted to
be resolved to FIAT assets. Even if they were not FIAT assets. This
basically got us in this code for each asset, and if the asset was in
the constant assets it automatically replaced itself with what was in
packaged DB.

Now this will no longer happen. Only if asset is not in the global DB
or is not what was expected and in the packaged DB it is, will the
replacement happen.

### [When querying current prices use asset resolution properly](https://github.com/rotki/rotki/commit/f5c39e3edcd8ffe01f1cec97add7cfa4b7f196f7) 

Before the code was doing asset resolution as an attempt to try and
see if it's a certain type of asset. For example for FiatAsset, or
EvmToken and used some kind of duck typing with exception suppression.

That's super ugly and hid a bug that made us overwrite user's
globalDB. (see previous commit)

Now instead of doing that we just resolve the asset once and then act
according to type.

