### PR TITLE
VCR test_maybe_schedule_ethereum_txreceipts

### DIFF
--- a/rotkehlchen/tests/api/blockchain/test_substrate.py
+++ b/rotkehlchen/tests/api/blockchain/test_substrate.py
@@ -51,7 +51,7 @@ def test_add_ksm_blockchain_account_invalid(rotkehlchen_api_server):
 @pytest.mark.vcr()
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('kusama_manager_connect_at_start', [(KusamaNodeName.OWN,)])
-@pytest.mark.parametrize('ksm_rpc_endpoint', [KUSAMA_TEST_RPC_ENDPOINT], ids=['KUSAMA_TEST_RPC_ENDPOINT'])  # setting ids to rename the argument to be processed by vcr, affects all other similar fixtures in this file # noqa: E501
+@pytest.mark.parametrize('ksm_rpc_endpoint', [KUSAMA_TEST_RPC_ENDPOINT], ids=['KUSAMA_TEST_RPC_ENDPOINT'])  # setting ids to rename the argument to be processed by vcr since its value can contain characters that are illegal in windows. Affects all other similar fixtures in this file # noqa: E501
 @pytest.mark.parametrize('network_mocking', [False])
 def test_add_ksm_blockchain_account(rotkehlchen_api_server, kusama_manager_connect_at_start):
     """Test adding a Kusama blockchain account when there is none in the db

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -192,6 +192,7 @@ def test_maybe_schedule_exchange_query_ignore_exchanges(
     assert task_manager._maybe_schedule_exchange_history_query() is None
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('one_receipt_in_db', [True, False])
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1, TEST_ADDR2]])
 def test_maybe_schedule_ethereum_txreceipts(


### PR DESCRIPTION
Whenever we see a failed test in a PR be a timeout, we should make sure that VCRing is an option and if yes just do it.