### PR TITLE
Process scientific notation timestamps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Importing timestamp in CSV in scientific format should now work without errors.
 * :bug:`7123` Adding an EVM EOA address that has only withdrawals/blocks activity will no longer fail.
 * :bug:`7082` Now disabling sync for an exchange instance won't prevent other instances in the same exchange from querying new trades.
 * :bug:`7071` Fix the issue where users on mobile devices need to scroll to login.

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -56,7 +56,7 @@ def deserialize_fee(fee: str | None) -> Fee:
     return result
 
 
-def deserialize_timestamp(timestamp: int | (str | FVal)) -> Timestamp:
+def deserialize_timestamp(timestamp: float | (str | FVal)) -> Timestamp:
     """Deserializes a timestamp from a json entry. Given entry can either be a
     string or an int.
 
@@ -75,13 +75,13 @@ def deserialize_timestamp(timestamp: int | (str | FVal)) -> Timestamp:
             raise DeserializationError(
                 'Tried to deserialize a timestamp from a non-exact int FVal entry',
             ) from e
-    elif isinstance(timestamp, str):
+    elif isinstance(timestamp, (str | float)):
         try:
-            processed_timestamp = Timestamp(int(timestamp))
-        except ValueError as e:
+            processed_timestamp = Timestamp(FVal(timestamp).to_int(exact=True))
+        except (ValueError, ConversionError) as e:
             # String could not be turned to an int
             raise DeserializationError(
-                f'Failed to deserialize a timestamp entry from string {timestamp}',
+                f'Failed to deserialize a timestamp entry from string {timestamp} due to {e}',
             ) from e
     else:
         raise DeserializationError(

--- a/rotkehlchen/tests/api/test_statistics.py
+++ b/rotkehlchen/tests/api/test_statistics.py
@@ -210,7 +210,7 @@ def test_query_statistics_asset_balance_errors(rotkehlchen_api_server: APIServer
     )
     assert_error_response(
         response=response,
-        contained_in_msg='"Failed to deserialize a timestamp entry. Unexpected type',
+        contained_in_msg='"Failed to deserialize a timestamp entry from string 53434.32',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/exchanges/test_bitmex.py
+++ b/rotkehlchen/tests/exchanges/test_bitmex.py
@@ -190,31 +190,21 @@ def test_bitmex_margin_history(sandbox_bitmex):
     )
     assert len(result) == 0
 
-    until_9_results_ts = 1536615593
+    until_5_results_ts = 1536615593
     result = sandbox_bitmex.query_margin_history(
         start_ts=0,
-        end_ts=until_9_results_ts,
+        end_ts=until_5_results_ts,
     )
     expected_result = [MarginPosition(
         location=Location.BITMEX,
         open_time=None,
         close_time=1536580800,
-        profit_loss=FVal('0.00000683'),
+        profit_loss=FVal('0.00000003'),
         pl_currency=A_BTC,
         fee=ZERO,
         fee_currency=A_BTC,
-        link='9ab9f275-9132-64aa-4aa6-8c6503418ac6',
-        notes='ETHUSD',
-    ), MarginPosition(
-        location=Location.BITMEX,
-        open_time=None,
-        close_time=1536580800,
-        profit_loss=FVal('0.00000183'),
-        pl_currency=A_BTC,
-        fee=ZERO,
-        fee_currency=A_BTC,
-        link='9c50e247-9bea-b10b-93c8-26845f202e9a',
-        notes='XBTJPY',
+        link='97402f76-828e-a8ea-5d26-920134924149',
+        notes='XBTZ18',
     ), MarginPosition(
         location=Location.BITMEX,
         open_time=None,
@@ -229,52 +219,22 @@ def test_bitmex_margin_history(sandbox_bitmex):
         location=Location.BITMEX,
         open_time=None,
         close_time=1536580800,
-        profit_loss=FVal('0.00000003'),
+        profit_loss=FVal('0.00000183'),
         pl_currency=A_BTC,
         fee=ZERO,
         fee_currency=A_BTC,
-        link='97402f76-828e-a8ea-5d26-920134924149',
-        notes='XBTZ18',
-    ), MarginPosition(
-        location=Location.BITMEX,
-        open_time=None,
-        close_time=1536494400,
-        profit_loss=FVal('-0.00007992'),
-        pl_currency=A_BTC,
-        fee=ZERO,
-        fee_currency=A_BTC,
-        link='df46338a-da5e-e16c-9753-3e863d83d92c',
-        notes='ETHU18',
-    ), MarginPosition(
-        location=Location.BITMEX,
-        open_time=None,
-        close_time=1536494400,
-        profit_loss=FVal('0.00000005'),
-        pl_currency=A_BTC,
-        fee=ZERO,
-        fee_currency=A_BTC,
-        link='05c8bbc0-9b03-ff55-60b9-4f22fd2eeab2',
-        notes='ETHUSD',
-    ), MarginPosition(
-        location=Location.BITMEX,
-        open_time=None,
-        close_time=1536494400,
-        profit_loss=FVal('0.00000003'),
-        pl_currency=A_BTC,
-        fee=ZERO,
-        fee_currency=A_BTC,
-        link='fa0f5415-0867-6164-e366-d1c73c5558bd',
+        link='9c50e247-9bea-b10b-93c8-26845f202e9a',
         notes='XBTJPY',
     ), MarginPosition(
         location=Location.BITMEX,
         open_time=None,
-        close_time=1536494400,
-        profit_loss=FVal('0.00000003'),
+        close_time=1536580800,
+        profit_loss=FVal('0.00000683'),
         pl_currency=A_BTC,
         fee=ZERO,
         fee_currency=A_BTC,
-        link='0227cf99-09d4-b6f0-86c3-69711cf8da1b',
-        notes='XBTUSD',
+        link='9ab9f275-9132-64aa-4aa6-8c6503418ac6',
+        notes='ETHUSD',
     ), MarginPosition(
         location=Location.BITMEX,
         open_time=None,
@@ -286,7 +246,7 @@ def test_bitmex_margin_history(sandbox_bitmex):
         link='7366644c-15ba-baa4-b300-615b0c5db567',
         notes='XRPU18',
     )]
-    assert result == expected_result
+    assert result[:5] == expected_result
 
 
 def test_bitmex_query_balances(sandbox_bitmex):

--- a/rotkehlchen/tests/unit/test_deserialization.py
+++ b/rotkehlchen/tests/unit/test_deserialization.py
@@ -1,0 +1,23 @@
+import pytest
+
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.fval import FVal
+from rotkehlchen.serialization.deserialize import deserialize_timestamp
+from rotkehlchen.types import Timestamp
+
+
+def test_deserialize_timestamp():
+    """Test various edge cases of deserialize timestamp and that they all work as expected"""
+    target_ts = Timestamp(1492980000)
+    ts_from_scientific_str = deserialize_timestamp('1.49298E+9')
+    assert ts_from_scientific_str == target_ts
+    ts_from_normal_str = deserialize_timestamp('1492980000')
+    assert ts_from_normal_str == target_ts
+    ts_from_normal_int = deserialize_timestamp(1492980000)
+    assert ts_from_normal_int == target_ts
+    ts_from_normal_scientific = deserialize_timestamp(1.49298E+9)
+    assert ts_from_normal_scientific == target_ts
+
+    for bad_argument in (-1, FVal('3.14'), 3.14, '3.14', '5.23267356186572e+8', ['lol']):
+        with pytest.raises(DeserializationError):
+            deserialize_timestamp(bad_argument)

--- a/rotkehlchen/tests/unit/test_fval.py
+++ b/rotkehlchen/tests/unit/test_fval.py
@@ -12,6 +12,8 @@ def test_simple_arithmetic():
     c = FVal(-23.124)
     d = FVal(5006337207657766294397)
     e = ZERO
+    f = FVal('1.49298E+12')
+    g = FVal('5.23267356186572e+8')
     FVal(b'0')
 
     assert a + b == FVal('7.33')
@@ -26,6 +28,8 @@ def test_simple_arithmetic():
     assert abs(c) == FVal('23.124')
     assert d == FVal('5006337207657766294397')
     assert e == FVal('0.0')
+    assert f == FVal('1492980000000')
+    assert g == FVal('523267356.186572')
 
     a += b
     assert a == FVal('7.33')


### PR DESCRIPTION
If a user imports a timestamp in scientific notation from a CSV or anywhere else it should now work properly.


Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=47247446