### PR TITLE
fix: slow latest prices loading

### DIFF
--- a/frontend/app/src/components/CurrencyDropdown.vue
+++ b/frontend/app/src/components/CurrencyDropdown.vue
@@ -59,86 +59,62 @@ const calculateFontSize = (symbol: string) => {
 </script>
 
 <template>
-  <div>
-    <VMenu
-      v-model="visible"
-      transition="slide-y-transition"
-      max-width="350px"
-      min-width="350px"
-      offset-y
-      :close-on-content-click="false"
-    >
-      <template #activator="{ on }">
-        <MenuTooltipButton
-          :tooltip="
-            t('currency_drop_down.profit_currency', {
-              currency: currency.tickerSymbol
-            })
-          "
-          class-name="secondary--text text--lighten-4"
-          :on-menu="on"
+  <VMenu
+    v-model="visible"
+    transition="slide-y-transition"
+    max-width="350px"
+    min-width="350px"
+    offset-y
+    :close-on-content-click="false"
+  >
+    <template #activator="{ on }">
+      <MenuTooltipButton
+        :tooltip="
+          t('currency_drop_down.profit_currency', {
+            currency: currency.tickerSymbol
+          })
+        "
+        class-name="secondary--text text--lighten-4 currency-dropdown text-[1.375rem] font-bold"
+        :on-menu="on"
+      >
+        {{ currency.unicodeSymbol }}
+      </MenuTooltipButton>
+    </template>
+    <RuiTextField
+      v-model="filter"
+      variant="outlined"
+      dense
+      autofocus
+      hide-details
+      class="m-3"
+      color="primary"
+      label="Filter"
+      prepend-inner-icon="mdi-magnify"
+      @keypress.enter="selectFirst()"
+    />
+    <RuiDivider />
+    <VList class="max-h-[25rem]">
+      <VListItem
+        v-for="item in filteredCurrencies"
+        :id="`change-to-${item.tickerSymbol.toLocaleLowerCase()}`"
+        :key="item.tickerSymbol"
+        @click="onSelected(item)"
+      >
+        <VListItemAvatar
+          class="font-bold text-rui-primary"
+          :style="{ fontSize: calculateFontSize(item.unicodeSymbol) }"
         >
-          <span class="currency-dropdown">
-            {{ currency.unicodeSymbol }}
-          </span>
-        </MenuTooltipButton>
-      </template>
-      <div>
-        <VRow class="px-4 py-3">
-          <VCol>
-            <VTextField
-              v-model="filter"
-              outlined
-              dense
-              autofocus
-              hide-details
-              label="Filter"
-              prepend-inner-icon="mdi-magnify"
-              @keypress.enter="selectFirst()"
-            />
-          </VCol>
-        </VRow>
-        <VDivider />
-        <VList class="currency-dropdown__list">
-          <VListItem
-            v-for="item in filteredCurrencies"
-            :id="`change-to-${item.tickerSymbol.toLocaleLowerCase()}`"
-            :key="item.tickerSymbol"
-            @click="onSelected(item)"
-          >
-            <VListItemAvatar
-              class="currency-list primary--text"
-              :style="{ fontSize: calculateFontSize(item.unicodeSymbol) }"
-            >
-              {{ item.unicodeSymbol }}
-            </VListItemAvatar>
-            <VListItemContent>
-              <VListItemTitle>
-                {{ item.name }}
-              </VListItemTitle>
-              <VListItemSubtitle>
-                {{ t('currency_drop_down.hint') }}
-              </VListItemSubtitle>
-            </VListItemContent>
-          </VListItem>
-        </VList>
-      </div>
-    </VMenu>
-  </div>
+          {{ item.unicodeSymbol }}
+        </VListItemAvatar>
+        <VListItemContent>
+          <VListItemTitle>
+            {{ item.name }}
+          </VListItemTitle>
+          <VListItemSubtitle>
+            {{ t('currency_drop_down.hint') }}
+          </VListItemSubtitle>
+        </VListItemContent>
+      </VListItem>
+    </VList>
+  </VMenu>
 </template>
-
-<style scoped lang="scss">
-.currency-dropdown {
-  font-size: 1.8em !important;
-  font-weight: bold !important;
-
-  &__list {
-    max-height: 400px;
-    overflow-y: scroll;
-  }
-}
-
-.currency-list {
-  font-weight: bold;
-}
-</style>

--- a/frontend/app/src/components/accounts/ModuleActivator.vue
+++ b/frontend/app/src/components/accounts/ModuleActivator.vue
@@ -52,7 +52,6 @@ const loading = isAccountOperationRunning();
       v-model="enabledModules"
       variant="outlined"
       color="primary"
-      required
       :disabled="loading"
       @change="updateSelection($event)"
     >

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -77,11 +77,13 @@ const cols = computed<DataTableColumn[]>(() => [
     label: t('common.location'),
     key: 'location',
     align: 'start',
-    width: '120px'
+    width: '120px',
+    cellClass: 'py-0'
   },
   {
     label: t('manual_balances_table.columns.label'),
-    key: 'label'
+    key: 'label',
+    sortable: true
   },
   {
     label: t('common.asset'),

--- a/frontend/app/src/components/display/amount/ManualPriceIndicator.vue
+++ b/frontend/app/src/components/display/amount/ManualPriceIndicator.vue
@@ -16,14 +16,19 @@ const isManualPrice = isManualAssetPrice(priceAsset);
 </script>
 
 <template>
-  <div v-if="isManualPrice" class="mr-2 d-inline-block">
-    <VTooltip bottom>
-      <template #activator="{ on }">
-        <VIcon class="mr-1" small color="warning" v-on="on">
-          mdi-auto-fix
-        </VIcon>
-      </template>
-      <span>{{ t('amount_display.manual_tooltip') }}</span>
-    </VTooltip>
-  </div>
+  <RuiTooltip
+    v-if="isManualPrice"
+    :popper="{ placement: 'top' }"
+    open-delay="400"
+  >
+    <template #activator>
+      <RuiIcon
+        class="mr-3 mb-1 inline cursor-pointer"
+        size="16"
+        color="warning"
+        name="sparkling-line"
+      />
+    </template>
+    <span>{{ t('amount_display.manual_tooltip') }}</span>
+  </RuiTooltip>
 </template>

--- a/frontend/app/src/components/price-manager/latest/LatestPriceContent.vue
+++ b/frontend/app/src/components/price-manager/latest/LatestPriceContent.vue
@@ -53,6 +53,7 @@ const router = useRouter();
 const route = useRoute();
 const { items, loading, refreshing, save, deletePrice, refresh } =
   useLatestPrices(filter, t);
+
 const {
   setPostSubmitFunc,
   openDialog,
@@ -97,7 +98,7 @@ const hideForm = () => {
 
 onMounted(async () => {
   setSubmitFunc(() => save(get(price), get(update)));
-  setPostSubmitFunc(refresh);
+  setPostSubmitFunc(() => refresh(true));
 
   const query = get(route).query;
 
@@ -122,7 +123,7 @@ onMounted(async () => {
             color="primary"
             variant="outlined"
             :loading="loading || refreshing"
-            @click="refresh()"
+            @click="refresh(true)"
           >
             <template #prepend>
               <RuiIcon name="refresh-line" />

--- a/frontend/app/src/components/status/notifications/PendingTask.vue
+++ b/frontend/app/src/components/status/notifications/PendingTask.vue
@@ -14,7 +14,7 @@ const time = computed(() => dayjs(task.value.time).format('LLL'));
 </script>
 
 <template>
-  <div class="flex items-center justify-between flex-nowrap">
+  <div class="flex items-center justify-between flex-nowrap break-all gap-4">
     <div>
       <div class="whitespace-nowrap overflow-hidden text-ellipsis">
         {{ task.meta.title }}

--- a/frontend/app/src/composables/price-manager/latest/index.ts
+++ b/frontend/app/src/composables/price-manager/latest/index.ts
@@ -94,7 +94,7 @@ export const useLatestPrices = (
     const { fromAsset } = item;
     try {
       await deleteLatestPrice(fromAsset);
-      await refresh();
+      await refresh(true);
     } catch (e: any) {
       const notification: NotificationPayload = {
         title: t('price_table.delete.failure.title'),
@@ -109,10 +109,14 @@ export const useLatestPrices = (
     }
   };
 
-  const refresh = async () => {
+  const refresh = async (refreshAll: boolean = false) => {
     set(refreshing, true);
     await getLatestPrices();
-    await refreshPrices(false, [...get(latestAssets), ...get(assets())]);
+    const assetToRefresh = [...get(latestAssets)];
+    if (refreshAll) {
+      assetToRefresh.push(...get(assets()));
+    }
+    await refreshPrices(false, assetToRefresh);
     resetStatus();
     set(refreshing, false);
   };

--- a/frontend/app/src/plugins/rui/index.ts
+++ b/frontend/app/src/plugins/rui/index.ts
@@ -100,6 +100,7 @@ import {
   RiSettings4Line,
   RiShuffleLine,
   RiSkipRightLine,
+  RiSparklingLine,
   RiStickyNoteLine,
   RiSubtractLine,
   RiSunLine,
@@ -232,6 +233,7 @@ Vue.use(RuiPlugin, {
     RiArrowUpDownLine,
     RiCornerLeftUpLine,
     RiPushpinLine,
-    RiUnpinLine
+    RiUnpinLine,
+    RiSparklingLine
   ]
 });

--- a/frontend/app/tests/unit/specs/components/display/amount-display.spec.ts
+++ b/frontend/app/tests/unit/specs/components/display/amount-display.spec.ts
@@ -354,7 +354,7 @@ describe('AmountDisplay.vue', () => {
         priceAsset: 'ETH'
       });
 
-      expect(wrapper.find('.v-icon.mdi-auto-fix').exists()).toBe(false);
+      expect(wrapper.find('.rui-icon').exists()).toBe(false);
     });
 
     test('Manual price icon visible', () => {
@@ -371,7 +371,7 @@ describe('AmountDisplay.vue', () => {
         priceAsset: 'ETH'
       });
 
-      expect(wrapper.find('.v-icon.mdi-auto-fix').exists()).toBe(true);
+      expect(wrapper.find('.rui-icon').exists()).toBe(true);
     });
   });
 

--- a/frontend/app/tests/unit/specs/stubs/RuiIcon.ts
+++ b/frontend/app/tests/unit/specs/stubs/RuiIcon.ts
@@ -1,5 +1,5 @@
 const RuiIconStub = {
-  template: '<div>{{ name }}</div>',
+  template: '<div class="rui-icon">{{ name }}</div>',
   props: { name: { type: String } }
 };
 


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- Only refresh prices for assets on the latest price table (onmounted)
- Refresh prices for all assets if the refresh button pressed.