### PR TITLE
Perform some kraken tweaks after reading a user's logs

### DIFF
--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -506,7 +506,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
                 tx_hashes=hashes,
                 send_ws_notifications=send_ws_notifications,
             )
-            log.debug(f'Finished task decoding transactions for {self.evm_inquirer.chain_name} with {limit=}')  # noqa: E501
+            log.debug(f'Finished task to process undecoded transactions for {self.evm_inquirer.chain_name} with {limit=}')  # noqa: E501
 
     def decode_transaction_hashes(
             self,


### PR DESCRIPTION
- Add handling for kraken ledger type: invite bonus
- Note that we don't process the margin trade kraken ledger entries and name which they are according to docs
- Adjust the used_query ranges saved for kraken ledgers query. Do not save anything if there was an error

