### PR TITLE
Accounting rule detection for spend events

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/balancer/v1/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v1/accountant.py
@@ -14,9 +14,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 class Balancerv1Accountant(DepositableAccountantInterface):
 
-    def event_callbacks(self) -> dict[int, EventsAccountantCallback]:
+    def event_callbacks(self) -> dict[int, tuple[int, EventsAccountantCallback]]:
         """Being defined at function call time is fine since this function is called only once"""
         return {
-            get_event_type_identifier(HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE_WRAPPED, CPT_BALANCER_V1): self._process_deposit_or_withdrawal,  # noqa: E501
-            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.RETURN_WRAPPED, CPT_BALANCER_V1): self._process_deposit_or_withdrawal,  # noqa: E501
+            get_event_type_identifier(HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE_WRAPPED, CPT_BALANCER_V1): (-1, self._process_deposit_or_withdrawal),  # noqa: E501
+            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.RETURN_WRAPPED, CPT_BALANCER_V1): (-1, self._process_deposit_or_withdrawal),  # noqa: E501
         }

--- a/rotkehlchen/chain/ethereum/modules/curve/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/accountant.py
@@ -15,9 +15,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 class CurveAccountant(DepositableAccountantInterface):
 
-    def event_callbacks(self) -> dict[int, EventsAccountantCallback]:
+    def event_callbacks(self) -> dict[int, tuple[int, EventsAccountantCallback]]:
         """Being defined at function call time is fine since this function is called only once"""
         return {
-            get_event_type_identifier(HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE_WRAPPED, CPT_CURVE): self._process_deposit_or_withdrawal,  # noqa: E501
-            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.RETURN_WRAPPED, CPT_CURVE): self._process_deposit_or_withdrawal,  # noqa: E501
+            get_event_type_identifier(HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE_WRAPPED, CPT_CURVE): (-1, self._process_deposit_or_withdrawal),  # noqa: E501
+            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.RETURN_WRAPPED, CPT_CURVE): (-1, self._process_deposit_or_withdrawal),  # noqa: E501
         }

--- a/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
@@ -30,16 +30,17 @@ class MakerdaoAccountant(ModuleAccountantInterface):
             pot: 'AccountingPot',  # pylint: disable=unused-argument
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],  # pylint: disable=unused-argument
-    ) -> None:
+    ) -> int:
         cdp_id = event.extra_data['cdp_id']  # type: ignore  # this event should have extra data
         self.vault_balances[cdp_id] += event.balance.amount
+        return 1
 
     def _process_vault_dai_payback(
             self,
             pot: 'AccountingPot',  # pylint: disable=unused-argument
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],  # pylint: disable=unused-argument
-    ) -> None:
+    ) -> int:
         cdp_id = event.extra_data['cdp_id']  # type: ignore  # this event should have extra_data
         self.vault_balances[cdp_id] -= event.balance.amount
         if self.vault_balances[cdp_id] < ZERO:
@@ -55,22 +56,24 @@ class MakerdaoAccountant(ModuleAccountantInterface):
                 extra_data={'tx_hash': event.tx_hash.hex()},
             )
             self.vault_balances[cdp_id] = ZERO
+        return 1
 
     def _process_dsr_deposit(
             self,
             pot: 'AccountingPot',  # pylint: disable=unused-argument
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],  # pylint: disable=unused-argument
-    ) -> None:
+    ) -> int:
         address = cast(ChecksumEvmAddress, event.location_label)  # should always exist
         self.dsr_balances[address] += event.balance.amount
+        return 1
 
     def _process_dsr_withdraw(
             self,
             pot: 'AccountingPot',  # pylint: disable=unused-argument
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],  # pylint: disable=unused-argument
-    ) -> None:
+    ) -> int:
         address = cast(ChecksumEvmAddress, event.location_label)  # should always exist
         self.dsr_balances[address] -= event.balance.amount
         if self.dsr_balances[address] < ZERO:
@@ -86,13 +89,14 @@ class MakerdaoAccountant(ModuleAccountantInterface):
                 extra_data={'tx_hash': event.tx_hash.hex()},
             )
             self.dsr_balances[address] = ZERO
+        return 1
 
