### PR TITLE
ws message for transactions by hash

### DIFF
--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -46,7 +46,6 @@ class Accountant:
             msg_aggregator: MessagesAggregator,
             chains_aggregator: 'ChainsAggregator',
             premium: Optional[Premium],
-            use_dummy_pot: bool = False,
     ) -> None:
         self.db = db
         self.msg_aggregator = msg_aggregator
@@ -59,7 +58,7 @@ class Accountant:
                 database=db,
                 evm_accounting_aggregators=evm_accounting_aggregators,
                 msg_aggregator=msg_aggregator,
-                is_dummy_pot=use_dummy_pot,
+                is_dummy_pot=False,
             ),
         ]
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2718,6 +2718,7 @@ class RestAPI:
                 decoded_events = chain_manager.transactions_decoder.decode_transaction_hashes(
                     ignore_cache=ignore_cache,
                     tx_hashes=entry['tx_hashes'],
+                    send_ws_notifications=True,
                 )
                 if entry['tx_hashes'] is not None and task_manager is not None:
                     # Trigger the task to query the missing prices for the decoded events


### PR DESCRIPTION
1. Set the ws message when decoding transactions by hash so it can be used by the frontend
2. Remove code only used in tests for the accountant