### PR TITLE
Adjust event category details mapping and move direction

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12130,14 +12130,37 @@ Event Mappings
             },
           },
           "event_category_details":{
+            "send":{
+	      "direction": "out",
+	      "counterparty_mappings": {
+                null: {
+		  "label":"send",
+                  "icon":"mdi-arrow-up",
+                  "color":null
+            }}},
+            "receive":{
+	      "direction": "in",
+	      "counterparty_mappings": {
+                null: {
+		  "label":"receive",
+                  "icon":"mdi-arrow-down",
+                  "color":"green"
+            }}},
+            "fee":{
+	      "direction": "out",
+	      "counterparty_mappings": {
+                null: {
+		  "label":"fee",
+                  "icon":"mdi-account-cash",
+                  "color":null
+            }, "gas": {
+		  "label":"gas fee",
+                  "icon":"mdi-fire",
+                  "color":null
+	    }}},
             "gas":{
               "label":"gas_fee",
               "icon":"mdi-fire",
-              "color":null
-            },
-            "send":{
-              "label":"send",
-              "icon":"mdi-arrow-up",
               "color":null
             },
             "receive":{
@@ -12151,7 +12174,7 @@ Event Mappings
 
   :resjson object global_mappings: keys of this object are the history event types names and values are mappings of subtypes' names to the ``EventCategory`` name. Contains mappings that should be applied if there is no a specific protocol rule.
   :resjson object per_protocol_mappings: same as global_mappings but contains specific mappings per chain and protocol.
-  :resjson object event_category_details: Properties for ``EventCategory``.
+  :resjson object event_category_details: This is a mapping of ``EventCategory`` to its direction and mapping of counterparty to details. For all the ``EventCategoryDetails`` mapping there is a ``null`` key mapping to the default details. For some exceptions there is also other keys which are counterparties. Such as for spend/fee and counterparty gas.
   :resjon object accounting_events_icons: Mapping of accounting event type to its corresponding icon name.
   :resjson string label: Label to show in the frontend for the event type.
   :resjson string icon: Icon to be used by the frontend for this event type.

--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -2,10 +2,10 @@ from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.structures.types import (
     EventCategory,
     EventCategoryDetails,
-    EventDirection,
     HistoryEventSubType,
     HistoryEventType,
 )
+from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 
 FREE_PNL_EVENTS_LIMIT = 1000
 FREE_REPORTS_LOOKUP_LIMIT = 20
@@ -80,163 +80,124 @@ EVENT_CATEGORY_MAPPINGS = {  # possible combinations of types and subtypes mappe
 }
 
 EVENT_CATEGORY_DETAILS = {
-    EventCategory.GAS: EventCategoryDetails(
-        label='gas fee',
-        icon='mdi-fire',
-        direction=EventDirection.OUT,
-    ), EventCategory.SEND: EventCategoryDetails(
+    EventCategory.SEND: {None: EventCategoryDetails(
         label='send',
         icon='mdi-arrow-up',
-        direction=EventDirection.OUT,
-    ), EventCategory.RECEIVE: EventCategoryDetails(
+    )}, EventCategory.RECEIVE: {None: EventCategoryDetails(
         label='receive',
         icon='mdi-arrow-down',
         color='green',
-        direction=EventDirection.IN,
-    ), EventCategory.SWAP_OUT: EventCategoryDetails(
+    )}, EventCategory.SWAP_OUT: {None: EventCategoryDetails(
         label='swap',
         icon='mdi-arrow-u-right-bottom',
-        direction=EventDirection.OUT,
-    ), EventCategory.SWAP_IN: EventCategoryDetails(
+    )}, EventCategory.SWAP_IN: {None: EventCategoryDetails(
         label='swap',
         icon='mdi-arrow-u-left-top',
         color='green',
-        direction=EventDirection.IN,
-    ), EventCategory.MIGRATE_OUT: EventCategoryDetails(
+    )}, EventCategory.MIGRATE_OUT: {None: EventCategoryDetails(
         label='migrate',
         icon='mdi-arrow-u-right-bottom',
-        direction=EventDirection.OUT,
-    ), EventCategory.MIGRATE_IN: EventCategoryDetails(
+    )}, EventCategory.MIGRATE_IN: {None: EventCategoryDetails(
         label='migrate',
         icon='mdi-arrow-u-left-top',
         color='green',
-        direction=EventDirection.IN,
-    ), EventCategory.APPROVAL: EventCategoryDetails(
+    )}, EventCategory.APPROVAL: {None: EventCategoryDetails(
         label='approval',
         icon='mdi-lock-open-outline',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.DEPOSIT: EventCategoryDetails(
+    )}, EventCategory.DEPOSIT: {None: EventCategoryDetails(
         label='deposit',
         icon='mdi-arrow-expand-up',
         color='green',
-        direction=EventDirection.OUT,
-    ), EventCategory.WITHDRAW: EventCategoryDetails(
+    )}, EventCategory.WITHDRAW: {None: EventCategoryDetails(
         label='withdraw',
         icon='mdi-arrow-expand-down',
-        direction=EventDirection.IN,
-    ), EventCategory.AIRDROP: EventCategoryDetails(
+    )}, EventCategory.AIRDROP: {None: EventCategoryDetails(
         label='airdrop',
         icon='mdi-airballoon-outline',
-        direction=EventDirection.IN,
-    ), EventCategory.BORROW: EventCategoryDetails(
+    )}, EventCategory.BORROW: {None: EventCategoryDetails(
         label='borrow',
         icon='mdi-hand-coin-outline',
-        direction=EventDirection.IN,
-    ), EventCategory.REPAY: EventCategoryDetails(
+    )}, EventCategory.REPAY: {None: EventCategoryDetails(
         label='repay',
         icon='mdi-history',
-        direction=EventDirection.OUT,
-    ), EventCategory.DEPLOY: EventCategoryDetails(
+    )}, EventCategory.DEPLOY: {None: EventCategoryDetails(
         label='deploy',
         icon='mdi-swap-horizontal',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.DEPLOY_WITH_SPEND: EventCategoryDetails(
+    )}, EventCategory.DEPLOY_WITH_SPEND: {None: EventCategoryDetails(
         label='deploy with spend',
         icon='mdi-swap-horizontal',
-        direction=EventDirection.OUT,
-    ), EventCategory.BRIDGE_DEPOSIT: EventCategoryDetails(
+    )}, EventCategory.BRIDGE_DEPOSIT: {None: EventCategoryDetails(
         label='bridge',
         icon='mdi-arrow-expand-up',
         color='red',
-        direction=EventDirection.OUT,
-    ), EventCategory.BRIDGE_WITHDRAWAL: EventCategoryDetails(
+    )}, EventCategory.BRIDGE_WITHDRAWAL: {None: EventCategoryDetails(
         label='bridge',
         icon='mdi-arrow-expand-down',
         color='green',
-        direction=EventDirection.IN,
-    ), EventCategory.GOVERNANCE: EventCategoryDetails(
+    )}, EventCategory.GOVERNANCE: {None: EventCategoryDetails(
         label='governance',
         icon='mdi-bank',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.DONATE: EventCategoryDetails(
+    )}, EventCategory.DONATE: {None: EventCategoryDetails(
         label='donate',
         icon='mdi-hand-heart-outline',
-        direction=EventDirection.OUT,
-    ), EventCategory.RECEIVE_DONATION: EventCategoryDetails(
+    )}, EventCategory.RECEIVE_DONATION: {None: EventCategoryDetails(
         label='receive donation',
         icon='mdi-hand-heart-outline',
-        direction=EventDirection.IN,
-    ), EventCategory.RENEW: EventCategoryDetails(
+    )}, EventCategory.RENEW: {None: EventCategoryDetails(
         label='renew',
         icon='mdi-calendar-refresh',
-        direction=EventDirection.OUT,
-    ), EventCategory.PLACE_ORDER: EventCategoryDetails(
+    )}, EventCategory.PLACE_ORDER: {None: EventCategoryDetails(
         label='place order',
         icon='mdi-briefcase-arrow-up-down',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.TRANSFER: EventCategoryDetails(
+    )}, EventCategory.TRANSFER: {None: EventCategoryDetails(
         label='transfer',
         icon='mdi-swap-horizontal',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.STAKING_REWARD: EventCategoryDetails(
+    )}, EventCategory.STAKING_REWARD: {None: EventCategoryDetails(
         label='staking reward',
         icon='mdi-treasure-chest',
-        direction=EventDirection.IN,
-    ), EventCategory.CLAIM_REWARD: EventCategoryDetails(
+    )}, EventCategory.CLAIM_REWARD: {None: EventCategoryDetails(
         label='claim reward',
         icon='mdi-gift',
-        direction=EventDirection.IN,
-    ), EventCategory.LIQUIDATION_REWARD: EventCategoryDetails(
+    )}, EventCategory.LIQUIDATION_REWARD: {None: EventCategoryDetails(
         label='liquidation reward',
         icon='mdi-water',
-        direction=EventDirection.IN,
-    ), EventCategory.LIQUIDATION_LOSS: EventCategoryDetails(
+    )}, EventCategory.LIQUIDATION_LOSS: {None: EventCategoryDetails(
         label='liquidation loss',
         icon='mdi-water',
-        direction=EventDirection.OUT,
-    ), EventCategory.INFORMATIONAL: EventCategoryDetails(
+    )}, EventCategory.INFORMATIONAL: {None: EventCategoryDetails(
         label='informational',
         icon='mdi-information-outline',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.CANCEL_ORDER: EventCategoryDetails(
+    )}, EventCategory.CANCEL_ORDER: {None: EventCategoryDetails(
         label='cancel order',
         icon='mdi-close-circle-multiple-outline',
         color='red',
-        direction=EventDirection.IN,
-    ), EventCategory.REFUND: EventCategoryDetails(
+    )}, EventCategory.REFUND: {None: EventCategoryDetails(
         label='refund',
         icon='mdi-cash-refund',
-        direction=EventDirection.IN,
-    ), EventCategory.FEE: EventCategoryDetails(
-        label='fee',
-        icon='mdi-account-cash',
-        direction=EventDirection.OUT,
-    ), EventCategory.MEV_REWARD: EventCategoryDetails(
+    )}, EventCategory.FEE: {
+        None: EventCategoryDetails(label='fee', icon='mdi-account-cash'),
+        CPT_GAS: EventCategoryDetails(label='gas fee', icon='mdi-fire'),
+    }, EventCategory.MEV_REWARD: {None: EventCategoryDetails(
         label='mev',
         icon='mdi-star-box',
-        direction=EventDirection.IN,
-    ), EventCategory.CREATE_BLOCK: EventCategoryDetails(
+    )}, EventCategory.CREATE_BLOCK: {None: EventCategoryDetails(
         label='new block',
         icon='mdi-cube-outline',
-        direction=EventDirection.IN,
-    ), EventCategory.CREATE_PROJECT: EventCategoryDetails(
+    )}, EventCategory.CREATE_PROJECT: {None: EventCategoryDetails(
         label='new project',
         icon='mdi-clipboard-check-outline',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.UPDATE_PROJECT: EventCategoryDetails(
+    )}, EventCategory.UPDATE_PROJECT: {None: EventCategoryDetails(
         label='update project',
         icon='mdi-clipboard-plus-outline',
-        direction=EventDirection.NEUTRAL,
-    ), EventCategory.APPLY: EventCategoryDetails(
+    )}, EventCategory.APPLY: {None: EventCategoryDetails(
         label='apply',
         icon='mdi-application-export',
-        direction=EventDirection.NEUTRAL,
-    ),
+    )},
 }
 
 ACCOUNTING_EVENTS_ICONS = {
     AccountingEventType.TRADE: 'mdi-shuffle-variant',
-    AccountingEventType.FEE: 'mdi-fire',
+    AccountingEventType.FEE: 'mdi-account-cash',
     AccountingEventType.ASSET_MOVEMENT: 'mdi-bank-transfer',
     AccountingEventType.MARGIN_POSITION: 'mdi-margin',
     AccountingEventType.LOAN: 'mdi-handshake',

--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import auto
 from typing import TYPE_CHECKING, Any, Optional, TypedDict, TypeVar
 
-from rotkehlchen.accounting.constants import EVENT_CATEGORY_DETAILS, EVENT_CATEGORY_MAPPINGS
+from rotkehlchen.accounting.constants import EVENT_CATEGORY_MAPPINGS
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.structures.types import (
     ActionType,
@@ -278,8 +278,7 @@ class HistoryBaseEntry(AccountingEventMixin, metaclass=ABCMeta):
         May raise:
         - KeyError if the combination of types is not valid
         """
-        event_category = EVENT_CATEGORY_MAPPINGS[self.event_type][self.event_subtype]
-        return EVENT_CATEGORY_DETAILS[event_category].direction
+        return EVENT_CATEGORY_MAPPINGS[self.event_type][self.event_subtype].direction
 
     @classmethod
     def _deserialize_base_history_data(cls: type[T], data: dict[str, Any]) -> HistoryBaseEntryData:

--- a/rotkehlchen/accounting/structures/types.py
+++ b/rotkehlchen/accounting/structures/types.py
@@ -1,4 +1,4 @@
-from enum import auto
+from enum import Enum, auto
 from typing import Literal, NamedTuple, Optional
 
 from rotkehlchen.errors.serialization import DeserializationError
@@ -116,47 +116,59 @@ class EventDirection(SerializableEnumNameMixin):
 class EventCategoryDetails(NamedTuple):
     label: str
     icon: str
-    direction: EventDirection
     color: Optional[Literal['green', 'red']] = None
 
 
-class EventCategory(SerializableEnumNameMixin):
+class EventCategory(Enum):
+    """User friendly categories to classify combinations of event type and event subtype
+
+    Can't use auto() yet cause has to be only thing in line.
+    https://docs.python.org/3/library/enum.html#enum.auto
+
+    From 3.11 and on we will be able to adjust.
     """
-    User friendly categories to classify combinations of event type and event subtype
-    """
-    GAS = auto()
-    SEND = auto()
-    RECEIVE = auto()
-    SWAP_OUT = auto()
-    SWAP_IN = auto()
-    MIGRATE_OUT = auto()
-    MIGRATE_IN = auto()
-    APPROVAL = auto()
-    DEPOSIT = auto()
-    WITHDRAW = auto()
-    AIRDROP = auto()
-    BORROW = auto()
-    REPAY = auto()
-    DEPLOY = auto()
-    DEPLOY_WITH_SPEND = auto()
-    BRIDGE_DEPOSIT = auto()
-    BRIDGE_WITHDRAWAL = auto()
-    GOVERNANCE = auto()
-    DONATE = auto()
-    RECEIVE_DONATION = auto()
-    RENEW = auto()
-    PLACE_ORDER = auto()
-    TRANSFER = auto()
-    CLAIM_REWARD = auto()
-    LIQUIDATION_REWARD = auto()
-    LIQUIDATION_LOSS = auto()
-    INFORMATIONAL = auto()
-    CANCEL_ORDER = auto()
-    REFUND = auto()
-    FEE = auto()
-    MEV_REWARD = auto()
-    STAKING_REWARD = auto()
-    CREATE_BLOCK = auto()
-    CREATE_PROJECT = auto()
-    UPDATE_PROJECT = auto()
-    APPLY = auto()
+    SEND = 1, EventDirection.OUT
+    RECEIVE = 2, EventDirection.IN
+    SWAP_OUT = 3, EventDirection.OUT
+    SWAP_IN = 4, EventDirection.IN
+    MIGRATE_OUT = 5, EventDirection.OUT
+    MIGRATE_IN = 6, EventDirection.IN
+    APPROVAL = 7, EventDirection.NEUTRAL
+    DEPOSIT = 8, EventDirection.OUT
+    WITHDRAW = 9, EventDirection.IN
+    AIRDROP = 10, EventDirection.IN
+    BORROW = 11, EventDirection.IN
+    REPAY = 12, EventDirection.OUT
+    DEPLOY = 12, EventDirection.NEUTRAL
+    DEPLOY_WITH_SPEND = 13, EventDirection.OUT
+    BRIDGE_DEPOSIT = 14, EventDirection.OUT
+    BRIDGE_WITHDRAWAL = 15, EventDirection.IN
+    GOVERNANCE = 16, EventDirection.NEUTRAL
+    DONATE = 17, EventDirection.OUT
+    RECEIVE_DONATION = 18, EventDirection.IN
+    RENEW = 19, EventDirection.OUT
+    PLACE_ORDER = 20, EventDirection.NEUTRAL
+    TRANSFER = 21, EventDirection.NEUTRAL
+    CLAIM_REWARD = 22, EventDirection.IN
+    LIQUIDATION_REWARD = 23, EventDirection.IN
+    LIQUIDATION_LOSS = 24, EventDirection.OUT
+    INFORMATIONAL = 25, EventDirection.NEUTRAL
+    CANCEL_ORDER = 26, EventDirection.IN
+    REFUND = 27, EventDirection.IN
+    FEE = 28, EventDirection.OUT
+    MEV_REWARD = 29, EventDirection.IN
+    STAKING_REWARD = 30, EventDirection.IN
+    CREATE_BLOCK = 31, EventDirection.IN
+    CREATE_PROJECT = 32, EventDirection.NEUTRAL
+    UPDATE_PROJECT = 33, EventDirection.NEUTRAL
+    APPLY = 34, EventDirection.NEUTRAL
+
+    @property
+    def direction(self) -> EventDirection:
+        return self.value[1]
+
+    def __str__(self) -> str:
+        return ' '.join(word.lower() for word in self.name.split('_'))  # pylint: disable=no-member
+
+    def serialize(self) -> str:
+        return str(self)

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4226,7 +4226,10 @@ class RestAPI:
     def get_types_mappings(self) -> Response:
         result = {
             'global_mappings': EVENT_CATEGORY_MAPPINGS,
-            'event_category_details': EVENT_CATEGORY_DETAILS,
+            'event_category_details': {
+                category: {'counterparty_mappings': entries, 'direction': category.direction.serialize()}  # noqa: E501
+                for category, entries in EVENT_CATEGORY_DETAILS.items()
+            },
             'accounting_events_icons': ACCOUNTING_EVENTS_ICONS,
         }
         return api_response(


### PR DESCRIPTION
EventCategory is now a more complicated enum, which also has the direction in it.

The event_category_details which is returned to the frontend for displaying icons and more per event type is now configurable also by counterparty on top of type/subtype.

This is now only used for spend/fee and counterparty gas as a specialization of spend/fee.