-    def event_callbacks(self) -> dict[int, EventsAccountantCallback]:
+    def event_callbacks(self) -> dict[int, tuple[int, EventsAccountantCallback]]:
         """Being defined at function call time is fine since this function is called only once"""
         # TODO: How can we count here loss from debt and gain from DSR? We need to keep state
         return {  # vault collateral deposit
-            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.PAYBACK_DEBT, CPT_VAULT): self._process_vault_dai_payback,  # generate DAI from vault  # noqa: E501
-            get_event_type_identifier(HistoryEventType.WITHDRAWAL, HistoryEventSubType.GENERATE_DEBT, CPT_VAULT): self._process_vault_dai_generation,  # Deposit DAI in the DSR  # noqa: E501
-            get_event_type_identifier(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET, CPT_DSR): self._process_dsr_deposit,  # Withdraw DAI from the DSR  # noqa: E501
-            get_event_type_identifier(HistoryEventType.WITHDRAWAL, HistoryEventSubType.REMOVE_ASSET, CPT_DSR): self._process_dsr_withdraw,  # Migrate SAI to DAI  # noqa: E501
+            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.PAYBACK_DEBT, CPT_VAULT): (1, self._process_vault_dai_payback),  # generate DAI from vault  # noqa: E501
+            get_event_type_identifier(HistoryEventType.WITHDRAWAL, HistoryEventSubType.GENERATE_DEBT, CPT_VAULT): (1, self._process_vault_dai_generation),  # Deposit DAI in the DSR  # noqa: E501
+            get_event_type_identifier(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET, CPT_DSR): (1, self._process_dsr_deposit),  # Withdraw DAI from the DSR  # noqa: E501
+            get_event_type_identifier(HistoryEventType.WITHDRAWAL, HistoryEventSubType.REMOVE_ASSET, CPT_DSR): (1, self._process_dsr_withdraw),  # Migrate SAI to DAI  # noqa: E501
         }

--- a/rotkehlchen/chain/evm/accounting/aggregator.py
+++ b/rotkehlchen/chain/evm/accounting/aggregator.py
@@ -86,8 +86,13 @@ class EVMAccountingAggregator:
         """Recursively check all submodules to get all accountants and initialize them"""
         self._recursively_initialize_accountants(self.modules_path)
 
-    def get_accounting_callbacks(self) -> dict[int, EventsAccountantCallback]:
-        """Iterate through loaded accountants and get accounting callbacks for each event type"""
+    def get_accounting_callbacks(self) -> dict[int, tuple[int, EventsAccountantCallback]]:
+        """
+        Iterate through loaded accountants and get accounting callbacks for each event type.
+        It returns a mapping of event type identifier to a tuple where the fist element is the
+        number of events processed (-1 if it is variable) and the callback that processes
+        those events.
+        """
         result = {}
         for accountant in self.accountants.values():
             result.update(accountant.event_callbacks())
@@ -108,8 +113,13 @@ class EVMAccountingAggregators:
     def __init__(self, aggregators: list[EVMAccountingAggregator]) -> None:
         self.aggregators = aggregators
 
-    def get_accounting_callbacks(self) -> dict[int, EventsAccountantCallback]:
-        """Iterate through loaded accountants and get accounting callbacks for each event type"""
+    def get_accounting_callbacks(self) -> dict[int, tuple[int, EventsAccountantCallback]]:
+        """
+        Iterate through loaded accountants and get accounting callbacks for each event type
+        It returns a mapping of event type identifier to a tuple where the fist element is the
+        number of events processed (-1 if it is variable) and the callback that processes
+        those events.
+        """
         result = {}
         for aggregator in self.aggregators:
             result.update(aggregator.get_accounting_callbacks())

--- a/rotkehlchen/chain/evm/accounting/structures.py
+++ b/rotkehlchen/chain/evm/accounting/structures.py
@@ -16,12 +16,13 @@ class EventsAccountantCallback(Protocol):
             pot: 'AccountingPot',
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],
-    ) -> None:
+    ) -> int:
         """
         Callback to be called by the accounting module.
         If the callback expects more than 1 events, it is supposed to iterate over the
         `other_events` iterator to get them.
         Note that events consumed by the callback from the iterator will not be re-processed later.
+        It returns the number of events processed by the callback.
         """
 
 

--- a/rotkehlchen/chain/optimism/modules/velodrome/accountant.py
+++ b/rotkehlchen/chain/optimism/modules/velodrome/accountant.py
@@ -15,9 +15,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 class VelodromeAccountant(DepositableAccountantInterface):
 
