### PR TITLE
Detect unicode in spam tokens.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ miniupnpc==2.2.3; sys_platform == 'win32'
 cryptography==41.0.4
 py-machineid==0.4.4
 more-itertools==10.1.0  # for peekable iterators
+regex==2023.10.3  # used for unicode information in detection of spam tokens
 
 # For the rest api
 flask-cors==4.0.0

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -1,7 +1,8 @@
 import logging
-import re
 from enum import auto
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional
+
+import regex
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset, AssetWithOracles, EvmToken, UnderlyingToken
@@ -32,15 +33,15 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 SPAM_ASSET_REGEX = r"""
-    https:// |                          # Matches 'https://'
-    claim | visit |                     # Matches 'claim' or 'visit' anywhere in the string
-    ^\$.+\..+ |                         # Matches strings that start with '$' and contain '.'
-    \.com | \.io| \.site | \.xyz        # Matches common domain extensions
-"""
+    https:// |                      # Matches 'https://'
+    claim | visit | invited |       # Matches 'claim' or 'visit' anywhere in the string
+    ^\$.+\..+ |                     # Matches strings that start with '$' and contain '.'
+    (\p{Sk}|\p{P})+(com|io|site|xyz|li|org|cc|net|pm)+  # Matches common domain extensions. It also detects any letter modifier or punctuation in unicode before the domain extension
+"""  # noqa: E501
 # Compile the regex pattern:
 # - re.IGNORECASE makes it case-insensitive
 # - re.VERBOSE allows to write comments in the regex and split it
-SPAM_ASSET_PATTERN = re.compile(SPAM_ASSET_REGEX, re.IGNORECASE | re.VERBOSE)
+SPAM_ASSET_PATTERN = regex.compile(SPAM_ASSET_REGEX, regex.IGNORECASE | regex.VERBOSE)
 
 
 def add_evm_token_to_db(token_data: EvmToken) -> EvmToken:

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -1,3 +1,4 @@
+from typing import Final
 from rotkehlchen.fval import FVal
 
 CURRENCYCONVERTER_API_KEY = 'feaa5a7ddc2d76789e58'
@@ -19,3 +20,5 @@ KRAKEN_API_VERSION = '0'
 DEFAULT_MAX_LOG_SIZE_IN_MB = 300
 DEFAULT_MAX_LOG_BACKUP_FILES = 3
 DEFAULT_SQL_VM_INSTRUCTIONS_CB = 5000
+
+LAST_SPAM_ASSETS_DETECT_KEY: Final = 'last_spam_assets_detect_key'

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, NamedTuple, Optional
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.chain.constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 from rotkehlchen.constants.assets import A_USD
+from rotkehlchen.constants.misc import LAST_SPAM_ASSETS_DETECT_KEY
 from rotkehlchen.constants.timing import YEAR_IN_SECONDS
 from rotkehlchen.data_migrations.constants import LAST_DATA_MIGRATION
 from rotkehlchen.db.constants import LAST_DATA_UPDATES_KEY, UpdateType
@@ -97,7 +98,7 @@ STRING_KEYS = (
     'frontend_settings',
 )
 TIMESTAMP_KEYS = ('last_write_ts', 'last_data_upload_ts', 'last_balance_save')
-IGNORED_KEYS = (LAST_EVM_ACCOUNTS_DETECT_KEY, LAST_DATA_UPDATES_KEY) + tuple(x.serialize() for x in UpdateType)  # noqa: E501
+IGNORED_KEYS = (LAST_EVM_ACCOUNTS_DETECT_KEY, LAST_DATA_UPDATES_KEY, LAST_SPAM_ASSETS_DETECT_KEY) + tuple(x.serialize() for x in UpdateType)  # noqa: E501
 
 
 CachedDBSettingsFieldNames = Literal[

--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -1,12 +1,11 @@
-from typing import Final
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import check_if_spam_token
+from rotkehlchen.constants.misc import LAST_SPAM_ASSETS_DETECT_KEY
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.types import SPAM_PROTOCOL
 from rotkehlchen.utils.misc import ts_now
 
-LAST_SPAM_ASSETS_DETECT_KEY: Final = 'last_spam_assets_detect_key'
 SYMBOL_AND_NAME_ASSETS_QUERY = (
     'SELECT C.symbol, A.name, A.identifier FROM evm_tokens as B LEFT JOIN '
     'common_asset_details AS C ON C.identifier = B.identifier JOIN assets as A on '

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -20,6 +20,7 @@ from rotkehlchen.chain.ethereum.modules.makerdao.cache import (
 )
 from rotkehlchen.chain.ethereum.modules.yearn.utils import query_yearn_vaults
 from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
+from rotkehlchen.constants.misc import LAST_SPAM_ASSETS_DETECT_KEY
 from rotkehlchen.constants.timing import (
     DATA_UPDATES_REFRESH,
     DAY_IN_SECONDS,
@@ -38,7 +39,7 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium, premium_create_and_verify
-from rotkehlchen.tasks.assets import LAST_SPAM_ASSETS_DETECT_KEY, autodetect_spam_assets_in_db
+from rotkehlchen.tasks.assets import autodetect_spam_assets_in_db
 from rotkehlchen.tasks.utils import query_missing_prices_of_base_entries, should_run_periodic_task
 from rotkehlchen.types import (
     EVM_CHAINS_WITH_TRANSACTIONS,

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb.py
@@ -1207,6 +1207,7 @@ def test_get_assets_missing_information_by_symbol(globaldb):
 
 def test_for_spam_tokens(database: 'DBHandler', ethereum_inquirer: EthereumInquirer) -> None:
     """Test different cases of spam assets that we already know"""
+    assert check_if_spam_token(symbol='USDC', name='USD-SWAP˳COM') is True  # test for unicode symbols that might resemble dots  # noqa: E501
     # $ aavereward.com
     token = EvmToken(ethaddress_to_identifier(string_to_evm_address('0x39cf57b4dECb8aE3deC0dFcA1E2eA2C320416288')))  # noqa: E501
     assert check_if_spam_token(symbol=token.symbol, name=token.name) is True

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -3,11 +3,12 @@ from unittest.mock import MagicMock, patch
 
 import gevent
 import pytest
-from rotkehlchen.assets.asset import EvmToken
 
+from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.bitcoin.hdkey import HDKey
 from rotkehlchen.chain.bitcoin.xpub import XpubData
 from rotkehlchen.chain.ethereum.modules.eth2.constants import WITHDRAWALS_TS_PREFIX
+from rotkehlchen.constants.misc import LAST_SPAM_ASSETS_DETECT_KEY
 from rotkehlchen.constants.timing import DATA_UPDATES_REFRESH
 from rotkehlchen.db.constants import LAST_DATA_UPDATES_KEY
 from rotkehlchen.db.evmtx import DBEvmTx
@@ -17,7 +18,6 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.premium.premium import Premium, PremiumCredentials, SubscriptionStatus
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
-from rotkehlchen.tasks.assets import LAST_SPAM_ASSETS_DETECT_KEY
 from rotkehlchen.tasks.manager import PREMIUM_STATUS_CHECK, TaskManager
 from rotkehlchen.tasks.utils import should_run_periodic_task
 from rotkehlchen.tests.utils.ethereum import (


### PR DESCRIPTION
This commit introduces regex to the list of dependencies that allows to use predefined groups in regular expressions. Is used to detect modifiers for punttuation and full stop variants that migh appear before a url.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
