### PR TITLE
Invalidate cache for accounting rules

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` The welcome message at first login after a version upgrade will now have the correct link to the release notes.
+* :bug:`-` Creating, editing and deleting accounting rules will now update warnings when rendered events get affected in the history view.
 
 * :release:`1.31.0 <2023-11-24>`
 * :feature:`-` Oneinch v3 swaps should be supported in Ethereum mainnet.

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -20,7 +20,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.types import EVM_CHAIN_IDS_WITH_TRANSACTIONS, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
-from rotkehlchen.utils.data_structures import LRUCacheWithRemove
+from rotkehlchen.utils.data_structures import DefaultLRUCache, LRUCacheWithRemove
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.mixins.event import AccountingEventMixin
@@ -66,6 +66,8 @@ class Accountant:
         self.first_processed_timestamp = Timestamp(-1)
         self.premium = premium
         self.processable_events_cache: LRUCacheWithRemove[int, bool] = LRUCacheWithRemove(maxsize=PROCESSABLE_EVENTS_CACHE_SIZE)  # noqa: E501
+        # map event rules signatures to a list of event identifiers affected by them
+        self.processable_events_cache_signatures: DefaultLRUCache[int, list[int]] = DefaultLRUCache(default_factory=list, maxsize=PROCESSABLE_EVENTS_CACHE_SIZE)  # noqa: E501
 
     def activate_premium_status(self, premium: Premium) -> None:
         self.premium = premium

--- a/rotkehlchen/tests/api/test_accounting_rules.py
+++ b/rotkehlchen/tests/api/test_accounting_rules.py
@@ -5,9 +5,15 @@ from typing import Literal, get_args
 
 import pytest
 import requests
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.evm_event import EvmEvent
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.api.server import APIServer
+from rotkehlchen.chain.ethereum.modules.compound.constants import CPT_COMPOUND
+from rotkehlchen.chain.evm.accounting.structures import TxAccountingTreatment
+from rotkehlchen.constants.assets import A_CUSDC, A_USDC
+from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.constants import LINKABLE_ACCOUNTING_PROPERTIES
 from rotkehlchen.db.updates import RotkiDataUpdater
 from rotkehlchen.rotkehlchen import Rotkehlchen
@@ -17,6 +23,9 @@ from rotkehlchen.tests.utils.api import (
     assert_proper_response_with_result,
     assert_simple_ok_response,
 )
+from rotkehlchen.tests.utils.factories import make_evm_tx_hash
+from rotkehlchen.tests.utils.history_base_entry import store_and_retrieve_events
+from rotkehlchen.types import Location, TimestampMS
 
 
 def _update_rules(rotki: Rotkehlchen, latest_accounting_rules: Path) -> None:
@@ -365,3 +374,127 @@ def test_listing_conflicts(
         },
     ]
     assert result['entries_total'] == 2
+
+
+@pytest.mark.parametrize('initialize_accounting_rules', [False])
+def test_cache_invalidation(rotkehlchen_api_server: APIServer):
+    """
+    Test that the cache for events affected by an accounting rule gets correctly invalidated
+    when operations happen modifying the rule that affects them.
+    """
+    rest = rotkehlchen_api_server.rest_api
+    rotki = rest.rotkehlchen
+    database = rotki.data.db
+
+    tx_hash = make_evm_tx_hash()
+    return_wrapped = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_CUSDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+    remove_asset = EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=1,
+        timestamp=TimestampMS(16433333000),
+        location=Location.ETHEREUM,
+        asset=A_USDC,
+        balance=Balance(amount=ONE),
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+        counterparty=CPT_COMPOUND,
+        notes='my notes',
+    )
+    events = store_and_retrieve_events([return_wrapped, remove_asset], database)
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'historyeventresource',
+        ), json={'event_identifiers': [events[0].event_identifier]},
+    )
+    result = assert_proper_response_with_result(response)
+    assert len(result['entries']) == 2
+    assert all(entry['missing_accounting_rule'] for entry in result['entries'])
+
+    # add a rule for the return event and check that the cache was updated
+    response = requests.put(
+        api_url_for(
+            rotkehlchen_api_server,
+            'accountingrulesresource',
+        ), json={
+            'event_type': HistoryEventType.DEPOSIT.serialize(),
+            'event_subtype': HistoryEventSubType.DEPOSIT_ASSET.serialize(),
+            'counterparty': CPT_COMPOUND,
+            'taxable': {'value': True},
+            'count_entire_amount_spend': {'value': True},
+            'count_cost_basis_pnl': {'value': True},
+            'accounting_treatment': None,
+        },
+    )
+    assert_simple_ok_response(response)
+
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'historyeventresource',
+        ), json={'event_identifiers': [events[0].event_identifier]},
+    )
+    result = assert_proper_response_with_result(response)
+    assert len(result['entries']) == 2
+    assert 'missing_accounting_rule' not in result['entries'][0]
+    assert result['entries'][1]['missing_accounting_rule'] is True
+
+    # update a rule to check that it removes the cache from the second event too
+    response = requests.patch(
+        api_url_for(
+            rotkehlchen_api_server,
+            'accountingrulesresource',
+        ), json={
+            'identifier': 1,
+            'event_type': HistoryEventType.DEPOSIT.serialize(),
+            'event_subtype': HistoryEventSubType.DEPOSIT_ASSET.serialize(),
+            'counterparty': CPT_COMPOUND,
+            'taxable': {'value': True},
+            'count_entire_amount_spend': {'value': True},
+            'count_cost_basis_pnl': {'value': True},
+            'accounting_treatment': TxAccountingTreatment.SWAP.serialize(),
+        },
+    )
+    assert_simple_ok_response(response)
+
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'historyeventresource',
+        ), json={'event_identifiers': [events[0].event_identifier]},
+    )
+    result = assert_proper_response_with_result(response)
+    assert len(result['entries']) == 2
+    for entry in result['entries']:
+        assert 'missing_accounting_rule' not in entry
+
+    # delete accounting rule and check that both events will not be processed now
+    # update a rule to check that it removes the cache from the second event too
+    response = requests.delete(
+        api_url_for(
+            rotkehlchen_api_server,
+            'accountingrulesresource',
+        ), json={'identifier': 1},
+    )
+    assert_simple_ok_response(response)
+
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'historyeventresource',
+        ), json={'event_identifiers': [events[0].event_identifier]},
+    )
+    result = assert_proper_response_with_result(response)
+    assert len(result['entries']) == 2
+    all(entry['missing_accounting_rule'] for entry in result['entries'])

--- a/rotkehlchen/tests/db/test_db_accounting_rules.py
+++ b/rotkehlchen/tests/db/test_db_accounting_rules.py
@@ -1,10 +1,8 @@
-from collections.abc import Sequence
 
 import pytest
 
 from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.structures.balance import Balance
-from rotkehlchen.accounting.structures.base import HistoryBaseEntry
 from rotkehlchen.accounting.structures.evm_event import EvmEvent
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.chain.ethereum.modules.balancer.constants import CPT_BALANCER_V1
@@ -17,31 +15,12 @@ from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.accounting_rules import DBAccountingRules, query_missing_accounting_rules
 from rotkehlchen.db.constants import NO_ACCOUNTING_COUNTERPARTY
 from rotkehlchen.db.dbhandler import DBHandler
-from rotkehlchen.db.filtering import AccountingRulesFilterQuery, HistoryEventFilterQuery
-from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.filtering import AccountingRulesFilterQuery
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
+from rotkehlchen.tests.utils.history_base_entry import store_and_retrieve_events
 from rotkehlchen.types import Location, TimestampMS
-
-
-def _store_and_retrieve_events(
-        events: Sequence[HistoryBaseEntry],
-        db: DBHandler,
-) -> Sequence[HistoryBaseEntry]:
-    """Store events in database and retrieve them again fully populated with identifiers"""
-    dbevents = DBHistoryEvents(db)
-    with db.user_write() as write_cursor:
-        for event in events:
-            dbevents.add_history_event(
-                write_cursor=write_cursor,
-                event=event,
-            )
-        return dbevents.get_history_events(
-            cursor=write_cursor,
-            filter_query=HistoryEventFilterQuery.make(event_identifiers=[events[0].event_identifier]),
-            has_premium=True,
-        )  # query them from db to retrieve them with their identifier
 
 
 def test_managing_accounting_rules(database: DBHandler) -> None:
@@ -240,7 +219,7 @@ def test_missing_accounting_rules_accounting_treatment(
         counterparty=CPT_COWSWAP,
         notes='my notes',
     )
-    events = _store_and_retrieve_events([swap_event_spend, swap_event_receive, swap_event_fee], database)  # noqa: E501
+    events = store_and_retrieve_events([swap_event_spend, swap_event_receive, swap_event_fee], database)  # noqa: E501
     assert not all(
         query_missing_accounting_rules(
             db=database,
@@ -301,7 +280,7 @@ def test_events_affected_by_others_accounting_treatment(
         notes='my notes',
     )
 
-    events = _store_and_retrieve_events([return_wrapped, remove_asset], database)
+    events = store_and_retrieve_events([return_wrapped, remove_asset], database)
     assert query_missing_accounting_rules(
         db=database,
         accounting_pot=accountant.pots[0],
@@ -372,7 +351,7 @@ def test_events_affected_by_others_accounting_treatment_with_fee(
         notes='my notes',
     )
 
-    events = _store_and_retrieve_events([return_wrapped, fee_event, remove_asset], database)
+    events = store_and_retrieve_events([return_wrapped, fee_event, remove_asset], database)
     assert query_missing_accounting_rules(
         db=database,
         accounting_pot=accountant.pots[0],
@@ -442,7 +421,7 @@ def test_events_affected_by_others_callbacks(
             extra_data=None,
         ),
     ]
-    db_events = _store_and_retrieve_events(events, database)
+    db_events = store_and_retrieve_events(events, database)
     assert query_missing_accounting_rules(
         db=database,
         accounting_pot=accountant.pots[0],
@@ -512,7 +491,7 @@ def test_events_affected_by_others_callbacks_with_fitlers(
             extra_data=None,
         ),
     ]
-    db_events = _store_and_retrieve_events(events, database)
+    db_events = store_and_retrieve_events(events, database)
     assert query_missing_accounting_rules(
         db=database,
         accounting_pot=accountant.pots[0],
@@ -584,7 +563,7 @@ def test_correct_accounting_treatment_is_selected(
         notes='my notes',
     )
 
-    events = _store_and_retrieve_events([return_wrapped, remove_asset], database)
+    events = store_and_retrieve_events([return_wrapped, remove_asset], database)
     assert query_missing_accounting_rules(
         db=database,
         accounting_pot=accountant.pots[0],

--- a/rotkehlchen/tests/utils/history_base_entry.py
+++ b/rotkehlchen/tests/utils/history_base_entry.py
@@ -1,5 +1,6 @@
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
+from typing import Any
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.base import (
@@ -18,12 +19,11 @@ from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_ETH2, A_USDT
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.filtering import HistoryEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
-
-if TYPE_CHECKING:
-    from rotkehlchen.db.history_events import DBHistoryEvents
-
 
 KEYS_IN_ENTRY_TYPE: dict[HistoryBaseEntryType, set[str]] = {
     HistoryBaseEntryType.HISTORY_EVENT: {'sequence_index', 'location', 'event_type', 'event_subtype', 'asset', 'notes', 'event_identifier'},  # noqa: E501
@@ -181,3 +181,22 @@ def add_entries(events_db: 'DBHistoryEvents') -> list['HistoryBaseEntry']:
             )
             entry.identifier = identifier
     return entries
+
+
+def store_and_retrieve_events(
+        events: Sequence[HistoryBaseEntry],
+        db: DBHandler,
+) -> Sequence[HistoryBaseEntry]:
+    """Store events in database and retrieve them again fully populated with identifiers"""
+    dbevents = DBHistoryEvents(db)
+    with db.user_write() as write_cursor:
+        for event in events:
+            dbevents.add_history_event(
+                write_cursor=write_cursor,
+                event=event,
+            )
+        return dbevents.get_history_events(
+            cursor=write_cursor,
+            filter_query=HistoryEventFilterQuery.make(event_identifiers=[events[0].event_identifier]),
+            has_premium=True,
+        )  # query them from db to retrieve them with their identifier

--- a/rotkehlchen/utils/data_structures.py
+++ b/rotkehlchen/utils/data_structures.py
@@ -1,5 +1,6 @@
 import collections
 from collections import OrderedDict
+from collections.abc import Callable
 from typing import Generic, TypeVar
 
 KT = TypeVar('KT')  # key type
@@ -31,6 +32,22 @@ class LRUCacheWithRemove(Generic[KT, VT]):
     def clear(self) -> None:
         """Delete all entries in the cache"""
         self.cache.clear()
+
+
+class DefaultLRUCache(LRUCacheWithRemove[KT, VT]):
+    """LRU cache that behaves like defaultdict when accessing objects"""
+
+    def __init__(self, default_factory: Callable[[], VT], maxsize: int = 512):
+        super().__init__(maxsize)
+        self.default_factory = default_factory
+
+    def get(self, key: KT) -> VT:
+        value = super().get(key)
+        if value is None:
+            value = self.default_factory()
+            self.add(key, value)
+
+        return value
 
 
 class LRUCacheLowerKey(LRUCacheWithRemove[str, VT]):


### PR DESCRIPTION
Editing accounting rules was not expiring the cache for processed events making that if you modify them the frontend won't correctly update this infomation

