### PR TITLE
Remove session_globaldb fixture and dependencies

### DIFF
--- a/rotkehlchen/tests/exchanges/test_bittrex.py
+++ b/rotkehlchen/tests/exchanges/test_bittrex.py
@@ -160,10 +160,9 @@ def test_bittrex_query_trade_history(bittrex):
     assert expected_trades == trades
 
 
-def test_bittrex_query_trade_history_unexpected_data(function_scope_bittrex):
+def test_bittrex_query_trade_history_unexpected_data(bittrex):
     """Test that turning a bittrex trade that contains unexpected data is handled gracefully"""
     # turn caching off
-    bittrex = function_scope_bittrex
     bittrex.cache_ttl_secs = 0
 
     def mock_order_history(url, method, json):  # pylint: disable=unused-argument
@@ -310,9 +309,8 @@ BITTREX_WITHDRAWAL_HISTORY_RESPONSE = """
 """
 
 
-def test_bittrex_query_deposits_withdrawals(function_scope_bittrex):
+def test_bittrex_query_deposits_withdrawals(bittrex):
     """Test the happy case of bittrex deposit withdrawal query"""
-    bittrex = function_scope_bittrex
 
     def mock_get_deposit_withdrawal(
             url,
@@ -370,7 +368,7 @@ def test_bittrex_query_deposits_withdrawals(function_scope_bittrex):
     assert movements[3].fee == FVal('0.0015')
 
 
-def test_bittrex_query_asset_movement_int_transaction_id(function_scope_bittrex):
+def test_bittrex_query_asset_movement_int_transaction_id(bittrex):
     """Test that if an integer is returned for bittrex transaction id we handle it properly
 
     Bittrex deposit withdrawals SHOULD NOT return an integer for transaction id
@@ -379,7 +377,6 @@ def test_bittrex_query_asset_movement_int_transaction_id(function_scope_bittrex)
 
     Regression test for https://github.com/rotki/rotki/issues/2175
     """
-    bittrex = function_scope_bittrex
 
     problematic_deposit = """
 [
@@ -444,9 +441,8 @@ def test_bittrex_query_asset_movement_int_transaction_id(function_scope_bittrex)
     assert db_movements[0] == movements[0]
 
 
-def test_bittrex_query_deposits_withdrawals_unexpected_data(function_scope_bittrex):
+def test_bittrex_query_deposits_withdrawals_unexpected_data(bittrex):
     """Test that we handle unexpected bittrex deposit withdrawal data gracefully"""
-    bittrex = function_scope_bittrex
 
     def mock_bittrex_and_query(deposits, withdrawals, expected_warnings_num, expected_errors_num):
 

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -153,8 +153,8 @@ def test_coverage_of_kraken_balances(kraken):
         assert asset_from_kraken(kraken_asset) == expected_asset
 
 
-def test_querying_balances(function_scope_kraken):
-    result, error_or_empty = function_scope_kraken.query_balances()
+def test_querying_balances(kraken):
+    result, error_or_empty = kraken.query_balances()
     assert error_or_empty == ''
     assert isinstance(result, dict)
     for asset, entry in result.items():
@@ -162,11 +162,10 @@ def test_querying_balances(function_scope_kraken):
         assert isinstance(entry, Balance)
 
 
-def test_querying_trade_history(function_scope_kraken):
-    kraken = function_scope_kraken
+def test_querying_trade_history(kraken):
     kraken.random_ledgers_data = False
     now = ts_now()
-    result = function_scope_kraken.query_trade_history(
+    result = kraken.query_trade_history(
         start_ts=1451606400,
         end_ts=now,
         only_cache=False,
@@ -178,13 +177,12 @@ def test_querying_trade_history(function_scope_kraken):
         assert isinstance(kraken_trade, Trade)
 
 
-def test_querying_rate_limit_exhaustion(function_scope_kraken, database):
+def test_querying_rate_limit_exhaustion(kraken, database):
     """Test that if kraken api rates limit us we don't get stuck in an infinite loop
     and also that we return what we managed to retrieve until rate limit occured.
 
     Regression test for https://github.com/rotki/rotki/issues/3629
     """
-    kraken = function_scope_kraken
     kraken.use_original_kraken = True
     kraken.reduction_every_secs = 0.05
 
@@ -227,11 +225,10 @@ def test_querying_rate_limit_exhaustion(function_scope_kraken, database):
     assert to_ts == 1638529919, 'should have saved only until the last trades timestamp'
 
 
-def test_querying_deposits_withdrawals(function_scope_kraken):
-    kraken = function_scope_kraken
+def test_querying_deposits_withdrawals(kraken):
     kraken.random_ledgers_data = False
     now = ts_now()
-    result = function_scope_kraken.query_deposits_withdrawals(
+    result = kraken.query_deposits_withdrawals(
         start_ts=1439994442,
         end_ts=now,
         only_cache=False,
@@ -291,10 +288,9 @@ def test_kraken_to_world_pair(kraken):
         kraken_to_world_pair('GABOOBABOO')
 
 
-def test_kraken_query_balances_unknown_asset(function_scope_kraken):
+def test_kraken_query_balances_unknown_asset(kraken):
     """Test that if a kraken balance query returns unknown asset no exception
     is raised and a warning is generated"""
-    kraken = function_scope_kraken
     kraken.random_balance_data = False
     balances, msg = kraken.query_balances()
 
@@ -311,11 +307,10 @@ def test_kraken_query_balances_unknown_asset(function_scope_kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_kraken_query_deposit_withdrawals_unknown_asset(function_scope_kraken):
+def test_kraken_query_deposit_withdrawals_unknown_asset(kraken):
     """Test that if a kraken deposits_withdrawals query returns unknown asset
     no exception is raised and a warning is generated and the deposits/withdrawals
     with valid assets are still returned"""
-    kraken = function_scope_kraken
     kraken.random_ledgers_data = False
 
     input_ledger = """
@@ -380,9 +375,8 @@ def test_kraken_query_deposit_withdrawals_unknown_asset(function_scope_kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_kraken_trade_with_spend_receive(function_scope_kraken):
+def test_kraken_trade_with_spend_receive(kraken):
     """Test that trades based on spend/receive events are correctly processed"""
-    kraken = function_scope_kraken
     kraken.random_trade_data = False
     kraken.random_ledgers_data = False
     kraken.cache_ttl_secs = 0
@@ -442,9 +436,8 @@ def test_kraken_trade_with_spend_receive(function_scope_kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_kraken_trade_with_adjustment(function_scope_kraken):
+def test_kraken_trade_with_adjustment(kraken):
     """Test that trades based on adjustment events are processed"""
-    kraken = function_scope_kraken
     kraken.random_trade_data = False
     kraken.random_ledgers_data = False
     kraken.cache_ttl_secs = 0
@@ -499,9 +492,8 @@ def test_kraken_trade_with_adjustment(function_scope_kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_kraken_trade_no_counterpart(function_scope_kraken):
+def test_kraken_trade_no_counterpart(kraken):
     """Test that trades with no counterpart are processed properly"""
-    kraken = function_scope_kraken
     kraken.random_trade_data = False
     kraken.random_ledgers_data = False
     kraken.cache_ttl_secs = 0
@@ -565,9 +557,8 @@ def test_kraken_trade_no_counterpart(function_scope_kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_kraken_failed_withdrawals(function_scope_kraken):
+def test_kraken_failed_withdrawals(kraken):
     """Test that failed withdrawals are processed properly"""
-    kraken = function_scope_kraken
     kraken.random_trade_data = False
     kraken.random_ledgers_data = False
     kraken.cache_ttl_secs = 0
@@ -610,10 +601,9 @@ def test_kraken_failed_withdrawals(function_scope_kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_trade_from_kraken_unexpected_data(function_scope_kraken):
+def test_trade_from_kraken_unexpected_data(kraken):
     """Test that getting unexpected data from kraken leads to skipping the trade
     and does not lead to a crash"""
-    kraken = function_scope_kraken
     kraken.random_trade_data = False
     kraken.random_ledgers_data = False
     kraken.cache_ttl_secs = 0

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -118,10 +118,8 @@ def test_poloniex_trade_with_asset_needing_conversion():
     assert trade.location == Location.POLONIEX
 
 
-def test_query_trade_history(function_scope_poloniex):
+def test_query_trade_history(poloniex):
     """Happy path test for poloniex trade history querying"""
-    poloniex = function_scope_poloniex
-
     def mock_api_return(url, **kwargs):  # pylint: disable=unused-argument
         return MockResponse(200, POLONIEX_TRADES_RESPONSE)
 
@@ -156,9 +154,8 @@ def test_query_trade_history(function_scope_poloniex):
     assert trades[1].fee_currency == A_BTC
 
 
-def test_query_trade_history_unexpected_data(function_scope_poloniex):
+def test_query_trade_history_unexpected_data(poloniex):
     """Test that poloniex trade history querying returning unexpected data is handled gracefully"""
-    poloniex = function_scope_poloniex
     poloniex.cache_ttl_secs = 0
 
     def mock_poloniex_and_query(given_trades, expected_warnings_num, expected_errors_num, expected_trades_len=0):  # noqa: E501
@@ -249,10 +246,9 @@ def test_poloniex_assets_are_known(poloniex):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_poloniex_query_balances_unknown_asset(function_scope_poloniex):
+def test_poloniex_query_balances_unknown_asset(poloniex):
     """Test that if a poloniex balance query returns unknown asset no exception
     is raised and a warning is generated. Same for unsupported assets"""
-    poloniex = function_scope_poloniex
 
     def mock_unknown_asset_return(url, **kwargs):  # pylint: disable=unused-argument
         return MockResponse(200, POLONIEX_BALANCES_RESPONSE)
@@ -275,10 +271,9 @@ def test_poloniex_query_balances_unknown_asset(function_scope_poloniex):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_poloniex_deposits_withdrawal_unknown_asset(function_scope_poloniex):
+def test_poloniex_deposits_withdrawal_unknown_asset(poloniex):
     """Test that if a poloniex asset movement query returns unknown asset no exception
     is raised and a warning is generated. Same for unsupported assets"""
-    poloniex = function_scope_poloniex
 
     def mock_api_return(url, **kwargs):  # pylint: disable=unused-argument
         response = MockResponse(
@@ -304,12 +299,11 @@ def test_poloniex_deposits_withdrawal_unknown_asset(function_scope_poloniex):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_poloniex_deposits_withdrawal_null_fee(function_scope_poloniex):
+def test_poloniex_deposits_withdrawal_null_fee(poloniex):
     """
     Test that if a poloniex asset movement query returns null for fee we don't crash.
     Regression test for issue #76
     """
-    poloniex = function_scope_poloniex
 
     def mock_api_return(url, **kwargs):  # pylint: disable=unused-argument
         response = MockResponse(
@@ -337,11 +331,10 @@ def test_poloniex_deposits_withdrawal_null_fee(function_scope_poloniex):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_poloniex_deposits_withdrawal_unexpected_data(function_scope_poloniex):
+def test_poloniex_deposits_withdrawal_unexpected_data(poloniex):
     """
     Test that if a poloniex asset movement query returns unexpected data we handle it gracefully
     """
-    poloniex = function_scope_poloniex
     poloniex.cache_ttl_secs = 0
 
     def mock_poloniex_and_query(given_movements, expected_warnings_num, expected_errors_num):

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -141,11 +141,6 @@ def fixture_should_mock_current_price_queries():
     return True
 
 
-@pytest.fixture(scope='session', name='session_should_mock_current_price_queries')
-def fixture_session_should_mock_current_price_queries():
-    return True
-
-
 @pytest.fixture(name='ignore_mocked_prices_for')
 def fixture_ignore_mocked_prices_for() -> Optional[list[str]]:
     """An optional list of asset identifiers to ignore mocking for"""
@@ -162,23 +157,8 @@ def fixture_mocked_current_prices_with_oracles():
     return {}
 
 
-@pytest.fixture(scope='session', name='session_mocked_current_prices')
-def fixture_session_mocked_current_prices():
-    return {}
-
-
-@pytest.fixture(scope='session', name='session_mocked_current_prices_with_oracles')
-def fixture_session_mocked_current_prices_with_oracles():
-    return {}
-
-
 @pytest.fixture(name='current_price_oracles_order')
 def fixture_current_price_oracles_order():
-    return DEFAULT_CURRENT_PRICE_ORACLES_ORDER
-
-
-@pytest.fixture(scope='session', name='session_current_price_oracles_order')
-def fixture_session_current_price_oracles_order():
     return DEFAULT_CURRENT_PRICE_ORACLES_ORDER
 
 
@@ -386,33 +366,6 @@ def fixture_inquirer(
         add_defi_oracles=False,
         ethereum_manager=None,
         ignore_mocked_prices_for=ignore_mocked_prices_for,
-    )
-
-
-@pytest.fixture(scope='session')
-def session_inquirer(
-        session_globaldb,  # pylint: disable=unused-argument  # needed for _create_inquirer
-        session_data_dir,
-        session_should_mock_current_price_queries,
-        session_mocked_current_prices,
-        session_mocked_current_prices_with_oracles,
-        session_current_price_oracles_order,
-):
-    """
-    The ethereum_manager argument is defined as None for the reasons explained in the
-    `inquirer` fixture
-
-    This fixtures is only used by 3 exchanges session objects for convenience.
-    At the time of writing: poloniex, kraken, bittrex. Grep to be sure current state of things
-    """
-    return _create_inquirer(
-        data_directory=session_data_dir,
-        should_mock_current_price_queries=session_should_mock_current_price_queries,
-        mocked_prices=session_mocked_current_prices,
-        mocked_current_prices_with_oracles=session_mocked_current_prices_with_oracles,
-        current_price_oracles_order=session_current_price_oracles_order,
-        ethereum_manager=None,
-        add_defi_oracles=False,
     )
 
 

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -33,24 +33,9 @@ def fixture_username():
     return 'testuser'
 
 
-@pytest.fixture(scope='session', name='session_ignored_assets')
-def fixture_session_ignored_assets() -> Optional[list[Asset]]:
-    return None
-
-
 @pytest.fixture(name='ignored_assets')
 def fixture_ignored_assets() -> Optional[list[Asset]]:
     return None
-
-
-@pytest.fixture(scope='session', name='session_username')
-def fixture_session_username():
-    return 'session_test_user'
-
-
-@pytest.fixture(scope='session', name='session_data_dir')
-def fixture_session_data_dir(tmpdir_factory) -> Path:
-    return Path(tmpdir_factory.mktemp('session_data'))
 
 
 @pytest.fixture(name='user_data_dir')
@@ -61,22 +46,8 @@ def fixture_user_data_dir(data_dir, username) -> Path:
     return user_data_dir
 
 
-@pytest.fixture(scope='session', name='session_user_data_dir')
-def fixture_session_user_data_dir(session_data_dir, session_username) -> Path:
-    """Create and return the session scoped user data directory"""
-    user_data_dir = session_data_dir / session_username
-    user_data_dir.mkdir(exist_ok=True)
-    return user_data_dir
-
-
 @pytest.fixture(name='include_cryptocompare_key')
 def fixture_include_cryptocompare_key() -> bool:
-    """By default use a cryptocompare API key only in the OSX CI"""
-    return 'CI' in os.environ and sys.platform == 'darwin'
-
-
-@pytest.fixture(scope='session', name='session_include_cryptocompare_key')
-def fixture_session_include_cryptocompare_key() -> bool:
     """By default use a cryptocompare API key only in the OSX CI"""
     return 'CI' in os.environ and sys.platform == 'darwin'
 
@@ -86,18 +57,8 @@ def fixture_include_etherscan_key() -> bool:
     return True
 
 
-@pytest.fixture(scope='session', name='session_include_etherscan_key')
-def fixture_session_include_etherscan_key() -> bool:
-    return True
-
-
 @pytest.fixture(name='tags')
 def fixture_tags() -> list[dict[str, Any]]:
-    return []
-
-
-@pytest.fixture(scope='session', name='session_tags')
-def fixture_session_tags() -> list[dict[str, Any]]:
     return []
 
 
@@ -106,18 +67,8 @@ def fixture_manually_tracked_balances() -> list[ManuallyTrackedBalance]:
     return []
 
 
-@pytest.fixture(scope='session', name='session_manually_tracked_balances')
-def fixture_session_manually_tracked_balances() -> list[ManuallyTrackedBalance]:
-    return []
-
-
 @pytest.fixture(name='sql_vm_instructions_cb')
 def fixture_sql_vm_instructions_cb() -> int:
-    return DEFAULT_SQL_VM_INSTRUCTIONS_CB
-
-
-@pytest.fixture(scope='session', name='session_sql_vm_instructions_cb')
-def fixture_session_sql_vm_instructions_cb() -> int:
     return DEFAULT_SQL_VM_INSTRUCTIONS_CB
 
 
@@ -215,70 +166,11 @@ def database(
         db_handler.logout()
 
 
-@pytest.fixture(scope='session')
-def session_database(
-        session_globaldb,  # pylint: disable=unused-argument  # needed for init_database
-        session_user_data_dir,
-        messages_aggregator,
-        session_db_password,
-        session_db_settings,
-        session_start_with_logged_in_user,
-        session_ignored_assets,
-        session_include_etherscan_key,
-        session_include_cryptocompare_key,
-        session_tags,
-        session_manually_tracked_balances,
-        data_migration_version,
-        session_use_custom_database,
-        session_sql_vm_instructions_cb,
-        session_perform_upgrades_at_unlock,
-) -> Generator[Optional[DBHandler], None, None]:
-    if not session_start_with_logged_in_user:
-        yield None
-    else:
-        # No sessions blockchain accounts given
-        blockchain_accounts = BlockchainAccounts()
-        db_handler = _init_database(
-            data_dir=session_user_data_dir,
-            msg_aggregator=messages_aggregator,
-            password=session_db_password,
-            db_settings=session_db_settings,
-            ignored_assets=session_ignored_assets,
-            blockchain_accounts=blockchain_accounts,
-            include_etherscan_key=session_include_etherscan_key,
-            include_cryptocompare_key=session_include_cryptocompare_key,
-            tags=session_tags,
-            manually_tracked_balances=session_manually_tracked_balances,
-            data_migration_version=data_migration_version,
-            use_custom_database=session_use_custom_database,
-            sql_vm_instructions_cb=session_sql_vm_instructions_cb,
-            perform_upgrades_at_unlock=session_perform_upgrades_at_unlock,
-        )
-        yield db_handler
-
-        db_handler.logout()
-
-
 @pytest.fixture(name='db_settings')
 def fixture_db_settings() -> Optional[dict[str, Any]]:
-    return None
-
-
-@pytest.fixture(scope='session', name='session_db_settings')
-def fixture_session_db_settings() -> Optional[dict[str, Any]]:
     return None
 
 
 @pytest.fixture(name='use_custom_database')
 def fixture_use_custom_database() -> Optional[str]:
     return None
-
-
-@pytest.fixture(scope='session', name='session_use_custom_database')
-def fixture_session_use_custom_database() -> Optional[str]:
-    return None
-
-
-@pytest.fixture(scope='session', name='session_perform_upgrades_at_unlock')
-def fixture_session_perform_upgrades_at_unlock() -> bool:
-    return True

--- a/rotkehlchen/tests/fixtures/exchanges/bittrex.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bittrex.py
@@ -3,17 +3,8 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_bittrex
 
 
-@pytest.fixture(scope='session')
-def bittrex(
-        session_database,
-        session_inquirer,  # pylint: disable=unused-argument
-        messages_aggregator,
-):
-    return create_test_bittrex(database=session_database, msg_aggregator=messages_aggregator)
-
-
-@pytest.fixture()
-def function_scope_bittrex(
+@pytest.fixture(name='bittrex')
+def fixture_bittrex(
         database,
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,

--- a/rotkehlchen/tests/fixtures/exchanges/kraken.py
+++ b/rotkehlchen/tests/fixtures/exchanges/kraken.py
@@ -3,20 +3,8 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_kraken
 
 
-@pytest.fixture(scope='session')
-def kraken(
-        session_inquirer,  # pylint: disable=unused-argument
-        messages_aggregator,
-        session_database,
-):
-    return create_test_kraken(
-        database=session_database,
-        msg_aggregator=messages_aggregator,
-    )
-
-
-@pytest.fixture()
-def function_scope_kraken(
+@pytest.fixture(name='kraken')
+def fixture_kraken(
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,
         database,

--- a/rotkehlchen/tests/fixtures/exchanges/poloniex.py
+++ b/rotkehlchen/tests/fixtures/exchanges/poloniex.py
@@ -3,20 +3,8 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_poloniex
 
 
-@pytest.fixture(scope='session')
-def poloniex(
-        session_database,
-        session_inquirer,  # pylint: disable=unused-argument
-        messages_aggregator,
-):
-    return create_test_poloniex(
-        database=session_database,
-        msg_aggregator=messages_aggregator,
-    )
-
-
-@pytest.fixture()
-def function_scope_poloniex(
+@pytest.fixture(name='poloniex')
+def fixture_poloniex(
         database,
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -132,27 +132,6 @@ def _initialize_fixture_globaldb(
     return globaldb
 
 
-@pytest.fixture(scope='session', name='session_globaldb')
-def fixture_session_globaldb(
-        tmpdir_factory,
-        session_sql_vm_instructions_cb,
-):
-    globaldb = _initialize_fixture_globaldb(
-        custom_globaldb=None,
-        tmpdir_factory=tmpdir_factory,
-        sql_vm_instructions_cb=session_sql_vm_instructions_cb,
-        reload_user_assets=True,
-        target_globaldb_version=GLOBAL_DB_VERSION,
-        globaldb_upgrades=[],
-        globaldb_migrations=[],
-        run_globaldb_migrations=True,
-        empty_global_addressbook=False,
-    )
-    yield globaldb
-
-    globaldb.cleanup()
-
-
 @pytest.fixture(name='globaldb')
 def fixture_globaldb(
         custom_globaldb,

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -55,11 +55,6 @@ def fixture_start_with_logged_in_user():
     return True
 
 
-@pytest.fixture(scope='session', name='session_start_with_logged_in_user')
-def fixture_session_start_with_logged_in_user():
-    return True
-
-
 @pytest.fixture(name='start_with_valid_premium')
 def fixture_start_with_valid_premium():
     return False

--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -17,11 +17,6 @@ def db_password():
     return '123'
 
 
-@pytest.fixture(scope='session')
-def session_db_password():
-    return '123'
-
-
 @pytest.fixture()
 def rest_api_port(port_generator):
     port = next(port_generator)


### PR DESCRIPTION
That fixture was not useful and was in fact broken. It became obvious when I tried to use it. We can't have a different globalDB fixture for session and a different for function scope in tests.

The reason being it's a singleton and the function one will modify the session one. So things get mixed up pretty badly causing undefined behaviour. Which can hit you when running tests with "trying to operate on a closed DB" if the cleanup of the function scope globalDB is done before a new test and a session scope fixture needing session globalDB tries to read it.

Generally bad idea