### PR TITLE
Upgrade ruff and other linters fixing the code

### DIFF
--- a/package.py
+++ b/package.py
@@ -474,14 +474,14 @@ class MacPackaging:
 
         :param wheel_metadata: Path to the wheel metadata file
         """
-        with open(wheel_metadata) as file:
+        with open(wheel_metadata, encoding='utf8') as file:
             data = file.readlines()
             for (index, line) in enumerate(data):
                 if not line.startswith('Tag'):
                     continue
                 data[index] = line.replace('x86_64', 'universal2')
 
-        with open(wheel_metadata, 'w') as file:
+        with open(wheel_metadata, 'w', encoding='utf8') as file:
             file.writelines(data)
 
     def __download_patched_pip(self) -> Path:
@@ -509,7 +509,7 @@ class MacPackaging:
         """
         requirements = self.__storage.working_directory / 'requirements.txt'
         package_versions: dict[str, str] = {}
-        with open(requirements) as fp:
+        with open(requirements, encoding='utf8') as fp:
             while True:
                 line = fp.readline()
                 if not line:

--- a/package.py
+++ b/package.py
@@ -205,7 +205,7 @@ class Environment:
         return self.is_mac_runner() or os.environ.get('MACOS_BUILD_ARCH') == 'universal2'
 
     def is_x86_64(self) -> bool:
-        return self.arch in ['x86_64', 'AMD64']
+        return self.arch in {'x86_64', 'AMD64'}
 
     def backend_suffix(self) -> str:
         """
@@ -1200,7 +1200,7 @@ class FrontendBuilder:
         os.chdir(frontend_build_dir)
         for path in frontend_build_dir.iterdir():
             name = path.name
-            if path.is_dir() or name in ['builder-debug.yml', 'builder-effective-config.yaml']:
+            if path.is_dir() or name in {'builder-debug.yml', 'builder-effective-config.yaml'}:
                 continue
 
             suffixes = ['dmg', 'zip', 'exe', 'AppImage', 'tar.xz', 'deb']
@@ -1267,12 +1267,12 @@ def main() -> None:
     if environment.is_windows():
         win = WindowsPackaging(storage, environment)
 
-    if args.build in ['backend', 'full']:
+    if args.build in {'backend', 'full'}:
         builder = BackendBuilder(storage, environment, mac, win)
         builder.clean()
         builder.build()
 
-    if args.build in ['full', 'frontend']:
+    if args.build in {'full', 'frontend'}:
         frontend_builder = FrontendBuilder(storage, environment, mac, win)
         frontend_builder.build()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ ignore = [
     "PLR0915", # too many statements -- we probably could use this ... but with custom statements number?
     "PLR0911", # too many return statements -- we dont care
     "PLR0912", # too many branches -- we dont care
+    "PLR6201", # Doesn't work only for constants: https://github.com/astral-sh/ruff/issues/8322
     "PLR6301", # could be a staticmethod or function -- breaks for interfaces
     "PLC1901", # we prefer direct comparison to empty string for explicitness
     # Some bandit rules we don't check for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ ignore = [
     "PLR0904", # too many public methods. This is a bit too much to enforce in the codebase
     "PLR0913", # too many arguments to function call. This is a bit too much to enforce in the codebase
     "PLR0915", # too many statements -- we probably could use this ... but with custom statements number?
+    "PLR0916", # too many boolean expressions -- we dont care
     "PLR0911", # too many return statements -- we dont care
     "PLR0912", # too many branches -- we dont care
     "PLR6201", # Doesn't work only for constants: https://github.com/astral-sh/ruff/issues/8322

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -2,7 +2,7 @@ mypy==1.6.1
 mypy-extensions==1.0.0
 pylint==3.0.2
 astroid==3.0.1  # engine of pylint, upgrade them together
-ruff==0.0.292
+ruff==0.1.3
 double-indent-rotki==0.1.7  # our fork of double indent
 flake8==6.1.0
 flake8-commas==2.1.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,7 +1,7 @@
 mypy==1.6.0
 mypy-extensions==1.0.0
-pylint==3.0.1
-astroid==3.0.0  # engine of pylint, upgrade them together
+pylint==3.0.2
+astroid==3.0.1  # engine of pylint, upgrade them together
 ruff==0.0.292
 double-indent-rotki==0.1.7  # our fork of double indent
 flake8==6.1.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,4 +1,4 @@
-mypy==1.6.0
+mypy==1.6.1
 mypy-extensions==1.0.0
 pylint==3.0.2
 astroid==3.0.1  # engine of pylint, upgrade them together

--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -106,7 +106,7 @@ class IncludeExcludeListField(fields.Field):
         values = value['values']
         behaviour = value['behaviour']
 
-        if behaviour not in ('include', 'exclude'):
+        if behaviour not in {'include', 'exclude'}:
             raise ValidationError(
                 message="Behaviour must be either 'include' or 'exclude'.",
                 field_name='behaviour',
@@ -823,7 +823,7 @@ class AssetConflictsField(fields.Field):
             except UnknownAsset as e:
                 raise ValidationError(f'Unknown asset identifier {asset_id}') from e
 
-            if choice not in ('remote', 'local'):
+            if choice not in {'remote', 'local'}:
                 raise ValidationError(
                     f'Unknown asset update choice: {choice}. Valid values '
                     f'are "remote" or "local"',

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -915,7 +915,7 @@ def asset_from_kraken(kraken_name: str) -> AssetWithOracles:
         name = 'DOGE'
     elif kraken_name == 'FLOWH':
         name = 'FLOW'
-    elif kraken_name in ('ETH', 'EUR', 'USD', 'GBP', 'CAD', 'JPY', 'KRW', 'CHF', 'AUD'):
+    elif kraken_name in {'ETH', 'EUR', 'USD', 'GBP', 'CAD', 'JPY', 'KRW', 'CHF', 'AUD'}:
         name = kraken_name
     else:
         name = KRAKEN_TO_WORLD.get(kraken_name, kraken_name)

--- a/rotkehlchen/chain/bitcoin/hdkey.py
+++ b/rotkehlchen/chain/bitcoin/hdkey.py
@@ -222,7 +222,7 @@ class HDKey:
             return idx
         if not isinstance(idx, str):
             raise XPUBError('XPUB path index must be string or integer')
-        if idx[-1] in ['h', "'"]:  # account for h or ' conventions
+        if idx[-1] in {'h', "'"}:  # account for h or ' conventions
             return int(idx[:-1]) + BIP32_HARDEN
         return int(idx)
 
@@ -310,7 +310,7 @@ class HDKey:
         # Go over all other nodes, and convert to indexes
         nodes = nodes[1:]
         for node in nodes:
-            if node[-1] in ['h', "'"]:  # Support 0h and 0' conventions
+            if node[-1] in {'h', "'"}:  # Support 0h and 0' conventions
                 int_nodes.append(int(node[:-1]) + BIP32_HARDEN)
             else:
                 int_nodes.append(int(node))

--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -80,7 +80,7 @@ def is_valid_base58_address(value: str) -> bool:
     except ValueError:
         return False
 
-    if len(abytes) == 0 or abytes[0] not in (0x00, 0x05):
+    if len(abytes) == 0 or abytes[0] not in {0x00, 0x05}:
         return False
 
     checksum = hashlib.sha256(hashlib.sha256(abytes[:-4]).digest()).digest()[:4]

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -299,7 +299,7 @@ def get_airdrop_data(name: str, data_dir: Path) -> Iterator[list[str]]:
                 len(response.content) < SMALLEST_AIRDROP_SIZE
             ):
                 raise csv.Error
-            with open(filename, 'w') as f:
+            with open(filename, 'w', encoding='utf8') as f:
                 f.write(content)
         except csv.Error as e:
             log.debug(f'airdrop file {filename} contains invalid data {content}')
@@ -307,7 +307,7 @@ def get_airdrop_data(name: str, data_dir: Path) -> Iterator[list[str]]:
                 f'File {filename} contains invalid data. Check logs.',
             ) from e
     # Verify the CSV file
-    with open(filename) as csvfile:
+    with open(filename, encoding='utf8') as csvfile:
         iterator = csv.reader(csvfile)
         next(iterator)  # skip header
         yield from iterator
@@ -329,10 +329,10 @@ def get_poap_airdrop_data(name: str, data_dir: Path) -> dict[str, Any]:
         except JSONDecodeError as e:
             raise RemoteError(f'POAP airdrops Gist contains an invalid JSON {e!s}') from e
 
-        with open(filename, 'w') as outfile:
+        with open(filename, 'w', encoding='utf8') as outfile:
             outfile.write(rlk_jsondumps(json_data))
 
-    with open(filename) as infile:
+    with open(filename, encoding='utf8') as infile:
         data_dict = jsonloads_dict(infile.read())
     return data_dict
 

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -392,7 +392,7 @@ def check_airdrops(
             addr, amount, *_ = row
             # not doing to_checksum_address() here since the file addresses are checksummed
             # and doing to_checksum_address() so many times hits performance
-            if protocol_name in (
+            if protocol_name in {
                 'cornichon',
                 'tornado',
                 'grain',
@@ -400,7 +400,7 @@ def check_airdrops(
                 'sdl',
                 'cow_mainnet',
                 'cow_gnosis',
-            ):
+            }:
                 amount = token_normalized_value_decimals(int(amount), 18)  # type: ignore
             if addr in addresses:
                 asset = airdrop_data[1]

--- a/rotkehlchen/chain/ethereum/defi/zerionsdk.py
+++ b/rotkehlchen/chain/ethereum/defi/zerionsdk.py
@@ -160,7 +160,7 @@ def _is_token_non_standard(symbol: str, address: ChecksumEvmAddress) -> bool:
     UNI-V2 is queried from the uniswap pairs code
     pDAI is useless since the hack so ignore it
     """
