### PR TITLE
Add rust arch when building release binaries too

### DIFF
--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -216,6 +216,8 @@ jobs:
           make install
           echo "::endgroup::"
         working-directory: libffi
+      - name: Add rust target for building deps
+        run: rustup target add aarch64-apple-darwin
       - name: Cache python pkg
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
