### PR TITLE
Allow the globaldb reset endpoint to be called async

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1412,11 +1412,12 @@ class RestAPI:
         AssetResolver().assets_cache.remove(source_identifier)
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
+    @async_api_call()
     def rebuild_assets_information(
             self,
             reset: Literal['soft', 'hard'],
             ignore_warnings: bool,
-    ) -> Response:
+    ) -> dict[str, Any]:
         msg = 'Invalid value for reset'
         if reset == 'soft':
             success, msg = GlobalDBHandler().soft_reset_assets_list()
@@ -1427,8 +1428,9 @@ class RestAPI:
             )
 
         if success:
-            return api_response(_wrap_in_ok_result(OK_RESULT), status_code=HTTPStatus.OK)
-        return api_response(wrap_in_fail_result(msg), status_code=HTTPStatus.CONFLICT)
+            AssetResolver.clean_memory_cache()  # clean the cache after deleting any possible asset
+            return _wrap_in_ok_result(OK_RESULT)
+        return wrap_in_fail_result(msg, status_code=HTTPStatus.CONFLICT)
 
     def query_netvalue_data(self, include_nfts: bool) -> Response:
         from_ts = Timestamp(0)

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -938,8 +938,14 @@ class AssetUpdatesResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(delete_schema, location='json_and_query')
-    def delete(self, reset: Literal['soft', 'hard'], ignore_warnings: bool) -> Response:
+    def delete(
+            self,
+            async_query: bool,
+            reset: Literal['soft', 'hard'],
+            ignore_warnings: bool,
+    ) -> Response:
         return self.rest_api.rebuild_assets_information(
+            async_query=async_query,
             reset=reset,
             ignore_warnings=ignore_warnings,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2239,7 +2239,7 @@ class AssetUpdatesRequestSchema(AsyncQueryArgumentSchema):
     conflicts = AssetConflictsField(load_default=None)
 
 
-class AssetResetRequestSchema(Schema):
+class AssetResetRequestSchema(AsyncQueryArgumentSchema):
     reset = fields.String(required=True)
     ignore_warnings = fields.Boolean(load_default=False)
 


### PR DESCRIPTION
It also removes the in memory cache for assets since they could have changed 

addresses https://github.com/orgs/rotki/projects/11?pane=issue&itemId=44296836