### PR TITLE
fix (#7082): add `location_name` in trade query

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -679,6 +679,7 @@ Getting or modifying settings
    :reqjson list active_module: A list of strings denoting the active modules with which rotki should run.
    :reqjson list current_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting current prices.
    :reqjson list historical_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting historical prices.
+   :reqjson list non_syncing_exchanges: A list of objects with the keys ``name`` and ``location`` of the exchange. These exchanges will be ignored when querying the trades. Example: ``[{"name": "my_exchange", "location": "binance"}]``. 
    :resjson int ssf_graph_multiplier: A multiplier to the snapshot saving frequency for zero amount graphs. Originally 0 by default. If set it denotes the multiplier of the snapshot saving frequency at which to insert 0 save balances for a graph between two saved values.
    :resjson bool infer_zero_timed_balances: A boolean denoting whether to infer zero timed balances for assets that have no balance at a specific time. This is useful for showing zero balance periods in graphs.
    :resjson int query_retry_limit: The number of times to retry a query to external services before giving up. Default is 5.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`7082` Now disabling sync for an exchange instance won't prevent other instances in the same exchange from querying new trades.
 * :bug:`7115` Fix the issue with decimal point for amount input.
 * :bug:`7119` Removed bittrex as an exchanged added via api key since it has shut down. But users can now import bittrex CSVs in order to get their history into rotki.
 * :bug:`-` Bitmex history queries should now work properly again after Bitmex changed their API without versioning.

--- a/rotkehlchen/tests/unit/test_trades.py
+++ b/rotkehlchen/tests/unit/test_trades.py
@@ -8,6 +8,7 @@ from rotkehlchen.db.filtering import TradesFilterQuery
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.data_structures import Trade, deserialize_trade, trades_from_dictlist
 from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.exchanges import create_test_coinbase
 from rotkehlchen.types import ExchangeLocationID, Location, Timestamp, TradeType
 from rotkehlchen.utils.serialization import rlk_jsondumps
 
@@ -132,19 +133,47 @@ def test_serialize_deserialize_trade():
 
 @pytest.mark.parametrize('db_settings', [
     {'non_syncing_exchanges': [ExchangeLocationID(name='Binance', location=Location.BINANCE)]}])
-def test_query_trade_history_online_but_exchange_excluded(events_historian):
-    """Test that if an online refresh of trades for an exchange is requested,
-    that exchange is not connected, but is also at the excluded exchanges we
-    don't end up querying trades of all exchanges"""
-
-    patch_latest_trades = patch.object(events_historian, 'query_location_latest_trades')
-    patch_iterate_exchanges = patch.object(events_historian.exchange_manager, 'iterate_exchanges')
-
-    with patch_latest_trades as latest_trades_mock, patch_iterate_exchanges as iterate_exchanges_mock:  # noqa: E501
+def test_query_trade_history_online_but_exchange_excluded(events_historian, function_scope_binance):  # noqa: E501
+    """
+    Test that if an online refresh of trades for an exchange is requested but is also at
+    the excluded exchanges we don't end up querying trades of all exchanges.
+    """
+    with (
+        patch.object(target=events_historian.exchange_manager, attribute='iterate_exchanges') as iterate_exchanges_mock,  # noqa: E501
+        patch.object(target=function_scope_binance, attribute='query_trade_history') as patch_query_trade_history,  # noqa: E501
+    ):
         events_historian.query_trades(
             filter_query=TradesFilterQuery.make(location=Location.BINANCE),
             only_cache=False,
         )
 
-    assert latest_trades_mock.call_count == 0
+    assert patch_query_trade_history.call_count == 0
     assert iterate_exchanges_mock.call_count == 0
+
+
+@pytest.mark.parametrize('db_settings', [
+    {'non_syncing_exchanges': [ExchangeLocationID(name='Coinbase', location=Location.COINBASE)]}])
+def test_query_trade_history_with_exchange_instance_excluded(events_historian):
+    """
+    Test that when an exchange is ignored and more instances of the same location exist
+    we only ignore the correct instance and not all.
+    """
+
+    coinbase_instances = [create_test_coinbase(
+        name=name,
+        database=events_historian,
+        msg_aggregator=events_historian.msg_aggregator,
+    ) for name in ('Coinbase', 'Coinbase2')]
+
+    events_historian.exchange_manager.connected_exchanges[Location.COINBASE] = coinbase_instances
+    with (
+        patch.object(target=coinbase_instances[0], attribute='query_trade_history') as coinbase_mock,  # noqa: E501
+        patch.object(target=coinbase_instances[1], attribute='query_trade_history') as coinbase2_mock,  # noqa: E501
+    ):
+        events_historian.query_trades(
+            filter_query=TradesFilterQuery.make(location=Location.COINBASE),
+            only_cache=False,
+        )
+
+    assert coinbase_mock.call_count == 0
+    assert coinbase2_mock.call_count == 1

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -557,9 +557,10 @@ def patch_poloniex_balances_query(poloniex: 'Poloniex'):
 def create_test_coinbase(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
+        name: str = 'coinbase',
 ) -> Coinbase:
     mock = Coinbase(
-        name='coinbase',
+        name=name,
         api_key=make_api_key(),
         secret=make_api_secret(),
         database=database,


### PR DESCRIPTION
Closes #7082 

## Checklist

- [x] Update `query_location_latest_trades` to use `excluded_instances` to filter along with names
- [x] Update `_query_services_for_trades` to pass `excluded_instances`
- [x] Add unit test to check this functionality
- [x] Also, add missing documentation for `non_syncing_exchanges` in PUT /settings