### PR TITLE
chore: replace v-alert with alert from lib, use correct variant

### DIFF
--- a/frontend/app/src/components/account-management/create-account/credentials/CreateAccountCredentials.vue
+++ b/frontend/app/src/components/account-management/create-account/credentials/CreateAccountCredentials.vue
@@ -53,7 +53,6 @@ const { t } = useI18n();
     <div>
       <RuiAlert
         v-if="syncDatabase"
-        text
         class="create-account__password-sync-requirement"
         type="warning"
       >

--- a/frontend/app/src/components/error/ActionStatusIndicator.vue
+++ b/frontend/app/src/components/error/ActionStatusIndicator.vue
@@ -18,7 +18,6 @@ withDefaults(
   >
     <RuiAlert
       class="mb-0"
-      dense
       :type="status.success ? 'success' : 'error'"
       variant="outlined"
     >

--- a/frontend/app/src/components/error/ActionStatusIndicator.vue
+++ b/frontend/app/src/components/error/ActionStatusIndicator.vue
@@ -20,8 +20,7 @@ withDefaults(
       class="mb-0"
       dense
       :type="status.success ? 'success' : 'error'"
-      text
-      outlined
+      variant="outlined"
     >
       {{ status.success || status.error }}
     </RuiAlert>

--- a/frontend/app/src/components/premium/PremiumLoadingError.vue
+++ b/frontend/app/src/components/premium/PremiumLoadingError.vue
@@ -4,9 +4,7 @@ const { t } = useI18n();
 
 <template>
   <RuiAlert
-    dense
     type="error"
-    text
     variant="outlined"
     :title="t('premium_loading_failed.title')"
   >

--- a/frontend/app/src/components/premium/PremiumLoadingError.vue
+++ b/frontend/app/src/components/premium/PremiumLoadingError.vue
@@ -3,16 +3,17 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <VCard>
-    <VAlert color="error" icon="mdi-alert" outlined prominent>
-      <span class="font-medium">
-        {{ t('premium_loading_failed.title') }}
-      </span>
-      <p class="mt-1">
-        {{ t('premium_loading_failed.description') }}
-      </p>
-      <p>{{ t('premium_loading_failed.try_again') }}</p>
-      <p>{{ t('premium_loading_failed.open_issue') }}</p>
-    </VAlert>
-  </VCard>
+  <RuiAlert
+    dense
+    type="error"
+    text
+    variant="outlined"
+    :title="t('premium_loading_failed.title')"
+  >
+    <p class="mt-1">
+      {{ t('premium_loading_failed.description') }}
+    </p>
+    <p>{{ t('premium_loading_failed.try_again') }}</p>
+    <p>{{ t('premium_loading_failed.open_issue') }}</p>
+  </RuiAlert>
 </template>

--- a/frontend/app/src/components/settings/data-security/backups/ManageCustomAssets.vue
+++ b/frontend/app/src/components/settings/data-security/backups/ManageCustomAssets.vue
@@ -49,7 +49,7 @@ const { t } = useI18n();
     <template #title>{{ t('manage_user_assets.title') }}</template>
 
     <div class="flex flex-col gap-4">
-      <RuiAlert type="info" dense>
+      <RuiAlert type="info">
         {{ t('manage_user_assets.warning') }}
       </RuiAlert>
 
@@ -58,7 +58,7 @@ const { t } = useI18n();
         <template #subheader>
           {{ t('manage_user_assets.export.subtitle') }}
         </template>
-        <RuiAlert v-if="exportError" class="my-2" type="error" dense>
+        <RuiAlert v-if="exportError" class="my-2" type="error">
           {{ exportError }}
         </RuiAlert>
         <div class="flex flex-row items-center">

--- a/frontend/app/src/pages/import/index.vue
+++ b/frontend/app/src/pages/import/index.vue
@@ -10,7 +10,11 @@ const { t } = useI18n();
       </HintMenuIcon>
     </template>
 
-    <RuiAlert outlined type="warning" :title="t('import_data.notice_warning')">
+    <RuiAlert
+      variant="outlined"
+      type="warning"
+      :title="t('import_data.notice_warning')"
+    >
       <i18n tag="span" path="import_data.notice">
         <template #link>
           <ExternalLink url="https://github.com/rotki/rotki/issues/new/choose">


### PR DESCRIPTION
## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
