### PR TITLE
Fix PnL report for case when non-history Event follows a swap

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`7009` PnL reports with an old type of event (such as DailyStats) following a swap will no longer fail with an exception.
 * :bug:`6998` If a username contains a '.' the user will now be able to log in properly again.
 * :feature:`6885` Users can now specify EVM chains for which no activity will be auto-detected by rotki.
 * :bug:`-` The welcome message at first login after a version upgrade will now have the correct link to the release notes.

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -95,18 +95,17 @@ class EventsAccountant:
                 )
                 return 1
 
-            next_event = cast(HistoryBaseEntry, next_event)
-            if next_event.event_identifier != event.event_identifier:
+            if not isinstance(next_event, HistoryBaseEntry) or next_event.event_identifier != event.event_identifier:  # noqa: E501
                 log.error(
                     f'Tried to process accounting swap but the in '
                     f'event for {event} is not there',
                 )
                 return 1
-            in_event = cast(HistoryBaseEntry, next(events_iterator))
+            in_event = cast(HistoryBaseEntry, next(events_iterator))  # guaranteed by the if check
 
-            next_event = cast(HistoryBaseEntry, events_iterator.peek(None))
-            if next_event and next_event.event_identifier == event.event_identifier and next_event.event_subtype == HistoryEventSubType.FEE:  # noqa: E501
-                fee_event = cast(HistoryBaseEntry, next(events_iterator))
+            next_event = events_iterator.peek(None)
+            if next_event and isinstance(next_event, HistoryBaseEntry) and next_event.event_identifier == event.event_identifier and next_event.event_subtype == HistoryEventSubType.FEE:  # noqa: E501
+                fee_event = cast(HistoryBaseEntry, next(events_iterator))  # guaranteed by if check
 
             return self._process_swap(
                 timestamp=timestamp,

--- a/rotkehlchen/tests/unit/accounting/evm/test_cowswap.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_cowswap.py
@@ -14,27 +14,12 @@ from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_USDC, A_WBTC
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.accounting import MOCKED_PRICES, TIMESTAMP_1_MS, TIMESTAMP_1_SEC
 from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
-from rotkehlchen.types import Location, Price, Timestamp, TimestampMS
+from rotkehlchen.types import Location, Price
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.accountant import Accountant
-
-TIMESTAMP_1_MS = TimestampMS(1000)
-TIMESTAMP_1_SEC = Timestamp(1)
-
-MOCKED_PRICES = {
-    A_WBTC.identifier: {
-        'EUR': {
-            TIMESTAMP_1_SEC: Price(ONE),
-        },
-    },
-    A_USDC.identifier: {
-        'EUR': {
-            TIMESTAMP_1_SEC: Price(ONE),
-        },
-    },
-}
 
 
 @pytest.mark.parametrize('mocked_price_queries', [MOCKED_PRICES])

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -8,13 +8,13 @@ from rotkehlchen.accounting.export.csv import CSV_INDEX_OFFSET, FILENAME_ALL_CSV
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
 from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
-from rotkehlchen.constants import ZERO
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants import ONE, ZERO
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USDC, A_WBTC
 from rotkehlchen.db.filtering import ReportDataFilterQuery
 from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TradeType
+from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TimestampMS, TradeType
 from rotkehlchen.utils.version_check import get_current_version
 
 if TYPE_CHECKING:
@@ -22,6 +22,23 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.rotkehlchen import Rotkehlchen
     from rotkehlchen.tests.fixtures.google import GoogleService
+
+
+TIMESTAMP_1_MS = TimestampMS(1000)
+TIMESTAMP_1_SEC = Timestamp(1)
+
+MOCKED_PRICES = {
+    A_WBTC.identifier: {
+        'EUR': {
+            TIMESTAMP_1_SEC: Price(ONE),
+        },
+    },
+    A_USDC.identifier: {
+        'EUR': {
+            TIMESTAMP_1_SEC: Price(ONE),
+        },
+    },
+}
 
 
 history1 = [


### PR DESCRIPTION
What was happening is that the code assumed any event from the iterator was a HistoryEvent. So if during the processing of a swap we peeked ahead to see if there is a fee and the next event was anything else, such as ValidatorDailystats then BOOM.

Ignoring mypy typing with a typecast was a bad mistake. Mypy had caught this error.

Fix #7009