### PR TITLE
Fix/#7099: add `exclude_ignored_assets` in trades and asset_movements query

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4214,6 +4214,7 @@ Dealing with trades
    :reqjson string quote_asset: Optionally filter trades by quote_asset. A valid asset identifier has to be provided. If missing trades are not filtered by quote asset.
    :reqjson string trade_type: Optionally filter trades by type. A valid trade type (buy, sell) has to be provided. If missing trades are not filtered by type.
    :reqjson bool include_ignored_trades: Determines whether ignored trades should be included in the result returned. Defaults to ``"true"``.
+   :reqjson bool exclude_ignored_assets: Determines whether the trades with ignored assets should be included in the result returned. Defaults to ``"true"``.
    :reqjson bool only_cache: Optional.If this is true then the equivalent exchange/location is not queried, but only what is already in the DB is returned.
 
    .. _trades_schema_section:
@@ -4477,6 +4478,7 @@ Querying asset movements
    :reqjson string asset: Optionally filter asset movements by asset. A valid asset identifier has to be provided. If missing, movements are not filtered by asset.
    :reqjson string action: Optionally filter asset movements by action type. A valid action type (deposit, withdrawals) has to be provided. If missing movements are not filtered by type.
    :reqjson bool only_cache: Optional. If this is true then the equivalent exchange/location is not queried, but only what is already in the DB is returned.
