### PR TITLE
Make taxable also linkable for accounting rules

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12597,7 +12597,7 @@ Managing custom accounting rules
       Content-Type: application/json;charset=UTF-8
 
       {
-         "taxable":true,
+         "taxable": {"value": true},
          "count_entire_amount_spend":{"value": false, "linked_setting": "include_crypto2crypto"},
          "count_cost_basis_pnl":{"value": true},
          "event_type":"staking",
@@ -12608,9 +12608,9 @@ Managing custom accounting rules
 
   .. _accounting_rules_fields:
 
-  :reqjsonarr boolean taxable: ``true`` if the event should be considered as taxable
-  :reqjsonarr object count_entire_amount_spend: if ``true`` then the entire amount is counted as a spend. Which means an expense (negative pnl). Allows to link the property to an accounting setting.
-  :reqjsonarr object count_cost_basis_pnl: if ``true`` then we also count any profit/loss the asset may have had compared to when it was acquired. Allows to link the property to an accounting setting.
+  :reqjsonarr object taxable: If ``value`` is set to ``true`` if the event should be considered as taxable. Allows to link the property to an accounting setting.
+  :reqjsonarr object count_entire_amount_spend: If ``value`` is set to ``true`` then the entire amount is counted as a spend. Which means an expense (negative pnl). Allows to link the property to an accounting setting.
+  :reqjsonarr object count_cost_basis_pnl: If ``value`` is set to ``true`` then we also count any profit/loss the asset may have had compared to when it was acquired. Allows to link the property to an accounting setting.
   :reqjsonarr string linked_setting: If it takes any value this property will take the value of the provided setting. Can be either `include_gas_costs` or `include_crypto2crypto`.
   :reqjsonarr string event_type: The event type that the rule targets.
   :reqjsonarr string event_subtype: The event subtype that the rule targets.
@@ -12631,7 +12631,7 @@ Managing custom accounting rules
 
   :resjson bool result: Boolean denoting success or failure.
   :statuscode 200: Entry correctly stored.
-  :statuscode 409: No user is currently logged in. Failed to validate the data.
+  :statuscode 409: No user is currently logged in. Failed to validate the data. Combination of type, subtype and counterparty already exists.
   :statuscode 500: Internal rotki error.
 
 
@@ -12676,7 +12676,7 @@ Managing custom accounting rules
 
   :resjson bool result: Boolean denoting success or failure.
   :statuscode 200: Entry correctly updated.
-  :statuscode 409: No user is currently logged in. Failed to validate the data. Or entry doesn't exist.
+  :statuscode 409: No user is currently logged in. Failed to validate the data. Entry doesn't exist. Combination of type, subtype and counterparty already exists.
   :statuscode 500: Internal rotki error.
 
 .. http:delete:: /api/(version)/accounting/rules

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4518,6 +4518,7 @@ class RestAPI:
         result = {
             'count_entire_amount_spend': possible_accounting_setting_names,
             'count_cost_basis_pnl': possible_accounting_setting_names,
+            'taxable': possible_accounting_setting_names,
         }
 
         return api_response(_wrap_in_ok_result(result), status_code=HTTPStatus.OK)

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3082,7 +3082,7 @@ class LinkedAccountingSetting(Schema):
 
 
 class CreateAccountingRuleSchema(AccountingRuleIdSchema):
-    taxable = fields.Boolean(required=True)
+    taxable = fields.Nested(LinkedAccountingSetting)
     count_entire_amount_spend = fields.Nested(LinkedAccountingSetting)
     count_cost_basis_pnl = fields.Nested(LinkedAccountingSetting)
     accounting_treatment = SerializableEnumField(enum_class=TxAccountingTreatment, required=False, load_default=None)  # noqa: E501
@@ -3093,7 +3093,7 @@ class CreateAccountingRuleSchema(AccountingRuleIdSchema):
             **_kwargs: Any,
     ) -> dict[str, Any]:
         rule = BaseEventSettings(
-            taxable=data['taxable'],
+            taxable=data['taxable']['value'],
             count_entire_amount_spend=data['count_entire_amount_spend']['value'],
             count_cost_basis_pnl=data['count_cost_basis_pnl']['value'],
             accounting_treatment=data['accounting_treatment'],

--- a/rotkehlchen/chain/evm/accounting/structures.py
+++ b/rotkehlchen/chain/evm/accounting/structures.py
@@ -71,7 +71,7 @@ class BaseEventSettings:
 
     def serialize(self) -> dict[str, Any]:
         return {
-            'taxable': self.taxable,
+            'taxable': {'value': self.taxable},
             'count_cost_basis_pnl': {'value': self.count_cost_basis_pnl},
             'count_entire_amount_spend': {'value': self.count_entire_amount_spend},
             'accounting_treatment': self.accounting_treatment,

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -24,6 +24,7 @@ LINKABLE_ACCOUNTING_SETTINGS_NAME = Literal[
     'include_crypto2crypto',
 ]
 LINKABLE_ACCOUNTING_PROPERTIES = Literal[
+    'taxable',
     'count_entire_amount_spend',
     'count_cost_basis_pnl',
 ]

--- a/rotkehlchen/tests/db/test_db_accounting_rules.py
+++ b/rotkehlchen/tests/db/test_db_accounting_rules.py
@@ -137,7 +137,7 @@ def test_accounting_rules_linking(database: 'DBHandler', counterparty: str) -> N
         'event_type': HistoryEventType.SPEND.serialize(),
         'event_subtype': HistoryEventSubType.FEE.serialize(),
         'counterparty': counterparty,
-        'taxable': True,
+        'taxable': {'value': True},
         'count_entire_amount_spend': {'value': True},
         'count_cost_basis_pnl': {'value': True, 'linked_setting': 'include_crypto2crypto'},
         'accounting_treatment': None,

--- a/rotkehlchen/tests/unit/test_data_updates.py
+++ b/rotkehlchen/tests/unit/test_data_updates.py
@@ -524,7 +524,7 @@ def test_accounting_rules_updates(data_updater: RotkiDataUpdater) -> None:
     assert n_rules == 3
     assert rules == [
         {
-            'taxable': False,
+            'taxable': {'value': False},
             'count_cost_basis_pnl': {'value': True},
             'count_entire_amount_spend': {'value': True},
             'accounting_treatment': None,
@@ -533,7 +533,7 @@ def test_accounting_rules_updates(data_updater: RotkiDataUpdater) -> None:
             'event_subtype': 'receive wrapped',
             'counterparty': 'test_counterparty',
         }, {
-            'taxable': False,
+            'taxable': {'value': False},
             'count_cost_basis_pnl': {'value': True},
             'count_entire_amount_spend': {'value': True},
             'accounting_treatment': None,
@@ -542,7 +542,7 @@ def test_accounting_rules_updates(data_updater: RotkiDataUpdater) -> None:
             'event_subtype': 'return wrapped',
             'counterparty': 'test_counterparty',
         }, {
-            'taxable': True,
+            'taxable': {'value': True},
             'count_cost_basis_pnl': {'value': True, 'linked_setting': 'include_crypto2crypto'},
             'count_entire_amount_spend': {'value': True},
             'accounting_treatment': None,


### PR DESCRIPTION
This PR:

- Fixes an unhandled 500 error
- Allows to link the taxable field (done in the gas fee with `include_gas_costs`)