### PR TITLE
[WIP] Integrate blockscout for withdrawal queries

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -493,7 +493,7 @@ Getting or modifying external services API credentials
       }
 
    :reqjson list services: The services parameter is a list of services along with their api keys.
-   :reqjsonarr string name: Each entry in the list should have a name for the service. Valid ones are ``"etherscan"``, ``"cryptocompare"``, ``"beaconchain"``, ``"loopring"``, ``"covalent"`` and ``"opensea"``.
+   :reqjsonarr string name: Each entry in the list should have a name for the service. Valid ones are ``"etherscan"``, ``"cryptocompare"``, ``"beaconchain"``, ``"loopring"``, ``"covalent"``, ``"opensea"`` and ``blockscount``.
    :reqjsonarr string api_key: Each entry in the list should have an api_key entry
 
    **Example Response**:

--- a/rotkehlchen/chain/ethereum/node_inquirer.py
+++ b/rotkehlchen/chain/ethereum/node_inquirer.py
@@ -29,6 +29,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.errors.misc import InputError, RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.externalapis.blockscout import Blockscout
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -87,6 +88,7 @@ class EthereumInquirer(DSProxyInquirerWithCacheData):
         self.etherscan: EthereumEtherscan
         self.blocks_subgraph = Graph('https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks')
         self.ens_reverse_records = self.contracts.contract(string_to_evm_address('0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C'))  # noqa: E501
+        self.blockscout = Blockscout(database=database, msg_aggregator=database.msg_aggregator)
 
     def ens_reverse_lookup(self, addresses: list[ChecksumEvmAddress]) -> dict[ChecksumEvmAddress, Optional[str]]:  # noqa: E501
         """Performs a reverse ENS lookup on a list of addresses


### PR DESCRIPTION
Followup from: https://github.com/rotki/rotki/pull/6891

Do not merge yet! Unfortunately blockscout seems to be missing data.

It got noticed in the etherscan comparison test that is being adjusted in this PR.

For example for address `0xCb2a5c130709a4C6c4BA39368879A523C0060c71`, at the moment of writing, etherscan finds 35 withdrawals: https://etherscan.io/txsBeaconWithdrawal?cn=0xCb2a5c130709a4C6c4BA39368879A523C0060c71

![2023-11-05_12-23](https://github.com/rotki/rotki/assets/1658405/3562bd1b-f616-44ff-adf5-346aad4f4eda)

Blockscout finds 34. It's missing the one in in red in the screenshot. https://eth.blockscout.com/api/v2/addresses/0xCb2a5c130709a4C6c4BA39368879A523C0060c71/withdrawals
![2023-11-05_12-25](https://github.com/rotki/rotki/assets/1658405/2eedcb1f-08cc-4647-b5ac-418802e5fe34)