+   :reqjson bool exclude_ignored_assets: Optional. If this is true then the asset movements of ignored assets are not returned, defaults to ``"true"``.
 
 
    **Example Response**:

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -374,6 +374,7 @@ class TradesQuerySchema(
     trade_type = SerializableEnumField(enum_class=TradeType, load_default=None)
     location = LocationField(load_default=None)
     include_ignored_trades = fields.Boolean(load_default=True)
+    exclude_ignored_assets = fields.Boolean(load_default=True)
 
     def __init__(self, db: 'DBHandler') -> None:
         super().__init__()
@@ -447,6 +448,7 @@ class TradesQuerySchema(
             trade_type=[data['trade_type']] if data['trade_type'] is not None else None,
             location=data['location'],
             trades_idx_to_ignore=trades_idx_to_ignore,
+            exclude_ignored_assets=data['exclude_ignored_assets'],
         )
 
         return {
@@ -883,6 +885,7 @@ class AssetMovementsQuerySchema(
     asset = AssetField(expected_type=Asset, load_default=None)
     action = SerializableEnumField(enum_class=AssetMovementCategory, load_default=None)
     location = LocationField(load_default=None)
+    exclude_ignored_assets = fields.Boolean(load_default=True)
 
     def __init__(
             self,
@@ -943,6 +946,7 @@ class AssetMovementsQuerySchema(
             assets=asset_list,
             action=[data['action']] if data['action'] is not None else None,
             location=data['location'],
+            exclude_ignored_assets=data['exclude_ignored_assets'],
         )
         return {
             'async_query': data['async_query'],

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -608,6 +608,7 @@ class TradesFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLocation):
             trade_type: list[TradeType] | None = None,
             location: Location | None = None,
             trades_idx_to_ignore: set[str] | None = None,
+            exclude_ignored_assets: bool = False,
     ) -> 'TradesFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -657,6 +658,18 @@ class TradesFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLocation):
                 values=trades_idx_to_ignore,
             ))
 
+        if exclude_ignored_assets is True:
+            filters.append(DBIgnoredAssetsFilter(
+                and_op=True,
+                asset_key='base_asset',
+                operator='NOT IN',
+            ))
+            filters.append(DBIgnoredAssetsFilter(
+                and_op=True,
+                asset_key='quote_asset',
+                operator='NOT IN',
+            ))
+
         filter_query.timestamp_filter = DBTimestampFilter(
             and_op=True,
             from_ts=from_ts,
@@ -681,6 +694,7 @@ class AssetMovementsFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLo
             assets: tuple[Asset, ...] | None = None,
             action: list[AssetMovementCategory] | None = None,
             location: Location | None = None,
+            exclude_ignored_assets: bool = False,
     ) -> 'AssetMovementsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]
@@ -708,6 +722,13 @@ class AssetMovementsFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLo
         if location is not None:
             filter_query.location_filter = DBLocationFilter(and_op=True, location=location)
             filters.append(filter_query.location_filter)
+
+        if exclude_ignored_assets is True:
+            filters.append(DBIgnoredAssetsFilter(
+                and_op=True,
+                asset_key='asset',
+                operator='NOT IN',
+            ))
 
         filter_query.timestamp_filter = DBTimestampFilter(
             and_op=True,

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -33,6 +33,7 @@ from rotkehlchen.exchanges.kucoin import API_KEY_ERROR_CODE_ACTION as KUCOIN_API
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.binance import GlobalDBBinance
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.tests.utils.accounting import toggle_ignore_an_asset
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
@@ -800,6 +801,40 @@ def test_query_asset_movements(rotkehlchen_api_server_with_exchanges, start_with
         response = requests.get(
             api_url_for(server, 'assetmovementsresource') + '?' + urlencode(data))
         assert_okay(response)
+
+    # now test `exclude_ignored_assets` query param
+    with setup.polo_patch:
+        data = {'only_cache': True}
+        without_ignore_response = requests.get(
+            api_url_for(server, 'assetmovementsresource'),
+            json=data,
+        )
+        without_ignore_response = assert_proper_response_with_result(without_ignore_response)
+
+        toggle_ignore_an_asset(rotkehlchen_api_server_with_exchanges, A_BTC)
+        data |= {'exclude_ignored_assets': True}
+        ignored_response = requests.get(api_url_for(server, 'assetmovementsresource'), json=data)
+        ignored_response = assert_proper_response_with_result(ignored_response)
+        default_response = requests.get(api_url_for(server, 'assetmovementsresource'))
+        default_response = assert_proper_response_with_result(default_response)
+        assert ignored_response == default_response, '`exclude_ignored_assets` should be True by default'  # noqa: E501
+
+        assert all(
+            x['entry']['asset'] != 'BTC'
+            for x in ignored_response['entries']
+        ), 'BTC asset movements should have now been ignored for accounting'
+        assert len(ignored_response['entries']) == 6, 'Only 6 asset movements should have been returned'  # noqa: E501
+
+        data['exclude_ignored_assets'] = False
+        not_exclude_response = requests.get(
+            api_url_for(server, 'assetmovementsresource'),
+            json=data,
+        )
+        not_exclude_response = assert_proper_response_with_result(not_exclude_response)
+        assert not_exclude_response == without_ignore_response, '`exclude_ignored_assets` = False should not exclude any asset movements'  # noqa: E501
+
+        # reset the ignored status of BTC
+        toggle_ignore_an_asset(rotkehlchen_api_server_with_exchanges, A_BTC)
 
     # and now test pagination
     data = {'only_cache': True, 'offset': 1, 'limit': 2, 'location': 'kraken'}

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -5,16 +5,21 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+import requests
+
 from rotkehlchen.accounting.export.csv import CSV_INDEX_OFFSET, FILENAME_ALL_CSV
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
 from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
+from rotkehlchen.api.server import APIServer
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USDC, A_WBTC
 from rotkehlchen.db.filtering import ReportDataFilterQuery
 from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.api import api_url_for
 from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TimestampMS, TradeType
 from rotkehlchen.utils.version_check import get_current_version
 
@@ -345,3 +350,47 @@ def assert_csv_export(
                 expected_csv_data=expected_csv_data,
                 expected_pnls=expected_pnls,
             )
+
+
+def toggle_ignore_an_asset(
+        rotkehlchen_api_server: APIServer,
+        asset_to_ignore: Asset,
+) -> None:
+    """Utility function to add/remove an ignored asset"""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    # check if the asset is already ignored
+    with rotki.data.db.conn.read_ctx() as cursor:
+        result = rotki.data.db.get_ignored_asset_ids(cursor)
+    already_ignored = asset_to_ignore.identifier in result
+
+    if already_ignored:
+        # remove the asset from the ignored list
+        response = requests.delete(
+            api_url_for(
+                rotkehlchen_api_server,
+                'ignoredassetsresource',
+            ), json={'assets': [asset_to_ignore.identifier]},
+        )
+        assert response.status_code == 200
+        response_result = response.json().get('result', [])
+        assert asset_to_ignore.identifier not in response_result
+
+        with rotki.data.db.conn.read_ctx() as cursor:
+            result = rotki.data.db.get_ignored_asset_ids(cursor)
+        assert asset_to_ignore.identifier not in result
+        return
+
+    # else add the asset to the ignored list
+    response = requests.put(
+        api_url_for(
+            rotkehlchen_api_server,
+            'ignoredassetsresource',
+        ), json={'assets': [asset_to_ignore.identifier]},
+    )
+    assert response.status_code == 200
+    response_result = response.json().get('result', [])
+    assert asset_to_ignore.identifier in response_result
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        result = rotki.data.db.get_ignored_asset_ids(cursor)
+    assert asset_to_ignore.identifier in result


### PR DESCRIPTION
Closes #7099

## Checklist
- [x] add `exclude_ignored_assets` query parameter in trades and asset_movements query
- [x] add their tests
- [x] update the API docs