### PR TITLE
Fix/#7123: Check for balance of EOA address on ethereum for checking its activity

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`7123` Adding an EVM EOA address that has only withdrawals/blocks activity will no longer fail.
 * :bug:`7082` Now disabling sync for an exchange instance won't prevent other instances in the same exchange from querying new trades.
 * :bug:`7071` Fix the issue where users on mobile devices need to scroll to login.
 * :bug:`7120` Fix the issue where after removing an exchange key, an error notification is shown.

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -12,6 +12,7 @@ from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
+from rotkehlchen.externalapis.etherscan import EtherscanHasChainActivity
 from rotkehlchen.globaldb.migrations.migration1 import ILK_REGISTRY_ABI
 from rotkehlchen.serialization.deserialize import deserialize_evm_transaction
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -192,3 +193,13 @@ def test_etherscan_get_contract_abi(temp_etherscan):
     abi = temp_etherscan.get_contract_abi('0x5a464C28D19848f44199D003BeF5ecc87d090F87')
     assert abi == json.loads(ILK_REGISTRY_ABI)
     assert temp_etherscan.get_contract_abi('0x9531C059098e3d194fF87FebB587aB07B30B1306') is None
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+def test_has_activity(temp_etherscan):
+    """Test to check if an address has any activity on ethereum mainnet"""
+    assert temp_etherscan.has_activity('0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5') == EtherscanHasChainActivity.TRANSACTIONS  # noqa: E501
+    assert temp_etherscan.has_activity('0x725E35e01bbEDadd6ac13cE1c4a98bA4Cf00dF21') == EtherscanHasChainActivity.TRANSACTIONS  # noqa: E501
+    assert temp_etherscan.has_activity('0x3C69Bc9B9681683890ad82953Fe67d13Cd91D5EE') == EtherscanHasChainActivity.BALANCE  # noqa: E501
+    assert temp_etherscan.has_activity('0x014cd0535b2Ea668150a681524392B7633c8681c') == EtherscanHasChainActivity.TOKENS  # noqa: E501
+    assert temp_etherscan.has_activity('0x6c66149E65c517605e0a2e4F707550ca342f9c1B') == EtherscanHasChainActivity.NONE  # noqa: E501

--- a/rotkehlchen/tests/unit/test_trades.py
+++ b/rotkehlchen/tests/unit/test_trades.py
@@ -158,7 +158,6 @@ def test_query_trade_history_with_exchange_instance_excluded(events_historian):
     Test that when an exchange is ignored and more instances of the same location exist
     we only ignore the correct instance and not all.
     """
-
     coinbase_instances = [create_test_coinbase(
         name=name,
         database=events_historian,


### PR DESCRIPTION
Closes #7123

## Checklist

- [x] Add check for balance in `has_activity` of Etherscan
- [x] Add test for `has_activity`
- [x] Cleanup from #7125 