-    if symbol in ('UNI-V2', 'pDAI'):
+    if symbol in {'UNI-V2', 'pDAI'}:
         return True
 
     if address in (

--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -106,7 +106,7 @@ class Aave(EthereumModule):
             for balance_entry in balance_entries:
                 # Aave also has "Aave • Staking" and "Aave • Uniswap Market" but
                 # here we are only querying the balances in the lending protocol
-                if balance_entry.protocol.name not in ('Aave', 'Aave V2', 'Aave V2 • Variable Debt', 'Aave V2 • Stable Debt'):  # noqa: E501
+                if balance_entry.protocol.name not in {'Aave', 'Aave V2', 'Aave V2 • Variable Debt', 'Aave V2 • Stable Debt'}:  # noqa: E501
                     continue
 
                 # Depending on whether it's asset or debt we find what the reserve asset is

--- a/rotkehlchen/chain/ethereum/modules/compound/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/compound.py
@@ -119,7 +119,7 @@ class Compound(EthereumModule):
             borrowing_map = {}
             rewards_map = {}
             for balance_entry in balance_entries:
-                if balance_entry.protocol.name not in ('Compound Governance', 'Compound'):
+                if balance_entry.protocol.name not in {'Compound Governance', 'Compound'}:
                     continue
 
                 entry = balance_entry.base_balance

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -42,7 +42,7 @@ class DxdaomesaDecoder(DecoderInterface):
             msg_aggregator=msg_aggregator,
         )
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        with open(os.path.join(dir_path, 'data', 'contracts.json')) as f:
+        with open(os.path.join(dir_path, 'data', 'contracts.json'), encoding='utf8') as f:
             contracts = json.loads(f.read())
 
         self.contract = EvmContract(

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -27,10 +27,10 @@ class GitcoinDecoder(DecoderInterface):
         - UnknownAsset
         - WrongAssetType
         """
-        if context.transaction.to_address not in (
+        if context.transaction.to_address not in {
                 '0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE',
                 '0x7d655c57f71464B6f83811C55D84009Cd9f5221C',
-        ):
+        }:
             return FAILED_ENRICHMENT_OUTPUT
         crypto_asset = context.event.asset.resolve_to_crypto_asset()
         if context.event.event_type == HistoryEventType.SPEND:

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -154,7 +154,7 @@ def _query_web3_get_logs(
                 msg = 'query returned more than 10000 results'
 
             # errors from: https://infura.io/docs/ethereum/json-rpc/eth-getLogs
-            if msg in ('query returned more than 10000 results', 'query timeout exceeded'):
+            if msg in {'query returned more than 10000 results', 'query timeout exceeded'}:
                 block_range = block_range // 2
                 if block_range < 50:
                     raise  # stop retrying if block range gets too small

--- a/rotkehlchen/data_import/importers/binance.py
+++ b/rotkehlchen/data_import/importers/binance.py
@@ -217,7 +217,7 @@ class BinanceTradeEntry(BinanceMultipleEntry):
         same_assets = True
         assets: dict[str, Optional[AssetWithOracles]] = defaultdict(lambda: None)
         for row in data:
-            if row['Operation'] in ('Fee', 'Transaction Fee'):
+            if row['Operation'] in {'Fee', 'Transaction Fee'}:
                 cur_operation = 'Fee'
             elif row['Change'] < 0:
                 cur_operation = 'Sold'
@@ -246,7 +246,7 @@ class BinanceTradeEntry(BinanceMultipleEntry):
         # Group rows depending on whether they are fee or not and then sort them by amount
         rows_grouped_by_fee: dict[bool, list[BinanceCsvRow]] = defaultdict(list)
         for row in data:
-            is_fee = row['Operation'] in ('Fee', 'Transaction Fee')
+            is_fee = row['Operation'] in {'Fee', 'Transaction Fee'}
             rows_grouped_by_fee[is_fee].append(row)
 
         for rows_group in rows_grouped_by_fee.values():
@@ -275,7 +275,7 @@ class BinanceTradeEntry(BinanceMultipleEntry):
             for row in trade_rows:
                 cur_asset = row['Coin']
                 amount = row['Change']
-                if row['Operation'] in ('Fee', 'Transaction Fee'):
+                if row['Operation'] in {'Fee', 'Transaction Fee'}:
                     fee_asset = cur_asset
                     fee_amount = Fee(abs(amount))
                 else:
@@ -485,12 +485,12 @@ class BinanceEarnProgram(BinanceSingleEntry):
         event_identifier = f'{EVENT_IDENTIFIER_PREFIX}{hash_csv_row(data)}'
         timestamp_ms = ts_sec_to_ms(timestamp)
         staking_event = None
-        if data['Operation'] in (
+        if data['Operation'] in {
             'Simple Earn Flexible Interest',
             'Simple Earn Locked Rewards',
             'BNB Vault Rewards',
             'Swap Farming Rewards',
-        ):
+        }:
             staking_event = HistoryEvent(
                 event_identifier=event_identifier,
                 sequence_index=0,
@@ -503,11 +503,11 @@ class BinanceEarnProgram(BinanceSingleEntry):
                 location_label='CSV import',
                 notes=f'Reward from {data["Operation"]}',
             )
-        elif data['Operation'] in (
+        elif data['Operation'] in {
             'Simple Earn Flexible Subscription',
             'Simple Earn Locked Subscription',
             'Staking Purchase',
-        ):
+        }:
             staking_event = HistoryEvent(
                 event_identifier=event_identifier,
                 sequence_index=0,
@@ -553,7 +553,7 @@ class BinanceUSDMProgram(BinanceSingleEntry):
     )
 
     def is_entry(self, requested_operation: str, account: str, change: AssetAmount) -> bool:
-        if requested_operation in ('Fee', 'Funding Fee') and change == abs(change):
+        if requested_operation in {'Fee', 'Funding Fee'} and change == abs(change):
             return False
         return requested_operation in self.AVAILABLE_OPERATIONS and account == self.ACCOUNT
 
@@ -564,7 +564,7 @@ class BinanceUSDMProgram(BinanceSingleEntry):
         - KeyError
         """
         amount = abs(data['Change'])
-        if data['Operation'] in ('Fee', 'Funding Fee'):
+        if data['Operation'] in {'Fee', 'Funding Fee'}:
             event_type = HistoryEventType.SPEND
             event_subtype = HistoryEventSubType.FEE
             notes = f'{amount} {data["Coin"].symbol} fee paid on binance USD-MFutures'

--- a/rotkehlchen/data_import/importers/bitcoin_tax.py
+++ b/rotkehlchen/data_import/importers/bitcoin_tax.py
@@ -72,7 +72,7 @@ class BitcoinTaxImporter(BaseExchangeImporter):
         May raise:
         - UnsupportedCSVEntry: When the action is not supported
         """
-        if action not in ('BUY', 'SELL', 'SWAP'):
+        if action not in {'BUY', 'SELL', 'SWAP'}:
             raise UnsupportedCSVEntry(f'Unsupported entry action type {action}. Data: {csv_row}')
         if action == 'SWAP':
             # The SWAP action is used by bitcoin tax when a crypto asset is renamed or forked.
@@ -205,7 +205,7 @@ class BitcoinTaxImporter(BaseExchangeImporter):
             location = Location.deserialize(csv_row['Account'])
         except DeserializationError:
             location = Location.EXTERNAL
-            if csv_row['Account'] in ('Coinbase Pro', 'GDAX'):
+            if csv_row['Account'] in {'Coinbase Pro', 'GDAX'}:
                 location = Location.COINBASEPRO
 
         asset_resolver = LOCATION_TO_ASSET_MAPPING.get(location, asset_from_common_identifier)

--- a/rotkehlchen/data_import/importers/bitmex.py
+++ b/rotkehlchen/data_import/importers/bitmex.py
@@ -117,7 +117,7 @@ class BitMEXImporter(BaseExchangeImporter):
                     if row['transactType'] == 'RealisedPNL':
                         margin_position = self._consume_realised_pnl(row, **kwargs)
                         self.add_margin_trade(write_cursor, margin_position)
-                    elif row['transactType'] in ['Deposit', 'Withdrawal']:
+                    elif row['transactType'] in {'Deposit', 'Withdrawal'}:
                         if row['transactStatus'] == 'Completed':
                             self.add_asset_movement(
                                 write_cursor, self._consume_deposits_or_withdrawals(row, **kwargs),

--- a/rotkehlchen/data_import/importers/bitstamp.py
+++ b/rotkehlchen/data_import/importers/bitstamp.py
@@ -109,7 +109,7 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
                 receive_trade_event,
                 fee_event,
             ])
-        elif csv_row['Type'] in ('Deposit', 'Withdrawal'):
+        elif csv_row['Type'] in {'Deposit', 'Withdrawal'}:
             amount = deserialize_asset_amount(amount)
             asset = asset_from_bitstamp(amount_symbol)
             transaction_type = csv_row['Type']

--- a/rotkehlchen/data_import/importers/blockfi_transactions.py
+++ b/rotkehlchen/data_import/importers/blockfi_transactions.py
@@ -62,7 +62,7 @@ class BlockfiTransactionsImporter(BaseExchangeImporter):
         fee = Fee(ZERO)
         fee_asset = A_USD  # Can be whatever
 
-        if entry_type in ('Deposit', 'Wire Deposit', 'ACH Deposit'):
+        if entry_type in {'Deposit', 'Wire Deposit', 'ACH Deposit'}:
             asset_movement = AssetMovement(
                 location=Location.BLOCKFI,
                 category=AssetMovementCategory.DEPOSIT,
@@ -76,7 +76,7 @@ class BlockfiTransactionsImporter(BaseExchangeImporter):
                 link='',
             )
             self.add_asset_movement(write_cursor, asset_movement)
-        elif entry_type in ('Withdrawal', 'Wire Withdrawal', 'ACH Withdrawal'):
+        elif entry_type in {'Withdrawal', 'Wire Withdrawal', 'ACH Withdrawal'}:
             asset_movement = AssetMovement(
                 location=Location.BLOCKFI,
                 category=AssetMovementCategory.WITHDRAWAL,
@@ -103,7 +103,7 @@ class BlockfiTransactionsImporter(BaseExchangeImporter):
                 notes=f'{entry_type} from BlockFi',
             )
             self.add_history_events(write_cursor, [event])
-        elif entry_type in ('Interest Payment', 'Bonus Payment', 'Referral Bonus'):
+        elif entry_type in {'Interest Payment', 'Bonus Payment', 'Referral Bonus'}:
             event = HistoryEvent(
                 event_identifier=f'{BLOCKFI_PREFIX}{hash_csv_row(csv_row)}',
                 sequence_index=0,

--- a/rotkehlchen/data_import/importers/cointracking.py
+++ b/rotkehlchen/data_import/importers/cointracking.py
@@ -61,7 +61,7 @@ def exchange_row_to_location(entry: str) -> Location:
         return Location.BITMEX
     if entry == 'Coinbase':
         return Location.COINBASE
-    if entry in ('CoinbasePro', 'GDAX'):
+    if entry in {'CoinbasePro', 'GDAX'}:
         return Location.COINBASEPRO
     if entry == 'Gemini':
         return Location.GEMINI
@@ -125,10 +125,10 @@ class CointrackingImporter(BaseExchangeImporter):
             fee = deserialize_fee(csv_row['Fee'])
             fee_currency = asset_resolver(csv_row['Cur.Fee'])
 
-        if row_type in ('Gift/Tip', 'Trade', 'Income'):
+        if row_type in {'Gift/Tip', 'Trade', 'Income'}:
             base_asset = asset_resolver(csv_row['Cur.Buy'])
             quote_asset = None if csv_row['Cur.Sell'] == '' else asset_resolver(csv_row['Cur.Sell'])  # noqa: E501
-            if quote_asset is None and row_type not in ('Gift/Tip', 'Income'):
+            if quote_asset is None and row_type not in {'Gift/Tip', 'Income'}:
                 raise DeserializationError('Got a trade entry with an empty quote asset')
 
             if quote_asset is None:
@@ -158,7 +158,7 @@ class CointrackingImporter(BaseExchangeImporter):
                 notes=notes,
             )
             self.add_trade(write_cursor, trade)
-        elif row_type in ('Deposit', 'Withdrawal'):
+        elif row_type in {'Deposit', 'Withdrawal'}:
             category = deserialize_asset_movement_category(row_type.lower())
             if category == AssetMovementCategory.DEPOSIT:
                 amount = deserialize_asset_amount(csv_row['Buy'])

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -70,14 +70,14 @@ class CryptocomImporter(BaseExchangeImporter):
         fee = Fee(ZERO)
         fee_currency = A_USD  # whatever (used only if there is no fee)
 
-        if row_type in (
+        if row_type in {
             'crypto_purchase',
             'crypto_exchange',
             'viban_purchase',
             'crypto_viban_exchange',
             'recurring_buy_order',
             'card_top_up',
-        ):
+        }:
             # variable mapping to raw data
             currency = csv_row['Currency']
             to_currency = csv_row['To Currency']
@@ -88,12 +88,12 @@ class CryptocomImporter(BaseExchangeImporter):
 
             trade_type = TradeType.BUY if to_currency != native_currency else TradeType.SELL
 
-            if row_type in (
+            if row_type in {
                 'crypto_exchange',
                 'crypto_viban_exchange',
                 'recurring_buy_order',
                 'viban_purchase',
-            ):
+            }:
                 # trades (fiat, crypto) to (crypto, fiat)
                 base_asset = asset_from_cryptocom(to_currency)
                 quote_asset = asset_from_cryptocom(currency)
@@ -128,13 +128,13 @@ class CryptocomImporter(BaseExchangeImporter):
             )
             self.add_trade(write_cursor, trade)
 
-        elif row_type in (
+        elif row_type in {
             'crypto_withdrawal',
             'crypto_deposit',
             'viban_deposit',
             'viban_card_top_up',
-        ):
-            if row_type in ('crypto_withdrawal', 'viban_deposit', 'viban_card_top_up'):
+        }:
+            if row_type in {'crypto_withdrawal', 'viban_deposit', 'viban_card_top_up'}:
                 category = AssetMovementCategory.WITHDRAWAL
                 amount = deserialize_asset_amount_force_positive(csv_row['Amount'])
             else:
@@ -155,7 +155,7 @@ class CryptocomImporter(BaseExchangeImporter):
                 link='',
             )
             self.add_asset_movement(write_cursor, asset_movement)
-        elif row_type in (
+        elif row_type in {
             'airdrop_to_exchange_transfer',
             'mco_stake_reward',
             'crypto_payment_refund',
@@ -170,7 +170,7 @@ class CryptocomImporter(BaseExchangeImporter):
             'referral_bonus',
             'crypto_earn_interest_paid',
             'reimbursement',
-        ):
+        }:
             asset = asset_from_cryptocom(csv_row['Currency'])
             amount = deserialize_asset_amount(csv_row['Amount'])
             event = HistoryEvent(
@@ -185,7 +185,7 @@ class CryptocomImporter(BaseExchangeImporter):
                 notes=notes,
             )
             self.add_history_events(write_cursor, [event])
-        elif row_type in ('crypto_payment', 'reimbursement_reverted', 'card_cashback_reverted'):
+        elif row_type in {'crypto_payment', 'reimbursement_reverted', 'card_cashback_reverted'}:
             asset = asset_from_cryptocom(csv_row['Currency'])
             amount = abs(deserialize_asset_amount(csv_row['Amount']))
             event = HistoryEvent(
@@ -253,7 +253,7 @@ class CryptocomImporter(BaseExchangeImporter):
                 notes=notes,
             )
             self.add_history_events(write_cursor, [event])
-        elif row_type in (
+        elif row_type in {
             'crypto_earn_program_created',
             'crypto_earn_program_withdrawn',
             'lockup_lock',
@@ -264,7 +264,6 @@ class CryptocomImporter(BaseExchangeImporter):
             'lockup_swap_debited',
             'lockup_swap_credited',
             'lockup_swap_rebate',
-            'dynamic_coin_swap_bonus_exchange_deposit',
             # we don't handle cryto.com exchange yet
             'crypto_to_exchange_transfer',
             'exchange_to_crypto_transfer',
@@ -280,7 +279,7 @@ class CryptocomImporter(BaseExchangeImporter):
             'interest_swap_debited',
             # The user has received an aidrop but can't claim it yet
             'airdrop_locked',
-        ):
+        }:
             # those types are ignored because it doesn't affect the wallet balance
             # or are not handled here
             return

--- a/rotkehlchen/data_import/importers/nexo.py
+++ b/rotkehlchen/data_import/importers/nexo.py
@@ -70,13 +70,13 @@ class NexoImporter(BaseExchangeImporter):
         entry_type = csv_row['Type']
         transaction = csv_row['Transaction']
 
-        if entry_type in ('Exchange', 'CreditCardStatus'):
+        if entry_type in {'Exchange', 'CreditCardStatus'}:
             self.db.msg_aggregator.add_warning(
                 'Found exchange/credit card status transaction in nexo csv import but the entry '
                 'will be ignored since not enough information is provided about the trade.',
             )
             return
-        if entry_type in ('Deposit', 'ExchangeDepositedOn'):
+        if entry_type in {'Deposit', 'ExchangeDepositedOn'}:
             asset_movement = AssetMovement(
                 location=Location.NEXO,
                 category=AssetMovementCategory.DEPOSIT,
@@ -90,7 +90,7 @@ class NexoImporter(BaseExchangeImporter):
                 link=transaction,
             )
             self.add_asset_movement(write_cursor, asset_movement)
-        elif entry_type in ('Withdrawal', 'WithdrawExchanged'):
+        elif entry_type in {'Withdrawal', 'WithdrawExchanged'}:
             asset_movement = AssetMovement(
                 location=Location.NEXO,
                 category=AssetMovementCategory.WITHDRAWAL,
@@ -118,7 +118,7 @@ class NexoImporter(BaseExchangeImporter):
                 notes=f'{entry_type} from Nexo',
             )
             self.add_history_events(write_cursor, [event])
-        elif entry_type in ('Interest', 'Bonus', 'Dividend', 'FixedTermInterest', 'Cashback', 'ReferralBonus'):  # noqa: E501
+        elif entry_type in {'Interest', 'Bonus', 'Dividend', 'FixedTermInterest', 'Cashback', 'ReferralBonus'}:  # noqa: E501
             # A user shared a CSV file where some entries marked as interest had negative amounts.
             # we couldn't find information about this since they seem internal transactions made
             # by nexo but they appear like a trade from asset -> nexo in order to gain interest

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -273,7 +273,7 @@ class DBHandler:
             log.error(f'At DB teardown could not open the DB: {e!s}')
             return
 
-        with open(self.user_data_dir / DBINFO_FILENAME, 'w') as f:
+        with open(self.user_data_dir / DBINFO_FILENAME, 'w', encoding='utf8') as f:
             f.write(rlk_jsondumps(dbinfo))
 
     def _run_actions_after_first_connection(self) -> None:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -789,7 +789,7 @@ class DBHandler:
 
     def delete_yearn_vaults_data(self, write_cursor: 'DBCursor', version: int) -> None:
         """Delete all historical yearn vault events data"""
-        if version not in (1, 2):
+        if version not in {1, 2}:
             log.error(f'Called delete yearn vault data with non valid version {version}')
             return None
         prefix = YEARN_VAULTS_PREFIX
@@ -2238,7 +2238,7 @@ class DBHandler:
             columns_str = ', '.join(columns)
             bindings: Union[tuple, tuple[str]] = ()
             condition = ''
-            if table_name in ('manually_tracked_balances', 'timed_balances'):
+            if table_name in {'manually_tracked_balances', 'timed_balances'}:
                 bindings = (BalanceType.LIABILITY.serialize_for_db(),)
                 condition = ' WHERE category!=?'
 

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -55,7 +55,7 @@ class DBFilterOrder(NamedTuple):
         for idx, (attribute, ascending) in enumerate(self.rules):
             if idx != 0:
                 querystr += ','
-            if attribute in ('amount', 'fee', 'rate'):
+            if attribute in {'amount', 'fee', 'rate'}:
                 order_by = f'CAST({attribute} AS REAL)'
             else:
                 order_by = attribute

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -347,7 +347,7 @@ def serialize_db_setting(
         value = None
     elif setting == 'active_modules' and is_modifiable is True:
         value = json.dumps(value)
-    elif setting in ('main_currency', 'cost_basis_method'):
+    elif setting in {'main_currency', 'cost_basis_method'}:
         value = value.serialize()  # pylint: disable=no-member
     elif setting == 'address_name_priority' and is_modifiable is True:
         value = json.dumps(value)

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -200,7 +200,7 @@ class RotkiDataUpdater:
                     event_subtype=event_subtype,
                     counterparty=counterparty,
                     rule=rule,
-                    links={} if 'links' not in rule_data else rule_data['links'],
+                    links=rule_data.get('links', {}),
                 )
             except InputError as e:
                 # there is a conflict in the rule. Notify the frontend about it

--- a/rotkehlchen/db/upgrades/v38_v39.py
+++ b/rotkehlchen/db/upgrades/v38_v39.py
@@ -70,7 +70,7 @@ def _reduce_eventid_size(write_cursor: 'DBCursor') -> None:
         if subtype == 'remove asset':
             days = int(timestamp / 1000 / 86400)
             updates.append((f'EW_{validator_index}_{days}', identifier))
-        elif subtype in ('mev reward', 'block production'):
+        elif subtype in {'mev reward', 'block production'}:
             updates.append((f'BP1_{blocknumber}', identifier))
 
     imported_events = write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v39_v40.py
+++ b/rotkehlchen/db/upgrades/v39_v40.py
@@ -196,10 +196,10 @@ def _migrate_ledger_actions(write_cursor: 'DBCursor', conn: 'DBConnection') -> N
                 notes = f'{notes}. {entry[7]}'
 
             # map the types. Making sure to have the as default/valid combinations
-            if ledger_action_type in ('A', 'D', 'G', 'H'):  # income, dividends income, gift, grant action type  # noqa: E501
+            if ledger_action_type in {'A', 'D', 'G', 'H'}:  # income, dividends income, gift, grant action type  # noqa: E501
                 event_type = 'receive'
                 event_subtype = 'none'
-            elif ledger_action_type in ('B', 'C'):  # expense, loss action type
+            elif ledger_action_type in {'B', 'C'}:  # expense, loss action type
                 event_type = 'spend'
                 event_subtype = 'none'
             elif ledger_action_type == 'E':

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -310,10 +310,10 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                 del call_options['signature']
 
             is_v3_api_method = api_type == 'api' and method in V3_METHODS
-            is_new_futures_api = api_type in ('fapi', 'dapi')
+            is_new_futures_api = api_type in {'fapi', 'dapi'}
             api_version = 3  # public methos are v3
             if method not in PUBLIC_METHODS:  # api call needs signature
-                if api_type in ('sapi', 'dapi'):
+                if api_type in {'sapi', 'dapi'}:
                     api_version = 1
                 elif api_type == 'fapi':
                     api_version = 2
@@ -348,7 +348,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                     f'{self.name} API request failed due to {e!s}',
                 ) from e
 
-            if response.status_code not in (200, 418, 429):
+            if response.status_code not in {200, 418, 429}:
                 code = 'no code found'
                 msg = 'no message found'
                 with suppress(JSONDecodeError):
@@ -377,7 +377,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                     f'{self.name} API request {response.url} for {method} failed with HTTP status '
                     f'code: {response.status_code}, error code: {code} and error message: {msg}')
 
-            if response.status_code in (418, 429):
+            if response.status_code in {418, 429}:
                 # Binance has limits and if we hit them we should backoff.
                 # A Retry-After header is sent with a 418 or 429 responses and
                 # will give the number of seconds required to wait, in the case
@@ -1181,7 +1181,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
         Can log error/warning and return None if something went wrong at deserialization
         """
         try:
-            if 'status' not in raw_data or raw_data['status'] not in ('Successful', 'Finished'):
+            if 'status' not in raw_data or raw_data['status'] not in {'Successful', 'Finished'}:
                 log.error(
                     f'Found {self.location!s} fiat deposit/withdrawal with failed status. Ignoring it.',  # noqa: E501
                 )

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -78,7 +78,7 @@ def bitcoinde_pair_to_world(pair: str) -> tuple[AssetWithOracles, AssetWithOracl
     if len(pair) == 6:
         tx_asset = bitcoinde_asset(pair[:3])
         native_asset = bitcoinde_asset(pair[3:])
-    elif len(pair) in (7, 8):
+    elif len(pair) in {7, 8}:
         tx_asset = bitcoinde_asset(pair[:4])
         native_asset = bitcoinde_asset(pair[4:])
     else:
@@ -179,7 +179,7 @@ class Bitcoinde(ExchangeInterface):
         """
         Queries Bitcoin.de with the given verb for the given path and options
         """
-        assert verb in ('get', 'post'), (
+        assert verb in {'get', 'post'}, (
             f'Given verb {verb} is not a valid HTTP verb'
         )
 
@@ -221,7 +221,7 @@ class Bitcoinde(ExchangeInterface):
         except JSONDecodeError as exc:
             raise RemoteError('Bitcoin.de returned invalid JSON response') from exc
 
-        if response.status_code not in (200, 401):
+        if response.status_code not in {200, 401}:
             if isinstance(json_ret, dict) and 'errors' in json_ret:
                 for error in json_ret['errors']:
                     if error.get('field') == 'X-API-KEY' and error.get('code') == 1:

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -194,7 +194,7 @@ class Bitfinex(ExchangeInterface):
         with self.nonce_lock:
             # Protect this region with a lock since Bitfinex will reject
             # non-increasing nonces for authenticated endpoints
-            if endpoint in ('movements', 'trades', 'wallets'):
+            if endpoint in {'movements', 'trades', 'wallets'}:
                 nonce = str(ts_now_in_ms())
                 message = f'/api/{api_path}{nonce}'
                 signature = hmac.new(
@@ -763,9 +763,9 @@ class Bitfinex(ExchangeInterface):
             msg = f'{self.name} {case} returned an invalid JSON response: {response.text}.'
             log.error(msg)
 
-            if case in ('validate_api_key', 'balances'):
+            if case in {'validate_api_key', 'balances'}:
                 return False, msg
-            if case in ('trades', 'asset_movements'):
+            if case in {'trades', 'asset_movements'}:
                 self.msg_aggregator.add_error(
                     f'Got remote error while querying {self.name} {case}: {msg}',
                 )
@@ -788,9 +788,9 @@ class Bitfinex(ExchangeInterface):
             )
             log.error(message)
 
-        if case in ('validate_api_key', 'balances'):
+        if case in {'validate_api_key', 'balances'}:
             return False, message
-        if case in ('trades', 'asset_movements'):
+        if case in {'trades', 'asset_movements'}:
             self.msg_aggregator.add_error(
                 f'Got remote error while querying {self.name} {case}: {message}',
             )

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -161,7 +161,7 @@ class Bitmex(ExchangeInterface):
         """
         Queries Bitmex with the given verb for the given path and options
         """
-        assert verb in ('get', 'post', 'push'), (
+        assert verb in {'get', 'post', 'push'}, (
             f'Given verb {verb} is not a valid HTTP verb'
         )
 
@@ -202,7 +202,7 @@ class Bitmex(ExchangeInterface):
         except requests.exceptions.RequestException as e:
             raise RemoteError(f'Bitmex API request failed due to {e!s}') from e
 
-        if response.status_code not in (200, 401):
+        if response.status_code not in {200, 401}:
             raise RemoteError(
                 'Bitmex api request for {} failed with HTTP status code {}'.format(
                     response.url,

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -159,7 +159,7 @@ class Bitpanda(ExchangeInterface):
         try:
             transaction_type = entry['type']
             if (
-                transaction_type not in ('fiat_wallet_transaction', 'wallet_transaction') or
+                transaction_type not in {'fiat_wallet_transaction', 'wallet_transaction'} or
                 entry['attributes']['status'] != 'finished'
             ):
                 return None

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -701,9 +701,9 @@ class Bitstamp(ExchangeInterface):
             msg = f'Bitstamp returned invalid JSON response: {response.text}.'
             log.error(msg)
 
-            if case in ('validate_api_key', 'balances'):
+            if case in {'validate_api_key', 'balances'}:
                 return False, msg
-            if case in ('trades', 'asset_movements'):
+            if case in {'trades', 'asset_movements'}:
                 self.msg_aggregator.add_error(
                     f'Got remote error while querying Bistamp {case_pretty}: {msg}',
                 )
@@ -722,9 +722,9 @@ class Bitstamp(ExchangeInterface):
             )
             log.error(msg)
 
-        if case in ('validate_api_key', 'balances'):
+        if case in {'validate_api_key', 'balances'}:
             return False, msg
-        if case in ('trades', 'asset_movements'):
+        if case in {'trades', 'asset_movements'}:
             self.msg_aggregator.add_error(
                 f'Got remote error while querying Bistamp {case_pretty}: {msg}',
             )

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -144,7 +144,7 @@ def trade_from_conversion(trade_a: dict[str, Any], trade_b: dict[str, Any]) -> O
     amount_before_fee = deserialize_asset_amount(trade_a['native_amount']['amount'])
     # amount_after_fee + amount_before_fee is a negative amount and the fee needs to be positive
     conversion_native_fee_amount = abs(amount_after_fee + amount_before_fee)
-    if ZERO not in (tx_amount, conversion_native_fee_amount, amount_before_fee, amount_after_fee):
+    if ZERO not in {tx_amount, conversion_native_fee_amount, amount_before_fee, amount_after_fee}:
         # To get the asset in which the fee is nominated we pay attention to the creation
         # date of each event. As per our hypothesis the fee is nominated in the asset
         # for which the first transaction part was initialized
@@ -776,7 +776,7 @@ class Coinbase(ExchangeInterface):
             if 'type' in raw_data:
                 # The parent method filtered with 'from' attribute, so it is from another user.
                 # https://developers.coinbase.com/api/v2?python#transaction-resource
-                if raw_data.get('type', '') not in ('send', 'inflation_reward'):
+                if raw_data.get('type', '') not in {'send', 'inflation_reward'}:
                     msg = (
                         'Non "send" or "inflation_reward" type '
                         'found in coinbase transactions processing'
@@ -855,8 +855,7 @@ class Coinbase(ExchangeInterface):
             for tx in txs:
                 if 'type' not in tx:
                     continue
-                if tx['type'] in ['send', 'inflation_reward'] and 'from' in tx \
-                        and 'resource' in tx['from'] and tx['from']['resource'] == 'user':
+                if tx['type'] in {'send', 'inflation_reward'} and 'from' in tx and 'resource' in tx['from'] and tx['from']['resource'] == 'user':  # noqa: E501
                     raw_data.append(tx)
 
         log.debug('coinbase transactions history result', results_num=len(raw_data))

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -181,7 +181,7 @@ class Gemini(ExchangeInterface):
         url = f'{self.base_uri}{v_endpoint}'
         retries_left = CachedSettings().get_query_retry_limit()
         while retries_left > 0:
-            if endpoint in ('mytrades', 'balances', 'transfers', 'roles', 'balances/earn'):
+            if endpoint in {'mytrades', 'balances', 'transfers', 'roles', 'balances/earn'}:
                 # private endpoints
                 timestamp = str(ts_now_in_ms())
                 payload = {'request': v_endpoint, 'nonce': timestamp}

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -127,7 +127,7 @@ class Iconomi(ExchangeInterface):
         """
         Queries ICONOMI with the given verb for the given path and options
         """
-        assert verb in ('get', 'post'), (
+        assert verb in {'get', 'post'}, (
             f'Given verb {verb} is not a valid HTTP verb'
         )
 
@@ -179,7 +179,7 @@ class Iconomi(ExchangeInterface):
         except JSONDecodeError as exc:
             raise RemoteError('ICONOMI returned invalid JSON response') from exc
 
-        if response.status_code not in (200, 201):
+        if response.status_code not in {200, 201}:
             if isinstance(json_ret, dict) and 'message' in json_ret:
                 raise RemoteError(json_ret['message'])
 
@@ -332,7 +332,7 @@ class Iconomi(ExchangeInterface):
             if timestamp > end_ts:
                 continue
 
-            if tx['type'] in ('buy_asset', 'sell_asset'):
+            if tx['type'] in {'buy_asset', 'sell_asset'}:
                 try:
                     trades.append(trade_from_iconomi(tx))
                 except UnknownAsset as e:

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -309,7 +309,7 @@ class Independentreserve(ExchangeInterface):
             except requests.exceptions.RequestException as e:
                 raise RemoteError(f'IndependentReserve API request failed due to {e!s}') from e
 
-            if response.status_code not in (200, 429):
+            if response.status_code not in {200, 429}:
                 raise RemoteError(
                     f'IndependentReserve api request for {response.url} failed with HTTP status '
                     f'code {response.status_code} and response {response.text}',
@@ -490,7 +490,7 @@ class Independentreserve(ExchangeInterface):
 
             for entry in resp:
                 entry_type = entry.get('Type')
-                if entry_type is None or entry_type not in ('Deposit', 'Withdrawal'):
+                if entry_type is None or entry_type not in {'Deposit', 'Withdrawal'}:
                     continue
 
                 try:

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -125,7 +125,7 @@ def _check_and_get_response(response: Response, method: str) -> Union[str, dict]
     May raise:
     - RemoteError if there is an unrecoverable/unexpected remote error
     """
-    if response.status_code in (520, 525, 504):
+    if response.status_code in {520, 525, 504}:
         log.debug(f'Kraken returned status code {response.status_code}')
         return 'Usual kraken 5xx shenanigans'
     if response.status_code != 200:
@@ -284,7 +284,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
 
     def _manage_call_counter(self, method: str) -> None:
         self.last_query_ts = ts_now()
-        if method in ('Ledgers', 'TradesHistory'):
+        if method in {'Ledgers', 'TradesHistory'}:
             self.call_counter += 2
         else:
             self.call_counter += 1

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -324,7 +324,7 @@ class Cryptocompare(ExternalServiceWithApiKey, HistoricalPriceOracleInterface, P
                     )
                     raise RemoteError(error_message)
 
-                return json_ret['Data'] if 'Data' in json_ret else json_ret
+                return json_ret.get('Data', json_ret)
             except KeyError as e:
                 raise RemoteError(
                     f'Unexpected format of Cryptocompare json_response. '

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -827,7 +827,7 @@ class Cryptocompare(ExternalServiceWithApiKey, HistoricalPriceOracleInterface, P
         coinlist_cache_path = os.path.join(self.data_directory, 'cryptocompare_coinlist.json')
         if os.path.isfile(coinlist_cache_path):
             log.info('Found cryptocompare coinlist cache', path=coinlist_cache_path)
-            with open(coinlist_cache_path) as f:
+            with open(coinlist_cache_path, encoding='utf8') as f:
                 try:
                     data = jsonloads_dict(f.read())
                     now = ts_now()
@@ -845,7 +845,7 @@ class Cryptocompare(ExternalServiceWithApiKey, HistoricalPriceOracleInterface, P
             data = self._api_query('all/coinlist')
 
             # Also save the cache
-            with open(coinlist_cache_path, 'w') as f:
+            with open(coinlist_cache_path, 'w', encoding='utf8') as f:
                 now = ts_now()
                 log.info('Writing coinlist cache', timestamp=now)
                 write_data = {'time': now, 'data': data}

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -276,7 +276,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             try:
                 result = json_ret.get('result', None)
                 if result is None:
-                    if action in ('eth_getTransactionByHash', 'eth_getTransactionReceipt', 'getcontractcreation'):  # noqa: E501
+                    if action in {'eth_getTransactionByHash', 'eth_getTransactionReceipt', 'getcontractcreation'}:  # noqa: E501
                         return None
 
                     raise RemoteError(
@@ -307,7 +307,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                     transaction_endpoint_and_none_found = (
                         status == 0 and
                         json_ret['message'] == 'No transactions found' and
-                        action in ('txlist', 'txlistinternal', 'tokentx')
+                        action in {'txlist', 'txlistinternal', 'tokentx'}
                     )
                     logs_endpoint_and_none_found = (
                         status == 0 and

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -72,7 +72,7 @@ class NFT(NamedTuple):
         return {
             'token_identifier': self.token_identifier,
             'background_color': self.background_color,
-            'image_url': self.image_url if self.image_url not in (None, '') else None,
+            'image_url': self.image_url if self.image_url not in {None, ''} else None,
             'name': self.name,
             'external_link': self.external_link,
             'permalink': self.permalink,
@@ -206,7 +206,7 @@ class Opensea(ExternalServiceWithApiKey):
         try:
             last_sale: Optional[dict[str, Any]] = entry.get('last_sale')
             if last_sale is not None and last_sale.get('payment_token') is not None:
-                if last_sale['payment_token']['symbol'] in ('ETH', 'WETH'):
+                if last_sale['payment_token']['symbol'] in {'ETH', 'WETH'}:
                     payment_asset = self.eth_asset
                 else:
                     payment_asset = Asset(

--- a/rotkehlchen/globaldb/assets_management.py
+++ b/rotkehlchen/globaldb/assets_management.py
@@ -33,7 +33,7 @@ def import_assets_from_file(
     - InputError: If the version of the file is not valid for the current
     globaldb version
     """
-    with open(path) as f:
+    with open(path, encoding='utf8') as f:
         data = ExportedAssetsSchema().loads(f.read())
 
     if int(data['version']) not in ASSETS_FILE_IMPORT_ACCEPTED_GLOBALDB_VERSIONS:

--- a/rotkehlchen/globaldb/upgrades/v2_v3.py
+++ b/rotkehlchen/globaldb/upgrades/v2_v3.py
@@ -543,7 +543,7 @@ def migrate_to_v3(connection: 'DBConnection') -> None:
         # This file contains the EVM version of the assets that are currently in the
         # database and are not EVM (matic tokens, Otimism tokens, etc) + their variants in
         # other chains. And populates them properly via sql statements
-        with open(dir_path / 'data' / 'globaldb_v2_v3_assets.sql') as f:
+        with open(dir_path / 'data' / 'globaldb_v2_v3_assets.sql', encoding='utf8') as f:
             raw_sql_sentences = f.read()
             per_table_sentences = raw_sql_sentences.split('\n\n')
             for sql_sentences in per_table_sentences:

--- a/rotkehlchen/globaldb/upgrades/v3_v4.py
+++ b/rotkehlchen/globaldb/upgrades/v3_v4.py
@@ -134,7 +134,7 @@ def _add_eth_abis_json(cursor: 'DBCursor') -> None:
     log.debug('Enter _add_eth_abis_json')
 
     root_dir = Path(__file__).resolve().parent.parent.parent
-    with open(root_dir / 'data' / 'eth_abi.json') as f:
+    with open(root_dir / 'data' / 'eth_abi.json', encoding='utf8') as f:
         abi_entries = json.loads(f.read())
 
     abi_entries_tuples = []
@@ -150,9 +150,9 @@ def _add_eth_contracts_json(cursor: 'DBCursor') -> tuple[int, int, int]:
 
     eth_scan_abi_id, multicall_abi_id, ds_registry_abi_id = None, None, None
     root_dir = Path(__file__).resolve().parent.parent.parent
-    with open(root_dir / 'data' / 'eth_contracts.json') as f:
+    with open(root_dir / 'data' / 'eth_contracts.json', encoding='utf8') as f:
         contract_entries = json.loads(f.read())
-    with open(root_dir / 'chain' / 'ethereum' / 'modules' / 'dxdaomesa' / 'data' / 'contracts.json') as f:  # noqa: E501
+    with open(root_dir / 'chain' / 'ethereum' / 'modules' / 'dxdaomesa' / 'data' / 'contracts.json', encoding='utf8') as f:  # noqa: E501
         dxdao_contracts = json.loads(f.read())
 
     contract_entries.update(dxdao_contracts)
@@ -304,7 +304,7 @@ def _copy_assets_from_packaged_db(
 def _populate_asset_collections(cursor: 'DBCursor', root_dir: Path) -> None:
     """Insert into the collections table the information about known collections"""
     log.debug('Enter _populate_asset_collection')
-    with open(root_dir / 'data' / 'populate_asset_collections.sql') as f:
+    with open(root_dir / 'data' / 'populate_asset_collections.sql', encoding='utf8') as f:
         cursor.execute(f.read())
     log.debug('Exit _populate_asset_collection')
 
@@ -317,7 +317,7 @@ def _populate_multiasset_mappings(cursor: 'DBCursor', root_dir: Path) -> None:
     """
     log.debug('Enter _populate_multiasset_mappings')
     asset_regex = re.compile(r'eip155[a-zA-F0-9:\/]+')
-    with open(root_dir / 'data' / 'populate_multiasset_mappings.sql') as f:
+    with open(root_dir / 'data' / 'populate_multiasset_mappings.sql', encoding='utf8') as f:
         sql_sentences = f.read()
         # check if we are adding the assets
         # in this case we need to ensure that the assets exist locally and

--- a/rotkehlchen/globaldb/upgrades/v4_v5.py
+++ b/rotkehlchen/globaldb/upgrades/v4_v5.py
@@ -37,7 +37,7 @@ def _create_new_tables(cursor: 'DBCursor') -> None:
 def _populate_rpc_nodes(cursor: 'DBCursor', root_dir: Path) -> None:
     log.debug('Enter _populate_rpc_nodes')
 
-    with open(root_dir / 'data' / 'nodes.json') as f:
+    with open(root_dir / 'data' / 'nodes.json', encoding='utf8') as f:
         nodes_info = json.loads(f.read())
 
     nodes_tuples = [

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -319,7 +319,7 @@ def pair_get_assets(pair: TradePair) -> tuple[AssetWithOracles, AssetWithOracles
 
 def get_pair_position_str(pair: TradePair, position: str) -> str:
     """Get the string representation of an asset of a trade pair"""
-    assert position in ('first', 'second')
+    assert position in {'first', 'second'}
     base_str, quote_str = _split_pair(pair)
     return base_str if position == 'first' else quote_str
 
@@ -348,7 +348,7 @@ def deserialize_asset_movement_category(
     if isinstance(value, str):
         if value.lower() == 'deposit':
             return AssetMovementCategory.DEPOSIT
-        if value.lower() in ('withdraw', 'withdrawal'):
+        if value.lower() in {'withdraw', 'withdrawal'}:
             return AssetMovementCategory.WITHDRAWAL
         raise DeserializationError(
             f'Failed to deserialize asset movement category symbol. Unknown {value}',

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -581,7 +581,7 @@ def test_get_assets_mappings(rotkehlchen_api_server):
     result = assert_proper_response_with_result(response)
     assets = result['assets']
     assert len(assets) == 2
-    assert all(identifier in ('BTC', 'TRY') for identifier in assets)
+    assert all(identifier in {'BTC', 'TRY'} for identifier in assets)
 
 
 def test_search_assets(rotkehlchen_api_server):

--- a/rotkehlchen/tests/api/test_defi.py
+++ b/rotkehlchen/tests/api/test_defi.py
@@ -28,7 +28,7 @@ def test_query_defi_balances(rotkehlchen_api_server, ethereum_accounts):  # pyli
         first_entry = result[AAVE_TEST_ACC_1][0]
         assert first_entry['protocol'] is not None
         assert first_entry['protocol']['name'] is not None
-        assert first_entry['balance_type'] in ('Asset', 'Debt')
+        assert first_entry['balance_type'] in {'Asset', 'Debt'}
         assert first_entry['base_balance'] is not None
         assert first_entry['underlying_balances'] is not None
     else:

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -889,9 +889,9 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         if entry['entry']['block_number'] == block_number:
             assert entry['grouped_events_num'] == 3
             event_identifier = entry['entry']['event_identifier']
-        elif entry['entry']['block_number'] in (17055026, 16589592, 15938405):
+        elif entry['entry']['block_number'] in {17055026, 16589592, 15938405}:
             assert entry['grouped_events_num'] == 2
-        elif entry['entry']['block_number'] in (16135531, 15849710, 15798693):
+        elif entry['entry']['block_number'] in {16135531, 15849710, 15798693}:
             assert entry['grouped_events_num'] == 1
 
     # now query the events of the combined group

--- a/rotkehlchen/tests/api/test_evm_transactions.py
+++ b/rotkehlchen/tests/api/test_evm_transactions.py
@@ -108,7 +108,7 @@ def test_query_transactions(rotkehlchen_api_server: 'APIServer'):
         result = assert_proper_response_with_result(response)
 
     expected_file = Path(__file__).resolve().parent.parent / 'data' / 'expected' / 'test_evm_transactions-test_query_transactions.json'  # noqa: E501
-    with open(expected_file) as f:
+    with open(expected_file, encoding='utf8') as f:
         expected_data = json.load(f)
 
     # check all expected data exists. User has done more transactions since then if we don't

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -405,7 +405,7 @@ def test_history_debug_import(rotkehlchen_api_server):
         else:
             assert_simple_ok_response(response)
     else:
-        with open(str(filepath)) as infile:
+        with open(str(filepath), encoding='utf8') as infile:
             response = requests.patch(
                 api_url_for(
                     rotkehlchen_api_server,

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -244,7 +244,7 @@ def test_add_edit_delete_entries(rotkehlchen_api_server: 'APIServer'):
 
         # now let's try to edit event_identifier for all possible events.
         for idx, entry in enumerate(entries):
-            if entry.identifier in (2, 4):
+            if entry.identifier in {2, 4}:
                 continue  # we deleted those
             entry.event_identifier = f'new_eventid{idx}'
             json_data = entry_to_input_dict(entry, include_identifier=True)

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -514,7 +514,7 @@ def assert_dsr_history_result_is_correct(result: dict[str, Any], setup: DSRTestS
                     for mov_key, mov_val in movement.items():
                         if mov_key == 'movement_type':
                             assert mov_val == result[account]['movements'][idx][mov_key]
-                        elif mov_key in ('gain_so_far', 'value'):
+                        elif mov_key in {'gain_so_far', 'value'}:
                             assert FVal(mov_val['amount']).is_close(FVal(
                                 result[account]['movements'][idx][mov_key]['amount'],
                             ), max_diff='1e-8')

--- a/rotkehlchen/tests/api/test_pnl_csv.py
+++ b/rotkehlchen/tests/api/test_pnl_csv.py
@@ -46,14 +46,14 @@ def assert_csv_export_response(response, csv_dir, is_download=False):
         count = 0
         for row in reader:
             assert len(row) == 12
-            assert row['location'] in (
+            assert row['location'] in {
                 'kraken',
                 'bittrex',
                 'binance',
                 'poloniex',
                 'ethereum',
                 'bitmex',
-            )
+            }
             assert row['type'] in (
                 str(AccountingEventType.TRADE),
                 str(AccountingEventType.FEE),

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -143,11 +143,11 @@ def test_set_settings(rotkehlchen_api_server):
             value = '%d/%m/%Y-%H:%M:%S'
         elif setting == 'main_currency':
             value = 'JPY'
-        elif type(raw_value) is bool:  # pylint: disable=unidiomatic-typecheck  # noqa: E721
+        elif type(raw_value) is bool:  # pylint: disable=unidiomatic-typecheck
             # here and below we HAVE to use type() equality checks since
             # isinstance of a bool succeeds for both bool and int (due to inheritance)
             value = not raw_value
-        elif type(raw_value) is int:  # pylint: disable=unidiomatic-typecheck  # noqa: E721
+        elif type(raw_value) is int:  # pylint: disable=unidiomatic-typecheck
             value = raw_value + 1
         elif setting == 'active_modules':
             value = ['makerdao_vaults']

--- a/rotkehlchen/tests/api/test_snapshots.py
+++ b/rotkehlchen/tests/api/test_snapshots.py
@@ -202,14 +202,14 @@ def _write_location_data_csv_row_with_invalid_headers(
 
 def _create_snapshot_with_valid_data(directory: str, timestamp: Timestamp) -> None:
     path = Path(directory) / BALANCES_FOR_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = BALANCES_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         _write_balances_csv_row(writer, timestamp)
 
     path = Path(directory) / LOCATION_DATA_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = LOCATION_DATA_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -218,14 +218,14 @@ def _create_snapshot_with_valid_data(directory: str, timestamp: Timestamp) -> No
 
 def _create_snapshot_with_unknown_asset(directory: str, timestamp: Timestamp) -> None:
     path = Path(directory) / BALANCES_FOR_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = BALANCES_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         _write_balances_csv_row(writer, timestamp, include_unknown_asset=True)
 
     path = Path(directory) / LOCATION_DATA_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = LOCATION_DATA_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -234,14 +234,14 @@ def _create_snapshot_with_unknown_asset(directory: str, timestamp: Timestamp) ->
 
 def _create_snapshot_with_valid_data_for_post(directory: str, timestamp: Timestamp) -> None:
     path = Path(directory) / BALANCES_FOR_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = BALANCES_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         _write_balances_csv_row(writer, timestamp)
 
     path = Path(directory) / LOCATION_DATA_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = LOCATION_DATA_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -250,7 +250,7 @@ def _create_snapshot_with_valid_data_for_post(directory: str, timestamp: Timesta
 
 def _create_snapshot_different_timestamps(directory: str, timestamp: Timestamp) -> None:
     path = Path(directory) / BALANCES_FOR_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = BALANCES_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -258,7 +258,7 @@ def _create_snapshot_different_timestamps(directory: str, timestamp: Timestamp) 
         _write_balances_csv_row(writer, Timestamp(timestamp + 500))
 
     path = Path(directory) / LOCATION_DATA_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = LOCATION_DATA_IMPORT_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -268,14 +268,14 @@ def _create_snapshot_different_timestamps(directory: str, timestamp: Timestamp) 
 
 def _create_snapshot_with_invalid_headers(directory: str, timestamp: Timestamp) -> None:
     path = Path(directory) / BALANCES_FOR_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = BALANCES_IMPORT_INVALID_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         _write_balances_csv_row_with_invalid_headers(writer, timestamp)
 
     path = Path(directory) / LOCATION_DATA_IMPORT_FILENAME
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf8') as f:
         fieldnames = LOCATION_DATA_IMPORT_INVALID_HEADERS
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -325,7 +325,7 @@ def assert_csv_export_response(
     else:
         assert_simple_ok_response(response)
 
-    with open(os.path.join(csv_dir, BALANCES_FILENAME), newline='') as csvfile:
+    with open(os.path.join(csv_dir, BALANCES_FILENAME), newline='', encoding='utf8') as csvfile:
         reader = csv.DictReader(csvfile)
         count = 0
         for row in reader:
@@ -350,7 +350,7 @@ def assert_csv_export_response(
             count += 1
         assert count == expected_entries
 
-    with open(os.path.join(csv_dir, BALANCES_FOR_IMPORT_FILENAME), newline='') as csvfile:
+    with open(os.path.join(csv_dir, BALANCES_FOR_IMPORT_FILENAME), newline='', encoding='utf8') as csvfile:  # noqa: E501
         reader = csv.DictReader(csvfile)
         count = 0
         for row in reader:
@@ -374,7 +374,7 @@ def assert_csv_export_response(
             count += 1
         assert count == expected_entries
 
-    with open(os.path.join(csv_dir, LOCATION_DATA_FILENAME), newline='') as csvfile:
+    with open(os.path.join(csv_dir, LOCATION_DATA_FILENAME), newline='', encoding='utf8') as csvfile:  # noqa: E501
         reader = csv.DictReader(csvfile)
         count = 0
         for row in reader:
@@ -393,7 +393,7 @@ def assert_csv_export_response(
             count += 1
         assert count == 3
 
-    with open(os.path.join(csv_dir, LOCATION_DATA_IMPORT_FILENAME), newline='') as csvfile:
+    with open(os.path.join(csv_dir, LOCATION_DATA_IMPORT_FILENAME), newline='', encoding='utf8') as csvfile:  # noqa: E501
         reader = csv.DictReader(csvfile)
         count = 0
         for row in reader:
@@ -569,7 +569,7 @@ def test_import_snapshot(rotkehlchen_api_server, tmpdir_factory):
     # check that POST with the file works.
     csv_dir2 = str(tmpdir_factory.mktemp('test_csv_dir_2'))
     _create_snapshot_with_valid_data_for_post(csv_dir2, Timestamp(1651075))
-    with open(f'{csv_dir2}/{BALANCES_FOR_IMPORT_FILENAME}') as balances_file, open(f'{csv_dir2}/{LOCATION_DATA_IMPORT_FILENAME}') as locations_file:  # noqa: E501
+    with open(f'{csv_dir2}/{BALANCES_FOR_IMPORT_FILENAME}', encoding='utf8') as balances_file, open(f'{csv_dir2}/{LOCATION_DATA_IMPORT_FILENAME}', encoding='utf8') as locations_file:  # noqa: E501
         response = requests.post(
             api_url_for(
                 rotkehlchen_api_server,

--- a/rotkehlchen/tests/api/test_snapshots.py
+++ b/rotkehlchen/tests/api/test_snapshots.py
@@ -330,10 +330,10 @@ def assert_csv_export_response(
         count = 0
         for row in reader:
             assert len(row) == 6
-            assert row['category'] in (
+            assert row['category'] in {
                 'asset',
                 'liability',
-            )
+            }
             assert row['amount'] is not None
             assert row['asset'] is not None
             assert row['asset_symbol'] == Asset(row['asset']).symbol_or_name()
@@ -355,10 +355,10 @@ def assert_csv_export_response(
         count = 0
         for row in reader:
             assert len(row) == 5
-            assert row['category'] in (
+            assert row['category'] in {
                 'asset',
                 'liability',
-            )
+            }
             assert row['amount'] is not None
             assert row['asset_identifier'] is not None
             if timestamp_validation_data is None:

--- a/rotkehlchen/tests/api/test_trades.py
+++ b/rotkehlchen/tests/api/test_trades.py
@@ -519,7 +519,7 @@ def assert_all_missing_fields_are_handled(correct_trade, server):
     fields = correct_trade.keys()
 
     for field in fields:
-        if field in ('link', 'notes', 'fee', 'fee_currency'):
+        if field in {'link', 'notes', 'fee', 'fee_currency'}:
             # Optional fields missing is fine
             continue
 

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -138,7 +138,7 @@ def _fixture_profiler(request):
         now = datetime.datetime.now(tz=datetime.timezone.utc)
         tmpdirname = tempfile.gettempdir()
         stack_path = Path(tmpdirname) / f'{now:%Y%m%d_%H%M}_stack.data'
-        with open(stack_path, 'w') as stack_stream:
+        with open(stack_path, 'w', encoding='utf8') as stack_stream:
             test_warnings.warn(UserWarning(
                 f'Stack data is saved at: {stack_path}',
             ))

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -100,10 +100,10 @@ def assert_add_addresses_migration_ws_messages(
             elif i == 7:
                 assert_progress_message(msg, i, 'Potentially write migrated addresses to the DB', migration_version, migration_steps)  # noqa: E501
 
-        elif migration_version in (11, 12):
+        elif migration_version in {11, 12}:
             if i == 1:
                 assert_progress_message(msg, i, 'Fetching new spam assets and rpc data info', migration_version, migration_steps)  # noqa: E501
-            elif i in (2, 3):
+            elif i in {2, 3}:
                 assert_progress_message(msg, i, 'EVM chain activity', migration_version, migration_steps)  # noqa: E501
             elif i == 4:
                 assert_progress_message(msg, i, 'Potentially write migrated addresses to the DB', migration_version, migration_steps)  # noqa: E501

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -1058,7 +1058,7 @@ def test_upgrade_db_35_to_36(user_data_dir):  # pylint: disable=unused-argument
         if entry[2] == 'tokens':
             assert entry[3].startswith('eip155:1/erc')
         elif entry[2] == 'last_queried_timestamp':
-            assert entry[3] in ('1669718731', '1669715131', '1669711531', '1669698971')
+            assert entry[3] in {'1669718731', '1669715131', '1669711531', '1669698971'}
         else:
             raise AssertionError(f'Unexpected type {entry[2]} in accounts_details')
     transactions_result = cursor.execute('SELECT * from ethereum_transactions').fetchall()
@@ -1228,7 +1228,7 @@ def test_upgrade_db_35_to_36(user_data_dir):  # pylint: disable=unused-argument
     assert len(new_tx_address_mappings_result) == 305
     for idx, entry in enumerate(new_tx_address_mappings_result):
         for i in range(4):
-            if i in (0, 1):
+            if i in {0, 1}:
                 assert entry[i] == tx_address_mappings_result[idx][i]
             elif i == 2:
                 assert entry[i] == 1

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -202,7 +202,7 @@ def test_querying_rate_limit_exhaustion(kraken, database):
         if 'AssetPairs' in url:
             dir_path = Path(__file__).resolve().parent.parent
             filepath = dir_path / 'data' / 'assets_kraken.json'
-            with open(filepath) as f:
+            with open(filepath, encoding='utf8') as f:
                 return MockResponse(200, f.read())
         # else
         raise AssertionError(f'Unexpected url in kraken query: {url}')

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -90,10 +90,10 @@ def test_asset_icons_for_collections(icon_manager: IconManager) -> None:
         times_api_was_queried += 1
         test_data_folder = Path(__file__).resolve().parent.parent / 'data' / 'mocks' / 'test_coingecko'  # noqa: E501
         if 'https://api.coingecko.com/api/v3/coins/dai' in url:
-            with open(test_data_folder / 'coins' / 'dai.json') as f:
+            with open(test_data_folder / 'coins' / 'dai.json', encoding='utf8') as f:
                 return MockResponse(HTTPStatus.OK, f.read())
         elif 'https://api.coingecko.com/api/v3/coins/ethereum' in url:
-            with open(test_data_folder / 'coins' / 'ethereum.json') as f:
+            with open(test_data_folder / 'coins' / 'ethereum.json', encoding='utf8') as f:
                 return MockResponse(HTTPStatus.OK, f.read())
         elif url in {
             'https://assets.coingecko.com/coins/images/9956/small/4943.png?1636636734',

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -54,7 +54,7 @@ def fixture_data_dir(use_clean_caching_directory, tmpdir_factory) -> Path:
     for x in data_directory.iterdir():
         directory_with_db = (
             x.is_dir() and
-            (x / 'rotkehlchen.db').exists() or (x / 'rotkehlchen_transient.db').exists()
+            ((x / 'rotkehlchen.db').exists() or (x / 'rotkehlchen_transient.db').exists())
         )
         if directory_with_db:
             shutil.rmtree(x, ignore_errors=True)

--- a/rotkehlchen/tests/fixtures/websockets.py
+++ b/rotkehlchen/tests/fixtures/websockets.py
@@ -18,7 +18,7 @@ class WebsocketReader:
     def read_forever(self) -> None:
         while self.should_read:
             msg = self.ws.recv()
-            if msg not in ('', '{}'):
+            if msg not in {'', '{}'}:
                 data = json.loads(msg)
                 self.messages.appendleft(data)
             gevent.sleep(0.2)

--- a/rotkehlchen/tests/unit/globaldb/test_upgrades.py
+++ b/rotkehlchen/tests/unit/globaldb/test_upgrades.py
@@ -49,7 +49,7 @@ def _count_sql_file_sentences(file_name: str, skip_statements: int = 0):
     insertions_made = 0
     skipped_statements = 0
     dir_path = Path(__file__).resolve().parent.parent.parent.parent
-    with open(dir_path / 'data' / file_name) as f:
+    with open(dir_path / 'data' / file_name, encoding='utf8') as f:
         insertions_made = 0
         line = ' '
         while line:
@@ -354,7 +354,7 @@ def test_upgrade_v4_v5(globaldb: GlobalDBHandler):
 
         # check that we have five nodes for each chain
         nodes_file_path = Path(__file__).resolve().parent.parent.parent.parent / 'data' / 'nodes.json'  # noqa: E501
-        with open(nodes_file_path) as f:
+        with open(nodes_file_path, encoding='utf8') as f:
             nodes_info = json.loads(f.read())
             nodes_tuples_from_file = [
                 (idx, node['name'], node['endpoint'], int(False), int(True), str(node['weight']), node['blockchain'])  # noqa: E501

--- a/rotkehlchen/tests/unit/test_base_inquirer.py
+++ b/rotkehlchen/tests/unit/test_base_inquirer.py
@@ -18,7 +18,7 @@ def test_base_nodes_prune_and_archive_status(
         if node_name.endpoint == 'https://base.blockpi.network/v1/rpc/public':
             assert not web3_node.is_pruned
             # not checking for archive here, as some times it is and some not
-        elif node_name.endpoint in ('https://mainnet.base.org', 'https://rpc.ankr.com/base'):
+        elif node_name.endpoint in {'https://mainnet.base.org', 'https://rpc.ankr.com/base'}:
             assert not web3_node.is_pruned
             assert web3_node.is_archive
         elif node_name.endpoint == 'https://base.publicnode.com':

--- a/rotkehlchen/tests/unit/test_cost_basis.py
+++ b/rotkehlchen/tests/unit/test_cost_basis.py
@@ -979,7 +979,7 @@ def test_accounting_average_cost_basis(accountant: Accountant):
             pnls=pot.pnls,
             directory=path_dir,
         )
-        with open(path_dir / FILENAME_ALL_CSV) as f:
+        with open(path_dir / FILENAME_ALL_CSV, encoding='utf8') as f:
             for event, row in zip_longest(events, csv.DictReader(f)):
                 if event.cost_basis is None:
                     assert row['cost_basis_taxable'] == ''

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -156,7 +156,7 @@ def mock_scrape_validator_daily_stats(network_mocking: bool):
         root_path = Path(__file__).resolve().parent.parent.parent
         file_path = root_path / 'tests' / 'data' / 'mocks' / 'test_eth2' / 'validator_daily_stats' / f'{validator_index}.html'  # noqa: E501
 
-        with open(file_path) as f:
+        with open(file_path, encoding='utf8') as f:
             data = f.read()
 
         return MockResponse(200, data)

--- a/rotkehlchen/tests/unit/test_gnosis_inquirer.py
+++ b/rotkehlchen/tests/unit/test_gnosis_inquirer.py
@@ -21,7 +21,7 @@ def test_gnosis_nodes_prune_and_archive_status(
         elif node_name.endpoint == 'https://rpc.ankr.com/gnosis':
             assert not web3_node.is_pruned
             assert web3_node.is_archive
-        elif node_name.endpoint in ('https://1rpc.io/gnosis', 'https://gnosis.publicnode.com'):
+        elif node_name.endpoint in {'https://1rpc.io/gnosis', 'https://gnosis.publicnode.com'}:
             assert web3_node.is_pruned
             assert not web3_node.is_archive
         else:

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -201,7 +201,7 @@ def test_find_usd_price_cache(inquirer, freezer):  # pylint: disable=unused-argu
         nonlocal call_count
         if call_count == 0:
             price = Price(FVal('1'))
-        elif call_count in (1, 2):
+        elif call_count in {1, 2}:
             price = Price(FVal('2'))
         else:
             raise AssertionError('Called too many times for this test')

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -19,7 +19,7 @@ def test_optimism_nodes_prune_and_archive_status(
         if node_name.endpoint == 'https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4':
             assert not web3_node.is_pruned
             assert not web3_node.is_archive
-        elif node_name.endpoint in ('https://mainnet.optimism.io', 'https://rpc.ankr.com/optimism'):
+        elif node_name.endpoint in {'https://mainnet.optimism.io', 'https://rpc.ankr.com/optimism'}:
             assert not web3_node.is_pruned
             assert web3_node.is_archive
         elif node_name.endpoint == 'https://optimism-mainnet.public.blastapi.io':

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -267,7 +267,7 @@ def assert_csv_export(
 
         calculated_pnls = PnlTotals()
         expected_csv_data = []
-        with open(tmpdir / FILENAME_ALL_CSV, newline='') as csvfile:
+        with open(tmpdir / FILENAME_ALL_CSV, newline='', encoding='utf8') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 expected_csv_data.append(row)
@@ -291,7 +291,7 @@ def assert_csv_export(
         index = CSV_INDEX_OFFSET
         at_summaries = False
         to_upload_data = []
-        with open(tmpdir / FILENAME_ALL_CSV, newline='') as csvfile:
+        with open(tmpdir / FILENAME_ALL_CSV, newline='', encoding='utf8') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 to_upload_data.append(row)

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -1293,7 +1293,7 @@ def kraken_to_world_pair(pair: str) -> tuple[AssetWithOracles, AssetWithOracles]
     if pair[-2:] == '.d':
         pair = pair[:-2]
 
-    if len(pair) == 6 and pair[0:3] in ('EUR', 'USD', 'AUD'):
+    if len(pair) == 6 and pair[0:3] in {'EUR', 'USD', 'AUD'}:
         # This is for the FIAT to FIAT pairs that kraken introduced
         base_asset_str = pair[0:3]
         quote_asset_str = pair[3:]
@@ -1304,7 +1304,7 @@ def kraken_to_world_pair(pair: str) -> tuple[AssetWithOracles, AssetWithOracles]
     elif pair[0:2] in KRAKEN_TO_WORLD:
         base_asset_str = pair[0:2]
         quote_asset_str = pair[2:]
-    elif pair[0:3] in KRAKEN_TO_WORLD or pair[0:3] in ('XBT', 'ETH', 'XDG', 'LTC', 'XRP'):
+    elif pair[0:3] in KRAKEN_TO_WORLD or pair[0:3] in {'XBT', 'ETH', 'XDG', 'LTC', 'XRP'}:
         base_asset_str = pair[0:3]
         quote_asset_str = pair[3:]
     elif pair[0:4] in KRAKEN_TO_WORLD:

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -1201,7 +1201,7 @@ def assert_pnl_debug_import(filepath: Path, database: DBHandler) -> None:
     """This function asserts that the debug PnL data in the DB matches
     the one in the file uploaded.
     """
-    with open(filepath) as f:
+    with open(filepath, encoding='utf8') as f:
         pnl_debug_json = json.load(f)
 
     settings_from_file = pnl_debug_json['settings']

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -496,7 +496,7 @@ class MockKraken(Kraken):
     def _load_results_from_file(filename: str) -> dict[str, Any]:
         dir_path = Path(__file__).resolve().parent.parent
         filepath = dir_path / 'data' / filename
-        with open(filepath) as f:
+        with open(filepath, encoding='utf8') as f:
             return jsonloads_dict(f.read())
 
     def online_api_query(self, method: str, req: Optional[dict] = None) -> dict:

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -544,7 +544,7 @@ class MockKraken(Kraken):
                 )
 
             # else use specific data
-            if ledger_type in ('deposit', 'withdrawal'):
+            if ledger_type in {'deposit', 'withdrawal'}:
                 data = json.loads(
                     KRAKEN_SPECIFIC_DEPOSITS_RESPONSE if ledger_type == 'deposit'
                     else KRAKEN_SPECIFIC_WITHDRAWALS_RESPONSE,

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -242,7 +242,7 @@ def patch_eth2_requests(eth2, mock_data):
                 if file_result is None:
                     raise AssertionError(f'Deposit data for {arg_len} addresses not found in mock data')  # noqa: E501
                 fullpath = MOCK_ROOT / 'test_eth2' / 'deposits' / file_result
-                with open(fullpath) as f:
+                with open(fullpath, encoding='utf8') as f:
                     response_data = json.load(f)
             else:
                 raise AssertionError(f'Unknown endpoint for beacon chain call: {url}')
@@ -279,7 +279,7 @@ def patch_avalanche_request(avalanche_manager, mock_data):
                 raise AssertionError('Test mock data should contain covalent transactions')
 
             fullpath = MOCK_ROOT / covalent_tx_path
-            with open(fullpath) as f:
+            with open(fullpath, encoding='utf8') as f:
                 response_data = json.load(f)
         elif module == 'balances_v2':
             if action != 'address':
@@ -291,7 +291,7 @@ def patch_avalanche_request(avalanche_manager, mock_data):
                 if covalent_balances_path is None:
                     raise AssertionError('Test mock data should contain covalent balances')
                 fullpath = MOCK_ROOT / covalent_balances_path
-                with open(fullpath) as f:
+                with open(fullpath, encoding='utf8') as f:
                     response_data = json.load(f)
             else:
                 raise AssertionError(f'Covalent balance query for unknown address during tests: {url}')  # noqa: E501

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -211,7 +211,7 @@ def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
         if (not f.endswith('backup') or f.startswith('rotkehlchen_db')) and not f.startswith('rotkehlchen_transient')  # noqa: E501
     ]
     msg = f'Expected 2 or 3 files in the directory but got {files}'
-    assert len(files) in (2, 3), msg  # 3rd file is the dbinfo.json
+    assert len(files) in {2, 3}, msg  # 3rd file is the dbinfo.json
     # The order of the files is not guaranteed
     main_db_exists = False
     backup_db_exists = False

--- a/rotkehlchen/tests/utils/rotkehlchen.py
+++ b/rotkehlchen/tests/utils/rotkehlchen.py
@@ -154,7 +154,7 @@ def setup_balances(
                 assert len(rotki.chains_aggregator.balances.eth) == 2, msg
                 d_liabilities = {
                     k: [
-                        x for idx, x in enumerate(v) if idx not in (0, 2)
+                        x for idx, x in enumerate(v) if idx not in {0, 2}
                     ] for k, v in liabilities.items()
                 }
 

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -675,13 +675,13 @@ class TradeType(DBCharEnumMixIn):
                 f'Failed to deserialize trade type symbol from {type(symbol)} entry',
             )
 
-        if symbol in ('buy', 'LIMIT_BUY', 'BUY', 'Buy'):
+        if symbol in {'buy', 'LIMIT_BUY', 'BUY', 'Buy'}:
             return TradeType.BUY
-        if symbol in ('sell', 'LIMIT_SELL', 'SELL', 'Sell'):
+        if symbol in {'sell', 'LIMIT_SELL', 'SELL', 'Sell'}:
             return TradeType.SELL
-        if symbol in ('settlement_buy', 'settlement buy'):
+        if symbol in {'settlement_buy', 'settlement buy'}:
             return TradeType.SETTLEMENT_BUY
-        if symbol in ('settlement_sell', 'settlement sell'):
+        if symbol in {'settlement_sell', 'settlement sell'}:
             return TradeType.SETTLEMENT_SELL
 
         # else

--- a/rotkehlchen/utils/snapshots.py
+++ b/rotkehlchen/utils/snapshots.py
@@ -117,7 +117,7 @@ def parse_import_snapshot_data(
 
 def _csv_to_dict(file: Path) -> list[dict[str, str]]:
     """Converts a csv file to a list of dictionary."""
-    with open(file) as csv_file:
+    with open(file, encoding='utf8') as csv_file:
         csv_reader = DictReader(csv_file)
         return list(csv_reader)
 

--- a/tools/profiling/graph.py
+++ b/tools/profiling/graph.py
@@ -294,7 +294,7 @@ def memory_data(filepath):
         """returns a tuple (timestamp, memory_usage)"""
         return (ts_to_dt(line[TIMESTAMP]), float(line[MEMORY]))
 
-    with open(filepath) as handler:
+    with open(filepath, encoding='utf8') as handler:
         # the format of the file has two columns:
         # timestamp memory_mb
         data = [line.split() for line in handler if line]
@@ -303,7 +303,7 @@ def memory_data(filepath):
 
 
 def latency_data(filepath):
-    with open(filepath) as handler:
+    with open(filepath, encoding='utf8') as handler:
         return [ts_to_dt(line.split()[0]) for line in handler if line]
 
 

--- a/tools/pylint/log_checker.py
+++ b/tools/pylint/log_checker.py
@@ -12,7 +12,7 @@ LOGNOKWARGS_MSG = (
 
 def is_normal_logging_call(inferred_func):
     return (
-        inferred_func.name in ('info', 'debug', 'error', 'warning') and
+        inferred_func.name in {'info', 'debug', 'error', 'warning'} and
         inferred_func.callable() and
         inferred_func.parent.name == 'Logger'
     )

--- a/tools/scripts/generate_changelog.py
+++ b/tools/scripts/generate_changelog.py
@@ -21,7 +21,7 @@ def generate_changelog(version: str, path: str) -> str:
     github_link = '- #{number} {text}'
     not_listed_change = '- {text}'
 
-    with open(path) as f:
+    with open(path, encoding='utf8') as f:
         lines = f.readlines()
         start = False
         for line in lines:

--- a/tools/scripts/generate_minimized_db_schema.py
+++ b/tools/scripts/generate_minimized_db_schema.py
@@ -58,5 +58,5 @@ lines.append('}')
 
 # Save to the file
 db_module = 'db' if db_name == 'user' else 'globaldb'
-with open(f'rotkehlchen/{db_module}/minimized_schema.py', 'w') as f:
+with open(f'rotkehlchen/{db_module}/minimized_schema.py', 'w', encoding='utf8') as f:
     f.write('\n'.join(lines) + '\n')

--- a/tools/scripts/pylint_useless_suppression.py
+++ b/tools/scripts/pylint_useless_suppression.py
@@ -57,7 +57,7 @@ for line in io.TextIOWrapper(pylint_call.stdout, encoding='utf-8'):
     )
 
 for filename, occurences in files.items():
-    with open(filename) as file:
+    with open(filename, encoding='utf8') as file:
         line_data = file.readlines()
 
     count = 0
@@ -69,7 +69,7 @@ for filename, occurences in files.items():
         line_data[idx] = line.replace(f'  # pylint: disable={suppression.error}', '')
         count += 1
 
-    with open(filename, 'w') as file:
+    with open(filename, 'w', encoding='utf8') as file:
         file.writelines(line_data)
     print(f'Replaced {count} lines in {filename}')
 


### PR DESCRIPTION
### [Use set for constant literal collection checks](https://github.com/rotki/rotki/commit/b262f3111e51379ac2318502ce807acdafcb2d84) 

According to https://docs.python.org/3/whatsnew/3.2.html#optimizations
since Python 3.2 constant literal collections are automatically loaded
as a frozen set at compile time which make their loading time
insignificant.

So at that point it's suggested to replace constant collections of
list/tuples with sets as set IN comparison is faster.

Used ruff's https://docs.astral.sh/ruff/rules/literal-membership/ for
this but had to be very careful and only accept constant literal
suggestions. Since it suggests all IN collection checks to have this
rule, I also disabled it from ruff's pyproject toml for now and opened
an issue: https://github.com/astral-sh/ruff/issues/8322

### [Use dict.get() instead of if/else](https://github.com/rotki/rotki/commit/1896b5debfc2bac451553e881aea9d69e11f202f) 

This is ruff's rule SIM401

### [Remove unneeded noqas after ruff upgrade and fix bugs](https://github.com/rotki/rotki/commit/a77748a4bdd0ab2ad23f13a6acc44fc6674d4686)

This fixes a bug where `cond1 and cond2 or cond3` should have been `cond1 and (cond2 or cond3)`

### [Always specify encoding for write/read file](https://github.com/rotki/rotki/commit/2c2bfe489c4d22326dc461330015414ce70bcd4d) 

This is fixing ruff rule PLW1514