### PR TITLE
Allow to call async the assets import

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10801,6 +10801,9 @@ Import assets added by the user
    .. note::
       If doing a POST the `action` field is not required.
 
+   .. note::
+      This endpoint can be called asynchronously.
+
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3564,7 +3564,8 @@ class RestAPI:
             status_code=HTTPStatus.OK,
         )
 
-    def import_user_assets(self, path: Path) -> Response:
+    @async_api_call()
+    def import_user_assets(self, path: Path) -> dict[str, Any]:
         try:
             if path.suffix == '.json':
                 import_assets_from_file(
@@ -3585,19 +3586,14 @@ class RestAPI:
                                 db_handler=self.rotkehlchen.data.db,
                             )
         except ValidationError as e:
-            return api_response(
-                result=wrap_in_fail_result(
-                    f'Provided file does not have the expected format. {e!s}',
-                ),
+            return wrap_in_fail_result(
+                message=f'Provided file does not have the expected format. {e!s}',
                 status_code=HTTPStatus.CONFLICT,
             )
         except InputError as e:
-            return api_response(
-                result=wrap_in_fail_result(f'{e!s}'),
-                status_code=HTTPStatus.CONFLICT,
-            )
+            return wrap_in_fail_result(f'{e!s}', status_code=HTTPStatus.CONFLICT)
 
-        return api_response(OK_RESULT, status_code=HTTPStatus.OK)
+        return OK_RESULT
 
     def get_user_db_snapshot(self, timestamp: Timestamp) -> Response:
         dbsnapshot = DBSnapshot(

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2469,7 +2469,7 @@ class HistoryEventsDeletionSchema(IdentifiersListSchema):
     force_delete = fields.Boolean(load_default=False)
 
 
-class AssetsImportingSchema(Schema):
+class AssetsImportingSchema(AsyncQueryArgumentSchema):
     file = FileField(allowed_extensions=['.zip', '.json'], load_default=None)
     destination = DirectoryField(load_default=None)
     action = fields.String(
@@ -2492,7 +2492,7 @@ class AssetsImportingSchema(Schema):
             )
 
 
-class AssetsImportingFromFormSchema(Schema):
+class AssetsImportingFromFormSchema(AsyncQueryArgumentSchema):
     file = FileField(allowed_extensions=['.zip', '.json'], required=True)
 
 

--- a/rotkehlchen/serialization/schemas.py
+++ b/rotkehlchen/serialization/schemas.py
@@ -185,8 +185,7 @@ class EvmTokenSchema(CryptoAssetFieldsSchema):
         strict=True,
         validate=webargs.validate.Range(
             min=0,
-            max=18,
-            error='Evm token decimals should range from 0 to 18',
+            error='Evm token decimals should be bigger or equal than 0',
         ),
         required=True,
     )


### PR DESCRIPTION
This PR:

- enables async_query for the globaldb restore functionality
- Removes a limit on 18 decimals for evm tokens. Not max limit is set