### PR TITLE
Handle no withdrawal response from etherscan properly

### DIFF
--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -310,7 +310,7 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                     transaction_endpoint_and_none_found = (
                         status == 0 and
                         json_ret['message'] == 'No transactions found' and
-                        action in {'txlist', 'txlistinternal', 'tokentx'}
+                        action in {'txlist', 'txlistinternal', 'tokentx', 'txsBeaconWithdrawal'}
                     )
                     logs_endpoint_and_none_found = (
                         status == 0 and


### PR DESCRIPTION
Instead of failing and falling back to blockscout, we now understand the "No transactions found" error message that etherscan throws when there is no withdrawals and properly return

Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=45696116