### PR TITLE
Optimize caches, specifically velodrome

### DIFF
--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, TypeVar
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.utils.data_structures import LRUCacheWithRemove
+from rotkehlchen.utils.data_structures import LRUCacheLowerKey
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import (
@@ -27,8 +27,8 @@ class AssetResolver:
     __instance: Optional['AssetResolver'] = None
     # A cache so that the DB is not hit every time
     # the cache maps identifier -> final representation of the asset
-    assets_cache: LRUCacheWithRemove['AssetWithNameAndType'] = LRUCacheWithRemove(maxsize=512)
-    types_cache: LRUCacheWithRemove[AssetType] = LRUCacheWithRemove(maxsize=512)
+    assets_cache: LRUCacheLowerKey['AssetWithNameAndType'] = LRUCacheLowerKey(maxsize=512)
+    types_cache: LRUCacheLowerKey[AssetType] = LRUCacheLowerKey(maxsize=512)
 
     def __new__(cls) -> 'AssetResolver':
         """Lazily initializes AssetResolver

--- a/rotkehlchen/chain/ethereum/modules/yearn/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaults.py
@@ -467,7 +467,7 @@ class YearnVaults(EthereumModule):
         argument_filters = {'from': address, 'to': vault.contract.address}
         deposit_events = self.ethereum.get_logs(
             contract_address=vault.underlying_token.evm_address,
-            abi=self.ethereum.contracts.abi('ERC20_TOKEN'),
+            abi=self.ethereum.contracts.erc20_abi,
             event_name='Transfer',
             argument_filters=argument_filters,
             from_block=from_block,
@@ -553,7 +553,7 @@ class YearnVaults(EthereumModule):
         argument_filters = {'from': vault.contract.address, 'to': address}
         withdraw_events = self.ethereum.get_logs(
             contract_address=vault.underlying_token.evm_address,
-            abi=self.ethereum.contracts.abi('ERC20_TOKEN'),
+            abi=self.ethereum.contracts.erc20_abi,
             event_name='Transfer',
             argument_filters=argument_filters,
             from_block=from_block,

--- a/rotkehlchen/chain/evm/constants.py
+++ b/rotkehlchen/chain/evm/constants.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from rotkehlchen.types import deserialize_evm_tx_hash
 
 from .types import string_to_evm_address
@@ -27,5 +29,6 @@ FAKE_GENESIS_TX_RECEIPT = {
     'type': '0x0',
 }
 
-ERC20_PROPERTIES = ('decimals', 'symbol', 'name')
-ERC721_PROPERTIES = ('symbol', 'name')
+ERC20_PROPERTIES: Final = ('decimals', 'symbol', 'name')
+ERC20_PROPERTIES_NUM: Final = len(ERC20_PROPERTIES)
+ERC721_PROPERTIES: Final = ('symbol', 'name')

--- a/rotkehlchen/chain/evm/constants.py
+++ b/rotkehlchen/chain/evm/constants.py
@@ -26,3 +26,6 @@ FAKE_GENESIS_TX_RECEIPT = {
     'transactionIndex': 0,
     'type': '0x0',
 }
+
+ERC20_PROPERTIES = ('decimals', 'symbol', 'name')
+ERC721_PROPERTIES = ('symbol', 'name')

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -33,6 +33,7 @@ from rotkehlchen.chain.ethereum.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.ethereum.utils import MULTICALL_CHUNKS, should_update_protocol_cache
 from rotkehlchen.chain.evm.constants import (
     ERC20_PROPERTIES,
+    ERC20_PROPERTIES_NUM,
     ERC721_PROPERTIES,
     FAKE_GENESIS_TX_RECEIPT,
     GENESIS_HASH,
@@ -70,6 +71,7 @@ from rotkehlchen.types import (
     EVMTxHash,
     Timestamp,
 )
+from rotkehlchen.utils.data_structures import LRUCacheWithRemove
 from rotkehlchen.utils.misc import from_wei, get_chunks, hex_or_bytes_to_str
 from rotkehlchen.utils.mixins.lockable import LockableQueryMixIn, protect_with_lock
 
@@ -226,8 +228,8 @@ class EvmNodeInquirer(metaclass=ABCMeta):
         self.contract_multicall = contract_multicall
 
         # A cache for erc20 and erc721 contract info to not requery the info
-        self.contract_info_erc20_cache: dict[ChecksumEvmAddress, dict[str, Any]] = {}
-        self.contract_info_erc721_cache: dict[ChecksumEvmAddress, dict[str, Any]] = {}
+        self.contract_info_erc20_cache: LRUCacheWithRemove[ChecksumEvmAddress, dict[str, Any]] = LRUCacheWithRemove(maxsize=1024)  # noqa: E501
+        self.contract_info_erc721_cache: LRUCacheWithRemove[ChecksumEvmAddress, dict[str, Any]] = LRUCacheWithRemove(maxsize=512)  # noqa: E501
         self.maybe_connect_to_nodes(when_tracked_accounts=True)
 
     def maybe_connect_to_nodes(self, when_tracked_accounts: bool) -> None:
@@ -1124,18 +1126,15 @@ class EvmNodeInquirer(metaclass=ABCMeta):
             return output
         return [contract.decode(x, method_name, arguments[0]) for x in output]
 
-    def get_multiple_erc20_contract_info(self, addresses: list[ChecksumEvmAddress]) -> dict[str, Any]:  # noqa: E501
-        all_info: dict[str, Any] = {}
-
+    def get_multiple_erc20_contract_info(self, addresses: list[ChecksumEvmAddress]) -> None:
+        """Query the token information for multiple ERC20 addresses and save them in cache"""
         if len(addresses) == 0:
-            return {}
+            return
 
         contract = EvmContract(address=addresses[0], abi=self.contracts.abi('ERC20_TOKEN'), deployed_block=0)  # noqa: E501
 
         for addresses_chunk in get_chunks(addresses, 8):  # chunk number seems to be highest that can work with etherscan url limit  # noqa: E501
-            calls = []
-            for address in addresses_chunk:
-                calls.extend([(address, contract.encode(method_name=prop)) for prop in ERC20_PROPERTIES])  # noqa: E501
+            calls = [(address, contract.encode(method_name=prop)) for address in addresses_chunk for prop in ERC20_PROPERTIES]  # noqa: E501
 
             try:
                 # Output contains call status and result
@@ -1143,18 +1142,15 @@ class EvmNodeInquirer(metaclass=ABCMeta):
             except RemoteError:
                 # If something happens in the connection the output should have
                 # the same length as the tuple of properties * addresses
-                output = [(False, b'')] * len(ERC20_PROPERTIES) * len(addresses_chunk)
+                output = [(False, b'')] * ERC20_PROPERTIES_NUM * len(addresses_chunk)
 
-            for idx, single_output in enumerate(get_chunks(output, 3)):
+            for idx, single_output in enumerate(get_chunks(output, ERC20_PROPERTIES_NUM)):
                 address = addresses_chunk[idx]
                 info = self._process_and_create_erc20_info(
                     output=single_output,
                     address=address,
                 )
-                self.contract_info_erc20_cache[address] = info
-                all_info[address] = info
-
-        return all_info
+                self.contract_info_erc20_cache.add(address, info)
 
     def _process_and_create_erc20_info(
             self,
@@ -1228,16 +1224,16 @@ class EvmNodeInquirer(metaclass=ABCMeta):
         if it is provided in the contract. This method may raise:
         - BadFunctionCallOutput: If there is an error calling a bad address
         """
-        cache = self.contract_info_erc20_cache.get(address)
-        if cache is not None:
+        if (cache := self.contract_info_erc20_cache.get(address)) is not None:
             return cache
 
         output = self._query_token_contract(token_abi_str='ERC20_TOKEN', properties=ERC20_PROPERTIES, address=address)  # noqa: E501
-        self.contract_info_erc20_cache[address] = self._process_and_create_erc20_info(
+        info = self._process_and_create_erc20_info(
             output=output,
             address=address,
         )
-        return self.contract_info_erc20_cache[address]
+        self.contract_info_erc20_cache.add(address, info)
+        return info
 
     def get_erc721_contract_info(self, address: ChecksumEvmAddress) -> dict[str, Any]:
         """
@@ -1251,8 +1247,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
         - BadFunctionCallOutput: If there is an error calling a bad address
         - NotERC721Conformant: If the address can't be decoded as an ERC721 contract
         """
-        cache = self.contract_info_erc721_cache.get(address)
-        if cache is not None:
+        if (cache := self.contract_info_erc721_cache.get(address)) is not None:
             return cache
 
         output = self._query_token_contract(token_abi_str='ERC721_TOKEN', properties=ERC721_PROPERTIES, address=address)  # noqa: E501
@@ -1273,7 +1268,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
                 value = value.rstrip(b'\x00').decode()  # noqa: PLW2901
             info[prop] = value
 
-        self.contract_info_erc721_cache[address] = info
+        self.contract_info_erc721_cache.add(address, info)
         return info
 
     def _process_contract_info(

--- a/rotkehlchen/chain/optimism/modules/velodrome/velodrome_cache.py
+++ b/rotkehlchen/chain/optimism/modules/velodrome/velodrome_cache.py
@@ -38,8 +38,8 @@ VELODROME_SUGAR_V2_CONTRACT = string_to_evm_address('0x7F45F1eA57E9231f846B2b4f5
 class VelodromePoolData(NamedTuple):
     pool_address: ChecksumEvmAddress
     pool_name: str
-    token0: ChecksumEvmAddress
-    token1: ChecksumEvmAddress
+    token0_address: ChecksumEvmAddress
+    token1_address: ChecksumEvmAddress
     gauge_address: Optional[ChecksumEvmAddress]
 
 
@@ -158,7 +158,7 @@ def query_velodrome_data_from_chain_and_maybe_create_tokens(
             continue
 
         try:
-            token0, token1 = deserialize_evm_address(pool[5]), deserialize_evm_address(pool[8])
+            token0_address, token1_address = deserialize_evm_address(pool[5]), deserialize_evm_address(pool[8])  # noqa: E501
             gauge_address = deserialize_evm_address(pool[11])
         except DeserializationError as e:
             log.error(
@@ -167,12 +167,12 @@ def query_velodrome_data_from_chain_and_maybe_create_tokens(
             )
             continue
 
-        addresses.extend([pool_address, token0, token1])
+        addresses.extend([pool_address, token0_address, token1_address])
         deserialized_pools.append(VelodromePoolData(
             pool_address=pool_address,
             pool_name=pool[1],
-            token0=token0,
-            token1=token1,
+            token0_address=token0_address,
+            token1_address=token1_address,
             gauge_address=gauge_address if gauge_address != ZERO_ADDRESS else None,
         ))
 
@@ -180,7 +180,7 @@ def query_velodrome_data_from_chain_and_maybe_create_tokens(
 
     returned_pools = []
     for entry in deserialized_pools:
-        for token in (entry.token0, entry.token1, entry.pool_address):  # create the tokens for the new pools. Keep in mind that the pool address is the address of the lp token received when depositing to the pool  # noqa: E501
+        for token in (entry.token0_address, entry.token1_address, entry.pool_address):  # create the tokens for the new pools. Keep in mind that the pool address is the address of the lp token received when depositing to the pool  # noqa: E501
             try:
                 get_or_create_evm_token(
                     userdb=inquirer.database,

--- a/rotkehlchen/globaldb/cache.py
+++ b/rotkehlchen/globaldb/cache.py
@@ -133,10 +133,10 @@ def globaldb_get_general_cache_like(
     key_parts should contain neither the "%" nor the "." symbol.
     """
     cache_key = compute_cache_key(key_parts)
-    return cursor.execute(
+    return [x[0] for x in cursor.execute(
         'SELECT value FROM general_cache WHERE key LIKE ?',
         (f'{cache_key}%',),
-    ).fetchall()
+    )]
 
 
 def globaldb_get_general_cache_keys_and_values_like(

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -31,6 +31,7 @@ from rotkehlchen.chain.base.node_inquirer import BaseInquirer
 from rotkehlchen.chain.ethereum.manager import EthereumManager
 from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 from rotkehlchen.chain.ethereum.oracles.uniswap import UniswapV2Oracle, UniswapV3Oracle
+from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.nodes import populate_rpc_nodes_in_database
 from rotkehlchen.chain.gnosis.manager import GnosisManager
 from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
@@ -183,6 +184,8 @@ class Rotkehlchen:
             manualcurrent=ManualCurrentOracle(),
             msg_aggregator=self.msg_aggregator,
         )
+        # Initialize EVM Contracts common abis
+        EvmContracts.initialize_common_abis()
         self.task_manager: Optional[TaskManager] = None
         self.shutdown_event = gevent.event.Event()
         self.migration_manager = DataMigrationManager(self)

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -151,13 +151,6 @@ VELODROME_SOME_EXPECTED_ADDRESBOOK_ENTRIES = [
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_velodrome_cache(optimism_inquirer):
-    with GlobalDBHandler().conn.write_ctx() as write_cursor:
-        # Make sure that no velodrome related data is stored in the database.
-        write_cursor.execute('DELETE FROM general_cache WHERE key LIKE "%VELO%"')
-        write_cursor.execute('DELETE FROM unique_cache WHERE key LIKE "%VELO%"')
-        write_cursor.execute('DELETE FROM address_book')
-        write_cursor.execute('DELETE FROM assets')
-
     optimism_inquirer.ensure_cache_data_is_updated(
         cache_type=CacheType.VELODROME_POOL_ADDRESS,
         query_method=query_velodrome_data,

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -374,6 +374,9 @@ def test_find_velodrome_v2_lp_token_price(inquirer, optimism_manager):
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_curve_lp_token_price(inquirer_defi, ethereum_manager):
+    with GlobalDBHandler().conn.write_ctx() as write_cursor:  # querying curve lp token price normally triggers curve cache query. Set all query ts to now, so it does not happen.  # noqa: E501
+        write_cursor.execute('UPDATE general_cache SET last_queried_ts=? WHERE key=?', (ts_now(), 'CURVE_LP_TOKENS'))  # noqa: E501
+
     lp_token_address = '0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c'
     pool_address = '0xc5424B857f758E906013F3555Dad202e4bdB4567'
     identifier = ethaddress_to_identifier(lp_token_address)

--- a/rotkehlchen/utils/data_structures.py
+++ b/rotkehlchen/utils/data_structures.py
@@ -2,40 +2,50 @@ import collections
 from collections import OrderedDict
 from typing import Generic, Optional, TypeVar
 
-RT = TypeVar('RT')
+KT = TypeVar('KT')  # key type
+VT = TypeVar('VT')  # value type
 
 
-class LRUCacheWithRemove(Generic[RT]):
+class LRUCacheWithRemove(Generic[KT, VT]):
     """Create a LRU cache with the option to remove keys from the cache"""
 
     def __init__(self, maxsize: int = 512):
-        self.cache: OrderedDict[str, RT] = collections.OrderedDict()
+        self.cache: OrderedDict[KT, VT] = collections.OrderedDict()
         self.maxsize: int = maxsize
 
-    def get(self, key: str) -> Optional[RT]:
-        lowered_key = key.lower()
-        if lowered_key in self.cache:
-            self.cache.move_to_end(lowered_key)
-            return self.cache[lowered_key]
+    def get(self, key: KT) -> Optional[VT]:
+        if key in self.cache:
+            self.cache.move_to_end(key)
+            return self.cache[key]
         return None
 
-    def add(self, key: str, value: RT) -> None:
-        self.cache[key.lower()] = value
+    def add(self, key: KT, value: VT) -> None:
+        self.cache[key] = value
         if len(self.cache) > self.maxsize:
             self.cache.popitem(last=False)
 
-    def remove(self, key: str) -> None:
-        """Remove an item from the cache"""
-        lowered_key = key.lower()
-        if lowered_key in self.cache:
-            self.cache.pop(lowered_key)
+    def remove(self, key: KT) -> None:
+        if key in self.cache:
+            self.cache.pop(key)
 
     def clear(self) -> None:
         """Delete all entries in the cache"""
         self.cache.clear()
 
 
-class LRUSetCache(Generic[RT]):
+class LRUCacheLowerKey(LRUCacheWithRemove[str, VT]):
+    """Create an LRU cache with string key which is always considered as lowercase"""
+    def get(self, key: str) -> Optional[VT]:
+        return super().get(key.lower())
+
+    def add(self, key: str, value: VT) -> None:
+        super().add(key.lower(), value)
+
+    def remove(self, key: str) -> None:
+        super().remove(key.lower())
+
+
+class LRUSetCache(Generic[VT]):
     """
     LRU cache that works like a set.
     Internally it uses an OrderedDict In order to be able to keep the order of insertion
@@ -44,22 +54,22 @@ class LRUSetCache(Generic[RT]):
     """
 
     def __init__(self, maxsize: int = 512):
-        self.cache: OrderedDict[RT, None] = collections.OrderedDict()
+        self.cache: OrderedDict[VT, None] = collections.OrderedDict()
         self.maxsize: int = maxsize
 
-    def __contains__(self, key: RT) -> bool:
+    def __contains__(self, key: VT) -> bool:
         return key in self.cache
 
-    def add(self, key: RT) -> None:
+    def add(self, key: VT) -> None:
         """Add an item to the cache"""
         self.cache[key] = None
         if len(self.cache) > self.maxsize:
             self.cache.popitem(last=False)
 
-    def remove(self, key: RT) -> None:
+    def remove(self, key: VT) -> None:
         """Remove an item from the cache"""
         if key in self.cache:
             self.cache.pop(key)
 
-    def get_values(self) -> set[RT]:
+    def get_values(self) -> set[VT]:
         return set(self.cache.keys())


### PR DESCRIPTION
### [Optimize velodrome cache query by grouping token info queries](https://github.com/rotki/rotki/commit/00b63f02ffa2377300de447b309865bb48da7644) 

The velodrome cache query was querying token info in a for loop. This
commit optimized it by making sure the token info queries are bundled
before the loop and thus reduces amount of external queries

### [Fix get_general_cache_like](https://github.com/rotki/rotki/commit/6264ccf3d213afa5bf147e54d72de5897c09a246) 

The function was returning a list of single entry tuples. So in the places where it
was used (curve and velodrome cache queries) instead of doing an `in
['0xfoo1', '0xfoo2']` check it was doing `in
[('0xfoo1',), ('0xfoo2',)] check. That was always false for addresses.

### [Turn evm_inquirer erc20/721 caches to LRU caches](https://github.com/rotki/rotki/pull/6788/commits/d8b66ad913ea637694f04cd167397fcc92562d59) 
Also some other fixes in the code and optimization in speed of some tests.

### [Move some commonly used ABIs in memory](https://github.com/rotki/rotki/pull/6788/commits/ecd65bfa9be28e05b43c228a9045a2267021cd97) 
Move erc20, erc721 and univ1 LP token ABIs as class attributes to the
contracts class so that they are only loaded once in memory and not
multiple times for each EVM Chain.

Since they are used quite very often, loading them from the DB and
doing a json importing each time a token query happens ends up getting expensive.