### PR TITLE
Python 3.10 style type annotation

### DIFF
--- a/package.py
+++ b/package.py
@@ -9,10 +9,10 @@ import stat
 import subprocess
 import sys
 import urllib.request
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Literal
 from zipfile import ZipFile
 
 from setuptools_scm import get_version
@@ -64,7 +64,7 @@ def log_group(name: str) -> Callable:
             logger.info('\n\n-----------------\n\n')
 
     def decorate(fn: Callable) -> Callable:
-        def wrapper(*args: Any, **kwargs: Optional[Any]) -> None:
+        def wrapper(*args: Any, **kwargs: Any | None) -> None:
             start_group(name)
             fn(*args, **kwargs)
             end_group()
@@ -108,7 +108,7 @@ class Environment:
             env.setdefault(APPLE_ID_PASS, self.__appleidpass)
         return env
 
-    def macos_sign_vars(self) -> dict[str, Optional[str]]:
+    def macos_sign_vars(self) -> dict[str, str | None]:
         return {
             'certificate': self.__certificate_mac,
             'key': self.__csc_password,
@@ -122,7 +122,7 @@ class Environment:
             env.setdefault(CERTIFICATE_KEY, self.__csc_password)
         return env
 
-    def win_sign_vars(self) -> dict[str, Optional[str]]:
+    def win_sign_vars(self) -> dict[str, str | None]:
         return {
             'certificate': self.__certificate_win,
             'key': self.__csc_password,
@@ -299,7 +299,7 @@ class Storage:
             logger.error(f'{backend} was missing or empty')
             sys.exit(1)
 
-    def copy_to_dist(self, src: Path, sub_dir: Optional[str] = None) -> None:
+    def copy_to_dist(self, src: Path, sub_dir: str | None = None) -> None:
         self.dist_directory.mkdir(exist_ok=True)
 
         dst = self.dist_directory
@@ -413,7 +413,7 @@ class MacPackaging:
     def __init__(self, storage: Storage, environment: Environment) -> None:
         self.__storage = storage
         self.__environment = environment
-        self.__default_keychain: Optional[str] = None
+        self.__default_keychain: str | None = None
         self.__keychain = 'rotki-build.keychain'
         self.__p12 = '/tmp/certificate.p12'  # noqa: S108  # ask Kelsos if this canchange
 
@@ -836,8 +836,8 @@ class BackendBuilder:
             self,
             storage: Storage,
             env: Environment,
-            mac: Optional[MacPackaging],
-            win: Optional[WindowsPackaging],
+            mac: MacPackaging | None,
+            win: WindowsPackaging | None,
     ) -> None:
         self.__mac = mac
         self.__win = win
@@ -1028,7 +1028,7 @@ class BackendBuilder:
                 self.__rust_add_target(target=target)
                 self.__cargo_build(target=target)
 
-    def __cargo_build(self, target: Optional[str] = None) -> None:
+    def __cargo_build(self, target: str | None = None) -> None:
         colibri_directory = self.__storage.colibri_directory
         target_arg = ''
 
@@ -1132,8 +1132,8 @@ class FrontendBuilder:
             self,
             storage: Storage,
             env: Environment,
-            mac: Optional[MacPackaging],
-            win: Optional[WindowsPackaging],
+            mac: MacPackaging | None,
+            win: WindowsPackaging | None,
     ):
         self.__storage = storage
         self.__frontend_directory = storage.working_directory / 'frontend'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ exclude = [
 ]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.per-file-ignores]
 

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import gevent
 from more_itertools import peekable
@@ -45,7 +45,7 @@ class Accountant:
             db: 'DBHandler',
             msg_aggregator: MessagesAggregator,
             chains_aggregator: 'ChainsAggregator',
-            premium: Optional[Premium],
+            premium: Premium | None,
     ) -> None:
         self.db = db
         self.msg_aggregator = msg_aggregator
@@ -304,7 +304,7 @@ class Accountant:
         consumed_events = event.process(self.pots[0], events_iterator)
         return consumed_events, prev_time
 
-    def export(self, directory_path: Optional[Path]) -> tuple[bool, str]:
+    def export(self, directory_path: Path | None) -> tuple[bool, str]:
         """Export the PnL report. Only CSV for now
 
         If a directory is given, it simply exports all event.csv in the given directory.

--- a/rotkehlchen/accounting/cost_basis/base.py
+++ b/rotkehlchen/accounting/cost_basis/base.py
@@ -2,9 +2,9 @@ import heapq
 import logging
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Optional, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, overload
 
 from rotkehlchen.accounting.types import MissingAcquisition, MissingPrice
 from rotkehlchen.assets.asset import Asset
@@ -171,7 +171,7 @@ class BaseCostBasisMethod(metaclass=ABCMeta):
             used_acquisitions: list[AssetAcquisitionEvent],
             settings: DBSettings,
             timestamp_to_date: Callable[[Timestamp], str],
-            average_cost_basis: Optional[FVal] = None,
+            average_cost_basis: FVal | None = None,
     ) -> 'CostBasisInfo':
         """
         When spending `spending_amount` of `spending_asset` at `timestamp` this function
@@ -388,7 +388,7 @@ class AverageCostBasisMethod(BaseCostBasisMethod):
             used_acquisitions: list[AssetAcquisitionEvent],
             settings: DBSettings,
             timestamp_to_date: Callable[[Timestamp], str],
-            average_cost_basis: Optional[FVal] = None,  # pylint: disable=unused-argument
+            average_cost_basis: FVal | None = None,  # pylint: disable=unused-argument
     ) -> 'CostBasisInfo':
         """Calculates the cost basis of the spend using the average cost basis method."""
         if self.current_amount == ZERO:
@@ -656,7 +656,7 @@ class CostBasisCalculator(CustomizableDateMixin):
             amount: FVal,
             rate: FVal,
             taxable_spend: bool,
-    ) -> Optional[CostBasisInfo]:
+    ) -> CostBasisInfo | None:
         ...
 
     def spend_asset(
@@ -667,7 +667,7 @@ class CostBasisCalculator(CustomizableDateMixin):
             amount: FVal,
             rate: FVal,
             taxable_spend: bool,
-    ) -> Optional[CostBasisInfo]:
+    ) -> CostBasisInfo | None:
         """
         Register an asset spending event. For example from a trade, a fee, a swap.
 
@@ -698,7 +698,7 @@ class CostBasisCalculator(CustomizableDateMixin):
         self.reduce_asset_amount(asset=asset, amount=amount, timestamp=timestamp)
         return None
 
-    def get_calculated_asset_amount(self, asset: Asset) -> Optional[FVal]:
+    def get_calculated_asset_amount(self, asset: Asset) -> FVal | None:
         """Get the amount of asset accounting has calculated we should have after
         the history has been processed
         """

--- a/rotkehlchen/accounting/export/csv.py
+++ b/rotkehlchen/accounting/export/csv.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 from csv import DictWriter
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from rotkehlchen.accounting.pnl import PnlTotals
@@ -54,7 +54,7 @@ class CSVWriteError(Exception):
 def dict_to_csv_file(
         path: Path,
         dictionary_list: list,
-        headers: Optional[Collection] = None,
+        headers: Collection | None = None,
 ) -> None:
     """Takes a filepath and a list of dictionaries representing the rows and writes them
     into the file as a CSV

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.rules import AccountingRulesManager
@@ -137,7 +137,7 @@ class EventsAccountant:
             timestamp: Timestamp,
             out_event: HistoryBaseEntry,
             in_event: HistoryBaseEntry,
-            fee_event: Optional[HistoryBaseEntry],
+            fee_event: HistoryBaseEntry | None,
             event_settings: BaseEventSettings,
             general_extra_data: dict[str, Any],
     ) -> int:

--- a/rotkehlchen/accounting/pnl.py
+++ b/rotkehlchen/accounting/pnl.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Iterator, MutableMapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.constants import ZERO
 from rotkehlchen.fval import FVal
@@ -31,7 +31,7 @@ class PNL:
     def __add__(self, x: Any) -> 'PNL':
         if isinstance(x, PNL):
             return PNL(taxable=self.taxable + x.taxable, free=self.free + x.free)
-        if isinstance(x, (FVal, int)):
+        if isinstance(x, FVal | int):
             return PNL(taxable=self.taxable + x, free=self.free + x)
 
         raise TypeError(f'Cant add type {type(x)} to PNL')
@@ -41,7 +41,7 @@ class PNL:
     def __sub__(self, x: Any) -> 'PNL':
         if isinstance(x, PNL):
             return PNL(taxable=self.taxable - x.taxable, free=self.free - x.free)
-        if isinstance(x, (FVal, int)):
+        if isinstance(x, FVal | int):
             return PNL(taxable=self.taxable - x, free=self.free - x)
 
         raise TypeError(f'Cant sub type {type(x)} from PNL')
@@ -51,7 +51,7 @@ class PNL:
     def __mul__(self, x: Any) -> 'PNL':
         if isinstance(x, PNL):
             return PNL(taxable=self.taxable * x.taxable, free=self.free * x.free)
-        if isinstance(x, (FVal, int)):
+        if isinstance(x, FVal | int):
             return PNL(taxable=self.taxable * x, free=self.free * x)
 
         raise TypeError(f'Cant mul type {type(x)} with PNL')
@@ -61,7 +61,7 @@ class PNL:
 
 class PnlTotals(MutableMapping):
 
-    def __init__(self, totals: Optional[dict['AccountingEventType', PNL]] = None) -> None:
+    def __init__(self, totals: dict['AccountingEventType', PNL] | None = None) -> None:
         self.totals: dict[AccountingEventType, PNL] = defaultdict(PNL)
         if totals is not None:
             for event_type, entry in totals.items():

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.accounting.cost_basis import CostBasisCalculator
 from rotkehlchen.accounting.cost_basis.prefork import (
@@ -74,7 +74,7 @@ class AccountingPot(CustomizableDateMixin):
             pot=self,
         )
         self.query_start_ts = self.query_end_ts = Timestamp(0)
-        self.report_id: Optional[int] = None
+        self.report_id: int | None = None
 
     def _add_processed_event(self, event: ProcessedAccountingEvent) -> None:
         dbpnl = DBAccountingReports(self.database)
@@ -140,8 +140,8 @@ class AccountingPot(CustomizableDateMixin):
             asset: Asset,
             amount: FVal,
             taxable: bool,
-            given_price: Optional[Price] = None,
-            extra_data: Optional[dict] = None,
+            given_price: Price | None = None,
+            extra_data: dict | None = None,
             **kwargs: Any,  # to be able to consume args given by add_asset_change_event
     ) -> None:
         """Add an asset acquisition event for the pot and count it in PnL if needed.
@@ -218,11 +218,11 @@ class AccountingPot(CustomizableDateMixin):
             asset: Asset,
             amount: FVal,
             taxable: bool,
-            given_price: Optional[Price] = None,
+            given_price: Price | None = None,
             taxable_amount_ratio: FVal = ONE,
             count_entire_amount_spend: bool = True,
             count_cost_basis_pnl: bool = True,
-            extra_data: Optional[dict[str, Any]] = None,
+            extra_data: dict[str, Any] | None = None,
     ) -> tuple[FVal, FVal]:
         """Add an asset spend event for the pot and count it in PnL if needed
 
@@ -315,7 +315,7 @@ class AccountingPot(CustomizableDateMixin):
             asset: Asset,
             amount: FVal,
             taxable: bool,
-            given_price: Optional[Price] = None,
+            given_price: Price | None = None,
             **kwargs: Any,
     ) -> None:
         if self.is_dummy_pot:
@@ -341,8 +341,8 @@ class AccountingPot(CustomizableDateMixin):
             asset_in: Asset,
             amount_out: FVal,
             asset_out: Asset,
-            fee_info: Optional[tuple[FVal, Asset]],
-    ) -> Optional[tuple[Price, Price]]:
+            fee_info: tuple[FVal, Asset] | None,
+    ) -> tuple[Price, Price] | None:
         """
         Calculates the prices for assets going in and out of a swap/trade.
 

--- a/rotkehlchen/accounting/rules.py
+++ b/rotkehlchen/accounting/rules.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry, get_event_type_identifier
 from rotkehlchen.accounting.structures.evm_event import EvmEvent
@@ -43,7 +43,7 @@ class AccountingRulesManager:
     def get_event_settings(
             self,
             event: HistoryBaseEntry,
-    ) -> tuple[Optional[BaseEventSettings], Optional[EventsAccountantCallback]]:
+    ) -> tuple[BaseEventSettings | None, EventsAccountantCallback | None]:
         """
         Return a matching rule for the event if it exists and an optional callback defined for
         the rule that should be executed

--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import auto
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar
 
 from rotkehlchen.accounting.constants import EVENT_CATEGORY_MAPPINGS
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
@@ -44,11 +44,11 @@ HISTORY_EVENT_DB_TUPLE_WRITE = tuple[
     int,            # sequence_index
     int,            # timestamp
     str,            # location
-    Optional[str],  # location label
+    str | None,  # location label
     str,            # asset
     str,            # amount
     str,            # usd value
-    Optional[str],  # notes
+    str | None,  # notes
     str,            # type
     str,            # subtype
 ]
@@ -75,9 +75,9 @@ class HistoryBaseEntryData(TypedDict):
     event_subtype: HistoryEventSubType
     asset: Asset
     balance: Balance
-    location_label: Optional[str]
-    notes: Optional[str]
-    identifier: Optional[int]
+    location_label: str | None
+    notes: str | None
+    identifier: int | None
 
 
 T = TypeVar('T', bound='HistoryBaseEntry')
@@ -99,9 +99,9 @@ class HistoryBaseEntry(AccountingEventMixin, metaclass=ABCMeta):
             event_subtype: HistoryEventSubType,
             asset: Asset,
             balance: Balance,
-            location_label: Optional[str] = None,
-            notes: Optional[str] = None,
-            identifier: Optional[int] = None,
+            location_label: str | None = None,
+            notes: str | None = None,
+            identifier: int | None = None,
     ) -> None:
         """
         - `event_identifier`: the identifier shared between related events
@@ -259,7 +259,7 @@ class HistoryBaseEntry(AccountingEventMixin, metaclass=ABCMeta):
             ignored_ids_mapping: dict[ActionType, set[str]],
             hidden_event_ids: list[int],
             missing_accounting_rule: bool,
-            grouped_events_num: Optional[int] = None,
+            grouped_events_num: int | None = None,
     ) -> dict[str, Any]:
         """Serialize event and extra flags for api"""
         result: dict[str, Any] = {'entry': self.serialize()}
@@ -375,9 +375,9 @@ class HistoryEvent(HistoryBaseEntry):
             event_subtype: HistoryEventSubType,
             asset: Asset,
             balance: Balance,
-            location_label: Optional[str] = None,
-            notes: Optional[str] = None,
-            identifier: Optional[int] = None,
+            location_label: str | None = None,
+            notes: str | None = None,
+            identifier: int | None = None,
     ) -> None:
         super().__init__(
             event_identifier=event_identifier,
@@ -515,7 +515,7 @@ class StakingEvent:
 def get_event_type_identifier(
         event_type: HistoryEventType,
         event_subtype: HistoryEventSubType,
-        counterparty: Optional[str] = None,
+        counterparty: str | None = None,
 ) -> int:
     key = f'{event_type.serialize()}{event_subtype.serialize()}'
     if counterparty is not None:

--- a/rotkehlchen/accounting/structures/defi.py
+++ b/rotkehlchen/accounting/structures/defi.py
@@ -1,7 +1,7 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.assets.asset import Asset, CryptoAsset
@@ -47,16 +47,16 @@ class DefiEvent(AccountingEventMixin):
     timestamp: Timestamp
     wrapped_event: Any
     event_type: DefiEventType
-    got_asset: Optional[CryptoAsset]
+    got_asset: CryptoAsset | None
     got_balance: Optional['Balance']
-    spent_asset: Optional[CryptoAsset]
+    spent_asset: CryptoAsset | None
     spent_balance: Optional['Balance']
-    pnl: Optional[list['AssetBalance']]
+    pnl: list['AssetBalance'] | None
     # If this is true then both got and spent asset count in cost basis
     # So it will count as if you got asset at given amount and price of timestamp
     # and spent asset at given amount and price of timestamp
     count_spent_got_cost_basis: bool
-    tx_hash: Optional[EVMTxHash] = None
+    tx_hash: EVMTxHash | None = None
 
     def __str__(self) -> str:
         """Default string constructor"""

--- a/rotkehlchen/accounting/structures/eth2.py
+++ b/rotkehlchen/accounting/structures/eth2.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -33,7 +33,7 @@ ETH_STAKING_EVENT_DB_TUPLE_READ = tuple[
     str,            # event_identifier
     int,            # sequence_index
     int,            # timestamp
-    Optional[str],  # location label
+    str | None,  # location label
     str,            # amount
     str,            # usd value
     str,            # event_subtype
@@ -72,7 +72,7 @@ class EthStakingEvent(HistoryBaseEntry, metaclass=ABCMeta):  # noqa: PLW1641  # 
             location_label: ChecksumEvmAddress,
             is_exit_or_blocknumber: int,
             notes: str,
-            identifier: Optional[int] = None,
+            identifier: int | None = None,
     ) -> None:
         self.validator_index = validator_index
         self.is_exit_or_blocknumber = is_exit_or_blocknumber
@@ -121,8 +121,8 @@ class EthWithdrawalEvent(EthStakingEvent):
             balance: Balance,
             withdrawal_address: ChecksumEvmAddress,
             is_exit: bool,
-            identifier: Optional[int] = None,
-            event_identifier: Optional[str] = None,
+            identifier: int | None = None,
+            event_identifier: str | None = None,
     ) -> None:
         if event_identifier is None:
             # withdrawals happen at least every couple of days. For them to happen in the same
@@ -241,8 +241,8 @@ class EthBlockEvent(EthStakingEvent):
             fee_recipient: ChecksumEvmAddress,
             block_number: int,
             is_mev_reward: bool,
-            identifier: Optional[int] = None,
-            event_identifier: Optional[str] = None,
+            identifier: int | None = None,
+            event_identifier: str | None = None,
     ) -> None:
 
         if is_mev_reward:
@@ -375,9 +375,9 @@ class EthDepositEvent(EvmEvent, EthStakingEvent):  # noqa: PLW1641  # hash in su
             timestamp: TimestampMS,
             balance: Balance,
             depositor: ChecksumEvmAddress,
-            extra_data: Optional[dict[str, Any]] = None,
-            identifier: Optional[int] = None,
-            event_identifier: Optional[str] = None,
+            extra_data: dict[str, Any] | None = None,
+            identifier: int | None = None,
+            event_identifier: str | None = None,
     ) -> None:
         suffix = f'{validator_index}' if validator_index != UNKNOWN_VALIDATOR_INDEX else 'with a not yet known validator index'  # noqa: E501
         super().__init__(  # super should call evm event

--- a/rotkehlchen/accounting/structures/evm_event.py
+++ b/rotkehlchen/accounting/structures/evm_event.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from enum import auto
-from typing import TYPE_CHECKING, Any, Final, Optional, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.structures.balance import Balance
@@ -92,14 +92,14 @@ class EvmEvent(HistoryBaseEntry):  # noqa: PLW1641  # hash in superclass
             event_subtype: HistoryEventSubType,
             asset: Asset,
             balance: Balance,
-            location_label: Optional[str] = None,
-            notes: Optional[str] = None,
-            identifier: Optional[int] = None,
-            counterparty: Optional[str] = None,
-            product: Optional[EvmProduct] = None,
-            address: Optional[ChecksumEvmAddress] = None,
-            extra_data: Optional[dict[str, Any]] = None,
-            event_identifier: Optional[str] = None,
+            location_label: str | None = None,
+            notes: str | None = None,
+            identifier: int | None = None,
+            counterparty: str | None = None,
+            product: EvmProduct | None = None,
+            address: ChecksumEvmAddress | None = None,
+            extra_data: dict[str, Any] | None = None,
+            event_identifier: str | None = None,
     ) -> None:
         if event_identifier is None:
             calculated_event_identifier = f'{location.to_chain_id()}{tx_hash.hex()}'
@@ -172,7 +172,7 @@ class EvmEvent(HistoryBaseEntry):  # noqa: PLW1641  # hash in superclass
             ignored_ids_mapping: dict[ActionType, set[str]],
             hidden_event_ids: list[int],
             missing_accounting_rule: bool,
-            grouped_events_num: Optional[int] = None,
+            grouped_events_num: int | None = None,
     ) -> dict[str, Any]:
         result = super().serialize_for_api(
             customized_event_ids=customized_event_ids,
@@ -224,7 +224,7 @@ class EvmEvent(HistoryBaseEntry):  # noqa: PLW1641  # hash in superclass
             return False
         return len(self.extra_data.keys() & ALL_DETAILS_KEYS) > 0
 
-    def get_details(self) -> Optional[dict[str, Any]]:
+    def get_details(self) -> dict[str, Any] | None:
         if self.extra_data is None:
             return None
 

--- a/rotkehlchen/accounting/structures/processed_event.py
+++ b/rotkehlchen/accounting/structures/processed_event.py
@@ -1,8 +1,9 @@
 import builtins
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, Callable, Literal, Optional, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 
 from rotkehlchen.accounting.cost_basis import CostBasisInfo
 from rotkehlchen.accounting.mixins.event import AccountingEventType
@@ -42,7 +43,7 @@ class ProcessedAccountingEvent:
     taxable_amount: FVal
     price: Price
     pnl: PNL
-    cost_basis: Optional[CostBasisInfo]
+    cost_basis: CostBasisInfo | None
     index: int
     # This is set only for some events to remember extra data that can be used later
     # such as the transaction hash of an event
@@ -65,7 +66,7 @@ class ProcessedAccountingEvent:
             self,
             ts_converter: Callable[[Timestamp], str],
             export_type: Literal[AccountingEventExportType.CSV],
-            evm_explorer: Optional[str],
+            evm_explorer: str | None,
     ) -> dict[str, Any]:
         ...
 
@@ -81,7 +82,7 @@ class ProcessedAccountingEvent:
             self,
             ts_converter: Callable[[Timestamp], str],
             export_type: AccountingEventExportType,
-            evm_explorer: Optional[str] = None,
+            evm_explorer: str | None = None,
     ) -> dict[str, Any]:
         """These are the fields that will appear in CSV, report API and are also exported to the
         database.

--- a/rotkehlchen/accounting/structures/types.py
+++ b/rotkehlchen/accounting/structures/types.py
@@ -1,15 +1,15 @@
 from enum import Enum, auto
-from typing import Any, Literal, NamedTuple, Optional
+from typing import Any, Literal, NamedTuple
 
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.utils.mixins.enums import DBCharEnumMixIn, SerializableEnumNameMixin
 
 EVM_EVENT_FIELDS = tuple[
     bytes,          # tx_hash
-    Optional[str],  # counterparty
-    Optional[str],  # product
-    Optional[str],  # address
-    Optional[str],  # extra_data
+    str | None,  # counterparty
+    str | None,  # product
+    str | None,  # address
+    str | None,  # extra_data
 ]
 
 
@@ -19,18 +19,18 @@ EVM_EVENT_DB_TUPLE_READ = tuple[
     int,            # sequence_index
     int,            # timestamp
     str,            # location
-    Optional[str],  # location label
+    str | None,  # location label
     str,            # asset
     str,            # amount
     str,            # usd value
-    Optional[str],  # notes
+    str | None,  # notes
     str,            # type
     str,            # subtype
     bytes,          # tx_hash
     str,            # address
-    Optional[str],  # counterparty
-    Optional[str],  # product
-    Optional[str],  # extra_data
+    str | None,  # counterparty
+    str | None,  # product
+    str | None,  # extra_data
 ]
 
 
@@ -103,7 +103,7 @@ class HistoryEventSubType(SerializableEnumNameMixin):
     CREATE = auto()  # used when tx creates a new entity like Maker vault or Gnosis safe
     ATTEST = auto()
 
-    def serialize_or_none(self) -> Optional[str]:
+    def serialize_or_none(self) -> str | None:
         return self.serialize()
 
 
@@ -117,7 +117,7 @@ class EventDirection(SerializableEnumNameMixin):
 class EventCategoryDetails(NamedTuple):
     label: str
     icon: str
-    color: Optional[Literal['success', 'error']] = None
+    color: Literal['success', 'error'] | None = None
 
     def serialize(self) -> dict[str, Any]:
         result = {'label': self.label, 'icon': self.icon}

--- a/rotkehlchen/accounting/types.py
+++ b/rotkehlchen/accounting/types.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, NamedTuple, Union
+from typing import Any, NamedTuple
 
 import jsonschema
 
@@ -112,7 +112,7 @@ class MissingAcquisition(NamedTuple):
     found_amount: FVal
     missing_amount: FVal
 
-    def serialize(self) -> dict[str, Union[str, int]]:
+    def serialize(self) -> dict[str, str | int]:
         return {
             'asset': self.asset.identifier,
             'time': self.time,
@@ -127,7 +127,7 @@ class MissingPrice(NamedTuple):
     time: Timestamp
     rate_limited: bool
 
-    def serialize(self) -> dict[str, Union[str, int, bool]]:
+    def serialize(self) -> dict[str, str | (int | bool)]:
         return {
             'from_asset': self.from_asset.identifier,
             'to_asset': self.to_asset.identifier,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3499,7 +3499,7 @@ class RestAPI:
                 evm_accounting_aggregator=accountant_pot.events_accountant.evm_accounting_aggregators,
                 events=[x for _, x in events_result],  # type: ignore
                 accountant=self.rotkehlchen.accountant,
-            )
+            )  # length of missing_accounting_rules and events guaranteeed by function
             entries = [  # type: ignore  # mypy doesn't understand significance of boolean check
                 x.serialize_for_api(  # type: ignore
                     customized_event_ids=customized_event_ids,
@@ -3507,7 +3507,7 @@ class RestAPI:
                     hidden_event_ids=hidden_event_ids,
                     missing_accounting_rule=missing_accounting_rule,
                     grouped_events_num=grouped_events_num,  # type: ignore
-                ) for (grouped_events_num, x), missing_accounting_rule in zip(events_result, missing_accounting_rules)  # noqa: E501
+                ) for (grouped_events_num, x), missing_accounting_rule in zip(events_result, missing_accounting_rules, strict=True)  # noqa: E501
             ]
         else:
             missing_accounting_rules = query_missing_accounting_rules(
@@ -3523,7 +3523,7 @@ class RestAPI:
                     ignored_ids_mapping=ignored_ids_mapping,
                     hidden_event_ids=hidden_event_ids,
                     missing_accounting_rule=missing_accounting_rule,
-                ) for x, missing_accounting_rule in zip(events_result, missing_accounting_rules)
+                ) for x, missing_accounting_rule in zip(events_result, missing_accounting_rules, strict=True)  # noqa: E501
             ]
         result = {
             'entries': entries,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -6,11 +6,11 @@ import sys
 import tempfile
 import traceback
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import reduce
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast, get_args, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast, get_args, overload
 from zipfile import BadZipFile, ZipFile
 
 import gevent
@@ -266,7 +266,7 @@ def _wrap_in_result(result: Any, message: str) -> dict[str, Any]:
     return {'result': result, 'message': message}
 
 
-def wrap_in_fail_result(message: str, status_code: Optional[HTTPStatus] = None) -> dict[str, Any]:
+def wrap_in_fail_result(message: str, status_code: HTTPStatus | None = None) -> dict[str, Any]:
     result: dict[str, Any] = {'result': None, 'message': message}
     if status_code:
         result['status_code'] = status_code
@@ -453,7 +453,7 @@ class RestAPI:
             result_dict = _wrap_in_ok_result(process_result(self.rotkehlchen.get_settings(cursor)))
         return api_response(result=result_dict, status_code=HTTPStatus.OK)
 
-    def query_tasks_outcome(self, task_id: Optional[int]) -> Response:
+    def query_tasks_outcome(self, task_id: int | None) -> Response:
         if task_id is None:
             # If no task id is given return list of all pending and completed tasks
             completed = []
@@ -542,7 +542,7 @@ class RestAPI:
 
     def _return_external_services_response(self) -> Response:
         credentials_list = self.rotkehlchen.data.db.get_all_external_service_credentials()
-        response_dict: dict[str, Union[dict[str, ApiKey], dict[str, dict[str, ApiKey]]]] = {}
+        response_dict: dict[str, dict[str, ApiKey] | dict[str, dict[str, ApiKey]]] = {}
         for credential in credentials_list:
             name = credential.service.name.lower()
             key_info = {'api_key': credential.api_key}
@@ -578,9 +578,9 @@ class RestAPI:
             location: Location,
             api_key: ApiKey,
             api_secret: ApiSecret,
-            passphrase: Optional[str],
+            passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
-            binance_markets: Optional[list[str]],
+            binance_markets: list[str] | None,
     ) -> Response:
         result = None
         status_code = HTTPStatus.OK
@@ -604,12 +604,12 @@ class RestAPI:
             self,
             name: str,
             location: Location,
-            new_name: Optional[str],
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
+            new_name: str | None,
+            api_key: ApiKey | None,
+            api_secret: ApiSecret | None,
+            passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
-            binance_markets: Optional[list[str]],
+            binance_markets: list[str] | None,
     ) -> Response:
         edited, msg = self.rotkehlchen.exchange_manager.edit_exchange(
             name=name,
@@ -621,7 +621,7 @@ class RestAPI:
             kraken_account_type=kraken_account_type,
             binance_selected_trade_pairs=binance_markets,
         )
-        result: Optional[bool] = True
+        result: bool | None = True
         status_code = HTTPStatus.OK
         if not edited:
             result = None
@@ -630,7 +630,7 @@ class RestAPI:
         return api_response(_wrap_in_result(result, msg), status_code=status_code)
 
     def remove_exchange(self, name: str, location: Location) -> Response:
-        result: Optional[bool]
+        result: bool | None
         result, message = self.rotkehlchen.exchange_manager.delete_exchange(
             name=name,
             location=location,
@@ -668,7 +668,7 @@ class RestAPI:
         return {'result': result, 'message': error_msg, 'status_code': status_code}
 
     @async_api_call()
-    def query_exchange_balances(self, location: Optional[Location], ignore_cache: bool) -> dict[str, Any]:  # noqa: E501
+    def query_exchange_balances(self, location: Location | None, ignore_cache: bool) -> dict[str, Any]:  # noqa: E501
         if location is None:
             # Query all exchanges
             return self._query_all_exchange_balances(ignore_cache=ignore_cache)
@@ -718,7 +718,7 @@ class RestAPI:
     @async_api_call()
     def query_blockchain_balances(
             self,
-            blockchain: Optional[SupportedBlockchain],
+            blockchain: SupportedBlockchain | None,
             ignore_cache: bool,
     ) -> dict[str, Any]:
         msg = ''
@@ -795,10 +795,10 @@ class RestAPI:
             trade_type: TradeType,
             amount: AssetAmount,
             rate: Price,
-            fee: Optional[Fee],
-            fee_currency: Optional[Asset],
-            link: Optional[str],
-            notes: Optional[str],
+            fee: Fee | None,
+            fee_currency: Asset | None,
+            link: str | None,
+            notes: str | None,
     ) -> Response:
         trade = Trade(
             timestamp=timestamp,
@@ -831,10 +831,10 @@ class RestAPI:
             trade_type: TradeType,
             amount: AssetAmount,
             rate: Price,
-            fee: Optional[Fee],
-            fee_currency: Optional[Asset],
-            link: Optional[str],
-            notes: Optional[str],
+            fee: Fee | None,
+            fee_currency: Asset | None,
+            link: str | None,
+            notes: str | None,
     ) -> Response:
         trade = Trade(
             timestamp=timestamp,
@@ -961,7 +961,7 @@ class RestAPI:
     def add_tag(
             self,
             name: str,
-            description: Optional[str],
+            description: str | None,
             background_color: HexColorCode,
             foreground_color: HexColorCode,
     ) -> Response:
@@ -983,9 +983,9 @@ class RestAPI:
     def edit_tag(
             self,
             name: str,
-            description: Optional[str],
-            background_color: Optional[HexColorCode],
-            foreground_color: Optional[HexColorCode],
+            description: str | None,
+            background_color: HexColorCode | None,
+            foreground_color: HexColorCode | None,
     ) -> Response:
         try:
             with self.rotkehlchen.data.db.user_write() as cursor:
@@ -1028,7 +1028,7 @@ class RestAPI:
             premium_api_key: str,
             premium_api_secret: str,
             sync_database: bool,
-            initial_settings: Optional[ModifiableDBSettings],
+            initial_settings: ModifiableDBSettings | None,
     ) -> dict[str, Any]:
 
         if self.rotkehlchen.user_is_logged_in:
@@ -1304,7 +1304,7 @@ class RestAPI:
     def search_assets_levenshtein(
             self,
             filter_query: LevenshteinFilterQuery,
-            limit: Optional[int],
+            limit: int | None,
             search_nfts: bool,
     ) -> Response:
         result = search_assets_levenshtein(
@@ -1450,8 +1450,8 @@ class RestAPI:
 
     def query_timed_balances_data(
             self,
-            asset: Optional[Asset],
-            collection_id: Optional[int],
+            asset: Asset | None,
+            collection_id: int | None,
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
     ) -> Response:
@@ -1482,7 +1482,7 @@ class RestAPI:
         )
 
     def query_value_distribution_data(self, distribution_by: str) -> Response:
-        data: Union[list[DBAssetBalance], list[LocationData]]
+        data: list[DBAssetBalance] | list[LocationData]
         if distribution_by == 'location':
             data = self.rotkehlchen.data.db.get_latest_location_value_distribution()
         else:
@@ -1536,7 +1536,7 @@ class RestAPI:
             self,
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
-            directory_path: Optional[Path],
+            directory_path: Path | None,
     ) -> dict[str, Any]:
         """This method exports all history events for a timestamp range.
         It also exports the user settings & ignored action identifiers for PnL debugging.
@@ -1589,7 +1589,7 @@ class RestAPI:
         def import_history_debug(
                 self,
                 async_query: bool,
-                filepath: Union[FileStorage, Path],
+                filepath: FileStorage | Path,
         ) -> Response:
             if isinstance(filepath, FileStorage):
                 _, tmpfilepath = tempfile.mkstemp()
@@ -1864,11 +1864,11 @@ class RestAPI:
 
     def _modify_manually_tracked_balances(
             self,
-            function: Union[
-                Callable[['DBHandler', list[ManuallyTrackedBalance]], None],
-                Callable[['DBHandler', list[int]], None],
-            ],
-            data_or_ids: Union[list[ManuallyTrackedBalance], list[int]],
+            function: (
+                Callable[['DBHandler', list[ManuallyTrackedBalance]], None] |
+                Callable[['DBHandler', list[int]], None]
+            ),
+            data_or_ids: list[ManuallyTrackedBalance] | list[int],
     ) -> dict[str, Any]:
         try:
             function(self.rotkehlchen.data.db, data_or_ids)  # type: ignore
@@ -2032,7 +2032,7 @@ class RestAPI:
             self,
             async_query: bool,
             source: DataImportSource,
-            filepath: Union[FileStorage, Path],
+            filepath: FileStorage | Path,
             **kwargs: Any,
     ) -> Response:
         if isinstance(filepath, FileStorage):
@@ -2139,8 +2139,8 @@ class RestAPI:
     @async_api_call()
     def add_eth2_validator(
             self,
-            validator_index: Optional[int],
-            public_key: Optional[Eth2PubKey],
+            validator_index: int | None,
+            public_key: Eth2PubKey | None,
             ownership_proportion: FVal,
     ) -> dict[str, Any]:
         try:
@@ -2266,7 +2266,7 @@ class RestAPI:
         manager.node_inquirer.connect_to_multiple_nodes(nodes_to_connect)
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
-    def purge_module_data(self, module_name: Optional[ModuleName]) -> Response:
+    def purge_module_data(self, module_name: ModuleName | None) -> Response:
         self.rotkehlchen.data.db.purge_module_data(module_name)
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
@@ -2274,7 +2274,7 @@ class RestAPI:
             self,
             module_name: ModuleName,
             method: str,
-            query_specific_balances_before: Optional[list[str]],
+            query_specific_balances_before: list[str] | None,
             **kwargs: Any,
     ) -> dict[str, Any]:
         """A function abstracting away calls to ethereum modules
@@ -2591,7 +2591,7 @@ class RestAPI:
     def _watcher_query(
             self,
             method: Literal['GET', 'PUT', 'PATCH', 'DELETE'],
-            data: Optional[dict[str, Any]],
+            data: dict[str, Any] | None,
     ) -> Response:
         try:
             # we know that premium exists here due to require_premium_user
@@ -2618,7 +2618,7 @@ class RestAPI:
     def delete_watchers(self, watchers: list[str]) -> Response:
         return self._watcher_query(method='DELETE', data={'watchers': watchers})
 
-    def purge_exchange_data(self, location: Optional[Location]) -> Response:
+    def purge_exchange_data(self, location: Location | None) -> Response:
         with self.rotkehlchen.data.db.user_write() as cursor:
             if location:
                 self.rotkehlchen.data.db.purge_exchange_data(cursor, location)
@@ -2628,7 +2628,7 @@ class RestAPI:
 
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
-    def purge_evm_transaction_data(self, chain_id: Optional[SUPPORTED_CHAIN_IDS]) -> Response:
+    def purge_evm_transaction_data(self, chain_id: SUPPORTED_CHAIN_IDS | None) -> Response:
         chain = None if chain_id is None else chain_id.to_blockchain()
         DBEvmTx(self.rotkehlchen.data.db).purge_evm_transaction_data(
             chain=chain,  # type: ignore  # chain_id.to_blockchain() will only give supported chain
@@ -2678,7 +2678,7 @@ class RestAPI:
             )
 
             entries_result = [{'entry': entry.serialize()} for entry in transactions]
-            result: Optional[dict[str, Any]] = None
+            result: dict[str, Any] | None = None
             kwargs = {}
             if filter_query.chain_id is not None:
                 kwargs['chain_id'] = filter_query.chain_id.serialize_for_db()
@@ -2793,7 +2793,7 @@ class RestAPI:
     def get_asset_icon(
             self,
             asset: AssetWithNameAndType,
-            match_header: Optional[str],
+            match_header: str | None,
     ) -> Response:
         icon_path = self.rotkehlchen.icon_manager.asset_icon_path(asset)
         if icon_path is not None:
@@ -2857,8 +2857,8 @@ class RestAPI:
             f'{", ".join([asset.identifier for asset in assets])}',
         )
         # Type is list instead of tuple here because you can't serialize a tuple
-        assets_price: dict[Asset, list[Union[Price, Optional[int], bool]]] = {}
-        oracle: Optional[CurrentPriceOracle]
+        assets_price: dict[Asset, list[Price | (int | None | bool)]] = {}
+        oracle: CurrentPriceOracle | None
         for asset in assets:
             if asset != target_asset:
                 if asset.asset_type == AssetType.NFT:
@@ -3027,8 +3027,8 @@ class RestAPI:
     @async_api_call()
     def perform_assets_updates(
             self,
-            up_to_version: Optional[int],
-            conflicts: Optional[dict[Asset, Literal['remote', 'local']]],
+            up_to_version: int | None,
+            conflicts: dict[Asset, Literal['remote', 'local']] | None,
     ) -> dict[str, Any]:
         try:
             result = self.rotkehlchen.assets_updater.perform_update(up_to_version, conflicts)
@@ -3123,8 +3123,8 @@ class RestAPI:
 
     def get_manual_prices(
             self,
-            from_asset: Optional[Asset],
-            to_asset: Optional[Asset],
+            from_asset: Asset | None,
+            to_asset: Asset | None,
     ) -> Response:
         return api_response(
             _wrap_in_ok_result(GlobalDBHandler().get_manual_prices(from_asset, to_asset)),
@@ -3211,8 +3211,8 @@ class RestAPI:
 
     def get_manual_latest_prices(
             self,
-            from_asset: Optional[Asset],
-            to_asset: Optional[Asset],
+            from_asset: Asset | None,
+            to_asset: Asset | None,
     ) -> Response:
         prices = GlobalDBHandler().get_all_manual_latest_prices(
             from_asset=from_asset,
@@ -3356,7 +3356,7 @@ class RestAPI:
 
     def get_pnl_reports(
             self,
-            report_id: Optional[int],
+            report_id: int | None,
     ) -> Response:
         with_limit = False
         entries_limit = -1
@@ -3556,7 +3556,7 @@ class RestAPI:
             event_subtypes=None,
         )
 
-    def get_user_added_assets(self, path: Optional[Path]) -> Response:
+    def get_user_added_assets(self, path: Path | None) -> Response:
         """
         Creates a zip file with the list of assets added by the user. If path is not None the zip
         file is saved in that folder and a json response including the path is returned.
@@ -3852,7 +3852,7 @@ class RestAPI:
     def detect_evm_tokens(
             self,
             only_cache: bool,
-            addresses: Optional[Sequence[ChecksumEvmAddress]],
+            addresses: Sequence[ChecksumEvmAddress] | None,
             blockchain: SUPPORTED_EVM_CHAINS,
     ) -> dict[str, Any]:
         manager: EvmManager = self.rotkehlchen.chains_aggregator.get_chain_manager(blockchain)
@@ -4045,8 +4045,8 @@ class RestAPI:
             event_types: list[HistoryEventType],
             query_filter: HistoryEventFilterQuery,
             value_filter: HistoryEventFilterQuery,
-            event_subtypes: Optional[list[HistoryEventSubType]] = None,
-            exclude_subtypes: Optional[list[HistoryEventSubType]] = None,
+            event_subtypes: list[HistoryEventSubType] | None = None,
+            exclude_subtypes: list[HistoryEventSubType] | None = None,
     ) -> dict[str, Any]:
         """Query exchanges for either staking or savings history.
 
@@ -4158,7 +4158,7 @@ class RestAPI:
             result.append({'id': chain.value, 'name': name, 'label': label})
         return api_response(result=_wrap_in_ok_result(result=result))
 
-    def get_ens_avatar(self, ens_name: str, match_header: Optional[str]) -> Response:
+    def get_ens_avatar(self, ens_name: str, match_header: str | None) -> Response:
         """
         Searches for the ENS avatar of the given `ens_name`.
         If found returns a response with the avatar, otherwise a 404 empty response if
@@ -4207,7 +4207,7 @@ class RestAPI:
 
         return maybe_create_image_response(image_path=avatar_path)
 
-    def clear_icons_cache(self, icons: Optional[list[AssetWithNameAndType]]) -> Response:
+    def clear_icons_cache(self, icons: list[AssetWithNameAndType] | None) -> Response:
         """Clears cache entries for the specified icons.
 
         If no icons are provided, the icons cache is cleared entirely.
@@ -4225,7 +4225,7 @@ class RestAPI:
 
         return api_response(OK_RESULT)
 
-    def clear_avatars_cache(self, avatars: Optional[list[str]]) -> Response:
+    def clear_avatars_cache(self, avatars: list[str] | None) -> Response:
         """Clears cache entries for the specified avatars of ENS names.
 
         If no avatars are provided, the avatars cache is cleared entirely.
@@ -4373,7 +4373,7 @@ class RestAPI:
         summary = get_skipped_external_events_summary(self.rotkehlchen)
         return api_response(result=_wrap_in_ok_result(summary), status_code=HTTPStatus.OK)
 
-    def export_skipped_external_events(self, directory_path: Optional[Path]) -> Response:
+    def export_skipped_external_events(self, directory_path: Path | None) -> Response:
         try:
             exportpath = export_skipped_external_events(
                 rotki=self.rotkehlchen,
@@ -4408,7 +4408,7 @@ class RestAPI:
     def export_history_events(
             self,
             filter_query: HistoryBaseEntryFilterQuery,
-            directory_path: Optional[Path],
+            directory_path: Path | None,
     ) -> Response:
         """ Export or Download history events data to a CSV file."""
         dbevents = DBHistoryEvents(self.rotkehlchen.data.db)
@@ -4478,7 +4478,7 @@ class RestAPI:
             self,
             event_type: HistoryEventType,
             event_subtype: HistoryEventSubType,
-            counterparty: Optional[str],
+            counterparty: str | None,
             rule: 'BaseEventSettings',
             links: dict[LINKABLE_ACCOUNTING_PROPERTIES, LINKABLE_ACCOUNTING_SETTINGS_NAME],
     ) -> Response:
@@ -4500,7 +4500,7 @@ class RestAPI:
             self,
             event_type: HistoryEventType,
             event_subtype: HistoryEventSubType,
-            counterparty: Optional[str],
+            counterparty: str | None,
             rule: 'BaseEventSettings',
             links: dict[LINKABLE_ACCOUNTING_PROPERTIES, LINKABLE_ACCOUNTING_SETTINGS_NAME],
             identifier: int,
@@ -4555,7 +4555,7 @@ class RestAPI:
     def solve_multiple_accounting_rule_conflicts(
             self,
             conflicts: list[tuple[int, Literal['remote', 'local']]],
-            solve_all_using: Optional[Literal['remote', 'local']],
+            solve_all_using: Literal['remote', 'local'] | None,
     ) -> Response:
         conflict_db = DBRemoteConflicts(self.rotkehlchen.data.db)
         try:

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -2,7 +2,7 @@ import json
 import logging
 import sys
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any
 
 import werkzeug
 from flask import Blueprint, Flask, Response, abort, jsonify, request
@@ -154,10 +154,7 @@ from rotkehlchen.api.websockets.notifier import RotkiNotifier, RotkiWSApp
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 URLS = list[
-    Union[
-        tuple[str, type[MethodView]],
-        tuple[str, type[MethodView], str],
-    ]
+    tuple[str, type[MethodView]] | tuple[str, type[MethodView], str]
 ]
 
 
@@ -363,8 +360,8 @@ def handle_request_parsing_error(
         err: ValidationError,
         _request: werkzeug.local.LocalProxy,
         _schema: Schema,
-        error_status_code: Optional[int],  # pylint: disable=unused-argument
-        error_headers: Optional[dict],  # pylint: disable=unused-argument
+        error_status_code: int | None,  # pylint: disable=unused-argument
+        error_headers: dict | None,  # pylint: disable=unused-argument
 ) -> None:
     """ This handles request parsing errors generated for example by schema
     field validation failing."""
@@ -389,7 +386,7 @@ class APIServer:
             self,
             rest_api: RestAPI,
             ws_notifier: RotkiNotifier,
-            cors_domain_list: Optional[list[str]] = None,
+            cors_domain_list: list[str] | None = None,
     ) -> None:
         flask_app = Flask(__name__)
         if cors_domain_list:
@@ -406,7 +403,7 @@ class APIServer:
         self.flask_app = flask_app
         self.blueprint = blueprint
 
-        self.wsgiserver: Optional[WSGIServer] = None
+        self.wsgiserver: WSGIServer | None = None
         self.flask_app.register_blueprint(self.blueprint)
 
         self.flask_app.errorhandler(HTTPStatus.NOT_FOUND)(endpoint_not_found)

--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -2,7 +2,7 @@ import logging
 import urllib
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 import webargs
 from eth_utils import to_checksum_address
@@ -91,8 +91,8 @@ class IncludeExcludeListField(fields.Field):
 
     def _deserialize(
             self,
-            value: dict[str, Union[list, str]],
-            attr: Optional[str],
+            value: dict[str, list | str],
+            attr: str | None,
             data: Any,
             **kwargs: Any,
     ) -> IncludeExcludeFilterData:
@@ -139,15 +139,15 @@ class DelimitedOrNormalList(webargs.fields.DelimitedList):
             self,
             cls_or_instance: Any,
             *,
-            _delimiter: Optional[str] = None,
+            _delimiter: str | None = None,
             **kwargs: Any,
     ) -> None:
         super().__init__(cls_or_instance, **kwargs)
 
     def _deserialize(  # type: ignore  # we may get a list in value
             self,
-            value: Union[list[str], str],
-            attr: Optional[str],
+            value: list[str] | str,
+            attr: str | None,
             data: dict[str, Any],
             **kwargs: Any,
     ) -> list[Any]:
@@ -184,8 +184,8 @@ class TimestampField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Timestamp:
         try:
@@ -204,8 +204,8 @@ class TimestampMSField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> TimestampMS:
         try:
@@ -221,8 +221,8 @@ class TimestampUntilNowField(TimestampField):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,
+            data: Mapping[str, Any] | None,
             **kwargs: Any,
     ) -> Timestamp:
         timestamp = super()._deserialize(value, attr, data, **kwargs)
@@ -237,8 +237,8 @@ class ColorField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> HexColorCode:
         try:
@@ -254,8 +254,8 @@ class TaxFreeAfterPeriodField(fields.Field):
     def _deserialize(
             self,
             value: int,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> int:
         try:
@@ -279,7 +279,7 @@ class AmountField(fields.Field):
     @staticmethod
     def _serialize(
             value: AssetAmount,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -287,9 +287,9 @@ class AmountField(fields.Field):
 
     def _deserialize(
             self,
-            value: Union[str, int],
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            value: str | int,
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> AssetAmount:
         try:
@@ -304,9 +304,9 @@ class PositiveAmountField(AmountField):
 
     def _deserialize(
             self,
-            value: Union[str, int],
-            attr: Optional[str],
-            data: Optional[Mapping[str, Any]],
+            value: str | int,
+            attr: str | None,
+            data: Mapping[str, Any] | None,
             **kwargs: Any,
     ) -> AssetAmount:
         amount = super()._deserialize(value, attr, data, **kwargs)
@@ -321,7 +321,7 @@ class PriceField(fields.Field):
     @staticmethod
     def _serialize(
             value: FVal,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -330,8 +330,8 @@ class PriceField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Price:
         try:
@@ -350,18 +350,18 @@ class FeeField(fields.Field):
     @staticmethod
     def _serialize(
             value: Fee,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
-    ) -> Optional[str]:
+    ) -> str | None:
         # Fee can be missing so we need to handle None when serializing from schema
         return str(value) if value else None
 
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Fee:
         try:
@@ -377,7 +377,7 @@ class FloatingPercentageField(fields.Field):
     @staticmethod
     def _serialize(
             value: FVal,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -386,8 +386,8 @@ class FloatingPercentageField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> FVal:
         try:
@@ -405,15 +405,15 @@ class FloatingPercentageField(fields.Field):
 
 class BlockchainField(fields.Field):
 
-    def __init__(self, *, exclude_types: Optional[Sequence[SupportedBlockchain]] = None, **kwargs: Any) -> None:  # noqa: E501
+    def __init__(self, *, exclude_types: Sequence[SupportedBlockchain] | None = None, **kwargs: Any) -> None:  # noqa: E501
         self.exclude_types = exclude_types
         super().__init__(**kwargs)
 
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> SupportedBlockchain:
         try:
@@ -429,7 +429,7 @@ class BlockchainField(fields.Field):
 class SerializableEnumField(fields.Field):
     """A field that takes an enum following the SerializableEnumMixin interface
     """
-    def __init__(self, enum_class: type[Union[SerializableEnumNameMixin, SerializableEnumIntValueMixin, DBCharEnumMixIn, DBIntEnumMixIn]], **kwargs: Any) -> None:  # noqa: E501
+    def __init__(self, enum_class: type[SerializableEnumNameMixin | (SerializableEnumIntValueMixin | (DBCharEnumMixIn | DBIntEnumMixIn))], **kwargs: Any) -> None:  # noqa: E501
         """We give all possible types as unions instead of just type[SerializableEnumMixin]
         due to this bug https://github.com/python/mypy/issues/4717
         Normally it should have sufficed to give just the former.
@@ -440,7 +440,7 @@ class SerializableEnumField(fields.Field):
     @staticmethod
     def _serialize(
             value: SerializableEnumMixin,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -449,8 +449,8 @@ class SerializableEnumField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Any:
         try:
@@ -466,24 +466,24 @@ class EvmChainNameField(fields.Field):
     chain to serialize to chain id, so the frontend does not have to remember a
     mapping of chain id to evm chain name"""
 
-    def __init__(self, *, limit_to: Optional[list[SUPPORTED_CHAIN_IDS]] = None, **kwargs: Any) -> None:  # noqa: E501
+    def __init__(self, *, limit_to: list[SUPPORTED_CHAIN_IDS] | None = None, **kwargs: Any) -> None:  # noqa: E501
         self.limit_to = limit_to
         super().__init__(**kwargs)
 
     @staticmethod
     def _serialize(
             value: ChainID,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
-    ) -> Optional[str]:
+    ) -> str | None:
         return value.to_name() if value else None
 
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> ChainID:
         try:
@@ -505,14 +505,7 @@ class AssetField(fields.Field):
     def __init__(
             self,
             *,
-            expected_type: type[Union[
-                Asset,
-                AssetWithNameAndType,
-                AssetWithOracles,
-                CryptoAsset,
-                EvmToken,
-                CustomAsset,
-            ]],
+            expected_type: type[Asset | (AssetWithNameAndType | (AssetWithOracles | (CryptoAsset | (EvmToken | CustomAsset))))],  # noqa: E501
             form_with_incomplete_data: bool = False,
             **kwargs: Any,
     ) -> None:
@@ -523,18 +516,18 @@ class AssetField(fields.Field):
     @staticmethod
     def _serialize(
             value: Asset,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
-    ) -> Optional[str]:
+    ) -> str | None:
         # Asset can be missing so we need to handle None when serializing from schema
         return value.identifier if value else None
 
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Asset:
         if isinstance(value, str) is False:
@@ -580,20 +573,20 @@ class MaybeAssetField(fields.Field):
     @staticmethod
     def _serialize(
             value: Asset,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
-    ) -> Optional[str]:
+    ) -> str | None:
         # Asset can be missing so we need to handle None when serializing from schema
         return str(value.identifier) if value else None
 
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
-    ) -> Optional[Asset]:
+    ) -> Asset | None:
         try:
             asset = Asset(identifier=value).resolve_to_asset_with_oracles()
         except DeserializationError as e:
@@ -610,7 +603,7 @@ class EvmAddressField(fields.Field):
     @staticmethod
     def _serialize(
             value: ChecksumEvmAddress,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -619,8 +612,8 @@ class EvmAddressField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> ChecksumEvmAddress:
         # Make sure that given value is an ethereum address
@@ -640,7 +633,7 @@ class EVMTransactionHashField(fields.Field):
     @staticmethod
     def _serialize(
             value: EVMTxHash,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -649,8 +642,8 @@ class EVMTransactionHashField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> EVMTxHash:
         # Make sure that given value is a transaction hash
@@ -671,14 +664,14 @@ class EVMTransactionHashField(fields.Field):
 
 class AssetTypeField(fields.Field):
 
-    def __init__(self, *, exclude_types: Optional[Sequence[AssetType]] = None, **kwargs: Any) -> None:  # noqa: E501
+    def __init__(self, *, exclude_types: Sequence[AssetType] | None = None, **kwargs: Any) -> None:
         self.exclude_types = exclude_types
         super().__init__(**kwargs)
 
     @staticmethod
     def _serialize(
             value: AssetType,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -687,8 +680,8 @@ class AssetTypeField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> AssetType:
         try:
@@ -704,14 +697,14 @@ class AssetTypeField(fields.Field):
 
 class LocationField(fields.Field):
 
-    def __init__(self, *, limit_to: Optional[tuple[Location, ...]] = None, **kwargs: Any) -> None:
+    def __init__(self, *, limit_to: tuple[Location, ...] | None = None, **kwargs: Any) -> None:
         self.limit_to = limit_to
         super().__init__(**kwargs)
 
     @staticmethod
     def _serialize(
             value: Location,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -720,8 +713,8 @@ class LocationField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Location:
         try:
@@ -743,8 +736,8 @@ class ApiKeyField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> ApiKey:
         if not isinstance(value, str):
@@ -757,7 +750,7 @@ class ApiSecretField(fields.Field):
     @staticmethod
     def _serialize(
             value: ApiSecret,
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> str:
@@ -766,8 +759,8 @@ class ApiSecretField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> ApiSecret:
         if not isinstance(value, str):
@@ -780,8 +773,8 @@ class DirectoryField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> Path:
         path = Path(value)
@@ -799,7 +792,7 @@ class AssetConflictsField(fields.Field):
     @staticmethod
     def _serialize(
             value: dict[str, Any],
-            attr: Optional[str],  # pylint: disable=unused-argument
+            attr: str | None,  # pylint: disable=unused-argument
             obj: Any,
             **_kwargs: Any,
     ) -> dict[str, Any]:
@@ -810,8 +803,8 @@ class AssetConflictsField(fields.Field):
     def _deserialize(
             self,
             value: dict[str, str],
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> dict[Asset, Literal['remote', 'local']]:
         if not isinstance(value, dict):
@@ -840,17 +833,17 @@ class AssetConflictsField(fields.Field):
 
 class FileField(fields.Field):
 
-    def __init__(self, *, allowed_extensions: Optional[Sequence[str]] = None, **kwargs: Any) -> None:  # noqa: E501
+    def __init__(self, *, allowed_extensions: Sequence[str] | None = None, **kwargs: Any) -> None:
         self.allowed_extensions = allowed_extensions
         super().__init__(**kwargs)
 
     def _deserialize(
             self,
-            value: Union[str, FileStorage],
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            value: str | FileStorage,
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
-    ) -> Union[Path, FileStorage]:
+    ) -> Path | FileStorage:
         if isinstance(value, FileStorage):
             if self.allowed_extensions is not None and value.filename and not any(value.filename.endswith(x) for x in self.allowed_extensions):  # noqa: E501
                 raise ValidationError(
@@ -884,8 +877,8 @@ class XpubField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> HDKey:
         if not isinstance(value, str):
@@ -904,8 +897,8 @@ class DerivationPathField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> str:
         valid, msg = is_valid_derivation_path(value)
@@ -920,8 +913,8 @@ class CurrentPriceOracleField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> CurrentPriceOracle:
         try:
@@ -937,8 +930,8 @@ class HistoricalPriceOracleField(fields.Field):
     def _deserialize(
             self,
             value: str,
-            attr: Optional[str],  # pylint: disable=unused-argument
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
             **_kwargs: Any,
     ) -> HistoricalPriceOracle:
         try:
@@ -954,8 +947,8 @@ class NonEmptyList(fields.List):
     def _deserialize(
             self,
             value: Any,
-            attr: Optional[str],
-            data: Optional[Mapping[str, Any]],
+            attr: str | None,
+            data: Mapping[str, Any] | None,
             **kwargs: Any,
     ) -> list[Any]:
         result = super()._deserialize(value=value, attr=attr, data=data, **kwargs)

--- a/rotkehlchen/api/v1/parser.py
+++ b/rotkehlchen/api/v1/parser.py
@@ -1,6 +1,6 @@
 import functools
-from collections.abc import Mapping
-from typing import Any, Callable, Optional
+from collections.abc import Callable, Mapping
+from typing import Any
 
 from flask import Request
 from flask.views import MethodView
@@ -15,16 +15,16 @@ class ResourceReadingParser(FlaskParser):
     def use_args(
             self,
             argmap: ArgMap,
-            req: Optional[Request] = None,
+            req: Request | None = None,
             *,
-            location: Optional[str] = None,
-            unknown: Optional[str] = _UNKNOWN_DEFAULT_PARAM,  # pylint: disable=unused-argument
+            location: str | None = None,
+            unknown: str | None = _UNKNOWN_DEFAULT_PARAM,  # pylint: disable=unused-argument
             as_kwargs: bool = False,
-            arg_name: Optional[str] = None,
-            validate: Optional[ValidateArg] = None,
-            error_status_code: Optional[int] = None,
-            error_headers: Optional[Mapping[str, str]] = None,
-            allow_async_validation: Optional[bool] = False,
+            arg_name: str | None = None,
+            validate: ValidateArg | None = None,
+            error_status_code: int | None = None,
+            error_headers: Mapping[str, str] | None = None,
+            allow_async_validation: bool | None = False,
     ) -> Callable:
         """Decorator that injects parsed arguments into a view function or method.
 
@@ -78,14 +78,14 @@ class ResourceReadingParser(FlaskParser):
             self,
             resource_object: MethodView,
             argmap: ArgMap,
-            req: Optional[Request] = None,
+            req: Request | None = None,
             *,
-            location: Optional[str] = None,
-            unknown: Optional[str] = _UNKNOWN_DEFAULT_PARAM,  # pylint: disable=unused-argument
-            validate: Optional[ValidateArg] = None,
-            error_status_code: Optional[int] = None,
-            error_headers: Optional[Mapping[str, str]] = None,
-            allow_async_validation: Optional[bool] = False,
+            location: str | None = None,
+            unknown: str | None = _UNKNOWN_DEFAULT_PARAM,  # pylint: disable=unused-argument
+            validate: ValidateArg | None = None,
+            error_status_code: int | None = None,
+            error_headers: Mapping[str, str] | None = None,
+            allow_async_validation: bool | None = False,
     ) -> dict[str, Any]:
         """Main request parsing method.
 

--- a/rotkehlchen/api/v1/types.py
+++ b/rotkehlchen/api/v1/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import auto
-from typing import Literal, Optional, TypedDict
+from typing import Literal, TypedDict
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntryType
 from rotkehlchen.types import SUPPORTED_CHAIN_IDS, EVMTxHash
@@ -9,7 +9,7 @@ from rotkehlchen.utils.mixins.enums import SerializableEnumNameMixin
 
 class EvmTransactionDecodingApiData(TypedDict):
     evm_chain: SUPPORTED_CHAIN_IDS
-    tx_hashes: Optional[list[EVMTxHash]]
+    tx_hashes: list[EVMTxHash] | None
 
 
 class EvmPendingTransactionDecodingApiData(TypedDict):

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from collections.abc import Callable
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from gevent.lock import Semaphore
 from geventwebsocket import WebSocketApplication
@@ -21,10 +22,10 @@ def _ws_send_impl(
         websocket: WebSocket,
         lock: Semaphore,
         to_send_msg: str,
-        success_callback: Optional[Callable] = None,
-        success_callback_args: Optional[dict[str, Any]] = None,
-        failure_callback: Optional[Callable] = None,
-        failure_callback_args: Optional[dict[str, Any]] = None,
+        success_callback: Callable | None = None,
+        success_callback_args: dict[str, Any] | None = None,
+        failure_callback: Callable | None = None,
+        failure_callback_args: dict[str, Any] | None = None,
 ) -> None:
     try:
         with lock:
@@ -62,11 +63,11 @@ class RotkiNotifier:
     def broadcast(
             self,
             message_type: 'WSMessageType',
-            to_send_data: Union[dict[str, Any], list[Any]],
-            success_callback: Optional[Callable] = None,
-            success_callback_args: Optional[dict[str, Any]] = None,
-            failure_callback: Optional[Callable] = None,
-            failure_callback_args: Optional[dict[str, Any]] = None,
+            to_send_data: dict[str, Any] | list[Any],
+            success_callback: Callable | None = None,
+            success_callback_args: dict[str, Any] | None = None,
+            failure_callback: Callable | None = None,
+            failure_callback_args: dict[str, Any] | None = None,
     ) -> None:
         """Broadcasts a websocket message
 
@@ -122,7 +123,7 @@ class RotkiWSApp(WebSocketApplication):
         rotki_notifier: RotkiNotifier = self.ws.environ['rotki_notifier']
         rotki_notifier.subscribe(self.ws)
 
-    def on_message(self, message: Optional[str], *args: Any, **kwargs: Any) -> None:
+    def on_message(self, message: str | None, *args: Any, **kwargs: Any) -> None:
         if self.ws.closed:
             return
         try:

--- a/rotkehlchen/args.py
+++ b/rotkehlchen/args.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 from rotkehlchen.constants.misc import (
     DEFAULT_MAX_LOG_BACKUP_FILES,
@@ -25,8 +25,8 @@ class CommandAction(argparse.Action):
             self,
             parser: argparse.ArgumentParser,
             namespace: argparse.Namespace,
-            values: Union[str, Sequence[Any], None],
-            option_string: Optional[str] = None,
+            values: str | (Sequence[Any] | None),
+            option_string: str | None = None,
     ) -> None:
         # Only command we have at the moment is version
         if values != 'version':

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -250,8 +250,8 @@ class AssetWithSymbol(AssetWithNameAndType, metaclass=abc.ABCMeta):
 
 class AssetWithOracles(AssetWithSymbol, metaclass=abc.ABCMeta):
     # None means no special mapping. '' means not supported
-    cryptocompare: Optional[str] = field(init=False)
-    coingecko: Optional[str] = field(init=False)
+    cryptocompare: str | None = field(init=False)
+    coingecko: str | None = field(init=False)
 
     def to_cryptocompare(self) -> str:
         """
@@ -315,10 +315,10 @@ class FiatAsset(AssetWithOracles):
     def initialize(
             cls: type['FiatAsset'],
             identifier: str,
-            name: Optional[str] = None,
-            symbol: Optional[str] = None,
-            coingecko: Optional[str] = None,
-            cryptocompare: Optional[str] = '',
+            name: str | None = None,
+            symbol: str | None = None,
+            coingecko: str | None = None,
+            cryptocompare: str | None = '',
     ) -> 'FiatAsset':
         asset = FiatAsset(identifier=identifier, direct_field_initialization=True)
         object.__setattr__(asset, 'asset_type', AssetType.FIAT)
@@ -331,7 +331,7 @@ class FiatAsset(AssetWithOracles):
 
 @dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
 class CryptoAsset(AssetWithOracles):
-    started: Optional[Timestamp] = field(init=False)
+    started: Timestamp | None = field(init=False)
     forked: Optional['CryptoAsset'] = field(init=False)
     swapped_for: Optional['CryptoAsset'] = field(init=False)
 
@@ -359,11 +359,11 @@ class CryptoAsset(AssetWithOracles):
             cls: type['CryptoAsset'],
             identifier: str,
             asset_type: AssetType,
-            name: Optional[str] = None,
-            symbol: Optional[str] = None,
-            coingecko: Optional[str] = None,
-            cryptocompare: Optional[str] = '',
-            started: Optional[Timestamp] = None,
+            name: str | None = None,
+            symbol: str | None = None,
+            coingecko: str | None = None,
+            cryptocompare: str | None = '',
+            started: Timestamp | None = None,
             forked: Optional['CryptoAsset'] = None,
             swapped_for: Optional['CryptoAsset'] = None,
     ) -> 'CryptoAsset':
@@ -398,7 +398,7 @@ class CryptoAsset(AssetWithOracles):
 
 
 class CustomAsset(AssetWithNameAndType):
-    notes: Optional[str] = field(init=False)
+    notes: str | None = field(init=False)
     custom_asset_type: str = field(init=False)
 
     @classmethod
@@ -407,7 +407,7 @@ class CustomAsset(AssetWithNameAndType):
             identifier: str,
             name: str,
             custom_asset_type: str,
-            notes: Optional[str] = None,
+            notes: str | None = None,
     ) -> 'CustomAsset':
         asset = CustomAsset(identifier=identifier)
         object.__setattr__(asset, 'asset_type', AssetType.CUSTOM_ASSET)
@@ -419,7 +419,7 @@ class CustomAsset(AssetWithNameAndType):
     @classmethod
     def deserialize_from_db(
             cls: type['CustomAsset'],
-            entry: tuple[str, str, str, Optional[str]],
+            entry: tuple[str, str, str, str | None],
     ) -> 'CustomAsset':
         """
         Takes a `custom_asset` entry from DB and turns it into a `CustomAsset` instance.
@@ -433,7 +433,7 @@ class CustomAsset(AssetWithNameAndType):
             notes=entry[3],
         )
 
-    def serialize_for_db(self) -> tuple[str, str, Optional[str]]:
+    def serialize_for_db(self) -> tuple[str, str, str | None]:
         return (
             self.identifier,
             self.custom_asset_type,
@@ -457,14 +457,14 @@ EthereumTokenDBTuple = tuple[
     str,                  # address
     str,                  # chain id
     str,                  # token type
-    Optional[int],        # decimals
-    Optional[str],        # name
-    Optional[str],        # symbol
-    Optional[int],        # started
-    Optional[str],        # swapped_for
-    Optional[str],        # coingecko
-    Optional[str],        # cryptocompare
-    Optional[str],        # protocol
+    int | None,        # decimals
+    str | None,        # name
+    str | None,        # symbol
+    int | None,        # started
+    str | None,        # swapped_for
+    str | None,        # coingecko
+    str | None,        # cryptocompare
+    str | None,        # protocol
 ]
 
 
@@ -500,16 +500,16 @@ class EvmToken(CryptoAsset):
             address: ChecksumEvmAddress,
             chain_id: ChainID,
             token_kind: EvmTokenKind,
-            name: Optional[str] = None,
-            symbol: Optional[str] = None,
-            started: Optional[Timestamp] = None,
-            forked: Optional[CryptoAsset] = None,
-            swapped_for: Optional[CryptoAsset] = None,
-            coingecko: Optional[str] = None,
-            cryptocompare: Optional[str] = '',
-            decimals: Optional[int] = None,
-            protocol: Optional[str] = None,
-            underlying_tokens: Optional[list[UnderlyingToken]] = None,
+            name: str | None = None,
+            symbol: str | None = None,
+            started: Timestamp | None = None,
+            forked: CryptoAsset | None = None,
+            swapped_for: CryptoAsset | None = None,
+            coingecko: str | None = None,
+            cryptocompare: str | None = '',
+            decimals: int | None = None,
+            protocol: str | None = None,
+            underlying_tokens: list[UnderlyingToken] | None = None,
     ) -> 'EvmToken':
         identifier = evm_address_to_identifier(
             address=address,
@@ -537,7 +537,7 @@ class EvmToken(CryptoAsset):
     def deserialize_from_db(
             cls: type['EvmToken'],
             entry: EthereumTokenDBTuple,
-            underlying_tokens: Optional[list[UnderlyingToken]] = None,
+            underlying_tokens: list[UnderlyingToken] | None = None,
     ) -> 'EvmToken':
         """May raise UnknownAsset if the swapped for asset can't be recognized
         That error would be bad because it would mean somehow an unknown id made it into the DB
@@ -600,8 +600,8 @@ class Nft(EvmToken):
             cls: type['EvmToken'],
             identifier: str,
             chain_id: ChainID,
-            name: Optional[str] = None,
-            symbol: Optional[str] = None,
+            name: str | None = None,
+            symbol: str | None = None,
     ) -> 'Nft':
         # TODO: This needs to change once we correctly track NFTs
         asset = Nft(identifier=identifier, direct_field_initialization=True)

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.assets.exchanges_mappings.binance import WORLD_TO_BINANCE
@@ -1046,7 +1046,7 @@ def asset_from_binance(binance_name: str) -> AssetWithOracles:
     return symbol_to_asset_or_token(name)
 
 
-def asset_from_coinbase(cb_name: str, time: Optional[Timestamp] = None) -> AssetWithOracles:
+def asset_from_coinbase(cb_name: str, time: Timestamp | None = None) -> AssetWithOracles:
     """May raise:
     - DeserializationError
     - UnknownAsset

--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -42,7 +42,7 @@ class AssetResolver:
         return AssetResolver.__instance
 
     @staticmethod
-    def clean_memory_cache(identifier: Optional[str] = None) -> None:
+    def clean_memory_cache(identifier: str | None = None) -> None:
         """Clean the memory cache of either a single or all assets"""
         assert AssetResolver.__instance is not None, 'when cleaning the cache instance should be set'  # noqa: E501
         if identifier is not None:

--- a/rotkehlchen/assets/types.py
+++ b/rotkehlchen/assets/types.py
@@ -57,16 +57,16 @@ class AssetData(NamedTuple):
     # Every asset should have a started timestamp except for FIAT which are
     # most of the times older than epoch
     started: Optional['Timestamp']
-    forked: Optional[str]
-    swapped_for: Optional[str]
+    forked: str | None
+    swapped_for: str | None
     address: Optional['ChecksumEvmAddress']
-    chain_id: Optional[ChainID]
-    token_kind: Optional[EvmTokenKind]
-    decimals: Optional[int]
+    chain_id: ChainID | None
+    token_kind: EvmTokenKind | None
+    decimals: int | None
     # None means, no special mapping. '' means not supported
-    cryptocompare: Optional[str]
-    coingecko: Optional[str]
-    protocol: Optional[str]
+    cryptocompare: str | None
+    coingecko: str | None
+    protocol: str | None
 
     def serialize(self) -> dict[str, Any]:
         result = self._asdict()  # pylint: disable=no-member

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -45,11 +45,11 @@ def add_evm_token_to_db(token_data: EvmToken) -> EvmToken:
 def _query_or_get_given_token_info(
         evm_inquirer: 'EvmNodeInquirer',
         evm_address: ChecksumEvmAddress,
-        name: Optional[str],
-        symbol: Optional[str],
-        decimals: Optional[int],
+        name: str | None,
+        symbol: str | None,
+        decimals: int | None,
         token_kind: EvmTokenKind,
-) -> tuple[Optional[str], Optional[str], Optional[int]]:
+) -> tuple[str | None, str | None, int | None]:
     """
     Query ethereum to retrieve basic contract information for the given address.
     If the contract is missing any of the queried methods then the respective value
@@ -81,10 +81,10 @@ def _query_or_get_given_token_info(
 
 def _edit_token_and_clean_cache(
         evm_token: EvmToken,
-        name: Optional[str],
-        decimals: Optional[int],
-        started: Optional[Timestamp],
-        underlying_tokens: Optional[list[UnderlyingToken]],
+        name: str | None,
+        decimals: int | None,
+        started: Timestamp | None,
+        underlying_tokens: list[UnderlyingToken] | None,
         evm_inquirer: Optional['EvmNodeInquirer'],
 ) -> None:
     """
@@ -129,7 +129,7 @@ def _edit_token_and_clean_cache(
         GlobalDBHandler().edit_evm_token(evm_token)
 
 
-def check_if_spam_token(symbol: Optional[str]) -> bool:
+def check_if_spam_token(symbol: str | None) -> bool:
     """Makes basic checks to test if a token could be spam or not"""
     if symbol is None:
         return False
@@ -154,8 +154,8 @@ class TokenEncounterInfo(NamedTuple):
     If should_notify is True then we will send a ws message with information
     about the new asset
     """
-    tx_hash: Optional[EVMTxHash] = None
-    description: Optional[str] = None
+    tx_hash: EVMTxHash | None = None
+    description: str | None = None
     should_notify: bool = True
 
 
@@ -164,14 +164,14 @@ def get_or_create_evm_token(
         evm_address: ChecksumEvmAddress,
         chain_id: ChainID,
         token_kind: EvmTokenKind = EvmTokenKind.ERC20,
-        symbol: Optional[str] = None,
-        name: Optional[str] = None,
-        decimals: Optional[int] = None,
-        protocol: Optional[str] = None,
-        started: Optional[Timestamp] = None,
-        underlying_tokens: Optional[list[UnderlyingToken]] = None,
+        symbol: str | None = None,
+        name: str | None = None,
+        decimals: int | None = None,
+        protocol: str | None = None,
+        started: Timestamp | None = None,
+        underlying_tokens: list[UnderlyingToken] | None = None,
         evm_inquirer: Optional['EvmNodeInquirer'] = None,
-        encounter: Optional[TokenEncounterInfo] = None,
+        encounter: TokenEncounterInfo | None = None,
 ) -> EvmToken:
     """Given a token address return the <EvmToken>
 
@@ -299,9 +299,9 @@ def set_token_protocol_if_missing(evm_token: EvmToken, protocol: str) -> None:
 
 def get_crypto_asset_by_symbol(
         symbol: str,
-        asset_type: Optional[AssetType] = None,
-        chain_id: Optional[ChainID] = None,
-) -> Optional[AssetWithOracles]:
+        asset_type: AssetType | None = None,
+        chain_id: ChainID | None = None,
+) -> AssetWithOracles | None:
     """Gets an asset by symbol from the DB.
 
     If no asset with that symbol or multiple assets (except for EVM tokens) with the same
@@ -324,7 +324,7 @@ def get_crypto_asset_by_symbol(
 
 def symbol_to_asset_or_token(
         symbol: str,
-        chain_id: Optional[ChainID] = None,
+        chain_id: ChainID | None = None,
 ) -> AssetWithOracles:
     """Tries to turn the given symbol to an asset or an ethereum Token
 

--- a/rotkehlchen/balances/manual.py
+++ b/rotkehlchen/balances/manual.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceType
 from rotkehlchen.assets.asset import Asset
@@ -20,7 +20,7 @@ class ManuallyTrackedBalance:
     label: str
     amount: FVal
     location: Location
-    tags: Optional[list[str]]
+    tags: list[str] | None
     balance_type: BalanceType
 
 
@@ -30,7 +30,7 @@ class ManuallyTrackedBalanceWithValue(NamedTuple):
     label: str
     value: Balance
     location: Location
-    tags: Optional[list[str]]
+    tags: list[str] | None
     balance_type: BalanceType
 
     def serialize(self) -> dict[str, Any]:
@@ -42,7 +42,7 @@ class ManuallyTrackedBalanceWithValue(NamedTuple):
 
 def get_manually_tracked_balances(
         db: 'DBHandler',
-        balance_type: Optional[BalanceType] = None,
+        balance_type: BalanceType | None = None,
 ) -> list[ManuallyTrackedBalanceWithValue]:
     """Gets the manually tracked balances"""
     with db.conn.read_ctx() as cursor:

--- a/rotkehlchen/chain/accounts.py
+++ b/rotkehlchen/chain/accounts.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Generic, NamedTuple, Optional, overload
+from typing import Any, Generic, NamedTuple, overload
 
 from rotkehlchen.chain.substrate.types import SubstrateAddress
 from rotkehlchen.types import (
@@ -56,15 +56,15 @@ class BlockchainAccounts:
 class BlockchainAccountData(NamedTuple):
     chain: SupportedBlockchain
     address: BlockchainAddress
-    label: Optional[str] = None
-    tags: Optional[list[str]] = None
+    label: str | None = None
+    tags: list[str] | None = None
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
 class SingleBlockchainAccountData(Generic[AnyBlockchainAddress]):
     address: AnyBlockchainAddress
-    label: Optional[str] = None
-    tags: Optional[list[str]] = None
+    label: str | None = None
+    tags: list[str] | None = None
 
     def serialize(self) -> dict[str, Any]:
         return {'address': self.address, 'label': self.label, 'tags': self.tags}

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1,20 +1,10 @@
 import logging
 import typing
 from collections import defaultdict
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from importlib import import_module
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    Optional,
-    TypeVar,
-    cast,
-    get_args,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, cast, get_args, overload
 
 import requests
 from gevent.lock import Semaphore
@@ -204,7 +194,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             msg_aggregator: MessagesAggregator,
             database: 'DBHandler',
             greenlet_manager: GreenletManager,
-            premium: Optional[Premium],
+            premium: Premium | None,
             data_directory: Path,
             beaconchain: 'BeaconChain',
             btc_derivation_gap_limit: int,
@@ -323,7 +313,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             result = QueriedAddresses(self.database).get_queried_addresses_for_module(cursor, module)  # noqa: E501
         return result if result is not None else self.accounts.eth
 
-    def activate_module(self, module_name: ModuleName) -> Optional[EthereumModule]:
+    def activate_module(self, module_name: ModuleName) -> EthereumModule | None:
         """Activates an ethereum module by module name"""
         module = self.eth_modules.get(module_name, None)
         if module:
@@ -372,7 +362,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         ...
 
     @overload
-    def get_module(self, module_name: Literal['balancer']) -> Optional[Balancer]:
+    def get_module(self, module_name: Literal['balancer']) -> Balancer | None:
         ...
 
     @overload
@@ -384,15 +374,15 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         ...
 
     @overload
-    def get_module(self, module_name: Literal['loopring']) -> Optional[Loopring]:
+    def get_module(self, module_name: Literal['loopring']) -> Loopring | None:
         ...
 
     @overload
-    def get_module(self, module_name: Literal['makerdao_dsr']) -> Optional[MakerdaoDsr]:
+    def get_module(self, module_name: Literal['makerdao_dsr']) -> MakerdaoDsr | None:
         ...
 
     @overload
-    def get_module(self, module_name: Literal['makerdao_vaults']) -> Optional[MakerdaoVaults]:
+    def get_module(self, module_name: Literal['makerdao_vaults']) -> MakerdaoVaults | None:
         ...
 
     @overload
@@ -404,33 +394,33 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         ...
 
     @overload
-    def get_module(self, module_name: Literal['yearn_vaults']) -> Optional[YearnVaults]:
+    def get_module(self, module_name: Literal['yearn_vaults']) -> YearnVaults | None:
         ...
 
     @overload
-    def get_module(self, module_name: Literal['yearn_vaults_v2']) -> Optional[YearnVaultsV2]:
+    def get_module(self, module_name: Literal['yearn_vaults_v2']) -> YearnVaultsV2 | None:
         ...
 
     @overload
-    def get_module(self, module_name: Literal['liquity']) -> Optional[Liquity]:
+    def get_module(self, module_name: Literal['liquity']) -> Liquity | None:
         ...
 
     @overload
-    def get_module(self, module_name: Literal['pickle_finance']) -> Optional[PickleFinance]:
+    def get_module(self, module_name: Literal['pickle_finance']) -> PickleFinance | None:
         ...
 
     @overload
     def get_module(self, module_name: Literal['nfts']) -> Optional['Nfts']:
         ...
 
-    def get_module(self, module_name: ModuleName) -> Optional[Any]:
+    def get_module(self, module_name: ModuleName) -> Any | None:
         instance = self.eth_modules.get(module_name, None)
         if instance is None:  # not activated
             return None
 
         return instance
 
-    def get_balances_update(self, chain: Optional[SupportedBlockchain]) -> BlockchainBalancesUpdate:  # noqa: E501
+    def get_balances_update(self, chain: SupportedBlockchain | None) -> BlockchainBalancesUpdate:
         """Returns a balances update to be consumed by the API."""
         return BlockchainBalancesUpdate(
             given_chain=chain,
@@ -482,7 +472,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     @cache_response_timewise(forward_ignore_cache=True)
     def query_balances(
             self,
-            blockchain: Optional[SupportedBlockchain] = None,
+            blockchain: SupportedBlockchain | None = None,
             ignore_cache: bool = False,
     ) -> BlockchainBalancesUpdate:
         """Queries either all, or specific blockchain balances
@@ -1298,8 +1288,8 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
 
     def add_eth2_validator(
             self,
-            validator_index: Optional[int],
-            public_key: Optional[Eth2PubKey],
+            validator_index: int | None,
+            public_key: Eth2PubKey | None,
             ownership_proportion: FVal,
     ) -> None:
         """May raise:
@@ -1492,7 +1482,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     def detect_evm_accounts(
             self,
             progress_handler: Optional['ProgressUpdater'] = None,
-            chains: Optional[list[SUPPORTED_EVM_CHAINS]] = None,
+            chains: list[SUPPORTED_EVM_CHAINS] | None = None,
     ) -> list[tuple[SUPPORTED_EVM_CHAINS, ChecksumEvmAddress]]:
         """
         Detects user's EVM accounts on different chains and adds them to the tracked accounts.

--- a/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
@@ -80,5 +81,5 @@ class ArbitrumOneTransactionDecoder(EVMTransactionDecoder):
         return False
 
     @staticmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:  # pylint: disable=unused-argument
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:  # pylint: disable=unused-argument
         return None

--- a/rotkehlchen/chain/arbitrum_one/decoding/interfaces.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/interfaces.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta
-from typing import Callable
+from collections.abc import Callable
 
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 

--- a/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken

--- a/rotkehlchen/chain/avalanche/manager.py
+++ b/rotkehlchen/chain/avalanche/manager.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 
 from eth_utils import to_checksum_address
 from web3 import HTTPProvider, Web3
@@ -157,7 +157,7 @@ class AvalancheManager:
             contract_address: ChecksumEvmAddress,
             abi: list,
             method_name: str,
-            arguments: Optional[list[Any]] = None,
+            arguments: list[Any] | None = None,
     ) -> Any:
         """Performs an eth_call to an ethereum contract
 

--- a/rotkehlchen/chain/balances.py
+++ b/rotkehlchen/chain/balances.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_args, overload
+from typing import TYPE_CHECKING, Any, Literal, get_args, overload
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.chain.bitcoin.xpub import XpubData
@@ -23,12 +23,12 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-ALL_BALANCE_TYPES = Union[
-    defaultdict[ChecksumEvmAddress, BalanceSheet],
-    dict[BTCAddress, Balance],
-    defaultdict[Eth2PubKey, BalanceSheet],
-    dict[SubstrateAddress, BalanceSheet],
-]
+ALL_BALANCE_TYPES = (
+    defaultdict[ChecksumEvmAddress, BalanceSheet] |
+    dict[BTCAddress, Balance] |
+    defaultdict[Eth2PubKey, BalanceSheet] |
+    dict[SubstrateAddress, BalanceSheet]
+)
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
@@ -129,7 +129,7 @@ class BlockchainBalances:
 
         return new_totals
 
-    def serialize(self, given_chain: Optional[SupportedBlockchain]) -> dict[str, dict]:
+    def serialize(self, given_chain: SupportedBlockchain | None) -> dict[str, dict]:
         """Serializes the blockchain balances to a dict for api consumption.
 
         If no chain is given then all balances are serialized, while if a chain
@@ -205,7 +205,7 @@ class BlockchainBalances:
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
 class BlockchainBalancesUpdate:
-    given_chain: Optional[SupportedBlockchain]
+    given_chain: SupportedBlockchain | None
     per_account: BlockchainBalances
     totals: BalanceSheet
 

--- a/rotkehlchen/chain/base/decoding/decoder.py
+++ b/rotkehlchen/chain/base/decoding/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -58,5 +58,5 @@ class BaseTransactionDecoder(OptimismSuperchainTransactionDecoder):
         return False
 
     @staticmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:  # pylint: disable=unused-argument
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:  # pylint: disable=unused-argument
         return None

--- a/rotkehlchen/chain/bitcoin/bch/utils.py
+++ b/rotkehlchen/chain/bitcoin/bch/utils.py
@@ -1,4 +1,3 @@
-from typing import Optional, Union
 
 import bech32
 from base58 import b58decode_check, b58encode_check
@@ -77,7 +76,7 @@ def _b32encode(inputs: list) -> str:
     return out
 
 
-def _address_type(address_type: str, version: Union[str, int]) -> tuple[str, int, bool]:
+def _address_type(address_type: str, version: str | int) -> tuple[str, int, bool]:
     for mapping in _VERSION_MAP[address_type]:
         if version in (mapping[0], mapping[1]):
             return mapping
@@ -96,7 +95,7 @@ def _code_list_to_string(code_list: list[int]) -> bytes:
     return output
 
 
-def legacy_to_cash_address(address: str) -> Optional[BTCAddress]:
+def legacy_to_cash_address(address: str) -> BTCAddress | None:
     """
     Converts a legacy BCH address to CashAddr format.
     Code is taken from:
@@ -119,7 +118,7 @@ def legacy_to_cash_address(address: str) -> Optional[BTCAddress]:
         return None
 
 
-def cash_to_legacy_address(address: str) -> Optional[BTCAddress]:
+def cash_to_legacy_address(address: str) -> BTCAddress | None:
     """
     Converts a legacy BCH address to CashAddr format.
     Code is taken from:

--- a/rotkehlchen/chain/bitcoin/hdkey.py
+++ b/rotkehlchen/chain/bitcoin/hdkey.py
@@ -5,7 +5,7 @@ import hashlib
 import hmac
 from dataclasses import dataclass
 from enum import auto
-from typing import NamedTuple, Optional, Union, cast
+from typing import NamedTuple, Optional, cast
 
 from base58check import b58decode, b58encode
 from coincurve import PrivateKey, PublicKey
@@ -132,25 +132,25 @@ def _parse_prefix(prefix: bytes) -> PrefixParsingResult:
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
 class HDKey:
 
-    path: Optional[str]
+    path: str | None
     network: str
-    depth: Optional[int]
-    parent_fingerprint: Optional[bytes]
-    index: Optional[int]
+    depth: int | None
+    parent_fingerprint: bytes | None
+    index: int | None
     parent: Optional['HDKey']  # forward type reference
-    chain_code: Optional[bytes]
+    chain_code: bytes | None
     fingerprint: bytes
-    xpub: Optional[str]
-    xpub_type: Optional[XpubType]
+    xpub: str | None
+    xpub_type: XpubType | None
     pubkey: PublicKey
-    privkey: Optional[PrivateKey]
+    privkey: PrivateKey | None
     hint: str
 
     @staticmethod
     def from_xpub(
             xpub: str,
-            xpub_type: Optional[XpubType] = None,
-            path: Optional[str] = None,
+            xpub_type: XpubType | None = None,
+            path: str | None = None,
     ) -> 'HDKey':
         """
         Instantiate an HDKey from an xpub. Populates all possible fields
@@ -210,7 +210,7 @@ class HDKey:
         )
 
     @staticmethod
-    def _normalize_index(idx: Union[int, str]) -> int:
+    def _normalize_index(idx: int | str) -> int:
         """
         Normalizes an index so that we can accept ints or strings
         Args:
@@ -236,7 +236,7 @@ class HDKey:
         Returns
             HDKey: the new child object
         """
-        path: Optional[str]
+        path: str | None
         if self.path is not None:
             path = f'{self.path}/{index!s}'
         else:
@@ -344,7 +344,7 @@ class HDKey:
             current_node = current_node.derive_child(path_nodes[i])
         return current_node
 
-    def derive_child(self, idx: Union[int, str]) -> 'HDKey':
+    def derive_child(self, idx: int | str) -> 'HDKey':
         """
         Derives a bip32 child node from the current node
         Args:

--- a/rotkehlchen/chain/bitcoin/xpub.py
+++ b/rotkehlchen/chain/bitcoin/xpub.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from gevent.lock import Semaphore
 
@@ -28,9 +28,9 @@ log = RotkehlchenLogsAdapter(logger)
 class XpubData(NamedTuple):
     xpub: HDKey
     blockchain: Literal[SupportedBlockchain.BITCOIN, SupportedBlockchain.BITCOIN_CASH]
-    derivation_path: Optional[str] = None
-    label: Optional[str] = None
-    tags: Optional[list[str]] = None
+    derivation_path: str | None = None
+    label: str | None = None
+    tags: list[str] | None = None
 
     def serialize_derivation_path_for_db(self) -> str:
         """
@@ -57,7 +57,7 @@ class XpubData(NamedTuple):
         return hash(self) == hash(other)
 
 
-def deserialize_derivation_path_for_db(path: str) -> Optional[str]:
+def deserialize_derivation_path_for_db(path: str) -> str | None:
     """
     In rotki we store non-existing path as None but in sql it must be ''
     https://stackoverflow.com/questions/43827629/why-does-sqlite-insert-duplicate-composite-primary-keys

--- a/rotkehlchen/chain/ethereum/abi.py
+++ b/rotkehlchen/chain/ethereum/abi.py
@@ -103,7 +103,7 @@ def decode_event_data_abi(
     decoded_topic_data = [
         WEB3.codec.decode_single(topic_type, topic_data)
         for topic_type, topic_data
-        in zip(log_topic_types, topics)
+        in zip(log_topic_types, topics, strict=True)  # checked above
     ]
     normalized_topic_data = map_abi_data(
         BASE_RETURN_NORMALIZERS,

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -81,7 +81,7 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
 
     def _maybe_enrich_transfers(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: list['EvmEvent'],
@@ -126,7 +126,7 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
 
     def _maybe_decode_governance(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
@@ -191,7 +191,7 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
         )
 
     @staticmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:
         name = ETHADDRESS_TO_KNOWN_NAME.get(address)
         if name and 'Kraken' in name:
             return CPT_KRAKEN

--- a/rotkehlchen/chain/ethereum/defi/defisaver_proxy.py
+++ b/rotkehlchen/chain/ethereum/defi/defisaver_proxy.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
@@ -22,7 +22,7 @@ class HasDSProxy(EthereumModule):
             self,
             ethereum_inquirer: 'EvmNodeInquirerWithDSProxy',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.ethereum = ethereum_inquirer

--- a/rotkehlchen/chain/ethereum/defi/price.py
+++ b/rotkehlchen/chain/ethereum/defi/price.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.evm.contracts import EvmContract
@@ -139,8 +139,8 @@ def handle_underlying_price_harvest_vault(
 def handle_defi_price_query(
         ethereum: 'EthereumInquirer',
         token: EvmToken,
-        underlying_asset_price: Optional[Price],
-) -> Optional[FVal]:
+        underlying_asset_price: Price | None,
+) -> FVal | None:
     """Handles price queries for token/protocols which are queriable on-chain
     (as opposed to cryptocompare/coingecko)
 

--- a/rotkehlchen/chain/ethereum/defi/structures.py
+++ b/rotkehlchen/chain/ethereum/defi/structures.py
@@ -1,4 +1,5 @@
-from typing import Callable, Literal, NamedTuple, Union
+from collections.abc import Callable
+from typing import Literal, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.types import ChecksumEvmAddress
@@ -29,13 +30,13 @@ class DefiProtocolBalances(NamedTuple):
 
 
 # Type of the argument given to functions that need the defi balances
-GIVEN_DEFI_BALANCES = Union[
-    dict[ChecksumEvmAddress, list[DefiProtocolBalances]],
-    Callable[[], dict[ChecksumEvmAddress, list[DefiProtocolBalances]]],
-]
+GIVEN_DEFI_BALANCES = (
+    dict[ChecksumEvmAddress, list[DefiProtocolBalances]] |
+    Callable[[], dict[ChecksumEvmAddress, list[DefiProtocolBalances]]]
+)
 
 # Type of the argument given to functions that need the eth balances
-GIVEN_ETH_BALANCES = Union[
-    dict[ChecksumEvmAddress, BalanceSheet],
-    Callable[[], dict[ChecksumEvmAddress, BalanceSheet]],
-]
+GIVEN_ETH_BALANCES = (
+    dict[ChecksumEvmAddress, BalanceSheet] |
+    Callable[[], dict[ChecksumEvmAddress, BalanceSheet]]
+)

--- a/rotkehlchen/chain/ethereum/defi/zerionsdk.py
+++ b/rotkehlchen/chain/ethereum/defi/zerionsdk.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
@@ -172,7 +172,7 @@ def _is_token_non_standard(symbol: str, address: ChecksumEvmAddress) -> bool:
     return False
 
 
-def _handle_pooltogether(normalized_balance: FVal, token_name: str) -> Optional[DefiBalance]:
+def _handle_pooltogether(normalized_balance: FVal, token_name: str) -> DefiBalance | None:
     """Special handling for pooltogether
 
     https://github.com/rotki/rotki/issues/1429
@@ -224,7 +224,7 @@ class ZerionSDK:
             deployed_block=1586199170,
         )
         self.database = database
-        self.protocol_names: Optional[list[str]] = None
+        self.protocol_names: list[str] | None = None
 
     def _get_protocol_names(self) -> list[str]:
         if self.protocol_names is not None:
@@ -400,7 +400,7 @@ class ZerionSDK:
             normalized_balance: FVal,
             token_address: str,
             token_name: str,
-    ) -> Optional[DefiBalance]:
+    ) -> DefiBalance | None:
         """Special handling for price for token/protocols which are easier to do onchain
         or need some kind of special treatment.
         This method can raise DeserializationError

--- a/rotkehlchen/chain/ethereum/graph.py
+++ b/rotkehlchen/chain/ethereum/graph.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import Any, Optional
+from typing import Any
 
 import gevent
 import requests
@@ -50,8 +50,8 @@ class Graph:
     def query(
             self,
             querystr: str,
-            param_types: Optional[dict[str, Any]] = None,
-            param_values: Optional[dict[str, Any]] = None,
+            param_types: dict[str, Any] | None = None,
+            param_values: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Queries The Graph for a particular query
 

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
@@ -9,7 +9,7 @@ This interface is used at the moment in:
 """
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.evm_event import EvmEvent
 from rotkehlchen.accounting.structures.types import HistoryEventSubType
@@ -63,7 +63,7 @@ class AMMSwapPlatform:
             counterparties: list[str],
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.counterparties = counterparties
@@ -123,7 +123,7 @@ class AMMSwapPlatform:
             pool_token = EvmToken(evm_address_to_identifier(address=pool_address, chain_id=ChainID.ETHEREUM, token_type=EvmTokenKind.ERC20))  # noqa: E501
             underlying0 = EvmToken(evm_address_to_identifier(address=pool_token.underlying_tokens[0].address, chain_id=ChainID.ETHEREUM, token_type=EvmTokenKind.ERC20))  # noqa: E501
             if underlying0 != A_WETH:
-                asset_list: Union[tuple[EvmToken], tuple[Asset, Asset]] = (underlying0,)
+                asset_list: tuple[EvmToken] | tuple[Asset, Asset] = (underlying0,)
             else:
                 asset_list = (A_ETH, A_WETH)
 

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/types.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/types.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
@@ -18,7 +18,7 @@ log = RotkehlchenLogsAdapter(logger)
 @dataclass(init=True, repr=True)
 class LiquidityPoolAsset:
     token: EvmToken
-    total_amount: Optional[FVal]
+    total_amount: FVal | None
     user_balance: Balance
     usd_price: Price = ZERO_PRICE
 
@@ -35,7 +35,7 @@ class LiquidityPoolAsset:
 class LiquidityPool:
     address: ChecksumEvmAddress
     assets: list[LiquidityPoolAsset]
-    total_supply: Optional[FVal]
+    total_supply: FVal | None
     user_balance: Balance
 
     def serialize(self) -> dict[str, Any]:

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -184,12 +184,16 @@ class ProtocolWithGauges(ProtocolWithBalance):
             call_order=call_order,
         )
         balances: dict[EvmToken, FVal] = defaultdict(FVal)
-        for token_balance, token in zip(result, tokens):
-            if token_balance == 0:
-                continue
+        try:
+            for token_balance, token in zip(result, tokens, strict=True):
+                if token_balance == 0:
+                    continue
 
-            normalized_balance = token_normalized_value(token_balance, token)
-            balances[token] += normalized_balance
+                normalized_balance = token_normalized_value(token_balance, token)
+                balances[token] += normalized_balance
+        except ValueError as e:
+            raise RemoteError('tokensBalance query returned less tokens than expected') from e
+
         return balances
 
     def query_balances(self) -> BalancesType:

--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, NamedTuple, Optional, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 from gevent.lock import Semaphore
 
@@ -64,7 +64,7 @@ class Aave(EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.ethereum = ethereum_inquirer
@@ -297,7 +297,7 @@ class Aave(EthereumModule):
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
             aave_balances: AaveBalances,
-    ) -> Optional[AaveStats]:
+    ) -> AaveStats | None:
         db = DBHistoryEvents(self.database)
         query_filter = EvmEventFilterQuery.make(
             counterparties=self.counterparties,

--- a/rotkehlchen/chain/ethereum/modules/aave/common.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/common.py
@@ -1,5 +1,5 @@
 import logging
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset, CryptoAsset, EvmToken
@@ -27,7 +27,7 @@ class AaveLendingBalance(NamedTuple):
     apy: FVal
     version: int
 
-    def serialize(self) -> dict[str, Union[str, dict[str, str]]]:
+    def serialize(self) -> dict[str, str | dict[str, str]]:
         return {
             'balance': self.balance.serialize(),
             'apy': self.apy.to_percentage(precision=2),
@@ -44,7 +44,7 @@ class AaveBorrowingBalance(NamedTuple):
     stable_apr: FVal
     version: int
 
-    def serialize(self) -> dict[str, Union[str, dict[str, str]]]:
+    def serialize(self) -> dict[str, str | dict[str, str]]:
         return {
             'balance': self.balance.serialize(),
             'variable_apr': self.variable_apr.to_percentage(precision=2),
@@ -58,7 +58,7 @@ class AaveBalances(NamedTuple):
     borrowing: dict[CryptoAsset, AaveBorrowingBalance]
 
 
-def asset_to_aave_reserve_address(asset: CryptoAsset) -> Optional[ChecksumEvmAddress]:
+def asset_to_aave_reserve_address(asset: CryptoAsset) -> ChecksumEvmAddress | None:
     if asset == A_ETH:  # for v2 this should be WETH
         return ETH_SPECIAL_ADDRESS
 
@@ -67,7 +67,7 @@ def asset_to_aave_reserve_address(asset: CryptoAsset) -> Optional[ChecksumEvmAdd
     return token.evm_address
 
 
-def atoken_to_asset(atoken: EvmToken) -> Optional[CryptoAsset]:
+def atoken_to_asset(atoken: EvmToken) -> CryptoAsset | None:
     if atoken == A_AETH_V1:
         return A_ETH.resolve_to_crypto_asset()
     if atoken == A_AREP_V1:
@@ -89,7 +89,7 @@ def atoken_to_asset(atoken: EvmToken) -> Optional[CryptoAsset]:
     return EvmToken(ethaddress_to_identifier(result[0][0]))
 
 
-def asset_to_atoken(asset: CryptoAsset, version: int) -> Optional[EvmToken]:
+def asset_to_atoken(asset: CryptoAsset, version: int) -> EvmToken | None:
     if asset == A_ETH:
         return A_AETH_V1.resolve_to_evm_token()
 

--- a/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/balancer.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from operator import add, sub
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from gevent.lock import Semaphore
 
@@ -93,7 +93,7 @@ class Balancer(EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.ethereum = ethereum_inquirer

--- a/rotkehlchen/chain/ethereum/modules/balancer/db.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/db.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -57,9 +57,9 @@ def add_balancer_events(
 def get_balancer_events(
         cursor: 'DBCursor',
         msg_aggregator: MessagesAggregator,
-        from_timestamp: Optional[Timestamp] = None,
-        to_timestamp: Optional[Timestamp] = None,
-        address: Optional[ChecksumEvmAddress] = None,
+        from_timestamp: Timestamp | None = None,
+        to_timestamp: Timestamp | None = None,
+        address: ChecksumEvmAddress | None = None,
 ) -> list[BalancerEvent]:
     """Returns a list of Balancer events optionally filtered by time and address"""
     query = 'SELECT * FROM balancer_events '

--- a/rotkehlchen/chain/ethereum/modules/balancer/types.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/types.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, NamedTuple, Optional, Union, cast
+from typing import Any, NamedTuple, cast
 
 from eth_typing.evm import ChecksumAddress
 
@@ -166,12 +166,12 @@ BalancerEventDBTuple = (
         str,  # usd_value
         str,  # amount0
         str,  # amount1
-        Optional[str],  # amount2
-        Optional[str],  # amount3
-        Optional[str],  # amount4
-        Optional[str],  # amount5
-        Optional[str],  # amount6
-        Optional[str],  # amount7
+        str | None,  # amount2
+        str | None,  # amount3
+        str | None,  # amount4
+        str | None,  # amount5
+        str | None,  # amount6
+        str | None,  # amount7
     ]
 )
 
@@ -246,9 +246,9 @@ class BalancerEvent(NamedTuple):
 
     def serialize(
             self,
-            pool_tokens: Optional[list[UnderlyingToken]] = None,
+            pool_tokens: list[UnderlyingToken] | None = None,
     ) -> dict[str, Any]:
-        amounts: Union[list[str], dict[str, Any]]
+        amounts: list[str] | dict[str, Any]
         if isinstance(pool_tokens, list) and len(pool_tokens) > 0:
             amounts = {}
             for pool_token, amount in zip(pool_tokens, self.amounts):

--- a/rotkehlchen/chain/ethereum/modules/balancer/types.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/types.py
@@ -250,8 +250,8 @@ class BalancerEvent(NamedTuple):
     ) -> dict[str, Any]:
         amounts: list[str] | dict[str, Any]
         if isinstance(pool_tokens, list) and len(pool_tokens) > 0:
-            amounts = {}
-            for pool_token, amount in zip(pool_tokens, self.amounts):
+            amounts = {}  # pool_tokens and amounts guaranteed same size
+            for pool_token, amount in zip(pool_tokens, self.amounts, strict=True):
                 token_identifier = ethaddress_to_identifier(pool_token.address)
                 amounts[token_identifier] = str(amount)
         else:
@@ -294,8 +294,8 @@ class BalancerPoolEventsBalance(NamedTuple):
 
     def serialize(self) -> dict[str, Any]:
         profit_loss_amounts: dict[str, Any] = {}  # Includes all assets, even with zero amount
-        tokens_and_weights = []
-        for pool_token, profit_loss_amount in zip(self.pool_address_token.underlying_tokens, self.profit_loss_amounts):  # noqa: E501
+        tokens_and_weights = []  # pool and amount lengths should be equal
+        for pool_token, profit_loss_amount in zip(self.pool_address_token.underlying_tokens, self.profit_loss_amounts, strict=True):  # noqa: E501
             token_identifier = ethaddress_to_identifier(pool_token.address)
             profit_loss_amounts[token_identifier] = str(profit_loss_amount)
             tokens_and_weights.append({

--- a/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.modules.balancer.constants import BALANCER_LABEL, CPT_BALANCER_V1
@@ -44,7 +45,7 @@ class Balancerv1Decoder(DecoderInterface):
             msg_aggregator=msg_aggregator,
         )
 
-    def _decode_v1_pool_event(self, all_logs: list[EvmTxReceiptLog]) -> Optional[list[dict[str, Any]]]:  # noqa: E501
+    def _decode_v1_pool_event(self, all_logs: list[EvmTxReceiptLog]) -> list[dict[str, Any]] | None:  # noqa: E501
         """Read the list of logs in search for a Balancer v1 event and return the information
         needed to decode the transfers made in the transaction to/from the ds proxy
         """

--- a/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken

--- a/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import AssetWithSymbol, EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
@@ -54,7 +54,7 @@ class BaseBridgeDecoder(DecoderInterface):
             asset: AssetWithSymbol,
             from_address: ChecksumEvmAddress,
             to_address: ChecksumEvmAddress,
-            amount: Optional[FVal] = None,
+            amount: FVal | None = None,
     ) -> None:
         """Given the filters for the events update the information of the bridging events"""
         expected_event_type, new_event_type, from_chain, to_chain, expected_location_label = bridge_prepare_data(  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/compound.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceType
 from rotkehlchen.accounting.structures.evm_event import EvmEvent
@@ -44,9 +44,9 @@ log = RotkehlchenLogsAdapter(logger)
 class CompoundBalance(NamedTuple):
     balance_type: BalanceType
     balance: Balance
-    apy: Optional[FVal]
+    apy: FVal | None
 
-    def serialize(self) -> dict[str, Union[Optional[str], dict[str, str]]]:
+    def serialize(self) -> dict[str, str | None | dict[str, str]]:
         return {
             'balance': self.balance.serialize(),
             'apy': self.apy.to_percentage(precision=2) if self.apy else None,
@@ -87,7 +87,7 @@ class Compound(EthereumModule):
         self.msg_aggregator = msg_aggregator
         self.comp = A_COMP.resolve_to_evm_token()
 
-    def _get_apy(self, address: ChecksumEvmAddress, supply: bool) -> Optional[FVal]:
+    def _get_apy(self, address: ChecksumEvmAddress, supply: bool) -> FVal | None:
         method_name = 'supplyRatePerBlock' if supply else 'borrowRatePerBlock'
 
         try:
@@ -224,7 +224,7 @@ class Compound(EthereumModule):
                     event.balance.amount -
                     profit_so_far[address][event.asset].amount
                 )
-                profit: Optional[Balance]
+                profit: Balance | None
                 if profit_amount >= 0:
                     usd_price = query_usd_price_zero_if_error(
                         asset=event.asset,

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
@@ -156,7 +156,7 @@ class Compoundv2Decoder(DecoderInterface):
         Decode borrow and repayments for compound tokens
         """
         underlying_token_symbol = compound_token.symbol[1:]
-        underlying_asset: Optional[CryptoAsset]
+        underlying_asset: CryptoAsset | None
 
         if underlying_token_symbol == self.eth.symbol:
             underlying_asset = self.eth

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/utils.py
@@ -1,10 +1,9 @@
-from typing import Optional
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
 from rotkehlchen.chain.ethereum.modules.compound.constants import CTOKEN_MAPPING
 from rotkehlchen.errors.asset import UnknownAsset
 
 
-def get_compound_underlying_token(token: EvmToken) -> Optional[CryptoAsset]:
+def get_compound_underlying_token(token: EvmToken) -> CryptoAsset | None:
     """
     Returns the underlying token for a compound token. If the provided token is
     unknown it returns None. If the underlying token is unknown it also returns None.

--- a/rotkehlchen/chain/ethereum/modules/convex/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/balances.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.evm_event import EvmProduct
@@ -46,7 +46,7 @@ class ConvexBalances(ProtocolWithGauges):
         )
         self.cvx = A_CVX.resolve_to_evm_token()
 
-    def get_gauge_address(self, event: 'EvmEvent') -> Optional[ChecksumEvmAddress]:
+    def get_gauge_address(self, event: 'EvmEvent') -> ChecksumEvmAddress | None:
         if event.extra_data is None:
             return None
         return event.extra_data.get('gauge_address')  # can be None

--- a/rotkehlchen/chain/ethereum/modules/convex/convex_cache.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/convex_cache.py
@@ -115,7 +115,7 @@ def query_convex_data_from_chain(
     lp_tokens_result = ethereum.multicall(calls=calls_to_lp_tokens)
 
     queried_convex_pools_info: dict[ChecksumEvmAddress, str] = {}
-    for convex_reward_addr, single_lp_token_result in zip(convex_rewards_addrs, lp_tokens_result):
+    for convex_reward_addr, single_lp_token_result in zip(convex_rewards_addrs, lp_tokens_result, strict=True):  # length should be equal # noqa: E501
         decoded_lp_token_symbol = lp_tokens_contract.decode(single_lp_token_result, 'symbol')[0]
         queried_convex_pools_info[convex_reward_addr] = decoded_lp_token_symbol
 

--- a/rotkehlchen/chain/ethereum/modules/convex/convex_cache.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/convex_cache.py
@@ -122,7 +122,7 @@ def query_convex_data_from_chain(
     return queried_convex_pools_info
 
 
-def query_convex_data(inquirer: 'EthereumInquirer') -> Optional[list[ConvexPoolData]]:
+def query_convex_data(inquirer: 'EthereumInquirer') -> list[ConvexPoolData] | None:
     """
     Queries chain for all convex rewards pools and returns a list of the mappings not cached
 

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.base import HistoryEventSubType, HistoryEventType
 from rotkehlchen.accounting.structures.evm_event import EvmProduct

--- a/rotkehlchen/chain/ethereum/modules/curve/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/balances.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithGauges
@@ -33,5 +33,5 @@ class CurveBalances(ProtocolWithGauges):
             gauge_deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},  # noqa: E501
         )
 
-    def get_gauge_address(self, event: 'EvmEvent') -> Optional[ChecksumEvmAddress]:
+    def get_gauge_address(self, event: 'EvmEvent') -> ChecksumEvmAddress | None:
         return event.address

--- a/rotkehlchen/chain/ethereum/modules/curve/curve_cache.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/curve_cache.py
@@ -153,7 +153,7 @@ def ensure_curve_tokens_existence(
         elif len(pool.coins) == len(pool.underlying_coins):
             # Coins and underlying coins lists represent a
             # mapping of coin -> underlying coin (each coin always has one underlying coin).
-            for token_address, underlying_token_address in zip(pool.coins, pool.underlying_coins):
+            for token_address, underlying_token_address in zip(pool.coins, pool.underlying_coins, strict=True):  # noqa: E501
                 if token_address == ETH_SPECIAL_ADDRESS:
                     continue
                 # ensure underlying token exists
@@ -395,7 +395,7 @@ def query_curve_data_from_chain(
         raw_pool_properties = ethereum.multicall_2(calls=calls, require_success=True)
         decoded_pool_properties = [
             metaregistry.decode(result=result[1], method_name=method_name, arguments=[pool_address])  # noqa: E501
-            for result, method_name in zip(raw_pool_properties, CURVE_METAREGISTRY_METHODS)
+            for result, method_name in zip(raw_pool_properties, CURVE_METAREGISTRY_METHODS, strict=True)  # length should be same due to the call # noqa: E501
         ]
         try:
             pool_name: str = decoded_pool_properties[0][0]

--- a/rotkehlchen/chain/ethereum/modules/curve/curve_cache.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/curve_cache.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.assets.asset import UnderlyingToken
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
@@ -71,9 +71,9 @@ class CurvePoolData(NamedTuple):
     pool_address: ChecksumEvmAddress
     pool_name: str
     lp_token_address: ChecksumEvmAddress
-    gauge_address: Optional[ChecksumEvmAddress]
+    gauge_address: ChecksumEvmAddress | None
     coins: list[ChecksumEvmAddress]
-    underlying_coins: Optional[list[ChecksumEvmAddress]]
+    underlying_coins: list[ChecksumEvmAddress] | None
 
 
 def read_curve_pools_and_gauges() -> tuple[dict[ChecksumEvmAddress, list[ChecksumEvmAddress]], set[ChecksumEvmAddress]]:  # noqa: E501
@@ -345,7 +345,7 @@ def query_curve_data_from_api(existing_pools: list[ChecksumEvmAddress]) -> list[
 def query_curve_data_from_chain(
         ethereum: 'EthereumInquirer',
         existing_pools: list[ChecksumEvmAddress],
-) -> Optional[list[CurvePoolData]]:
+) -> list[CurvePoolData] | None:
     """
     Query all curve information(lp tokens, pools, gagues, pool coins) from metaregistry.
 
@@ -431,7 +431,7 @@ def query_curve_data_from_chain(
     return new_pools
 
 
-def query_curve_data(inquirer: 'EthereumInquirer') -> Optional[list[CurvePoolData]]:
+def query_curve_data(inquirer: 'EthereumInquirer') -> list[CurvePoolData] | None:
     """Query curve lp tokens, curve pools and curve gauges.
     First tries to find data via curve api and if fails to do so, queries the chain (metaregistry).
 
@@ -450,7 +450,7 @@ def query_curve_data(inquirer: 'EthereumInquirer') -> Optional[list[CurvePoolDat
             for address in globaldb_get_general_cache_like(cursor=cursor, key_parts=(CacheType.CURVE_LP_TOKENS,))  # noqa: E501
         ]
     try:
-        pools_data: Optional[list[CurvePoolData]] = query_curve_data_from_api(existing_pools=existing_pools)  # noqa: E501
+        pools_data: list[CurvePoolData] | None = query_curve_data_from_api(existing_pools=existing_pools)  # noqa: E501
     except (RemoteError, UnableToDecryptRemoteData) as e:
         log.error(f'Could not query curve api due to: {e}. Will query metaregistry on chain')
         try:

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.evm_event import EvmProduct
@@ -118,9 +119,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 def _read_curve_asset(
-        asset_address: Optional[ChecksumEvmAddress],
+        asset_address: ChecksumEvmAddress | None,
         chain_id: ChainID,
-) -> Optional[Asset]:
+) -> Asset | None:
     """
     A thin wrapper that turns asset address into an asset object.
 
@@ -177,7 +178,7 @@ class CurveDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
     ) -> DecodingOutput:
         """Decode information related to withdrawing assets from curve pools"""
         withdrawal_events: list[EvmEvent] = []
-        return_event: Optional[EvmEvent] = None
+        return_event: EvmEvent | None = None
         for event in decoded_events:
             try:
                 crypto_asset = event.asset.resolve_to_crypto_asset()
@@ -293,7 +294,7 @@ class CurveDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
     ) -> DecodingOutput:
         """Decode information related to depositing assets in curve pools"""
         deposit_events: list[EvmEvent] = []
-        receive_event: Optional[EvmEvent] = None
+        receive_event: EvmEvent | None = None
         for event in decoded_events:
             try:
                 crypto_asset = event.asset.resolve_to_crypto_asset()
@@ -398,8 +399,8 @@ class CurveDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
 
         # These are nullable because in case a curve pool is not stored in our cache or if it
         # is a swap in a metapool (TOKEN_EXCHANGE_UNDERLYING) we will skip token check.
-        sold_token_address: Optional[ChecksumEvmAddress] = None
-        bought_token_address: Optional[ChecksumEvmAddress] = None
+        sold_token_address: ChecksumEvmAddress | None = None
+        bought_token_address: ChecksumEvmAddress | None = None
 
         swapping_contract: ChecksumEvmAddress
         if context.tx_log.topics[0] in (TOKEN_EXCHANGE, TOKEN_EXCHANGE_UNDERLYING):
@@ -441,8 +442,8 @@ class CurveDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
 
         sold_asset = _read_curve_asset(sold_token_address, self.evm_inquirer.chain_id)
         bought_asset = _read_curve_asset(bought_token_address, self.evm_inquirer.chain_id)
-        spend_event: Optional[EvmEvent] = None
-        receive_event: Optional[EvmEvent] = None
+        spend_event: EvmEvent | None = None
+        receive_event: EvmEvent | None = None
         for event in context.decoded_events:
             if event.address != swapping_contract:
                 continue

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import content_hash
 from ens import ENS
@@ -296,7 +296,7 @@ class EnsDecoder(GovernableDecoderInterface, CustomizableDateMixin):
         ))
         return DEFAULT_DECODING_OUTPUT
 
-    def _get_name_to_show(self, node: bytes) -> Optional[str]:
+    def _get_name_to_show(self, node: bytes) -> str | None:
         """Try to find the name associated with the ENS namehash/node that is being modified
 
         Returns the fullname

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -4,7 +4,7 @@ import re
 import sys
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import gevent
 from gevent.lock import Semaphore
@@ -69,7 +69,7 @@ class Eth2(EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
             beaconchain: 'BeaconChain',
     ) -> None:
@@ -145,7 +145,7 @@ class Eth2(EthereumModule):
         usd_price = Inquirer().find_usd_price(A_ETH)
         dbeth2 = DBEth2(self.database)
         balance_mapping: dict[Eth2PubKey, Balance] = defaultdict(Balance)
-        validators: Union[list[ValidatorID], list[Eth2Validator]]
+        validators: list[ValidatorID] | list[Eth2Validator]
         if fetch_validators_for_eth1:
             validators = self.fetch_and_update_eth1_validator_data(addresses)
         else:
@@ -400,8 +400,8 @@ class Eth2(EthereumModule):
 
     def add_validator(
             self,
-            validator_index: Optional[int],
-            public_key: Optional[Eth2PubKey],
+            validator_index: int | None,
+            public_key: Eth2PubKey | None,
             ownership_proportion: FVal,
     ) -> None:
         """Adds the given validator to the DB. Due to marshmallow here at least

--- a/rotkehlchen/chain/ethereum/modules/eth2/structures.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/structures.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.structures.balance import Balance
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 class ValidatorID(NamedTuple):
     # not using index due to : https://github.com/python/mypy/issues/9043
-    index: Optional[int]  # type: ignore  # may be null if the index is not yet determined
+    index: int | None  # type: ignore  # may be null if the index is not yet determined
     public_key: Eth2PubKey
     ownership_proportion: FVal
 
@@ -215,9 +215,9 @@ DEPOSITING_VALIDATOR_PERFORMANCE = ValidatorPerformance(
 
 
 class ValidatorDetails(NamedTuple):
-    validator_index: Optional[int]
+    validator_index: int | None
     public_key: str
-    eth1_depositor: Optional[ChecksumEvmAddress]
+    eth1_depositor: ChecksumEvmAddress | None
     has_exited: bool
     performance: ValidatorPerformance
 

--- a/rotkehlchen/chain/ethereum/modules/eth2/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/utils.py
@@ -1,6 +1,6 @@
 import logging
 from http import HTTPStatus
-from typing import Literal, Optional
+from typing import Literal
 
 import gevent
 import requests
@@ -87,7 +87,7 @@ def _query_page(url: str, event: Literal['stats', 'withdrawals']) -> requests.Re
 def scrape_validator_daily_stats(
         validator_index: int,
         last_known_timestamp: Timestamp,
-        exit_ts: Optional[Timestamp],
+        exit_ts: Timestamp | None,
 ) -> list[ValidatorDailyStats]:
     """Scrapes the website of beaconcha.in and parses the data directly out of the data table.
 

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.evm.decoding.constants import CPT_GITCOIN, GITCOIN_CPT_DETAILS

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import CryptoAsset

--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -2,7 +2,7 @@ import json
 import logging
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, overload
 from urllib.parse import urlencode
 
 import requests
@@ -313,7 +313,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
     def _api_query(
             self,
             endpoint: Literal['user/balances'],
-            options: Optional[dict[str, Any]],
+            options: dict[str, Any] | None,
     ) -> list[dict[str, Any]]:
         ...
 
@@ -321,15 +321,15 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
     def _api_query(
             self,
             endpoint: Literal['account'],
-            options: Optional[dict[str, Any]],
+            options: dict[str, Any] | None,
     ) -> dict[str, Any]:
         ...
 
     def _api_query(
             self,
             endpoint: str,
-            options: Optional[dict[str, Any]],
-    ) -> Union[dict[str, Any], list[dict[str, Any]]]:
+            options: dict[str, Any] | None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         querystr = self.base_url + endpoint
         if options is not None:
             querystr += '?' + urlencode(options)

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.evm_event import LIQUITY_STAKING_DETAILS
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from gevent.lock import Semaphore
 
@@ -36,8 +36,8 @@ log = RotkehlchenLogsAdapter(logger)
 class Trove(NamedTuple):
     collateral: AssetBalance
     debt: AssetBalance
-    collateralization_ratio: Optional[FVal]
-    liquidation_price: Optional[FVal]
+    collateralization_ratio: FVal | None
+    liquidation_price: FVal | None
     active: bool
     trove_id: int
 
@@ -53,8 +53,8 @@ class Trove(NamedTuple):
 
 
 class LiquityBalanceWithProxy(TypedDict):
-    proxies: Optional[dict[ChecksumEvmAddress, dict[str, AssetBalance]]]
-    balances: Optional[dict[str, AssetBalance]]
+    proxies: dict[ChecksumEvmAddress, dict[str, AssetBalance]] | None
+    balances: dict[str, AssetBalance] | None
 
 
 def default_balance_with_proxy_factory() -> LiquityBalanceWithProxy:
@@ -67,7 +67,7 @@ class Liquity(HasDSProxy):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         super().__init__(
@@ -132,8 +132,8 @@ class Liquity(HasDSProxy):
                         ),
                     )
                     # Avoid division errors
-                    collateralization_ratio: Optional[FVal]
-                    liquidation_price: Optional[FVal]
+                    collateralization_ratio: FVal | None
+                    liquidation_price: FVal | None
                     if debt > 0:
                         collateralization_ratio = eth_price * collateral / debt * 100
                     else:

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -212,7 +212,7 @@ class Liquity(HasDSProxy):
             # make sure that variables always have a value set. It is guaranteed that the response
             # will have the desired format because we include and process failed queries.
             key, asset, gain_info = keys[0], assets[0], 0
-            for method_idx, (method, _asset, _key) in enumerate(zip(methods, assets, keys)):
+            for method_idx, (method, _asset, _key) in enumerate(zip(methods, assets, keys, strict=True)):  # noqa: E501
                 # get the asset, key used in the response and the amount based on the index
                 # for this address
                 if idx % 3 == method_idx:

--- a/rotkehlchen/chain/ethereum/modules/makerdao/cache.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/cache.py
@@ -32,7 +32,7 @@ GENERAL_ILK_CACHE_KEY = f'{CacheType.MAKERDAO_VAULT_ILK.serialize()}ETH-A'
 def _collateral_type_to_info(
         cursor: 'DBCursor',
         collateral_type: str,
-) -> Optional[tuple[int, ChecksumEvmAddress, ChecksumEvmAddress]]:
+) -> tuple[int, ChecksumEvmAddress, ChecksumEvmAddress] | None:
     cursor.execute(
         'SELECT value from unique_cache WHERE key=?',
         (f'{CacheType.MAKERDAO_VAULT_ILK.serialize()}{collateral_type}',),
@@ -50,7 +50,7 @@ def _collateral_type_to_info(
     return int(info[0]), info[1], info[2]
 
 
-def collateral_type_to_underlying_asset(collateral_type: str) -> Optional[CryptoAsset]:
+def collateral_type_to_underlying_asset(collateral_type: str) -> CryptoAsset | None:
     """Get the underlying asset for a collateral type by asking the global DB cache"""
     with GlobalDBHandler().conn.read_ctx() as cursor:
         info = _collateral_type_to_info(cursor, collateral_type)

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -143,7 +143,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):
             )],
         )
         mapping = {}
-        for result_encoded, method_name in zip(output, ('urns', 'owns')):
+        for result_encoded, method_name in zip(output, ('urns', 'owns'), strict=True):
             result = self.makerdao_cdp_manager.decode(
                 result_encoded,
                 method_name,

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -108,7 +108,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):
         self.makerdao_cdp_manager = self.ethereum.contracts.contract(string_to_evm_address('0x5ef30b9986345249bc32d8928B7ee64DE9435E39'))  # noqa: E501
         self.makerdao_dai_join = self.ethereum.contracts.contract(string_to_evm_address('0x9759A6Ac90977b93B58547b4A71c78317f391A28'))  # noqa: E501
 
-    def _get_address_or_proxy(self, address: ChecksumEvmAddress) -> Optional[ChecksumEvmAddress]:
+    def _get_address_or_proxy(self, address: ChecksumEvmAddress) -> ChecksumEvmAddress | None:
         if self.base.is_tracked(address):
             return address
 
@@ -457,7 +457,7 @@ class MakerdaoDecoder(DecoderInterface, HasDSProxy):
         if context.tx_log.topics[0] == SDAI_DEPOSIT:  # DAI -> SDAI: owner receives sdai
             owner_address = self._get_address_or_proxy(hex_or_bytes_to_address(context.tx_log.topics[2]))  # noqa: E501
             to_address = owner_address
-            from_address: Optional[ChecksumEvmAddress] = self.sdai.evm_address
+            from_address: ChecksumEvmAddress | None = self.sdai.evm_address
         elif context.tx_log.topics[0] == SDAI_REDEEM:  # SDAI -> DAI: owner deposits sdai
             owner_address = self._get_address_or_proxy(hex_or_bytes_to_address(context.tx_log.topics[3]))  # noqa: E501
             from_address = owner_address

--- a/rotkehlchen/chain/ethereum/modules/makerdao/dsr.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/dsr.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from gevent.lock import Semaphore
 
@@ -97,7 +97,7 @@ class DSRAccountReport(NamedTuple):
         return serialized_report
 
 
-def _dsrdai_to_dai(value: Union[int, FVal]) -> FVal:
+def _dsrdai_to_dai(value: int | FVal) -> FVal:
     """Turns a big integer that is the value of DAI in DSR into a proper DAI decimal FVal"""
     return FVal(value / FVal(RAD))
 
@@ -108,7 +108,7 @@ class MakerdaoDsr(HasDSProxy):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
 
@@ -173,7 +173,7 @@ class MakerdaoDsr(HasDSProxy):
             proxy_address: ChecksumEvmAddress,
             block_number: int,
             transaction_index: int,
-    ) -> Optional[int]:
+    ) -> int | None:
         """Returns values in DSR DAI that were deposited/withdrawn at a block number and tx index
 
         DSR DAI means they need they have a lot more digits than normal DAI and they

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -453,7 +454,7 @@ class MakerdaosaiDecoder(DecoderInterface):
 
     def _decode_sai_cdp_migration(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from gevent.lock import Semaphore
 
@@ -86,11 +86,11 @@ class MakerdaoVault(NamedTuple):
     # amount/usd value of DAI drawn
     debt: Balance
     # The current collateralization_ratio of the Vault. None if nothing is locked in.
-    collateralization_ratio: Optional[str]
+    collateralization_ratio: str | None
     # The ratio at which the vault is open for liquidation. (e.g. 1.5 for 150%)
     liquidation_ratio: FVal
     # The USD price of collateral at which the Vault becomes unsafe. None if nothing is locked in.
-    liquidation_price: Optional[FVal]
+    liquidation_price: FVal | None
     urn: ChecksumEvmAddress
     stability_fee: FVal
 
@@ -142,7 +142,7 @@ class MakerdaoVaults(HasDSProxy):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
 
@@ -190,7 +190,7 @@ class MakerdaoVaults(HasDSProxy):
             owner: ChecksumEvmAddress,
             urn: ChecksumEvmAddress,
             ilk: bytes,
-    ) -> Optional[MakerdaoVault]:
+    ) -> MakerdaoVault | None:
         collateral_type = ilk.split(b'\0', 1)[0].decode()
         asset = collateral_type_to_underlying_asset(collateral_type)
         if asset is None:
@@ -246,7 +246,7 @@ class MakerdaoVaults(HasDSProxy):
             vault: MakerdaoVault,
             proxy: ChecksumEvmAddress,
             urn: ChecksumEvmAddress,
-    ) -> Optional[MakerdaoVaultDetails]:
+    ) -> MakerdaoVaultDetails | None:
         # They can raise:
         # DeserializationError due to hex_or_bytes_to_address, hexstr_to_int
         # RemoteError due to external query errors
@@ -659,8 +659,8 @@ class MakerdaoVaults(HasDSProxy):
                 if timestamp > to_timestamp:
                     break
 
-                got_asset: Optional[CryptoAsset]
-                spent_asset: Optional[CryptoAsset]
+                got_asset: CryptoAsset | None
+                spent_asset: CryptoAsset | None
                 pnl = got_asset = got_balance = spent_asset = spent_balance = None
                 count_spent_got_cost_basis = False
                 if event.event_type == VaultEventType.GENERATE_DEBT:

--- a/rotkehlchen/chain/ethereum/modules/nft/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nft/nfts.py
@@ -35,30 +35,30 @@ log = RotkehlchenLogsAdapter(logger)
 
 NFT_DB_WRITE_TUPLE = tuple[
     str,  # identifier
-    Optional[str],  # name
-    Optional[str],  # price_in_asset
-    Optional[str],  # price_asset
+    str | None,  # name
+    str | None,  # price_in_asset
+    str | None,  # price_asset
     bool,  # whether the price is manually input
     ChecksumEvmAddress,  # owner address
     bool,  # whether is an lp
-    Optional[str],  # image_url
-    Optional[str],  # collection_name
+    str | None,  # image_url
+    str | None,  # collection_name
 ]
 NFT_DB_READ_TUPLE = tuple[
     str,  # identifier
-    Optional[str],  # name
-    Optional[str],  # price_in_asset
-    Optional[str],  # price_asset
+    str | None,  # name
+    str | None,  # price_in_asset
+    str | None,  # price_asset
     bool,  # whether the price is manually input
     bool,  # whether is an lp
-    Optional[str],  # image_url
-    Optional[str],  # collection_name
+    str | None,  # image_url
+    str | None,  # collection_name
 ]
 
 
 def _deserialize_nft_price(
-        last_price: Optional[str],
-        last_price_asset: Optional[str],
+        last_price: str | None,
+        last_price_asset: str | None,
 ) -> tuple[FVal, Asset, FVal]:
     """Deserialize last price and last price asset from a DB entry
     TODO: Both last_price and last_price_asset are optional in the current DB schema
@@ -202,7 +202,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
     def query_balances(
             self,
             addresses: Sequence[ChecksumEvmAddress],
-            uniswap_nfts: Optional[AddressToUniswapV3LPBalances],
+            uniswap_nfts: AddressToUniswapV3LPBalances | None,
     ) -> None:
         """Queries NFT balances for the specified addresses and saves them to the db.
         Doesn't return anything. The actual opensea querying part is protected by a lock.
@@ -269,10 +269,10 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
 
     def get_nfts_with_price(
             self,
-            identifier: Optional[str] = None,
+            identifier: str | None = None,
             lps_handling: NftLpHandling = NftLpHandling.ALL_NFTS,
-            from_asset: Optional[Asset] = None,
-            to_asset: Optional[Asset] = None,
+            from_asset: Asset | None = None,
+            to_asset: Asset | None = None,
             only_with_manual_prices: bool = False,
     ) -> list[dict[str, Any]]:
         """

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import AssetBalance, Balance
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
@@ -38,7 +38,7 @@ class PickleFinance(EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.ethereum = ethereum_inquirer

--- a/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import Asset

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP_V2
@@ -37,7 +38,7 @@ class SushiswapDecoder(DecoderInterface):
 
     def _maybe_decode_v2_swap(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],
@@ -58,7 +59,7 @@ class SushiswapDecoder(DecoderInterface):
 
     def _maybe_decode_v2_liquidity_addition_and_removal(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: list['EvmEvent'],

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/sushiswap.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.ethereum.interfaces.ammswap.ammswap import AMMSwapPlatform
 from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP_V2
@@ -27,7 +27,7 @@ class Sushiswap(AMMSwapPlatform, EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/uniswap.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.chain.ethereum.interfaces.ammswap.ammswap import AMMSwapPlatform
@@ -42,7 +42,7 @@ class Uniswap(AMMSwapPlatform, EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.defi.zerionsdk import ZERION_ADAPTER_ADDRESS

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
@@ -33,7 +34,7 @@ class Uniswapv1Decoder(DecoderInterface):
 
     def _maybe_decode_swap(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: list['EvmEvent'],

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
-from typing import TYPE_CHECKING, Callable, Literal, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
 
 from web3 import Web3
 
@@ -206,8 +207,8 @@ def decode_uniswap_like_deposit_and_withdrawals(
     amount0_raw = hex_or_bytes_to_int(tx_log.data[:32])
     amount1_raw = hex_or_bytes_to_int(tx_log.data[32:64])
 
-    token0: Optional[EvmToken] = None
-    token1: Optional[EvmToken] = None
+    token0: EvmToken | None = None
+    token1: EvmToken | None = None
     event0_idx = event1_idx = None
 
     if event_action_type == 'addition':

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.modules.uniswap.constants import (
@@ -73,7 +74,7 @@ class Uniswapv2Decoder(DecoderInterface):
 
     def _maybe_decode_v2_swap(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],
@@ -103,7 +104,7 @@ class Uniswapv2Decoder(DecoderInterface):
 
     def _maybe_decode_v2_liquidity_addition_and_removal(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: list['EvmEvent'],

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -406,7 +406,7 @@ class Uniswapv3Decoder(DecoderInterface):
 
         resolved_assets_and_amounts: list[CryptoAssetAmount] = []
         # index 2 -> first token in pair; index 3 -> second token in pair
-        for token, amount in zip(liquidity_pool_position_info[2:4], (amount0_raw, amount1_raw)):
+        for token, amount in zip(liquidity_pool_position_info[2:4], (amount0_raw, amount1_raw), strict=True):  # noqa: E501
             token_with_data: CryptoAsset = get_or_create_evm_token(
                 userdb=self.evm_inquirer.database,
                 evm_address=token,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -63,12 +64,12 @@ class CryptoAssetAmount(NamedTuple):
     amount: FVal
 
 
-def _find_from_asset_and_amount(events: list['EvmEvent']) -> Optional[tuple[Asset, FVal]]:
+def _find_from_asset_and_amount(events: list['EvmEvent']) -> tuple[Asset, FVal] | None:
     """
     Searches for uniswap v2/v3 swaps, detects `from_asset` and sums up `from_amount`.
     Works only with `from_asset` being the same for all swaps.
     """
-    from_asset: Optional[Asset] = None
+    from_asset: Asset | None = None
     from_amount = ZERO
     for event in events:
         if (
@@ -88,13 +89,13 @@ def _find_from_asset_and_amount(events: list['EvmEvent']) -> Optional[tuple[Asse
     return from_asset, from_amount
 
 
-def _find_to_asset_and_amount(events: list['EvmEvent']) -> Optional[tuple[Asset, FVal]]:
+def _find_to_asset_and_amount(events: list['EvmEvent']) -> tuple[Asset, FVal] | None:
     """
     Searches for uniswap v2/v3 swaps, detects `to_asset` and sums up `to_amount`.
     Works only with `to_asset` being the same for all swaps.
     Also works with a special case where there is only one receive event at the end.
     """
-    to_asset: Optional[Asset] = None
+    to_asset: Asset | None = None
     to_amount = ZERO
     for event in events:
         if (
@@ -159,7 +160,7 @@ class Uniswapv3Decoder(DecoderInterface):
 
     def _maybe_decode_v3_swap(
             self,
-            token: Optional[EvmToken],  # pylint: disable=unused-argument
+            token: EvmToken | None,  # pylint: disable=unused-argument
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,  # pylint: disable=unused-argument
             decoded_events: list['EvmEvent'],
@@ -205,7 +206,7 @@ class Uniswapv3Decoder(DecoderInterface):
             decoded_events: list['EvmEvent'],
             send_eth_event: 'EvmEvent',
             receive_eth_event: Optional['EvmEvent'],
-    ) -> Optional[SwapData]:
+    ) -> SwapData | None:
         """
         Decode a swap of ETH to a token. Such swap consists of 3 events:
         1. Sending ETH to the router.
@@ -231,7 +232,7 @@ class Uniswapv3Decoder(DecoderInterface):
             self,
             decoded_events: list['EvmEvent'],
             receive_eth_event: 'EvmEvent',
-    ) -> Optional[SwapData]:
+    ) -> SwapData | None:
         from_data = _find_from_asset_and_amount(decoded_events)
         if from_data is None:
             return None
@@ -246,7 +247,7 @@ class Uniswapv3Decoder(DecoderInterface):
     def _decode_token_to_token_swap(
             self,
             decoded_events: list['EvmEvent'],
-    ) -> Optional[SwapData]:
+    ) -> SwapData | None:
         from_data = _find_from_asset_and_amount(decoded_events)
         to_data = _find_to_asset_and_amount(decoded_events)
         if from_data is None or to_data is None:

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/utils.py
@@ -192,15 +192,16 @@ def uniswap_v3_lp_token_balances(
                 require_success=False,
                 calls=[
                     (entry[0], entry[1].encode('slot0'))
-                    for entry in zip(pool_addresses, pool_contracts)
+                    for entry in zip(pool_addresses, pool_contracts, strict=True)
                 ],
             )
         except RemoteError as e:
             log.error(UNISWAP_V3_ERROR_MSG.format('pool contract slot0', str(e)))
             continue
+
         slots_0 = [
-            entry[0].decode(entry[1][1], 'slot0')
-            for entry in zip(pool_contracts, slots_0_multicall) if entry[1][0] is True
+            entry[0].decode(entry[1][1], 'slot0')  # length equal due to multical args
+            for entry in zip(pool_contracts, slots_0_multicall, strict=True) if entry[1][0] is True
         ]
         tokens_a, tokens_b = [], []
         for position in positions:
@@ -220,7 +221,7 @@ def uniswap_v3_lp_token_balances(
         price_ranges = []
         amounts_0 = []
         amounts_1 = []
-        for (position, slot_0, token_a, token_b) in zip(positions, slots_0, tokens_a, tokens_b):
+        for (position, slot_0, token_a, token_b) in zip(positions, slots_0, tokens_a, tokens_b, strict=True):  # noqa: E501
             price_ranges.append(
                 calculate_price_range(
                     tick_lower=position[5],
@@ -257,7 +258,7 @@ def uniswap_v3_lp_token_balances(
                 require_success=False,
                 calls=[
                     (entry[0], entry[1].encode('liquidity'))
-                    for entry in zip(pool_addresses, pool_contracts)
+                    for entry in zip(pool_addresses, pool_contracts, strict=True)
                 ],
             )
         except RemoteError as e:
@@ -265,12 +266,13 @@ def uniswap_v3_lp_token_balances(
             continue
 
         for _entry in zip(
-            pool_contracts,
-            liquidity_in_pools_multicall,
-            positions,
-            slots_0,
-            tokens_a,
-            tokens_b,
+                pool_contracts,
+                liquidity_in_pools_multicall,
+                positions,
+                slots_0,
+                tokens_a,
+                tokens_b,
+                strict=True,
         ):
             liquidity_in_pool = _entry[0].decode(_entry[1][1], 'liquidity')[0]
             try:
@@ -290,15 +292,16 @@ def uniswap_v3_lp_token_balances(
                 continue
 
         for item in zip(
-            tokens_ids,
-            pool_addresses,
-            positions,
-            price_ranges,
-            tokens_a,
-            tokens_b,
-            amounts_0,
-            amounts_1,
-            total_tokens_in_pools,
+                tokens_ids,
+                pool_addresses,
+                positions,
+                price_ranges,
+                tokens_a,
+                tokens_b,
+                amounts_0,
+                amounts_1,
+                total_tokens_in_pools,
+                strict=True,
         ):
             if FVal(item[6]) > ZERO or FVal(item[7]) > ZERO:
                 item[4].update({

--- a/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken

--- a/rotkehlchen/chain/ethereum/modules/yearn/structures.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/structures.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Literal, NamedTuple, Optional
+from typing import Any, Literal, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
@@ -20,8 +20,8 @@ YEARN_EVENT_DB_TUPLE = tuple[
     str,  # to_asset idientifier
     str,  # to_value amount
     str,  # to value usd_value
-    Optional[str],  # pnl amount
-    Optional[str],  # pnl usd value
+    str | None,  # pnl amount
+    str | None,  # pnl usd value
     str,  # block number
     str,  # str of timestamp
     bytes,  # tx hash
@@ -39,7 +39,7 @@ class YearnVaultEvent:
     from_value: Balance
     to_asset: CryptoAsset
     to_value: Balance
-    realized_pnl: Optional[Balance]
+    realized_pnl: Balance | None
     tx_hash: EVMTxHash
     log_index: int
     version: int

--- a/rotkehlchen/chain/ethereum/modules/yearn/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/utils.py
@@ -1,7 +1,7 @@
 import logging
 from http import HTTPStatus
 from json import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def _maybe_reset_yearn_cache_timestamp(data: Optional[dict[str, Any]]) -> bool:
+def _maybe_reset_yearn_cache_timestamp(data: dict[str, Any] | None) -> bool:
     """Get the number of vaults processed in the last execution of this function.
     If it was the same number of vaults this response has then we don't need to take
     action since vaults are not removed from their API response.
@@ -49,7 +49,7 @@ def _maybe_reset_yearn_cache_timestamp(data: Optional[dict[str, Any]]) -> bool:
     It returns if we should stop updating (True) or not (False)
     """
     with GlobalDBHandler().conn.read_ctx() as cursor:
-        yearn_api_cache: Optional[str] = globaldb_get_unique_cache_value(
+        yearn_api_cache: str | None = globaldb_get_unique_cache_value(
             cursor=cursor,
             key_parts=(CacheType.YEARN_VAULTS,),
         )

--- a/rotkehlchen/chain/ethereum/modules/yearn/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaults.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from gevent.lock import Semaphore
 
@@ -120,7 +120,7 @@ class YearnVaultBalance(NamedTuple):
     vault_token: CryptoAsset
     underlying_value: Balance
     vault_value: Balance
-    roi: Optional[FVal]
+    roi: FVal | None
 
     def serialize(self) -> dict[str, Any]:
         result = self._asdict()  # pylint: disable=no-member
@@ -168,7 +168,7 @@ class YearnVaults(EthereumModule):
             self,
             ethereum_inquirer: 'EthereumInquirer',
             database: 'DBHandler',
-            premium: Optional[Premium],
+            premium: Premium | None,
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.ethereum = ethereum_inquirer
@@ -636,7 +636,7 @@ class YearnVaults(EthereumModule):
                 total -= event.from_value
             else:  # withdraws
                 profit_amount = total.amount + event.to_value.amount - profit_so_far.amount
-                profit: Optional[Balance]
+                profit: Balance | None
                 if profit_amount >= 0:
                     usd_price = get_usd_price_zero_if_error(
                         asset=event.to_asset,
@@ -661,7 +661,7 @@ class YearnVaults(EthereumModule):
             address: ChecksumEvmAddress,
             from_block: int,
             to_block: int,
-    ) -> Optional[YearnVaultHistory]:
+    ) -> YearnVaultHistory | None:
         """Queries for vault events history and saves it in the database"""
         from_block = max(from_block, vault.contract.deployed_block)
         with self.database.conn.read_ctx() as cursor:

--- a/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vaultsv2.py
@@ -60,7 +60,7 @@ class YearnVaultsV2(EthereumModule):
             )
             raise ModuleInitializationFailure('Yearn Vaults v2 Subgraph remote error') from e
 
-    def _calculate_vault_roi_and_pps(self, vault: EvmToken) -> tuple[Optional[FVal], int]:
+    def _calculate_vault_roi_and_pps(self, vault: EvmToken) -> tuple[FVal | None, int]:
         """
         getPricePerFullShare A @ block X
         getPricePerFullShare B @ block Y
@@ -174,7 +174,7 @@ class YearnVaultsV2(EthereumModule):
                 total -= event.from_value
             else:  # withdraws
                 profit_amount = total.amount + event.to_value.amount - profit_so_far.amount
-                profit: Optional[Balance]
+                profit: Balance | None
                 if profit_amount >= 0:
                     usd_price = get_usd_price_zero_if_error(
                         asset=event.to_asset,

--- a/rotkehlchen/chain/ethereum/node_inquirer.py
+++ b/rotkehlchen/chain/ethereum/node_inquirer.py
@@ -108,7 +108,7 @@ class EthereumInquirer(DSProxyInquirerWithCacheData):
                 method_name='getNames',
                 arguments=[chunk],
             )
-            for addr, name in zip(chunk, result):
+            for addr, name in zip(chunk, result, strict=True):
                 if name == '':
                     human_names[addr] = None
                 else:

--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -2,7 +2,7 @@ import abc
 import logging
 from functools import reduce
 from operator import mul
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple
 
 from eth_utils import to_checksum_address
 from web3.types import BlockIdentifier
@@ -66,7 +66,7 @@ class UniswapOracle(CurrentPriceOracleInterface, CacheableMixIn):
 
     def rate_limited_in_last(
             self,
-            seconds: Optional[int] = None,  # pylint: disable=unused-argument
+            seconds: int | None = None,  # pylint: disable=unused-argument
     ) -> bool:
         return False
 

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -68,14 +68,14 @@ ENS_RESOLVER_ABI_MULTICHAIN_ADDRESS = [
 MULTICALL_CHUNKS = 20
 
 
-def token_normalized_value_decimals(token_amount: int, token_decimals: Optional[int]) -> FVal:
+def token_normalized_value_decimals(token_amount: int, token_decimals: int | None) -> FVal:
     if token_decimals is None:  # if somehow no info on decimals ends up here assume 18
         token_decimals = 18
 
     return token_amount / (FVal(10) ** FVal(token_decimals))
 
 
-def token_raw_value_decimals(token_amount: FVal, token_decimals: Optional[int]) -> int:
+def token_raw_value_decimals(token_amount: FVal, token_decimals: int | None) -> int:
     if token_decimals is None:  # if somehow no info on decimals ends up here assume 18
         token_decimals = 18
 

--- a/rotkehlchen/chain/evm/accounting/aggregator.py
+++ b/rotkehlchen/chain/evm/accounting/aggregator.py
@@ -4,7 +4,7 @@ import pkgutil
 from collections.abc import Sequence
 from contextlib import suppress
 from types import ModuleType
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.errors.misc import ModuleLoadingError
@@ -36,7 +36,7 @@ class EVMAccountingAggregator:
             node_inquirer: 'EvmNodeInquirer',
             msg_aggregator: MessagesAggregator,
             modules_path: str,
-            airdrops_list: Optional[Sequence[CounterpartyDetails]] = None,
+            airdrops_list: Sequence[CounterpartyDetails] | None = None,
     ) -> None:
         self.node_inquirer = node_inquirer
         self.msg_aggregator = msg_aggregator
@@ -46,7 +46,7 @@ class EVMAccountingAggregator:
         self.initialize_all_accountants()
 
     def _recursively_initialize_accountants(
-            self, package: Union[str, ModuleType],
+            self, package: str | ModuleType,
     ) -> None:
         modules_prefix_length = len(self.modules_path) + 1  # +1 is for '.'
         if isinstance(package, str):

--- a/rotkehlchen/chain/evm/accounting/structures.py
+++ b/rotkehlchen/chain/evm/accounting/structures.py
@@ -1,5 +1,5 @@
 from enum import auto
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, Protocol
 
 from rotkehlchen.utils.mixins.enums import DBCharEnumMixIn
 
@@ -35,7 +35,7 @@ ACCOUNTING_SETTING_DB_TUPLE = tuple[
     int,  # taxable
     int,  # count_entire_amount_spend
     int,  # count_cost_basis_pnl
-    Union[str, None],  # accounting_treatment
+    str | None,  # accounting_treatment
 ]
 
 
@@ -46,7 +46,7 @@ class BaseEventSettings:
             taxable: bool,
             count_entire_amount_spend: bool,
             count_cost_basis_pnl: bool,
-            accounting_treatment: Optional[TxAccountingTreatment] = None,
+            accounting_treatment: TxAccountingTreatment | None = None,
     ):
         self.taxable = taxable
         self.count_entire_amount_spend = count_entire_amount_spend
@@ -92,8 +92,8 @@ class TxEventSettings(BaseEventSettings):
             taxable: bool,
             count_entire_amount_spend: bool,
             count_cost_basis_pnl: bool,
-            accounting_treatment: Optional[TxAccountingTreatment] = None,
-            accountant_cb: Optional[EventsAccountantCallback] = None,
+            accounting_treatment: TxAccountingTreatment | None = None,
+            accountant_cb: EventsAccountantCallback | None = None,
     ):
         super().__init__(
             taxable=taxable,

--- a/rotkehlchen/chain/evm/contracts.py
+++ b/rotkehlchen/chain/evm/contracts.py
@@ -1,17 +1,7 @@
 import json
 import logging
 from collections.abc import Sequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Literal,
-    NamedTuple,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, Literal, NamedTuple, TypeVar, overload
 
 from eth_typing.abi import Decodable
 from web3 import Web3
@@ -44,8 +34,8 @@ class EvmContract(NamedTuple):
             self,
             node_inquirer: 'EvmNodeInquirer',
             method_name: str,
-            arguments: Optional[list[Any]] = None,
-            call_order: Optional[Sequence['WeightedNode']] = None,
+            arguments: list[Any] | None = None,
+            call_order: Sequence['WeightedNode'] | None = None,
             block_identifier: BlockIdentifier = 'latest',
     ) -> Any:
         return node_inquirer.call_contract(
@@ -62,8 +52,8 @@ class EvmContract(NamedTuple):
             node_inquirer: 'EvmNodeInquirer',
             event_name: str,
             argument_filters: dict[str, Any],
-            to_block: Union[int, Literal['latest']] = 'latest',
-            call_order: Optional[Sequence['WeightedNode']] = None,
+            to_block: int | Literal['latest'] = 'latest',
+            call_order: Sequence['WeightedNode'] | None = None,
     ) -> Any:
         return node_inquirer.get_logs(
             contract_address=self.address,
@@ -81,8 +71,8 @@ class EvmContract(NamedTuple):
             event_name: str,
             argument_filters: dict[str, Any],
             from_block: int,
-            to_block: Union[int, Literal['latest']] = 'latest',
-            call_order: Optional[Sequence['WeightedNode']] = None,
+            to_block: int | Literal['latest'] = 'latest',
+            call_order: Sequence['WeightedNode'] | None = None,
     ) -> Any:
         return node_inquirer.get_logs(
             contract_address=self.address,
@@ -94,7 +84,7 @@ class EvmContract(NamedTuple):
             call_order=call_order,
         )
 
-    def encode(self, method_name: str, arguments: Optional[list[Any]] = None) -> str:
+    def encode(self, method_name: str, arguments: list[Any] | None = None) -> str:
         contract = WEB3.eth.contract(address=self.address, abi=self.abi)
         return contract.encodeABI(method_name, args=arguments if arguments else [])
 
@@ -102,7 +92,7 @@ class EvmContract(NamedTuple):
             self,
             result: Decodable,
             method_name: str,
-            arguments: Optional[list[Any]] = None,
+            arguments: list[Any] | None = None,
     ) -> tuple[Any, ...]:
         contract = WEB3.eth.contract(address=self.address, abi=self.abi)
         fn_abi = contract._find_matching_fn_abi(
@@ -116,7 +106,7 @@ class EvmContract(NamedTuple):
             self,
             tx_log: 'EvmTxReceiptLog',
             event_name: str,
-            argument_names: Optional[Sequence[str]],
+            argument_names: Sequence[str] | None,
     ) -> tuple[list, list]:
         """Decodes an event by finding the event ABI in the given contract's abi
 
@@ -159,7 +149,7 @@ class EvmContracts(Generic[T]):
             self,
             address: ChecksumEvmAddress,
             fallback_to_packaged_db: bool = True,
-    ) -> Optional[EvmContract]:
+    ) -> EvmContract | None:
         """
         Returns contract data by address if found. Can fall back to packaged global db if
         not found in the normal global DB
@@ -231,7 +221,7 @@ class EvmContracts(Generic[T]):
             cls,
             name: str,
             fallback_to_packaged_db: bool = False,
-    ) -> Optional[list[dict[str, Any]]]:
+    ) -> list[dict[str, Any]] | None:
         """Gets abi of an evm contract from the abi json file and optionally falls back to
         the packaged db if the abi is not found.
 

--- a/rotkehlchen/chain/evm/decoding/airdrops.py
+++ b/rotkehlchen/chain/evm/decoding/airdrops.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 
@@ -15,7 +15,7 @@ def match_airdrop_claim(
         amount: 'FVal',
         asset: 'Asset',
         counterparty: str,
-        notes: Optional[str] = None,
+        notes: str | None = None,
 ) -> bool:
     """It matches a transfer event to an airdrop claim, changes the required fields
      then returns `True` if a match was found"""

--- a/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
@@ -1,6 +1,7 @@
 import abc
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -182,7 +183,7 @@ class CowswapCommonDecoder(DecoderInterface, metaclass=abc.ABCMeta):
             ):
                 related_transfer_events[(event.event_type, event.asset, event.balance.amount)] = event  # noqa: E501
 
-        trades_events: list[tuple[EvmEvent, EvmEvent, Optional[EvmEvent], SwapData]] = []
+        trades_events: list[tuple[EvmEvent, EvmEvent, EvmEvent | None, SwapData]] = []
         for swap_data in all_swap_data:
             receive_event = related_transfer_events.get((HistoryEventType.RECEIVE, swap_data.to_asset, swap_data.to_amount))  # noqa: E501
             if receive_event is None:

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -2,10 +2,11 @@ import importlib
 import logging
 import pkgutil
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, Optional, Protocol
 
 from gevent.lock import Semaphore
 
@@ -69,7 +70,7 @@ class EventDecoderFunction(Protocol):
 
     def __call__(
             self,
-            token: Optional[EvmToken],
+            token: EvmToken | None,
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],
@@ -226,7 +227,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
 
     def _recursively_initialize_decoders(
             self,
-            package: Union[str, ModuleType],
+            package: str | ModuleType,
     ) -> DecodingRules:
         if isinstance(package, str):
             package = importlib.import_module(package)
@@ -288,13 +289,13 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
 
     def try_all_rules(
             self,
-            token: Optional[EvmToken],
+            token: EvmToken | None,
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
-    ) -> Optional[DecodingOutput]:
+    ) -> DecodingOutput | None:
         """
         Execute event rules for the current tx log. Returns None when no
         new event or actions need to be propagated.
@@ -485,7 +486,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
 
     def get_and_decode_undecoded_transactions(
             self,
-            limit: Optional[int] = None,
+            limit: int | None = None,
             send_ws_notifications: bool = False,
     ) -> None:
         """Checks the DB for up to `limit` undecoded transactions and decodes them.
@@ -511,7 +512,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
     def decode_transaction_hashes(
             self,
             ignore_cache: bool,
-            tx_hashes: Optional[list[EVMTxHash]],
+            tx_hashes: list[EVMTxHash] | None,
             send_ws_notifications: bool = False,
     ) -> list['EvmEvent']:
         """Make sure that receipts are pulled + events decoded for the given transaction hashes.
@@ -695,7 +696,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
 
     def _maybe_decode_erc20_approve(
             self,
-            token: Optional[EvmToken],
+            token: EvmToken | None,
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
@@ -810,7 +811,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
 
     def _maybe_decode_erc20_721_transfer(
             self,
-            token: Optional[EvmToken],
+            token: EvmToken | None,
             tx_log: EvmTxReceiptLog,
             transaction: EvmTransaction,
             decoded_events: list['EvmEvent'],  # pylint: disable=unused-argument
@@ -970,7 +971,7 @@ class EVMTransactionDecoder(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:
         """Takes an address and returns if it's an exchange in the given chain
         and the counterparty to use if it is."""
 

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.evm_event import EvmProduct
@@ -182,7 +182,7 @@ class ReloadableDecoderMixin(metaclass=ABCMeta):
     remote data source, to the decoder's memory."""
 
     @abstractmethod
-    def reload_data(self) -> Optional[Mapping[ChecksumEvmAddress, tuple[Any, ...]]]:
+    def reload_data(self) -> Mapping[ChecksumEvmAddress, tuple[Any, ...]] | None:
         """Subclasses may implement this to be able to reload some of the decoder's properties
         Returns only new mappings of addresses to decode functions"""
 
@@ -196,12 +196,9 @@ class ReloadableCacheDecoderMixin(ReloadableDecoderMixin, metaclass=ABCMeta):
             self,
             evm_inquirer: 'EvmNodeInquirer',
             cache_type_to_check_for_freshness: CacheType,
-            query_data_method: Union[
-                Callable[['OptimismInquirer'], Optional[list['VelodromePoolData']]],
-                Callable[['EthereumInquirer'], Optional[list]],
-            ],
+            query_data_method: Callable[['OptimismInquirer'], list['VelodromePoolData'] | None] | Callable[['EthereumInquirer'], list | None],  # noqa: E501
             save_data_to_cache_method: Callable[['DBCursor', 'DBHandler', list], None],
-            read_data_from_cache_method: Callable[[], tuple[Union[dict[ChecksumEvmAddress, Any], set[ChecksumEvmAddress]], ...]],  # noqa: E501
+            read_data_from_cache_method: Callable[[], tuple[dict[ChecksumEvmAddress, Any] | set[ChecksumEvmAddress], ...]],  # noqa: E501
     ) -> None:
         """
         :param evm_inquirer: The evm inquirer used to query the remote data source.
@@ -223,7 +220,7 @@ class ReloadableCacheDecoderMixin(ReloadableDecoderMixin, metaclass=ABCMeta):
     def _cache_mapping_methods(self) -> tuple[Callable, ...]:
         """Methods used to decode cache data"""
 
-    def reload_data(self) -> Optional[Mapping[ChecksumEvmAddress, tuple[Any, ...]]]:
+    def reload_data(self) -> Mapping[ChecksumEvmAddress, tuple[Any, ...]] | None:
         """Make sure cache_data is recently queried from the remote source,
         saved in the DB and loaded to the decoder's memory.
 
@@ -260,7 +257,7 @@ class ReloadablePoolsAndGaugesDecoderMixin(ReloadableCacheDecoderMixin, metaclas
     """
     @property
     @abstractmethod
-    def pools(self) -> Union[dict[ChecksumEvmAddress, Any], set[ChecksumEvmAddress]]:
+    def pools(self) -> dict[ChecksumEvmAddress, Any] | set[ChecksumEvmAddress]:
         """abstractmethod to get pools from `cache_data`"""
 
     @property

--- a/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.modules.balancer.v2.constants import (

--- a/rotkehlchen/chain/evm/decoding/safe/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/safe/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -21,13 +21,13 @@ class ActionItem(NamedTuple):
     amount: 'FVal'
     to_event_type: Optional['HistoryEventType'] = None
     to_event_subtype: Optional['HistoryEventSubType'] = None
-    to_notes: Optional[str] = None
-    to_counterparty: Optional[str] = None
-    to_address: Optional[ChecksumEvmAddress] = None
-    extra_data: Optional[dict] = None
+    to_notes: str | None = None
+    to_counterparty: str | None = None
+    to_address: ChecksumEvmAddress | None = None
+    extra_data: dict | None = None
     # Optional event data that pairs it with the event of the action item
     # Contains a tuple with the paired event and whether it's an out event (True) or in event
-    paired_event_data: Optional[tuple['EvmEvent', bool]] = None
+    paired_event_data: tuple['EvmEvent', bool] | None = None
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
@@ -68,7 +68,7 @@ class DecodingOutput:
     """
     event: Optional['EvmEvent'] = None
     action_items: list[ActionItem] = field(default_factory=list)
-    matched_counterparty: Optional[str] = None
+    matched_counterparty: str | None = None
     refresh_balances: bool = False
 
 
@@ -81,7 +81,7 @@ class TransferEnrichmentOutput(NamedTuple):
     - refresh_balances may be set to True if the user's on-chain balances in some protocols has
     changed (for example if the user has deposited / withdrawn funds from a curve gauge).
     """
-    matched_counterparty: Optional[str] = None
+    matched_counterparty: str | None = None
     refresh_balances: bool = False
 
 

--- a/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
@@ -1,6 +1,6 @@
 import abc
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
@@ -36,7 +36,7 @@ class XdaiBridgeCommonDecoder(DecoderInterface, metaclass=abc.ABCMeta):
             base_tools: 'BaseDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             deposit_topic: bytes,
-            withdrawal_topic: Optional[bytes],  # withdrawal is currently unsupported on gnosis
+            withdrawal_topic: bytes | None,  # withdrawal is currently unsupported on gnosis
             bridge_address: ChecksumEvmAddress,
             bridged_asset: 'Asset',
             source_chain: ChainID,

--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -38,7 +38,7 @@ class EvmManager(metaclass=ABCMeta):  # noqa: B024
             self,
             address: ChecksumEvmAddress,
             block_number: int,
-    ) -> Optional[FVal]:
+    ) -> FVal | None:
         """Attempts to get a historical eth balance from the local own node only.
         If there is no node or the node can't query historical balance (not archive) then
         returns None"""

--- a/rotkehlchen/chain/evm/names.py
+++ b/rotkehlchen/chain/evm/names.py
@@ -1,5 +1,5 @@
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, cast
 
 from rotkehlchen.chain.ethereum.decoding.constants import ETHADDRESS_TO_KNOWN_NAME
 from rotkehlchen.constants import ENS_UPDATE_INTERVAL
@@ -100,7 +100,7 @@ def search_for_addresses_names(
     return prioritized_addresses
 
 
-FetcherFunc = Callable[[DBHandler, OptionalChainAddress], Optional[str]]
+FetcherFunc = Callable[[DBHandler, OptionalChainAddress], str | None]
 
 
 class NamePrioritizer:
@@ -130,7 +130,7 @@ class NamePrioritizer:
                         f'address name fetcher for "{name_source}" is not implemented',
                     )
 
-                name: Optional[str] = fetcher(self._db, chain_address)
+                name: str | None = fetcher(self._db, chain_address)
                 if name is None:
                     continue
                 top_prio_names.append(AddressbookEntry(
@@ -146,7 +146,7 @@ class NamePrioritizer:
 def _blockchain_address_to_name(
         db: DBHandler,
         chain_address: OptionalChainAddress,
-) -> Optional[str]:
+) -> str | None:
     """Returns the label of an evm blockchain account with the given address or
     None if there is no such account or the account has no label set or blockchain is
     not specified.
@@ -161,7 +161,7 @@ def _blockchain_address_to_name(
 def _private_addressbook_address_to_name(
         db: DBHandler,
         chain_address: OptionalChainAddress,
-) -> Optional[str]:
+) -> str | None:
     """Returns the name of a private addressbook entry with the given address or
     None if there is no such entry or the entry has no name set.
     """
@@ -175,7 +175,7 @@ def _private_addressbook_address_to_name(
 def _global_addressbook_address_to_name(
         db: DBHandler,
         chain_address: OptionalChainAddress,
-) -> Optional[str]:
+) -> str | None:
     """Returns the name of a global addressbook entry with the given address or
     None if there is no such entry or the entry has no name set.
     """
@@ -189,7 +189,7 @@ def _global_addressbook_address_to_name(
 def _hardcoded_address_to_name(
         _: DBHandler,
         chain_address: OptionalChainAddress,
-) -> Optional[str]:
+) -> str | None:
     """Returns the name of a known address or None if there is no such address"""
     if chain_address.blockchain != SupportedBlockchain.ETHEREUM:
         return None
@@ -199,7 +199,7 @@ def _hardcoded_address_to_name(
 def _token_mappings_address_to_name(
         _: DBHandler,
         chain_address: OptionalChainAddress,
-) -> Optional[str]:
+) -> str | None:
     """Returns the token name for a token address/chain id combination
     in the global database or None if the address is no token address
     """
@@ -211,7 +211,7 @@ def _token_mappings_address_to_name(
 def _ens_address_to_name(
         db: DBHandler,
         chain_address: OptionalChainAddress,
-) -> Optional[str]:
+) -> str | None:
     """Returns the ens name for an address or None if the address doesn't have one"""
     db_ens = DBEns(db)
     with db.conn.read_ctx() as cursor:

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -1285,7 +1285,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
         - InsufficientDataBytes
         """
         decoded_contract_info = []
-        for method_name, method_value in zip(properties, output):
+        for method_name, method_value in zip(properties, output, strict=True):
             if method_value[0] is True and len(method_value[1]) != 0:
                 decoded_contract_info.append(contract.decode(method_value[1], method_name)[0])
                 continue

--- a/rotkehlchen/chain/evm/proxies_inquirer.py
+++ b/rotkehlchen/chain/evm/proxies_inquirer.py
@@ -1,7 +1,7 @@
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.constants.timing import DAY_IN_SECONDS
@@ -40,7 +40,7 @@ class EvmProxiesInquirer:
         """Reset the last query timestamps, effectively cleaning the caches"""
         self.last_proxy_mapping_query_ts = 0
 
-    def get_account_proxy(self, address: ChecksumEvmAddress) -> Optional[ChecksumEvmAddress]:
+    def get_account_proxy(self, address: ChecksumEvmAddress) -> ChecksumEvmAddress | None:
         """Checks if a DS proxy exists for the given address and returns it if it does.
 
         May raise:

--- a/rotkehlchen/chain/evm/structures.py
+++ b/rotkehlchen/chain/evm/structures.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO
@@ -20,7 +20,7 @@ class EvmTxReceiptLog:
 class EvmTxReceipt:
     tx_hash: EVMTxHash
     chain_id: ChainID
-    contract_address: Optional[ChecksumEvmAddress]
+    contract_address: ChecksumEvmAddress | None
     status: bool
     type: int
     logs: list[EvmTxReceiptLog] = dataclasses.field(default_factory=list)

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
@@ -30,7 +30,7 @@ TokenBalancesType = tuple[
 
 DetectedTokensType = dict[
     ChecksumEvmAddress,
-    tuple[Optional[list[EvmToken]], Optional[Timestamp]],
+    tuple[list[EvmToken] | None, Timestamp | None],
 ]
 
 # 08/08/2020
@@ -128,7 +128,7 @@ class EvmTokens(metaclass=ABCMeta):
             self,
             address: ChecksumEvmAddress,
             tokens: list[EvmToken],
-            call_order: Optional[Sequence[WeightedNode]],
+            call_order: Sequence[WeightedNode] | None,
     ) -> dict[EvmToken, FVal]:
         """Queries the balances of multiple tokens for an address
 
@@ -165,7 +165,7 @@ class EvmTokens(metaclass=ABCMeta):
     def _get_multicall_token_balances(
             self,
             chunk: list[tuple[ChecksumEvmAddress, list[EvmToken]]],
-            call_order: Optional[Sequence['WeightedNode']] = None,
+            call_order: Sequence['WeightedNode'] | None = None,
     ) -> dict[ChecksumEvmAddress, dict[EvmToken, FVal]]:
         """Gets token balances from a chunk of address -> token address
 

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -3,7 +3,7 @@ from abc import ABCMeta
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from gevent.lock import Semaphore
 
@@ -154,7 +154,7 @@ class EvmTransactions(metaclass=ABCMeta):  # noqa: B024
             self,
             address: ChecksumEvmAddress,
             period: TimestampOrBlockRange,
-            location_string: Optional[str] = None,
+            location_string: str | None = None,
     ) -> None:
         """Helper function to abstract tx querying functionality for different range types"""
         for new_transactions in self.evm_inquirer.etherscan.get_transactions(
@@ -243,9 +243,9 @@ class EvmTransactions(metaclass=ABCMeta):  # noqa: B024
 
     def _query_and_save_internal_transactions_for_range_or_parent_hash(
             self,
-            address: Optional[ChecksumEvmAddress],
-            period_or_hash: Union[TimestampOrBlockRange, EVMTxHash],
-            location_string: Optional[str] = None,
+            address: ChecksumEvmAddress | None,
+            period_or_hash: TimestampOrBlockRange | EVMTxHash,
+            location_string: str | None = None,
     ) -> None:
         """Helper function to abstract internal tx querying for different range types
         or for a specific parent transaction hash.
@@ -635,8 +635,8 @@ class EvmTransactions(metaclass=ABCMeta):  # noqa: B024
 
     def get_receipts_for_transactions_missing_them(
             self,
-            limit: Optional[int] = None,
-            addresses: Optional[list[ChecksumEvmAddress]] = None,
+            limit: int | None = None,
+            addresses: list[ChecksumEvmAddress] | None = None,
     ) -> None:
         """
         Searches the database for up to `limit` transactions that have no corresponding receipt

--- a/rotkehlchen/chain/evm/types.py
+++ b/rotkehlchen/chain/evm/types.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 from eth_typing import HexAddress, HexStr
 from web3 import Web3
@@ -92,7 +92,7 @@ class WeightedNode:
 
 class EvmAccount(NamedTuple):
     address: ChecksumEvmAddress
-    chain_id: Optional[SUPPORTED_CHAIN_IDS] = None
+    chain_id: SUPPORTED_CHAIN_IDS | None = None
 
 
 class Web3Node(NamedTuple):
@@ -105,7 +105,7 @@ class Web3Node(NamedTuple):
 ASSET_ID_RE = re.compile(r'eip155:(.*?)/(.*?):(.*)')
 
 
-def asset_id_is_evm_token(asset_id: str) -> Optional[tuple[ChainID, ChecksumEvmAddress]]:
+def asset_id_is_evm_token(asset_id: str) -> tuple[ChainID, ChecksumEvmAddress] | None:
     """Takes an asset identifier and checks if it's an evm token.
 
     If it is, returns chain ID and token address. If not it returns None

--- a/rotkehlchen/chain/evm/utils.py
+++ b/rotkehlchen/chain/evm/utils.py
@@ -91,7 +91,7 @@ def lp_price_from_uniswaplike_pool_contract(
 
     # decode output
     decoded = []
-    for (method_output, method_name) in zip(output, methods):
+    for (method_output, method_name) in zip(output, methods, strict=True):
         call_success = True
         if call_success and len(method_output) != 0:
             decoded_method = contract.decode(method_output, method_name)

--- a/rotkehlchen/chain/evm/utils.py
+++ b/rotkehlchen/chain/evm/utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Final, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Final
 
 from web3.types import BlockIdentifier
 
@@ -37,7 +38,7 @@ def lp_price_from_uniswaplike_pool_contract(
         token_price_func: Callable,
         token_price_func_args: list[Any],
         block_identifier: BlockIdentifier,
-) -> Optional[Price]:
+) -> Price | None:
     """
     This works for any uniswap like LP token. It calculates the price for an LP token the contract
     of which is also the contract of the pool it represents. For example velodrome or uniswap lp

--- a/rotkehlchen/chain/gnosis/decoding/decoder.py
+++ b/rotkehlchen/chain/gnosis/decoding/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
@@ -54,5 +54,5 @@ class GnosisTransactionDecoder(EVMTransactionDecoder):
         return False
 
     @staticmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:  # pylint: disable=unused-argument
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:  # pylint: disable=unused-argument
         return None

--- a/rotkehlchen/chain/optimism/decoding/decoder.py
+++ b/rotkehlchen/chain/optimism/decoding/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderToolsWithDSProxy
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -58,5 +58,5 @@ class OptimismTransactionDecoder(OptimismSuperchainTransactionDecoder):
         return False
 
     @staticmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:  # pylint: disable=unused-argument
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:  # pylint: disable=unused-argument
         return None

--- a/rotkehlchen/chain/optimism/modules/velodrome/balances.py
+++ b/rotkehlchen/chain/optimism/modules/velodrome/balances.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithGauges
@@ -34,5 +34,5 @@ class VelodromeBalances(ProtocolWithGauges):
             gauge_deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},  # noqa: E501
         )
 
-    def get_gauge_address(self, event: 'EvmEvent') -> Optional[ChecksumEvmAddress]:
+    def get_gauge_address(self, event: 'EvmEvent') -> ChecksumEvmAddress | None:
         return event.address

--- a/rotkehlchen/chain/optimism/modules/velodrome/velodrome_cache.py
+++ b/rotkehlchen/chain/optimism/modules/velodrome/velodrome_cache.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -40,7 +40,7 @@ class VelodromePoolData(NamedTuple):
     pool_name: str
     token0_address: ChecksumEvmAddress
     token1_address: ChecksumEvmAddress
-    gauge_address: Optional[ChecksumEvmAddress]
+    gauge_address: ChecksumEvmAddress | None
 
 
 def save_velodrome_data_to_cache(
@@ -114,7 +114,7 @@ def read_velodrome_pools_and_gauges_from_cache() -> tuple[set[ChecksumEvmAddress
 def query_velodrome_data_from_chain_and_maybe_create_tokens(
         inquirer: 'OptimismInquirer',
         existing_pools: list[ChecksumEvmAddress],
-) -> Optional[list[VelodromePoolData]]:
+) -> list[VelodromePoolData] | None:
     """
     Queries velodrome data from chain from the Velodrome Finance LP Sugar v2 contract.
     If new pools are found their tokens are created and the pools are returned.
@@ -204,7 +204,7 @@ def query_velodrome_data_from_chain_and_maybe_create_tokens(
     return returned_pools
 
 
-def query_velodrome_data(inquirer: 'OptimismInquirer') -> Optional[list[VelodromePoolData]]:
+def query_velodrome_data(inquirer: 'OptimismInquirer') -> list[VelodromePoolData] | None:
     """
     Queries velodrome pools and tokens.
     Returns a list of pool data if the query was successful.

--- a/rotkehlchen/chain/optimism/types.py
+++ b/rotkehlchen/chain/optimism/types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTransaction, EVMTxHash, Timestamp
 
@@ -19,7 +19,7 @@ class OptimismTransaction(EvmTransaction):  # noqa: PLW1641  # hash implemented 
             timestamp: Timestamp,
             block_number: int,
             from_address: ChecksumEvmAddress,
-            to_address: Optional[ChecksumEvmAddress],
+            to_address: ChecksumEvmAddress | None,
             value: int,
             gas: int,
             gas_price: int,

--- a/rotkehlchen/chain/optimism_superchain/etherscan.py
+++ b/rotkehlchen/chain/optimism_superchain/etherscan.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.chain.optimism.types import OptimismTransaction
 from rotkehlchen.externalapis.etherscan import Etherscan
@@ -46,8 +46,8 @@ class OptimismSuperchainEtherscan(Etherscan, metaclass=ABCMeta):
 
     def _additional_transaction_processing(
             self,
-            tx: Union[OptimismTransaction, EvmInternalTransaction],  # type: ignore[override]
-    ) -> Union[OptimismTransaction, EvmInternalTransaction]:
+            tx: OptimismTransaction | EvmInternalTransaction,  # type: ignore[override]
+    ) -> OptimismTransaction | EvmInternalTransaction:
         if not isinstance(tx, EvmInternalTransaction):
             # TODO: write this tx_receipt to DB so it doesn't need to be queried again
             # https://github.com/rotki/rotki/pull/6359#discussion_r1252850465

--- a/rotkehlchen/chain/optimism_superchain/transactions.py
+++ b/rotkehlchen/chain/optimism_superchain/transactions.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from rotkehlchen.chain.base.node_inquirer import BaseInquirer
 from rotkehlchen.chain.evm.transactions import EvmTransactions
@@ -29,10 +29,7 @@ class OptimismSuperchainTransactions(EvmTransactions, metaclass=ABCMeta):
 
     def __init__(
             self,
-            node_inquirer: Union[
-                OptimismInquirer,
-                BaseInquirer,
-            ],
+            node_inquirer: OptimismInquirer | BaseInquirer,
             database: 'DBHandler',
     ) -> None:
         super().__init__(evm_inquirer=node_inquirer, database=database)

--- a/rotkehlchen/chain/polygon_pos/decoding/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/decoding/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
@@ -54,5 +54,5 @@ class PolygonPOSTransactionDecoder(EVMTransactionDecoder):
         return False
 
     @staticmethod
-    def _address_is_exchange(address: ChecksumEvmAddress) -> Optional[str]:  # pylint: disable=unused-argument
+    def _address_is_exchange(address: ChecksumEvmAddress) -> str | None:  # pylint: disable=unused-argument
         return None

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -1,9 +1,9 @@
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from functools import wraps
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import Any, Callable, NamedTuple, Optional, Union, cast
+from typing import Any, NamedTuple, cast
 from urllib.parse import urlparse
 
 import gevent
@@ -497,7 +497,7 @@ class SubstrateManager:
         preference, then are ordered depending on how close they are to the
         chain height; the higher 'weight_block' the better.
         """
-        own_node: Union[KusamaNodeName, PolkadotNodeName]
+        own_node: KusamaNodeName | PolkadotNodeName
         if self.chain == SupportedBlockchain.KUSAMA:
             own_node = KusamaNodeName.OWN
         else:
@@ -546,7 +546,7 @@ class SubstrateManager:
     def get_account_balance(
             self,
             account: SubstrateAddress,
-            node_interface: Optional[SubstrateInterface] = None,
+            node_interface: SubstrateInterface | None = None,
     ) -> FVal:
         """Given an account get its amount of chain native token.
 
@@ -578,7 +578,7 @@ class SubstrateManager:
     @request_available_nodes
     def get_chain_id(
             self,
-            node_interface: Optional[SubstrateInterface] = None,
+            node_interface: SubstrateInterface | None = None,
     ) -> SubstrateChainId:
         """
         May raise:
@@ -590,7 +590,7 @@ class SubstrateManager:
     @request_available_nodes
     def get_chain_properties(
             self,
-            node_interface: Optional[SubstrateInterface] = None,
+            node_interface: SubstrateInterface | None = None,
     ) -> SubstrateChainProperties:
         """
         May raise:
@@ -602,7 +602,7 @@ class SubstrateManager:
     @request_available_nodes
     def get_last_block(
             self,
-            node_interface: Optional[SubstrateInterface] = None,
+            node_interface: SubstrateInterface | None = None,
     ) -> BlockNumber:
         """
         May raise:
@@ -615,7 +615,7 @@ class SubstrateManager:
         """Attempt to set the RPC endpoint for the user's own node.
         If connection at endpoint is successful it will set `own_rpc_endpoint`.
         """
-        own_node: Union[KusamaNodeName, PolkadotNodeName]
+        own_node: KusamaNodeName | PolkadotNodeName
         if self.chain == SupportedBlockchain.KUSAMA:
             own_node = KusamaNodeName.OWN
         else:

--- a/rotkehlchen/chain/substrate/types.py
+++ b/rotkehlchen/chain/substrate/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import NamedTuple, NewType, Union
+from typing import NamedTuple, NewType
 
 from substrateinterface import SubstrateInterface
 
@@ -86,7 +86,7 @@ class PolkadotNodeName(Enum):
         raise AssertionError(f'Unexpected PolkadotNodeName: {self}')
 
 
-NodeName = Union[KusamaNodeName, PolkadotNodeName]
+NodeName = KusamaNodeName | PolkadotNodeName
 
 
 class NodeNameAttributes(NamedTuple):

--- a/rotkehlchen/constants/resolver.py
+++ b/rotkehlchen/constants/resolver.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind
 
@@ -11,7 +10,7 @@ def evm_address_to_identifier(
         address: str,
         chain_id: ChainID,
         token_type: EvmTokenKind,
-        collectible_id: Optional[str] = None,
+        collectible_id: str | None = None,
 ) -> str:
     """Format EVM token information into the CAIPs identifier format"""
     ident = f'{EVM_CHAIN_DIRECTIVE}:{chain_id.value}/{token_type!s}:{address}'

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -5,7 +5,6 @@ import shutil
 import tempfile
 import zlib
 from pathlib import Path
-from typing import Optional
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.crypto import decrypt, encrypt
@@ -40,7 +39,7 @@ class DataHandler:
     def logout(self) -> None:
         if self.logged_in:
             self.username = 'no_user'
-            self.user_data_dir: Optional[Path] = None
+            self.user_data_dir: Path | None = None
             db = getattr(self, 'db', None)
             if db is not None:
                 with self.db.conn.read_ctx() as cursor:
@@ -54,7 +53,7 @@ class DataHandler:
             password: str,
             create_new: bool,
             resume_from_backup: bool,
-            initial_settings: Optional[ModifiableDBSettings] = None,
+            initial_settings: ModifiableDBSettings | None = None,
     ) -> Path:
         """Unlocks a user, either logging them in or creating a new user
 
@@ -121,7 +120,7 @@ class DataHandler:
         self.username = username
         return user_data_dir
 
-    def add_ignored_assets(self, assets: list[Asset]) -> tuple[Optional[set[str]], str]:
+    def add_ignored_assets(self, assets: list[Asset]) -> tuple[set[str] | None, str]:
         """Adds ignored assets to the DB.
 
         If any of the given assets is already in the DB the function does nothing
@@ -142,7 +141,7 @@ class DataHandler:
 
             return self.db.get_ignored_asset_ids(cursor), ''
 
-    def remove_ignored_assets(self, assets: list[Asset]) -> tuple[Optional[set[str]], str]:
+    def remove_ignored_assets(self, assets: list[Asset]) -> tuple[set[str] | None, str]:
         """Removes ignored assets from the DB.
 
         If any of the given assets is not in the DB the call function does nothing

--- a/rotkehlchen/data_import/importers/binance.py
+++ b/rotkehlchen/data_import/importers/binance.py
@@ -3,7 +3,7 @@ import csv
 import logging
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry, HistoryEvent
@@ -215,7 +215,7 @@ class BinanceTradeEntry(BinanceMultipleEntry):
 
         # Checking assets
         same_assets = True
-        assets: dict[str, Optional[AssetWithOracles]] = defaultdict(lambda: None)
+        assets: dict[str, AssetWithOracles | None] = defaultdict(lambda: None)
         for row in data:
             if row['Operation'] in {'Fee', 'Transaction Fee'}:
                 cur_operation = 'Fee'
@@ -264,13 +264,13 @@ class BinanceTradeEntry(BinanceMultipleEntry):
         # Creating trades structures based on grouped rows data
         raw_trades: list[Trade] = []
         for trade_rows in grouped_trade_rows:
-            to_asset: Optional[AssetWithOracles] = None
-            to_amount: Optional[AssetAmount] = None
-            from_asset: Optional[AssetWithOracles] = None
-            from_amount: Optional[AssetAmount] = None
-            fee_asset: Optional[AssetWithOracles] = None
-            fee_amount: Optional[Fee] = None
-            trade_type: Optional[TradeType] = None
+            to_asset: AssetWithOracles | None = None
+            to_amount: AssetAmount | None = None
+            from_asset: AssetWithOracles | None = None
+            from_amount: AssetAmount | None = None
+            fee_asset: AssetWithOracles | None = None
+            fee_amount: Fee | None = None
+            trade_type: TradeType | None = None
 
             for row in trade_rows:
                 cur_asset = row['Coin']
@@ -729,7 +729,7 @@ class BinanceImporter(BaseExchangeImporter):
             write_cursor: DBCursor,
             timestamp: Timestamp,
             rows: list[BinanceCsvRow],
-    ) -> tuple[Optional[BinanceEntry], int]:
+    ) -> tuple[BinanceEntry | None, int]:
         """Processes binance entries that are represented with 2+ rows in a csv file.
         Returns Entry type and entries count if any entries were processed. Otherwise, None and 0.
         """

--- a/rotkehlchen/data_import/importers/bitcoin_tax.py
+++ b/rotkehlchen/data_import/importers/bitcoin_tax.py
@@ -1,7 +1,7 @@
 import csv
 import logging
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from rotkehlchen.accounting.structures.balance import AssetBalance, Balance
 from rotkehlchen.accounting.structures.base import HistoryEvent
@@ -61,7 +61,7 @@ class BitcoinTaxImporter(BaseExchangeImporter):
             action: str,
             base_asset_balance: AssetBalance,
             quote_asset_balance: AssetBalance,
-            fee_asset_balance: Optional[AssetBalance],
+            fee_asset_balance: AssetBalance | None,
             memo: str,
     ) -> None:
         """
@@ -132,7 +132,7 @@ class BitcoinTaxImporter(BaseExchangeImporter):
             location: Location,
             action: str,
             asset_balance: AssetBalance,
-            fee_asset_balance: Optional[AssetBalance],
+            fee_asset_balance: AssetBalance | None,
             memo: str,
     ) -> None:
         """

--- a/rotkehlchen/data_import/importers/cointracking.py
+++ b/rotkehlchen/data_import/importers/cointracking.py
@@ -233,14 +233,14 @@ class CointrackingImporter(BaseExchangeImporter):
             header = remap_header(next(data))
             for row in data:
                 try:
-                    self._consume_cointracking_entry(write_cursor, dict(zip(header, row)), **kwargs)  # noqa: E501
+                    self._consume_cointracking_entry(write_cursor, dict(zip(header, row, strict=True)), **kwargs)  # noqa: E501
                 except UnknownAsset as e:
                     self.db.msg_aggregator.add_warning(
                         f'During cointracking CSV import found action with unknown '
                         f'asset {e.identifier}. Ignoring entry',
                     )
                     continue
-                except IndexError:
+                except (IndexError, ValueError):
                     self.db.msg_aggregator.add_warning(
                         'During cointracking CSV import found entry with '
                         'unexpected number of columns',

--- a/rotkehlchen/data_import/utils.py
+++ b/rotkehlchen/data_import/utils.py
@@ -2,7 +2,7 @@ import hashlib
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -82,7 +82,7 @@ class UnsupportedCSVEntry(Exception):
 def process_rotki_generic_import_csv_fields(
         csv_row: dict[str, Any],
         currency_colname: str,
-) -> tuple[AssetWithOracles, Optional[Fee], Optional[Asset], Location, TimestampMS]:
+) -> tuple[AssetWithOracles, Fee | None, Asset | None, Location, TimestampMS]:
     """
     Process the imported csv for generic rotki trades and events
     """

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
-from typing import TYPE_CHECKING, Callable, NamedTuple
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.data_migrations.migrations.migration_1 import data_migration_1
 from rotkehlchen.data_migrations.migrations.migration_2 import data_migration_2

--- a/rotkehlchen/data_migrations/progress.py
+++ b/rotkehlchen/data_migrations/progress.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.utils.interfaces import ProgressUpdater
@@ -6,7 +5,7 @@ from rotkehlchen.utils.interfaces import ProgressUpdater
 
 class MigrationProgressHandler(ProgressUpdater):
 
-    def _notify_frontend(self, step_name: Optional[str] = None) -> None:
+    def _notify_frontend(self, step_name: str | None = None) -> None:
         self.messages_aggregator.add_message(
             message_type=WSMessageType.DATA_MIGRATION_STATUS,
             data={

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -424,7 +424,7 @@ def query_missing_accounting_rules(
     ]
 
     callbacks = evm_accounting_aggregator.get_accounting_callbacks()
-    bindings_and_events_iterator = peekable(zip(bindings, related_events))
+    bindings_and_events_iterator = peekable(zip(bindings, related_events, strict=True))
     with db.conn.read_ctx() as cursor:
         # index to keep the current event in the list of related events. It is used in the
         # callbacks since we need to process events but we don't want to consume the current

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from more_itertools import peekable
 from pysqlcipher3 import dbapi2 as sqlcipher
@@ -46,7 +46,7 @@ class RuleInformation(NamedTuple):
     links contains the properties in rule that have been linked to an accounting setting.
     """
     identifier: int
-    event_key: tuple[HistoryEventType, HistoryEventSubType, Union[str, None]]
+    event_key: tuple[HistoryEventType, HistoryEventSubType, str | None]
     rule: BaseEventSettings
     links: dict[str, str]
 
@@ -61,7 +61,7 @@ class DBAccountingRules:
             cls,
             event_type: HistoryEventType,
             event_subtype: HistoryEventSubType,
-            counterparty: Optional[str],
+            counterparty: str | None,
     ) -> str:
         return f'Rule for ({event_type.serialize()}, {event_subtype.serialize()}, {counterparty})'
 
@@ -69,7 +69,7 @@ class DBAccountingRules:
             self,
             event_type: HistoryEventType,
             event_subtype: HistoryEventSubType,
-            counterparty: Optional[str],
+            counterparty: str | None,
             rule: 'BaseEventSettings',
             links: dict[LINKABLE_ACCOUNTING_PROPERTIES, LINKABLE_ACCOUNTING_SETTINGS_NAME],
     ) -> int:
@@ -135,7 +135,7 @@ class DBAccountingRules:
             self,
             event_type: HistoryEventType,
             event_subtype: HistoryEventSubType,
-            counterparty: Optional[str],
+            counterparty: str | None,
             rule: 'BaseEventSettings',
             links: dict[LINKABLE_ACCOUNTING_PROPERTIES, LINKABLE_ACCOUNTING_SETTINGS_NAME],
             identifier: int,

--- a/rotkehlchen/db/addressbook.py
+++ b/rotkehlchen/db/addressbook.py
@@ -1,7 +1,7 @@
 import sqlite3
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pysqlcipher3 import dbapi2
 
@@ -166,7 +166,7 @@ class DBAddressbook:
             self,
             book_type: AddressbookType,
             chain_address: OptionalChainAddress,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Returns the name for the specified address and blockchain.
         It will search for the pair of address and the exact blockchain (or null).

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2071,7 +2071,7 @@ class DBHandler:
             'ORDER BY timestamp ASC',
             (from_ts, to_ts),
         )
-        all_timestamps, all_categories = zip(*cursor)
+        all_timestamps, all_categories = zip(*cursor, strict=True)
         # dicts maintain insertion order in python 3.7+
         timestamps_have_asset_balance = dict.fromkeys(all_timestamps, False)
         timestamps_with_asset_balance = dict.fromkeys(asset_timestamps, True)

--- a/rotkehlchen/db/ens.py
+++ b/rotkehlchen/db/ens.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -20,7 +20,7 @@ class DBEns:
             self,
             write_cursor: 'DBCursor',
             address: ChecksumEvmAddress,
-            name: Optional[str],
+            name: str | None,
             now: Timestamp,
     ) -> None:
         """Adds an ens mapping to the DB for an address
@@ -41,7 +41,7 @@ class DBEns:
             self,
             cursor: 'DBCursor',
             addresses: list[ChecksumEvmAddress],
-    ) -> dict[ChecksumEvmAddress, Union[EnsMapping, Timestamp]]:
+    ) -> dict[ChecksumEvmAddress, EnsMapping | Timestamp]:
         """Returns a mapping of addresses to ens mappings if found in the DB
 
         - If the address has a name mapping in the DB it is returned as part of the dict
@@ -69,7 +69,7 @@ class DBEns:
     def update_values(
             self,
             write_cursor: 'DBCursor',
-            ens_lookup_results: dict[ChecksumEvmAddress, Optional[str]],
+            ens_lookup_results: dict[ChecksumEvmAddress, str | None],
             mappings_to_send: dict[ChecksumEvmAddress, str],
     ) -> dict[ChecksumEvmAddress, str]:
         """Update the ENS mapping values in the DB and return updates mappings to return via api"""

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -140,7 +140,7 @@ class DBEth2:
             self,
             cursor: 'DBCursor',
             field: Literal['validator_index', 'public_key'],
-            arg: Union[int, str],
+            arg: int | str,
     ) -> bool:
         cursor.execute(f'SELECT COUNT(*) from eth2_validators WHERE {field}=?', (arg,))
         return cursor.fetchone()[0] == 1  # count always returns

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional, get_args
+from typing import TYPE_CHECKING, Any, get_args
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -57,7 +57,7 @@ class DBEvmTx:
             self,
             write_cursor: 'DBCursor',
             evm_transactions: list[EvmTransaction],
-            relevant_address: Optional[ChecksumEvmAddress],
+            relevant_address: ChecksumEvmAddress | None,
     ) -> None:
         """Adds evm transactions to the database"""
         tx_tuples = [(
@@ -102,7 +102,7 @@ class DBEvmTx:
             self,
             write_cursor: 'DBCursor',
             transactions: list[EvmInternalTransaction],
-            relevant_address: Optional[ChecksumEvmAddress],
+            relevant_address: ChecksumEvmAddress | None,
     ) -> None:
         """Adds evm internal transactions to the database"""
         tx_tuples = [(
@@ -206,7 +206,7 @@ class DBEvmTx:
         total_found_result = cursor.execute(query, bindings)
         return txs, total_found_result.fetchone()[0]  # always returns result
 
-    def purge_evm_transaction_data(self, chain: Optional[SUPPORTED_EVM_CHAINS]) -> None:
+    def purge_evm_transaction_data(self, chain: SUPPORTED_EVM_CHAINS | None) -> None:
         """Deletes all evm transaction related data from the DB"""
         query_ranges_tuples = []
         delete_query = 'DELETE FROM evm_transactions'
@@ -233,8 +233,8 @@ class DBEvmTx:
 
     def get_transaction_hashes_no_receipt(
             self,
-            tx_filter_query: Optional[EvmTransactionsFilterQuery],
-            limit: Optional[int],
+            tx_filter_query: EvmTransactionsFilterQuery | None,
+            limit: int | None,
     ) -> list[EVMTxHash]:
         cursor = self.db.conn.cursor()
         querystr = 'SELECT DISTINCT evm_transactions.tx_hash FROM evm_transactions '
@@ -262,8 +262,8 @@ class DBEvmTx:
 
     def get_transaction_hashes_not_decoded(
             self,
-            chain_id: Optional[ChainID],
-            limit: Optional[int],
+            chain_id: ChainID | None,
+            limit: int | None,
     ) -> list[EVMTxHash]:
         """Get transaction hashes for the transactions that have not been decoded.
         Optionally by chain id.
@@ -284,7 +284,7 @@ class DBEvmTx:
 
     def count_hashes_not_decoded(
             self,
-            chain_id: Optional[ChainID],
+            chain_id: ChainID | None,
     ) -> int:
         """
         Count the number of transactions queried that have not been decoded. When the addresses
@@ -376,7 +376,7 @@ class DBEvmTx:
             cursor: 'DBCursor',
             tx_hash: EVMTxHash,
             chain_id: ChainID,
-    ) -> Optional[EvmTxReceipt]:
+    ) -> EvmTxReceipt | None:
         """Get the evm receipt for the given tx_hash and chain id"""
         chain_id_serialized = chain_id.serialize_for_db()
         result = cursor.execute(

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from collections.abc import Collection
 from dataclasses import dataclass, field
-from typing import Any, Generic, Literal, NamedTuple, Optional, TypeVar, Union, cast
+from typing import Any, Generic, Literal, NamedTuple, TypeVar, cast
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntryType
 from rotkehlchen.accounting.structures.evm_event import EvmProduct
@@ -117,10 +117,10 @@ class DBNestedFilter(DBFilter):
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBTimestampFilter(DBFilter):
-    from_ts: Optional[Timestamp] = None
-    to_ts: Optional[Timestamp] = None
-    scaling_factor: Optional[FVal] = None
-    timestamp_field: Optional[str] = None
+    from_ts: Timestamp | None = None
+    to_ts: Timestamp | None = None
+    scaling_factor: FVal | None = None
+    timestamp_field: str | None = None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         filters = []
@@ -154,7 +154,7 @@ class DBEvmTransactionJoinsFilter(DBFilter):
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         query_filters: list[str] = []
-        bindings: list[Union[ChecksumEvmAddress, int]] = []
+        bindings: list[ChecksumEvmAddress | int] = []
         query_filter_str = (
             'INNER JOIN evmtx_address_mappings WHERE '
             'evm_transactions.identifier=evmtx_address_mappings.tx_id AND ('
@@ -180,7 +180,7 @@ class DBTransactionsPendingDecodingFilter(DBFilter):
     This filter is used to find the ethereum transactions that have not been decoded yet
     using the query in `TRANSACTIONS_MISSING_DECODING_QUERY`. It allows filtering by chain.
     """
-    chain_id: Optional[ChainID]
+    chain_id: ChainID | None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         query_filters = ['B.tx_id is NULL']
@@ -195,7 +195,7 @@ class DBTransactionsPendingDecodingFilter(DBFilter):
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBEvmTransactionHashFilter(DBFilter):
-    tx_hash: Optional[EVMTxHash] = None
+    tx_hash: EVMTxHash | None = None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         if self.tx_hash is None:
@@ -206,8 +206,8 @@ class DBEvmTransactionHashFilter(DBFilter):
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBEvmChainIDFilter(DBFilter):
-    chain_id: Optional[SUPPORTED_CHAIN_IDS] = None
-    table_name: Optional[str] = None
+    chain_id: SUPPORTED_CHAIN_IDS | None = None
+    table_name: str | None = None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         if self.chain_id is None:
@@ -219,7 +219,7 @@ class DBEvmChainIDFilter(DBFilter):
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBReportDataReportIDFilter(DBFilter):
-    report_id: Optional[Union[str, int]] = None
+    report_id: str | int | None = None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         if self.report_id is None:
@@ -239,7 +239,7 @@ class DBReportDataReportIDFilter(DBFilter):
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBReportDataEventTypeFilter(DBFilter):
-    event_type: Optional[Union[str, SchemaEventType]] = None
+    event_type: str | SchemaEventType | None = None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         if self.event_type is None:
@@ -278,10 +278,10 @@ class DBSubStringFilter(DBFilter):
 class DBFilterQuery(metaclass=ABCMeta):
     and_op: bool
     filters: list[DBFilter]
-    join_clause: Optional[DBFilter] = None
-    group_by: Optional[DBFilterGroupBy] = None
-    order_by: Optional[DBFilterOrder] = None
-    pagination: Optional[DBFilterPagination] = None
+    join_clause: DBFilter | None = None
+    group_by: DBFilterGroupBy | None = None
+    order_by: DBFilterOrder | None = None
+    pagination: DBFilterPagination | None = None
 
     def prepare(
             self,
@@ -346,11 +346,11 @@ class DBFilterQuery(metaclass=ABCMeta):
     def create(
             cls: type[T_FilterQ],
             and_op: bool,
-            limit: Optional[int],
-            offset: Optional[int],
+            limit: int | None,
+            offset: int | None,
             order_by_case_sensitive: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            group_by_field: Optional[str] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            group_by_field: str | None = None,
     ) -> T_FilterQ:
         if limit is None or offset is None:
             pagination = None
@@ -386,7 +386,7 @@ class FilterWithTimestamp:
         return self.timestamp_filter.from_ts
 
     @from_ts.setter
-    def from_ts(self, from_ts: Optional[Timestamp]) -> None:
+    def from_ts(self, from_ts: Timestamp | None) -> None:
         self.timestamp_filter.from_ts = from_ts
 
     @property
@@ -397,16 +397,16 @@ class FilterWithTimestamp:
         return self.timestamp_filter.to_ts
 
     @to_ts.setter
-    def to_ts(self, to_ts: Optional[Timestamp]) -> None:
+    def to_ts(self, to_ts: Timestamp | None) -> None:
         self.timestamp_filter.to_ts = to_ts
 
 
 class FilterWithLocation:
 
-    location_filter: Optional[DBLocationFilter] = None
+    location_filter: DBLocationFilter | None = None
 
     @property
-    def location(self) -> Optional[Location]:
+    def location(self) -> Location | None:
         if self.location_filter is None:
             return None
 
@@ -417,7 +417,7 @@ class FilterWithLocation:
 class EvmTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
 
     @property
-    def accounts(self) -> Optional[list[EvmAccount]]:
+    def accounts(self) -> list[EvmAccount] | None:
         if self.join_clause is None:
             return None
 
@@ -425,7 +425,7 @@ class EvmTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
         return ethaddress_filter.accounts
 
     @property
-    def chain_id(self) -> Optional[SUPPORTED_CHAIN_IDS]:
+    def chain_id(self) -> SUPPORTED_CHAIN_IDS | None:
         if isinstance(self.filters[-1], DBEvmChainIDFilter):
             return self.filters[-1].chain_id
         return None
@@ -434,14 +434,14 @@ class EvmTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['EvmTransactionsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            accounts: Optional[list[EvmAccount]] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            tx_hash: Optional[EVMTxHash] = None,
-            chain_id: Optional[SUPPORTED_CHAIN_IDS] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            accounts: list[EvmAccount] | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            tx_hash: EVMTxHash | None = None,
+            chain_id: SUPPORTED_CHAIN_IDS | None = None,
     ) -> 'EvmTransactionsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -506,7 +506,7 @@ class DBIgnoreValuesFilter(DBFilter):
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBEth2ValidatorIndicesFilter(DBFilter):
     """A filter for Eth2 validator indices"""
-    validators: Optional[list[int]]
+    validators: list[int] | None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         if self.validators is None:
@@ -518,10 +518,7 @@ class DBEth2ValidatorIndicesFilter(DBFilter):
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBTypeFilter(DBFilter):
     """A filter for type/category/HistoryBaseEntry enums"""
-    filter_types: Union[
-        list[TradeType],
-        list[AssetMovementCategory],
-    ]
+    filter_types: list[TradeType] | list[AssetMovementCategory]
     type_key: Literal['type', 'subtype', 'category']
 
     def prepare(self) -> tuple[list[str], list[Any]]:
@@ -537,8 +534,8 @@ class DBTypeFilter(DBFilter):
 class DBEqualsFilter(DBFilter):
     """Filter a column by comparing its column to its value for equality."""
     column: str
-    value: Union[str, bytes, int, bool]
-    alias: Optional[str] = None
+    value: str | (bytes | (int | bool))
+    alias: str | None = None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         key_name = self.column
@@ -579,11 +576,11 @@ class DBMultiIntegerFilter(DBMultiValueFilter[int]):
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBOptionalChainAddressesFilter(DBFilter):
     """Filter the address column by a selection of optional chain addresses"""
-    optional_chain_addresses: Optional[list[OptionalChainAddress]]
+    optional_chain_addresses: list[OptionalChainAddress] | None
 
     def prepare(self) -> tuple[list[str], list[str]]:
         query_filters = []
-        bindings: list[Union[str, ChecksumEvmAddress]] = []
+        bindings: list[str | ChecksumEvmAddress] = []
         if self.optional_chain_addresses is not None:
             for optional_chain_address in self.optional_chain_addresses:
                 query_part = 'address = ?'
@@ -601,16 +598,16 @@ class TradesFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLocation):
     def make(
             cls: type['TradesFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            base_assets: Optional[tuple[Asset, ...]] = None,
-            quote_assets: Optional[tuple[Asset, ...]] = None,
-            trade_type: Optional[list[TradeType]] = None,
-            location: Optional[Location] = None,
-            trades_idx_to_ignore: Optional[set[str]] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            base_assets: tuple[Asset, ...] | None = None,
+            quote_assets: tuple[Asset, ...] | None = None,
+            trade_type: list[TradeType] | None = None,
+            location: Location | None = None,
+            trades_idx_to_ignore: set[str] | None = None,
     ) -> 'TradesFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -676,14 +673,14 @@ class AssetMovementsFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLo
     def make(
             cls: type['AssetMovementsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            assets: Optional[tuple[Asset, ...]] = None,
-            action: Optional[list[AssetMovementCategory]] = None,
-            location: Optional[Location] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            assets: tuple[Asset, ...] | None = None,
+            action: list[AssetMovementCategory] | None = None,
+            location: Location | None = None,
     ) -> 'AssetMovementsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -728,12 +725,12 @@ class Eth2DailyStatsFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['Eth2DailyStatsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            validators: Optional[list[int]] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            validators: list[int] | None = None,
     ) -> 'Eth2DailyStatsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -761,26 +758,26 @@ class Eth2DailyStatsFilterQuery(DBFilterQuery, FilterWithTimestamp):
 class ReportDataFilterQuery(DBFilterQuery, FilterWithTimestamp):
 
     @property
-    def report_id_filter(self) -> Optional[DBReportDataReportIDFilter]:
+    def report_id_filter(self) -> DBReportDataReportIDFilter | None:
         if len(self.filters) >= 1 and isinstance(self.filters[0], DBReportDataReportIDFilter):
             return self.filters[0]
         return None
 
     @property
-    def event_type_filter(self) -> Optional[DBReportDataEventTypeFilter]:
+    def event_type_filter(self) -> DBReportDataEventTypeFilter | None:
         if len(self.filters) >= 2 and isinstance(self.filters[1], DBReportDataEventTypeFilter):
             return self.filters[1]
         return None
 
     @property
-    def report_id(self) -> Optional[Union[str, int]]:
+    def report_id(self) -> str | int | None:
         report_id_filter = self.report_id_filter
         if report_id_filter is None:
             return None
         return report_id_filter.report_id
 
     @property
-    def event_type(self) -> Optional[Union[str, SchemaEventType]]:
+    def event_type(self) -> str | SchemaEventType | None:
         event_type_filter = self.event_type_filter
         if event_type_filter is None:
             return None
@@ -790,13 +787,13 @@ class ReportDataFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['ReportDataFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            report_id: Optional[int] = None,
-            event_type: Optional[str] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            report_id: int | None = None,
+            event_type: str | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
     ) -> 'ReportDataFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -841,7 +838,7 @@ class HistoryEventCustomizedOnlyJoinsFilter(DBFilter):
             'ON history_events_mappings.parent_identifier = history_events.identifier '
             'WHERE history_events_mappings.name = ? AND history_events_mappings.value = ?'
         )
-        bindings: list[Union[str, int]] = [HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED]  # noqa: E501
+        bindings: list[str | int] = [HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED]
         return [query], bindings
 
 
@@ -851,21 +848,21 @@ class HistoryBaseEntryFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWith
     def make(
             cls: type[T_HistoryBaseEntryFilterQ],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            assets: Optional[tuple[Asset, ...]] = None,
-            event_types: Optional[list[HistoryEventType]] = None,
-            event_subtypes: Optional[list[HistoryEventSubType]] = None,
-            exclude_subtypes: Optional[list[HistoryEventSubType]] = None,
-            location: Optional[Location] = None,
-            location_labels: Optional[list[str]] = None,
-            ignored_ids: Optional[list[str]] = None,
-            null_columns: Optional[list[str]] = None,
-            event_identifiers: Optional[list[str]] = None,
-            entry_types: Optional[IncludeExcludeFilterData] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            assets: tuple[Asset, ...] | None = None,
+            event_types: list[HistoryEventType] | None = None,
+            event_subtypes: list[HistoryEventSubType] | None = None,
+            exclude_subtypes: list[HistoryEventSubType] | None = None,
+            location: Location | None = None,
+            location_labels: list[str] | None = None,
+            ignored_ids: list[str] | None = None,
+            null_columns: list[str] | None = None,
+            event_identifiers: list[str] | None = None,
+            entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
             customized_events_only: bool = False,
     ) -> T_HistoryBaseEntryFilterQ:
@@ -1000,27 +997,27 @@ class EvmEventFilterQuery(HistoryBaseEntryFilterQuery):
     def make(
             cls: type['EvmEventFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            assets: Optional[tuple[Asset, ...]] = None,
-            event_types: Optional[list[HistoryEventType]] = None,
-            event_subtypes: Optional[list[HistoryEventSubType]] = None,
-            exclude_subtypes: Optional[list[HistoryEventSubType]] = None,
-            location: Optional[Location] = None,
-            location_labels: Optional[list[str]] = None,
-            ignored_ids: Optional[list[str]] = None,
-            null_columns: Optional[list[str]] = None,
-            event_identifiers: Optional[list[str]] = None,
-            entry_types: Optional[IncludeExcludeFilterData] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            assets: tuple[Asset, ...] | None = None,
+            event_types: list[HistoryEventType] | None = None,
+            event_subtypes: list[HistoryEventSubType] | None = None,
+            exclude_subtypes: list[HistoryEventSubType] | None = None,
+            location: Location | None = None,
+            location_labels: list[str] | None = None,
+            ignored_ids: list[str] | None = None,
+            null_columns: list[str] | None = None,
+            event_identifiers: list[str] | None = None,
+            entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
             customized_events_only: bool = False,
-            tx_hashes: Optional[list[EVMTxHash]] = None,
-            counterparties: Optional[list[str]] = None,
-            products: Optional[list[EvmProduct]] = None,
-            addresses: Optional[list[ChecksumEvmAddress]] = None,
+            tx_hashes: list[EVMTxHash] | None = None,
+            counterparties: list[str] | None = None,
+            products: list[EvmProduct] | None = None,
+            addresses: list[ChecksumEvmAddress] | None = None,
     ) -> 'EvmEventFilterQuery':
         if entry_types is None:
             entry_type_values = [HistoryBaseEntryType.EVM_EVENT]
@@ -1095,24 +1092,24 @@ class EthStakingEventFilterQuery(HistoryBaseEntryFilterQuery, metaclass=ABCMeta)
     def make(
             cls: type[T_EthSTakingFilterQ],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            assets: Optional[tuple[Asset, ...]] = None,
-            event_types: Optional[list[HistoryEventType]] = None,
-            event_subtypes: Optional[list[HistoryEventSubType]] = None,
-            exclude_subtypes: Optional[list[HistoryEventSubType]] = None,
-            location: Optional[Location] = None,
-            location_labels: Optional[list[str]] = None,
-            ignored_ids: Optional[list[str]] = None,
-            null_columns: Optional[list[str]] = None,
-            event_identifiers: Optional[list[str]] = None,
-            entry_types: Optional[IncludeExcludeFilterData] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            assets: tuple[Asset, ...] | None = None,
+            event_types: list[HistoryEventType] | None = None,
+            event_subtypes: list[HistoryEventSubType] | None = None,
+            exclude_subtypes: list[HistoryEventSubType] | None = None,
+            location: Location | None = None,
+            location_labels: list[str] | None = None,
+            ignored_ids: list[str] | None = None,
+            null_columns: list[str] | None = None,
+            event_identifiers: list[str] | None = None,
+            entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
             customized_events_only: bool = False,
-            validator_indices: Optional[list[int]] = None,
+            validator_indices: list[int] | None = None,
     ) -> T_EthSTakingFilterQ:
         if entry_types is None:
             entry_type_values = [HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT, HistoryBaseEntryType.ETH_BLOCK_EVENT, HistoryBaseEntryType.ETH_DEPOSIT_EVENT]  # noqa: E501
@@ -1170,25 +1167,25 @@ class EthDepositEventFilterQuery(EvmEventFilterQuery, EthStakingEventFilterQuery
     def make(  # type: ignore  # it is expected to be incompatible with supertype
             cls: type['EthDepositEventFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            assets: Optional[tuple[Asset, ...]] = None,
-            event_types: Optional[list[HistoryEventType]] = None,
-            event_subtypes: Optional[list[HistoryEventSubType]] = None,
-            exclude_subtypes: Optional[list[HistoryEventSubType]] = None,
-            location: Optional[Location] = None,
-            location_labels: Optional[list[str]] = None,
-            ignored_ids: Optional[list[str]] = None,
-            null_columns: Optional[list[str]] = None,
-            event_identifiers: Optional[list[str]] = None,
-            entry_types: Optional[IncludeExcludeFilterData] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            assets: tuple[Asset, ...] | None = None,
+            event_types: list[HistoryEventType] | None = None,
+            event_subtypes: list[HistoryEventSubType] | None = None,
+            exclude_subtypes: list[HistoryEventSubType] | None = None,
+            location: Location | None = None,
+            location_labels: list[str] | None = None,
+            ignored_ids: list[str] | None = None,
+            null_columns: list[str] | None = None,
+            event_identifiers: list[str] | None = None,
+            entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
             customized_events_only: bool = False,
-            tx_hashes: Optional[list[EVMTxHash]] = None,
-            validator_indices: Optional[list[int]] = None,
+            tx_hashes: list[EVMTxHash] | None = None,
+            validator_indices: list[int] | None = None,
     ) -> 'EthDepositEventFilterQuery':
         if entry_types is None:
             entry_type_values = [HistoryBaseEntryType.ETH_DEPOSIT_EVENT]
@@ -1241,7 +1238,7 @@ class DBSubtableSelectFilter(DBFilter):
     operator: Literal['IN', 'NOT IN']
     select_value: str
     select_table: str
-    select_condition: Optional[str]
+    select_condition: str | None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         null_check = ''  # for NOT IN comparison remember NULL is a special case
@@ -1271,13 +1268,13 @@ class UserNotesFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['UserNotesFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-            location: Optional[str] = None,
-            substring_search: Optional[str] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+            location: str | None = None,
+            substring_search: str | None = None,
     ) -> 'UserNotesFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('last_update_timestamp', True)]
@@ -1316,11 +1313,11 @@ class AddressbookFilterQuery(DBFilterQuery):
     def make(
             cls: type['AddressbookFilterQuery'],
             and_op: bool = True,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            blockchain: Optional[SupportedBlockchain] = None,
-            optional_chain_addresses: Optional[list[OptionalChainAddress]] = None,
-            substring_search: Optional[str] = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            blockchain: SupportedBlockchain | None = None,
+            optional_chain_addresses: list[OptionalChainAddress] | None = None,
+            substring_search: str | None = None,
     ) -> 'AddressbookFilterQuery':
         filter_query = cls.create(
             and_op=and_op,
@@ -1354,19 +1351,19 @@ class AssetsFilterQuery(DBFilterQuery):
     def make(
             cls: type['AssetsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            name: Optional[str] = None,
-            symbol: Optional[str] = None,
-            address: Optional[ChecksumEvmAddress] = None,
-            substring_search: Optional[str] = None,
-            search_column: Optional[str] = None,
-            asset_type: Optional[AssetType] = None,
-            identifiers: Optional[list[str]] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            name: str | None = None,
+            symbol: str | None = None,
+            address: ChecksumEvmAddress | None = None,
+            substring_search: str | None = None,
+            search_column: str | None = None,
+            asset_type: AssetType | None = None,
+            identifiers: list[str] | None = None,
             show_user_owned_assets_only: bool = False,
             return_exact_matches: bool = False,
-            chain_id: Optional[ChainID] = None,
+            chain_id: ChainID | None = None,
             identifier_column_name: str = 'identifier',
             ignored_assets_handling: IgnoredAssetsHandling = IgnoredAssetsHandling.NONE,
     ) -> 'AssetsFilterQuery':
@@ -1453,12 +1450,12 @@ class CustomAssetsFilterQuery(DBFilterQuery):
     @classmethod
     def make(
             cls: type['CustomAssetsFilterQuery'],
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            identifier: Optional[str] = None,
-            name: Optional[str] = None,
-            custom_asset_type: Optional[str] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            identifier: str | None = None,
+            name: str | None = None,
+            custom_asset_type: str | None = None,
     ) -> 'CustomAssetsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('name', True)]
@@ -1498,16 +1495,16 @@ class NFTFilterQuery(DBFilterQuery):
     @classmethod
     def make(
             cls: type['NFTFilterQuery'],
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            owner_addresses: Optional[list[str]] = None,
-            name: Optional[str] = None,
-            collection_name: Optional[str] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            owner_addresses: list[str] | None = None,
+            name: str | None = None,
+            collection_name: str | None = None,
             ignored_assets_handling: IgnoredAssetsHandling = IgnoredAssetsHandling.NONE,
             lps_handling: NftLpHandling = NftLpHandling.ALL_NFTS,
-            nft_id: Optional[str] = None,
-            last_price_asset: Optional[Asset] = None,
+            nft_id: str | None = None,
+            last_price_asset: Asset | None = None,
             only_with_manual_prices: bool = False,
             with_price: bool = True,
     ) -> 'NFTFilterQuery':
@@ -1625,7 +1622,7 @@ class LevenshteinFilterQuery(MultiTableFilterQuery):
             cls,
             and_op: bool = True,
             substring_search: str = '',  # substring is always required for levenstein
-            chain_id: Optional[ChainID] = None,
+            chain_id: ChainID | None = None,
             ignored_assets_handling: IgnoredAssetsHandling = IgnoredAssetsHandling.NONE,
     ) -> 'LevenshteinFilterQuery':
         filter_query = LevenshteinFilterQuery(
@@ -1693,8 +1690,8 @@ class TransactionsNotDecodedFilterQuery(DBFilterQuery):
     @classmethod
     def make(
             cls: type['TransactionsNotDecodedFilterQuery'],
-            limit: Optional[int] = None,
-            chain_id: Optional[ChainID] = None,
+            limit: int | None = None,
+            chain_id: ChainID | None = None,
     ) -> 'TransactionsNotDecodedFilterQuery':
         filter_query = cls.create(
             and_op=True,
@@ -1720,12 +1717,12 @@ class AccountingRulesFilterQuery(DBFilterQuery):
     def make(
             cls: type['AccountingRulesFilterQuery'],
             and_op: bool = True,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            event_types: Optional[list[HistoryEventType]] = None,
-            event_subtypes: Optional[list[HistoryEventSubType]] = None,
-            counterparties: Optional[list[str]] = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            event_types: list[HistoryEventType] | None = None,
+            event_subtypes: list[HistoryEventSubType] | None = None,
+            counterparties: list[str] | None = None,
     ) -> 'AccountingRulesFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('identifier', False)]
@@ -1770,9 +1767,9 @@ class PaginatedFilterQuery(DBFilterQuery):
     def make(
             cls,
             and_op: bool = True,
-            limit: Optional[int] = None,
-            offset: Optional[int] = None,
-            order_by_rules: Optional[list[tuple[str, bool]]] = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
     ) -> 'PaginatedFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('identifier', False)]

--- a/rotkehlchen/db/loopring.py
+++ b/rotkehlchen/db/loopring.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.types import ChecksumEvmAddress
 
@@ -33,7 +33,7 @@ class DBLoopring:
             self,
             cursor: 'DBCursor',
             address: ChecksumEvmAddress,
-    ) -> Optional[int]:
+    ) -> int | None:
         cursor.execute(
             'SELECT value FROM multisettings WHERE name=?;',
             (f'loopring_{address}_account_id',),

--- a/rotkehlchen/db/optimismtx.py
+++ b/rotkehlchen/db/optimismtx.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.optimism.types import OptimismTransaction
 from rotkehlchen.db.evmtx import DBEvmTx
@@ -22,7 +22,7 @@ class DBOptimismTx(DBEvmTx):
             self,
             write_cursor: 'DBCursor',
             evm_transactions: list[OptimismTransaction],  # type: ignore[override]
-            relevant_address: Optional[ChecksumEvmAddress],
+            relevant_address: ChecksumEvmAddress | None,
     ) -> None:
         """Adds optimism transactions to the database"""
         super().add_evm_transactions(

--- a/rotkehlchen/db/queried_addresses.py
+++ b/rotkehlchen/db/queried_addresses.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -52,7 +52,7 @@ class QueriedAddresses:
             self,
             cursor: 'DBCursor',
             module: ModuleName,
-    ) -> Optional[tuple[ChecksumAddress, ...]]:
+    ) -> tuple[ChecksumAddress, ...] | None:
         """Get a List of addresses to query for module or None if none is set"""
         cursor = self.db.conn.cursor()
         query = cursor.execute(

--- a/rotkehlchen/db/reports.py
+++ b/rotkehlchen/db/reports.py
@@ -1,6 +1,7 @@
 import logging
+from collections.abc import Callable
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -45,9 +46,9 @@ def _get_reports_or_events_maybe_limit(
 def _get_reports_or_events_maybe_limit(
         entry_type: Literal['events', 'reports'],
         entries_found: int,
-        entries: Union[list[dict[str, Any]], list[ProcessedAccountingEvent]],
+        entries: list[dict[str, Any]] | list[ProcessedAccountingEvent],
         with_limit: bool,
-) -> tuple[Union[list[dict[str, Any]], list[ProcessedAccountingEvent]], int]:
+) -> tuple[list[dict[str, Any]] | list[ProcessedAccountingEvent], int]:
     if with_limit is False:
         return entries, entries_found
 
@@ -139,14 +140,14 @@ class DBAccountingReports:
 
     def get_reports(
             self,
-            report_id: Optional[int],
+            report_id: int | None,
             with_limit: bool,
     ) -> tuple[list[dict[str, Any]], int]:
         """Queries all historical saved PnL reports.
 
         If `with_limit` is true then the api limit is applied
         """
-        bindings: Union[tuple, tuple[int]] = ()
+        bindings: tuple | tuple[int] = ()
         query = 'SELECT * from pnl_reports'
         reports: list[dict[str, Any]] = []
         if report_id is not None:

--- a/rotkehlchen/db/search_assets.py
+++ b/rotkehlchen/db/search_assets.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from polyleven import levenshtein
 
@@ -105,7 +105,7 @@ def _search_only_assets_levenstein(
 def search_assets_levenshtein(
         db: 'DBHandler',
         filter_query: 'LevenshteinFilterQuery',
-        limit: Optional[int],
+        limit: int | None,
         search_nfts: bool,
 ) -> list[dict[str, Any]]:
     """Returns a list of asset details that match the search keyword using the Levenshtein distance approach."""  # noqa: E501

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass, field, fields
-from typing import Any, Literal, NamedTuple, Optional, Union
+from typing import Any, Literal, NamedTuple, Optional
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.chain.constants import LAST_EVM_ACCOUNTS_DETECT_KEY
@@ -138,19 +138,19 @@ CachedDBSettingsFieldNames = Literal[
     'read_timeout',
 ]
 
-DBSettingsFieldTypes = Union[
-    bool,
-    int,
-    Timestamp,
-    str,
-    Asset,
-    Sequence[ModuleName],
-    Sequence[CurrentPriceOracle],
-    Sequence[HistoricalPriceOracle],
-    Sequence[ExchangeLocationID],
-    CostBasisMethod,
-    Sequence[AddressNameSource],
-]
+DBSettingsFieldTypes = (
+    bool |
+    int |
+    Timestamp |
+    str |
+    Asset |
+    Sequence[ModuleName] |
+    Sequence[CurrentPriceOracle] |
+    Sequence[HistoricalPriceOracle] |
+    Sequence[ExchangeLocationID] |
+    CostBasisMethod |
+    Sequence[AddressNameSource]
+)
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
@@ -162,7 +162,7 @@ class DBSettings:
     include_crypto2crypto: bool = DEFAULT_INCLUDE_CRYPTO2CRYPTO
     last_data_upload_ts: Timestamp = field(default=Timestamp(0))
     ui_floating_precision: int = DEFAULT_UI_FLOATING_PRECISION
-    taxfree_after_period: Optional[int] = DEFAULT_TAXFREE_AFTER_PERIOD
+    taxfree_after_period: int | None = DEFAULT_TAXFREE_AFTER_PERIOD
     balance_save_frequency: int = DEFAULT_BALANCE_SAVE_FREQUENCY
     include_gas_costs: bool = DEFAULT_INCLUDE_GAS_COSTS
     ksm_rpc_endpoint: str = 'http://localhost:9933'
@@ -213,38 +213,38 @@ class DBSettings:
 
 
 class ModifiableDBSettings(NamedTuple):
-    premium_should_sync: Optional[bool] = None
-    include_crypto2crypto: Optional[bool] = None
-    ui_floating_precision: Optional[int] = None
-    taxfree_after_period: Optional[int] = None
-    balance_save_frequency: Optional[int] = None
-    include_gas_costs: Optional[bool] = None
-    ksm_rpc_endpoint: Optional[str] = None
-    dot_rpc_endpoint: Optional[str] = None
-    main_currency: Optional[AssetWithOracles] = None
-    date_display_format: Optional[str] = None
-    submit_usage_analytics: Optional[bool] = None
-    active_modules: Optional[list[ModuleName]] = None
-    frontend_settings: Optional[str] = None
-    account_for_assets_movements: Optional[bool] = None
-    btc_derivation_gap_limit: Optional[int] = None
-    calculate_past_cost_basis: Optional[bool] = None
-    display_date_in_localtime: Optional[bool] = None
-    current_price_oracles: Optional[list[CurrentPriceOracle]] = None
-    historical_price_oracles: Optional[list[HistoricalPriceOracle]] = None
-    pnl_csv_with_formulas: Optional[bool] = None
-    pnl_csv_have_summary: Optional[bool] = None
-    ssf_graph_multiplier: Optional[int] = None
-    non_syncing_exchanges: Optional[list[ExchangeLocationID]] = None
-    cost_basis_method: Optional[CostBasisMethod] = None
-    treat_eth2_as_eth: Optional[bool] = None
-    eth_staking_taxable_after_withdrawal_enabled: Optional[bool] = None
-    address_name_priority: Optional[list[AddressNameSource]] = None
-    include_fees_in_cost_basis: Optional[bool] = None
-    infer_zero_timed_balances: Optional[bool] = None
-    query_retry_limit: Optional[int] = None
-    connect_timeout: Optional[int] = None
-    read_timeout: Optional[int] = None
+    premium_should_sync: bool | None = None
+    include_crypto2crypto: bool | None = None
+    ui_floating_precision: int | None = None
+    taxfree_after_period: int | None = None
+    balance_save_frequency: int | None = None
+    include_gas_costs: bool | None = None
+    ksm_rpc_endpoint: str | None = None
+    dot_rpc_endpoint: str | None = None
+    main_currency: AssetWithOracles | None = None
+    date_display_format: str | None = None
+    submit_usage_analytics: bool | None = None
+    active_modules: list[ModuleName] | None = None
+    frontend_settings: str | None = None
+    account_for_assets_movements: bool | None = None
+    btc_derivation_gap_limit: int | None = None
+    calculate_past_cost_basis: bool | None = None
+    display_date_in_localtime: bool | None = None
+    current_price_oracles: list[CurrentPriceOracle] | None = None
+    historical_price_oracles: list[HistoricalPriceOracle] | None = None
+    pnl_csv_with_formulas: bool | None = None
+    pnl_csv_have_summary: bool | None = None
+    ssf_graph_multiplier: int | None = None
+    non_syncing_exchanges: list[ExchangeLocationID] | None = None
+    cost_basis_method: CostBasisMethod | None = None
+    treat_eth2_as_eth: bool | None = None
+    eth_staking_taxable_after_withdrawal_enabled: bool | None = None
+    address_name_priority: list[AddressNameSource] | None = None
+    include_fees_in_cost_basis: bool | None = None
+    infer_zero_timed_balances: bool | None = None
+    query_retry_limit: int | None = None
+    connect_timeout: int | None = None
+    read_timeout: int | None = None
 
     def serialize(self) -> dict[str, Any]:
         settings_dict = {}
@@ -260,7 +260,7 @@ class ModifiableDBSettings(NamedTuple):
         return settings_dict
 
 
-def read_boolean(value: Union[str, bool]) -> bool:
+def read_boolean(value: str | bool) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -397,7 +397,7 @@ class CachedSettings:
     def get_entry(self, attr: CachedDBSettingsFieldNames) -> DBSettingsFieldTypes:
         return getattr(self._settings, attr)
 
-    def get_settings(self) -> Optional[DBSettings]:
+    def get_settings(self) -> DBSettings | None:
         return self._settings
 
     # commonly used settings with their own get function

--- a/rotkehlchen/db/snapshots.py
+++ b/rotkehlchen/db/snapshots.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from rotkehlchen.accounting.export.csv import CSVWriteError, dict_to_csv_file
@@ -123,7 +123,7 @@ class DBSnapshot:
     def export(
             self,
             timestamp: Timestamp,
-            directory_path: Optional[Path],
+            directory_path: Path | None,
     ) -> tuple[bool, str]:
         """Export the database's snapshot for specified timestamp.
 

--- a/rotkehlchen/db/upgrade_manager.py
+++ b/rotkehlchen/db/upgrade_manager.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import traceback
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
@@ -101,7 +101,7 @@ UPGRADES_LIST = [
 class DBUpgradeProgressHandler(ProgressUpdater):
     """Class to notify users through websockets about progress of upgrading the database."""
 
-    def _notify_frontend(self, step_name: Optional[str] = None) -> None:
+    def _notify_frontend(self, step_name: str | None = None) -> None:
         """Sends to the user through websockets all information about db upgrading progress."""
         self.messages_aggregator.add_message(
             message_type=WSMessageType.DB_UPGRADE_STATUS,

--- a/rotkehlchen/db/utils.py
+++ b/rotkehlchen/db/utils.py
@@ -1,13 +1,13 @@
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
 from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
+    Concatenate,
     Literal,
     NamedTuple,
-    Optional,
     Protocol,
     TypeVar,
     Union,
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from eth_utils import is_checksum_address
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import ParamSpec
 
 from rotkehlchen.accounting.structures.balance import BalanceType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -127,9 +127,9 @@ class DBAssetBalance:
 
     def serialize(
             self,
-            currency_and_price: Optional[tuple[AssetWithOracles, Price]] = None,
+            currency_and_price: tuple[AssetWithOracles, Price] | None = None,
             display_date_in_localtime: bool = True,
-    ) -> dict[str, Union[str, int]]:
+    ) -> dict[str, str | int]:
         """Serializes a `DBAssetBalance` to dict.
         It accepts an `export_data` tuple of the user's local currency and the value of the
         currency in USD e.g (EUR, 1.01). If provided, the data is serialized for human consumption.
@@ -198,9 +198,9 @@ class LocationData(NamedTuple):
 
     def serialize(
             self,
-            currency_and_price: Optional[tuple[AssetWithOracles, Price]] = None,
+            currency_and_price: tuple[AssetWithOracles, Price] | None = None,
             display_date_in_localtime: bool = True,
-    ) -> dict[str, Union[str, int]]:
+    ) -> dict[str, str | int]:
         if currency_and_price:
             return {
                 'timestamp': timestamp_to_date(
@@ -220,7 +220,7 @@ class LocationData(NamedTuple):
 
 class Tag(NamedTuple):
     name: str
-    description: Optional[str]
+    description: str | None
     background_color: HexColorCode
     foreground_color: HexColorCode
 
@@ -235,9 +235,9 @@ def str_to_bool(s: str) -> bool:
 def form_query_to_filter_timestamps(
         query: str,
         timestamp_attribute: str,
-        from_ts: Optional[Timestamp],
-        to_ts: Optional[Timestamp],
-) -> tuple[str, Union[tuple, tuple[Timestamp], tuple[Timestamp, Timestamp]]]:
+        from_ts: Timestamp | None,
+        to_ts: Timestamp | None,
+) -> tuple[str, tuple | (tuple[Timestamp] | tuple[Timestamp, Timestamp])]:
     """Formulates the query string and its bindings to filter for timestamps"""
     got_from_ts = from_ts is not None
     got_to_ts = to_ts is not None
@@ -259,7 +259,7 @@ def form_query_to_filter_timestamps(
     return query, tuple(bindings)
 
 
-def deserialize_tags_from_db(val: Optional[str]) -> Optional[list[str]]:
+def deserialize_tags_from_db(val: str | None) -> list[str] | None:
     """Read tags from the DB and turn it into a List of tags"""
     if val is None:
         tags = None
@@ -300,7 +300,7 @@ def _prepare_tag_mappings(
 
 def insert_tag_mappings(
         write_cursor: 'DBCursor',
-        data: Union[list['ManuallyTrackedBalance'], list[BlockchainAccountData], list['XpubData']],
+        data: list['ManuallyTrackedBalance'] | (list[BlockchainAccountData] | list['XpubData']),
         object_reference_keys: list[
             Literal['id', 'chain', 'address', 'xpub.xpub', 'derivation_path'],
         ],
@@ -321,7 +321,7 @@ def insert_tag_mappings(
 
 def replace_tag_mappings(
         write_cursor: 'DBCursor',
-        data: Union[list['ManuallyTrackedBalance'], list[BlockchainAccountData], list['XpubData']],
+        data: list['ManuallyTrackedBalance'] | (list[BlockchainAccountData] | list['XpubData']),
         object_reference_keys: list[
             Literal['id', 'chain', 'address', 'xpub.xpub', 'derivation_path'],
         ],
@@ -448,9 +448,9 @@ def update_table_schema(
         write_cursor: 'DBCursor',
         table_name: str,
         schema: str,
-        insert_columns: Optional[str] = None,
+        insert_columns: str | None = None,
         insert_order: str = '',
-        insert_where: Optional[str] = None,
+        insert_where: str | None = None,
 ) -> bool:
     """Update the schema of a given table. Need to provide:
     1. The name

--- a/rotkehlchen/errors/api.py
+++ b/rotkehlchen/errors/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 
 class RotkehlchenPermissionError(Exception):
@@ -7,7 +7,7 @@ class RotkehlchenPermissionError(Exception):
     The payload contains information to be shown to the user by the frontend so
     they can decide what to do
     """
-    def __init__(self, error_message: str, payload: Optional[dict[str, Any]]) -> None:
+    def __init__(self, error_message: str, payload: dict[str, Any] | None) -> None:
         super().__init__(error_message)
         self.error_message = error_message
         self.message_payload = payload if payload is not None else {}

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -5,7 +5,7 @@ import logging
 from collections import defaultdict
 from contextlib import suppress
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 from uuid import uuid4
 
@@ -206,7 +206,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             database: 'DBHandler',
             msg_aggregator: MessagesAggregator,
             uri: str = BINANCE_BASE_URL,
-            binance_selected_trade_pairs: Optional[list[str]] = None,
+            binance_selected_trade_pairs: list[str] | None = None,
     ):
         exchange_location = Location.BINANCE
         if uri == BINANCEUS_BASE_URL:
@@ -295,8 +295,8 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             self,
             api_type: BINANCE_API_TYPE,
             method: str,
-            options: Optional[dict] = None,
-    ) -> Union[list, dict]:
+            options: dict | None = None,
+    ) -> list | dict:
         """Performs a binance api query
 
         May raise:
@@ -366,7 +366,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                     log.debug(f'Couldnt query {self.name} trades for {symbol} since its delisted')
                     return []
 
-                exception_class: type[Union[RemoteError, BinancePermissionError]]
+                exception_class: type[RemoteError | BinancePermissionError]
                 if response.status_code == 401 and code == REJECTED_MBX_KEY:
                     # Either API key permission error or if futures/dapi then not enabled yet
                     exception_class = BinancePermissionError
@@ -422,7 +422,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             self,
             api_type: BINANCE_API_TYPE,
             method: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> dict:
         """May raise RemoteError and BinancePermissionError due to api_query"""
         result = self.api_query(api_type, method, options)
@@ -437,7 +437,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             self,
             api_type: BINANCE_API_TYPE,
             method: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> list:
         """May raise RemoteError and BinancePermissionError due to api_query"""
         result = self.api_query(api_type, method, options)
@@ -1108,7 +1108,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             self,
             raw_data: dict[str, Any],
             trade_type: TradeType,
-    ) -> Optional[Trade]:
+    ) -> Trade | None:
         """Processes a single deposit/withdrawal from binance and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization
@@ -1175,7 +1175,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             self,
             raw_data: dict[str, Any],
             category: AssetMovementCategory,
-    ) -> Optional[AssetMovement]:
+    ) -> AssetMovement | None:
         """Processes a single deposit/withdrawal from binance and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization
@@ -1233,7 +1233,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
 
         return None
 
-    def _deserialize_asset_movement(self, raw_data: dict[str, Any]) -> Optional[AssetMovement]:
+    def _deserialize_asset_movement(self, raw_data: dict[str, Any]) -> AssetMovement | None:
         """Processes a single deposit/withdrawal from binance and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization
@@ -1311,7 +1311,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                 'fiat/payments',
                 'lending/union/interestHistory',
             ],
-            additional_options: Optional[dict] = None,
+            additional_options: dict | None = None,
     ) -> list[dict[str, Any]]:
         """Request via `api_query_dict()` from `start_ts` `end_ts` using a time
         delta (offset) less than `time_delta`.

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import requests
@@ -174,7 +174,7 @@ class Bitcoinde(ExchangeInterface):
             self,
             verb: Literal['get', 'post'],
             path: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> dict:
         """
         Queries Bitcoin.de with the given verb for the given path and options

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 import requests
@@ -156,8 +156,8 @@ class Bitmex(ExchangeInterface):
             self,
             verb: str,
             path: str,
-            options: Optional[dict] = None,
-    ) -> Union[list, dict]:
+            options: dict | None = None,
+    ) -> list | dict:
         """
         Queries Bitmex with the given verb for the given path and options
         """
@@ -224,7 +224,7 @@ class Bitmex(ExchangeInterface):
             self,
             verb: str,
             path: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> dict:
         result = self._api_query(verb, path, options)
         assert isinstance(result, dict)  # pylint: disable=isinstance-second-argument-not-valid-type
@@ -234,7 +234,7 @@ class Bitmex(ExchangeInterface):
             self,
             verb: str,
             path: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> list:
         result = self._api_query(verb, path, options)
         assert isinstance(result, list)  # pylint: disable=isinstance-second-argument-not-valid-type

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import defaultdict
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 from urllib.parse import urlencode
 
 import gevent
@@ -149,7 +149,7 @@ class Bitpanda(ExchangeInterface):
             entry: dict[str, Any],
             from_ts: Timestamp,
             to_ts: Timestamp,
-    ) -> Optional[AssetMovement]:
+    ) -> AssetMovement | None:
         """Deserializes a bitpanda fiatwallets/transactions or wallets/transactions
         entry to a deposit/withdrawal
 
@@ -227,7 +227,7 @@ class Bitpanda(ExchangeInterface):
             entry: dict[str, Any],
             from_ts: Timestamp,
             to_ts: Timestamp,
-    ) -> Optional[Trade]:
+    ) -> Trade | None:
         """Deserializes a bitpanda trades result entry to a Trade
 
         Returns None and logs error is there is a problem or simpy None if
@@ -319,23 +319,23 @@ class Bitpanda(ExchangeInterface):
                 'fiatwallets/transactions',
                 'wallets/transactions',
             ],
-            options: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[Any], Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+            options: dict[str, Any] | None = None,
+    ) -> tuple[list[Any], dict[str, Any] | None, dict[str, Any] | None]:
         ...
 
     @overload
     def _api_query(
             self,
             endpoint: Literal['asset-wallets'],
-            options: Optional[dict[str, Any]] = None,
-    ) -> tuple[dict[str, Any], Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+            options: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
         ...
 
     def _api_query(
             self,
             endpoint: str,
-            options: Optional[dict[str, Any]] = None,
-    ) -> tuple[Union[list[Any], dict[str, Any]], Optional[dict[str, Any]], Optional[dict[str, Any]]]:  # noqa: E501
+            options: dict[str, Any] | None = None,
+    ) -> tuple[list[Any] | dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
         """Performs a bitpanda API Query for endpoint
 
         You can optionally provide extra arguments to the endpoint via the options argument.
@@ -402,9 +402,9 @@ class Bitpanda(ExchangeInterface):
     def _query_endpoint_until_end(
             self,
             endpoint: Literal['trades'],
-            from_ts: Optional[Timestamp],
-            to_ts: Optional[Timestamp],
-            options: Optional[dict[str, Any]] = None,
+            from_ts: Timestamp | None,
+            to_ts: Timestamp | None,
+            options: dict[str, Any] | None = None,
     ) -> list[Trade]:
         ...
 
@@ -412,19 +412,19 @@ class Bitpanda(ExchangeInterface):
     def _query_endpoint_until_end(
             self,
             endpoint: Literal['fiatwallets/transactions', 'wallets/transactions'],
-            from_ts: Optional[Timestamp],
-            to_ts: Optional[Timestamp],
-            options: Optional[dict[str, Any]] = None,
+            from_ts: Timestamp | None,
+            to_ts: Timestamp | None,
+            options: dict[str, Any] | None = None,
     ) -> list[AssetMovement]:
         ...
 
     def _query_endpoint_until_end(
             self,
             endpoint: Literal['trades', 'fiatwallets/transactions', 'wallets/transactions'],
-            from_ts: Optional[Timestamp],
-            to_ts: Optional[Timestamp],
-            options: Optional[dict[str, Any]] = None,
-    ) -> Union[list[Trade], list[AssetMovement]]:
+            from_ts: Timestamp | None,
+            to_ts: Timestamp | None,
+            options: dict[str, Any] | None = None,
+    ) -> list[Trade] | list[AssetMovement]:
         """Query a paginated endpoint until all pages are read
 
         May raise RemoteError

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 from urllib.parse import urlencode
 
 import requests
@@ -49,6 +49,7 @@ from rotkehlchen.utils.mixins.lockable import protect_with_lock
 from rotkehlchen.utils.serialization import jsonloads_dict, jsonloads_list
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from rotkehlchen.accounting.structures.base import HistoryEvent
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.fval import FVal
@@ -309,7 +310,7 @@ class Bitstamp(ExchangeInterface):
             self,
             endpoint: Literal['balance', 'user_transactions'],
             method: Literal['post'] = 'post',
-            options: Optional[dict[str, Any]] = None,
+            options: dict[str, Any] | None = None,
     ) -> Response:
         """Request a Bistamp API v2 endpoint (from `endpoint`).
         """
@@ -389,7 +390,7 @@ class Bitstamp(ExchangeInterface):
             end_ts: Timestamp,
             options: dict[str, Any],
             case: Literal['trades', 'asset_movements'],
-    ) -> Union[list[Trade], list[AssetMovement], list]:
+    ) -> list[Trade] | (list[AssetMovement] | list):
         """Request a Bitstamp API v2 endpoint paginating via an options
         attribute.
 
@@ -403,7 +404,7 @@ class Bitstamp(ExchangeInterface):
             * limit: 1000 (API v2 default using `since_id`).
             * sort: 'asc'
         """
-        deserialization_method: Callable[[dict[str, Any]], Union[Trade, AssetMovement]]
+        deserialization_method: Callable[[dict[str, Any]], Trade | AssetMovement]
         endpoint: Literal['user_transactions']
         response_case: Literal['trades', 'asset_movements']
         if case == 'trades':
@@ -454,7 +455,7 @@ class Bitstamp(ExchangeInterface):
 
             has_results = False
             is_result_timestamp_gt_end_ts = False
-            result: Union[Trade, AssetMovement]
+            result: Trade | AssetMovement
             for raw_result in response_list:
                 try:
                     entry_type = deserialize_int_from_str(raw_result['type'], 'bitstamp event')
@@ -686,11 +687,7 @@ class Bitstamp(ExchangeInterface):
             self,
             response: Response,
             case: Literal['validate_api_key', 'balances', 'trades', 'asset_movements'],
-    ) -> Union[
-        list,
-        tuple[bool, str],
-        ExchangeQueryBalances,
-    ]:
+    ) -> list | (tuple[bool, str] | ExchangeQueryBalances):
         """This function processes not successful responses for the following
         cases listed in `case`.
         """

--- a/rotkehlchen/exchanges/bittrex.py
+++ b/rotkehlchen/exchanges/bittrex.py
@@ -4,7 +4,7 @@ import json
 import logging
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import gevent
@@ -197,7 +197,7 @@ class Bittrex(ExchangeInterface):
             self,
             endpoint: str,
             method: Literal['get', 'put', 'delete'] = 'get',
-            options: Optional[dict[str, Any]] = None,
+            options: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Queries Bittrex api v3 for given endpoint, method and options
@@ -366,7 +366,7 @@ class Bittrex(ExchangeInterface):
             self,
             endpoint: str,
             method: Literal['get', 'put', 'delete'] = 'get',
-            options: Optional[dict[str, Any]] = None,
+            options: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Handle pagination for bittrex v3 api queries
 
@@ -393,9 +393,9 @@ class Bittrex(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-            market: Optional[TradePair] = None,
+            market: TradePair | None = None,
     ) -> tuple[list[Trade], tuple[Timestamp, Timestamp]]:
-        options: dict[str, Union[str, int]] = {
+        options: dict[str, str | int] = {
             'pageSize': 200,  # max page size according to their docs
             'startDate': timestamp_to_iso8601(start_ts, utc_as_z=True),
             'endDate': timestamp_to_iso8601(end_ts, utc_as_z=True),
@@ -447,7 +447,7 @@ class Bittrex(ExchangeInterface):
 
         return trades, (start_ts, end_ts)
 
-    def _deserialize_asset_movement(self, raw_data: dict[str, Any]) -> Optional[AssetMovement]:
+    def _deserialize_asset_movement(self, raw_data: dict[str, Any]) -> AssetMovement | None:
         """Processes a single deposit/withdrawal from bittrex and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization
@@ -512,7 +512,7 @@ class Bittrex(ExchangeInterface):
             start_ts: Timestamp,
             end_ts: Timestamp,
     ) -> list[AssetMovement]:
-        options: dict[str, Union[str, int]] = {
+        options: dict[str, str | int] = {
             'pageSize': 200,  # max page size according to their docs
             'startDate': timestamp_to_iso8601(start_ts, utc_as_z=True),
             'endDate': timestamp_to_iso8601(end_ts, utc_as_z=True),

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -5,7 +5,7 @@ import time
 from collections import defaultdict
 from contextlib import suppress
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 import requests
@@ -63,7 +63,7 @@ log = RotkehlchenLogsAdapter(logger)
 CB_EVENTS_PREFIX = 'CBE_'
 
 
-def trade_from_coinbase(raw_trade: dict[str, Any]) -> Optional[Trade]:
+def trade_from_coinbase(raw_trade: dict[str, Any]) -> Trade | None:
     """Turns a coinbase transaction into a rotkehlchen Trade.
 
     https://developers.coinbase.com/api/v2?python#buys
@@ -114,7 +114,7 @@ def trade_from_coinbase(raw_trade: dict[str, Any]) -> Optional[Trade]:
     )
 
 
-def trade_from_conversion(trade_a: dict[str, Any], trade_b: dict[str, Any]) -> Optional[Trade]:
+def trade_from_conversion(trade_a: dict[str, Any], trade_b: dict[str, Any]) -> Trade | None:
     """Turn information from a conversion into a trade
 
     Mary raise:
@@ -227,7 +227,7 @@ class Coinbase(ExchangeInterface):
             self,
             method_str: str,
             ignore_pagination: bool = False,
-    ) -> tuple[Optional[list[Any]], str]:
+    ) -> tuple[list[Any] | None, str]:
         try:
             result = self._api_query(method_str, ignore_pagination=ignore_pagination)
 
@@ -344,7 +344,7 @@ class Coinbase(ExchangeInterface):
     def _api_query(
             self,
             endpoint: str,
-            options: Optional[dict[str, Any]] = None,
+            options: dict[str, Any] | None = None,
             ignore_pagination: bool = False,
     ) -> list[Any]:
         """Performs a coinbase API Query for endpoint
@@ -607,7 +607,7 @@ class Coinbase(ExchangeInterface):
 
         return trades, (start_ts, end_ts)
 
-    def _deserialize_asset_movement(self, raw_data: dict[str, Any]) -> Optional[AssetMovement]:
+    def _deserialize_asset_movement(self, raw_data: dict[str, Any]) -> AssetMovement | None:
         """Processes a single deposit/withdrawal from coinbase and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization
@@ -757,7 +757,7 @@ class Coinbase(ExchangeInterface):
 
         return movements
 
-    def _deserialize_history_event(self, raw_data: dict[str, Any]) -> Optional[HistoryEvent]:
+    def _deserialize_history_event(self, raw_data: dict[str, Any]) -> HistoryEvent | None:
         """Processes a single transaction from coinbase and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization

--- a/rotkehlchen/exchanges/coinbasepro.py
+++ b/rotkehlchen/exchanges/coinbasepro.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 from contextlib import suppress
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import gevent
@@ -118,7 +118,7 @@ class Coinbasepro(ExchangeInterface):
         )
         self.base_uri = 'https://api.pro.coinbase.com'
         self.msg_aggregator = msg_aggregator
-        self.account_to_currency: Optional[dict[str, AssetWithOracles]] = None
+        self.account_to_currency: dict[str, AssetWithOracles] | None = None
         self.available_products = {0}
 
         self.session.headers.update({
@@ -179,9 +179,9 @@ class Coinbasepro(ExchangeInterface):
             self,
             endpoint: str,
             request_method: Literal['GET', 'POST'] = 'GET',
-            options: Optional[dict[str, Any]] = None,
-            query_options: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[Any], Optional[str]]:
+            options: dict[str, Any] | None = None,
+            query_options: dict[str, Any] | None = None,
+    ) -> tuple[list[Any], str | None]:
         """Performs a coinbase PRO API Query for endpoint
 
         You can optionally provide extra arguments to the endpoint via the options argument.
@@ -255,7 +255,7 @@ class Coinbasepro(ExchangeInterface):
                 # get out of the retry loop, we did not get 429 complaint
                 break
 
-        json_ret: Union[list[Any], dict[str, Any]]
+        json_ret: list[Any] | dict[str, Any]
         if response.status_code == HTTPStatus.BAD_REQUEST:
             json_ret = jsonloads_dict(response.text)
             if json_ret['message'] == 'invalid signature':
@@ -382,7 +382,7 @@ class Coinbasepro(ExchangeInterface):
     def _paginated_query(
             self,
             endpoint: str,
-            query_options: Optional[dict[str, Any]] = None,
+            query_options: dict[str, Any] | None = None,
             limit: int = COINBASEPRO_PAGINATION_LIMIT,
     ) -> Iterator[list[dict[str, Any]]]:
         if query_options is None:

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.structures.types import ActionType, EventDirection
@@ -68,8 +68,8 @@ class AssetMovement(AccountingEventMixin):
     category: AssetMovementCategory
     timestamp: Timestamp
     # The source address if this is a deposit and the destination address if withdrawal
-    address: Optional[str]
-    transaction_id: Optional[str]
+    address: str | None
+    transaction_id: str | None
     asset: Asset
     # Amount is the original amount removed from the account
     amount: FVal
@@ -246,15 +246,15 @@ class Trade(AccountingEventMixin):
     # sold if it's a sell. Should NOT include fees
     amount: AssetAmount
     rate: Price
-    fee: Optional[Fee] = None
-    fee_currency: Optional[Asset] = None
+    fee: Fee | None = None
+    fee_currency: Asset | None = None
     # For external trades this is optional and is a link to the trade in an explorer
     # For exchange trades this should be the exchange unique trade identifer
     # For trades imported from third parties we should generate a unique id for this.
     # If trades are both imported from third parties like cointracking.info and from
     # the exchanges themselves then there is no way to avoid duplicates.
-    link: Optional[str] = None
-    notes: Optional[str] = None
+    link: str | None = None
+    notes: str | None = None
 
     @property
     def identifier(self) -> TradeID:
@@ -470,7 +470,7 @@ MarginPositionDBTuple = tuple[
 class MarginPosition(AccountingEventMixin):
     """We only support margin positions on poloniex and bitmex at the moment"""
     location: Location
-    open_time: Optional[Timestamp]
+    open_time: Timestamp | None
     close_time: Timestamp
     # Profit loss in pl_currency (does not include fees)
     profit_loss: AssetAmount

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -1,6 +1,7 @@
 import logging
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-ExchangeQueryBalances = tuple[Optional[dict[AssetWithOracles, Balance]], str]
+ExchangeQueryBalances = tuple[dict[AssetWithOracles, Balance] | None, str]
 
 ExchangeHistoryFailCallback = Callable[[str], None]
 ExchangeHistoryNewStepCallback = Callable[[str], None]
@@ -150,7 +151,7 @@ class ExchangeInterface(CacheableMixIn, LockableQueryMixIn):
             self,
             start_ts: Timestamp,  # pylint: disable=unused-argument
             end_ts: Timestamp,  # pylint: disable=unused-argument
-    ) -> Optional[Any]:
+    ) -> Any | None:
         """Has to be implemented by exchanges if they have anything exchange specific
 
 
@@ -465,7 +466,7 @@ class ExchangeInterface(CacheableMixIn, LockableQueryMixIn):
             start_ts: Timestamp,
             end_ts: Timestamp,
             fail_callback: ExchangeHistoryFailCallback,
-            new_step_data: Optional[tuple[ExchangeHistoryNewStepCallback, str]] = None,
+            new_step_data: tuple[ExchangeHistoryNewStepCallback, str] | None = None,
     ) -> None:
         """Queries the historical event endpoints for this exchange and performs actions.
         The results are saved in the DB.

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import requests
@@ -121,7 +121,7 @@ class Iconomi(ExchangeInterface):
             self,
             verb: Literal['get', 'post'],
             path: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
             authenticated: bool = True,
     ) -> Any:
         """

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -5,7 +5,7 @@ import logging
 import time
 from collections import OrderedDict
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 import gevent
 import requests
@@ -175,7 +175,7 @@ def _trade_from_independentreserve(raw_trade: dict) -> Trade:
     )
 
 
-def _asset_movement_from_independentreserve(raw_tx: dict) -> Optional[AssetMovement]:
+def _asset_movement_from_independentreserve(raw_tx: dict) -> AssetMovement | None:
     """Convert IndependentReserve raw data to an AssetMovement
 
     https://www.independentreserve.com/products/api#GetTransactions
@@ -246,7 +246,7 @@ class Independentreserve(ExchangeInterface):
         self.uri = 'https://api.independentreserve.com'
         self.msg_aggregator = msg_aggregator
         self.session.headers.update({'Content-Type': 'application/json'})
-        self.account_guids: Optional[list] = None
+        self.account_guids: list | None = None
 
     def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
         changed = super().edit_exchange_credentials(credentials)
@@ -259,7 +259,7 @@ class Independentreserve(ExchangeInterface):
             verb: Literal['get', 'post'],
             method_type: Literal['Public', 'Private'],
             path: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> dict:
         """An IndependentrReserve query
 
@@ -394,7 +394,7 @@ class Independentreserve(ExchangeInterface):
         self.account_guids = account_guids
         return assets_balance, ''
 
-    def _gather_paginated_data(self, path: str, extra_options: Optional[dict] = None) -> list[dict[str, Any]]:  # noqa: E501
+    def _gather_paginated_data(self, path: str, extra_options: dict | None = None) -> list[dict[str, Any]]:  # noqa: E501
         """May raise KeyError"""
         page = 1
         page_size = 50

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -45,7 +45,7 @@ class ExchangeManager:
     def connected_and_syncing_exchanges_num(self) -> int:
         return len(list(self.iterate_exchanges()))
 
-    def get_exchange(self, name: str, location: Location) -> Optional[ExchangeInterface]:
+    def get_exchange(self, name: str, location: Location) -> ExchangeInterface | None:
         """Get the exchange object for an exchange with a given name and location
 
         Returns None if it can not be found
@@ -74,12 +74,12 @@ class ExchangeManager:
             self,
             name: str,
             location: Location,
-            new_name: Optional[str],
-            api_key: Optional[ApiKey],
-            api_secret: Optional[ApiSecret],
-            passphrase: Optional[str],
+            new_name: str | None,
+            api_key: ApiKey | None,
+            api_secret: ApiSecret | None,
+            passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
-            binance_selected_trade_pairs: Optional[list[str]],
+            binance_selected_trade_pairs: list[str] | None,
     ) -> tuple[bool, str]:
         """Edits both the exchange object and the database entry
 
@@ -200,7 +200,7 @@ class ExchangeManager:
             api_key: ApiKey,
             api_secret: ApiSecret,
             database: 'DBHandler',
-            passphrase: Optional[str] = None,
+            passphrase: str | None = None,
             **kwargs: Any,
     ) -> tuple[bool, str]:
         """

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode, urljoin
 
 import requests
@@ -102,7 +102,7 @@ class Okx(ExchangeInterface):
     def _api_query(
             self,
             endpoint: Literal['currencies', 'balance', 'trades', 'deposits', 'withdrawals'],
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> dict:
         """
         Makes an API query to OKX
@@ -176,7 +176,7 @@ class Okx(ExchangeInterface):
     def _api_query_list(
             self,
             endpoint: Literal['currencies', 'balance', 'trades', 'deposits', 'withdrawals'],
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> list:
         """
         Makes an API query and parses the response into a list
@@ -196,7 +196,7 @@ class Okx(ExchangeInterface):
             self,
             endpoint: Literal['currencies', 'balance', 'trades', 'deposits', 'withdrawals'],
             pagination_key: str,
-            options: Optional[dict] = None,
+            options: dict | None = None,
     ) -> list:
         """
         Makes subsequent API queries until response list length is less than MAX_RESULTS.
@@ -377,7 +377,7 @@ class Okx(ExchangeInterface):
     ) -> list['HistoryEvent']:
         return []  # noop for okx
 
-    def trade_from_okx(self, raw_trade: dict[str, Any]) -> Optional[Trade]:
+    def trade_from_okx(self, raw_trade: dict[str, Any]) -> Trade | None:
         """
         Converts a raw trade from OKX into a Trade object.
         If there is an error `None` is returned and error is logged.
@@ -443,7 +443,7 @@ class Okx(ExchangeInterface):
             self,
             raw_movement: dict[str, Any],
             category: AssetMovementCategory,
-    ) -> Optional[AssetMovement]:
+    ) -> AssetMovement | None:
         """
         Converts a raw asset movement from OKX into an AssetMovement object.
         If there is an error `None` is returned and error is logged.

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -4,7 +4,7 @@ import hmac
 import json
 import logging
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import gevent
@@ -158,7 +158,7 @@ class Poloniex(ExchangeInterface):
             raise
         return True, ''
 
-    def api_query_dict(self, command: str, req: Optional[dict] = None) -> dict:
+    def api_query_dict(self, command: str, req: dict | None = None) -> dict:
         result = self._api_query(command, req)
         if not isinstance(result, dict):
             raise RemoteError(
@@ -166,7 +166,7 @@ class Poloniex(ExchangeInterface):
             )
         return result
 
-    def api_query_list(self, command: str, req: Optional[dict] = None) -> list:
+    def api_query_list(self, command: str, req: dict | None = None) -> list:
         result = self._api_query(command, req)
         if not isinstance(result, list):
             raise RemoteError(
@@ -199,7 +199,7 @@ class Poloniex(ExchangeInterface):
         signature = base64.b64encode(digest)
         return signature.decode()
 
-    def _single_query(self, path: str, req: dict[str, Any]) -> Optional[requests.Response]:
+    def _single_query(self, path: str, req: dict[str, Any]) -> requests.Response | None:
         """A single api query for poloniex
 
         Returns the response if all went well or None if a recoverable poloniex
@@ -238,7 +238,7 @@ class Poloniex(ExchangeInterface):
         # else all is good
         return response
 
-    def _api_query(self, command: str, req: Optional[dict] = None) -> Union[dict, list]:
+    def _api_query(self, command: str, req: dict | None = None) -> dict | list:
         """An api query to poloniex. May make multiple requests
 
         Can raise:
@@ -277,7 +277,7 @@ class Poloniex(ExchangeInterface):
                 f'incremental backoff retries',
             )
 
-        result: Union[dict, list]
+        result: dict | list
         try:
             result = response.json()
         except JSONDecodeError as e:
@@ -494,7 +494,7 @@ class Poloniex(ExchangeInterface):
             self,
             movement_type: AssetMovementCategory,
             movement_data: dict[str, Any],
-    ) -> Optional[AssetMovement]:
+    ) -> AssetMovement | None:
         """Processes a single deposit/withdrawal from polo and deserializes it
 
         Can log error/warning and return None if something went wrong at deserialization

--- a/rotkehlchen/exchanges/utils.py
+++ b/rotkehlchen/exchanges/utils.py
@@ -1,6 +1,6 @@
 import logging
 from json.decoder import JSONDecodeError
-from typing import Any, Optional
+from typing import Any
 
 import requests
 from eth_utils.address import to_checksum_address
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def get_key_if_has_val(mapping: dict[str, Any], key: str) -> Optional[str]:
+def get_key_if_has_val(mapping: dict[str, Any], key: str) -> str | None:
     """Gets the key from mapping if it exists and has a value (non empty string)
 
     The assumption here is that the value of the key is str. If it's not str
@@ -38,7 +38,7 @@ def deserialize_asset_movement_address(
         mapping: dict[str, Any],
         key: str,
         asset: Asset,
-) -> Optional[str]:
+) -> str | None:
     """Gets the address from an asset movement mapping making sure that if it's
     an ethereum deposit/withdrawal the address is returned checksummed"""
     value = get_key_if_has_val(mapping, key)

--- a/rotkehlchen/exchanges/woo.py
+++ b/rotkehlchen/exchanges/woo.py
@@ -3,9 +3,10 @@ import hmac
 import logging
 import urllib
 from collections import defaultdict
+from collections.abc import Callable
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
 import requests
 
@@ -228,7 +229,7 @@ class Woo(ExchangeInterface):
             self,
             endpoint: str,
             method: Literal['GET', 'POST'] = 'GET',
-            options: Optional[dict[str, Any]] = None,
+            options: dict[str, Any] | None = None,
     ) -> dict:
         """
         Query a  Woo API endpoint
@@ -304,7 +305,7 @@ class Woo(ExchangeInterface):
             options: dict[str, Any],
             deserialization_method: Callable[[dict[str, Any]], Any],
             entries_key: Literal['data', 'rows'],
-    ) -> Union[list[Trade], list[AssetMovement], list]:
+    ) -> list[Trade] | (list[AssetMovement] | list):
         """Request a Woo API endpoint paginating via an options attribute."""
         assert list(options.keys()) == sorted(options.keys())  # options need to be in alphabetic order as stated in their api: https://docs.woo.org/#example  # noqa: E501
         results = []

--- a/rotkehlchen/externalapis/beaconchain/service.py
+++ b/rotkehlchen/externalapis/beaconchain/service.py
@@ -1,6 +1,6 @@
 import logging
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import gevent
@@ -33,8 +33,8 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 def _calculate_query_chunks(
-        indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
-) -> Union[list[list[int]], list[list[Eth2PubKey]]]:
+        indices_or_pubkeys: list[int] | list[Eth2PubKey],
+) -> list[list[int]] | list[list[Eth2PubKey]]:
     """Create chunks of queries.
 
     Beaconcha.in allows up to 100 validator or public keys in one query for most calls.
@@ -65,10 +65,10 @@ class BeaconChain(ExternalServiceWithApiKey):
     def _query(
             self,
             module: Literal['validator', 'execution'],
-            endpoint: Optional[Literal['performance', 'eth1', 'deposits', 'produced']],
+            endpoint: Literal['performance', 'eth1', 'deposits', 'produced'] | None,
             encoded_args: str,
-            extra_args: Optional[dict[str, Any]] = None,
-    ) -> Union[list[dict[str, Any]], dict[str, Any]]:
+            extra_args: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """
         May raise:
         - RemoteError due to problems querying beaconcha.in API
@@ -177,9 +177,9 @@ class BeaconChain(ExternalServiceWithApiKey):
 
     def _query_chunked_endpoint(
             self,
-            indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
+            indices_or_pubkeys: list[int] | list[Eth2PubKey],
             module: Literal['validator'],
-            endpoint: Optional[Literal['performance']],
+            endpoint: Literal['performance'] | None,
     ) -> list[dict[str, Any]]:
         chunks = _calculate_query_chunks(indices_or_pubkeys)
         data: list[dict[str, Any]] = []
@@ -198,7 +198,7 @@ class BeaconChain(ExternalServiceWithApiKey):
 
     def _query_chunked_endpoint_with_pagination(
             self,
-            indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
+            indices_or_pubkeys: list[int] | list[Eth2PubKey],
             module: Literal['execution'],
             endpoint: Literal['produced'],
             limit: int,
@@ -230,7 +230,7 @@ class BeaconChain(ExternalServiceWithApiKey):
 
     def get_validator_data(
             self,
-            indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
+            indices_or_pubkeys: list[int] | list[Eth2PubKey],
     ) -> list[dict[str, Any]]:
         """Returns data for the given validators
 
@@ -248,7 +248,7 @@ class BeaconChain(ExternalServiceWithApiKey):
 
     def get_performance(
             self,
-            indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
+            indices_or_pubkeys: list[int] | list[Eth2PubKey],
     ) -> dict[int, ValidatorPerformance]:
         """Get the performance of all the validators given from the list of indices or pubkeys
 
@@ -282,14 +282,14 @@ class BeaconChain(ExternalServiceWithApiKey):
 
     def get_and_store_produced_blocks(
             self,
-            indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
+            indices_or_pubkeys: list[int] | list[Eth2PubKey],
     ) -> None:
         with self.produced_blocks_lock:
             return self._get_and_store_produced_blocks(indices_or_pubkeys)
 
     def _get_and_store_produced_blocks(
             self,
-            indices_or_pubkeys: Union[list[int], list[Eth2PubKey]],
+            indices_or_pubkeys: list[int] | list[Eth2PubKey],
     ) -> None:
         """Get blocks produced by a set of validator indices/pubkeys and store the
         data in the DB.

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import gevent
@@ -48,7 +48,7 @@ class Blockscout(ExternalServiceWithApiKey):
             module: Literal['addresses'],
             endpoint: Literal['withdrawals'],
             encoded_args: str,
-            extra_args: Optional[dict[str, Any]] = None,
+            extra_args: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Query blockscout
 

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from http import HTTPStatus
-from typing import Any, Literal, NamedTuple, Optional, Union, overload
+from typing import Any, Literal, NamedTuple, overload
 from urllib.parse import urlencode
 
 import requests
@@ -505,15 +505,15 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
         PenalizablePriceOracleMixin.__init__(self)
         self.session = requests.session()
         set_user_agent(self.session)
-        self.all_coins_cache: Optional[dict[str, dict[str, Any]]] = None
+        self.all_coins_cache: dict[str, dict[str, Any]] | None = None
         self.last_rate_limit = 0
 
     @overload
     def _query(
             self,
             module: Literal['coins/list'],
-            subpath: Optional[str] = None,
-            options: Optional[dict[str, str]] = None,
+            subpath: str | None = None,
+            options: dict[str, str] | None = None,
     ) -> list[dict[str, Any]]:
         ...
 
@@ -521,17 +521,17 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
     def _query(
             self,
             module: Literal['coins', 'simple/price'],
-            subpath: Optional[str] = None,
-            options: Optional[dict[str, str]] = None,
+            subpath: str | None = None,
+            options: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         ...
 
     def _query(
             self,
             module: str,
-            subpath: Optional[str] = None,
-            options: Optional[dict[str, str]] = None,
-    ) -> Union[dict[str, Any], list[dict[str, Any]]]:
+            subpath: str | None = None,
+            options: dict[str, str] | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         """Performs a coingecko query
 
         May raise:
@@ -643,7 +643,7 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
             from_asset: AssetWithOracles,
             to_asset: AssetWithOracles,
             location: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         vs_currency = to_asset.identifier.lower()
         if vs_currency not in COINGECKO_SIMPLE_VS_CURRENCIES:
             log.warning(
@@ -710,13 +710,13 @@ class Coingecko(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
             from_asset: Asset,  # pylint: disable=unused-argument
             to_asset: Asset,
             timestamp: Timestamp,
-            seconds: Optional[int] = None,
+            seconds: int | None = None,
     ) -> bool:
         return not self.is_penalized()
 
     def rate_limited_in_last(
             self,
-            seconds: Optional[int] = None,
+            seconds: int | None = None,
     ) -> bool:
         if seconds is None:
             return False

--- a/rotkehlchen/externalapis/covalent.py
+++ b/rotkehlchen/externalapis/covalent.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from json.decoder import JSONDecodeError
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
@@ -96,10 +96,10 @@ class Covalent(ExternalServiceWithApiKey):
             self,
             module: str,
             action: str,
-            address: Optional[str] = None,
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
-    ) -> Optional[dict[str, Any]]:
+            address: str | None = None,
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
+    ) -> dict[str, Any] | None:
         """Queries Covalent
 
         May raise:
@@ -159,9 +159,9 @@ class Covalent(ExternalServiceWithApiKey):
     def get_transactions(
             self,
             account: ChecksumEvmAddress,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
-    ) -> Optional[list[CovalentTransaction]]:
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
+    ) -> list[CovalentTransaction] | None:
         """Gets a list of transactions for account.
         - account is address for wallet.
         - to_ts is latest date.
@@ -231,7 +231,7 @@ class Covalent(ExternalServiceWithApiKey):
 
         return transactions
 
-    def get_transaction_receipt(self, tx_hash: EVMTxHash) -> Optional[dict[str, Any]]:
+    def get_transaction_receipt(self, tx_hash: EVMTxHash) -> dict[str, Any] | None:
         """Gets the receipt for the given transaction hash
 
         May raise:
@@ -258,7 +258,7 @@ class Covalent(ExternalServiceWithApiKey):
     def get_token_balances_address(
             self,
             address: ChecksumEvmAddress,
-    ) -> Optional[list[dict[str, Any]]]:
+    ) -> list[dict[str, Any]] | None:
         options = {'limit': COVALENT_QUERY_LIMIT, 'page-size': PAGESIZE}
         result = self._query(
             module='balances_v2',

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -210,7 +210,7 @@ class Cryptocompare(ExternalServiceWithApiKey, HistoricalPriceOracleInterface, P
             from_asset: Asset,
             to_asset: Asset,
             timestamp: Timestamp,
-            seconds: Optional[int] = CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME,
+            seconds: int | None = CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME,
     ) -> bool:
         """Checks if it's okay to query cryptocompare historical price. This is determined by:
 
@@ -238,7 +238,7 @@ class Cryptocompare(ExternalServiceWithApiKey, HistoricalPriceOracleInterface, P
 
     def rate_limited_in_last(
             self,
-            seconds: Optional[int] = CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME,
+            seconds: int | None = CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME,
     ) -> bool:
         """Checks when we were last rate limited by CC and if it was within the given seconds"""
         if seconds is None:

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from http import HTTPStatus
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlencode
 
 import requests
@@ -40,14 +40,14 @@ class Defillama(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
         PenalizablePriceOracleMixin.__init__(self)
         self.session = requests.session()
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
-        self.all_coins_cache: Optional[dict[str, dict[str, Any]]] = None
+        self.all_coins_cache: dict[str, dict[str, Any]] | None = None
         self.last_rate_limit = 0
 
     def _query(
             self,
             module: str,
-            subpath: Optional[str] = None,
-            options: Optional[dict[str, str]] = None,
+            subpath: str | None = None,
+            options: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Performs a defillama query
 
@@ -191,13 +191,13 @@ class Defillama(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
             from_asset: Asset,  # pylint: disable=unused-argument
             to_asset: Asset,
             timestamp: Timestamp,
-            seconds: Optional[int] = None,
+            seconds: int | None = None,
     ) -> bool:
         return not self.is_penalized()
 
     def rate_limited_in_last(
             self,
-            seconds: Optional[int] = None,
+            seconds: int | None = None,
     ) -> bool:
         if seconds is None:
             return False

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from enum import Enum, auto
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import gevent
 import requests
@@ -128,8 +128,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                 'getLogs',
                 'txsBeaconWithdrawal',
             ],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
     ) -> list[dict[str, Any]]:
         ...
 
@@ -141,9 +141,9 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                 'eth_getTransactionReceipt',
                 'eth_getTransactionByHash',
             ],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
-    ) -> Optional[dict[str, Any]]:
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
+    ) -> dict[str, Any] | None:
         ...
 
     @overload
@@ -153,9 +153,9 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             action: Literal[
                 'getcontractcreation',
             ],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
-    ) -> Optional[list[dict[str, Any]]]:
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
+    ) -> list[dict[str, Any]] | None:
         ...
 
     @overload
@@ -165,9 +165,9 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             action: Literal[
                 'getabi',
             ],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
-    ) -> Optional[str]:
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
+    ) -> str | None:
         ...
 
     @overload
@@ -177,8 +177,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             action: Literal[
                 'eth_getBlockByNumber',
             ],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
     ) -> dict[str, Any]:
         ...
 
@@ -194,8 +194,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                 'eth_call',
                 'getblocknobytime',
             ],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
     ) -> str:
         ...
 
@@ -203,9 +203,9 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             self,
             module: str,
             action: str,
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
-    ) -> Union[list[dict[str, Any]], str, list[EvmTransaction], dict[str, Any], None]:
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
+    ) -> list[dict[str, Any]] | (str | (list[EvmTransaction] | (dict[str, Any] | None))):
         """Queries etherscan
 
         May raise:
@@ -352,7 +352,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         options['endBlock'] = str(to_block)
         return options
 
-    def _maybe_paginate(self, result: list[dict[str, Any]], options: dict[str, Any]) -> Optional[dict[str, Any]]:  # noqa: E501
+    def _maybe_paginate(self, result: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any] | None:  # noqa: E501
         """Check if the results have hit the pagination limit.
         If yes adjust the options accordingly. Otherwise signal we are done"""
         if len(result) != ETHERSCAN_QUERY_LIMIT:
@@ -369,27 +369,27 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
     @overload
     def get_transactions(
             self,
-            account: Optional[ChecksumEvmAddress],
+            account: ChecksumEvmAddress | None,
             action: Literal['txlistinternal'],
-            period_or_hash: Optional[Union[TimestampOrBlockRange, EVMTxHash]] = None,
+            period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
     ) -> Iterator[list[EvmInternalTransaction]]:
         ...
 
     @overload
     def get_transactions(
             self,
-            account: Optional[ChecksumEvmAddress],
+            account: ChecksumEvmAddress | None,
             action: Literal['txlist'],
-            period_or_hash: Optional[Union[TimestampOrBlockRange, EVMTxHash]] = None,
+            period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
     ) -> Iterator[list[EvmTransaction]]:
         ...
 
     def get_transactions(
             self,
-            account: Optional[ChecksumEvmAddress],
+            account: ChecksumEvmAddress | None,
             action: Literal['txlist', 'txlistinternal'],
-            period_or_hash: Optional[Union[TimestampOrBlockRange, EVMTxHash]] = None,
-    ) -> Union[Iterator[list[EvmTransaction]], Iterator[list[EvmInternalTransaction]]]:
+            period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
+    ) -> Iterator[list[EvmTransaction]] | Iterator[list[EvmInternalTransaction]]:
         """Gets a list of transactions (either normal or internal) for an account.
 
         Can specify a given timestamp or block period.
@@ -412,7 +412,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                 options['txHash'] = period_or_hash.hex()
                 parent_tx_hash = period_or_hash
 
-        transactions: Union[list[EvmTransaction], list[EvmInternalTransaction]] = []
+        transactions: list[EvmTransaction] | list[EvmInternalTransaction] = []
         is_internal = action == 'txlistinternal'
         chain_id = self.chain.to_chain_id()
         while True:
@@ -487,8 +487,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
     def get_token_transaction_hashes(
             self,
             account: ChecksumEvmAddress,
-            from_ts: Optional[Timestamp] = None,
-            to_ts: Optional[Timestamp] = None,
+            from_ts: Timestamp | None = None,
+            to_ts: Timestamp | None = None,
     ) -> Iterator[list[EVMTxHash]]:
         options = {'address': str(account), 'sort': 'asc'}
         if from_ts is not None:
@@ -578,7 +578,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
 
         return block_data
 
-    def get_transaction_by_hash(self, tx_hash: EVMTxHash) -> Optional[dict[str, Any]]:
+    def get_transaction_by_hash(self, tx_hash: EVMTxHash) -> dict[str, Any] | None:
         """
         Gets a transaction object by hash
 
@@ -599,7 +599,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         result = self._query(module='proxy', action='eth_getCode', options={'address': account})
         return result
 
-    def get_transaction_receipt(self, tx_hash: EVMTxHash) -> Optional[dict[str, Any]]:
+    def get_transaction_receipt(self, tx_hash: EVMTxHash) -> dict[str, Any] | None:
         """Gets the receipt for the given transaction hash
 
         May raise:
@@ -636,7 +636,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             contract_address: ChecksumEvmAddress,
             topics: list[str],
             from_block: int,
-            to_block: Union[int, str] = 'latest',
+            to_block: int | str = 'latest',
     ) -> list[dict[str, Any]]:
         """Performs the etherscan style of eth_getLogs as explained here:
         https://etherscan.io/apis#logs
@@ -686,7 +686,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
 
         return number
 
-    def get_contract_creation_hash(self, address: ChecksumEvmAddress) -> Optional[EVMTxHash]:
+    def get_contract_creation_hash(self, address: ChecksumEvmAddress) -> EVMTxHash | None:
         """Get the contract creation block from etherscan for the given address.
 
         Returns `None` if the address is not a contract.
@@ -702,7 +702,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         )
         return deserialize_evm_tx_hash(result[0]['txHash']) if result is not None else None
 
-    def get_contract_abi(self, address: ChecksumEvmAddress) -> Optional[str]:
+    def get_contract_abi(self, address: ChecksumEvmAddress) -> str | None:
         """Get the contract abi from etherscan for the given address if verified.
 
         Returns `None` if the address is not a verified contract.
@@ -724,6 +724,6 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
         except json.JSONDecodeError:
             return None
 
-    def _additional_transaction_processing(self, tx: Union[EvmTransaction, EvmInternalTransaction]) -> Union[EvmTransaction, EvmInternalTransaction]:  # noqa: E501
+    def _additional_transaction_processing(self, tx: EvmTransaction | EvmInternalTransaction) -> EvmTransaction | EvmInternalTransaction:  # noqa: E501
         """Performs additional processing on chain-specific tx attributes"""
         return tx

--- a/rotkehlchen/externalapis/interface.py
+++ b/rotkehlchen/externalapis/interface.py
@@ -20,11 +20,11 @@ class ExternalServiceWithApiKey:
 
     def __init__(self, database: Optional['DBHandler'], service_name: ExternalService) -> None:
         self.db = database
-        self.api_key: Optional[ApiKey] = None
+        self.api_key: ApiKey | None = None
         self.service_name = service_name
         self.last_ts = Timestamp(0)
 
-    def _get_api_key(self) -> Optional[ApiKey]:
+    def _get_api_key(self) -> ApiKey | None:
         """A function to get the API key from the DB (if we have one initialized)"""
         if not self.db:
             return None

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 import re
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
 import gevent
 import requests
@@ -42,10 +42,10 @@ log = RotkehlchenLogsAdapter(logger)
 @dataclasses.dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=False)  # noqa: E501
 class Collection:
     name: str
-    banner_image: Optional[str]
-    description: Optional[str]
+    banner_image: str | None
+    description: str | None
     large_image: str
-    floor_price: Optional[FVal] = None
+    floor_price: FVal | None = None
 
     def serialize(self) -> dict[str, Any]:
         return {
@@ -59,14 +59,14 @@ class Collection:
 
 class NFT(NamedTuple):
     token_identifier: str
-    background_color: Optional[str]
-    image_url: Optional[str]
-    name: Optional[str]
-    external_link: Optional[str]
-    permalink: Optional[str]
+    background_color: str | None
+    image_url: str | None
+    name: str | None
+    external_link: str | None
+    permalink: str | None
     price_eth: FVal
     price_usd: FVal
-    collection: Optional[Collection]
+    collection: Collection | None
 
     def serialize(self) -> dict[str, Any]:
         return {
@@ -96,15 +96,15 @@ class Opensea(ExternalServiceWithApiKey):
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',  # noqa: E501
         })
         self.collections: dict[str, Collection] = {}
-        self.backup_key: Optional[str] = None
+        self.backup_key: str | None = None
         self.eth_asset = A_ETH.resolve_to_crypto_asset()
 
     @overload
     def _query(
             self,
             endpoint: Literal['assets', 'collectionstats', 'asset'],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
     ) -> dict[str, Any]:
         ...
 
@@ -112,17 +112,17 @@ class Opensea(ExternalServiceWithApiKey):
     def _query(
             self,
             endpoint: Literal['collections'],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
     ) -> list[dict[str, Any]]:
         ...
 
     def _query(
             self,
             endpoint: Literal['assets', 'collections', 'collectionstats', 'asset'],
-            options: Optional[dict[str, Any]] = None,
-            timeout: Optional[tuple[int, int]] = None,
-    ) -> Union[list[dict[str, Any]], dict[str, Any]]:
+            options: dict[str, Any] | None = None,
+            timeout: tuple[int, int] | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """May raise RemoteError"""
         api_key = self._get_api_key()
         if api_key is not None:
@@ -205,7 +205,7 @@ class Opensea(ExternalServiceWithApiKey):
             )
 
         try:
-            last_sale: Optional[dict[str, Any]] = entry.get('last_sale')
+            last_sale: dict[str, Any] | None = entry.get('last_sale')
             if last_sale is not None and last_sale.get('payment_token') is not None:
                 if last_sale['payment_token']['symbol'] in {'ETH', 'WETH'}:
                     payment_asset = self.eth_asset
@@ -344,7 +344,7 @@ class Opensea(ExternalServiceWithApiKey):
     def get_nft_image(
             self,
             nft_address: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Returns the url of the image of an nft or None in error"""
         match = ERC721_RE.search(nft_address)
         if match is None:

--- a/rotkehlchen/fval.py
+++ b/rotkehlchen/fval.py
@@ -32,7 +32,7 @@ class FVal:
                 # This elif has to come before the isinstance(int) check due to
                 # https://stackoverflow.com/questions/37888620/comparing-boolean-and-int-using-isinstance
                 raise ValueError('Invalid type bool for data given to FVal constructor')
-            elif isinstance(data, (Decimal, int, str)):
+            elif isinstance(data, Decimal | int | str):
                 self.num = Decimal(data)
             elif isinstance(data, FVal):
                 self.num = data.num
@@ -71,7 +71,7 @@ class FVal:
         return self.num.compare_signal(evaluated_other) in (Decimal('1'), Decimal('0'))
 
     def __eq__(self, other: object) -> bool:
-        evaluated_other: Union[Decimal, int]
+        evaluated_other: Decimal | int
         if isinstance(other, FVal):
             evaluated_other = other.num
         elif not isinstance(other, int):
@@ -180,7 +180,7 @@ class FVal:
         return diff_num <= evaluated_max_diff.num
 
 
-def _evaluate_input(other: Any) -> Union[Decimal, int]:
+def _evaluate_input(other: Any) -> Decimal | int:
     """Evaluate 'other' and return its Decimal representation"""
     if isinstance(other, FVal):
         return other.num

--- a/rotkehlchen/globaldb/assets_management.py
+++ b/rotkehlchen/globaldb/assets_management.py
@@ -2,7 +2,7 @@ import json
 import logging
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from rotkehlchen.assets.asset import Asset, AssetWithNameAndType
@@ -75,7 +75,7 @@ def import_assets_from_file(
 
 
 def export_assets_from_file(
-        dirpath: Optional[Path],
+        dirpath: Path | None,
         db_handler: 'DBHandler',
 ) -> Path:
     """

--- a/rotkehlchen/globaldb/cache.py
+++ b/rotkehlchen/globaldb/cache.py
@@ -1,6 +1,5 @@
 """Functions dealing with the general_cache table of the Global DB"""
 from collections.abc import Iterable
-from typing import Optional, Union
 
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -15,7 +14,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import ts_now
 
 
-def compute_cache_key(key_parts: Iterable[Union[str, CacheType]]) -> str:
+def compute_cache_key(key_parts: Iterable[str | CacheType]) -> str:
     """Function that computes the cache key for accessing the globaldb general or unique cache
     tables. It computes the cache key by iterating through `key_parts` and making one string
     from them. Only a tuple with the same values and the same order represents the same key."""
@@ -34,7 +33,7 @@ BASE_POOL_TOKENS_KEY_LENGTH = len(compute_cache_key([CacheType.CURVE_POOL_TOKENS
 
 def globaldb_set_general_cache_values_at_ts(
         write_cursor: DBCursor,
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+        key_parts: Iterable[str | GeneralCacheType],
         values: Iterable[str],
         timestamp: Timestamp,
 ) -> None:
@@ -51,7 +50,7 @@ def globaldb_set_general_cache_values_at_ts(
 
 def globaldb_set_general_cache_values(
         write_cursor: DBCursor,
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+        key_parts: Iterable[str | GeneralCacheType],
         values: Iterable[str],
 ) -> None:
     """Function to update general cache in globaldb. Inserts the value paired with the cache key.
@@ -67,7 +66,7 @@ def globaldb_set_general_cache_values(
 
 def globaldb_get_general_cache_values(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+        key_parts: Iterable[str | GeneralCacheType],
 ) -> list[str]:
     """Function that reads from the general cache table.
     It returns all the values that are paired with the given key."""
@@ -78,7 +77,7 @@ def globaldb_get_general_cache_values(
 
 def globaldb_set_unique_cache_value_at_ts(
         write_cursor: DBCursor,
-        key_parts: Iterable[Union[str, UniqueCacheType]],
+        key_parts: Iterable[str | UniqueCacheType],
         value: str,
         timestamp: Timestamp,
 ) -> None:
@@ -94,7 +93,7 @@ def globaldb_set_unique_cache_value_at_ts(
 
 def globaldb_set_unique_cache_value(
         write_cursor: DBCursor,
-        key_parts: Iterable[Union[str, UniqueCacheType]],
+        key_parts: Iterable[str | UniqueCacheType],
         value: str,
 ) -> None:
     """Function that updates the unique cache in globaldb. Inserts the value paired with the
@@ -110,8 +109,8 @@ def globaldb_set_unique_cache_value(
 
 def globaldb_get_unique_cache_value(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, UniqueCacheType]],
-) -> Optional[str]:
+        key_parts: Iterable[str | UniqueCacheType],
+) -> str | None:
     """Function that reads from the unique cache table.
     It returns the value that is paired with the given key."""
     cache_key = compute_cache_key(key_parts)
@@ -124,7 +123,7 @@ def globaldb_get_unique_cache_value(
 
 def globaldb_get_general_cache_like(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+        key_parts: Iterable[str | GeneralCacheType],
 ) -> list[str]:
     """
     Function to read globaldb cache.
@@ -141,7 +140,7 @@ def globaldb_get_general_cache_like(
 
 def globaldb_get_general_cache_keys_and_values_like(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+        key_parts: Iterable[str | GeneralCacheType],
 ) -> list[tuple[str, str]]:
     """
     Function that reads globaldb general cache.
@@ -158,7 +157,7 @@ def globaldb_get_general_cache_keys_and_values_like(
 
 def globaldb_get_general_cache_last_queried_ts_by_key(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, GeneralCacheType]],
+        key_parts: Iterable[str | GeneralCacheType],
 ) -> Timestamp:
     """
     Get the last_queried_ts of the oldest stored element by key_parts. If there is no such
@@ -178,7 +177,7 @@ def globaldb_get_general_cache_last_queried_ts_by_key(
 
 def globaldb_get_unique_cache_last_queried_ts_by_key(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, UniqueCacheType]],
+        key_parts: Iterable[str | UniqueCacheType],
 ) -> Timestamp:
     """
     Get the last_queried_ts of the oldest stored element by key_parts. If there is no such

--- a/rotkehlchen/globaldb/manual_price_oracles.py
+++ b/rotkehlchen/globaldb/manual_price_oracles.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.prices import ZERO_PRICE
@@ -26,7 +26,7 @@ class ManualPriceOracle:
             from_asset: Asset,  # pylint: disable=unused-argument
             to_asset: Asset,  # pylint: disable=unused-argument
             timestamp: Timestamp,  # pylint: disable=unused-argument
-            seconds: Optional[int] = None,  # pylint: disable=unused-argument
+            seconds: int | None = None,  # pylint: disable=unused-argument
     ) -> bool:
         return True
 
@@ -59,12 +59,12 @@ class ManualCurrentOracle(CurrentPriceOracleInterface):
 
     def __init__(self) -> None:
         super().__init__(oracle_name='manual current price oracle')
-        self.database: Optional[DBHandler] = None
+        self.database: DBHandler | None = None
 
     def set_database(self, database: 'DBHandler') -> None:
         self.database = database
 
-    def rate_limited_in_last(self, seconds: Optional[int] = None) -> bool:
+    def rate_limited_in_last(self, seconds: int | None = None) -> bool:
         return False
 
     def query_current_price(

--- a/rotkehlchen/globaldb/migrations/manager.py
+++ b/rotkehlchen/globaldb/migrations/manager.py
@@ -1,7 +1,8 @@
 import logging
 import sqlite3
 import traceback
-from typing import TYPE_CHECKING, Callable, NamedTuple
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -492,62 +492,68 @@ class AssetsUpdater:
         If conflicts appear while processing the assets those are handled. Deserialization
         errors are caught and the user is warned about them.
         """
-        lines = text.splitlines()
-        for action, full_insert in zip(*[iter(lines)] * 2):
-            if full_insert.strip() == '*':
-                full_insert = action  # noqa: PLW2901
+        lines = [x for x in text.splitlines() if x.strip() != '']
+        try:  # strip() check above is to remove empty lines (say trailing newline in the file
+            for action, full_insert in zip(*[iter(lines)] * 2, strict=True):
+                if full_insert.strip() == '*':
+                    full_insert = action  # noqa: PLW2901
 
-            if update_file_type == UpdateFileType.ASSETS:
-                remote_asset_data = None
-                try:
-                    remote_asset_data = self._parse_full_insert_assets(full_insert)
-                except DeserializationError as e:
-                    log.error(
-                        f'Failed to add asset with action {action} during update to v{version}',
-                    )
-                    self.msg_aggregator.add_warning(
-                        f'Skipping entry during assets update to v{version} due '
-                        f'to a deserialization error. {e!s}',
-                    )
+                if update_file_type == UpdateFileType.ASSETS:
+                    remote_asset_data = None
+                    try:
+                        remote_asset_data = self._parse_full_insert_assets(full_insert)
+                    except DeserializationError as e:
+                        log.error(
+                            f'Failed to add asset with action {action} during update to v{version}',  # noqa: E501
+                        )
+                        self.msg_aggregator.add_warning(
+                            f'Skipping entry during assets update to v{version} due '
+                            f'to a deserialization error. {e!s}',
+                        )
 
-                if remote_asset_data is not None:
-                    self._handle_asset_update(
-                        connection=connection,
-                        remote_asset_data=remote_asset_data,
-                        assets_conflicts=assets_conflicts,
-                        action=action,
-                        full_insert=full_insert,
-                        version=version,
-                    )
-            elif update_file_type == UpdateFileType.ASSET_COLLECTIONS:
-                try:
-                    self._process_asset_collection(
-                        connection=connection,
-                        action=action,
-                        full_insert=full_insert,
-                    )
-                except DeserializationError as e:
-                    self.msg_aggregator.add_warning(
-                        f'Skipping entry during assets collection update to v{version} due '
-                        f'to a deserialization error. {e!s}',
-                    )
-            else:
-                assert update_file_type == UpdateFileType.ASSET_COLLECTIONS_MAPPINGS
-                try:
-                    self._process_multiasset_mapping(
-                        connection=connection,
-                        action=action,
-                        full_insert=full_insert,
-                    )
-                except DeserializationError as e:
-                    self.msg_aggregator.add_warning(
-                        f'Skipping entry during assets collection multimapping update to '
-                        f'v{version} due to a deserialization error. {e!s}',
-                    )
-                except UnknownAsset as e:
-                    self.msg_aggregator.add_warning(
-                        f'Tried to add unknown asset {e.identifier} to collection of assets. Skipping',  # noqa: E501
-                    )
+                    if remote_asset_data is not None:
+                        self._handle_asset_update(
+                            connection=connection,
+                            remote_asset_data=remote_asset_data,
+                            assets_conflicts=assets_conflicts,
+                            action=action,
+                            full_insert=full_insert,
+                            version=version,
+                        )
+                elif update_file_type == UpdateFileType.ASSET_COLLECTIONS:
+                    try:
+                        self._process_asset_collection(
+                            connection=connection,
+                            action=action,
+                            full_insert=full_insert,
+                        )
+                    except DeserializationError as e:
+                        self.msg_aggregator.add_warning(
+                            f'Skipping entry during assets collection update to v{version} due '
+                            f'to a deserialization error. {e!s}',
+                        )
+                else:
+                    assert update_file_type == UpdateFileType.ASSET_COLLECTIONS_MAPPINGS
+                    try:
+                        self._process_multiasset_mapping(
+                            connection=connection,
+                            action=action,
+                            full_insert=full_insert,
+                        )
+                    except DeserializationError as e:
+                        self.msg_aggregator.add_warning(
+                            f'Skipping entry during assets collection multimapping update to '
+                            f'v{version} due to a deserialization error. {e!s}',
+                        )
+                    except UnknownAsset as e:
+                        self.msg_aggregator.add_warning(
+                            f'Tried to add unknown asset {e.identifier} to collection of assets. Skipping',  # noqa: E501
+                        )
+        except ValueError:
+            self.msg_aggregator.add_error(
+                f'Last entry of update {update_file_type} has an odd number of '
+                f'lines. Skipping. Report this to the developers',
+            )
 
         # at the very end update the current version in the DB
         connection.execute(

--- a/rotkehlchen/greenlets/manager.py
+++ b/rotkehlchen/greenlets/manager.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import gevent
 
@@ -35,7 +36,7 @@ class GreenletManager:
 
     def spawn_and_track(
             self,
-            after_seconds: Optional[float],
+            after_seconds: float | None,
             task_name: str,
             exception_is_error: bool,
             method: Callable,

--- a/rotkehlchen/history/events.py
+++ b/rotkehlchen/history/events.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.accounting.structures.base import HistoryBaseEntry, HistoryEvent
 from rotkehlchen.constants import ZERO
@@ -226,7 +226,7 @@ class EventsHistorian:
             cursor: 'DBCursor',
             location: Literal[Location.KRAKEN, Location.BINANCE, Location.BINANCEUS],
             filter_query: HistoryEventFilterQuery,
-            task_manager: Optional[TaskManager],
+            task_manager: TaskManager | None,
             only_cache: bool,
     ) -> tuple[list[HistoryEvent], int]:
         """

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -212,7 +212,7 @@ class PriceHistorian:
             'PriceHistorian should never be called before setting the oracles'
         )
         rate_limited = False
-        for oracle, oracle_instance in zip(oracles, oracle_instances):
+        for oracle, oracle_instance in zip(oracles, oracle_instances, strict=True):
             can_query_history = oracle_instance.can_query_history(
                 from_asset=from_asset,
                 to_asset=to_asset,

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -80,12 +80,12 @@ class PriceHistorian:
     _coingecko: 'Coingecko'
     _defillama: 'Defillama'
     _manual: ManualPriceOracle  # This is used when iterating through all oracles
-    _oracles: Optional[Sequence[HistoricalPriceOracle]] = None
-    _oracle_instances: Optional[list[HistoricalPriceOracleInstance]] = None
+    _oracles: Sequence[HistoricalPriceOracle] | None = None
+    _oracle_instances: list[HistoricalPriceOracleInstance] | None = None
 
     def __new__(
             cls,
-            data_directory: Optional[Path] = None,
+            data_directory: Path | None = None,
             cryptocompare: Optional['Cryptocompare'] = None,
             coingecko: Optional['Coingecko'] = None,
             defillama: Optional['Defillama'] = None,
@@ -121,7 +121,7 @@ class PriceHistorian:
             from_asset: Asset,
             to_asset: Asset,
             timestamp: Timestamp,
-    ) -> Optional[Price]:
+    ) -> Price | None:
         """
         Query the historical price on `timestamp` for `from_asset` in `to_asset`
         for the case where `from_asset` needs a special handling.

--- a/rotkehlchen/history/skipped.py
+++ b/rotkehlchen/history/skipped.py
@@ -3,7 +3,7 @@ import logging
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from rotkehlchen.accounting.export.csv import (
     FILENAME_SKIPPED_EXTERNAL_EVENTS_CSV,
@@ -37,7 +37,7 @@ def get_skipped_external_events_summary(rotki: 'Rotkehlchen') -> dict[str, Any]:
     return summary
 
 
-def export_skipped_external_events(rotki: 'Rotkehlchen', directory: Optional[Path]) -> Path:
+def export_skipped_external_events(rotki: 'Rotkehlchen', directory: Path | None) -> Path:
     """
     Export the skipped events in a CSV file.
 

--- a/rotkehlchen/icons.py
+++ b/rotkehlchen/icons.py
@@ -5,7 +5,7 @@ import shutil
 import urllib.parse
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import gevent
 import requests
@@ -44,7 +44,7 @@ def _build_http_header_for_images(image_path: Path) -> dict[str, str]:
     return {'mimetype': f'image/{http_type}', 'Content-Type': f'image/{http_type}'}
 
 
-def check_if_image_is_cached(image_path: Path, match_header: Optional[str]) -> Optional[Response]:
+def check_if_image_is_cached(image_path: Path, match_header: str | None) -> Response | None:
     """Checks whether the file at `image_path` is an already cached image.
 
     Returns a response indicating the image has not been modified if that's the case,
@@ -84,7 +84,7 @@ def create_image_response(image_path: Path) -> Response:
     return response
 
 
-def maybe_create_image_response(image_path: Optional[Path]) -> Response:
+def maybe_create_image_response(image_path: Path | None) -> Response:
     """Checks whether the file at `image_path` exists.
 
     Returns a response with the image if it exists, otherwise a NOT FOUND response.
@@ -127,7 +127,7 @@ class IconManager:
     def iconfile_path(self, asset: AssetWithNameAndType) -> Path:
         return self.icons_dir / f'{urllib.parse.quote_plus(asset.identifier)}_small.png'
 
-    def custom_iconfile_path(self, asset: Asset) -> Optional[Path]:
+    def custom_iconfile_path(self, asset: Asset) -> Path | None:
         asset_id_quoted = urllib.parse.quote_plus(asset.identifier)
         for suffix in ALLOWED_ICON_EXTENSIONS:
             icon_path = self.custom_icons_dir / f'{asset_id_quoted}{suffix}'
@@ -139,7 +139,7 @@ class IconManager:
     def asset_icon_path(
             self,
             asset: AssetWithNameAndType,
-    ) -> Optional[Path]:
+    ) -> Path | None:
         # First try with the custom icon path
         custom_icon_path = self.custom_iconfile_path(asset)
         if custom_icon_path is not None:
@@ -190,7 +190,7 @@ class IconManager:
     def get_icon(
             self,
             asset: AssetWithNameAndType,
-    ) -> tuple[Optional[Path], bool]:
+    ) -> tuple[Path | None, bool]:
         """
         Returns the file path of the requested icon and whether it has been scheduled to be
         queried if the file is not in the system and is possible to obtain it from coingecko.

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -150,7 +150,7 @@ def _check_curve_contract_call(decoded: tuple[Any, ...]) -> bool:
     )
 
 
-def get_underlying_asset_price(token: EvmToken) -> tuple[Optional[Price], CurrentPriceOracle]:
+def get_underlying_asset_price(token: EvmToken) -> tuple[Price | None, CurrentPriceOracle]:
     """Gets the underlying asset price for the given ethereum token
 
     TODO: This should be eventually pulled from the assets DB. All of these
@@ -209,7 +209,7 @@ def get_underlying_asset_price(token: EvmToken) -> tuple[Optional[Price], Curren
     return price, oracle
 
 
-def _query_currency_converterapi(base: FiatAsset, quote: FiatAsset) -> Optional[Price]:
+def _query_currency_converterapi(base: FiatAsset, quote: FiatAsset) -> Price | None:
     log.debug(
         'Query free.currencyconverterapi.com fiat pair',
         base_currency=base.identifier,
@@ -251,10 +251,10 @@ class Inquirer:
     _uniswapv2: Optional['UniswapV2Oracle'] = None
     _uniswapv3: Optional['UniswapV3Oracle'] = None
     _evm_managers: dict[ChainID, 'EvmManager']
-    _oracles: Optional[Sequence[CurrentPriceOracle]] = None
-    _oracle_instances: Optional[list[CurrentPriceOracleInstance]] = None
-    _oracles_not_onchain: Optional[Sequence[CurrentPriceOracle]] = None
-    _oracle_instances_not_onchain: Optional[list[CurrentPriceOracleInstance]] = None
+    _oracles: Sequence[CurrentPriceOracle] | None = None
+    _oracle_instances: list[CurrentPriceOracleInstance] | None = None
+    _oracles_not_onchain: Sequence[CurrentPriceOracle] | None = None
+    _oracle_instances_not_onchain: list[CurrentPriceOracleInstance] | None = None
     _msg_aggregator: 'MessagesAggregator'
     # save only the identifier of the special tokens since we only check if assets are in this set
     special_tokens: set[str]
@@ -263,7 +263,7 @@ class Inquirer:
 
     def __new__(
             cls,
-            data_dir: Optional[Path] = None,
+            data_dir: Path | None = None,
             cryptocompare: Optional['Cryptocompare'] = None,
             coingecko: Optional['Coingecko'] = None,
             defillama: Optional['Defillama'] = None,
@@ -356,7 +356,7 @@ class Inquirer:
     def get_cached_current_price_entry(
             cache_key: tuple[Asset, Asset],
             match_main_currency: bool,
-    ) -> Optional[CachedPriceEntry]:
+    ) -> CachedPriceEntry | None:
         cache = Inquirer()._cached_current_price.get(cache_key, None)
         if cache is None or ts_now() - cache.time > CURRENT_PRICE_CACHE_SECS or cache.used_main_currency != match_main_currency:  # noqa: E501
             return None
@@ -721,7 +721,7 @@ class Inquirer:
     def find_lp_price_from_uniswaplike_pool(
             self,
             token: EvmToken,
-    ) -> Optional[Price]:
+    ) -> Price | None:
         """Calculates the price for a uniswaplike LP token the contract of which is also
         the contract of the pool it represents. For example uniswap or velodrome LP tokens."""
         return lp_price_from_uniswaplike_pool_contract(
@@ -735,7 +735,7 @@ class Inquirer:
     def find_curve_pool_price(
             self,
             lp_token: EvmToken,
-    ) -> Optional[Price]:
+    ) -> Price | None:
         """
         1. Obtain the pool for this token
         2. Obtain prices for assets in pool
@@ -852,7 +852,7 @@ class Inquirer:
     def find_yearn_price(
             self,
             token: EvmToken,
-    ) -> Optional[Price]:
+    ) -> Price | None:
         """
         Query price for a yearn vault v2 token using the pricePerShare method
         and the price of the underlying token.
@@ -951,7 +951,7 @@ class Inquirer:
             from_fiat_currency: FiatAsset,
             to_fiat_currency: FiatAsset,
             timestamp: Timestamp,
-    ) -> Optional[Price]:
+    ) -> Price | None:
         assert from_fiat_currency.is_fiat(), 'fiat currency should have been provided'
         assert to_fiat_currency.is_fiat(), 'fiat currency should have been provided'
 

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -389,7 +389,7 @@ class Inquirer:
         instance._oracle_instances = [getattr(instance, f'_{oracle!s}') for oracle in oracles]
         instance._oracles_not_onchain = []
         instance._oracle_instances_not_onchain = []
-        for oracle, oracle_instance in zip(instance._oracles, instance._oracle_instances):
+        for oracle, oracle_instance in zip(instance._oracles, instance._oracle_instances, strict=True):  # noqa: E501
             if oracle not in (CurrentPriceOracle.UNISWAPV2, CurrentPriceOracle.UNISWAPV3):
                 instance._oracles_not_onchain.append(oracle)
                 instance._oracle_instances_not_onchain.append(oracle_instance)
@@ -432,7 +432,7 @@ class Inquirer:
         price = ZERO_PRICE
         oracle_queried = CurrentPriceOracle.BLOCKCHAIN
         used_main_currency = False
-        for oracle, oracle_instance in zip(oracles, oracle_instances):
+        for oracle, oracle_instance in zip(oracles, oracle_instances, strict=True):
             if (
                 isinstance(oracle_instance, CurrentPriceOracleInterface) and
                 (

--- a/rotkehlchen/interfaces.py
+++ b/rotkehlchen/interfaces.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Optional
+from typing import Any
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.types import Price, Timestamp
@@ -16,7 +16,7 @@ class CurrentPriceOracleInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def rate_limited_in_last(
             self,
-            seconds: Optional[int] = None,
+            seconds: int | None = None,
     ) -> bool:
         """Denotes if the oracles has been rate limited in the last ``seconds``"""
 
@@ -47,7 +47,7 @@ class HistoricalPriceOracleInterface(CurrentPriceOracleInterface):
             from_asset: Asset,
             to_asset: Asset,
             timestamp: Timestamp,
-            seconds: Optional[int] = None,
+            seconds: int | None = None,
     ) -> bool:
         """Checks if it's okay to query historical price"""
 

--- a/rotkehlchen/logging.py
+++ b/rotkehlchen/logging.py
@@ -3,7 +3,7 @@ import logging.config
 import re
 from collections.abc import MutableMapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import gevent
 
@@ -18,7 +18,7 @@ TRACE = logging.DEBUG - 5
 def add_logging_level(
         level_name: str,
         level_num: int,
-        method_name: Optional[str] = None,
+        method_name: str | None = None,
 ) -> None:
     """
     Comprehensively adds a new logging level to the `logging` module and the

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 from enum import Enum
 from http import HTTPStatus
 from json import JSONDecodeError
-from typing import Any, Literal, NamedTuple, Optional, cast
+from typing import Any, Literal, NamedTuple, cast
 from urllib.parse import urlencode
 
 import machineid
@@ -389,7 +389,7 @@ class Premium:
             user_msg='Size limit reached' if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE else f'Could not upload database backup due to: {response.text}',  # noqa: E501
         )
 
-    def pull_data(self) -> Optional[bytes]:
+    def pull_data(self) -> bytes | None:
         """Pulls data from the server and returns the binary file with the database encrypted
 
         Returns None if there is no DB saved in the server.
@@ -487,7 +487,7 @@ class Premium:
     def watcher_query(
             self,
             method: Literal['GET', 'PUT', 'PATCH', 'DELETE'],
-            data: Optional[dict[str, Any]],
+            data: dict[str, Any] | None,
     ) -> Any:
         if data is None:
             data = {}

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
 from enum import Enum
-from typing import Any, Literal, NamedTuple, Optional, Union
+from typing import Any, Literal, NamedTuple
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.data_handler import DataHandler
@@ -32,7 +32,7 @@ class SyncCheckResult(NamedTuple):
     can_sync: CanSync
     # If result is ASK_USER, what should the message be?
     message: str
-    payload: Optional[dict[str, Any]]
+    payload: dict[str, Any] | None
 
 
 class PremiumSyncManager:
@@ -47,7 +47,7 @@ class PremiumSyncManager:
         self.last_remote_data_upload_ts = 0  # gets populated only after the first API call
         self.data = data
         self.migration_manager = migration_manager
-        self.premium: Optional[Premium] = None
+        self.premium: Premium | None = None
 
     def _query_last_data_metadata(self) -> RemoteMetadata:
         """Query remote metadata and keep up to date the last remote data upload ts"""
@@ -160,7 +160,7 @@ class PremiumSyncManager:
     def maybe_upload_data_to_server(
             self,
             force_upload: bool = False,
-    ) -> tuple[bool, Optional[str]]:
+    ) -> tuple[bool, str | None]:
         """
         Returns a boolean value denoting whether we can upload the DB to the server.
         In case of error we also return a message to provide information to the user.
@@ -300,7 +300,7 @@ class PremiumSyncManager:
     def _abort_new_syncing_premium_user(
             self,
             username: str,
-            original_exception: Union[PremiumAuthenticationError, RemoteError],
+            original_exception: PremiumAuthenticationError | RemoteError,
     ) -> None:
         """At this point we are at a new user trying to create an account with
         premium API keys and we failed. But a directory was created. Remove it.
@@ -318,12 +318,12 @@ class PremiumSyncManager:
 
     def try_premium_at_start(
             self,
-            given_premium_credentials: Optional[PremiumCredentials],
+            given_premium_credentials: PremiumCredentials | None,
             username: str,
             create_new: bool,
             sync_approval: Literal['yes', 'no', 'unknown'],
             sync_database: bool,
-    ) -> Optional[Premium]:
+    ) -> Premium | None:
         """
         Check if new user provided api pair or we already got one in the DB
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict
 from pathlib import Path
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
 
 import gevent
 
@@ -130,7 +130,7 @@ class Rotkehlchen:
         """
         # Can also be None after unlock if premium credentials did not
         # authenticate or premium server temporarily offline
-        self.premium: Optional[Premium] = None
+        self.premium: Premium | None = None
         self.user_is_logged_in: bool = False
 
         self.args = args
@@ -186,7 +186,7 @@ class Rotkehlchen:
         )
         # Initialize EVM Contracts common abis
         EvmContracts.initialize_common_abis()
-        self.task_manager: Optional[TaskManager] = None
+        self.task_manager: TaskManager | None = None
         self.shutdown_event = gevent.event.Event()
         self.migration_manager = DataMigrationManager(self)
 
@@ -248,9 +248,9 @@ class Rotkehlchen:
             password: str,
             create_new: bool,
             sync_approval: Literal['yes', 'no', 'unknown'],
-            premium_credentials: Optional[PremiumCredentials],
+            premium_credentials: PremiumCredentials | None,
             resume_from_backup: bool,
-            initial_settings: Optional[ModifiableDBSettings] = None,
+            initial_settings: ModifiableDBSettings | None = None,
             sync_database: bool = True,
     ) -> None:
         """Unlocks an existing user or creates a new one if `create_new` is True
@@ -607,7 +607,7 @@ class Rotkehlchen:
             self,
             cursor: 'DBCursor',
             blockchain: SupportedBlockchain,
-    ) -> Union[list[SingleBlockchainAccountData], dict[str, Any]]:
+    ) -> list[SingleBlockchainAccountData] | dict[str, Any]:
         account_data = self.data.db.get_blockchain_account_data(cursor, blockchain)
         if blockchain not in (SupportedBlockchain.BITCOIN, SupportedBlockchain.BITCOIN_CASH):
             return account_data
@@ -855,7 +855,7 @@ class Rotkehlchen:
             self,
             requested_save_data: bool = False,
             save_despite_errors: bool = False,
-            timestamp: Optional[Timestamp] = None,
+            timestamp: Timestamp | None = None,
             ignore_cache: bool = False,
     ) -> dict[str, Any]:
         """Query all balances rotkehlchen can see.
@@ -1078,9 +1078,9 @@ class Rotkehlchen:
             location: Location,
             api_key: ApiKey,
             api_secret: ApiSecret,
-            passphrase: Optional[str] = None,
+            passphrase: str | None = None,
             kraken_account_type: Optional['KrakenAccountType'] = None,
-            binance_selected_trade_pairs: Optional[list[str]] = None,
+            binance_selected_trade_pairs: list[str] | None = None,
     ) -> tuple[bool, str]:
         """
         Setup a new exchange with an api key and an api secret and optionally a passphrase
@@ -1108,9 +1108,9 @@ class Rotkehlchen:
             )
         return is_success, msg
 
-    def query_periodic_data(self) -> dict[str, Union[bool, dict[str, list[str]], Timestamp]]:
+    def query_periodic_data(self) -> dict[str, bool | (dict[str, list[str]] | Timestamp)]:
         """Query for frequently changing data"""
-        result: dict[str, Union[bool, dict[str, list[str]], Timestamp]] = {}
+        result: dict[str, bool | (dict[str, list[str]] | Timestamp)] = {}
 
         if self.user_is_logged_in:
             with self.data.db.conn.read_ctx() as cursor:

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union, overload
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, overload
 
 from eth_utils import to_checksum_address
 
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def deserialize_fee(fee: Optional[str]) -> Fee:
+def deserialize_fee(fee: str | None) -> Fee:
     """Deserializes a fee from a json entry. Fee in the JSON entry can also be null
     in which case a ZERO fee is returned.
 
@@ -55,7 +56,7 @@ def deserialize_fee(fee: Optional[str]) -> Fee:
     return result
 
 
-def deserialize_timestamp(timestamp: Union[int, str, FVal]) -> Timestamp:
+def deserialize_timestamp(timestamp: int | (str | FVal)) -> Timestamp:
     """Deserializes a timestamp from a json entry. Given entry can either be a
     string or an int.
 
@@ -97,7 +98,7 @@ def deserialize_timestamp(timestamp: Union[int, str, FVal]) -> Timestamp:
 
 
 def deserialize_timestamp_from_date(
-        date: Optional[str],
+        date: str | None,
         formatstr: str,
         location: str,
         skip_milliseconds: bool = False,
@@ -156,7 +157,7 @@ def deserialize_timestamp_from_bitstamp_date(date: str) -> Timestamp:
     )
 
 
-def deserialize_timestamp_from_floatstr(time: Union[str, FVal, float]) -> Timestamp:
+def deserialize_timestamp_from_floatstr(time: str | (FVal | float)) -> Timestamp:
     """Deserializes a timestamp from a kraken api query result entry
     Kraken has timestamps in floating point strings. Example: '1561161486.3056'.
 
@@ -171,7 +172,7 @@ def deserialize_timestamp_from_floatstr(time: Union[str, FVal, float]) -> Timest
 
     if isinstance(time, int):
         return Timestamp(time)
-    if isinstance(time, (float, str)):
+    if isinstance(time, float | str):
         try:
             return Timestamp(convert_to_int(time, accept_only_exact=False))
         except ConversionError as e:
@@ -220,7 +221,7 @@ def deserialize_fval(
 
 
 def deserialize_optional_to_fval(
-        value: Optional[AcceptableFValInitInput],
+        value: AcceptableFValInitInput | None,
         name: str,
         location: str,
 ) -> FVal:
@@ -236,10 +237,10 @@ def deserialize_optional_to_fval(
 
 
 def deserialize_optional_to_optional_fval(
-        value: Optional[AcceptableFValInitInput],
+        value: AcceptableFValInitInput | None,
         name: str,
         location: str,
-) -> Optional[FVal]:
+) -> FVal | None:
     """
     Deserializes an FVal from a field that was optional and if None returns None
     """
@@ -250,7 +251,7 @@ def deserialize_optional_to_optional_fval(
 
 
 def deserialize_fval_or_zero(
-        value: Optional[AcceptableFValInitInput],
+        value: AcceptableFValInitInput | None,
         name: str,
         location: str,
 ) -> FVal:
@@ -339,7 +340,7 @@ def deserialize_trade_pair(pair: str) -> TradePair:
 
 
 def deserialize_asset_movement_category(
-        value: Union[str, HistoryEventType],
+        value: str | HistoryEventType,
 ) -> AssetMovementCategory:
     """Takes a string and determines whether to accept it as an asset movement category
 
@@ -452,7 +453,7 @@ def deserialize_int_from_hex(symbol: str, location: str) -> int:
     return result
 
 
-def deserialize_int_from_hex_or_int(symbol: Union[str, int], location: str) -> int:
+def deserialize_int_from_hex_or_int(symbol: str | int, location: str) -> int:
     """Takes a symbol which can either be an int or a hex string and
     turns it into an integer
 
@@ -484,7 +485,7 @@ X = TypeVar('X')
 Y = TypeVar('Y')
 
 
-def deserialize_optional(input_val: Optional[X], fn: Callable[[X], Y]) -> Optional[Y]:
+def deserialize_optional(input_val: X | None, fn: Callable[[X], Y]) -> Y | None:
     """An optional deserialization wrapper for any deserialize function"""
     if input_val is None:
         return None
@@ -542,7 +543,7 @@ def deserialize_evm_transaction(
         chain_id: ChainID,
         evm_inquirer: Optional['EvmNodeInquirer'] = None,
         parent_tx_hash: Optional['EVMTxHash'] = None,
-) -> tuple[Union[EvmTransaction, EvmInternalTransaction], Optional[dict[str, Any]]]:
+) -> tuple[EvmTransaction | EvmInternalTransaction, dict[str, Any] | None]:
     """Reads dict data of a transaction and deserializes it.
     If the transaction is not from etherscan then it's missing some data
     so evm inquirer is used to fetch it.

--- a/rotkehlchen/serialization/schemas.py
+++ b/rotkehlchen/serialization/schemas.py
@@ -135,7 +135,7 @@ class CryptoAssetSchema(CryptoAssetFieldsSchema):
             identifier_required: bool,
             coingecko: Optional['Coingecko'] = None,
             cryptocompare: Optional['Cryptocompare'] = None,
-            expected_asset_type: Optional[AssetType] = None,
+            expected_asset_type: AssetType | None = None,
     ) -> None:
         super().__init__(
             identifier_required=identifier_required,
@@ -306,7 +306,7 @@ class AssetSchema(Schema):
     def __init__(
             self,
             identifier_required: bool,
-            disallowed_asset_types: Optional[list[AssetType]] = None,
+            disallowed_asset_types: list[AssetType] | None = None,
             coingecko: Optional['Coingecko'] = None,
             cryptocompare: Optional['Cryptocompare'] = None,
             **kwargs: Any,

--- a/rotkehlchen/serialization/serialize.py
+++ b/rotkehlchen/serialization/serialize.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 from hexbytes import HexBytes
 from web3.datastructures import AttributeDict
@@ -84,18 +84,18 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.version_check import VersionCheckResult
 
 
-def _process_entry(entry: Any) -> Union[str, list[Any], dict[str, Any], Any]:
+def _process_entry(entry: Any) -> str | (list[Any] | (dict[str, Any] | Any)):
     if isinstance(entry, FVal):
         return str(entry)
     if isinstance(entry, list):
         return [_process_entry(x) for x in entry]
 
-    if isinstance(entry, (dict, AttributeDict)):
+    if isinstance(entry, dict | AttributeDict):
         new_dict = {}
         for k, v in entry.items():
             if isinstance(k, Asset) is True:
                 k = k.identifier  # noqa: PLW2901
-            elif isinstance(k, (HistoryEventType, HistoryEventSubType, EventCategory, Location, AccountingEventType)) is True:  # noqa: E501
+            elif isinstance(k, HistoryEventType | HistoryEventSubType | EventCategory | Location | AccountingEventType) is True:  # noqa: E501
                 k = _process_entry(k)  # noqa: PLW2901
             new_dict[k] = _process_entry(v)
         return new_dict
@@ -123,67 +123,67 @@ def _process_entry(entry: Any) -> Union[str, list[Any], dict[str, Any], Any]:
             'usd_value': str(entry.usd_value),
         }
     if isinstance(entry, (
-            AddressbookEntry,
-            AssetBalance,
-            DefiProtocol,
-            MakerdaoVault,
-            XpubData,
-            StakingEvent,
-            NodeName,
-            NodeName,
-            ChainID,
-            SingleBlockchainAccountData,
-            SupportedBlockchain,
-            HistoryEventType,
-            HistoryEventSubType,
-            EventDirection,
-            LocationDetails,
-            EvmProduct,
-            DBSettings,
-            TxAccountingTreatment,
-            EventCategoryDetails,
+            AddressbookEntry |
+            AssetBalance |
+            DefiProtocol |
+            MakerdaoVault |
+            XpubData |
+            StakingEvent |
+            NodeName |
+            NodeName |
+            ChainID |
+            SingleBlockchainAccountData |
+            SupportedBlockchain |
+            HistoryEventType |
+            HistoryEventSubType |
+            EventDirection |
+            LocationDetails |
+            EvmProduct |
+            DBSettings |
+            TxAccountingTreatment |
+            EventCategoryDetails
     )):
         return entry.serialize()
     if isinstance(entry, (
-            Trade,
-            EvmTransaction,
-            OptimismTransaction,
-            MakerdaoVault,
-            DSRAccountReport,
-            Balance,
-            AaveLendingBalance,
-            AaveBorrowingBalance,
-            CompoundBalance,
-            YearnVaultEvent,
-            YearnVaultBalance,
-            LiquidityPool,
-            LiquidityPoolAsset,
-            LiquidityPoolEventsBalance,
-            BalancerBPTEventPoolToken,
-            BalancerEvent,
-            BalancerPoolEventsBalance,
-            BalancerPoolBalance,
-            BalancerPoolTokenBalance,
-            ManuallyTrackedBalanceWithValue,
-            Trove,
-            DillBalance,
-            NFTResult,
-            ExchangeLocationID,
-            WeightedNode,
+            Trade |
+            EvmTransaction |
+            OptimismTransaction |
+            MakerdaoVault |
+            DSRAccountReport |
+            Balance |
+            AaveLendingBalance |
+            AaveBorrowingBalance |
+            CompoundBalance |
+            YearnVaultEvent |
+            YearnVaultBalance |
+            LiquidityPool |
+            LiquidityPoolAsset |
+            LiquidityPoolEventsBalance |
+            BalancerBPTEventPoolToken |
+            BalancerEvent |
+            BalancerPoolEventsBalance |
+            BalancerPoolBalance |
+            BalancerPoolTokenBalance |
+            ManuallyTrackedBalanceWithValue |
+            Trove |
+            DillBalance |
+            NFTResult |
+            ExchangeLocationID |
+            WeightedNode
     )):
         return process_result(entry.serialize())
     if isinstance(entry, (
-            VersionCheckResult,
-            DSRCurrentBalances,
-            VaultEvent,
-            MakerdaoVaultDetails,
-            AaveBalances,
-            DefiBalance,
-            DefiProtocolBalances,
-            YearnVaultHistory,
-            BlockchainAccountData,
-            CounterpartyDetails,
-            AaveStats,
+            VersionCheckResult |
+            DSRCurrentBalances |
+            VaultEvent |
+            MakerdaoVaultDetails |
+            AaveBalances |
+            DefiBalance |
+            DefiProtocolBalances |
+            YearnVaultHistory |
+            BlockchainAccountData |
+            CounterpartyDetails |
+            AaveStats
     )):
         return process_result(entry._asdict())
     if isinstance(entry, tuple):
@@ -191,20 +191,20 @@ def _process_entry(entry: Any) -> Union[str, list[Any], dict[str, Any], Any]:
     if isinstance(entry, Asset):
         return entry.identifier
     if isinstance(entry, (
-            TradeType,
-            Location,
-            KrakenAccountType,
-            Location,
-            VaultEventType,
-            AssetMovementCategory,
-            CurrentPriceOracle,
-            HistoricalPriceOracle,
-            BalanceType,
-            CostBasisMethod,
-            EvmTokenKind,
-            HistoryBaseEntryType,
-            EventCategory,
-            AccountingEventType,
+            TradeType |
+            Location |
+            KrakenAccountType |
+            Location |
+            VaultEventType |
+            AssetMovementCategory |
+            CurrentPriceOracle |
+            HistoricalPriceOracle |
+            BalanceType |
+            CostBasisMethod |
+            EvmTokenKind |
+            HistoryBaseEntryType |
+            EventCategory |
+            AccountingEventType
     )):
         return str(entry)
 
@@ -223,7 +223,7 @@ def process_result(result: Any) -> dict[Any, Any]:
         - all enums and more
     """
     processed_result = _process_entry(result)
-    assert isinstance(processed_result, (dict, AttributeDict))  # pylint: disable=isinstance-second-argument-not-valid-type
+    assert isinstance(processed_result, dict | AttributeDict)  # pylint: disable=isinstance-second-argument-not-valid-type
     return processed_result  # type: ignore
 
 

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -1,7 +1,8 @@
 import logging
 import random
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, NamedTuple
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple
 
 import gevent
 

--- a/rotkehlchen/tasks/utils.py
+++ b/rotkehlchen/tasks/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.errors.misc import RemoteError
@@ -42,7 +42,7 @@ def should_run_periodic_task(
 def query_missing_prices_of_base_entries(
         database: 'DBHandler',
         entries_missing_prices: list[tuple[str, 'FVal', 'Asset', 'Timestamp']],
-        base_entries_ignore_set: Optional[set[str]] = None,
+        base_entries_ignore_set: set[str] | None = None,
 ) -> None:
     """
     Queries missing prices for HistoryBaseEntry in database updating

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 import requests
-from flaky import flaky
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.api.server import APIServer
@@ -32,7 +31,6 @@ AAVE_BALANCESV1_TEST_ACC = '0xC2cB1040220768554cf699b0d863A3cd4324ce32'
 AAVE_BALANCESV2_TEST_ACC = '0x8Fe178db26ebA2eEdb22575265bf10A63c395a3d'
 
 
-@flaky(max_runs=3, min_passes=1)  # open nodes some times time out
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_BALANCESV1_TEST_ACC, AAVE_BALANCESV2_TEST_ACC]])  # noqa: E501
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 def test_query_aave_balances(

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -2,7 +2,7 @@ import random
 import warnings as test_warnings
 from contextlib import ExitStack
 from http import HTTPStatus
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 import requests
@@ -37,7 +37,7 @@ AAVE_BALANCESV2_TEST_ACC = '0x8Fe178db26ebA2eEdb22575265bf10A63c395a3d'
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 def test_query_aave_balances(
         rotkehlchen_api_server: APIServer,
-        ethereum_accounts: Optional[list[ChecksumEvmAddress]],
+        ethereum_accounts: list[ChecksumEvmAddress] | None,
 ) -> None:
     """Check querying the aave balances endpoint works. Uses real data.
 
@@ -105,7 +105,7 @@ def test_query_aave_balances(
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_dsr']])
 def test_query_aave_balances_module_not_activated(
         rotkehlchen_api_server: APIServer,
-        ethereum_accounts: Optional[list[ChecksumEvmAddress]],
+        ethereum_accounts: list[ChecksumEvmAddress] | None,
 ) -> None:
     async_query = random.choice([False, True])
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
@@ -136,7 +136,7 @@ def test_query_aave_balances_module_not_activated(
 @pytest.mark.parametrize('ethereum_modules', [['aave']])
 def test_query_aave_defi_borrowing(
         rotkehlchen_api_server: APIServer,
-        ethereum_accounts: Optional[list[ChecksumEvmAddress]],
+        ethereum_accounts: list[ChecksumEvmAddress] | None,
 ) -> None:
     """Checks that the apr/apy values are correctly returned from the API for a mocked position"""
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen

--- a/rotkehlchen/tests/api/test_assets_updates.py
+++ b/rotkehlchen/tests/api/test_assets_updates.py
@@ -83,6 +83,8 @@ INSERT INTO assets(identifier, name, type) VALUES("121-ada-FADS-as", "A name", "
 UPDATE assets SET name="Ευρώ" WHERE identifier="EUR";
 INSERT INTO assets(identifier, name, type) VALUES("EUR", "Ευρώ", "A"); INSERT INTO common_asset_details(identifier, symbol, coingecko, cryptocompare, forked, started, swapped_for) VALUES("EUR", "Ευρώ", "EUR", NULL, NULL, NULL, NULL, NULL);
     """  # noqa: E501
+    # The update_4_assets has an extra newline which is put there on purpose to see
+    # that the consuming logic can handle trailing newlines
     update_4_collections = """INSERT INTO asset_collections(id, name, symbol) VALUES (99999999, "My custom ETH", "ETHS")
     *"""  # noqa: E501
     update_4_mappings = """INSERT INTO multiasset_mappings(collection_id, asset) VALUES (99999999, "ETH");

--- a/rotkehlchen/tests/api/test_compound.py
+++ b/rotkehlchen/tests/api/test_compound.py
@@ -2,7 +2,6 @@ import random
 import warnings as test_warnings
 from contextlib import ExitStack
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 import requests
@@ -27,7 +26,7 @@ TEST_ACC1 = '0x2bddEd18E2CA464355091266B7616956944ee7eE'
 @pytest.mark.parametrize('ethereum_modules', [['compound']])
 def test_query_compound_balances(
         rotkehlchen_api_server: APIServer,
-        ethereum_accounts: Optional[list[ChecksumEvmAddress]],
+        ethereum_accounts: list[ChecksumEvmAddress] | None,
 ) -> None:
     """Check querying the compound balances endpoint works. Uses real data.
 
@@ -85,7 +84,7 @@ def test_query_compound_balances(
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_dsr']])
 def test_query_compound_balances_module_not_activated(
         rotkehlchen_api_server: APIServer,
-        ethereum_accounts: Optional[list[ChecksumEvmAddress]],
+        ethereum_accounts: list[ChecksumEvmAddress] | None,
 ) -> None:
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     setup = setup_balances(rotki, ethereum_accounts=ethereum_accounts, btc_accounts=None)

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -2,7 +2,7 @@ import os
 import random
 from contextlib import ExitStack
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import gevent
@@ -212,7 +212,7 @@ def query_events(server, json, expected_num_with_grouping, expected_totals_with_
     return remove_added_event_fields(augmented_entries)
 
 
-def assert_force_redecode_txns_works(api_server: 'APIServer', hashes: Optional[list[EVMTxHash]]):
+def assert_force_redecode_txns_works(api_server: 'APIServer', hashes: list[EVMTxHash] | None):
     rotki = api_server.rest_api.rotkehlchen
     get_eth_txns_patch = patch.object(
         rotki.chains_aggregator.ethereum.transactions_decoder.transactions,

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -1,6 +1,6 @@
 import random
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import requests
@@ -54,7 +54,7 @@ def assert_editing_works(
         rotkehlchen_api_server: 'APIServer',
         events_db: 'DBHistoryEvents',
         sequence_index: int,
-        autoedited: Optional[dict[str, Any]] = None,
+        autoedited: dict[str, Any] | None = None,
 ):
     """A function to assert editing works per entry type. If autoedited is given
     then we check that some fields, given in autoedited, were automatically edited

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -119,7 +119,7 @@ def mock_etherscan_for_dsr(
     proxy2 = make_evm_address()
     targets = [address_to_32byteshexstr(proxy1), address_to_32byteshexstr(proxy2), '0x0000000000000000000000000000000000000000000000000000000000000000']  # noqa: E501
 
-    sorted_accounts = sorted(zip([account1, account2, account3], targets), key=lambda x: x[0])
+    sorted_accounts = sorted(zip([account1, account2, account3], targets, strict=True), key=lambda x: x[0])  # noqa: E501
     proxies = [y[1] for y in sorted_accounts]
 
     account1_join1_event = f"""{{"address": "{makerdao_pot.address}", "topics": ["0x049878f300000000000000000000000000000000000000000000000000000000", "{address_to_32byteshexstr(proxy1)}", "{int_to_32byteshexstr(params.account1_join1_normalized_balance)}", "0x0000000000000000000000000000000000000000000000000000000000000000"], "data": "0x1", "blockNumber": "{hex(params.account1_join1_blocknumber)}", "timeStamp": "{hex(blocknumber_to_timestamp(params.account1_join1_blocknumber))}", "gasPrice": "0x1", "gasUsed": "0x1", "logIndex": "0x6c", "transactionHash": "0xd81bddb97599cfab91b9ee52b5c505ffa730b71f1e484dc46d0f4ecb57893d2f", "transactionIndex": "0x79"}}"""  # noqa: E501

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -2,7 +2,7 @@
 
 import random
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pytest
 import requests
@@ -192,7 +192,7 @@ def _check_vaults_values(vaults, owner):
     assert_serialized_lists_equal(expected_vaults, vaults[:1], ignore_keys=VAULT_IGNORE_KEYS)  # Check only the first vault so that if the user adds more vaults, the test still runs normally  # noqa: E501
 
 
-def _check_vault_details_values(details, total_interest_owed_list: list[Optional[FVal]]):
+def _check_vault_details_values(details, total_interest_owed_list: list[FVal | None]):
     expected_details = [VAULT_8015_DETAILS]
     assert_serialized_lists_equal(
         expected_details,

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -1,7 +1,7 @@
 import os
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -27,9 +27,9 @@ from rotkehlchen.utils.misc import get_system_spec
 def generate_expected_info(
         expected_version: str,
         data_dir: Path,
-        latest_version: Optional[str] = None,
+        latest_version: str | None = None,
         accept_docker_risk: bool = False,
-        download_url: Optional[str] = None,
+        download_url: str | None = None,
 ):
     result = {
         'version': {

--- a/rotkehlchen/tests/api/test_snapshots.py
+++ b/rotkehlchen/tests/api/test_snapshots.py
@@ -5,7 +5,7 @@ import tempfile
 import zipfile
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pytest
 import requests
@@ -107,7 +107,7 @@ def _populate_db_with_location_data(write_cursor: 'DBCursor', db: 'DBHandler', t
 def _write_balances_csv_row(
         writer: 'csv.DictWriter',
         timestamp: Timestamp,
-        include_unknown_asset: Optional[bool] = None,
+        include_unknown_asset: bool | None = None,
 ) -> None:
     if include_unknown_asset:
         writer.writerow(
@@ -318,7 +318,7 @@ def assert_csv_export_response(
         main_currency: AssetWithOracles,
         is_download=False,
         expected_entries=2,
-        timestamp_validation_data: Optional[tuple[Timestamp, bool]] = None,
+        timestamp_validation_data: tuple[Timestamp, bool] | None = None,
 ):
     if is_download:
         assert response.status_code == HTTPStatus.OK

--- a/rotkehlchen/tests/api/test_users.py
+++ b/rotkehlchen/tests/api/test_users.py
@@ -4,7 +4,7 @@ import shutil
 from contextlib import ExitStack
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -37,7 +37,7 @@ from rotkehlchen.utils.misc import ts_now
 
 def check_proper_unlock_result(
         response_data: dict[str, Any],
-        settings_to_check: Optional[dict[str, Any]] = None,
+        settings_to_check: dict[str, Any] | None = None,
 ) -> None:
 
     assert isinstance(response_data['exchanges'], list)

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -11,7 +11,7 @@ from http import HTTPStatus
 from json import JSONDecodeError
 from pathlib import Path
 from subprocess import PIPE, Popen
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import py
 import pytest
@@ -190,7 +190,7 @@ def vcr_fixture(vcr: 'VCR') -> 'VCR':
     # pytest-deadfixtures ignore
     """
 
-    def before_record_response(response: dict[str, Any]) -> Optional[dict[str, Any]]:
+    def before_record_response(response: dict[str, Any]) -> dict[str, Any] | None:
         if (
             'RECORD_CASSETTES' in os.environ and
             response['status']['code'] != HTTPStatus.OK or

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -60,7 +60,7 @@ def assert_tx_hash_is_bytes(
     - Checks that comparing the entries after converting the bytes to its string equivalent yields
     the same as its `old` counterpart.
     """
-    for _old, _new in zip(old, new):
+    for _old, _new in zip(old, new, strict=True):
         assert isinstance(_new[tx_hash_index], bytes)
         assert isinstance(_old[tx_hash_index], str)
         _old = list(_old)
@@ -813,7 +813,7 @@ def test_upgrade_db_34_to_35(user_data_dir):  # pylint: disable=unused-argument
         ('_ceth_0xdAC17F958D2ee523a2206206994597C13D831ec7',),
     ]
     with db_v34.conn.read_ctx() as cursor:
-        for table_name, expected_result in zip(upgraded_tables, expected_timestamps):
+        for table_name, expected_result in zip(upgraded_tables, expected_timestamps, strict=True):
             cursor.execute(f'SELECT time from {table_name}')
             assert cursor.fetchall() == expected_result
 
@@ -937,7 +937,7 @@ def test_upgrade_db_34_to_35(user_data_dir):  # pylint: disable=unused-argument
     ]
 
     with db_v35.conn.read_ctx() as cursor:
-        for table_name, expected_result in zip(upgraded_tables, expected_timestamps):
+        for table_name, expected_result in zip(upgraded_tables, expected_timestamps, strict=True):
             cursor.execute(f'SELECT timestamp from {table_name}')
             assert cursor.fetchall() == expected_result
         cursor.execute('SELECT blockchain from web3_nodes LIMIT 1')

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -260,7 +260,7 @@ def test_read_write_customized_events_from_db(database: DBHandler) -> None:
     ]
 
     with db.db.conn.read_ctx() as cursor:
-        for (filtering_class, filter_args), expected_ids in zip(filter_query_args, expected_identifiers):  # noqa: E501
+        for (filtering_class, filter_args), expected_ids in zip(filter_query_args, expected_identifiers, strict=True):  # noqa: E501
             events = db.get_history_events(
                 cursor=cursor,
                 filter_query=filtering_class.make(**filter_args),

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.base import HistoryBaseEntryType, HistoryEvent
@@ -95,7 +95,7 @@ def test_get_customized_event_identifiers(database):
         assert db.get_customized_event_identifiers(cursor, chain_id=ChainID.OPTIMISM) == [4]
 
 
-def add_history_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[str, TimestampMS, FVal, Optional[dict]]]) -> None:  # noqa: E501
+def add_history_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[str, TimestampMS, FVal, dict | None]]) -> None:  # noqa: E501
     """Helper function to create HistoryEvent fixtures"""
     with db.db.user_write() as write_cursor:
         for entry in data.values():
@@ -115,7 +115,7 @@ def add_history_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[str, Tim
             )
 
 
-def add_evm_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[EVMTxHash, TimestampMS, FVal, str, EvmProduct, str, Optional[dict]]]) -> None:  # noqa: E501
+def add_evm_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[EVMTxHash, TimestampMS, FVal, str, EvmProduct, str, dict | None]]) -> None:  # noqa: E501
     """Helper function to create EvmEvent fixtures"""
     with db.db.user_write() as write_cursor:
         for entry in data.values():
@@ -138,7 +138,7 @@ def add_evm_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[EVMTxHash, T
             )
 
 
-def add_eth2_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[EVMTxHash, TimestampMS, FVal, str, Optional[dict]]]) -> None:  # noqa: E501
+def add_eth2_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[EVMTxHash, TimestampMS, FVal, str, dict | None]]) -> None:  # noqa: E501
     """Helper function to create fixtures for various Beacon chain staking events"""
     with db.db.user_write() as write_cursor:
         for entry in data.values():
@@ -243,7 +243,7 @@ def test_read_write_customized_events_from_db(database: DBHandler) -> None:
 
     filter_query_args: list[
         tuple[
-            type[Union[HistoryEventFilterQuery, EvmEventFilterQuery, EthDepositEventFilterQuery]],
+            type[HistoryEventFilterQuery | (EvmEventFilterQuery | EthDepositEventFilterQuery)],
             dict[str, Any],
         ]
     ] = [

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -5,7 +5,6 @@ import sys
 from collections import defaultdict
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -73,7 +72,7 @@ def fixture_should_mock_price_queries():
 
 
 @pytest.fixture()
-def default_mock_price_value() -> Optional[FVal]:
+def default_mock_price_value() -> FVal | None:
     """Determines test behavior If a mock price is not found
 
     If it's None, then test fails with an error. If it is any other
@@ -167,7 +166,7 @@ def fixture_accountant(
         latest_accounting_rules,
         accountant_without_rules,
         use_dummy_pot,
-) -> Optional[Accountant]:
+) -> Accountant | None:
     if not start_with_logged_in_user:
         return None
 
@@ -224,7 +223,7 @@ def fixture_should_mock_current_price_queries():
 
 
 @pytest.fixture(name='ignore_mocked_prices_for')
-def fixture_ignore_mocked_prices_for() -> Optional[list[str]]:
+def fixture_ignore_mocked_prices_for() -> list[str] | None:
     """An optional list of asset identifiers to ignore mocking for"""
     return None
 

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from contextlib import ExitStack
-from typing import Literal, Optional, Union
+from typing import Literal
 from unittest.mock import patch
 
 import pytest
@@ -206,7 +206,7 @@ def fixture_blockchain_accounts(
 
 
 @pytest.fixture(name='ethrpc_endpoint')
-def fixture_ethrpc_endpoint() -> Optional[str]:
+def fixture_ethrpc_endpoint() -> str | None:
     return None
 
 
@@ -216,7 +216,7 @@ def fixture_covalent_avalanche(messages_aggregator, database):
 
 
 @pytest.fixture(name='ethereum_manager_connect_at_start')
-def fixture_ethereum_manager_connect_at_start() -> Union[Literal['DEFAULT'], Sequence[NodeName]]:
+def fixture_ethereum_manager_connect_at_start() -> Literal['DEFAULT'] | Sequence[NodeName]:
     """A sequence of nodes to connect to at the start of the test.
 
     Can be either a sequence of nodes to connect to for this chain.
@@ -322,7 +322,7 @@ def fixture_eth_transactions(
 
 
 @pytest.fixture(name='optimism_manager_connect_at_start')
-def fixture_optimism_manager_connect_at_start() -> Union[Literal['DEFAULT'], Sequence[NodeName]]:
+def fixture_optimism_manager_connect_at_start() -> Literal['DEFAULT'] | Sequence[NodeName]:
     """A sequence of nodes to connect to at the start of the test.
 
     Can be either a sequence of nodes to connect to for this chain.
@@ -385,7 +385,7 @@ def fixture_optimism_transaction_decoder(
 
 
 @pytest.fixture(name='polygon_pos_manager_connect_at_start')
-def fixture_polygon_pos_manager_connect_at_start() -> Union[Literal['DEFAULT'], Sequence[NodeName]]:  # noqa: E501
+def fixture_polygon_pos_manager_connect_at_start() -> Literal['DEFAULT'] | Sequence[NodeName]:
     """A sequence of nodes to connect to at the start of the test.
 
     Can be either a sequence of nodes to connect to for this chain.
@@ -422,7 +422,7 @@ def fixture_polygon_pos_manager(polygon_pos_inquirer):
 
 
 @pytest.fixture(name='arbitrum_one_manager_connect_at_start')
-def fixture_arbitrum_one_manager_connect_at_start() -> Union[Literal['DEFAULT'], Sequence[NodeName]]:  # noqa: E501
+def fixture_arbitrum_one_manager_connect_at_start() -> Literal['DEFAULT'] | Sequence[NodeName]:
     """A sequence of nodes to connect to at the start of the test.
 
     Can be either a sequence of nodes to connect to for this chain.
@@ -459,7 +459,7 @@ def fixture_arbitrum_one_manager(arbitrum_one_inquirer):
 
 
 @pytest.fixture(name='base_manager_connect_at_start')
-def fixture_base_manager_connect_at_start() -> Union[Literal['DEFAULT'], Sequence[NodeName]]:
+def fixture_base_manager_connect_at_start() -> Literal['DEFAULT'] | Sequence[NodeName]:
     """A sequence of nodes to connect to at the start of the test.
     Can be either a sequence of nodes to connect to for this chain.
     Or an empty sequence to connect to no nodes for this chain.
@@ -495,7 +495,7 @@ def fixture_base_manager(base_inquirer):
 
 
 @pytest.fixture(name='gnosis_manager_connect_at_start')
-def fixture_gnosis_manager_connect_at_start() -> Union[Literal['DEFAULT'], Sequence[NodeName]]:
+def fixture_gnosis_manager_connect_at_start() -> Literal['DEFAULT'] | Sequence[NodeName]:
     """A sequence of nodes to connect to at the start of the test.
     Can be either a sequence of nodes to connect to for this chain.
     Or an empty sequence to connect to no nodes for this chain.
@@ -542,12 +542,12 @@ def fixture_gnosis_transactions(
 
 
 @pytest.fixture(name='ksm_rpc_endpoint')
-def fixture_ksm_rpc_endpoint() -> Optional[str]:
+def fixture_ksm_rpc_endpoint() -> str | None:
     return None
 
 
 @pytest.fixture(name='dot_rpc_endpoint')
-def fixture_dot_rpc_endpoint() -> Optional[str]:
+def fixture_dot_rpc_endpoint() -> str | None:
     return None
 
 

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -3,7 +3,7 @@ import sys
 from collections.abc import Generator
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -34,7 +34,7 @@ def fixture_username():
 
 
 @pytest.fixture(name='ignored_assets')
-def fixture_ignored_assets() -> Optional[list[Asset]]:
+def fixture_ignored_assets() -> list[Asset] | None:
     return None
 
 
@@ -76,15 +76,15 @@ def _init_database(
         data_dir: Path,
         password: str,
         msg_aggregator: MessagesAggregator,
-        db_settings: Optional[dict[str, Any]],
-        ignored_assets: Optional[list[Asset]],
+        db_settings: dict[str, Any] | None,
+        ignored_assets: list[Asset] | None,
         blockchain_accounts: BlockchainAccounts,
         include_etherscan_key: bool,
         include_cryptocompare_key: bool,
         tags: list[dict[str, Any]],
         manually_tracked_balances: list[ManuallyTrackedBalance],
         data_migration_version: int,
-        use_custom_database: Optional[str],
+        use_custom_database: str | None,
         sql_vm_instructions_cb: int,
         perform_upgrades_at_unlock: bool,
 ) -> DBHandler:
@@ -139,7 +139,7 @@ def database(
         new_db_unlock_actions,
         sql_vm_instructions_cb,
         perform_upgrades_at_unlock,
-) -> Generator[Optional[DBHandler], None, None]:
+) -> Generator[DBHandler | None, None, None]:
     if not start_with_logged_in_user:
         yield None
     else:
@@ -167,10 +167,10 @@ def database(
 
 
 @pytest.fixture(name='db_settings')
-def fixture_db_settings() -> Optional[dict[str, Any]]:
+def fixture_db_settings() -> dict[str, Any] | None:
     return None
 
 
 @pytest.fixture(name='use_custom_database')
-def fixture_use_custom_database() -> Optional[str]:
+def fixture_use_custom_database() -> str | None:
     return None

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
 from shutil import copyfile
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -29,7 +30,7 @@ def fixture_generatable_user_ethereum_tokens() -> bool:
 
 
 @pytest.fixture(name='user_ethereum_tokens')
-def fixture_user_ethereum_tokens() -> Optional[Union[list[EvmToken], Callable]]:
+def fixture_user_ethereum_tokens() -> list[EvmToken] | Callable | None:
     return None
 
 
@@ -161,7 +162,7 @@ def fixture_globaldb(
 
 
 @pytest.fixture(name='custom_globaldb')
-def fixture_custom_globaldb() -> Optional[int]:
+def fixture_custom_globaldb() -> int | None:
     return None
 
 

--- a/rotkehlchen/tests/fixtures/google.py
+++ b/rotkehlchen/tests/fixtures/google.py
@@ -4,7 +4,7 @@ import warnings as test_warnings
 from collections.abc import Generator
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from google.oauth2.service_account import Credentials
@@ -179,7 +179,7 @@ class GoogleService:
 
 
 @pytest.fixture(scope='session', name='session_google_service')
-def fixture_session_google_service() -> Generator[Optional[GoogleService], None, None]:
+def fixture_session_google_service() -> Generator[GoogleService | None, None, None]:
     service = None
     credentials_file_path = os.environ.get('GOOGLE_CREDENTIALS_FILE', None)
     if credentials_file_path is None:
@@ -210,7 +210,7 @@ def fixture_upload_csv_to_google() -> bool:
 
 
 @pytest.fixture(name='google_service')
-def fixture_google_service(session_google_service, upload_csv_to_google) -> Optional[GoogleService]:  # noqa: E501
+def fixture_google_service(session_google_service, upload_csv_to_google) -> GoogleService | None:
     if session_google_service is None:
         return None
 

--- a/rotkehlchen/tests/fixtures/messages.py
+++ b/rotkehlchen/tests/fixtures/messages.py
@@ -1,4 +1,4 @@
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, NamedTuple
 import pytest
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 
@@ -7,7 +7,7 @@ from rotkehlchen.user_messages import MessagesAggregator
 
 class MockedWsMessage(NamedTuple):
     type: WSMessageType
-    data: Union[dict[str, Any], list[Any]]
+    data: dict[str, Any] | list[Any]
 
 
 class MockRotkiNotifier:
@@ -17,12 +17,12 @@ class MockRotkiNotifier:
     def broadcast(  # pylint: disable=unused-argument
             self,
             message_type: 'WSMessageType',
-            to_send_data: Union[dict[str, Any], list[Any]],
+            to_send_data: dict[str, Any] | list[Any],
             **kwargs: Any,
     ) -> None:
         self.messages.append(MockedWsMessage(type=message_type, data=to_send_data))
 
-    def pop_message(self) -> Optional[MockedWsMessage]:
+    def pop_message(self) -> MockedWsMessage | None:
         if len(self.messages) == 0:
             return None
 

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -1,7 +1,6 @@
 import base64
 import json
 from contextlib import ExitStack
-from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -282,7 +281,7 @@ def initialize_mock_rotkehlchen_instance(
             password: str,
             create_new: bool,
             resume_from_backup: bool,
-            initial_settings: Optional[ModifiableDBSettings] = None,
+            initial_settings: ModifiableDBSettings | None = None,
     ):
         """This is an augmented_unlock for the tests where after the original data.unlock
         happening in the start of rotkehlchen.unlock_user() we also add various fixture data

--- a/rotkehlchen/tests/unit/accounting/test_default_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_default_settings.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 from more_itertools import peekable
@@ -100,7 +100,7 @@ def _gain_one_ether(
         entry_type: Literal['history_event', 'evm_event'] = 'evm_event',
 ) -> None:
     """Helper function to gain 1 ETH, so that spending events have something to spend"""
-    event_class: type[Union[HistoryEvent, EvmEvent]]
+    event_class: type[HistoryEvent | EvmEvent]
     kwargs: dict[str, Any]
     if entry_type == 'history_event':
         event_class = HistoryEvent
@@ -214,7 +214,7 @@ def test_accounting_spend_settings(
         event_type: 'HistoryEventType',
         event_subtype: 'HistoryEventSubType',
         is_taxable: bool,
-        counterparty: Optional[str],
+        counterparty: str | None,
         include_crypto2crypto,
 ):
     _gain_one_ether(events_accountant=accounting_pot.events_accountant)

--- a/rotkehlchen/tests/unit/globaldb/test_asset_updates.py
+++ b/rotkehlchen/tests/unit/globaldb/test_asset_updates.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -332,7 +331,7 @@ def mock_github_assets_response(url, timeout):  # pylint: disable=unused-argumen
 def test_parse_full_insert_assets(
         assets_updater: AssetsUpdater,
         text: str,
-        expected_data: Optional[AssetData],
+        expected_data: AssetData | None,
         error_msg: str,
 ) -> None:
     text = text.replace('\n', '')

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -239,19 +239,19 @@ def test_native_token_balance(blockchain, polygon_pos_accounts):
         balances = blockchain.balances.polygon_pos[address].assets
         assert balances == {
             A_POLYGON_POS_MATIC: Balance(
-                amount=FVal('16.942897779121303751'),
-                usd_value=FVal('25.4143466686819556265'),
-            ),
-            Asset('eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'): Balance(  # USDC
-                amount=FVal('9.982'),
-                usd_value=FVal('14.9730'),
+                amount=FVal('14.625551850495690815'),
+                usd_value=FVal('21.9383277757435362225'),
             ),
             Asset('eip155:137/erc20:0x625E7708f30cA75bfd92586e17077590C60eb4cD'): Balance(  # aPolUSDC  # noqa: E501
-                amount=FVal('20.017082'),
-                usd_value=FVal('30.0256230'),
+                amount=FVal('20.299941'),
+                usd_value=FVal('30.4499115'),
             ),
             Asset('eip155:137/erc20:0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'): Balance(  # WETH
-                amount=FVal('0.009792189476215069'),
-                usd_value=FVal('0.0146882842143226035'),
+                amount=FVal('0.010320301779068381'),
+                usd_value=FVal('0.0154804526686025715'),
+            ),
+            Asset('eip155:137/erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F'): Balance(  # USDT
+                amount=FVal('0.076457'),
+                usd_value=FVal('0.1146855'),
             ),
         }

--- a/rotkehlchen/tests/unit/test_cost_basis.py
+++ b/rotkehlchen/tests/unit/test_cost_basis.py
@@ -1164,7 +1164,7 @@ def test_fees(accountant: 'Accountant', expected_pnls: list[FVal]):
         end_ts=Timestamp(1677593077),
         history_list=history,  # type: ignore[arg-type]  # invariant problem
     )
-    for event, expected_pnl in zip(accountant.pots[0].processed_events, expected_pnls):
+    for event, expected_pnl in zip(accountant.pots[0].processed_events, expected_pnls, strict=True):  # noqa: E501
         assert event.pnl.taxable == expected_pnl
 
 

--- a/rotkehlchen/tests/unit/test_data_updates.py
+++ b/rotkehlchen/tests/unit/test_data_updates.py
@@ -1,11 +1,11 @@
 import json
+from collections.abc import Callable
 from contextlib import ExitStack
-from typing import Callable, Optional
 from unittest.mock import patch
 
 import pytest
-from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 
+from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.db.accounting_rules import DBAccountingRules
@@ -183,7 +183,7 @@ def make_single_mock_github_data_response(target: UpdateType):
     return mock_github_data_response
 
 
-def make_mock_github_response(latest: int, min_version: Optional[str] = None, max_version: Optional[str] = None) -> Callable:  # noqa: E501
+def make_mock_github_response(latest: int, min_version: str | None = None, max_version: str | None = None) -> Callable:  # noqa: E501
     """Creates a mocking function for all update types for github requests."""
     def mock_github_response(url, timeout):  # pylint: disable=unused-argument
         if 'info' in url:

--- a/rotkehlchen/tests/unit/test_evm_names.py
+++ b/rotkehlchen/tests/unit/test_evm_names.py
@@ -1,7 +1,7 @@
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import pytest
@@ -62,7 +62,7 @@ def test_get_name_of_lowest_prio_name_source(
     the name with the last priority
     """
     prioritizer = NamePrioritizer(Mock())
-    fetchers: Mapping[AddressNameSource, Optional[str]] = {
+    fetchers: Mapping[AddressNameSource, str | None] = {
         'blockchain_account': None,
         'ens_names': None,
         'global_addressbook': 'global addressbook label',
@@ -80,11 +80,11 @@ def test_get_name_of_lowest_prio_name_source(
 
 
 def get_fetchers_with_names(
-        fetchers_to_name: Mapping[AddressNameSource, Optional[str]],
+        fetchers_to_name: Mapping[AddressNameSource, str | None],
 ) -> dict[AddressNameSource, FetcherFunc]:
     fetchers: dict[AddressNameSource, FetcherFunc] = {}
     for source_id, returned_name in fetchers_to_name.items():
-        def make_fetcher(label: Optional[str]) -> FetcherFunc:
+        def make_fetcher(label: str | None) -> FetcherFunc:
             return lambda db, chain_address: label
 
         fetchers[source_id] = make_fetcher(returned_name)

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -93,7 +93,7 @@ def test_fiat_to_fiat(
             from_fiat_currency: 'FiatAsset',
             to_fiat_currency: 'FiatAsset',
             timestamp: Timestamp,
-    ) -> Optional[Price]:
+    ) -> Price | None:
         """
         Mock query for price checking that the assets are the expected and so is
         the timestamp queried.

--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any
 
 import gevent
 import psutil
@@ -18,7 +18,7 @@ else:
 
 
 def _wait_for_listening_port(
-        port_number: int, tries: int = 10, sleep: float = 0.1, pid: Optional[int] = None,
+        port_number: int, tries: int = 10, sleep: float = 0.1, pid: int | None = None,
 ) -> None:
     if pid is None:
         pid = os.getpid()
@@ -60,8 +60,8 @@ def api_url_for(api_server: APIServer, endpoint: str, **kwargs) -> str:
 
 
 def assert_proper_response(
-        response: Optional[requests.Response],
-        status_code: Optional[HTTPStatus] = HTTPStatus.OK,
+        response: requests.Response | None,
+        status_code: HTTPStatus | None = HTTPStatus.OK,
 ) -> None:
     assert (
         response is not None and
@@ -79,8 +79,8 @@ def assert_simple_ok_response(response: requests.Response) -> None:
 
 
 def assert_proper_response_with_result(
-        response: Optional[requests.Response],
-        message: Optional[str] = None,
+        response: requests.Response | None,
+        message: str | None = None,
         status_code: HTTPStatus = HTTPStatus.OK,
 ) -> Any:
     assert_proper_response(response, status_code)
@@ -95,8 +95,8 @@ def assert_proper_response_with_result(
 
 def _check_error_response_properties(
         response_data: dict[str, Any],
-        contained_in_msg: Optional[Union[str, list[str]]],
-        status_code: Optional[HTTPStatus],
+        contained_in_msg: str | list[str] | None,
+        status_code: HTTPStatus | None,
         result_exists: bool,
 ):
     if status_code != HTTPStatus.INTERNAL_SERVER_ERROR:
@@ -113,8 +113,8 @@ def _check_error_response_properties(
 
 
 def assert_error_response(
-        response: Optional[requests.Response],
-        contained_in_msg: Optional[Union[str, list[str]]] = None,
+        response: requests.Response | None,
+        contained_in_msg: str | list[str] | None = None,
         status_code: HTTPStatus = HTTPStatus.BAD_REQUEST,
         result_exists: bool = False,
 ):
@@ -132,9 +132,9 @@ def assert_error_response(
 
 
 def assert_error_async_response(
-        response_data: Optional[dict[str, Any]],
-        contained_in_msg: Optional[Union[str, list[str]]] = None,
-        status_code: Optional[HTTPStatus] = HTTPStatus.BAD_REQUEST,
+        response_data: dict[str, Any] | None,
+        contained_in_msg: str | list[str] | None = None,
+        status_code: HTTPStatus | None = HTTPStatus.BAD_REQUEST,
         result_exists: bool = False,
 ):
     assert response_data is not None and response_data.get('status_code') == status_code

--- a/rotkehlchen/tests/utils/args.py
+++ b/rotkehlchen/tests/utils/args.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from rotkehlchen.constants.misc import (
     DEFAULT_MAX_LOG_BACKUP_FILES,
@@ -8,10 +8,10 @@ from rotkehlchen.constants.misc import (
 
 
 class ConfigurationArgs(NamedTuple):
-    data_dir: Optional[str]
-    ethrpc_endpoint: Optional[str]
-    logfile: Optional[str]
-    logtarget: Optional[str]
+    data_dir: str | None
+    ethrpc_endpoint: str | None
+    logfile: str | None
+    logtarget: str | None
     loglevel: str
     logfromothermodules: bool
     max_size_in_mb_all_logs: int = DEFAULT_MAX_LOG_SIZE_IN_MB
@@ -20,8 +20,8 @@ class ConfigurationArgs(NamedTuple):
 
 
 def default_args(
-        data_dir: Optional[str] = None,
-        ethrpc_endpoint: Optional[str] = None,
+        data_dir: str | None = None,
+        ethrpc_endpoint: str | None = None,
         max_size_in_mb_all_logs: int = DEFAULT_MAX_LOG_SIZE_IN_MB,
         loglevel: str = 'debug',
 ):

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -347,6 +347,10 @@ def mock_etherscan_query(
             else:
                 raise AssertionError('Unknown multicall in mocked tests')
 
+            if '86f25b64e1fe4c5162cdeed5245575d32ec549db' in url:
+                # can appear mixed with above so multibalance can trump the rest since actionable
+                multicall_purpose = 'multibalance_query'
+
             if 'data=0x252dba42' in url:  # aggregate
                 data = url.split('data=')[1]
                 if '&apikey' in data:

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from web3 import Web3
@@ -87,7 +87,7 @@ def assert_eth_balances_result(
         eth_balances: list[str],
         token_balances: dict[EvmToken, list[str]],
         also_btc: bool,
-        expected_liabilities: Optional[dict[EvmToken, list[str]]] = None,
+        expected_liabilities: dict[EvmToken, list[str]] | None = None,
         totals_only: bool = False,
 ) -> None:
     """Asserts for correct ETH blockchain balances when mocked in tests
@@ -165,7 +165,7 @@ def assert_eth_balances_result(
             assert FVal(totals[symbol]['usd_value']) > ZERO
 
 
-def _get_token(value: Any) -> Optional[EvmToken]:
+def _get_token(value: Any) -> EvmToken | None:
     """Interprets the given value as token if possible"""
     if isinstance(value, str):
         try:
@@ -188,7 +188,7 @@ def _get_token(value: Any) -> Optional[EvmToken]:
 
 def mock_beaconchain(
         beaconchain: BeaconChain,
-        original_queries: Optional[list[str]],
+        original_queries: list[str] | None,
         original_requests_get,
 ):
 
@@ -207,11 +207,11 @@ def mock_beaconchain(
 
 
 def mock_etherscan_query(
-        eth_map: dict[ChecksumEvmAddress, dict[Union[str, EvmToken], Any]],
+        eth_map: dict[ChecksumEvmAddress, dict[str | EvmToken, Any]],
         etherscan: Etherscan,
         ethereum: 'EthereumInquirer',
-        original_queries: Optional[list[str]],
-        extra_flags: Optional[list[str]],
+        original_queries: list[str] | None,
+        extra_flags: list[str] | None,
         original_requests_get,
 ):
     eth_scan = ethereum.contracts.contract(string_to_evm_address('0x86F25b64e1Fe4C5162cDEeD5245575D32eC549db'))  # noqa: E501
@@ -612,12 +612,12 @@ def setup_evm_addresses_activity_mock(
         chains_aggregator: 'ChainsAggregator',
         eth_contract_addresses: list[ChecksumEvmAddress],
         ethereum_addresses: list[ChecksumEvmAddress],  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
-        avalanche_addresses: Optional[list[ChecksumEvmAddress]] = None,
-        optimism_addresses: Optional[list[ChecksumEvmAddress]] = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
-        polygon_pos_addresses: Optional[list[ChecksumEvmAddress]] = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
-        arbitrum_one_addresses: Optional[list[ChecksumEvmAddress]] = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
-        base_addresses: Optional[list[ChecksumEvmAddress]] = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
-        gnosis_addresses: Optional[list[ChecksumEvmAddress]] = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
+        avalanche_addresses: list[ChecksumEvmAddress] | None = None,
+        optimism_addresses: list[ChecksumEvmAddress] | None = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
+        polygon_pos_addresses: list[ChecksumEvmAddress] | None = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
+        arbitrum_one_addresses: list[ChecksumEvmAddress] | None = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
+        base_addresses: list[ChecksumEvmAddress] | None = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
+        gnosis_addresses: list[ChecksumEvmAddress] | None = None,  # pylint: disable=unused-argument  # used by the saved locals  # noqa: E501, RUF100
 ) -> 'ExitStack':
     saved_locals = locals()  # bit hacky, but save locals here so they can be accessed by mock_chain_has_activity  # noqa: E501
 
@@ -669,7 +669,7 @@ def setup_evm_addresses_activity_mock(
 def maybe_modify_rpc_nodes(
         database: 'DBHandler',
         blockchain: SupportedBlockchain,
-        manager_connect_at_start: Union[str, Sequence['WeightedNode']],
+        manager_connect_at_start: str | Sequence['WeightedNode'],
 ) -> Sequence['WeightedNode']:
     """Modify the rpc nodes in the DB for the given blockchain depending on
     the value of the managager_connect_at_start.

--- a/rotkehlchen/tests/utils/checks.py
+++ b/rotkehlchen/tests/utils/checks.py
@@ -1,5 +1,4 @@
 from contextlib import suppress
-from typing import Optional
 
 from rotkehlchen.fval import FVal
 
@@ -7,9 +6,9 @@ from rotkehlchen.fval import FVal
 def assert_serialized_lists_equal(
         a: list,
         b: list,
-        max_length_to_check: Optional[int] = None,
-        ignore_keys: Optional[list] = None,
-        length_list_keymap: Optional[dict] = None,
+        max_length_to_check: int | None = None,
+        ignore_keys: list | None = None,
+        length_list_keymap: dict | None = None,
         max_diff: str = '1e-6',
 ) -> None:
     """Compares lists of serialized dicts"""
@@ -37,8 +36,8 @@ def assert_serialized_lists_equal(
 def assert_serialized_dicts_equal(
         a: dict,
         b: dict,
-        ignore_keys: Optional[list] = None,
-        length_list_keymap: Optional[dict] = None,
+        ignore_keys: list | None = None,
+        length_list_keymap: dict | None = None,
         max_diff: str = '1e-6',
         same_key_length=True,
 ) -> None:

--- a/rotkehlchen/tests/utils/database.py
+++ b/rotkehlchen/tests/utils/database.py
@@ -3,7 +3,7 @@ import random
 from dataclasses import asdict
 from pathlib import Path
 from shutil import copyfile
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import _patch, patch
 
 from pysqlcipher3 import dbapi2 as sqlcipher
@@ -97,9 +97,9 @@ def add_blockchain_accounts_to_db(db: DBHandler, blockchain_accounts: Blockchain
 
 def add_settings_to_test_db(
         db: DBHandler,
-        db_settings: Optional[dict[str, Any]],
-        ignored_assets: Optional[list[Asset]],
-        data_migration_version: Optional[int],
+        db_settings: dict[str, Any] | None,
+        ignored_assets: list[Asset] | None,
+        data_migration_version: int | None,
 ) -> None:
     settings = {
         # DO not submit usage analytics during tests

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -2071,7 +2071,7 @@ def assert_rotki_generic_events_import_results(rotki: Rotkehlchen):
     assert len(expected_history_events) == 5
     assert len(warnings) == 3
     assert warnings == expected_warnings
-    for actual, expected in zip(history_events, expected_history_events):
+    for actual, expected in zip(history_events, expected_history_events, strict=True):
         assert_is_equal_history_event(actual=actual, expected=expected)
 
 
@@ -2194,7 +2194,7 @@ def assert_bitcoin_tax_trades_import_results(
             )
         assert len(history_events) == 6
         assert len(expected_history_events) == 6
-        for actual, expected in zip(history_events, expected_history_events):
+        for actual, expected in zip(history_events, expected_history_events, strict=True):
             assert_is_equal_history_event(actual=actual, expected=expected)
 
     elif csv_file_name == 'bitcoin_tax_spending.csv':
@@ -2227,7 +2227,7 @@ def assert_bitcoin_tax_trades_import_results(
         assert len(history_events) == 7  # events from trades import + 1
         assert len(expected_history_events) == 1
         history_events = history_events[6:]  # only check the last event
-        for actual, expected in zip(history_events, expected_history_events):
+        for actual, expected in zip(history_events, expected_history_events, strict=True):
             assert_is_equal_history_event(actual=actual, expected=expected)
 
     else:
@@ -2328,5 +2328,5 @@ def assert_bitstamp_trades_import_results(rotki: Rotkehlchen):
         ),
     ]
 
-    for actual, expected in zip(history_events, expected_history_events):
+    for actual, expected in zip(history_events, expected_history_events, strict=True):
         assert_is_equal_history_event(actual=actual, expected=expected)

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import random
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import gevent
 
@@ -406,7 +406,7 @@ def get_decoded_events_of_transaction(
         evm_inquirer: 'EvmNodeInquirer',
         database: DBHandler,
         tx_hash: EVMTxHash,
-        transactions: Optional[EvmTransactions] = None,
+        transactions: EvmTransactions | None = None,
 ) -> tuple[list['EvmEvent'], EVMTransactionDecoder]:
     """A convenience function to ask get transaction, receipt and decoded event for a tx_hash
 

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -602,8 +602,8 @@ def create_test_binance(
 def create_test_bitfinex(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
-        api_key: Optional[ApiKey] = None,
-        secret: Optional[ApiSecret] = None,
+        api_key: ApiKey | None = None,
+        secret: ApiSecret | None = None,
 ) -> Bitfinex:
     if api_key is None:
         api_key = make_api_key()
@@ -638,8 +638,8 @@ def create_test_bitmex(
 def create_test_bitstamp(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
-        api_key: Optional[ApiKey] = None,
-        secret: Optional[ApiSecret] = None,
+        api_key: ApiKey | None = None,
+        secret: ApiSecret | None = None,
 ) -> Bitstamp:
     if api_key is None:
         api_key = make_api_key()
@@ -719,9 +719,9 @@ def create_test_kraken(
 def create_test_kucoin(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
-        api_key: Optional[ApiKey] = None,
-        secret: Optional[ApiSecret] = None,
-        passphrase: Optional[str] = None,
+        api_key: ApiKey | None = None,
+        secret: ApiSecret | None = None,
+        passphrase: str | None = None,
 ) -> Kucoin:
     if api_key is None:
         api_key = make_api_key()
@@ -795,8 +795,8 @@ def create_test_independentreserve(
 def create_test_bitpanda(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
-        api_key: Optional[ApiKey] = None,
-        secret: Optional[ApiSecret] = None,
+        api_key: ApiKey | None = None,
+        secret: ApiSecret | None = None,
 ) -> Bitpanda:
     if api_key is None:
         api_key = make_api_key()
@@ -831,8 +831,8 @@ def create_test_okx(
 def create_test_woo(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
-        api_key: Optional[ApiKey] = None,
-        secret: Optional[ApiSecret] = None,
+        api_key: ApiKey | None = None,
+        secret: ApiSecret | None = None,
 ) -> Woo:
     return Woo(
         name='woo',
@@ -846,7 +846,7 @@ def create_test_woo(
 def try_get_first_exchange(
         exchange_manager: ExchangeManager,
         location: Location,
-) -> Optional[ExchangeInterface]:
+) -> ExchangeInterface | None:
     """Tries to get the first exchange of a given type from the exchange manager
 
     If no such exchange exists returns None.

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -1,7 +1,7 @@
 import base64
 import random
 import string
-from typing import Any, Optional
+from typing import Any
 
 from eth_utils.address import to_checksum_address
 
@@ -56,8 +56,8 @@ def make_random_positive_fval(max_num: int = 1000000) -> FVal:
 
 
 def make_random_timestamp(
-        start: Optional[Timestamp] = DEFAULT_START_TS,
-        end: Optional[Timestamp] = None,
+        start: Timestamp | None = DEFAULT_START_TS,
+        end: Timestamp | None = None,
 ) -> Timestamp:
     if end is None:
         end = ts_now()
@@ -83,8 +83,8 @@ def make_evm_tx_hash() -> EVMTxHash:
 
 
 def make_ethereum_transaction(
-        tx_hash: Optional[bytes] = None,
-        timestamp: Optional[Timestamp] = None,
+        tx_hash: bytes | None = None,
+        timestamp: Timestamp | None = None,
 ) -> EvmTransaction:
     if tx_hash is None:
         tx_hash = make_random_bytes(42)
@@ -123,15 +123,15 @@ CUSTOM_USDT = EvmToken.initialize(
 
 def make_ethereum_event(
         index: int,
-        tx_hash: Optional[bytes] = None,
-        location_label: Optional[str] = None,
+        tx_hash: bytes | None = None,
+        location_label: str | None = None,
         asset: CryptoAsset = CUSTOM_USDT,
-        counterparty: Optional[str] = None,
+        counterparty: str | None = None,
         event_type: HistoryEventType = HistoryEventType.INFORMATIONAL,
         event_subtype: HistoryEventSubType = HistoryEventSubType.NONE,
         timestamp: TimestampMS = ZERO_TIMESTAMP_MS,
-        address: Optional[ChecksumEvmAddress] = None,
-        product: Optional[EvmProduct] = None,
+        address: ChecksumEvmAddress | None = None,
+        product: EvmProduct | None = None,
 ) -> EvmEvent:
     if tx_hash is None:
         tx_hash = make_random_bytes(32)

--- a/rotkehlchen/tests/utils/globaldb.py
+++ b/rotkehlchen/tests/utils/globaldb.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from contextlib import ExitStack
 from copy import deepcopy
-from typing import Literal, Optional, Union
+from typing import Literal
 from unittest.mock import patch
 
 from rotkehlchen.assets.asset import EvmToken, UnderlyingToken
@@ -114,9 +114,9 @@ def patch_for_globaldb_migrations(stack: ExitStack, new_list: list) -> ExitStack
 
 def globaldb_get_general_cache_last_queried_ts(
         cursor: DBCursor,
-        key_parts: Iterable[Union[str, CacheType]],
+        key_parts: Iterable[str | CacheType],
         value: str,
-) -> Optional[Timestamp]:
+) -> Timestamp | None:
     """Function to get timestamp at which pair key - value was queried last time."""
     cache_key = compute_cache_key(key_parts)
     cursor.execute(

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from unittest.mock import _patch, patch
 
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin
@@ -271,7 +271,7 @@ def check_result_of_history_creation_for_remote_errors(  # type: ignore[return] 
         start_ts: Timestamp,  # pylint: disable=unused-argument
         end_ts: Timestamp,  # pylint: disable=unused-argument
         events: list[AccountingEventMixin],
-) -> Optional[int]:
+) -> int | None:
     assert len(events) == 0
 
 
@@ -590,7 +590,7 @@ def assert_asset_movements(
         expected: list[AssetMovement],
         to_check_list: list[Any],
         deserialized: bool,
-        movements_to_check: Optional[tuple[int, ...]] = None,
+        movements_to_check: tuple[int, ...] | None = None,
 ) -> None:
     if deserialized:
         expected = process_result_list([x.serialize() for x in expected])
@@ -606,7 +606,7 @@ def assert_asset_movements(
 def assert_poloniex_asset_movements(
         to_check_list: list[Any],
         deserialized: bool,
-        movements_to_check: Optional[tuple[int, ...]] = None,
+        movements_to_check: tuple[int, ...] | None = None,
 ) -> None:
     expected = [AssetMovement(
         location=Location.POLONIEX,
@@ -659,7 +659,7 @@ def assert_poloniex_asset_movements(
 def assert_kraken_asset_movements(
         to_check_list: list[Any],
         deserialized: bool,
-        movements_to_check: Optional[tuple[int, ...]] = None,
+        movements_to_check: tuple[int, ...] | None = None,
 ):
     expected = [
         AssetMovement(
@@ -738,8 +738,8 @@ def mock_history_processing(
         rotki: Rotkehlchen,
         should_mock_history_processing: bool = True,
         remote_errors: bool = False,
-        history_start_ts: Optional[Timestamp] = None,
-        history_end_ts: Optional[Timestamp] = None,
+        history_start_ts: Timestamp | None = None,
+        history_end_ts: Timestamp | None = None,
 ):
     """ Patch away the processing of history """
     if remote_errors is True and should_mock_history_processing is False:
@@ -752,7 +752,7 @@ def mock_history_processing(
             start_ts: Timestamp,
             end_ts: Timestamp,
             events: list[AccountingEventMixin],
-    ) -> Optional[int]:
+    ) -> int | None:
         """This function offers some simple assertions on the result of the
         created history. The entire processing part of the history is mocked
         away by this checking function"""
@@ -868,7 +868,7 @@ def mock_history_processing(
             start_ts: Timestamp,
             end_ts: Timestamp,
             events: list[AccountingEventMixin],
-    ) -> Optional[int]:
+    ) -> int | None:
         """Checks results of history creation but also proceeds to normal history processing"""
         check_result_of_history_creation(
             start_ts=start_ts,
@@ -963,8 +963,8 @@ class TradesTestSetup(NamedTuple):
 def mock_history_processing_and_exchanges(
         rotki: Rotkehlchen,
         should_mock_history_processing: bool = True,
-        history_start_ts: Optional[Timestamp] = None,
-        history_end_ts: Optional[Timestamp] = None,
+        history_start_ts: Timestamp | None = None,
+        history_end_ts: Timestamp | None = None,
         remote_errors: bool = False,
 ) -> TradesTestSetup:
     """Prepare patches to mock querying of trade history from various locations for testing
@@ -1003,8 +1003,8 @@ def mock_history_processing_and_exchanges(
 def prepare_rotki_for_history_processing_test(
         rotki: Rotkehlchen,
         should_mock_history_processing: bool = True,
-        history_start_ts: Optional[Timestamp] = None,
-        history_end_ts: Optional[Timestamp] = None,
+        history_start_ts: Timestamp | None = None,
+        history_end_ts: Timestamp | None = None,
         remote_errors: bool = False,
 ) -> TradesTestSetup:
     """Prepares rotki for the history processing tests
@@ -1028,7 +1028,7 @@ def prepare_rotki_for_history_processing_test(
 
 def assert_binance_trades_result(
         trades: list[dict[str, Any]],
-        trades_to_check: Optional[tuple[int, ...]] = None,
+        trades_to_check: tuple[int, ...] | None = None,
 ) -> None:
     """Convenience function to assert on the trades returned by binance's mock
 
@@ -1079,7 +1079,7 @@ def assert_binance_trades_result(
 
 def assert_poloniex_trades_result(
         trades: list[dict[str, Any]],
-        trades_to_check: Optional[tuple[int, ...]] = None,
+        trades_to_check: tuple[int, ...] | None = None,
 ) -> None:
     """Convenience function to assert on the trades returned by poloniex's mock
 
@@ -1145,9 +1145,9 @@ def maybe_mock_historical_price_queries(
         historian,
         should_mock_price_queries: bool,
         mocked_price_queries,
-        default_mock_value: Optional[FVal] = None,
-        dont_mock_price_for: Optional[list['Asset']] = None,
-        force_no_price_found_for: Optional[list[tuple['Asset', Timestamp]]] = None,
+        default_mock_value: FVal | None = None,
+        dont_mock_price_for: list['Asset'] | None = None,
+        force_no_price_found_for: list[tuple['Asset', Timestamp]] | None = None,
 ) -> None:
     """If needed will make sure the historian's price queries are mocked"""
     if not should_mock_price_queries:

--- a/rotkehlchen/tests/utils/kraken.py
+++ b/rotkehlchen/tests/utils/kraken.py
@@ -1,7 +1,7 @@
 import json
 import random
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from rotkehlchen.assets.converters import KRAKEN_TO_WORLD
 from rotkehlchen.assets.exchanges_mappings.kraken import WORLD_TO_KRAKEN
@@ -346,15 +346,15 @@ def generate_random_kraken_id() -> str:
 
 def create_kraken_trade(
         tradeable_pairs: list[str],
-        base_asset: Optional[str] = None,
-        quote_asset: Optional[str] = None,
-        time: Optional[Timestamp] = None,
-        start_ts: Optional[Timestamp] = None,
-        end_ts: Optional[Timestamp] = None,
-        trade_type: Optional[TradeType] = None,
-        rate: Optional[FVal] = None,
-        amount: Optional[FVal] = None,
-        fee: Optional[FVal] = None,
+        base_asset: str | None = None,
+        quote_asset: str | None = None,
+        time: Timestamp | None = None,
+        start_ts: Timestamp | None = None,
+        end_ts: Timestamp | None = None,
+        trade_type: TradeType | None = None,
+        rate: FVal | None = None,
+        amount: FVal | None = None,
+        fee: FVal | None = None,
 ) -> dict[str, str]:
     trade = {}
     trade['ordertxid'] = str(generate_random_kraken_id())
@@ -499,10 +499,10 @@ class MockKraken(Kraken):
         with open(filepath, encoding='utf8') as f:
             return jsonloads_dict(f.read())
 
-    def online_api_query(self, method: str, req: Optional[dict] = None) -> dict:
+    def online_api_query(self, method: str, req: dict | None = None) -> dict:
         return super().api_query(method, req)
 
-    def api_query(self, method: str, req: Optional[dict] = None) -> dict:
+    def api_query(self, method: str, req: dict | None = None) -> dict:
         # Pretty ugly ... mock a kraken remote eror
         if self.remote_errors:
             raise RemoteError('Kraken remote error')

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 from unittest.mock import patch
 
 import requests
@@ -23,7 +23,7 @@ class MockResponse:
             status_code: int,
             text: str,
             content: Any = None,
-            headers: Optional[dict['str', Any]] = None,
+            headers: dict['str', Any] | None = None,
     ) -> None:
         self.status_code = status_code
         self.text = text

--- a/rotkehlchen/tests/utils/pnl_report.py
+++ b/rotkehlchen/tests/utils/pnl_report.py
@@ -1,6 +1,5 @@
 import random
 from contextlib import ExitStack
-from typing import Optional
 
 import requests
 
@@ -19,8 +18,8 @@ def query_api_create_and_get_report(
         start_ts: Timestamp,
         end_ts: Timestamp,
         prepare_mocks: bool,
-        events_offset: Optional[int] = None,
-        events_limit: Optional[int] = None,
+        events_offset: int | None = None,
+        events_limit: int | None = None,
         events_ascending_timestamp: bool = False,
 ):
     async_query = random.choice([False, True])

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -1,6 +1,6 @@
 import os
 from http import HTTPStatus
-from typing import Literal, Optional
+from typing import Literal
 from unittest.mock import patch
 
 from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
@@ -37,7 +37,7 @@ def mock_query_last_metadata(last_modify_ts, data_hash, data_size):
     return do_mock_query_last_metadata
 
 
-def mock_get_backup(saved_data: Optional[bytes]):
+def mock_get_backup(saved_data: bytes | None):
     def do_mock_get_backup(url, timeout, params, data=None):  # pylint: disable=unused-argument
         if data is not None:
             assert len(data) == 1
@@ -55,7 +55,7 @@ def create_patched_requests_get_for_premium(
         metadata_last_modify_ts=None,
         metadata_data_hash=None,
         metadata_data_size=None,
-        saved_data: Optional[bytes] = None,
+        saved_data: bytes | None = None,
         consider_authentication_invalid: bool = False,
 ):
     def mocked_get(url, *args, **kwargs):
@@ -89,10 +89,10 @@ def create_patched_premium(
         premium_credentials: PremiumCredentials,
         username: str,
         patch_get: bool,
-        metadata_last_modify_ts: Optional[Timestamp] = None,
-        metadata_data_hash: Optional[str] = None,
-        metadata_data_size: Optional[int] = None,
-        saved_data: Optional[bytes] = None,
+        metadata_last_modify_ts: Timestamp | None = None,
+        metadata_data_hash: str | None = None,
+        metadata_data_size: int | None = None,
+        saved_data: bytes | None = None,
         consider_authentication_invalid: bool = False,
 ):
     premium = Premium(credentials=premium_credentials, username=username)
@@ -136,7 +136,7 @@ def setup_starting_environment(
         newer_remote_db: bool,
         db_can_sync_setting: bool,
         premium_credentials: PremiumCredentials,
-        remote_data: Optional[bytes],
+        remote_data: bytes | None,
         sync_approval: Literal['yes', 'no', 'unknown'] = 'yes',
         sync_database: bool = True,
 ):
@@ -176,7 +176,7 @@ def setup_starting_environment(
         saved_data=remote_data,
     )
 
-    given_premium_credentials: Optional[PremiumCredentials]
+    given_premium_credentials: PremiumCredentials | None
     if first_time:
         given_premium_credentials = premium_credentials
         create_new = True

--- a/rotkehlchen/tests/utils/rotkehlchen.py
+++ b/rotkehlchen/tests/utils/rotkehlchen.py
@@ -1,5 +1,5 @@
 from contextlib import ExitStack
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, NamedTuple
 from unittest.mock import _patch, patch
 
 import requests
@@ -47,8 +47,8 @@ class BalancesTestSetup(NamedTuple):
     beaconchain_patch: _patch
     evmtokens_max_chunks_patch: _patch
     bitcoin_patch: _patch
-    defi_balances_addition_method_patch: Optional[_patch]
-    defichad_query_balances_patch: Optional[_patch]
+    defi_balances_addition_method_patch: _patch | None
+    defichad_query_balances_patch: _patch | None
 
     def enter_all_patches(self, stack: ExitStack):
         stack.enter_context(self.poloniex_patch)
@@ -74,18 +74,18 @@ class BalancesTestSetup(NamedTuple):
 
 def setup_balances(
         rotki,
-        ethereum_accounts: Optional[list[ChecksumEvmAddress]],
-        btc_accounts: Optional[list[BTCAddress]],
-        eth_balances: Optional[list[str]] = None,
-        token_balances: Optional[dict[EvmToken, list[str]]] = None,
+        ethereum_accounts: list[ChecksumEvmAddress] | None,
+        btc_accounts: list[BTCAddress] | None,
+        eth_balances: list[str] | None = None,
+        token_balances: dict[EvmToken, list[str]] | None = None,
         populate_detected_tokens: bool = True,
-        liabilities: Optional[dict[EvmToken, list[str]]] = None,
-        btc_balances: Optional[list[str]] = None,
-        manually_tracked_balances: Optional[list[ManuallyTrackedBalance]] = None,
-        manual_current_prices: Optional[list[tuple[Asset, Asset, Price]]] = None,
-        original_queries: Optional[list[str]] = None,
-        extra_flags: Optional[list[str]] = None,
-        defi_balances: Optional[dict[ChecksumEvmAddress, list[DefiProtocolBalances]]] = None,
+        liabilities: dict[EvmToken, list[str]] | None = None,
+        btc_balances: list[str] | None = None,
+        manually_tracked_balances: list[ManuallyTrackedBalance] | None = None,
+        manual_current_prices: list[tuple[Asset, Asset, Price]] | None = None,
+        original_queries: list[str] | None = None,
+        extra_flags: list[str] | None = None,
+        defi_balances: dict[ChecksumEvmAddress, list[DefiProtocolBalances]] | None = None,
 ) -> BalancesTestSetup:
     """Setup the blockchain, exchange and fiat balances for some tests
 
@@ -133,7 +133,7 @@ def setup_balances(
     else:
         btc_balances = []
 
-    eth_map: dict[ChecksumEvmAddress, dict[Union[str, EvmToken], Any]] = {}
+    eth_map: dict[ChecksumEvmAddress, dict[str | EvmToken, Any]] = {}
     with rotki.data.db.user_write() as write_cursor:
         for idx, acc in enumerate(ethereum_accounts):
             eth_map[acc] = {}

--- a/rotkehlchen/tests/utils/substrate.py
+++ b/rotkehlchen/tests/utils/substrate.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Sequence
-from typing import Optional
 
 import gevent
 import requests
@@ -49,7 +48,7 @@ KUSAMA_TEST_RPC_ENDPOINT = 'https://ksm.getblock.io/ae78eb1d-2643-4e22-b691-0ecb
 def attempt_connect_test_nodes(
         chain: SupportedBlockchain,
         timeout: int = NODE_CONNECTION_TIMEOUT,
-        node_names: Optional[Sequence[NodeName]] = None,
+        node_names: Sequence[NodeName] | None = None,
 ) -> DictNodeNameNodeAttributes:
     """Attempt to connect to either a default sequence of reliable nodes for
     testing (e.g. Parity ones) or to a custom ones (via `node_names` param).
@@ -57,7 +56,7 @@ def attempt_connect_test_nodes(
 
     NB: prioritising nodes by block_number is disabled.
     """
-    def attempt_connect_node(node: NodeName) -> tuple[NodeName, Optional[NodeNameAttributes]]:
+    def attempt_connect_node(node: NodeName) -> tuple[NodeName, NodeNameAttributes | None]:
         try:
             node_interface = SubstrateInterface(
                 url=node.endpoint(),

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -11,7 +11,6 @@ from typing import (
     NewType,
     Optional,
     TypeVar,
-    Union,
     get_args,
 )
 
@@ -171,7 +170,7 @@ T_EVMTxHash = HexBytes
 EVMTxHash = NewType('EVMTxHash', T_EVMTxHash)
 
 
-def deserialize_evm_tx_hash(val: Union[Web3HexBytes, bytearray, bytes, str]) -> EVMTxHash:
+def deserialize_evm_tx_hash(val: Web3HexBytes | (bytearray | (bytes | str))) -> EVMTxHash:
     """Super lightweight wrapper to forward arguments to HexBytes and return an EVMTxHash
 
     HexBytes constructor handles the deserialization from whatever is given as input.
@@ -190,27 +189,15 @@ BTCAddress = NewType('BTCAddress', T_BTCAddress)
 T_Eth2PubKey = str
 Eth2PubKey = NewType('Eth2PubKey', T_Eth2PubKey)
 
-BlockchainAddress = Union[
-    BTCAddress,
-    ChecksumEvmAddress,
-    SubstrateAddress,
-]
+BlockchainAddress = BTCAddress | ChecksumEvmAddress | SubstrateAddress
 AnyBlockchainAddress = TypeVar(
     'AnyBlockchainAddress',
     BTCAddress,
     ChecksumEvmAddress,
     SubstrateAddress,
 )
-ListOfBlockchainAddresses = Union[
-    list[BTCAddress],
-    list[ChecksumEvmAddress],
-    list[SubstrateAddress],
-]
-TuplesOfBlockchainAddresses = Union[
-    tuple[BTCAddress, ...],
-    tuple[ChecksumEvmAddress, ...],
-    tuple[SubstrateAddress, ...],
-]
+ListOfBlockchainAddresses = list[BTCAddress] | list[ChecksumEvmAddress] | list[SubstrateAddress]
+TuplesOfBlockchainAddresses = tuple[BTCAddress, ...] | tuple[ChecksumEvmAddress, ...] | tuple[SubstrateAddress, ...]  # noqa: E501
 
 
 T_Fee = FVal
@@ -338,7 +325,7 @@ class EvmTransaction:
     timestamp: Timestamp
     block_number: int
     from_address: ChecksumEvmAddress
-    to_address: Optional[ChecksumEvmAddress]
+    to_address: ChecksumEvmAddress | None
     value: int
     gas: int
     gas_price: int
@@ -392,7 +379,7 @@ class EvmInternalTransaction(NamedTuple):
     chain_id: ChainID
     trace_id: int
     from_address: ChecksumEvmAddress
-    to_address: Optional[ChecksumEvmAddress]
+    to_address: ChecksumEvmAddress | None
     value: int
 
     def serialize(self) -> dict[str, Any]:
@@ -422,7 +409,7 @@ class CovalentTransaction(NamedTuple):
     timestamp: Timestamp
     block_number: int
     from_address: ChecksumEvmAddress
-    to_address: Optional[ChecksumEvmAddress]
+    to_address: ChecksumEvmAddress | None
     value: int
     gas: int
     gas_price: int
@@ -794,9 +781,9 @@ EVM_LOCATIONS: tuple[EVM_LOCATIONS_TYPE_, ...] = typing.get_args(EVM_LOCATIONS_T
 
 class LocationDetails(NamedTuple):
     """Information about Location enum values to display them to the user"""
-    label: Optional[str] = None
-    icon: Optional[str] = None
-    image: Optional[str] = None
+    label: str | None = None
+    icon: str | None = None
+    image: str | None = None
 
     def serialize(self) -> dict[str, str]:
         data = {}
@@ -823,9 +810,9 @@ class ExchangeAuthCredentials(NamedTuple):
     If a certain field is not None, it is modified in the exchange, otherwise
     the current value is kept.
     """
-    api_key: Optional[ApiKey]
-    api_secret: Optional[ApiSecret]
-    passphrase: Optional[str]
+    api_key: ApiKey | None
+    api_secret: ApiSecret | None
+    passphrase: str | None
 
 
 class ExchangeApiCredentials(NamedTuple):
@@ -837,7 +824,7 @@ class ExchangeApiCredentials(NamedTuple):
     location: Location
     api_key: ApiKey
     api_secret: ApiSecret
-    passphrase: Optional[str] = None
+    passphrase: str | None = None
 
 
 EXTERNAL_EXCHANGES = (
@@ -889,16 +876,16 @@ class CostBasisMethod(SerializableEnumNameMixin):
 class AddressbookEntry(NamedTuple):
     address: ChecksumEvmAddress
     name: str
-    blockchain: Optional[SupportedBlockchain]
+    blockchain: SupportedBlockchain | None
 
-    def serialize(self) -> dict[str, Optional[str]]:
+    def serialize(self) -> dict[str, str | None]:
         return {
             'address': self.address,
             'name': self.name,
             'blockchain': self.blockchain.serialize() if self.blockchain is not None else None,
         }
 
-    def serialize_for_db(self) -> tuple[str, str, Optional[str]]:
+    def serialize_for_db(self) -> tuple[str, str, str | None]:
         blockchain = self.blockchain.value if self.blockchain is not None else None
         return (self.address, self.name, blockchain)
 
@@ -919,7 +906,7 @@ class AddressbookEntry(NamedTuple):
 
 class OptionalChainAddress(NamedTuple):
     address: ChecksumAddress
-    blockchain: Optional[SupportedBlockchain]
+    blockchain: SupportedBlockchain | None
 
 
 class ChainAddress(OptionalChainAddress):
@@ -939,7 +926,7 @@ class UserNote(NamedTuple):
     last_update_timestamp: Timestamp
     is_pinned: bool
 
-    def serialize(self) -> dict[str, Union[str, int]]:
+    def serialize(self) -> dict[str, str | int]:
         """Serialize a `UserNote` object into a dict."""
         return {
             'identifier': self.identifier,

--- a/rotkehlchen/usage_analytics.py
+++ b/rotkehlchen/usage_analytics.py
@@ -4,7 +4,7 @@ import shutil
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 import maxminddb
 import miniupnpc
@@ -24,7 +24,7 @@ class GeolocationData(NamedTuple):
     country_code: str
 
 
-def retrieve_location_data(data_dir: Path) -> Optional[GeolocationData]:
+def retrieve_location_data(data_dir: Path) -> GeolocationData | None:
     """This functions tries to get the country of the user based on the ip.
     To do that it makes use of an open ip to country database and tries to obtain
     the ip ussing UPnP protocol.

--- a/rotkehlchen/user_messages.py
+++ b/rotkehlchen/user_messages.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import deque
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -23,7 +23,7 @@ class MessagesAggregator:
     def __init__(self) -> None:
         self.warnings: deque = deque()
         self.errors: deque = deque()
-        self.rotki_notifier: Optional[RotkiNotifier] = None
+        self.rotki_notifier: RotkiNotifier | None = None
 
     def _append_warning(self, msg: str) -> None:
         self.warnings.appendleft(msg)
@@ -67,7 +67,7 @@ class MessagesAggregator:
     def add_message(
             self,
             message_type: WSMessageType,
-            data: Union[dict[str, Any], list[Any]],
+            data: dict[str, Any] | list[Any],
     ) -> None:
         """Sends a websocket message
 

--- a/rotkehlchen/utils/data_structures.py
+++ b/rotkehlchen/utils/data_structures.py
@@ -1,6 +1,6 @@
 import collections
 from collections import OrderedDict
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 KT = TypeVar('KT')  # key type
 VT = TypeVar('VT')  # value type
@@ -13,7 +13,7 @@ class LRUCacheWithRemove(Generic[KT, VT]):
         self.cache: OrderedDict[KT, VT] = collections.OrderedDict()
         self.maxsize: int = maxsize
 
-    def get(self, key: KT) -> Optional[VT]:
+    def get(self, key: KT) -> VT | None:
         if key in self.cache:
             self.cache.move_to_end(key)
             return self.cache[key]
@@ -35,7 +35,7 @@ class LRUCacheWithRemove(Generic[KT, VT]):
 
 class LRUCacheLowerKey(LRUCacheWithRemove[str, VT]):
     """Create an LRU cache with string key which is always considered as lowercase"""
-    def get(self, key: str) -> Optional[VT]:
+    def get(self, key: str) -> VT | None:
         return super().get(key.lower())
 
     def add(self, key: str, value: VT) -> None:

--- a/rotkehlchen/utils/hexbytes.py
+++ b/rotkehlchen/utils/hexbytes.py
@@ -17,14 +17,14 @@ def hexstring_to_bytes(hexstr: str) -> bytes:
         raise DeserializationError(f'Failed to turn {hexstr} to bytes') from e
 
 
-def to_bytes(val: Union[Web3HexBytes, bytearray, bytes, str]) -> bytes:
+def to_bytes(val: Web3HexBytes | (bytearray | (bytes | str))) -> bytes:
     """
     Equivalent to: `eth_utils.hexstr_if_str(eth_utils.to_bytes, val)` .
 
     Convert a hex string, integer, or bool, to a bytes representation.
     Alternatively, pass through bytes or bytearray as a bytes value.
     """
-    if isinstance(val, (Web3HexBytes, bytearray)):
+    if isinstance(val, Web3HexBytes | bytearray):
         return bytes(val)
     if isinstance(val, bytes):
         return val
@@ -45,7 +45,7 @@ class HexBytes(bytes):
     """
     def __new__(
             cls: type[bytes],
-            val: Union[Web3HexBytes, bytearray, bytes, str],
+            val: Web3HexBytes | (bytearray | (bytes | str)),
     ) -> 'HexBytes':
         bytesval = to_bytes(val)
         return cast(HexBytes, super().__new__(cls, bytesval))  # type: ignore  # https://github.com/python/typeshed/issues/2630
@@ -69,7 +69,7 @@ class HexBytes(bytes):
     def __getitem__(self, key: slice) -> 'HexBytes':
         ...
 
-    def __getitem__(self, key: Union[int, slice]) -> Union[int, bytes, 'HexBytes']:
+    def __getitem__(self, key: int | slice) -> Union[int, bytes, 'HexBytes']:
         result = super().__getitem__(key)
         if hasattr(result, 'hex'):
             return type(self)(result)  # type: ignore  # cant be an int

--- a/rotkehlchen/utils/interfaces.py
+++ b/rotkehlchen/utils/interfaces.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional
 
 from rotkehlchen.types import ChecksumEvmAddress
 
@@ -27,7 +28,7 @@ class EthereumModule(metaclass=ABCMeta):
     # Optional callback to run on a module's startup
     # Is optional as opposed to a no-op  since at initialization we
     # start a greenlet to run it and there is no reason to bring up no-op greenlets
-    on_startup: Optional[Callable[['EthereumModule'], None]] = None
+    on_startup: Callable[['EthereumModule'], None] | None = None
 
     @abstractmethod
     def on_account_addition(self, address: ChecksumEvmAddress) -> None:
@@ -55,8 +56,8 @@ class ProgressUpdater(metaclass=ABCMeta):
     def __init__(self, messages_aggregator: 'MessagesAggregator', target_version: int) -> None:
         self.messages_aggregator = messages_aggregator
         self.target_version = target_version
-        self.start_version: Optional[int] = None
-        self.current_version: Optional[int] = None
+        self.start_version: int | None = None
+        self.current_version: int | None = None
         self.current_round_total_steps = 0
         self.current_round_current_step = 0
 
@@ -80,7 +81,7 @@ class ProgressUpdater(metaclass=ABCMeta):
         """
         self.current_round_total_steps = steps
 
-    def new_step(self, name: Optional[str] = None) -> None:
+    def new_step(self, name: str | None = None) -> None:
         """
         Should be called when currently running round reaches a new step.
         Informs users about the new step. Total number of calls to this method must be equal to
@@ -90,5 +91,5 @@ class ProgressUpdater(metaclass=ABCMeta):
         self._notify_frontend(name)
 
     @abstractmethod
-    def _notify_frontend(self, step_name: Optional[str] = None) -> None:
+    def _notify_frontend(self, step_name: str | None = None) -> None:
         """Sends to the user through websockets all information about progress."""

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -322,7 +322,7 @@ def pairwise(iterable: Iterable[Any]) -> Iterator:
     For a function that does so check pairwise_longest.
     s -> (s0, s1), (s2, s3), (s4, s5), ..."""
     a = iter(iterable)
-    return zip(a, a)
+    return zip(a, a, strict=False)
 
 
 def pairwise_longest(iterable: Iterable[Any]) -> Iterator:

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -7,9 +7,9 @@ import re
 import sys
 import time
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from eth_utils import is_hexstr
 from eth_utils.address import to_checksum_address
@@ -106,7 +106,7 @@ def timestamp_to_iso8601(ts: Timestamp, utc_as_z: bool = False) -> str:
     return res if utc_as_z is False else res.replace('+00:00', 'Z')
 
 
-def satoshis_to_btc(satoshis: Union[int, FVal]) -> FVal:
+def satoshis_to_btc(satoshis: int | FVal) -> FVal:
     return satoshis * FVal('0.00000001')
 
 
@@ -132,7 +132,7 @@ def from_wei(wei_value: FVal) -> FVal:
     return wei_value / FVal(10 ** 18)
 
 
-def from_gwei(gwei_value: Union[FVal, int]) -> FVal:
+def from_gwei(gwei_value: FVal | int) -> FVal:
     return gwei_value / FVal(10 ** 9)
 
 
@@ -155,10 +155,10 @@ def combine_dicts(
 
 
 def combine_dicts(
-        a: Union[dict[K, V], defaultdict[K, V]],
-        b: Union[dict[K, V], defaultdict[K, V]],
+        a: dict[K, V] | defaultdict[K, V],
+        b: dict[K, V] | defaultdict[K, V],
         op: Callable = operator.add,
-) -> Union[dict[K, V], defaultdict[K, V]]:
+) -> dict[K, V] | defaultdict[K, V]:
     new_dict = a.copy()
     # issue for pylint's false positive here: https://github.com/PyCQA/pylint/issues/3987
     if op == operator.sub:  # pylint: disable=comparison-with-callable
@@ -188,7 +188,7 @@ def combine_stat_dicts(list_of_dicts: list[dict]) -> dict:
 
 
 def convert_to_int(
-        val: Union[FVal, bytes, str, float],
+        val: FVal | (bytes | (str | float)),
         accept_only_exact: bool = True,
 ) -> int:
     """Try to convert to an int. Either from an FVal or a string. If it's a float
@@ -200,7 +200,7 @@ def convert_to_int(
     """
     if isinstance(val, FVal):
         return val.to_int(accept_only_exact)
-    if isinstance(val, (bytes, str)):
+    if isinstance(val, bytes | str):
         # Since float string are not converted to int we have to first convert
         # to float and try to convert to int afterwards
         try:
@@ -242,7 +242,7 @@ def hexstr_to_int(value: str) -> int:
 
 
 def hex_or_bytes_to_int(
-        value: Union[bytes, str],
+        value: bytes | str,
         signed: bool = False,
         byteorder: Literal['little', 'big'] = 'big',
 ) -> int:
@@ -262,7 +262,7 @@ def hex_or_bytes_to_int(
     return int_value
 
 
-def hex_or_bytes_to_str(value: Union[bytes, str]) -> str:
+def hex_or_bytes_to_str(value: bytes | str) -> str:
     """Turns a bytes/HexBytes or a hexstring into an hex string"""
     if isinstance(value, bytes):
         hexstr = value.hex()
@@ -272,7 +272,7 @@ def hex_or_bytes_to_str(value: Union[bytes, str]) -> str:
     return hexstr
 
 
-def hex_or_bytes_to_address(value: Union[bytes, str]) -> ChecksumEvmAddress:
+def hex_or_bytes_to_address(value: bytes | str) -> ChecksumEvmAddress:
     """Turns a 32bit bytes/HexBytes or a hexstring into an address
 
     May raise:
@@ -362,10 +362,10 @@ def is_valid_ethereum_tx_hash(val: str) -> bool:
 
 def create_order_by_rules_list(
         data: dict[str, Any],
-        default_order_by_fields: Optional[list[str]] = None,
-        default_ascending: Optional[list[bool]] = None,
+        default_order_by_fields: list[str] | None = None,
+        default_ascending: list[bool] | None = None,
         is_ascending_by_default: bool = False,
-) -> Optional[list[tuple[str, bool]]]:
+) -> list[tuple[str, bool]] | None:
     """Create a list of attributes and sorting order taking values from DBOrderBySchema
     to be used by the filters that allow sorting. By default, the attribute used for sorting is
     timestamp and the ascending value for this field is False.

--- a/rotkehlchen/utils/mixins/cacheable.py
+++ b/rotkehlchen/utils/mixins/cacheable.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
 from copy import deepcopy
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rotkehlchen.utils.misc import ts_now
 

--- a/rotkehlchen/utils/mixins/lockable.py
+++ b/rotkehlchen/utils/mixins/lockable.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable
+from typing import Any
 
 from gevent.lock import Semaphore
 

--- a/rotkehlchen/utils/network.py
+++ b/rotkehlchen/utils/network.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, Callable, Literal, Union, overload
+from typing import Any, Literal, overload
 
 import gevent
 import requests
@@ -20,7 +21,7 @@ def request_get(
         timeout: int = GLOBAL_REQUESTS_TIMEOUT,
         handle_429: bool = False,
         backoff_in_seconds: float = 0,
-) -> Union[dict, list]:
+) -> dict | list:
     """
     May raise:
     - UnableToDecryptRemoteData from request_get
@@ -129,7 +130,7 @@ def query_file(url: str, is_json: Literal[False]) -> str:
     ...
 
 
-def query_file(url: str, is_json: bool = False) -> Union[str, dict[str, Any]]:
+def query_file(url: str, is_json: bool = False) -> str | dict[str, Any]:
     """
     Query the given file url and return the contents of the file
     May raise:

--- a/rotkehlchen/utils/serialization.py
+++ b/rotkehlchen/utils/serialization.py
@@ -1,6 +1,6 @@
 import json
 from json.decoder import JSONDecodeError
-from typing import Any, Optional, Union
+from typing import Any
 
 from rotkehlchen.assets.asset import (
     Asset,
@@ -21,7 +21,7 @@ class RKLEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Any:
         if isinstance(obj, FVal):
             return str(obj)
-        if isinstance(obj, (TradeType, Location)):
+        if isinstance(obj, TradeType | Location):
             return str(obj)
         if isinstance(obj, float):
             raise ValueError('Trying to json encode a float.')
@@ -58,7 +58,7 @@ def jsonloads_list(data: str) -> list:
     return value
 
 
-def rlk_jsondumps(data: Union[dict, list]) -> str:
+def rlk_jsondumps(data: dict | list) -> str:
     return json.dumps(data, cls=RKLEncoder)
 
 
@@ -75,7 +75,7 @@ def pretty_json_dumps(data: dict) -> str:
 def deserialize_asset_with_oracles_from_db(
         asset_type: AssetType,
         asset_data: list[Any],
-        underlying_tokens: Optional[list[UnderlyingToken]],
+        underlying_tokens: list[UnderlyingToken] | None,
 ) -> AssetWithOracles:
     """
     From a db tuple containing information about any asset deserialize to the correct Asset class
@@ -129,7 +129,7 @@ def deserialize_asset_with_oracles_from_db(
 def deserialize_generic_asset_from_db(
         asset_type: AssetType,
         asset_data: list[Any],
-        underlying_tokens: Optional[list[UnderlyingToken]],
+        underlying_tokens: list[UnderlyingToken] | None,
 ) -> AssetWithNameAndType:
     """
     From a db tuple containing information about any asset deserialize to the correct Asset class

--- a/rotkehlchen/utils/upgrades.py
+++ b/rotkehlchen/utils/upgrades.py
@@ -1,7 +1,8 @@
-from typing import Any, Callable, NamedTuple, Optional
+from collections.abc import Callable
+from typing import Any, NamedTuple
 
 
 class UpgradeRecord(NamedTuple):
     from_version: int
     function: Callable
-    kwargs: Optional[dict[str, Any]] = None
+    kwargs: dict[str, Any] | None = None

--- a/rotkehlchen/utils/version_check.py
+++ b/rotkehlchen/utils/version_check.py
@@ -35,8 +35,8 @@ def get_system_spec() -> dict[str, str]:
 
 class VersionCheckResult(NamedTuple):
     our_version: str
-    latest_version: Optional[str] = None
-    download_url: Optional[str] = None
+    latest_version: str | None = None
+    download_url: str | None = None
 
 
 def get_current_version(github: Optional['Github'] = None) -> VersionCheckResult:

--- a/tools/profiling/graph.py
+++ b/tools/profiling/graph.py
@@ -210,7 +210,7 @@ def memory_subplot(output, data_list):
     memory_max *= 1.1
 
     hour_fmt = dates.DateFormatter('%H:%M')
-    for count, (data, memory_axes) in enumerate(zip(data_list, all_memory_axes)):
+    for count, (data, memory_axes) in enumerate(zip(data_list, all_memory_axes, strict=True)):
         timestamp = [line[TIMESTAMP] for line in data]
         memory = [line[MEMORY] for line in data]
 

--- a/tools/profiling/graph.py
+++ b/tools/profiling/graph.py
@@ -36,7 +36,7 @@ import datetime
 import pickle
 from contextlib import suppress
 from itertools import chain
-from typing import Any, Optional
+from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib import dates
@@ -166,7 +166,7 @@ def memory_timeline(output, data_list):
 
     fig, memory_axes = plt.subplots()
 
-    last_ts: Optional[Any] = None
+    last_ts: Any | None = None
     memory_max = 0.0
 
     for data in data_list:
@@ -254,7 +254,7 @@ def latency_scatter(output, data_list):
         axes.set_xlim(min(timestamp), max(timestamp))
         axes.set_ylim(0, max(latency) * 1.1)
 
-    last_ts: Optional[Any] = None
+    last_ts: Any | None = None
     for timestamps in data_list:
         if not timestamps:
             continue

--- a/tools/profiling/sampler.py
+++ b/tools/profiling/sampler.py
@@ -5,7 +5,7 @@ import sys
 import threading
 import time
 from types import FrameType
-from typing import IO, Any, NewType, Optional
+from typing import IO, Any, NewType
 
 import greenlet
 import objgraph
@@ -31,7 +31,7 @@ def frame_format(frame: FrameType) -> str:
 
 def collect_frames(frame: FrameType) -> list[str]:
     callstack = []
-    optional_frame: Optional[FrameType] = frame
+    optional_frame: FrameType | None = frame
     while optional_frame is not None:
         callstack.append(frame_format(optional_frame))
         optional_frame = optional_frame.f_back
@@ -77,7 +77,7 @@ def sample_objects(timestamp: float, stream: IO) -> None:
 
 
 class FlameGraphCollector:
-    last_timestamp: Optional[float]
+    last_timestamp: float | None
 
     def __init__(self, stack_stream: IO) -> None:
         self.stack_stream = stack_stream
@@ -139,7 +139,7 @@ class ObjectCollector:
 
 
 class TraceSampler:
-    old_frame: Optional[FrameType]
+    old_frame: FrameType | None
 
     def __init__(self, collector, sample_interval=0.1):
         self.collector = collector

--- a/tools/profiling/timer.py
+++ b/tools/profiling/timer.py
@@ -1,7 +1,7 @@
 import os
 import signal
+from collections.abc import Callable
 from types import FrameType
-from typing import Callable
 
 from .constants import INTERVAL_SECONDS
 

--- a/tools/pylint/not_checker.py
+++ b/tools/pylint/not_checker.py
@@ -45,5 +45,5 @@ class NotBooleanChecker(BaseChecker):
         if operand_type is None:
             return
 
-        if operand_type.name != 'bool':
+        if hasattr(operand_type, 'name') and operand_type.name != 'bool':
             self.add_message(NONBOOLEANNOT_SYMBOL, node=node)


### PR DESCRIPTION
## [Switch to python 3.10 type annotation style](https://github.com/rotki/rotki/commit/9426bf5b00adb8e5eca70829279365fc8c53f639) 

Use ruff's auto-fix for this. Along with some manual tweaking.

## [Solve B905 error. zip() without specifying strict argument](https://github.com/rotki/rotki/commit/dbefae325bfdc16b71b9a9a29084d3f4403d0a4e) 

The purpose of this argument is to let the reader know if it's okay to
have zip silently create a zip of the length of the shortest
list (strict=False) or if the zipped lists are not equal length to
raise a `ValueError` (strict=True)


-----

Adding this to bugfixes due to it being a huge diff and wanting to avoid conflicts.