-    def event_callbacks(self) -> dict[int, EventsAccountantCallback]:
+    def event_callbacks(self) -> dict[int, tuple[int, EventsAccountantCallback]]:
         """Being defined at function call time is fine since this function is called only once"""
         return {
-            get_event_type_identifier(HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE_WRAPPED, CPT_VELODROME): self._process_deposit_or_withdrawal,  # noqa: E501
-            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.RETURN_WRAPPED, CPT_VELODROME): self._process_deposit_or_withdrawal,  # noqa: E501
+            get_event_type_identifier(HistoryEventType.RECEIVE, HistoryEventSubType.RECEIVE_WRAPPED, CPT_VELODROME): (-1, self._process_deposit_or_withdrawal),  # noqa: E501
+            get_event_type_identifier(HistoryEventType.SPEND, HistoryEventSubType.RETURN_WRAPPED, CPT_VELODROME): (-1, self._process_deposit_or_withdrawal),  # noqa: E501
         }

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -1,24 +1,36 @@
 import logging
+from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
-from rotkehlchen.accounting.structures.base import HistoryBaseEntry
+from rotkehlchen.accounting.structures.base import HistoryBaseEntry, HistoryEvent
+from rotkehlchen.accounting.structures.eth2 import EthStakingEvent
+from rotkehlchen.accounting.structures.evm_event import EvmEvent
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.chain.evm.accounting.structures import BaseEventSettings, TxAccountingTreatment
+from rotkehlchen.chain.evm.accounting.structures import (
+    BaseEventSettings,
+    EventsAccountantCallback,
+    TxAccountingTreatment,
+)
+from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.db.constants import (
     LINKABLE_ACCOUNTING_PROPERTIES,
     LINKABLE_ACCOUNTING_SETTINGS_NAME,
     NO_ACCOUNTING_COUNTERPARTY,
 )
-from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.db.filtering import AccountingRulesFilterQuery
+from rotkehlchen.db.filtering import AccountingRulesFilterQuery, HistoryEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import DEFAULT_INCLUDE_CRYPTO2CRYPTO, DEFAULT_INCLUDE_GAS_COSTS
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
+    from rotkehlchen.accounting.accountant import Accountant
+    from rotkehlchen.accounting.pot import AccountingPot
+    from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.drivers.gevent import DBCursor
 
 
 logger = logging.getLogger(__name__)
