### PR TITLE
Restructure the rotki data directory

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` The welcome message at first login after a version upgrade will now have the correct link to the release notes.
+* :feature:`4841` The rotki data directory is now more organized.
 
 * :release:`1.31.0 <2023-11-24>`
 * :feature:`-` Oneinch v3 swaps should be supported in Ethereum mainnet.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -877,9 +877,9 @@ Database Location
 
 Databases are stored in directories under the `rotki data directory <https://rotki.readthedocs.io/en/latest/usage_guide.html#rotki-data-directory>`__.
 
-The global database is stored at ``global_data/global.db``.
+The global database is stored at ``global/global.db``.
 
-The accounts you create in rotki have their own database stored at ``<account_name>/rotkehlchen.db``.
+The accounts you create in rotki have their own database stored at ``users/<account_name>/rotkehlchen.db``.
 
 Exploring the database
 ======================

--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -107,7 +107,7 @@ Bear in mind that in case of using multiple accounts/devices with the data sync 
    :alt: Replace local database with remote backup
    :align: center
 
-You can manually move the global DB that contains the assets from one system to the other too. Find the :ref:`rotki_data_directory` in the source system. Assuming it's linux it will be :file:`~/.local/share/rotki/data`. The global db is then :file:`~/.local/share/rotki/data/global_data/global.db`. Manually move it to the equivalent location in the new system.
+You can manually move the global DB that contains the assets from one system to the other too. Find the :ref:`rotki_data_directory` in the source system. Assuming it's linux it will be :file:`~/.local/share/rotki/data`. The global db is then :file:`~/.local/share/rotki/data/global/global.db`. Manually move it to the equivalent location in the new system.
 
 
 Upgrading rotki after a very long time

