### PR TITLE
chore: bump ui-compat library to 0.7.4

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@rotki/common": "workspace:*",
     "@rotki/eslint-config-ts": "1.1.2",
-    "@rotki/ui-library-compat": "0.7.3",
+    "@rotki/ui-library-compat": "0.7.4",
     "@types/lodash-es": "4.17.10",
     "@vuelidate/core": "2.0.3",
     "@vuelidate/validators": "2.0.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(eslint@8.51.0)
       '@rotki/ui-library-compat':
-        specifier: 0.7.3
-        version: 0.7.3(@vueuse/core@10.5.0)(@vueuse/shared@10.5.0)(vue@2.7.14)
+        specifier: 0.7.4
+        version: 0.7.4(@vueuse/core@10.5.0)(@vueuse/shared@10.5.0)(vue@2.7.14)
       '@types/lodash-es':
         specifier: 4.17.10
         version: 4.17.10
@@ -2452,8 +2452,8 @@ packages:
       - vue
     dev: true
 
-  /@rotki/ui-library-compat@0.7.3(@vueuse/core@10.5.0)(@vueuse/shared@10.5.0)(vue@2.7.14):
-    resolution: {integrity: sha512-EQB0O5fTPI37iwL9/PCM7S4n5QLlTxAROAZ9mbZlmnhtzn5sMdxPEvlgjye61gPEQ2qWS6Rw+FOXlBhUzRCyXQ==}
+  /@rotki/ui-library-compat@0.7.4(@vueuse/core@10.5.0)(@vueuse/shared@10.5.0)(vue@2.7.14):
+    resolution: {integrity: sha512-fe63UHlZr85uCo9sqySPKMXxreboYGDNI15CTehCfqzeXneP1bnOAO4rvuvo2XSqSzHhLMqbyQtivKHuc+uk8g==}
     engines: {pnpm: '>=8 <9'}
     peerDependencies:
       '@vueuse/core': '>10.0.0'


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
