### PR TITLE
refactor: change tooltip delay to number instead of string

### DIFF
--- a/frontend/app/src/components/About.vue
+++ b/frontend/app/src/components/About.vue
@@ -124,7 +124,7 @@ const { copy } = useClipboard({ source: versionText });
             </td>
             <td>
               <div class="flex flex-row justify-between">
-                <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+                <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
                   <template #activator>
                     <div
                       class="text-truncate text-rui-text-secondary"
@@ -138,7 +138,7 @@ const { copy } = useClipboard({ source: versionText });
                   </span>
                 </RuiTooltip>
                 <div v-if="isPackaged" class="ml-2">
-                  <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+                  <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
                     <template #activator>
                       <RuiButton
                         icon

--- a/frontend/app/src/components/GlobalSearch.vue
+++ b/frontend/app/src/components/GlobalSearch.vue
@@ -429,7 +429,7 @@ onBeforeMount(async () => {
   <VDialog
     v-model="open"
     max-width="800"
-    open-delay="100"
+    :open-delay="100"
     height="400"
     :content-class="$style.dialog"
     transition="slide-y-transition"

--- a/frontend/app/src/components/NavigationMenuItem.vue
+++ b/frontend/app/src/components/NavigationMenuItem.vue
@@ -54,7 +54,7 @@ const [DefineImage, ReuseImage] = createReusableTemplate();
     <RuiTooltip
       v-if="showTooltips"
       :popper="{ placement: 'right' }"
-      open-delay="400"
+      :open-delay="400"
     >
       <template #activator>
         <ReuseImage />

--- a/frontend/app/src/components/account-management/login/LoginForm.vue
+++ b/frontend/app/src/components/account-management/login/LoginForm.vue
@@ -446,8 +446,8 @@ const abortLogin = () => {
                     </RuiCheckbox>
                   </div>
                   <RuiTooltip
-                    open-delay="400"
-                    close-delay="0"
+                    :open-delay="400"
+                    :close-delay="0"
                     class="ml-2"
                     tooltip-class="max-w-[16rem]"
                     :text="t('login.remember_password_tooltip')"
@@ -459,8 +459,8 @@ const abortLogin = () => {
                 </div>
               </div>
               <RuiTooltip
-                open-delay="400"
-                close-delay="0"
+                :open-delay="400"
+                :close-delay="0"
                 :text="t('login.custom_backend.tooltip')"
               >
                 <template #activator>

--- a/frontend/app/src/components/accounts/AccountGroupHeader.vue
+++ b/frontend/app/src/components/accounts/AccountGroupHeader.vue
@@ -91,7 +91,7 @@ const editClicked = (_payload: XpubAccountWithBalance) =>
           {{ t('account_group_header.xpub') }}
         </span>
         <span :class="{ blur: !shouldShowAmount }">
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               {{ displayXpub }}
             </template>

--- a/frontend/app/src/components/accounts/ModuleActivator.vue
+++ b/frontend/app/src/components/accounts/ModuleActivator.vue
@@ -67,7 +67,7 @@ const loading = isAccountOperationRunning();
           <RuiTooltip
             class="flex"
             :popper="{ placement: 'top' }"
-            open-delay="400"
+            :open-delay="400"
           >
             <template #activator>
               <VImg height="24px" width="24px" contain :src="module.icon" />

--- a/frontend/app/src/components/accounts/balances/DetectEvmAccounts.vue
+++ b/frontend/app/src/components/accounts/balances/DetectEvmAccounts.vue
@@ -11,7 +11,7 @@ const { t } = useI18n();
 <template>
   <RuiTooltip
     :popper="{ placement: 'right' }"
-    open-delay="400"
+    :open-delay="400"
     tooltip-class="max-w-[16rem]"
   >
     <template #activator>

--- a/frontend/app/src/components/accounts/blockchain/TokenDetection.vue
+++ b/frontend/app/src/components/accounts/blockchain/TokenDetection.vue
@@ -23,7 +23,7 @@ const { t } = useI18n();
       {{ detectedTokens.total }}
     </div>
     <div>
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/accounts/blockchain/XpubInput.vue
+++ b/frontend/app/src/components/accounts/blockchain/XpubInput.vue
@@ -164,7 +164,7 @@ watch(errorMessages, errors => {
         @paste="onPasteXpub($event)"
       />
       <div>
-        <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+        <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
           <template #activator>
             <div class="account-form__advanced">
               <RuiButton

--- a/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
+++ b/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
@@ -99,7 +99,7 @@ const loading = isAccountOperationRunning();
     >
       {{ t('input_mode_select.metamask_import.missing') }}
 
-      <VMenu open-on-hover right offset-x close-delay="400" max-width="300">
+      <VMenu open-on-hover right offset-x :close-delay="400" max-width="300">
         <template #activator="{ on }">
           <div v-on="on">
             <RuiIcon class="px-1" name="question-line" />

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalancesForm.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalancesForm.vue
@@ -242,7 +242,7 @@ onMounted(async () => {
         :disabled="submitting"
         @blur="v$.asset.$touch()"
       />
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/asset-manager/AssetIconForm.vue
+++ b/frontend/app/src/components/asset-manager/AssetIconForm.vue
@@ -83,7 +83,7 @@ defineExpose({
         <RuiTooltip
           v-if="preview && refreshable"
           :popper="{ placement: 'right' }"
-          open-delay="400"
+          :open-delay="400"
           class="absolute -top-3 -right-3"
         >
           <template #activator>

--- a/frontend/app/src/components/asset-manager/RestoreAssetDbButton.vue
+++ b/frontend/app/src/components/asset-manager/RestoreAssetDbButton.vue
@@ -131,7 +131,7 @@ const showDoneConfirmation = () => {
     </VList>
   </VMenu>
   <div v-else class="flex flex-row gap-2">
-    <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+    <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
       <template #activator>
         <RuiButton
           variant="outlined"
@@ -143,7 +143,7 @@ const showDoneConfirmation = () => {
       </template>
       {{ t('asset_update.restore.soft_reset_hint') }}
     </RuiTooltip>
-    <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+    <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
       <template #activator>
         <RuiButton color="primary" @click="showRestoreConfirmation('hard')">
           {{ t('asset_update.restore.hard_reset') }}

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetContent.vue
@@ -209,7 +209,7 @@ watch(identifier, async assetId => {
         <VList>
           <RestoreAssetDbButton dropdown />
           <RuiTooltip
-            open-delay="400"
+            :open-delay="400"
             class="w-full"
             :popper="{ placement: 'left' }"
             tooltip-class="max-w-[200px]"

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetForm.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetForm.vue
@@ -457,7 +457,7 @@ const { coingeckoContributeUrl, cryptocompareContributeUrl } = useInterop();
               />
             </template>
           </RuiTextField>
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiCheckbox
                 v-model="coingeckoEnabled"
@@ -489,7 +489,7 @@ const { coingeckoContributeUrl, cryptocompareContributeUrl } = useInterop();
               />
             </template>
           </RuiTextField>
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiCheckbox
                 v-model="cryptocompareEnabled"

--- a/frontend/app/src/components/base/IconLink.vue
+++ b/frontend/app/src/components/base/IconLink.vue
@@ -16,7 +16,7 @@ const { href, onLinkClick } = useLinks(url);
 </script>
 
 <template>
-  <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+  <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
     <template #activator>
       <RuiButton
         size="sm"

--- a/frontend/app/src/components/dashboard/SnapshotActionButton.vue
+++ b/frontend/app/src/components/dashboard/SnapshotActionButton.vue
@@ -137,7 +137,7 @@ const importSnapshot = async () => {
           {{ t('snapshot_action_button.force_save') }}
         </RuiButton>
 
-        <RuiTooltip open-delay="400" tooltip-class="max-w-[16rem]">
+        <RuiTooltip :open-delay="400" tooltip-class="max-w-[16rem]">
           <template #activator>
             <RuiIcon name="information-line" color="primary" />
           </template>
@@ -145,7 +145,7 @@ const importSnapshot = async () => {
         </RuiTooltip>
       </div>
 
-      <RuiTooltip class="mt-2" open-delay="400" tooltip-class="max-w-[16rem]">
+      <RuiTooltip class="mt-2" :open-delay="400" tooltip-class="max-w-[16rem]">
         <template #activator>
           <RuiCheckbox v-model="ignoreErrors" color="primary" hide-details>
             {{ t('snapshot_action_button.ignore_errors_label') }}

--- a/frontend/app/src/components/defi/ActiveModules.vue
+++ b/frontend/app/src/components/defi/ActiveModules.vue
@@ -96,7 +96,7 @@ const showConfirmation = () => {
           :key="module.identifier"
           class="flex"
         >
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiButton
                 variant="text"

--- a/frontend/app/src/components/defi/QueriedAddressDialog.vue
+++ b/frontend/app/src/components/defi/QueriedAddressDialog.vue
@@ -138,7 +138,7 @@ const close = () => {
             <LabeledAddressDisplay :account="getAccount(address)" />
             <TagDisplay :tags="getAccount(address).tags" :small="true" />
           </div>
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiButton
                 variant="text"

--- a/frontend/app/src/components/defi/display/DefiProtocolIcon.vue
+++ b/frontend/app/src/components/defi/display/DefiProtocolIcon.vue
@@ -47,7 +47,7 @@ const css = useCssModule();
     <RuiTooltip
       :popper="{ placement: 'top' }"
       :disabled="mode !== 'icon'"
-      open-delay="400"
+      :open-delay="400"
     >
       <template #activator>
         <VImg

--- a/frontend/app/src/components/defi/uniswap/UniswapPoolDetails.vue
+++ b/frontend/app/src/components/defi/uniswap/UniswapPoolDetails.vue
@@ -21,7 +21,7 @@ const getTotal = ({ totalAmount, usdPrice }: XswapAsset) =>
 <template>
   <VDialog v-model="details" scrollable max-width="450px">
     <template #activator="{ on, attrs }">
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/display/AccountDisplay.vue
+++ b/frontend/app/src/components/display/AccountDisplay.vue
@@ -48,7 +48,7 @@ const { t } = useI18n();
 <template>
   <RuiTooltip
     :popper="{ placement: 'top' }"
-    open-delay="400"
+    :open-delay="400"
     :disabled="!truncate"
     class="flex items-center flex-nowrap"
   >
@@ -60,7 +60,7 @@ const { t } = useI18n();
             size="24px"
             :chain="account.chain"
           />
-          <RuiTooltip v-else :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip v-else :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiIcon name="links-line" />
             </template>

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -96,7 +96,7 @@ const truncatedAliasName: ComputedRef<string> = computed(() => {
   >
     <RuiTooltip
       :popper="{ placement: 'top' }"
-      open-delay="400"
+      :open-delay="400"
       :disabled="!truncated && !aliasName"
       class="truncate mr-auto"
     >

--- a/frontend/app/src/components/helper/BackButton.vue
+++ b/frontend/app/src/components/helper/BackButton.vue
@@ -41,7 +41,7 @@ const { t } = useI18n();
   <RuiTooltip
     v-if="canNavigateBack || page"
     :popper="{ placement: 'top' }"
-    open-delay="400"
+    :open-delay="400"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/components/helper/CopyButton.vue
+++ b/frontend/app/src/components/helper/CopyButton.vue
@@ -12,7 +12,7 @@ const { copy } = useClipboard({ source: value });
 <template>
   <RuiTooltip
     :popper="{ placement: 'top', offsetDistance: 0 }"
-    open-delay="400"
+    :open-delay="400"
   >
     <template #activator>
       <RuiButton :size="size" variant="text" icon @click="copy()">

--- a/frontend/app/src/components/helper/HelpLink.vue
+++ b/frontend/app/src/components/helper/HelpLink.vue
@@ -17,7 +17,7 @@ const { href, onLinkClick } = useLinks(url);
 </script>
 
 <template>
-  <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+  <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
     <template #activator>
       <RuiButton
         type="button"

--- a/frontend/app/src/components/helper/ListItem.vue
+++ b/frontend/app/src/components/helper/ListItem.vue
@@ -71,7 +71,7 @@ const click = () => emit('click');
           <RuiTooltip
             :disabled="large"
             :popper="{ placement: 'top' }"
-            open-delay="400"
+            :open-delay="400"
           >
             <template #activator>
               <span class="text-truncate">

--- a/frontend/app/src/components/helper/MenuTooltipButton.vue
+++ b/frontend/app/src/components/helper/MenuTooltipButton.vue
@@ -31,8 +31,8 @@ const click = () => emit('click');
 <template>
   <RuiTooltip
     :popper="{ placement: 'bottom' }"
-    open-delay="250"
-    close-delay="0"
+    :open-delay="250"
+    :close-delay="0"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/components/helper/NftDetails.vue
+++ b/frontend/app/src/components/helper/NftDetails.vue
@@ -128,7 +128,7 @@ const fallbackData = computed(() => {
         <RuiTooltip
           :popper="{ placement: 'top' }"
           :disabled="renderImage"
-          open-delay="400"
+          :open-delay="400"
           class="w-full"
           tooltip-class="max-w-[10rem]"
         >

--- a/frontend/app/src/components/helper/PrioritizedList.vue
+++ b/frontend/app/src/components/helper/PrioritizedList.vue
@@ -200,7 +200,7 @@ const autoCompleteHint: ComputedRef<string> = computed(() => {
               <RuiTooltip
                 v-if="!disableDelete"
                 :popper="{ placement: 'top' }"
-                open-delay="400"
+                :open-delay="400"
               >
                 <template #activator>
                   <RuiButton

--- a/frontend/app/src/components/helper/RefreshButton.vue
+++ b/frontend/app/src/components/helper/RefreshButton.vue
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+  <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
     <template #activator>
       <RuiButton
         icon

--- a/frontend/app/src/components/helper/SortingSelector.vue
+++ b/frontend/app/src/components/helper/SortingSelector.vue
@@ -23,7 +23,7 @@ const { t } = useI18n();
 
 <template>
   <div class="flex">
-    <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+    <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
       <template #activator>
         <RuiButton
           variant="text"

--- a/frontend/app/src/components/helper/display/icons/EvmChainIcon.vue
+++ b/frontend/app/src/components/helper/display/icons/EvmChainIcon.vue
@@ -33,7 +33,7 @@ const style = computed(() => ({
 </script>
 
 <template>
-  <RuiTooltip v-if="tooltip" :popper="{ placement: 'top' }" open-delay="400">
+  <RuiTooltip v-if="tooltip" :popper="{ placement: 'top' }" :open-delay="400">
     <template #activator>
       <img
         :class="{

--- a/frontend/app/src/components/helper/hint/ValueAccuracyHint.vue
+++ b/frontend/app/src/components/helper/hint/ValueAccuracyHint.vue
@@ -12,7 +12,7 @@ const notUsd = computed(() => get(currencySymbol) !== CURRENCY_USD);
     v-if="notUsd"
     class="mx-2 text-rui-text-secondary"
     :popper="{ placement: 'top' }"
-    open-delay="400"
+    :open-delay="400"
     tooltip-class="max-w-[10rem]"
   >
     <template #activator>

--- a/frontend/app/src/components/history/IgnoreButtons.vue
+++ b/frontend/app/src/components/history/IgnoreButtons.vue
@@ -8,7 +8,7 @@ const { t } = useI18n();
 
 <template>
   <div class="flex flex-row gap-2">
-    <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+    <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
       <template #activator>
         <RuiButton
           class="min-w-[90px]"
@@ -21,7 +21,7 @@ const { t } = useI18n();
       </template>
       <span>{{ t('ignore_buttons.ignore_tooltip') }}</span>
     </RuiTooltip>
-    <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+    <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
       <template #activator>
         <RuiButton
           class="min-w-[90px]"

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -141,7 +141,7 @@ watch(loading, async (isLoading, wasLoading) => {
     :title="[t('navigation_menu.history'), t('deposits_withdrawals.title')]"
   >
     <template #buttons>
-      <RuiTooltip open-delay="400">
+      <RuiTooltip :open-delay="400">
         <template #activator>
           <RuiButton
             variant="outlined"

--- a/frontend/app/src/components/history/events/HistoryEventTypeCombination.vue
+++ b/frontend/app/src/components/history/events/HistoryEventTypeCombination.vue
@@ -36,7 +36,7 @@ const { t } = useI18n();
       <div class="font-bold text-uppercase text-sm">
         {{ type.label }}
       </div>
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <div
             class="cursor-pointer rounded-full bg-rui-grey-200 dark:bg-rui-grey-800 p-1"

--- a/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
+++ b/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
@@ -49,7 +49,7 @@ const [DefineText, ReuseText] = createReusableTemplate();
     <template v-if="counterparty || event.address">
       <VBadge v-if="!text" avatar overlap color="white">
         <template #badge>
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <ReuseImage />
             </template>

--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -636,7 +636,7 @@ watchImmediate(route, async route => {
     :title="[t('navigation_menu.history'), usedTitle]"
   >
     <template #buttons>
-      <RuiTooltip open-delay="400">
+      <RuiTooltip :open-delay="400">
         <template #activator>
           <RuiButton
             :disabled="refreshing"

--- a/frontend/app/src/components/history/events/query-status/QueryStatusDialog.vue
+++ b/frontend/app/src/components/history/events/query-status/QueryStatusDialog.vue
@@ -48,7 +48,7 @@ const { t } = useI18n();
               <RuiTooltip
                 v-if="showTooltip ? showTooltip(item) : true"
                 class="cursor-pointer"
-                open-delay="400"
+                :open-delay="400"
                 tooltip-class="max-w-[12rem]"
               >
                 <template #activator>

--- a/frontend/app/src/components/history/trades/TradeDetails.vue
+++ b/frontend/app/src/components/history/trades/TradeDetails.vue
@@ -45,7 +45,7 @@ const { href, hasLink, onLinkClick } = useLinks(link);
         <RuiTooltip
           v-if="hasLink"
           :popper="{ placement: 'top' }"
-          open-delay="400"
+          :open-delay="400"
         >
           <template #activator>
             <RuiButton

--- a/frontend/app/src/components/nft/NftGalleryItem.vue
+++ b/frontend/app/src/components/nft/NftGalleryItem.vue
@@ -103,7 +103,7 @@ const mediaStyle: ComputedRef<StyleValue> = computed(() => {
       <RuiTooltip
         :popper="{ placement: 'top' }"
         :disabled="renderImage"
-        open-delay="400"
+        :open-delay="400"
         class="w-full"
         tooltip-class="max-w-[10rem]"
       >
@@ -132,7 +132,7 @@ const mediaStyle: ComputedRef<StyleValue> = computed(() => {
       <RuiTooltip
         v-if="!renderImage"
         :popper="{ placement: 'top' }"
-        open-delay="400"
+        :open-delay="400"
         :class="css['unlock-button']"
       >
         <template #activator>
@@ -147,7 +147,7 @@ const mediaStyle: ComputedRef<StyleValue> = computed(() => {
     <div class="flex items-center justify-between gap-2 px-4 mt-2">
       <RuiTooltip
         :popper="{ placement: 'top' }"
-        open-delay="400"
+        :open-delay="400"
         tooltip-class="max-w-[20rem]"
         class="text-truncate block text-subtitle-1 font-medium"
       >
@@ -165,7 +165,7 @@ const mediaStyle: ComputedRef<StyleValue> = computed(() => {
     <div class="flex items-center justify-between gap-2 px-4">
       <RuiTooltip
         :popper="{ placement: 'top' }"
-        open-delay="400"
+        :open-delay="400"
         tooltip-class="max-w-[20rem]"
         class="text-truncate block text-subtitle-1 font-medium"
       >

--- a/frontend/app/src/components/notes/UserNotesSidebar.vue
+++ b/frontend/app/src/components/notes/UserNotesSidebar.vue
@@ -100,7 +100,7 @@ const { smAndDown } = useDisplay();
             {{ t('notes_menu.tabs.general') }}
           </RuiTab>
           <RuiTab v-if="locationName">
-            <RuiTooltip :popper="{ placement: 'bottom' }" open-delay="400">
+            <RuiTooltip :popper="{ placement: 'bottom' }" :open-delay="400">
               <template #activator>
                 {{ t('notes_menu.tabs.in_this_page', { page: locationName }) }}
               </template>

--- a/frontend/app/src/components/profitloss/ExportReportCsv.vue
+++ b/frontend/app/src/components/profitloss/ExportReportCsv.vue
@@ -71,7 +71,7 @@ const label = computed(() =>
       </RuiButton>
     </DefineButton>
     <span v-if="icon">
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <ReuseButton />
         </template>

--- a/frontend/app/src/components/profitloss/ProfitLossEvents.vue
+++ b/frontend/app/src/components/profitloss/ProfitLossEvents.vue
@@ -185,7 +185,7 @@ const css = useCssModule();
         <RuiTooltip
           v-if="item.groupId && (item.groupLine.top || item.groupLine.bottom)"
           :popper="{ placement: 'right' }"
-          open-delay="400"
+          :open-delay="400"
           class="h-full"
         >
           <template #activator>

--- a/frontend/app/src/components/profitloss/ReportActionableCard.vue
+++ b/frontend/app/src/components/profitloss/ReportActionableCard.vue
@@ -234,7 +234,7 @@ const { mdAndUp } = useDisplay();
 
       <VSpacer />
 
-      <RuiTooltip :popper="{ placement: 'bottom' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'bottom' }" :open-delay="400">
         <template #activator>
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/profitloss/ReportGenerator.vue
+++ b/frontend/app/src/components/profitloss/ReportGenerator.vue
@@ -47,7 +47,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
       {{ t('common.actions.generate') }}
     </template>
     <template #details>
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RouterLink :to="accountSettingsRoute">
             <RuiButton variant="text" icon color="primary">

--- a/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
@@ -175,7 +175,7 @@ const isIgnored = (asset: string) => get(isAssetIgnored(asset));
             </VList>
           </VMenu>
 
-          <RuiTooltip v-if="isIgnored(item.asset)" open-delay="400">
+          <RuiTooltip v-if="isIgnored(item.asset)" :open-delay="400">
             <template #activator>
               <BadgeDisplay color="grey" class="py-1">
                 <RuiIcon size="18" name="eye-off-line" />

--- a/frontend/app/src/components/profitloss/ReportMissingPrices.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingPrices.vue
@@ -222,7 +222,7 @@ const refreshHistoricalPrice = async (item: EditableMissingPrice) => {
                 <RuiTooltip
                   v-if="item.rateLimited"
                   :popper="{ placement: 'top' }"
-                  open-delay="400"
+                  :open-delay="400"
                   tooltip-class="max-w-[16rem]"
                   :disabled="refreshing"
                 >

--- a/frontend/app/src/components/profitloss/ReportsTable.vue
+++ b/frontend/app/src/components/profitloss/ReportsTable.vue
@@ -127,7 +127,7 @@ const expand = (item: Report) => {
       <template #item.actions="{ item }">
         <div class="flex justify-end gap-1">
           <ExportReportCsv v-if="latestReport(item.identifier)" icon />
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RouterLink :to="getReportUrl(item.identifier)">
                 <RuiButton size="sm" icon variant="text" color="primary">
@@ -137,7 +137,7 @@ const expand = (item: Report) => {
             </template>
             <span>{{ t('reports_table.load.tooltip') }}</span>
           </RuiTooltip>
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiButton
                 icon

--- a/frontend/app/src/components/settings/SettingResetButton.vue
+++ b/frontend/app/src/components/settings/SettingResetButton.vue
@@ -7,7 +7,7 @@ const { t } = useI18n();
   <div class="mt-n2">
     <RuiTooltip
       :popper="{ placement: 'top' }"
-      open-delay="400"
+      :open-delay="400"
       tooltip-class="max-w-[12rem]"
     >
       <template #activator>

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -257,7 +257,7 @@ const save = async () => {
           <template #header.taxable>
             <RuiTooltip
               :popper="{ placement: 'top' }"
-              open-delay="400"
+              :open-delay="400"
               class="flex items-center"
               tooltip-class="max-w-[10rem]"
             >
@@ -273,7 +273,7 @@ const save = async () => {
           <template #header.countEntireAmountSpend>
             <RuiTooltip
               :popper="{ placement: 'top' }"
-              open-delay="400"
+              :open-delay="400"
               class="flex items-center"
               tooltip-class="max-w-[10rem]"
             >
@@ -297,7 +297,7 @@ const save = async () => {
           <template #header.countCostBasisPnl>
             <RuiTooltip
               :popper="{ placement: 'top' }"
-              open-delay="400"
+              :open-delay="400"
               class="flex items-center"
               tooltip-class="max-w-[10rem]"
             >

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleSetting.vue
@@ -305,7 +305,7 @@ const conflictsDialogOpen: Ref<boolean> = ref(false);
             <template #header.taxable>
               <RuiTooltip
                 :popper="{ placement: 'top' }"
-                open-delay="400"
+                :open-delay="400"
                 class="flex items-center"
                 tooltip-class="max-w-[10rem]"
               >
@@ -325,7 +325,7 @@ const conflictsDialogOpen: Ref<boolean> = ref(false);
             <template #header.countEntireAmountSpend>
               <RuiTooltip
                 :popper="{ placement: 'top' }"
-                open-delay="400"
+                :open-delay="400"
                 class="flex items-center"
                 tooltip-class="max-w-[10rem]"
               >
@@ -353,7 +353,7 @@ const conflictsDialogOpen: Ref<boolean> = ref(false);
             <template #header.countCostBasisPnl>
               <RuiTooltip
                 :popper="{ placement: 'top' }"
-                open-delay="400"
+                :open-delay="400"
                 class="flex items-center"
                 tooltip-class="max-w-[10rem]"
               >

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue
@@ -52,7 +52,7 @@ const value: ComputedRef<boolean> = computed(() => {
       <RuiTooltip
         v-if="selectedLinkableSetting"
         :popper="{ placement: 'top' }"
-        open-delay="400"
+        :open-delay="400"
       >
         <template #activator>
           <RuiIcon size="12" name="links-line" />

--- a/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -229,7 +229,7 @@ const v$ = setValidation(rules, exchange, { $autoDirty: true });
 
     <div v-if="editMode" class="flex items-center gap-2 text-subtitle-2 pb-4">
       {{ t('exchange_settings.keys') }}
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RuiButton variant="text" class="!p-2" icon @click="toggleEdit()">
             <RuiIcon

--- a/frontend/app/src/components/settings/data-security/OracleCacheManagement.vue
+++ b/frontend/app/src/components/settings/data-security/OracleCacheManagement.vue
@@ -217,7 +217,7 @@ const showDeleteConfirmation = (entry: OracleCacheMeta) => {
             <RuiIcon name="close-line" />
           </RuiButton>
         </div>
-        <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+        <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
           <template #activator>
             <RuiButton
               :loading="pending"
@@ -249,7 +249,7 @@ const showDeleteConfirmation = (entry: OracleCacheMeta) => {
           <DateDisplay :timestamp="item.fromTimestamp" />
         </template>
         <template #item.actions="{ item }">
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiButton
                 color="primary"

--- a/frontend/app/src/components/settings/data-security/data-management/PurgeData.vue
+++ b/frontend/app/src/components/settings/data-security/data-management/PurgeData.vue
@@ -143,7 +143,11 @@ const { txEvmChainsToLocation } = useSupportedChains();
           :hint="t('purge_selector.evm_chain_to_clear.hint')"
         />
       </div>
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400" class="-mt-8">
+      <RuiTooltip
+        :popper="{ placement: 'top' }"
+        :open-delay="400"
+        class="-mt-8"
+      >
         <template #activator>
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/settings/data-security/data-management/PurgeImagesCache.vue
+++ b/frontend/app/src/components/settings/data-security/data-management/PurgeImagesCache.vue
@@ -117,7 +117,11 @@ const css = useCssModule();
         />
       </div>
 
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400" class="-mt-8">
+      <RuiTooltip
+        :popper="{ placement: 'top' }"
+        :open-delay="400"
+        class="-mt-8"
+      >
         <template #activator="{ on, attrs }">
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/settings/data-security/data-management/RefreshCache.vue
+++ b/frontend/app/src/components/settings/data-security/data-management/RefreshCache.vue
@@ -65,7 +65,7 @@ const { status, pending, showConfirmation } = useCacheClear<RefreshableCache>(
         :disabled="pending"
       />
 
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RuiButton
             variant="text"

--- a/frontend/app/src/components/settings/general/DateDisplayFormatSetting.vue
+++ b/frontend/app/src/components/settings/general/DateDisplayFormatSetting.vue
@@ -87,7 +87,7 @@ onMounted(() => {
           </RuiButton>
         </template>
       </VTextField>
-      <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+      <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
         <template #activator>
           <RuiButton
             class="general-settings__date-restore mt-1"

--- a/frontend/app/src/components/settings/general/rpc/EvmRpcNodeManager.vue
+++ b/frontend/app/src/components/settings/general/rpc/EvmRpcNodeManager.vue
@@ -147,7 +147,7 @@ onUnmounted(() => {
                 <RuiTooltip
                   v-if="!item.owned"
                   :popper="{ placement: 'top' }"
-                  open-delay="400"
+                  :open-delay="400"
                 >
                   <template #activator>
                     <RuiIcon
@@ -160,7 +160,7 @@ onUnmounted(() => {
                 <RuiTooltip
                   v-else
                   :popper="{ placement: 'top' }"
-                  open-delay="400"
+                  :open-delay="400"
                 >
                   <template #activator>
                     <RuiIcon name="user-2-line" />
@@ -173,7 +173,7 @@ onUnmounted(() => {
                 <RuiTooltip
                   v-if="isNodeConnected(item)"
                   :popper="{ placement: 'top' }"
-                  open-delay="400"
+                  :open-delay="400"
                 >
                   <template #activator>
                     <RuiIcon color="success" size="16" name="wifi-line" />
@@ -185,7 +185,7 @@ onUnmounted(() => {
                 <RuiTooltip
                   v-else
                   :popper="{ placement: 'top' }"
-                  open-delay="400"
+                  :open-delay="400"
                 >
                   <template #activator>
                     <RuiIcon color="error" size="16" name="wifi-off-line" />

--- a/frontend/app/src/components/staking/eth/EthStakingPage.vue
+++ b/frontend/app/src/components/staking/eth/EthStakingPage.vue
@@ -147,7 +147,7 @@ const refreshClick = async () => {
         <div class="flex items-center gap-3">
           <ActiveModules :modules="[module]" />
 
-          <RuiTooltip open-delay="400">
+          <RuiTooltip :open-delay="400">
             <template #activator>
               <RuiButton
                 variant="outlined"

--- a/frontend/app/src/components/staking/eth/EthValidatorFilter.vue
+++ b/frontend/app/src/components/staking/eth/EthValidatorFilter.vue
@@ -27,7 +27,7 @@ const { t } = useI18n();
   <div class="flex flex-col md:flex-row md:items-center gap-4 md:gap-12">
     <RuiTooltip
       :popper="{ placement: 'top' }"
-      open-delay="400"
+      :open-delay="400"
       tooltip-class="max-w-[12rem]"
     >
       <template #activator>

--- a/frontend/app/src/components/staking/kraken/KrakenPage.vue
+++ b/frontend/app/src/components/staking/kraken/KrakenPage.vue
@@ -44,7 +44,7 @@ const refresh = () => load(true);
     child
   >
     <template #buttons>
-      <RuiTooltip open-delay="400">
+      <RuiTooltip :open-delay="400">
         <template #activator>
           <RuiButton
             variant="outlined"

--- a/frontend/app/src/components/staking/kraken/KrakenStakingOverview.vue
+++ b/frontend/app/src/components/staking/kraken/KrakenStakingOverview.vue
@@ -45,7 +45,7 @@ const { t } = useI18n();
       <div class="flex justify-between items-center">
         <div class="flex items-center text-rui-text-secondary gap-2 font-light">
           {{ t('kraken_staking_overview.historical') }}
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiIcon size="20" name="information-line" />
             </template>
@@ -65,7 +65,7 @@ const { t } = useI18n();
       <div class="flex justify-between items-center">
         <div class="flex items-center text-rui-text-secondary gap-2 font-light">
           {{ t('kraken_staking_overview.current') }}
-          <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+          <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
             <template #activator>
               <RuiIcon size="20" name="information-line" />
             </template>

--- a/frontend/app/src/components/staking/liquity/LiquityStakingDetails.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStakingDetails.vue
@@ -267,7 +267,7 @@ const slots = useSlots();
         <div v-if="slots.modules">
           <slot name="modules" />
         </div>
-        <RuiTooltip open-delay="400">
+        <RuiTooltip :open-delay="400">
           <template #activator>
             <RuiButton
               variant="outlined"

--- a/frontend/app/src/components/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStatistics.vue
@@ -315,7 +315,7 @@ const totalPnl: ComputedRef<BigNumber | null> = computed(() => {
                     >
                       <RuiTooltip
                         :popper="{ placement: 'top' }"
-                        open-delay="400"
+                        :open-delay="400"
                         tooltip-class="max-w-[10rem]"
                       >
                         <template #activator>

--- a/frontend/app/src/components/status/AppUpdateIndicator.vue
+++ b/frontend/app/src/components/status/AppUpdateIndicator.vue
@@ -50,7 +50,7 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <RuiTooltip v-if="updateNeeded" open-delay="400">
+  <RuiTooltip v-if="updateNeeded" :open-delay="400">
     <template #activator>
       <RuiButton color="info" icon @click="update()">
         <RuiIcon name="arrow-up-circle-line" />

--- a/frontend/app/src/components/status/notifications/Notification.vue
+++ b/frontend/app/src/components/status/notifications/Notification.vue
@@ -99,7 +99,7 @@ const action = async (notification: NotificationData) => {
         </VListItemContent>
         <RuiTooltip
           :popper="{ placement: 'bottom', offsetDistance: 0 }"
-          open-delay="400"
+          :open-delay="400"
           class="z-[9999]"
         >
           <template #activator>
@@ -139,7 +139,7 @@ const action = async (notification: NotificationData) => {
         </div>
         <RuiTooltip
           :popper="{ placement: 'bottom', offsetDistance: 0 }"
-          open-delay="400"
+          :open-delay="400"
           class="z-[9999]"
         >
           <template #activator>

--- a/frontend/app/src/components/status/notifications/NotificationPopup.vue
+++ b/frontend/app/src/components/status/notifications/NotificationPopup.vue
@@ -61,7 +61,7 @@ const { dark } = useTheme();
       <div
         class="flex justify-between p-2 items-center border-t border-default"
       >
-        <RuiTooltip open-delay="400" :popper="{ placement: 'right' }">
+        <RuiTooltip :open-delay="400" :popper="{ placement: 'right' }">
           <template #activator>
             <RuiChip class="!p-1.5" color="primary" size="sm">
               {{ queue.length }}
@@ -70,7 +70,7 @@ const { dark } = useTheme();
           <span v-text="t('notification_popup.tooltip')" />
         </RuiTooltip>
 
-        <RuiTooltip open-delay="400" :popper="{ placement: 'left' }">
+        <RuiTooltip :open-delay="400" :popper="{ placement: 'left' }">
           <template #activator>
             <RuiButton variant="text" class="!p-1.5" icon @click="dismissAll()">
               <RuiIcon name="list-unordered" />

--- a/frontend/app/src/components/status/sync/SyncButtons.vue
+++ b/frontend/app/src/components/status/sync/SyncButtons.vue
@@ -24,7 +24,7 @@ const action = (action: SyncAction) => {
 
 <template>
   <div class="flex flex-row justify-between gap-1">
-    <RuiTooltip open-delay="400" class="w-full">
+    <RuiTooltip :open-delay="400" class="w-full">
       <template #activator>
         <RuiButton
           variant="outlined"
@@ -42,7 +42,7 @@ const action = (action: SyncAction) => {
       <span>{{ t('sync_buttons.upload_tooltip') }}</span>
     </RuiTooltip>
 
-    <RuiTooltip open-delay="400" class="w-full">
+    <RuiTooltip :open-delay="400" class="w-full">
       <template #activator>
         <RuiButton
           variant="outlined"

--- a/frontend/app/src/components/table-filter/SavedFilterManagement.vue
+++ b/frontend/app/src/components/table-filter/SavedFilterManagement.vue
@@ -80,7 +80,7 @@ const css = useCssModule();
   <div class="flex items-center">
     <RuiTooltip
       :popper="{ placement: 'top' }"
-      open-delay="400"
+      :open-delay="400"
       :disabled="disabled"
     >
       <template #activator>
@@ -117,7 +117,7 @@ const css = useCssModule();
       <template #activator="{ on }">
         <RuiTooltip
           :popper="{ placement: 'top' }"
-          open-delay="400"
+          :open-delay="400"
           :disabled="disabled"
         >
           <template #activator>
@@ -149,7 +149,7 @@ const css = useCssModule();
               </VChip>
             </div>
             <div class="flex items-center gap-1">
-              <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+              <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
                 <template #activator>
                   <RuiButton
                     color="primary"
@@ -167,7 +167,7 @@ const css = useCssModule();
                 </span>
               </RuiTooltip>
 
-              <RuiTooltip :popper="{ placement: 'top' }" open-delay="400">
+              <RuiTooltip :popper="{ placement: 'top' }" :open-delay="400">
                 <template #activator>
                   <RuiButton
                     color="primary"

--- a/frontend/app/src/components/table-filter/TableFilter.vue
+++ b/frontend/app/src/components/table-filter/TableFilter.vue
@@ -348,8 +348,8 @@ const { t } = useI18n();
   <RuiTooltip
     :popper="{ placement: 'top' }"
     :disabled="!disabled || !slots.tooltip"
-    open-delay="400"
-    close-delay="1000"
+    :open-delay="400"
+    :close-delay="1000"
     class="block"
     tooltip-class="max-w-[12rem]"
   >

--- a/frontend/app/src/pages/balances/exchange/index.vue
+++ b/frontend/app/src/pages/balances/exchange/index.vue
@@ -122,7 +122,7 @@ const isBinance = (
     ]"
   >
     <template #buttons>
-      <RuiTooltip open-delay="400">
+      <RuiTooltip :open-delay="400">
         <template #activator>
           <RuiButton
             color="primary"


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.


> Vue 3 strictly checks types and I don't want to allow strings there. so this change should make it a bit easier to switch