--- a/frontend/app/scripts/start-backend.js
+++ b/frontend/app/scripts/start-backend.js
@@ -15,7 +15,7 @@ process.stdout.write(`Using ${dataDir} to start tests\n`);
 const cleanupData = () => {
   const contents = fs.readdirSync(dataDir);
   for (const name of contents) {
-    if (['icons', 'price_history', 'global_data'].includes(name)) {
+    if (['images', 'global'].includes(name)) {
       continue;
     }
 

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -7,6 +7,7 @@ from distutils.spawn import find_executable
 
 from PyInstaller.utils.hooks import collect_submodules
 
+from rotkehlchen.constants.misc import GLOBALDB_NAME
 from rotkehlchen.exchanges.constants import SUPPORTED_EXCHANGES
 from rotkehlchen.types import Location
 from rotkehlchen.utils.misc import get_system_spec
@@ -103,7 +104,7 @@ a = Entrypoint(
         # This list should be kept in sync with setup.py (package_data)
         ('rotkehlchen/data/eth_abi.json', 'rotkehlchen/data'),
         ('rotkehlchen/data/eth_contracts.json', 'rotkehlchen/data'),
-        ('rotkehlchen/data/global.db', 'rotkehlchen/data'),
+        (f'rotkehlchen/data/{GLOBALDB_NAME}', 'rotkehlchen/data'),
         ('rotkehlchen/data/globaldb_v2_v3_assets.sql', 'rotkehlchen/data'),
         ('rotkehlchen/data/nodes.json', 'rotkehlchen/data'),
         ('rotkehlchen/data/nodes_as_of_1-26-1.json', 'rotkehlchen/data'),

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -103,10 +103,12 @@ from rotkehlchen.constants.limits import (
     FREE_USER_NOTES_LIMIT,
 )
 from rotkehlchen.constants.misc import (
+    AVATARIMAGESDIR_NAME,
     DEFAULT_MAX_LOG_BACKUP_FILES,
     DEFAULT_MAX_LOG_SIZE_IN_MB,
     DEFAULT_SQL_VM_INSTRUCTIONS_CB,
     HTTP_STATUS_INTERNAL_DB_ERROR,
+    IMAGESDIR_NAME,
 )
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.constants.resolver import ChainID
@@ -1030,7 +1032,6 @@ class RestAPI:
             sync_database: bool,
             initial_settings: ModifiableDBSettings | None,
     ) -> dict[str, Any]:
-
         if self.rotkehlchen.user_is_logged_in:
             message = (
                 f'Can not create a new user because user '
@@ -4166,7 +4167,7 @@ class RestAPI:
 
         Also supports etag mechanism that helps with caching on the client side.
         """
-        avatars_dir = self.rotkehlchen.data_dir / 'icons' / 'avatars'
+        avatars_dir = self.rotkehlchen.data_dir / IMAGESDIR_NAME / AVATARIMAGESDIR_NAME
         avatar_path = avatars_dir / f'{ens_name}.png'
         if avatar_path.is_file():
             response = check_if_image_is_cached(image_path=avatar_path, match_header=match_header)
@@ -4215,7 +4216,7 @@ class RestAPI:
         icons_dir = self.rotkehlchen.icon_manager.icons_dir
         if icons is None:
             for entry in icons_dir.iterdir():
-                if entry.is_file() and entry.parent != icons_dir / 'avatars':
+                if entry.is_file():
                     entry.unlink()
 
             return api_response(OK_RESULT)
@@ -4230,7 +4231,7 @@ class RestAPI:
 
         If no avatars are provided, the avatars cache is cleared entirely.
         """
-        avatars_dir = self.rotkehlchen.icon_manager.icons_dir / 'avatars'
+        avatars_dir = self.rotkehlchen.data_dir / IMAGESDIR_NAME / AVATARIMAGESDIR_NAME
         if avatars is None:
             for entry in avatars_dir.iterdir():
                 if entry.is_file():

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from rotkehlchen.fval import FVal
 
 CURRENCYCONVERTER_API_KEY = 'feaa5a7ddc2d76789e58'
@@ -19,3 +21,15 @@ KRAKEN_API_VERSION = '0'
 DEFAULT_MAX_LOG_SIZE_IN_MB = 300
 DEFAULT_MAX_LOG_BACKUP_FILES = 3
 DEFAULT_SQL_VM_INSTRUCTIONS_CB = 5000
+
+GLOBALDIR_NAME: Final = 'global'
+GLOBALDB_NAME: Final = 'global.db'
+USERSDIR_NAME: Final = 'users'
+USERDB_NAME: Final = 'rotkehlchen.db'
+IMAGESDIR_NAME: Final = 'images'
+ASSETIMAGESDIR_NAME: Final = 'assets'
+AVATARIMAGESDIR_NAME: Final = 'avatars'
+ALLASSETIMAGESDIR_NAME: Final = 'all'
+CUSTOMASSETIMAGESDIR_NAME: Final = 'custom'
+MISCDIR_NAME: Final = 'misc'
+APPDIR_NAME: Final = 'app'

--- a/rotkehlchen/db/upgrade_manager.py
+++ b/rotkehlchen/db/upgrade_manager.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
+from rotkehlchen.constants.misc import USERDB_NAME
 from rotkehlchen.db.settings import ROTKEHLCHEN_DB_VERSION
 from rotkehlchen.db.upgrades.v26_v27 import upgrade_v26_to_v27
 from rotkehlchen.db.upgrades.v27_v28 import upgrade_v27_to_v28
@@ -195,7 +196,7 @@ class DBUpgradeManager:
             tmp_db_filename = f'{ts_now()}_rotkehlchen_db_v{upgrade.from_version}.backup'
             tmp_db_path = os.path.join(tmpdirname, tmp_db_filename)
             shutil.copyfile(
-                os.path.join(self.db.user_data_dir, 'rotkehlchen.db'),
+                os.path.join(self.db.user_data_dir, USERDB_NAME),
                 tmp_db_path,
             )
 
@@ -220,7 +221,7 @@ class DBUpgradeManager:
                 log.error(f'{error_message}\n{stacktrace}')
                 shutil.copyfile(
                     tmp_db_path,
-                    os.path.join(self.db.user_data_dir, 'rotkehlchen.db'),
+                    os.path.join(self.db.user_data_dir, USERDB_NAME),
                 )
                 raise DBUpgradeError(error_message) from e
 

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -13,6 +13,7 @@ import requests
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.types import AssetData, AssetType
+from rotkehlchen.constants.misc import GLOBALDB_NAME, GLOBALDIR_NAME
 from rotkehlchen.db.drivers.gevent import DBCursor
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset
@@ -585,7 +586,7 @@ class AssetsUpdater:
         local_schema_version = GlobalDBHandler().get_schema_version()
         data_directory = GlobalDBHandler()._data_directory
         assert data_directory is not None, 'data directory should be initialized at this point'
-        global_db_path = data_directory / 'global_data' / 'global.db'
+        global_db_path = data_directory / GLOBALDIR_NAME / GLOBALDB_NAME
 
         # We retrieve first all the files required for the different updates that will be performed
         updates = self._retrieve_update_files(

--- a/rotkehlchen/globaldb/utils.py
+++ b/rotkehlchen/globaldb/utils.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 GLOBAL_DB_VERSION = 6
 ASSETS_FILE_IMPORT_ACCEPTED_GLOBALDB_VERSIONS = (3, GLOBAL_DB_VERSION)
 MIN_SUPPORTED_GLOBAL_DB_VERSION = 2
-GLOBAL_DB_FILENAME = 'global.db'
 
 # Some functions that split the logic out of some GlobalDB query functions that are
 # complicated enough to be abstracted and are used in multiple places. The main reason

--- a/rotkehlchen/icons.py
+++ b/rotkehlchen/icons.py
@@ -13,6 +13,12 @@ from flask import Response, make_response
 
 from rotkehlchen.assets.asset import Asset, AssetWithNameAndType
 from rotkehlchen.assets.types import AssetType
+from rotkehlchen.constants.misc import (
+    ALLASSETIMAGESDIR_NAME,
+    ASSETIMAGESDIR_NAME,
+    CUSTOMASSETIMAGESDIR_NAME,
+    IMAGESDIR_NAME,
+)
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset, WrongAssetType
 from rotkehlchen.errors.misc import RemoteError
@@ -116,8 +122,9 @@ class IconManager:
             coingecko: Coingecko,
             greenlet_manager: 'GreenletManager',
     ) -> None:
-        self.icons_dir = data_dir / 'icons'
-        self.custom_icons_dir = self.icons_dir / 'custom'
+        asset_images_dir = data_dir / IMAGESDIR_NAME / ASSETIMAGESDIR_NAME
+        self.icons_dir = asset_images_dir / ALLASSETIMAGESDIR_NAME
+        self.custom_icons_dir = asset_images_dir / CUSTOMASSETIMAGESDIR_NAME
         self.coingecko = coingecko
         self.icons_dir.mkdir(parents=True, exist_ok=True)
         self.custom_icons_dir.mkdir(parents=True, exist_ok=True)

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Any, Literal, NamedTuple
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
+from rotkehlchen.constants.misc import USERSDIR_NAME
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.data_migrations.manager import DataMigrationManager
 from rotkehlchen.errors.api import PremiumAuthenticationError, RotkehlchenPermissionError
@@ -310,7 +311,7 @@ class PremiumSyncManager:
         self.data.logout()  # wipes self.data.user_data_dir, so store it
         shutil.move(
             user_data_dir,  # type: ignore
-            self.data.data_directory / f'auto_backup_{username}_{ts_now()}',
+            self.data.data_directory / USERSDIR_NAME / f'auto_backup_{username}_{ts_now()}',
         )
         raise PremiumAuthenticationError(
             f'Could not verify keys for the new account. {original_exception!s}',

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -100,6 +100,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.usage_analytics import maybe_submit_usage_analytics
 from rotkehlchen.user_messages import MessagesAggregator
+from rotkehlchen.utils.datadir import maybe_restructure_rotki_data_directory
 from rotkehlchen.utils.misc import combine_dicts
 
 if TYPE_CHECKING:
@@ -139,6 +140,8 @@ class Rotkehlchen:
         else:
             self.data_dir = Path(self.args.data_dir)
             self.data_dir.mkdir(parents=True, exist_ok=True)
+
+        maybe_restructure_rotki_data_directory(self.data_dir)
 
         if not os.access(self.data_dir, os.W_OK | os.R_OK):
             raise SystemPermissionError(

--- a/rotkehlchen/tests/api/test_caching.py
+++ b/rotkehlchen/tests/api/test_caching.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from rotkehlchen.constants.misc import AVATARIMAGESDIR_NAME, IMAGESDIR_NAME
 from rotkehlchen.db.ens import DBEns
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -18,7 +19,8 @@ if TYPE_CHECKING:
 def test_icons_and_avatars_cache_deletion(rotkehlchen_api_server):
     """Checks that clearing the cache for avatars and icons work as expected."""
     icons_dir = rotkehlchen_api_server.rest_api.rotkehlchen.icon_manager.icons_dir
-    avatars_dir = icons_dir / 'avatars'
+    data_dir = rotkehlchen_api_server.rest_api.rotkehlchen.data_dir
+    avatars_dir = data_dir / IMAGESDIR_NAME / AVATARIMAGESDIR_NAME
     avatars_dir.mkdir(exist_ok=True)
 
     dbens = DBEns(rotkehlchen_api_server.rest_api.rotkehlchen.data.db)

--- a/rotkehlchen/tests/api/test_icons.py
+++ b/rotkehlchen/tests/api/test_icons.py
@@ -8,6 +8,11 @@ from tempfile import TemporaryDirectory
 import pytest
 import requests
 
+from rotkehlchen.constants.misc import (
+    ASSETIMAGESDIR_NAME,
+    CUSTOMASSETIMAGESDIR_NAME,
+    IMAGESDIR_NAME,
+)
 from rotkehlchen.icons import ALLOWED_ICON_EXTENSIONS
 from rotkehlchen.tests.utils.api import (
     api_url_for,
@@ -50,7 +55,7 @@ def test_upload_custom_icon(rotkehlchen_api_server, file_upload, data_dir):
 
     result = assert_proper_response_with_result(response)
     assert result == {'identifier': A_GNO.identifier}
-    uploaded_icon = data_dir / 'icons' / 'custom' / f'{gno_id_quoted}.svg'
+    uploaded_icon = data_dir / IMAGESDIR_NAME / ASSETIMAGESDIR_NAME / CUSTOMASSETIMAGESDIR_NAME / f'{gno_id_quoted}.svg'  # noqa: E501
     assert uploaded_icon.is_file()
     assert filecmp.cmp(uploaded_icon, filepath)
 

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -321,8 +321,7 @@ def test_migration_5(database, data_dir, greenlet_manager):
     Path(icons_path, '_ceth_0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D_small.png').touch()
     Path(icons_path, '_ceth_0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9_small.png').touch()
     Path(icons_path, 'eip155%3A1%2Ferc20%3A0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9_small.png').touch()  # noqa: E501
-    # the two files + the custom assets folder
-    assert len(list(icon_manager.icons_dir.iterdir())) == 5
+    assert len(list(icon_manager.icons_dir.iterdir())) == 4
     with migration_patch:
         DataMigrationManager(rotki).maybe_migrate_data()
 

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-import os
 import time
 from contextlib import suppress
 from copy import deepcopy
@@ -25,6 +24,7 @@ from rotkehlchen.constants.assets import (
     A_USD,
     A_USDC,
 )
+from rotkehlchen.constants.misc import USERSDIR_NAME
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.filtering import AssetMovementsFilterQuery, TradesFilterQuery
@@ -156,9 +156,10 @@ def test_data_init_and_password(data_dir, username, sql_vm_instructions_cb):
     """DB Creation logic and tables at start testing"""
     msg_aggregator = MessagesAggregator()
     # Creating a new data dir should work
+    users_dir = data_dir / USERSDIR_NAME
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
     data.unlock(username, '123', create_new=True, resume_from_backup=False)
-    assert os.path.exists(os.path.join(data_dir, username))
+    assert (users_dir / username).exists()
 
     # Trying to re-create it should throw
     with pytest.raises(AuthenticationError):

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -29,7 +29,7 @@ from rotkehlchen.types import (
 
 @pytest.fixture(name='temp_etherscan')
 def fixture_temp_etherscan(function_scope_messages_aggregator, tmpdir_factory, sql_vm_instructions_cb):  # noqa: E501
-    directory = tmpdir_factory.mktemp('data')
+    directory = tmpdir_factory.mktemp('someuserdata')
     db = DBHandler(
         user_data_dir=directory,
         password='123',

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -10,6 +10,7 @@ import pytest
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
+from rotkehlchen.constants.misc import GLOBALDB_NAME, GLOBALDIR_NAME
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.globaldb.upgrades.manager import UPGRADES_LIST
@@ -98,13 +99,13 @@ def _initialize_fixture_globaldb(
     AssetResolver().clean_memory_cache()
     root_dir = Path(__file__).resolve().parent.parent.parent
     if custom_globaldb is None:  # no specific version -- normal test
-        source_db_path = root_dir / 'data' / 'global.db'
+        source_db_path = root_dir / 'data' / GLOBALDB_NAME
     else:
         source_db_path = root_dir / 'tests' / 'data' / custom_globaldb
     new_data_dir = Path(tmpdir_factory.mktemp('test_data_dir'))
-    new_global_dir = new_data_dir / 'global_data'
+    new_global_dir = new_data_dir / GLOBALDIR_NAME
     new_global_dir.mkdir(parents=True, exist_ok=True)
-    copyfile(source_db_path, new_global_dir / 'global.db')
+    copyfile(source_db_path, new_global_dir / GLOBALDB_NAME)
     with ExitStack() as stack:
         stack.enter_context(
             patch('rotkehlchen.globaldb.migrations.manager.MIGRATIONS_LIST', globaldb_migrations),

--- a/rotkehlchen/tests/test_users.py
+++ b/rotkehlchen/tests/test_users.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from rotkehlchen.constants.misc import USERDB_NAME, USERSDIR_NAME
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.errors.misc import SystemPermissionError
 from rotkehlchen.user_messages import MessagesAggregator
@@ -99,12 +100,13 @@ def test_users_query_permission_error(
         function_scope_messages_aggregator: MessagesAggregator,
         sql_vm_instructions_cb: int,
 ):
-    not_allowed_dir = os.path.join(data_dir, 'notallowed')
-    allowed_user_dir = os.path.join(data_dir, 'allowed_user')
-    os.mkdir(not_allowed_dir)
+    users_dir = data_dir / USERSDIR_NAME
+    not_allowed_dir = users_dir / 'notallowed'
+    allowed_user_dir = users_dir / 'allowed_user'
+    not_allowed_dir.mkdir(parents=True)
     os.chmod(not_allowed_dir, 0o200)
-    os.mkdir(allowed_user_dir)
-    Path(Path(allowed_user_dir) / 'rotkehlchen.db').touch()
+    allowed_user_dir.mkdir(parents=True)
+    (allowed_user_dir / USERDB_NAME).touch()
     handler = DataHandler(
         data_directory=data_dir,
         msg_aggregator=function_scope_messages_aggregator,

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb.py
@@ -26,7 +26,7 @@ from rotkehlchen.chain.ethereum.modules.compound.constants import CPT_COMPOUND
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_BAT, A_CRV, A_DAI, A_ETH, A_LUSD, A_PICKLE, A_USD
-from rotkehlchen.constants.misc import NFT_DIRECTIVE
+from rotkehlchen.constants.misc import GLOBALDB_NAME, GLOBALDIR_NAME, NFT_DIRECTIVE
 from rotkehlchen.constants.resolver import ethaddress_to_identifier, evm_address_to_identifier
 from rotkehlchen.db.custom_assets import DBCustomAssets
 from rotkehlchen.db.filtering import CustomAssetsFilterQuery
@@ -157,9 +157,9 @@ def test_open_new_globaldb_with_old_rotki(tmpdir_factory, sql_vm_instructions_cb
     root_dir = Path(__file__).resolve().parent.parent.parent.parent
     source_db_path = root_dir / 'tests' / 'data' / f'v{version}_global.db'
     new_data_dir = Path(tmpdir_factory.mktemp('test_data_dir'))
-    new_global_dir = new_data_dir / 'global_data'
+    new_global_dir = new_data_dir / GLOBALDIR_NAME
     new_global_dir.mkdir(parents=True, exist_ok=True)
-    copyfile(source_db_path, new_global_dir / 'global.db')
+    copyfile(source_db_path, new_global_dir / GLOBALDB_NAME)
     with pytest.raises(ValueError) as excinfo:
         create_globaldb(new_data_dir, sql_vm_instructions_cb)
 
@@ -663,7 +663,7 @@ def test_global_db_restore(globaldb, database):
 
     # Check that the number of assets is the expected
     root_dir = Path(__file__).resolve().parent.parent.parent.parent
-    builtin_database = root_dir / 'data' / 'global.db'
+    builtin_database = root_dir / 'data' / GLOBALDB_NAME
     conn = sqlite3.connect(builtin_database)
     cursor_clean_db = conn.cursor()
     tokens_expected = cursor_clean_db.execute('SELECT COUNT(*) FROM assets;')
@@ -805,7 +805,7 @@ def test_global_db_reset(globaldb, database):
 
     # Check that the number of assets is the expected
     root_dir = Path(__file__).resolve().parent.parent.parent.parent
-    builtin_database = root_dir / 'data' / 'global.db'
+    builtin_database = root_dir / 'data' / GLOBALDB_NAME
     conn = sqlite3.connect(builtin_database)
     cursor_clean_db = conn.cursor()
     tokens_expected = cursor_clean_db.execute('SELECT COUNT(*) FROM assets;')

--- a/rotkehlchen/tests/unit/globaldb/test_upgrades.py
+++ b/rotkehlchen/tests/unit/globaldb/test_upgrades.py
@@ -9,6 +9,7 @@ from eth_utils.address import to_checksum_address
 from freezegun import freeze_time
 
 from rotkehlchen.assets.types import AssetType
+from rotkehlchen.constants.misc import GLOBALDB_NAME, GLOBALDIR_NAME
 from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType
 from rotkehlchen.errors.misc import DBUpgradeError
 from rotkehlchen.globaldb.cache import (
@@ -29,7 +30,7 @@ from rotkehlchen.globaldb.upgrades.v3_v4 import (
     YEARN_ABI_GROUP_4,
 )
 from rotkehlchen.globaldb.upgrades.v5_v6 import V5_V6_UPGRADE_UNIQUE_CACHE_KEYS
-from rotkehlchen.globaldb.utils import GLOBAL_DB_FILENAME, GLOBAL_DB_VERSION
+from rotkehlchen.globaldb.utils import GLOBAL_DB_VERSION
 from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 from rotkehlchen.tests.utils.globaldb import patch_for_globaldb_upgrade_to
 from rotkehlchen.types import YEARN_VAULTS_V1_PROTOCOL, CacheType, ChainID, EvmTokenKind, Timestamp
@@ -104,8 +105,8 @@ def test_upgrade_v2_v3(globaldb: GlobalDBHandler):
         patch_for_globaldb_upgrade_to(stack, 3)
         maybe_upgrade_globaldb(
             connection=globaldb.conn,
-            global_dir=globaldb._data_directory / 'global_data',  # type: ignore
-            db_filename=GLOBAL_DB_FILENAME,
+            global_dir=globaldb._data_directory / GLOBALDIR_NAME,  # type: ignore
+            db_filename=GLOBALDB_NAME,
         )
 
     assert globaldb.get_setting_value('version', 0) == 3
@@ -209,8 +210,8 @@ def test_upgrade_v3_v4(globaldb: GlobalDBHandler):
         patch_for_globaldb_upgrade_to(stack, 4)
         maybe_upgrade_globaldb(
             connection=globaldb.conn,
-            global_dir=globaldb._data_directory / 'global_data',  # type: ignore
-            db_filename=GLOBAL_DB_FILENAME,
+            global_dir=globaldb._data_directory / GLOBALDIR_NAME,  # type: ignore
+            db_filename=GLOBALDB_NAME,
         )
 
     assert globaldb.get_setting_value('version', 0) == 4
@@ -336,8 +337,8 @@ def test_upgrade_v4_v5(globaldb: GlobalDBHandler):
         patch_for_globaldb_upgrade_to(stack, 5)
         maybe_upgrade_globaldb(
             connection=globaldb.conn,
-            global_dir=globaldb._data_directory / 'global_data',  # type: ignore
-            db_filename=GLOBAL_DB_FILENAME,
+            global_dir=globaldb._data_directory / GLOBALDIR_NAME,  # type: ignore
+            db_filename=GLOBALDB_NAME,
         )
 
     assert globaldb.get_setting_value('version', 0) == 5
@@ -448,8 +449,8 @@ def test_upgrade_v5_v6(globaldb: GlobalDBHandler):
         patch_for_globaldb_upgrade_to(stack, 6)
         maybe_upgrade_globaldb(
             connection=globaldb.conn,
-            global_dir=globaldb._data_directory / 'global_data',  # type: ignore
-            db_filename=GLOBAL_DB_FILENAME,
+            global_dir=globaldb._data_directory / GLOBALDIR_NAME,  # type: ignore
+            db_filename=GLOBALDB_NAME,
         )
     assert globaldb.get_setting_value('version', 0) == 6
     with globaldb.conn.read_ctx() as cursor:
@@ -520,7 +521,7 @@ def test_unfinished_upgrades(globaldb: GlobalDBHandler):
         create_globaldb(globaldb._data_directory, 0)
 
     # Add a backup
-    backup_path = globaldb._data_directory / 'global_data' / f'{ts_now()}_global_db_v2.backup'  # type: ignore  # _data_directory is definitely not null here
+    backup_path = globaldb._data_directory / GLOBALDIR_NAME / f'{ts_now()}_global_db_v2.backup'  # type: ignore  # _data_directory is definitely not null here
     shutil.copy(Path(__file__).parent.parent.parent / 'data' / 'v2_global.db', backup_path)
     backup_connection = DBConnection(
         path=str(backup_path),
@@ -551,8 +552,8 @@ def test_applying_all_upgrade(globaldb: GlobalDBHandler):
 
     maybe_upgrade_globaldb(
         connection=globaldb.conn,
-        global_dir=globaldb._data_directory / 'global_data',  # type: ignore
-        db_filename=GLOBAL_DB_FILENAME,
+        global_dir=globaldb._data_directory / GLOBALDIR_NAME,  # type: ignore
+        db_filename=GLOBALDB_NAME,
     )
 
     assert globaldb.get_setting_value('version', 0) == GLOBAL_DB_VERSION

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -13,6 +13,7 @@ from rotkehlchen.assets.asset import Asset, CryptoAsset, CustomAsset, EvmToken, 
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.assets.utils import get_or_create_evm_token, symbol_to_evm_token
 from rotkehlchen.constants.assets import A_DAI, A_USDT
+from rotkehlchen.constants.misc import GLOBALDB_NAME
 from rotkehlchen.constants.resolver import evm_address_to_identifier, strethaddress_to_identifier
 from rotkehlchen.db.custom_assets import DBCustomAssets
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
@@ -754,12 +755,12 @@ def test_symbol_or_name(database):
 
 def test_load_from_packaged_db(globaldb: GlobalDBHandler):
     """Test that connecting to the packaged globaldb doesn't try to write into it."""
-    packaged_db_path = Path(__file__).resolve().parent.parent.parent / 'data' / 'global.db'
+    packaged_db_path = Path(__file__).resolve().parent.parent.parent / 'data' / GLOBALDB_NAME
     with TemporaryDirectory(
             ignore_cleanup_errors=True,  # needed on windows, see https://tinyurl.com/tmp-win-err
     ) as tmpdirname:
         # Create a copy of the global db in a temp file
-        dest_file = Path(tmpdirname) / 'data' / 'global.db'
+        dest_file = Path(tmpdirname) / 'data' / GLOBALDB_NAME
         os.makedirs(dest_file.parent, exist_ok=True)
         backup = shutil.copy(packaged_db_path, dest_file)
 

--- a/rotkehlchen/tests/unit/test_data_dir.py
+++ b/rotkehlchen/tests/unit/test_data_dir.py
@@ -1,0 +1,145 @@
+import pytest
+
+from rotkehlchen.constants.misc import (
+    AVATARIMAGESDIR_NAME,
+    CUSTOMASSETIMAGESDIR_NAME,
+    GLOBALDB_NAME,
+    MISCDIR_NAME,
+    USERDB_NAME,
+)
+from rotkehlchen.utils.datadir import maybe_restructure_rotki_data_directory
+
+USERS = ['lefteris', 'kelsos', 'luki']
+BAD_USERS = ['app', 'global']
+MISC_FILE = 'geoip-1234.mmdb'
+ASSET_ICONS = ('ETH_small.png', 'KSM_small.png')
+AIRDROPS = ('coswap.csv', 'lido.csv')
+AVATARS = ('lefteris.eth.png', 'lito.eth.png')
+CUSTOM_ICONS = ('f69e047e-cb4a-48a8-8382-8c78269866d5.png', 'cb4a-48a8-8382-8c78269844d5.png')
+REMNANT_FILES = ('file1.txt', 'file2.json')
+REMNANT_DIRS = ('random_dir1', 'random_dir2')
+
+
+def _create_old_directory_structure(data_dir):
+    """Create the old directory tree structure to test against it"""
+    global_data = data_dir / 'global_data'
+    global_data.mkdir(parents=True, exist_ok=True)
+    (global_data / GLOBALDB_NAME).touch()
+
+    for user in USERS:
+        user_dir = data_dir / user
+        user_dir.mkdir(parents=True, exist_ok=True)
+        (user_dir / USERDB_NAME).touch()
+
+    misc_data = data_dir / MISCDIR_NAME
+    misc_data.mkdir(parents=True, exist_ok=True)
+    (misc_data / MISC_FILE).touch()
+
+    for name in ('airdrops', 'airdrops_poap'):
+        subdir = data_dir / name
+        subdir.mkdir(parents=True, exist_ok=True)
+        for filename in AIRDROPS:
+            (subdir / filename).touch()
+
+    icons_data = data_dir / 'icons'
+    icons_data.mkdir(parents=True, exist_ok=True)
+    for name in ASSET_ICONS:
+        (icons_data / name).touch()
+
+    avatars_data = icons_data / AVATARIMAGESDIR_NAME
+    avatars_data.mkdir(parents=True, exist_ok=True)
+    for name in AVATARS:
+        (avatars_data / name).touch()
+
+    custom_data = icons_data / CUSTOMASSETIMAGESDIR_NAME
+    custom_data.mkdir(parents=True, exist_ok=True)
+    for name in CUSTOM_ICONS:
+        (custom_data / name).touch()
+
+    # also add two bad edge cases of username same as the new root directories we want to have
+    for bad_user in BAD_USERS:
+        user_dir = data_dir / bad_user
+        user_dir.mkdir(parents=True, exist_ok=True)
+        (user_dir / USERDB_NAME).touch()
+
+    # add some random files / dirs to see they are not lost
+    for random_file in REMNANT_FILES:
+        (data_dir / random_file).touch()
+    for random_dir in REMNANT_DIRS:
+        (data_dir / random_dir).mkdir()
+
+
+def _assert_dir_matches(directory, expected):
+    contents = set()
+    for x in directory.iterdir():
+        contents.add(x.name)
+
+    assert contents == set(expected)
+
+
+def _assert_directory_structure(data_dir):
+    """Asserts that the directory structure has been properly migrated"""
+    for x in data_dir.iterdir():
+        assert x.is_dir() and x.name in ('users', 'app', 'global', 'images', 'restructuring_remnants')  # noqa: E501
+
+    # assert the proper directory structure for users
+    users_dir = data_dir / 'users'
+    users = set()
+    for x in users_dir.iterdir():
+        assert x.is_dir() and (x / USERDB_NAME).exists()
+        users.add(x.name)
+    assert users == set(USERS + BAD_USERS)
+
+    # assert the proper directory structure for global data
+    global_dir = data_dir / 'global'
+    assert global_dir.is_dir()
+    assert (global_dir / GLOBALDB_NAME).exists()
+
+    # assert the proper directory structure for app data
+    app_dir = data_dir / 'app'
+    users = set()
+    for x in app_dir.iterdir():
+        if x.name in ('airdrops', 'airdrops_poap'):
+            _assert_dir_matches(x, AIRDROPS)
+        elif x.name == MISCDIR_NAME:
+            assert (x / MISC_FILE).exists()
+        else:
+            raise AssertionError(f'Found unexpected path {x}')
+
+    # assert the proper directory structure for images
+    images_dir = data_dir / 'images'
+    for x in images_dir.iterdir():
+        if x.name == AVATARIMAGESDIR_NAME:
+            _assert_dir_matches(x, AVATARS)
+        elif x.name == 'assets':
+            for y in x.iterdir():
+                if y.name == 'all':
+                    _assert_dir_matches(y, ASSET_ICONS)
+                elif y.name == CUSTOMASSETIMAGESDIR_NAME:
+                    _assert_dir_matches(y, CUSTOM_ICONS)
+                else:
+                    raise AssertionError(f'Found unexpected path {y}')
+        else:
+            raise AssertionError(f'Found unexpected path {x}')
+
+    # assert remnants
+    remnants_dir = data_dir / 'restructuring_remnants'
+    for x in remnants_dir.iterdir():
+        if x.name in REMNANT_FILES:
+            assert x.exists()
+        elif x.name in REMNANT_DIRS:
+            assert x.is_dir()
+        else:
+            raise AssertionError(f'Found unexpected path {x}')
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_restructure_rotki_data_directory(data_dir):
+    """Test that restructuring the rotki data directory works as expected"""
+    _create_old_directory_structure(data_dir)
+    maybe_restructure_rotki_data_directory(data_dir)
+    _assert_directory_structure(data_dir)
+
+    # make sure that running again does not mess things up
+    maybe_restructure_rotki_data_directory(data_dir)
+    _assert_directory_structure(data_dir)

--- a/rotkehlchen/tests/utils/database.py
+++ b/rotkehlchen/tests/utils/database.py
@@ -12,6 +12,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccountData, BlockchainAccounts
 from rotkehlchen.chain.evm.nodes import populate_rpc_nodes_in_database
+from rotkehlchen.constants.misc import USERDB_NAME
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.errors.misc import InputError
@@ -172,7 +173,7 @@ def _use_prepared_db(user_data_dir: Path, filename: str) -> None:
     dir_path = os.path.dirname(os.path.realpath(__file__))
     copyfile(
         os.path.join(os.path.dirname(dir_path), 'data', filename),
-        user_data_dir / 'rotkehlchen.db',
+        user_data_dir / USERDB_NAME,
     )
 
 

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -4,6 +4,7 @@ from typing import Literal
 from unittest.mock import patch
 
 from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
+from rotkehlchen.constants.misc import USERDB_NAME, USERSDIR_NAME
 from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.constants import A_GBP, DEFAULT_TESTS_MAIN_CURRENCY
@@ -205,7 +206,7 @@ def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
     with rotkehlchen_instance.data.db.conn.read_ctx() as cursor:
         assert rotkehlchen_instance.data.db.get_setting(cursor, name='main_currency') == A_GBP
     # Also check a copy of our old DB is kept around.
-    directory = os.path.join(rotkehlchen_instance.data.data_directory, username)
+    directory = rotkehlchen_instance.data.data_directory / USERSDIR_NAME / username
     files = [
         os.path.join(directory, f) for f in os.listdir(directory)
         if (not f.endswith('backup') or f.startswith('rotkehlchen_db')) and not f.startswith('rotkehlchen_transient')  # noqa: E501
@@ -216,7 +217,7 @@ def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
     main_db_exists = False
     backup_db_exists = False
     for file in files:
-        if 'rotkehlchen.db' in file:
+        if USERDB_NAME in file:
             main_db_exists = True
         elif 'backup' in file:
             backup_db_exists = True

--- a/rotkehlchen/usage_analytics.py
+++ b/rotkehlchen/usage_analytics.py
@@ -10,6 +10,7 @@ import maxminddb
 import miniupnpc
 import requests
 
+from rotkehlchen.constants.misc import APPDIR_NAME, MISCDIR_NAME
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -33,7 +34,7 @@ def retrieve_location_data(data_dir: Path) -> GeolocationData | None:
 
     **IMPORTANT:** The ip never leaves the user's machine. It's all calculated locally.
     """
-    geoip_dir = data_dir / 'misc'
+    geoip_dir = data_dir / APPDIR_NAME / MISCDIR_NAME
     geoip_dir.mkdir(parents=True, exist_ok=True)
     # get latest database version
     metadata_query_failed = False

--- a/rotkehlchen/utils/datadir.py
+++ b/rotkehlchen/utils/datadir.py
@@ -1,0 +1,140 @@
+import logging
+from pathlib import Path
+from shutil import Error, copytree, move, rmtree
+
+from rotkehlchen.constants.misc import (
+    ALLASSETIMAGESDIR_NAME,
+    APPDIR_NAME,
+    ASSETIMAGESDIR_NAME,
+    AVATARIMAGESDIR_NAME,
+    CUSTOMASSETIMAGESDIR_NAME,
+    GLOBALDIR_NAME,
+    IMAGESDIR_NAME,
+    MISCDIR_NAME,
+    USERDB_NAME,
+    USERSDIR_NAME,
+)
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.utils.misc import ts_now
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+def _create_directory_with_potential_backup(data_dir: Path, name: str) -> Path:
+    """Create a subdirectory under the main data directory. If the directory
+    already exists and has a user database in it, that means that someone made
+    a user with that name. In which edge case we will try to rename and backup"""
+    subdir = data_dir / name
+    if (subdir / USERDB_NAME).exists():
+        # someone had a user, called name ... and did not get moved with initial for loop
+        try:  # this should not happen actually ...
+            backup_name = f'auto_backup_{name}_user_{ts_now()}'
+            copytree(subdir, backup_name)
+            log.debug(f'Found old style user with name {name}. Backing it up at {backup_name}')
+        except (PermissionError, Error) as e:
+            log.error(f'During restructuring data directory failed to make a backup of a user called {name} due to {e}')  # noqa: E501
+        else:
+            rmtree(subdir, ignore_errors=True)
+
+    subdir.mkdir(parents=True, exist_ok=True)
+    return subdir
+
+
+def _move_paths_to_directory(paths: list[Path], target_dir: Path) -> None:
+    """Move given paths to the target directory"""
+    for path in paths:
+        target_path_dir = target_dir / path.name
+        try:
+            move(path, target_path_dir)
+        except (PermissionError, Error) as e:
+            log.error(f'During restructuring data directory failed to copy {path} to {target_path_dir} due to {e}')  # noqa: E501
+
+
+def _handle_images(data_dir: Path, icons_path: Path | None) -> None:
+    """Create the images data directory and move paths there"""
+    if icons_path is not None:
+        img_data_dir = _create_directory_with_potential_backup(data_dir, IMAGESDIR_NAME)
+        assets_dir = img_data_dir / ASSETIMAGESDIR_NAME
+        assets_dir.mkdir(parents=True, exist_ok=True)
+
+        targetpath = assets_dir / ALLASSETIMAGESDIR_NAME
+        try:
+            move(icons_path, targetpath)
+        except (PermissionError, Error) as e:
+            log.error(f'During restructuring data directory failed to move {icons_path} to {targetpath} due to {e}')  # noqa: E501
+            return
+
+        all_assets_dir = targetpath
+        for name, target_dir in ((AVATARIMAGESDIR_NAME, img_data_dir), (CUSTOMASSETIMAGESDIR_NAME, assets_dir)):  # noqa: E501
+            subdir = all_assets_dir / name
+            if not subdir.exists():
+                continue
+
+            targetpath = target_dir / name
+            try:
+                move(subdir, targetpath)
+            except (PermissionError, Error) as e:
+                log.error(f'During restructuring data directory failed to move {subdir} to {targetpath} due to {e}')  # noqa: E501
+
+
+def maybe_restructure_rotki_data_directory(data_dir: Path) -> None:
+    """Restructures the data directory to contain users under a specficic subdirectory
+    and other kind of data under other ones. Essentially implement:
+    https://github.com/rotki/rotki/issues/4841
+
+    TODO: This should stay here for only a few versions and later be removed. This
+    restructuring can always be done by the user in a super weird edge case, by hand.
+    """
+    if not (data_dir / 'global_data').is_dir():
+        return  # probably already restructured
+
+    user_paths = []
+    other_paths = []
+    global_path = airdrops_path = airdrops_poap_path = misc_path = icons_path = None
+    for x in data_dir.iterdir():
+        try:
+            if not x.is_dir():
+                other_paths.append(x)
+                continue
+
+            if (x / USERDB_NAME).exists():
+                user_paths.append(x)
+            elif x.name == 'global_data':
+                global_path = x
+            elif x.name == 'airdrops':
+                airdrops_path = x
+            elif x.name == 'airdrops_poap':
+                airdrops_poap_path = x
+            elif x.name == MISCDIR_NAME:
+                misc_path = x
+            elif x.name == 'icons':
+                icons_path = x
+            else:
+                other_paths.append(x)
+
+        except PermissionError:
+            # ignore directories that can't be accessed
+            continue
+
+    # create the user_data directory and move users there
+    user_data_dir = _create_directory_with_potential_backup(data_dir, USERSDIR_NAME)
+    _move_paths_to_directory(user_paths, user_data_dir)
+
+    # create the application data directory and move paths there
+    app_data_dir = _create_directory_with_potential_backup(data_dir, APPDIR_NAME)
+    _move_paths_to_directory([x for x in (airdrops_path, airdrops_poap_path, misc_path) if x is not None], app_data_dir)  # noqa: E501
+
+    _handle_images(data_dir=data_dir, icons_path=icons_path)
+    if global_path is not None:
+        global_data_dir = _create_directory_with_potential_backup(data_dir, GLOBALDIR_NAME)
+        rmtree(global_data_dir)
+        try:
+            move(global_path, global_data_dir)
+        except (PermissionError, Error) as e:
+            log.error(f'During restructuring data directory failed to copy {global_path} to {global_data_dir} due to {e}')  # noqa: E501
+
+    # create the restructuring remnants directory and move all other paths there
+    if len(other_paths) != 0:
+        remnants_dir = _create_directory_with_potential_backup(data_dir, 'restructuring_remnants')
+        _move_paths_to_directory(other_paths, remnants_dir)

--- a/tools/assets_database/main.py
+++ b/tools/assets_database/main.py
@@ -1,5 +1,6 @@
 """Tool to pull an assets database from Github, and apply updates to it"""
 from gevent import monkey
+
 monkey.patch_all()  # isort:skip
 
 import argparse
@@ -10,6 +11,7 @@ from tempfile import TemporaryDirectory
 
 import requests
 
+from rotkehlchen.constants.misc import GLOBALDB_NAME, GLOBALDIR_NAME
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.globaldb.updates import AssetsUpdater
@@ -66,7 +68,7 @@ def get_remote_global_db(directory: Path, version: int, branch: str) -> Path:
         sys.exit(1)
 
     total_bytes = 0
-    dbpath = directory / 'global.db'
+    dbpath = directory / GLOBALDB_NAME
     chunk_size = 4096
     print(f'Downloading v{version} globaldb from the remote...')
     with open(dbpath, 'wb') as f:
@@ -87,8 +89,8 @@ def main() -> None:
     if not target_directory.is_dir():
         print(f'Given directory {target_directory} not a valid directory')
         sys.exit(1)
-    # The way global db works it needs to be under a directory called 'global_data'
-    target_global_dir = target_directory / 'global_data'
+    # The way global db works it needs to be under a directory called 'global'
+    target_global_dir = target_directory / GLOBALDIR_NAME
     target_global_dir.mkdir(parents=True, exist_ok=True)
     get_remote_global_db(
         directory=target_global_dir,
@@ -112,8 +114,8 @@ def main() -> None:
 
     # Due to the way globaldb initializes we have two of them. Clean up the extra one
     print('Cleaning up...')
-    (target_directory / 'global_data' / 'global.db').rename(target_directory / 'global.db')
-    shutil.rmtree(target_directory / 'global_data')
+    (target_directory / GLOBALDIR_NAME / GLOBALDB_NAME).rename(target_directory / GLOBALDB_NAME)
+    shutil.rmtree(target_directory / GLOBALDIR_NAME)
     print('Done!')
 
 


### PR DESCRIPTION
Properly structure the rotki data directory so that data is organized properly in various directories and not just all thrown under a root directory with potential clashes between usernames and other stuff.

Fix https://github.com/rotki/rotki/issues/4841

