### PR TITLE
Fix data migration version

### DIFF
--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -8,7 +8,7 @@ from rotkehlchen.data_migrations.migrations.migration_3 import data_migration_3
 from rotkehlchen.data_migrations.migrations.migration_5 import data_migration_5
 from rotkehlchen.data_migrations.migrations.migration_10 import data_migration_10
 from rotkehlchen.data_migrations.migrations.migration_11 import data_migration_11
-from rotkehlchen.data_migrations.migrations.migrations_12 import data_migration_12
+from rotkehlchen.data_migrations.migrations.migrations_13 import data_migration_13
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 from .constants import LAST_DATA_MIGRATION
@@ -33,7 +33,7 @@ MIGRATION_LIST = [  # remember to bump LAST_DATA_MIGRATION if editing this
     MigrationRecord(version=5, function=data_migration_5),
     MigrationRecord(version=10, function=data_migration_10),
     MigrationRecord(version=11, function=data_migration_11),
-    MigrationRecord(version=12, function=data_migration_12),
+    MigrationRecord(version=13, function=data_migration_13),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migrations_13.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_13.py
@@ -18,13 +18,13 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def data_migration_12(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
+def data_migration_13(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
     """
     Introduced at v1.31.0
 
     Detects Gnosis and Base chain accounts that have activity and are not yet tracked.
     """
-    log.debug('Enter data_migration_12')
+    log.debug('Enter data_migration_13')
 
     # steps are: ethereum accounts + 3 (potentially write to db + updating spam assets and rpc nodes + new round msg)  # noqa: E501
     progress_handler.set_total_steps(len(rotki.chains_aggregator.accounts.eth) + 3)
@@ -42,4 +42,4 @@ def data_migration_12(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
         rotki=rotki,
         progress_handler=progress_handler,
     )
-    log.debug('Exit data_migration_12')
+    log.debug('Exit data_migration_13')

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -427,7 +427,7 @@ def test_migration_11(
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('data_migration_version', [11])
+@pytest.mark.parametrize('data_migration_version', [12])
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [True])
 @pytest.mark.parametrize('ethereum_accounts', [[
     '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',  # mainnet contract
@@ -435,13 +435,13 @@ def test_migration_11(
 ]])
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])
 @pytest.mark.parametrize('network_mocking', [False])
-def test_migration_12(
+def test_migration_13(
         rotkehlchen_api_server: 'APIServer',
         ethereum_accounts: list[ChecksumEvmAddress],
         websocket_connection: 'WebsocketReader',
 ) -> None:
     """
-    Test migration 12.
+    Test migration 13
 
     - Test that detecting gnosis and base accounts works properly
     """
@@ -450,7 +450,7 @@ def test_migration_12(
             SupportedBlockchain.GNOSIS: [ethereum_accounts[1]],
             SupportedBlockchain.BASE: [ethereum_accounts[1]],
         },
-        migration_version=12,
+        migration_version=13,
         migration_steps=5,  # 2 (current eth accounts) + 3 (potentially write to db + updating spam assets and rpc nodes + new round msg)  # noqa: E501
         migration_list=[MIGRATION_LIST[6]],
         current_evm_accounts=ethereum_accounts,


### PR DESCRIPTION
In master we have that the last data migration is 12 https://github.com/rotki/rotki/blob/31d62792a165ce70c4b71d27c092ac9728a3ad56/rotkehlchen/data_migrations/migrations/migration_12.py#L27 for 1.30.X

but for 1.31 we have the same version so it breaks and it doesn't apply on 1.31
