### PR TITLE
Reduce false positives in accounting rules

### DIFF
--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -270,7 +270,7 @@ class HistoryBaseEntry(AccountingEventMixin, metaclass=ABCMeta):
             result['hidden'] = True
         if grouped_events_num is not None:
             result['grouped_events_num'] = grouped_events_num
-        if missing_accounting_rule:
+        if missing_accounting_rule is True and self.get_direction() != EventDirection.NEUTRAL:
             result['missing_accounting_rule'] = True
 
         return result

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -214,11 +214,13 @@ class DBAccountingRules:
         For a list of events returns a list of the same length with boolean values where True
         means that the event won't be affected by any accounting rule
         """
-        query = 'SELECT COUNT(*) FROM accounting_rules WHERE (type=? AND subtype=? AND counterparty=?)'  # noqa: E501
+        query = 'SELECT COUNT(*) FROM accounting_rules WHERE (type=? AND subtype=? AND (counterparty=? OR counterparty=?))'  # noqa: E501
         bindings = [
             (
-                event.event_type.serialize(), event.event_subtype.serialize(),
+                event.event_type.serialize(),
+                event.event_subtype.serialize(),
                 NO_ACCOUNTING_COUNTERPARTY if (counterparty := getattr(event, 'counterparty', None)) is None else counterparty,  # noqa: E501
+                NO_ACCOUNTING_COUNTERPARTY,  # account for rules based only on type/subtype
             ) for event in events
         ]
         missing_accounting_rule: list[bool] = []


### PR DESCRIPTION
This PR:
- Removes the false positives from rules that can be used for any counterparty
- Removes neutral event

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
