### PR TITLE
Fix login for usernames containing a '.'

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`6998` If a username contains a '.' the user will now be able to log in properly again.
 * :feature:`6885` Users can now specify EVM chains for which no activity will be auto-detected by rotki.
 * :bug:`-` The welcome message at first login after a version upgrade will now have the correct link to the release notes.
 * :bug:`-` Creating, editing and deleting accounting rules will now update warnings when rendered events get affected in the history view.

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -172,7 +172,7 @@ class DataHandler:
         for x in self.data_directory.iterdir():
             try:
                 if x.is_dir() and (x / 'rotkehlchen.db').exists():
-                    users[x.stem] = 'loggedin' if x.stem == self.username else 'loggedout'
+                    users[x.name] = 'loggedin' if x.name == self.username else 'loggedout'
             except PermissionError:
                 # ignore directories that can't be accessed
                 continue


### PR DESCRIPTION
This is a fun one. Since 2019 we were using `path.stem` to show the full username for the api returning the users. Which was ignoring everything after a `.`.

Fix #6998