### PR TITLE
VCR bisq tests and other small fixes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12871,7 +12871,7 @@ Solving conflicts in accounting rules
 
   :reqjsonarr string local_id: The identifier of the rule that will be updated.
   :reqjsonarr string solve_using: Either ``remote`` or ``local``.
-  :reqjsonarr strin solve_all_using: Either ``remote`` or ``local``.
+  :reqjsonarr string solve_all_using: Either ``remote`` or ``local``. If this is given it should be the only key in the request.
 
   **Example Response**:
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3204,7 +3204,7 @@ class MultipleAccountingRuleConflictsResolutionSchema(Schema):
             )
 
     @post_load
-    def exctract_conflicts(
+    def extract_conflicts(
             self,
             data: dict[str, Any],
             **_kwargs: Any,

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -1,6 +1,6 @@
 from rotkehlchen.fval import FVal
 
-CURRENCYCONVERTER_API_KEY = '0529ead07a5a12d2db0e'
+CURRENCYCONVERTER_API_KEY = 'feaa5a7ddc2d76789e58'
 
 ZERO = FVal(0)
 ONE = FVal(1)

--- a/rotkehlchen/db/unresolved_conflicts.py
+++ b/rotkehlchen/db/unresolved_conflicts.py
@@ -37,7 +37,7 @@ def _serialize_accounting_dict_to_rule(raw_data: dict[str, Any]) -> dict[str, An
 
 
 def build_rule_from_remote_data(remote_data: dict[str, Any]) -> BaseEventSettings:
-    """build the event setting rule for accounting rules from the remote data dict"""
+    """Build the event setting rule for accounting rules from the remote data dict"""
     return BaseEventSettings(
         taxable=remote_data['taxable'],
         count_entire_amount_spend=remote_data['count_entire_amount_spend'],
@@ -124,13 +124,13 @@ class DBRemoteConflicts:
         - InputError: if a conflict couldn't be found
         - KeyError: if the remote data doesn't have the expected format
         """
-        use_remote_updates, use_local_updates = {}, []
+        use_remote_updates, updated_rules_data = {}, []
         # extract ids that will keep local version of rules and remote information for
         # remote resolution rules.
         with self.db.conn.read_ctx() as cursor:
             for local_id, solve_using in conflicts:
                 if solve_using == 'local':
-                    use_local_updates.append(local_id)
+                    updated_rules_data.append((ConflictType.ACCOUNTING_RULE.value, local_id))
                 else:
                     cursor.execute(
                         'SELECT remote_data FROM unresolved_remote_conflicts WHERE '
@@ -151,13 +151,13 @@ class DBRemoteConflicts:
                 links=remote_data.get('links', {}),
                 identifier=local_id,
             )
+            updated_rules_data.append((ConflictType.ACCOUNTING_RULE.value, local_id))
 
         # delete the conflicts for the rules that have been updated
         with self.db.conn.write_ctx() as write_cursor:
             write_cursor.executemany(
                 'DELETE FROM unresolved_remote_conflicts WHERE type=? AND local_id=?',
-                [(ConflictType.ACCOUNTING_RULE.value, local_id) for local_id in use_remote_updates] +  # noqa: E501
-                [(ConflictType.ACCOUNTING_RULE.value, local_id) for local_id in use_local_updates],
+                updated_rules_data,
             )
 
     def solve_all_conflicts(self, solve_all_using: Literal['remote', 'local']) -> None:

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -180,6 +180,7 @@ class RotkiDataUpdater:
         """
         log.info(f'Applying update for accounting rules to v{version}')
         rules_db = DBAccountingRules(self.user_db)
+        serialized_type = ConflictType.ACCOUNTING_RULE.serialize_for_db()
         conflicts = []
         for rule_data in data:
             try:
@@ -217,7 +218,7 @@ class RotkiDataUpdater:
                     conflicts.append((
                         rules[0]['identifier'],
                         json.dumps(rule_data),
-                        ConflictType.ACCOUNTING_RULE.value,
+                        serialized_type,
                     ))
 
                 log.debug(f'Failed to add accounting rule {rule_data} due to {e}')

--- a/rotkehlchen/serialization/schemas.py
+++ b/rotkehlchen/serialization/schemas.py
@@ -185,7 +185,7 @@ class EvmTokenSchema(CryptoAssetFieldsSchema):
         strict=True,
         validate=webargs.validate.Range(
             min=0,
-            error='Evm token decimals should be bigger or equal than 0',
+            error='Evm token decimals should be greater than or equal to 0',
         ),
         required=True,
     )

--- a/rotkehlchen/tests/external_apis/test_bisq_market.py
+++ b/rotkehlchen/tests/external_apis/test_bisq_market.py
@@ -8,10 +8,15 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.bisq_market import get_bisq_market_price
 
 
+@pytest.mark.vcr()
 def test_market_request():
     """Test that we can query bisq for market prices"""
     price_in_btc = get_bisq_market_price(A_BSQ.resolve_to_crypto_asset())
     assert price_in_btc != ZERO_PRICE
-    # Test that error is correctly raised when there is no market
+
+
+def test_missing_market_request():
+    """Test that error is correctly raised when there is no market. Not VCRed since
+    the only failure is timeout here and VCR does not record them"""
     with patch('rotkehlchen.db.settings.CachedSettings.get_timeout_tuple', return_value=(1, 1)), pytest.raises(RemoteError):  # noqa: E501
         get_bisq_market_price(A_3CRV.resolve_to_crypto_asset())

--- a/rotkehlchen/utils/mixins/enums.py
+++ b/rotkehlchen/utils/mixins/enums.py
@@ -165,7 +165,7 @@ class DBIntEnumMixIn(SerializableEnumNameMixin, DBEnumMixIn):
     """A serializable enum with an int value that also goes into
     the DB and gets saved as an int there but gets serialized/to from API as a string"""
 
-    def serialize_for_db(self) -> str:
+    def serialize_for_db(self) -> int:  # type: ignore[override]  # changed return on purpose
         return self.value
 
     @classmethod


### PR DESCRIPTION
- VCR bisq tests
- Some small fixes
- Nitpicks and fixes from https://github.com/rotki/rotki/pull/6897
- Making ConflictType Enum use the `DBIntEnumMixIn` as this is what it does and should use standardized functions and not just `value` which is error prone