### PR TITLE
Remove address from the filter for undecoded transactions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1937,15 +1937,10 @@ Decode transactions that haven't been decoded yet
 
       {
           "async_query": false,
-          "data": [{
-              "evm_chain": "ethereum",
-              "addresses": ["0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12", "0xed8Bdb5895B8B7f9Fdb3C087628FD8410E853D48"]
-          }, {
-              "evm_chain": "optimism"
-          }]
+          "evm_chains": ["ethereum", "optimism"]
       }
 
-   :reqjson list data: A list of data explaining what transactions to decode. Each data entry consists of an ``"evm_chain"`` key specifying the evm chain for which to decode tx_hashes and an ``"addresses"`` key which is an optional list of addresses for which to request decoding of pending transactions in that chain. If the list of addresses is not passed or is null then all transactions for that chain are decoded. Passing an empty list is not allowed.
+   :reqjson list evm_chains: A list specifying the evm chains for which to decode tx_hashes. The possible values are limited to the chains with evm transactions. If the list is not provided all transactions from all the chains will be decoded. 
 
    **Example Response**:
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -208,6 +208,7 @@ from rotkehlchen.serialization.schemas import (
 )
 from rotkehlchen.serialization.serialize import process_result
 from rotkehlchen.types import (
+    EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
     SUPPORTED_CHAIN_IDS,
     SUPPORTED_EVM_CHAINS,
     AddressbookEntry,
@@ -234,12 +235,7 @@ from rotkehlchen.types import (
     UserNote,
 )
 
-from .types import (
-    EvmPendingTransactionDecodingApiData,
-    EvmTransactionDecodingApiData,
-    ModuleWithBalances,
-    ModuleWithStats,
-)
+from .types import EvmTransactionDecodingApiData, ModuleWithBalances, ModuleWithStats
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.structures.base import HistoryBaseEntry
@@ -626,11 +622,11 @@ class EvmPendingTransactionsDecodingResource(BaseMethodView):
     def post(
             self,
             async_query: bool,
-            data: list[EvmPendingTransactionDecodingApiData],
+            evm_chains: list[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE],
     ) -> Response:
         return self.rest_api.decode_pending_evm_transactions(
             async_query=async_query,
-            data=data,
+            evm_chains=evm_chains,
         )
 
     @require_loggedin_user()

--- a/rotkehlchen/api/v1/types.py
+++ b/rotkehlchen/api/v1/types.py
@@ -3,7 +3,7 @@ from enum import auto
 from typing import Literal, Optional, TypedDict
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntryType
-from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ChecksumEvmAddress, EVMTxHash
+from rotkehlchen.types import SUPPORTED_CHAIN_IDS, EVMTxHash
 from rotkehlchen.utils.mixins.enums import SerializableEnumNameMixin
 
 
@@ -14,7 +14,6 @@ class EvmTransactionDecodingApiData(TypedDict):
 
 class EvmPendingTransactionDecodingApiData(TypedDict):
     evm_chain: SUPPORTED_CHAIN_IDS
-    addresses: Optional[list[ChecksumEvmAddress]]
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -486,7 +486,6 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
     def get_and_decode_undecoded_transactions(
             self,
             limit: Optional[int] = None,
-            addresses: Optional[list[ChecksumEvmAddress]] = None,
             send_ws_notifications: bool = False,
     ) -> None:
         """Checks the DB for up to `limit` undecoded transactions and decodes them.
@@ -499,13 +498,14 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
             hashes = self.dbevmtx.get_transaction_hashes_not_decoded(
                 chain_id=self.evm_inquirer.chain_id,
                 limit=limit,
-                addresses=addresses,
             )
-            self.decode_transaction_hashes(
-                ignore_cache=False,
-                tx_hashes=hashes,
-                send_ws_notifications=send_ws_notifications,
-            )
+            if len(hashes) != 0:
+                log.debug(f'Will decode {len(hashes)} transactions for {self.evm_inquirer.chain_name}')  # noqa: E501
+                self.decode_transaction_hashes(
+                    ignore_cache=False,
+                    tx_hashes=hashes,
+                    send_ws_notifications=send_ws_notifications,
+                )
             log.debug(f'Finished task to process undecoded transactions for {self.evm_inquirer.chain_name} with {limit=}')  # noqa: E501
 
     def decode_transaction_hashes(

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -264,7 +264,6 @@ class DBEvmTx:
             self,
             chain_id: Optional[ChainID],
             limit: Optional[int],
-            addresses: Optional[list[ChecksumEvmAddress]],
     ) -> list[EVMTxHash]:
         """Get transaction hashes for the transactions that have not been decoded.
         Optionally by chain id.
@@ -275,7 +274,6 @@ class DBEvmTx:
         """
         query, bindings = TransactionsNotDecodedFilterQuery.make(
             limit=limit,
-            addresses=addresses,
             chain_id=chain_id,
         ).prepare()
         querystr = 'SELECT C.tx_hash from ' + TRANSACTIONS_MISSING_DECODING_QUERY + query
@@ -287,7 +285,6 @@ class DBEvmTx:
     def count_hashes_not_decoded(
             self,
             chain_id: Optional[ChainID],
-            addresses: Optional[list[ChecksumEvmAddress]],
     ) -> int:
         """
         Count the number of transactions queried that have not been decoded. When the addresses
@@ -295,7 +292,6 @@ class DBEvmTx:
         """
         query, bindings = TransactionsNotDecodedFilterQuery.make(
             limit=None,
-            addresses=addresses,
             chain_id=chain_id,
         ).prepare()
 

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -423,7 +423,6 @@ class TaskManager:
         random.shuffle(shuffled_chains)
         for blockchain in shuffled_chains:
             number_of_tx_to_decode = dbevmtx.count_hashes_not_decoded(
-                addresses=None,
                 chain_id=blockchain.to_chain_id(),
             )
             if number_of_tx_to_decode == 0:

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -199,9 +199,9 @@ def test_query_and_decode_transactions_works_with_different_chains(
     assert dbevmtx.get_transaction_hashes_no_receipt(tx_filter_query=None, limit=None) == [evmhash_eth_yabir]  # noqa: E501
 
     # check that the transactions have not been decoded
-    hashes = dboptimismtx.get_transaction_hashes_not_decoded(chain_id=ChainID.OPTIMISM, limit=None, addresses=None)  # noqa: E501
+    hashes = dboptimismtx.get_transaction_hashes_not_decoded(chain_id=ChainID.OPTIMISM, limit=None)
     assert len(hashes) == 1
-    hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None, addresses=None)  # noqa: E501
+    hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None)
     assert len(hashes) == 1
 
     # decode evm transactions using the optimism decoder and without providing any tx hash
@@ -209,9 +209,9 @@ def test_query_and_decode_transactions_works_with_different_chains(
 
     # verify that the optimism transactions got decoded but not the
     # ethereum one (would raise an error if tried)
-    hashes = dboptimismtx.get_transaction_hashes_not_decoded(chain_id=ChainID.OPTIMISM, limit=None, addresses=None)  # noqa: E501
+    hashes = dboptimismtx.get_transaction_hashes_not_decoded(chain_id=ChainID.OPTIMISM, limit=None)
     assert len(hashes) == 0
-    hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None, addresses=None)  # noqa: E501
+    hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None)
     assert len(hashes) == 1
 
 


### PR DESCRIPTION
We noticed that the query to decode undecoded transactions was failing because the filter when used with addresses was only checking for transactions where the address in to/from fields and this excluded other transactions where there was a transfer executed by another contract like in bridges.


