### PR TITLE
Improve UX for uniswap and sushiswap tokens

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`7015` Users will be able to sort the blockchain accounts by displayed name.
+* :feature:`7024` When a Uniswap-V2 or Sushiswap deposit gets decoded it will update the default symbol of the LP token to include information about the underlying tokens.
 * :bug:`7017` Fix the issue where clicking on the chain in the blockchain balance summary didn't show the correct section.
 * :bug:`6999` Chai token balances should not appear doubled under certain conditions.
 * :bug:`-` Fix styling issue with the lock icon for "Add collateralization ratio watcher" for non-premium user.

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -91,13 +91,14 @@ def _query_or_get_given_token_info(
     return name, symbol, decimals
 
 
-def _edit_token_and_clean_cache(
+def edit_token_and_clean_cache(
         evm_token: EvmToken,
         name: str | None,
+        symbol: str | None,
         decimals: int | None,
         started: Timestamp | None,
         underlying_tokens: list[UnderlyingToken] | None,
-        evm_inquirer: Optional['EvmNodeInquirer'],
+        evm_inquirer: 'EvmNodeInquirer | None',
 ) -> None:
     """
     Update information regarding name and decimals for an ethereum token.
@@ -122,6 +123,10 @@ def _edit_token_and_clean_cache(
             object.__setattr__(evm_token, 'name', on_chain_name)
             object.__setattr__(evm_token, 'decimals', on_chain_decimals)
             updated_fields = True
+
+    if symbol is not None and evm_token.symbol != symbol:
+        object.__setattr__(evm_token, 'symbol', symbol)
+        updated_fields = True
 
     if decimals is not None and evm_token.decimals != decimals:
         object.__setattr__(evm_token, 'decimals', decimals)
@@ -217,9 +222,10 @@ def get_or_create_evm_token(
             # It can happen that the asset is missing basic information but can be queried on
             # is provided by the developer. In that case make sure that no information
             # is cached and trigger the edit process.
-            _edit_token_and_clean_cache(
+            edit_token_and_clean_cache(
                 evm_token=evm_token,
                 name=name,
+                symbol=symbol,
                 decimals=decimals,
                 started=started,
                 underlying_tokens=underlying_tokens,

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -7,7 +7,6 @@ from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import (
     SUSHISWAP_ROUTER,
     decode_uniswap_like_deposit_and_withdrawals,
     decode_uniswap_v2_like_swap,
-    enrich_uniswap_v2_like_lp_tokens_transfers,
 )
 from rotkehlchen.chain.ethereum.modules.uniswap.v2.constants import SWAP_SIGNATURE
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
@@ -15,13 +14,11 @@ from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
     DecodingOutput,
-    EnricherContext,
-    TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
-from rotkehlchen.types import SUSHISWAP_PROTOCOL, EvmTransaction
+from rotkehlchen.types import EvmTransaction
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.structures.evm_event import EvmEvent
@@ -94,25 +91,12 @@ class SushiswapDecoder(DecoderInterface):
             )
         return DEFAULT_DECODING_OUTPUT
 
-    @staticmethod
-    def _maybe_enrich_lp_tokens_transfers(context: EnricherContext) -> TransferEnrichmentOutput:
-        return enrich_uniswap_v2_like_lp_tokens_transfers(
-            context=context,
-            counterparty=CPT_SUSHISWAP_V2,
-            lp_token_symbol=SUSHISWAP_PROTOCOL,
-        )
-
     # -- DecoderInterface methods
 
     def decoding_rules(self) -> list[Callable]:
         return [
             self._maybe_decode_v2_swap,
             self._maybe_decode_v2_liquidity_addition_and_removal,
-        ]
-
-    def enricher_rules(self) -> list[Callable]:
-        return [
-            self._maybe_enrich_lp_tokens_transfers,
         ]
 
     @staticmethod

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
@@ -7,22 +7,21 @@ from web3 import Web3
 
 from rotkehlchen.accounting.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken, UnderlyingToken
+from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.utils import (
     TokenEncounterInfo,
     get_or_create_evm_token,
     set_token_protocol_if_missing,
 )
 from rotkehlchen.chain.ethereum.modules.constants import AMM_ASSETS_SYMBOLS
+from rotkehlchen.chain.ethereum.modules.uniswap.constants import CPT_UNISWAP_V2
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, generate_address_via_create2
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
-    FAILED_ENRICHMENT_OUTPUT,
     ActionItem,
     DecodingOutput,
-    EnricherContext,
-    TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -249,10 +248,57 @@ def decode_uniswap_like_deposit_and_withdrawals(
     if token0 is None or token1 is None:
         return DEFAULT_DECODING_OUTPUT
 
+    # determine the pool address from the pair of token addresses, if it matches
+    # the one found earlier, mutate the decoded event or create an action item where necessary.
+    pool_address = _compute_uniswap_v2_like_pool_address(
+        token0=token0,
+        token1=token1,
+        factory_address=factory_address,
+        init_code_hash=init_code_hash,
+    )
+    if pool_address != target_pool_address:  # we didn't find the correct pool
+        return DEFAULT_DECODING_OUTPUT
+
     amount0 = asset_normalized_value(amount0_raw, token0)
     amount1 = asset_normalized_value(amount1_raw, token1)
+    underlying_tokens = [
+        UnderlyingToken(address=token0.evm_address, token_kind=EvmTokenKind.ERC20, weight=FVal(0.5)),  # noqa: E501
+        UnderlyingToken(address=token1.evm_address, token_kind=EvmTokenKind.ERC20, weight=FVal(0.5)),  # noqa: E501
+    ]
 
-    # Second, find already decoded events of the transfers and store the id to mutate after
+    try:
+        token_is_uniswap_v2_lp = counterparty == CPT_UNISWAP_V2
+        pool_token = get_or_create_evm_token(
+            userdb=database,
+            evm_address=pool_address,
+            chain_id=ChainID.ETHEREUM,
+            token_kind=EvmTokenKind.ERC20,
+            evm_inquirer=ethereum_inquirer,
+            encounter=TokenEncounterInfo(tx_hash=tx_hash),
+            underlying_tokens=underlying_tokens,
+            protocol=UNISWAP_PROTOCOL if token_is_uniswap_v2_lp else None,
+        )
+
+        if len(pool_token.underlying_tokens) == 0:
+            pool_token = dataclasses.replace(pool_token, underlying_tokens=underlying_tokens)
+            GlobalDBHandler().edit_evm_token(pool_token)
+            AssetResolver().clean_memory_cache(pool_token.identifier)
+
+        if pool_token.symbol in {UNISWAP_PROTOCOL, SUSHISWAP_PROTOCOL}:
+            # uniswap and sushiswap provide the same symbol for all the LP tokens. In order to
+            # provide a a better UX if the default symbol is used then change the symbol to
+            # include the symbols of the underlying tokens.
+            object.__setattr__(pool_token, 'symbol', f'{pool_token.symbol} {token0.symbol}-{token1.symbol}')  # noqa: E501
+            GlobalDBHandler().edit_evm_token(pool_token)
+            AssetResolver.clean_memory_cache(pool_token.identifier)
+    except NotERC20Conformant:
+        log.error(
+            f'Failed to create the pool token since it does not conform to ERC20. '
+            f'expected: {pool_address} for {token0.evm_address}-{token1.evm_address}',
+        )
+        return DEFAULT_DECODING_OUTPUT
+
+    # find already decoded events of the transfers and store the id to mutate after
     # confirmation that it is indeed Uniswap V2 like Pool.
     for idx, event in enumerate(decoded_events):
         resolved_asset = event.asset.resolve_to_crypto_asset()
@@ -264,7 +310,6 @@ def decode_uniswap_like_deposit_and_withdrawals(
         ):
             asset_0 = resolved_asset  # here we know exactly if it is ETH or WETH (or any other asset) so assign the asset  # noqa: E501
             event0_idx = idx
-
         elif (
             event.event_type == from_event_type[0] and
             event.event_subtype == from_event_type[1] and
@@ -273,108 +318,62 @@ def decode_uniswap_like_deposit_and_withdrawals(
         ):
             asset_1 = resolved_asset
             event1_idx = idx
-
-    # Finally, determine the pool address from the pair of token addresses, if it matches
-    # the one found earlier, mutate the decoded event or create an action item where necessary.
-    pool_address = _compute_uniswap_v2_like_pool_address(
-        token0=token0,
-        token1=token1,
-        factory_address=factory_address,
-        init_code_hash=init_code_hash,
-    )
-    underlying_tokens = [
-        UnderlyingToken(address=token0.evm_address, token_kind=EvmTokenKind.ERC20, weight=FVal(0.5)),  # noqa: E501
-        UnderlyingToken(address=token1.evm_address, token_kind=EvmTokenKind.ERC20, weight=FVal(0.5)),  # noqa: E501
-    ]
-    try:
-        pool_token = get_or_create_evm_token(
-            userdb=database,
-            evm_address=pool_address,
-            chain_id=ChainID.ETHEREUM,
-            token_kind=EvmTokenKind.ERC20,
-            evm_inquirer=ethereum_inquirer,
-            encounter=TokenEncounterInfo(tx_hash=tx_hash),
-            underlying_tokens=underlying_tokens,
-        )
-        if len(pool_token.underlying_tokens) == 0:
-            pool_token = dataclasses.replace(pool_token, underlying_tokens=underlying_tokens)
-            GlobalDBHandler().edit_evm_token(pool_token)
-    except NotERC20Conformant:
-        log.error(
-            f'Failed to create the pool token since it does not conform to ERC20. '
-            f'expected: {pool_address} for {token0.evm_address}-{token1.evm_address}',
-        )
+        elif (
+            resolved_asset == pool_token and
+            event.event_type == HistoryEventType.RECEIVE and
+            event.event_subtype == HistoryEventSubType.NONE and
+            event.address == ZERO_ADDRESS
+        ):
+            event.counterparty = counterparty
+            event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
+            event.notes = f'Receive {event.balance.amount} {resolved_asset.symbol} from {counterparty} pool'  # noqa: E501
+            set_token_protocol_if_missing(event.asset.resolve_to_evm_token(), UNISWAP_PROTOCOL if resolved_asset.symbol.startswith('UNI-V2') else SUSHISWAP_PROTOCOL)  # noqa: E501
+        elif (
+            resolved_asset == pool_token and
+            event.event_type == HistoryEventType.SPEND and
+            event.event_subtype == HistoryEventSubType.NONE and
+            event.address == tx_log.address  # the recipient of the transfer is the pool  # noqa: E501
+        ):
+            event.counterparty = counterparty
+            event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
+            event.notes = f'Send {event.balance.amount} {resolved_asset.symbol} to {counterparty} pool'  # noqa: E501
 
     new_action_items = []
-    if pool_address == target_pool_address:
-        for asset, decoded_event_idx, amount in [(asset_0, event0_idx, amount0), (asset_1, event1_idx, amount1)]:  # noqa: E501
-            extra_data = {'pool_address': pool_address}
-            if decoded_event_idx is None:
-                action_item = ActionItem(
-                    action='transform',
-                    from_event_type=from_event_type[0],
-                    from_event_subtype=from_event_type[1],
-                    asset=asset,
-                    amount=amount,
-                    to_event_type=to_event_type[0],
-                    to_event_subtype=to_event_type[1],
-                    to_notes=notes.format(
-                        amount=amount,
-                        asset=asset.symbol,
-                        counterparty=counterparty,
-                        pool_address=pool_address,
-                    ),
-                    to_counterparty=counterparty,
-                    extra_data=extra_data,
-                )
-                new_action_items.append(action_item)
-                continue
-
-            decoded_events[decoded_event_idx].counterparty = counterparty
-            decoded_events[decoded_event_idx].event_type = to_event_type[0]
-            decoded_events[decoded_event_idx].event_subtype = to_event_type[1]
-            decoded_events[decoded_event_idx].notes = notes.format(
+    extra_data = {'pool_address': pool_address}
+    for asset, decoded_event_idx, amount in ((asset_0, event0_idx, amount0), (asset_1, event1_idx, amount1)):  # noqa: E501
+        if decoded_event_idx is None:
+            action_item = ActionItem(
+                action='transform',
+                from_event_type=from_event_type[0],
+                from_event_subtype=from_event_type[1],
+                asset=asset,
                 amount=amount,
-                asset=asset.symbol,
-                counterparty=counterparty,
-                pool_address=pool_address,
+                to_event_type=to_event_type[0],
+                to_event_subtype=to_event_type[1],
+                to_notes=notes.format(
+                    amount=amount,
+                    asset=asset.symbol,
+                    counterparty=counterparty,
+                    pool_address=pool_address,
+                ),
+                to_counterparty=counterparty,
+                extra_data=extra_data,
             )
-            decoded_events[decoded_event_idx].extra_data = extra_data
+            new_action_items.append(action_item)
+            continue
+
+        decoded_events[decoded_event_idx].counterparty = counterparty
+        decoded_events[decoded_event_idx].event_type = to_event_type[0]
+        decoded_events[decoded_event_idx].event_subtype = to_event_type[1]
+        decoded_events[decoded_event_idx].notes = notes.format(
+            amount=amount,
+            asset=asset.symbol,
+            counterparty=counterparty,
+            pool_address=pool_address,
+        )
+        decoded_events[decoded_event_idx].extra_data = extra_data
 
     return DecodingOutput(action_items=new_action_items)
-
-
-def enrich_uniswap_v2_like_lp_tokens_transfers(
-        context: EnricherContext,
-        counterparty: str,
-        lp_token_symbol: Literal['UNI-V2', 'SLP'],
-) -> TransferEnrichmentOutput:
-    """This function enriches LP tokens transfers of Uniswap V2 like AMMs."""
-    resolved_asset = context.event.asset.resolve_to_crypto_asset()
-    if (
-        resolved_asset.symbol == lp_token_symbol and
-        context.event.event_type == HistoryEventType.RECEIVE and
-        context.event.event_subtype == HistoryEventSubType.NONE and
-        context.event.address == ZERO_ADDRESS
-    ):
-        context.event.counterparty = counterparty
-        context.event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
-        context.event.notes = f'Receive {context.event.balance.amount} {resolved_asset.symbol} from {counterparty} pool'  # noqa: E501
-        set_token_protocol_if_missing(context.event.asset.resolve_to_evm_token(), UNISWAP_PROTOCOL if lp_token_symbol == 'UNI-V2' else SUSHISWAP_PROTOCOL)  # noqa: E501
-        return TransferEnrichmentOutput(matched_counterparty=counterparty)
-
-    if (
-        resolved_asset.symbol == lp_token_symbol and
-        context.event.event_type == HistoryEventType.SPEND and
-        context.event.event_subtype == HistoryEventSubType.NONE and
-        context.event.address == context.tx_log.address  # the recipient of the transfer is the pool  # noqa: E501
-    ):
-        context.event.counterparty = counterparty
-        context.event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
-        context.event.notes = f'Send {context.event.balance.amount} {resolved_asset.symbol} to {counterparty} pool'  # noqa: E501
-        return TransferEnrichmentOutput(matched_counterparty=counterparty)
-
-    return FAILED_ENRICHMENT_OUTPUT
 
 
 def _compute_uniswap_v2_like_pool_address(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -12,7 +12,6 @@ from rotkehlchen.chain.ethereum.modules.uniswap.v2.common import (
     UNISWAP_V2_ROUTER,
     decode_uniswap_like_deposit_and_withdrawals,
     decode_uniswap_v2_like_swap,
-    enrich_uniswap_v2_like_lp_tokens_transfers,
 )
 from rotkehlchen.chain.ethereum.modules.uniswap.v2.constants import SWAP_SIGNATURE
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
@@ -20,14 +19,12 @@ from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
     DecodingOutput,
-    EnricherContext,
-    TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
-from rotkehlchen.types import UNISWAP_PROTOCOL, EvmTransaction
+from rotkehlchen.types import EvmTransaction
 from rotkehlchen.utils.misc import hex_or_bytes_to_int
 
 if TYPE_CHECKING:
@@ -139,25 +136,12 @@ class Uniswapv2Decoder(DecoderInterface):
             )
         return DEFAULT_DECODING_OUTPUT
 
-    @staticmethod
-    def _maybe_enrich_lp_tokens_transfers(context: EnricherContext) -> TransferEnrichmentOutput:
-        return enrich_uniswap_v2_like_lp_tokens_transfers(
-            context=context,
-            counterparty=CPT_UNISWAP_V2,
-            lp_token_symbol=UNISWAP_PROTOCOL,
-        )
-
     # -- DecoderInterface methods
 
     def decoding_rules(self) -> list[Callable]:
         return [
             self._maybe_decode_v2_swap,
             self._maybe_decode_v2_liquidity_addition_and_removal,
-        ]
-
-    def enricher_rules(self) -> list[Callable]:
-        return [
-            self._maybe_enrich_lp_tokens_transfers,
         ]
 
     @staticmethod

--- a/rotkehlchen/tests/api/test_uniswap.py
+++ b/rotkehlchen/tests/api/test_uniswap.py
@@ -22,7 +22,7 @@ from rotkehlchen.tests.utils.api import (
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.constants import A_DOLLAR_BASED
-from rotkehlchen.tests.utils.ethereum import INFURA_ETH_NODE, get_decoded_events_of_transaction
+from rotkehlchen.tests.utils.ethereum import ANKR_NODE, get_decoded_events_of_transaction
 from rotkehlchen.types import AssetAmount, Price, deserialize_evm_tx_hash
 
 if TYPE_CHECKING:
@@ -56,11 +56,10 @@ def test_get_balances_module_not_activated(
     )
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[LP_HOLDER_ADDRESS]])
 @pytest.mark.parametrize('ethereum_modules', [['uniswap']])
 @pytest.mark.parametrize('network_mocking', [False])
-@pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
+@pytest.mark.parametrize('ethereum_manager_connect_at_start', [(ANKR_NODE,)])
 def test_get_balances(
         rotkehlchen_api_server: 'APIServer',
         start_with_valid_premium: bool,
@@ -69,6 +68,8 @@ def test_get_balances(
     """
     Check querying the uniswap balances endpoint works. Uses real data. Needs the deposit
     event in uniswap to trigger the logic based on events to query pool balances.
+
+    TODO: https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=46377335
     """
     tx_hex = deserialize_evm_tx_hash('0x856a5b5d95623f85923938e1911dfda6ad1dd185f45ab101bac99371aeaed329')  # noqa: E501
     ethereum_inquirer = rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator.ethereum.node_inquirer  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -331,7 +331,7 @@ def test_sushiswap_v2_remove_liquidity(database, ethereum_inquirer, eth_transact
             asset=Asset('eip155:1/erc20:0x06da0fd433C1A5d7a4faa01111c044910A184553'),
             balance=Balance(amount=FVal('0.0000243611620791')),
             location_label=ADDY_2,
-            notes='Send 0.0000243611620791 SLP to sushiswap-v2 pool',
+            notes='Send 0.0000243611620791 SLP WETH-USDT to sushiswap-v2 pool',
             counterparty=CPT_SUSHISWAP_V2,
             address=string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553'),
         ), EvmEvent(
@@ -521,7 +521,7 @@ def test_sushiswap_v2_add_liquidity(database, ethereum_inquirer, eth_transaction
             asset=Asset(lp_token_identifier),
             balance=Balance(amount=FVal('1.7297304741E-8')),
             location_label=ADDY_3,
-            notes='Receive 0.000000017297304741 SLP from sushiswap-v2 pool',
+            notes='Receive 0.000000017297304741 SLP WETH-USDT from sushiswap-v2 pool',
             counterparty=CPT_SUSHISWAP_V2,
             address=ZERO_ADDRESS,
         ),

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -554,13 +554,15 @@ def test_uniswap_v2_add_liquidity(database, ethereum_inquirer, eth_transactions)
             asset=Asset(lp_token_identifier),
             balance=Balance(amount=FVal('0.000022187913295974')),
             location_label=ADDY_2,
-            notes='Receive 0.000022187913295974 UNI-V2 from uniswap-v2 pool',
+            notes='Receive 0.000022187913295974 UNI-V2 DAI-USDC from uniswap-v2 pool',
             counterparty=CPT_UNISWAP_V2,
             address=ZERO_ADDRESS,
         ),
     ]
     assert events == expected_events
-    assert EvmToken(lp_token_identifier).protocol == UNISWAP_PROTOCOL
+    lp_token = EvmToken(lp_token_identifier)
+    assert lp_token.protocol == UNISWAP_PROTOCOL
+    assert lp_token.symbol == 'UNI-V2 DAI-USDC'
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_3]])
@@ -752,7 +754,7 @@ def test_uniswap_v2_remove_liquidity(database, ethereum_inquirer, eth_transactio
             asset=Asset('eip155:1/erc20:0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc'),
             balance=Balance(amount=FVal('9.6176228659E-8')),
             location_label=ADDY_3,
-            notes='Send 0.000000096176228659 UNI-V2 to uniswap-v2 pool',
+            notes='Send 0.000000096176228659 UNI-V2 USDC-WETH to uniswap-v2 pool',
             counterparty=CPT_UNISWAP_V2,
             address=string_to_evm_address('0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc'),
         ), EvmEvent(
@@ -1012,7 +1014,7 @@ def test_remove_liquidity_with_weth(database, ethereum_inquirer, ethereum_accoun
             asset=Asset('eip155:1/erc20:0xFfA98A091331Df4600F87C9164cD27e8a5CD2405'),
             balance=Balance(amount=FVal('17.988110986983157473')),
             location_label=user_address,
-            notes='Send 17.988110986983157473 UNI-V2 to uniswap-v2 pool',
+            notes='Send 17.988110986983157473 UNI-V2 POLS-WETH to uniswap-v2 pool',
             counterparty=CPT_UNISWAP_V2,
             address=string_to_evm_address('0xFfA98A091331Df4600F87C9164cD27e8a5CD2405'),
         ), EvmEvent(

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -68,6 +68,16 @@ PRUNED_AND_NOT_ARCHIVED_NODE = WeightedNode(
     active=True,
     weight=ONE,
 )
+ANKR_NODE = WeightedNode(
+    node_info=NodeName(
+        name='own',
+        endpoint='https://rpc.ankr.com/eth',
+        owned=True,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    ),
+    weight=ONE,
+    active=True,
+)
 
 ETHERSCAN_AND_INFURA_PARAMS: tuple[str, list[tuple]] = ('ethereum_manager_connect_at_start, call_order', [  # noqa: E501
     ((), (ETHEREUM_ETHERSCAN_NODE,)),


### PR DESCRIPTION
1. Fixes a case where if the user extended the symbol of a uniswap token making the logic fail to populate correctly the protocol of the token
2. Adds information about underlying tokens to symbols of uniswap and sushiswap LP tokens

![imagen](https://github.com/rotki/rotki/assets/5068010/e6685bec-2532-4640-9ad6-49c09a42b7c5)

Closes #7024