### PR TITLE
Fix welcome message during version upgrade broken tag link

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` The welcome message at first login after a version upgrade will now have the correct link to the release notes.
+
 * :release:`1.31.0 <2023-11-24>`
 * :feature:`-` Oneinch v3 swaps should be supported in Ethereum mainnet.
 * :feature:`-` Attestation events for the Ethereum Attestation service in Mainnet, Optimism, Arbitrum One and Base will be properly shown to the user.

--- a/frontend/app/src/composables/update-message.ts
+++ b/frontend/app/src/composables/update-message.ts
@@ -5,7 +5,7 @@ export const useUpdateMessage = createSharedComposable(() => {
   const { appVersion } = storeToRefs(useMainStore());
 
   const link = computed(
-    () => `https://github.com/rotki/rotki/releases/tag/${get(appVersion)}`
+    () => `https://github.com/rotki/rotki/releases/tag/v${get(appVersion)}`
   );
 
   const setShowNotes = (appVersion: string, lastUsed: string): void => {


### PR DESCRIPTION
The welcome message at first login after a version upgrade will now have the correct link to the release notes.

It was a broken link since we prepend our tags with a `v` and it was missing that.
