### PR TITLE
Handle settings keys that are not present in the db for accounting rules

### DIFF
--- a/rotkehlchen/tests/api/test_accounting_rules.py
+++ b/rotkehlchen/tests/api/test_accounting_rules.py
@@ -78,6 +78,20 @@ def test_manage_rules(rotkehlchen_api_server):
     assert result['entries_found'] == 1
     assert result['entries_total'] == 2
 
+    # filter by a type that is not present in the database
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'accountingrulesresource',
+        ), json={
+            'event_types': ['adjustment'],
+        },
+    )
+    result = assert_proper_response_with_result(response)
+    assert result['entries'] == []
+    assert result['entries_found'] == 0
+    assert result['entries_total'] == 2
+
     # update rule 2
     rule_2['counterparty'] = 'compound'
     rule_2['accounting_treatment'] = None


### PR DESCRIPTION
It might be possible that an accounting setting is not present in the db when it takes the default value. This commit ensures that when a setting is used in the rules then it is present in the database.

Also fixes an issue with the filters not being applied to the linked rules when filtering