@@ -174,7 +186,7 @@ class DBAccountingRules:
 
     def add_linked_setting(
             self,
-            write_cursor: DBCursor,
+            write_cursor: 'DBCursor',
             rule_identifier: int,
             rule_property: LINKABLE_ACCOUNTING_PROPERTIES,
             setting_name: LINKABLE_ACCOUNTING_SETTINGS_NAME,
@@ -208,50 +220,6 @@ class DBAccountingRules:
             raise InputError(
                 f'Link of rule for {rule_property} to setting {setting_name} already exists',
             ) from e
-
-    def missing_accounting_rules(self, events: list[HistoryBaseEntry]) -> list[bool]:
-        """
-        For a list of events returns a list of the same length with boolean values where True
-        means that the event won't be affected by any accounting rule
-        """
-        query = 'SELECT COUNT(*) FROM accounting_rules WHERE (type=? AND subtype=? AND (counterparty=? OR counterparty=?))'  # noqa: E501
-        bindings = [
-            (
-                event.event_type.serialize(),
-                event.event_subtype.serialize(),
-                NO_ACCOUNTING_COUNTERPARTY if (counterparty := getattr(event, 'counterparty', None)) is None else counterparty,  # noqa: E501
-                NO_ACCOUNTING_COUNTERPARTY,  # account for rules based only on type/subtype
-            ) for event in events
-        ]
-        missing_accounting_rule: list[bool] = []
-        with self.db.conn.read_ctx() as cursor:
-            for idx, event in enumerate(events):
-                row = cursor.execute(query, bindings[idx]).fetchone()
-                if (is_missing_rule := row[0] == 0) is False:
-                    missing_accounting_rule.append(is_missing_rule)
-                    continue
-
-                if (  # check for cases that could use accounting_treatment
-                    event.event_type == HistoryEventType.TRADE and
-                    event.event_subtype in (HistoryEventSubType.RECEIVE, HistoryEventSubType.FEE)
-                ):
-                    cursor.execute(
-                        query + ' AND (accounting_treatment=? OR accounting_treatment=?)',
-                        (
-                            HistoryEventType.TRADE.serialize(),
-                            HistoryEventSubType.SPEND.serialize(),
-                            NO_ACCOUNTING_COUNTERPARTY if (counterparty := getattr(event, 'counterparty', None)) is None else counterparty,  # noqa: E501
-                            NO_ACCOUNTING_COUNTERPARTY,
-                            TxAccountingTreatment.SWAP.serialize_for_db(),
-                            TxAccountingTreatment.SWAP_WITH_FEE.serialize_for_db(),
-
-                        ),
-                    )
-                    missing_accounting_rule.append(cursor.fetchone()[0] == 0)
-                else:
-                    missing_accounting_rule.append(is_missing_rule)
-
-        return missing_accounting_rule
 
     def query_rules(
             self,
@@ -336,3 +304,149 @@ class DBAccountingRules:
                 data[linked_property]['linked_setting'] = setting_name
             entries.append(data)
         return entries, total_found_result
+
+
+def _events_to_consume(
+        cursor: 'DBCursor',
+        callbacks: dict[int, tuple[int, EventsAccountantCallback]],
+        events_iterator: Iterator[tuple[tuple[Any, ...], 'HistoryEvent']],
+        next_events: Sequence[HistoryBaseEntry],
+        event: HistoryBaseEntry,
+        pot: 'AccountingPot',
+) -> list[int]:
+    """
+    Returns a list of event identifiers processed after checking possible accounting
+    treatments and callbacks.
+    """
+    ids_processed: list[int] = []
+    counterparty = getattr(event, 'counterparty', None)
+    if counterparty == CPT_GAS:  # avoid checking the case of gas in evm events
+        return ids_processed
+
+    # query the accounting rule for the related event
+    cursor.execute(
+        'SELECT accounting_treatment FROM accounting_rules WHERE (type=? AND subtype=? AND (counterparty=? OR counterparty=?))',  # noqa: E501
+        (
+            event.event_type.serialize(),
+            event.event_subtype.serialize(),
+            NO_ACCOUNTING_COUNTERPARTY if counterparty is None else counterparty,
+            NO_ACCOUNTING_COUNTERPARTY,
+        ),
+    )
+
+    if (raw_treatment := cursor.fetchone()) is not None and raw_treatment[0] is not None:
+        accounting_treatment = TxAccountingTreatment.deserialize_from_db(raw_treatment[0])
+        if accounting_treatment == TxAccountingTreatment.SWAP:
+            _, next_event = next(events_iterator)
+            ids_processed.append(next_event.identifier)  # type: ignore[arg-type]
+        else:
+            for _ in range(2):  # swap_with_fee consumes two events
+                _, next_event = next(events_iterator)
+                ids_processed.append(next_event.identifier)  # type: ignore[arg-type]
+
+        return ids_processed
+
+    if isinstance(event, EvmEvent) is False:
+        return ids_processed  # only evm events have callbacks
+
+    # if there is no accounting treatment check for callbacks
+    if (callback_data := callbacks.get(event.get_type_identifier())) is None:
+        return ids_processed
+
+    processed_events_num, callback = callback_data
+    if processed_events_num == 1:  # we know that this callback only processes the current event
+        return ids_processed
+
+    # count the number of events that will be processed if accounting ran
+    processed_events_num = callback(
+        pot=pot,
+        event=event,  # type: ignore[arg-type] # mypy doesn't recognize that this is an evm event
+        other_events=iter(next_events),  # type: ignore[arg-type]  # mypy doesn't recognize that this is an evm event
+    )
+
+    for _ in range(processed_events_num - 1):  # -1 because we exclude the current event here
+        _, next_event = next(events_iterator)
+        ids_processed.append(next_event.identifier)  # type: ignore
+
+    return ids_processed
+
+
+def query_missing_accounting_rules(
+        db: 'DBHandler',
+        accountant: 'Accountant',
+        accounting_pot: 'AccountingPot',
+        evm_accounting_aggregator: 'EVMAccountingAggregators',
+        events: Sequence[HistoryBaseEntry],
+) -> list[bool]:
+    """
+    For a list of events returns a list of the same length with boolean values where True
+    means that the event won't be affected by any accounting rule or processed in accounting
+    """
+    history_db = DBHistoryEvents(db)
+    with db.conn.read_ctx() as cursor:
+        # to know if an event will be processed or not in accounting we also need the related
+        # events since they might use callbacks or special treatments
+        related_events = history_db.get_history_events(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(
+                event_identifiers=list({event.event_identifier for event in events}),
+                order_by_rules=[('event_identifier', True), ('sequence_index', True)],
+            ),
+            has_premium=True,
+        )
+
+    query = 'SELECT COUNT(*) FROM accounting_rules WHERE (type=? AND subtype=? AND (counterparty=? OR counterparty=?))'  # noqa: E501
+    bindings = [
+        (
+            event.event_type.serialize(),
+            event.event_subtype.serialize(),
+            NO_ACCOUNTING_COUNTERPARTY if (counterparty := getattr(event, 'counterparty', None)) is None else counterparty,  # noqa: E501
+            NO_ACCOUNTING_COUNTERPARTY,  # account for rules based only on type/subtype
+        ) for event in related_events
+    ]
+
+    callbacks = evm_accounting_aggregator.get_accounting_callbacks()
+    bindings_and_events_iterator = zip(bindings, related_events)
+    with db.conn.read_ctx() as cursor:
+        # index to keep the current event in the list of related events. It is used in the
+        # callbacks since we need to process events but we don't want to consume the current
+        # iterator
+        current_event_index = 0
+        for event_binding, event in bindings_and_events_iterator:
+            if accountant.processable_events_cache.get(event.identifier) is not None:  # type: ignore
+                current_event_index += 1
+                continue
+
+            if isinstance(event, EthStakingEvent) is True:
+                # staking events all have a process() function for accounting
+                accountant.processable_events_cache.add(event.identifier, False)  # type: ignore
+                current_event_index += 1
+                continue
+
+            # check the rule in the database
+            row = cursor.execute(query, event_binding).fetchone()
+            is_missing_rule = row[0] == 0
+            accountant.processable_events_cache.add(event.identifier, is_missing_rule)  # type: ignore
+
+            # the current event in addition to have an accounting rule could have a callback that
+            # affects events that come after and is not enough to check the accounting rule
+            new_missing_accounting_rule = _events_to_consume(
+                cursor=cursor,
+                callbacks=callbacks,
+                events_iterator=bindings_and_events_iterator,
+                next_events=related_events[current_event_index + 1:],
+                event=event,
+                pot=accounting_pot,
+            )
+            if len(new_missing_accounting_rule) != 0:
+                current_event_index += len(new_missing_accounting_rule)
+                if is_missing_rule is True:  # we processed it in the callback so is not missing
+                    accountant.processable_events_cache.add(event.identifier, False)  # type: ignore
+
+                # update information about the new events
+                for processed_event_id in new_missing_accounting_rule:
+                    accountant.processable_events_cache.add(processed_event_id, False)
+
+    # we use bool because the cache can return None and in order to cover this case we use
+    # `None`'s Falsy value meaning that the event doesn't have an accounting rule
+    return [bool(accountant.processable_events_cache.get(event.identifier)) for event in events]  # type: ignore[arg-type]

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -407,7 +407,6 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
 
     # check if the accounting rule check is respected
     assert 'missing_accounting_rule' not in result['entries'][1]
-    assert result['entries'][0]['missing_accounting_rule'] is True
 
     # now try with grouping
     response = requests.post(
@@ -425,7 +424,6 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
 
     # check also that in groups we add the missing_accounting_rule key
     assert 'missing_accounting_rule' not in result['entries'][1]
-    assert result['entries'][0]['missing_accounting_rule'] is True
 
     # now try with grouping and pagination
     response = requests.post(

--- a/rotkehlchen/tests/db/test_db_accounting_rules.py
+++ b/rotkehlchen/tests/db/test_db_accounting_rules.py
@@ -1,18 +1,45 @@
+from collections.abc import Sequence
 import pytest
+from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.evm_event import EvmEvent
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.chain.ethereum.modules.balancer.constants import CPT_BALANCER_V1
+from rotkehlchen.chain.ethereum.modules.compound.constants import CPT_COMPOUND
 from rotkehlchen.chain.evm.accounting.structures import TxAccountingTreatment, TxEventSettings
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
-from rotkehlchen.constants.assets import A_ETH, A_USDC
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_CUSDC, A_ETH, A_USDC, A_WETH
 from rotkehlchen.constants.misc import ONE
-from rotkehlchen.db.accounting_rules import DBAccountingRules
+from rotkehlchen.db.accounting_rules import DBAccountingRules, query_missing_accounting_rules
 from rotkehlchen.db.constants import NO_ACCOUNTING_COUNTERPARTY
 from rotkehlchen.db.dbhandler import DBHandler
-from rotkehlchen.db.filtering import AccountingRulesFilterQuery
+from rotkehlchen.db.filtering import AccountingRulesFilterQuery, HistoryEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import InputError
+from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.types import Location, TimestampMS
+
+
+def _store_and_retrieve_events(
+        events: Sequence[HistoryBaseEntry],
+        db: DBHandler,
+) -> Sequence[HistoryBaseEntry]:
+    """Store events in database and retrieve them again fully populated with identifiers"""
+    dbevents = DBHistoryEvents(db)
+    with db.user_write() as write_cursor:
+        for event in events:
+            dbevents.add_history_event(
+                write_cursor=write_cursor,
+                event=event,
+            )
+        return dbevents.get_history_events(
+            cursor=write_cursor,
+            filter_query=HistoryEventFilterQuery.make(event_identifiers=[events[0].event_identifier]),
+            has_premium=True,
+        )  # query them from db to retrieve them with their identifier
 
 
 def test_managing_accounting_rules(database: DBHandler) -> None:
@@ -151,7 +178,12 @@ def test_accounting_rules_linking(database: 'DBHandler', counterparty: str) -> N
     }
 
 
-def test_missing_accounting_rules_accounting_treatment(database: 'DBHandler') -> None:
+@pytest.mark.parametrize('accountant_without_rules', [True])
+@pytest.mark.parametrize('use_dummy_pot', [True])
+def test_missing_accounting_rules_accounting_treatment(
+        database: 'DBHandler',
+        accountant: Accountant,
+) -> None:
     """
     Test that if a rule has a special accounting treatment then the events
     that can be affected by it are not marked as missing the accounting rule.
@@ -184,7 +216,7 @@ def test_missing_accounting_rules_accounting_treatment(database: 'DBHandler') ->
     )
     swap_event_receive = EvmEvent(
         tx_hash=tx_hash,
-        sequence_index=0,
+        sequence_index=1,
         timestamp=TimestampMS(16433333000),
         location=Location.GNOSIS,
         asset=A_ETH,
@@ -196,7 +228,7 @@ def test_missing_accounting_rules_accounting_treatment(database: 'DBHandler') ->
     )
     swap_event_fee = EvmEvent(
         tx_hash=tx_hash,
-        sequence_index=0,
+        sequence_index=2,
         timestamp=TimestampMS(16433333000),
         location=Location.GNOSIS,
         asset=A_ETH,
@@ -206,6 +238,283 @@ def test_missing_accounting_rules_accounting_treatment(database: 'DBHandler') ->
         counterparty=CPT_COWSWAP,
         notes='my notes',
     )
+    events = _store_and_retrieve_events([swap_event_spend, swap_event_receive, swap_event_fee], database)  # noqa: E501
     assert not all(
-        db.missing_accounting_rules([swap_event_spend, swap_event_receive, swap_event_fee]),
+        query_missing_accounting_rules(
+            db=database,
+            accounting_pot=accountant.pots[0],
+            evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+            events=events,
+            accountant=accountant,
+        ),
     )
+
+
+@pytest.mark.parametrize('accountant_without_rules', [True])
+@pytest.mark.parametrize('use_dummy_pot', [True])
+def test_events_affeced_by_others_accounting_treatment(
+        database: 'DBHandler',
+        accountant: Accountant,
+) -> None:
+    """
+    Test that if a rule has a special accounting treatment then the events
+    that can be affected by it are not marked as missing the accounting rule.
+    """
+    db = DBAccountingRules(database)
+    db.add_accounting_rule(
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        counterparty=CPT_COMPOUND,
+        rule=TxEventSettings(
+            taxable=True,
+            count_entire_amount_spend=True,
+            count_cost_basis_pnl=True,
+            accounting_treatment=TxAccountingTreatment.SWAP,
+        ),
+        links={},
+    )
+    tx_hash = make_evm_tx_hash()
+    return_wrapped = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_CUSDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+    remove_asset = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=1,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_USDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REMOVE_ASSET,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+
+    events = _store_and_retrieve_events([return_wrapped, remove_asset], database)
+    assert query_missing_accounting_rules(
+        db=database,
+        accounting_pot=accountant.pots[0],
+        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        events=events,
+        accountant=accountant,
+    ) == [False, False]
+
+
+@pytest.mark.parametrize('accountant_without_rules', [True])
+@pytest.mark.parametrize('use_dummy_pot', [True])
+def test_events_affeced_by_others_accounting_treatment_with_fee(
+        database: 'DBHandler',
+        accountant: Accountant,
+) -> None:
+    """
+    Test that if a rule has an accounting treatment with fee then the events
+    that can be affected by it are not marked as missing the accounting rule.
+    """
+    db = DBAccountingRules(database)
+    db.add_accounting_rule(
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        counterparty=CPT_COMPOUND,
+        rule=TxEventSettings(
+            taxable=True,
+            count_entire_amount_spend=True,
+            count_cost_basis_pnl=True,
+            accounting_treatment=TxAccountingTreatment.SWAP_WITH_FEE,
+        ),
+        links={},
+    )
+    tx_hash = make_evm_tx_hash()
+    return_wrapped = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_CUSDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+    fee_event = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=1,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_CUSDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+    remove_asset = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=2,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_USDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REMOVE_ASSET,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+
+    events = _store_and_retrieve_events([return_wrapped, fee_event, remove_asset], database)
+    assert query_missing_accounting_rules(
+        db=database,
+        accounting_pot=accountant.pots[0],
+        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        events=events,
+        accountant=accountant,
+    ) == [False, False, False]
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x7716a99194d758c8537F056825b75Dd0C8FDD89f']])
+@pytest.mark.parametrize('accountant_without_rules', [True])
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+@pytest.mark.parametrize('use_dummy_pot', [True])
+def test_events_affected_by_others_callbacks(
+        database: 'DBHandler',
+        accountant: Accountant,
+        ethereum_accounts,
+) -> None:
+    """
+    Test that if a rule has a special accounting treatment then the events
+    that can be affected by it are not marked as missing the accounting rule.
+    """
+    tx_hash = make_evm_tx_hash()
+    user_address = ethereum_accounts[0]
+    events = [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=1,
+            timestamp=TimestampMS(1646375440000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+            asset=A_USDC,
+            balance=Balance(amount=FVal('0.042569019597126949')),
+            location_label=user_address,
+            notes='Return 0.042569019597126949 BPT to a Balancer v1 pool',
+            counterparty=CPT_BALANCER_V1,
+            address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
+            extra_data={'withdrawal_events_num': 2},
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=2,
+            timestamp=TimestampMS(1646375440000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_USDC,
+            location_label=user_address,
+            balance=Balance(amount=FVal('0.744372160905819159')),
+            notes='Receive 0.744372160905819159 BAL after removing liquidity from a Balancer v1 pool',  # noqa: E501
+            counterparty=CPT_BALANCER_V1,
+            address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
+            extra_data=None,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=3,
+            timestamp=TimestampMS(1646375440000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_WETH,
+            location_label=user_address,
+            balance=Balance(amount=FVal('0.010687148200906598')),
+            notes='Receive 0.010687148200906598 WETH after removing liquidity from a Balancer v1 pool',  # noqa: E501
+            counterparty=CPT_BALANCER_V1,
+            address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
+            extra_data=None,
+        ),
+    ]
+    db_events = _store_and_retrieve_events(events, database)
+    assert query_missing_accounting_rules(
+        db=database,
+        accounting_pot=accountant.pots[0],
+        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        events=db_events,
+        accountant=accountant,
+    ) == [False, False, False]
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x7716a99194d758c8537F056825b75Dd0C8FDD89f']])
+@pytest.mark.parametrize('accountant_without_rules', [True])
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+@pytest.mark.parametrize('use_dummy_pot', [True])
+def test_events_affected_by_others_callbacks_with_fitlers(
+        database: 'DBHandler',
+        accountant: Accountant,
+        ethereum_accounts,
+) -> None:
+    """
+    Test that a callback with a filtered list of events is correctly accounted even if the
+    event with the callback is not in the processed set.
+    """
+    tx_hash = make_evm_tx_hash()
+    user_address = ethereum_accounts[0]
+    events = [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=1,
+            timestamp=TimestampMS(1646375440000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+            asset=A_USDC,
+            balance=Balance(amount=FVal('0.042569019597126949')),
+            location_label=user_address,
+            notes='Return 0.042569019597126949 BPT to a Balancer v1 pool',
+            counterparty=CPT_BALANCER_V1,
+            address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
+            extra_data={'withdrawal_events_num': 2},
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=2,
+            timestamp=TimestampMS(1646375440000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_USDC,
+            location_label=user_address,
+            balance=Balance(amount=FVal('0.744372160905819159')),
+            notes='Receive 0.744372160905819159 BAL after removing liquidity from a Balancer v1 pool',  # noqa: E501
+            counterparty=CPT_BALANCER_V1,
+            address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
+            extra_data=None,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=3,
+            timestamp=TimestampMS(1646375440000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_WETH,
+            location_label=user_address,
+            balance=Balance(amount=FVal('0.010687148200906598')),
+            notes='Receive 0.010687148200906598 WETH after removing liquidity from a Balancer v1 pool',  # noqa: E501
+            counterparty=CPT_BALANCER_V1,
+            address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
+            extra_data=None,
+        ),
+    ]
+    db_events = _store_and_retrieve_events(events, database)
+    assert query_missing_accounting_rules(
+        db=database,
+        accounting_pot=accountant.pots[0],
+        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        events=db_events[1:],
+        accountant=accountant,
+    ) == [False, False]

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -108,6 +108,22 @@ def fixture_initialize_accounting_rules() -> bool:
     return False
 
 
+@pytest.fixture(name='accountant_without_rules')
+def fixture_accountant_without_rules() -> bool:
+    """
+    If set to False the accountant fixture will be initialized without pre-loaded rules
+    """
+    return False
+
+
+@pytest.fixture(name='use_dummy_pot')
+def fixture_use_dummy_pot() -> bool:
+    """
+    If set to true then we will initialize the pot in accounting as a dummy pot
+    """
+    return False
+
+
 @pytest.fixture(name='last_accounting_rules_version', scope='session')
 def fixture_last_accounting_rules_version() -> int:
     return 1
@@ -147,6 +163,8 @@ def fixture_accountant(
         rotki_premium_credentials,
         username,
         latest_accounting_rules,
+        accountant_without_rules,
+        use_dummy_pot,
 ) -> Optional[Accountant]:
     if not start_with_logged_in_user:
         return None
@@ -160,17 +178,20 @@ def fixture_accountant(
         msg_aggregator=function_scope_messages_aggregator,
         user_db=database,
     )
-    with open(latest_accounting_rules, encoding='utf-8') as f:
-        data_updater.update_accounting_rules(
-            data=json.loads(f.read())['accounting_rules'],
-            version=999999,  # only for logs
-        )
+
+    if accountant_without_rules is False:
+        with open(latest_accounting_rules, encoding='utf-8') as f:
+            data_updater.update_accounting_rules(
+                data=json.loads(f.read())['accounting_rules'],
+                version=999999,  # only for logs
+            )
 
     accountant = Accountant(
         db=database,
         chains_aggregator=blockchain,
         msg_aggregator=function_scope_messages_aggregator,
         premium=premium,
+        use_dummy_pot=use_dummy_pot,
     )
 
     if accounting_initialize_parameters:


### PR DESCRIPTION
- Check related events to identify if an event will be processed by a accounting treatment rule
- For staking event add an exception since they don't use accounting rules

closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=45155775

----

logic:

for accounting rules what we do is check wether the combination of type/subtype/counterparty is present in the accounting rules to decide if the event will be processed or not.

For all the other things that use accounting treatment the combination of type/subtype for the first and second event is not fixed as you saw with the different cases that you found. 

so let say that for [event_1, event_2] we have that event_1 has accounting rule with accounting_treatment = SWAP and event_2 doesn't have a rule because it will be processed together with event_1.

When checking if event_2 has a rule or not the logic will be

```
1. Check if (event_2.type, event_2.subtype, event_2.counterparty) a matching accounting rule
2. Since it doesn't have fetch the related events, that is [event_1, event_2]
3. Get the index for that event that we are checking in the previous list, in this case 1.
4. Check if the event just before event_2 has the accounting treatment that would affect event_2. In this case since event_1 does a SWAP treatment event_2 will be processed.
```