### PR TITLE
Fix loading for invalid event type/subtype combinations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 * :bug:`-` The welcome message at first login after a version upgrade will now have the correct link to the release notes.
 * :bug:`-` Swaps using 1inch where the Uniswap V3 decoder processed part of the transaction will be correctly decoded now.
 * :bug:`-` Creating, editing and deleting accounting rules will now update warnings when rendered events get affected in the history view.
+* :bug:`-` Showing a page with a history event with a non-recognized type/subtype combination will no longer stop the page from loading due to an error.
 
 * :release:`1.31.0 <2023-11-24>`
 * :feature:`-` Oneinch v3 swaps should be supported in Ethereum mainnet.

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -51,9 +51,8 @@ class EventsAccountant:
             events_iterator: "peekable['AccountingEventMixin']",
     ) -> int:
         """Process a history base entry and return number of actions consumed from the iterator"""
-        try:
-            event_direction = event.get_direction()
-        except KeyError:
+        event_direction = event.maybe_get_direction()
+        if event_direction is None:
             log.error(
                 f'Failed to retrieve direction for {event.event_type=} {event.event_subtype}. '
                 f'Skipping...',

--- a/rotkehlchen/accounting/structures/base.py
+++ b/rotkehlchen/accounting/structures/base.py
@@ -271,18 +271,21 @@ class HistoryBaseEntry(AccountingEventMixin, metaclass=ABCMeta):
             result['hidden'] = True
         if grouped_events_num is not None:
             result['grouped_events_num'] = grouped_events_num
-        if missing_accounting_rule is True and self.get_direction() != EventDirection.NEUTRAL:
+        if missing_accounting_rule is True and self.maybe_get_direction() != EventDirection.NEUTRAL:  # noqa: E501
             result['missing_accounting_rule'] = True
 
         return result
 
-    def get_direction(self) -> 'EventDirection':
+    def maybe_get_direction(self) -> EventDirection | None:
         """
         Get direction based on type, subtype.
-        May raise:
-        - KeyError if the combination of types is not valid
+
+        If the combination of type/subtype is invalid return `None`.
         """
-        return EVENT_CATEGORY_MAPPINGS[self.event_type][self.event_subtype].direction
+        try:
+            return EVENT_CATEGORY_MAPPINGS[self.event_type][self.event_subtype].direction
+        except KeyError:
+            return None
 
     @classmethod
     def _deserialize_base_history_data(cls: type[T], data: dict[str, Any]) -> HistoryBaseEntryData:

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -1,0 +1,51 @@
+from rotkehlchen.accounting.constants import EVENT_CATEGORY_MAPPINGS
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.base import (
+    HistoryEvent,
+    HistoryEventSubType,
+    HistoryEventType,
+)
+from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import Location, TimestampMS
+
+
+def test_serialize_with_invalid_type_subtype():
+    """Test that serialize an event with invalid type/subtype does not raise exception"""
+    event_type = HistoryEventType.TRANSFER
+    event_subtype = HistoryEventSubType.SPEND
+    assert event_subtype not in EVENT_CATEGORY_MAPPINGS[event_type]
+    event = HistoryEvent(
+        event_identifier='1',
+        sequence_index=1,
+        timestamp=TimestampMS(1),
+        location=Location.KRAKEN,
+        event_type=event_type,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        balance=Balance(amount=FVal(1)),
+    )
+    event.event_subtype = event_subtype  # do here cause ctor will raise for invalid subtype
+    assert event.serialize_for_api(
+        customized_event_ids=[],
+        ignored_ids_mapping={},
+        hidden_event_ids=[],
+        missing_accounting_rule=True,  # needed to recreate the error thistestsfor
+        grouped_events_num=None,
+    ) == {
+        'entry': {
+            'asset': 'ETH',
+            'balance': {'amount': '1', 'usd_value': '0'},
+            'entry_type': 'history event',
+            'event_identifier': '1',
+            'event_subtype': 'spend',
+            'event_type': 'transfer',
+            'identifier': None,
+            'location': 'kraken',
+            'location_label': None,
+            'notes': None,
+            'sequence_index': 1,
+            'timestamp': 1,
+        },
+        'missing_accounting_rule': True,
+    }


### PR DESCRIPTION
Before this patch any invalid type/subtype combination would raise an error in the history view.

And we can have invalid rules that were just created from versions before 1.31.0.

