### PR TITLE
Handle etherscan backoff failure better.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Failure to resolve etherscan api or hitting maximum backoff after too many retries will now no longer raise an exception.
 * :bug:`-` Some coinbase trades imported via the API should no longer show negative amounts. If you see negative amounts, purge and repull coinbase data.
 
 * :release:`1.31.2 <2023-12-22>`


### PR DESCRIPTION
Before this PR in 1.31.2 if etherscan hit maximum backoff then we would end up out of the loop with `result` being undefined and as such this exception would be raised:

```
[24/12/2023 01:22:12 +04] ERROR rotkehlchen.api.rest Greenlet with id 4774699584: Greenlet for task 22 dies with exception: local variable 'result' referenced before assignment.
Exception Name: <class 'UnboundLocalError'>
Exception Info: local variable 'result' referenced before assignment
Traceback:
   File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/api/rest.py", line 417, in _do_query_async
  File "rotkehlchen/api/v1/resources.py", line 354, in _do_async_validation
  File "rotkehlchen/api/v1/resources.py", line 1598, in put
  File "rotkehlchen/api/rest.py", line 1781, in add_single_blockchain_accounts
  File "rotkehlchen/rotkehlchen.py", line 741, in add_single_blockchain_accounts
  File "rotkehlchen/chain/aggregator.py", line 780, in modify_blockchain_accounts
  File "rotkehlchen/chain/aggregator.py", line 736, in _append_eth_account_modification
  File "rotkehlchen/chain/ethereum/modules/makerdao/vaults.py", line 725, in on_account_addition
  File "rotkehlchen/chain/ethereum/defi/defisaver_proxy.py", line 37, in on_account_addition
  File "rotkehlchen/chain/evm/proxies_inquirer.py", line 53, in get_account_proxy
  File "rotkehlchen/chain/evm/contracts.py", line 41, in call
  File "rotkehlchen/chain/evm/node_inquirer.py", line 669, in call_contract
  File "rotkehlchen/chain/evm/node_inquirer.py", line 530, in _query
  File "rotkehlchen/chain/evm/node_inquirer.py", line 696, in _call_contract
  File "rotkehlchen/chain/evm/node_inquirer.py", line 637, in _call_contract_etherscan
  File "rotkehlchen/externalapis/etherscan.py", line 633, in eth_call
  File "rotkehlchen/externalapis/etherscan.py", line 336, in _query
  ```