### PR TITLE
Optimizations on inquirer and assets

### DIFF
--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -77,7 +77,7 @@ class Asset:
         if isinstance(self, AssetWithNameAndType):
             return self.asset_type
 
-        return AssetResolver().get_asset_type(self.identifier)
+        return AssetResolver.get_asset_type(self.identifier)
 
     def exists(self, query_packaged_db: bool = True) -> bool:
         """Returns True if this asset exists. False otherwise
@@ -101,7 +101,7 @@ class Asset:
         May raise:
         - UnknownAsset
         """
-        normalized_id = AssetResolver().check_existence(self.identifier, query_packaged_db=query_packaged_db)  # noqa: E501
+        normalized_id = AssetResolver.check_existence(self.identifier, query_packaged_db=query_packaged_db)  # noqa: E501
         object.__setattr__(self, 'identifier', normalized_id)
         return self
 
@@ -136,40 +136,40 @@ class Asset:
                 chain_id=ChainID.ETHEREUM,
             )
 
-        return AssetResolver().resolve_asset(identifier=self.identifier)
+        return AssetResolver.resolve_asset(identifier=self.identifier)
 
     def resolve_to_asset_with_name_and_type(self) -> 'AssetWithNameAndType':
-        return AssetResolver().resolve_asset_to_class(
+        return AssetResolver.resolve_asset_to_class(
             identifier=self.identifier,
             expected_type=AssetWithNameAndType,
         )
 
     def resolve_to_asset_with_symbol(self) -> 'AssetWithSymbol':
-        return AssetResolver().resolve_asset_to_class(
+        return AssetResolver.resolve_asset_to_class(
             identifier=self.identifier,
             expected_type=AssetWithSymbol,
         )
 
     def resolve_to_crypto_asset(self) -> 'CryptoAsset':
-        return AssetResolver().resolve_asset_to_class(
+        return AssetResolver.resolve_asset_to_class(
             identifier=self.identifier,
             expected_type=CryptoAsset,
         )
 
     def resolve_to_evm_token(self) -> 'EvmToken':
-        return AssetResolver().resolve_asset_to_class(
+        return AssetResolver.resolve_asset_to_class(
             identifier=self.identifier,
             expected_type=EvmToken,
         )
 
     def resolve_to_asset_with_oracles(self) -> 'AssetWithOracles':
-        return AssetResolver().resolve_asset_to_class(
+        return AssetResolver.resolve_asset_to_class(
             identifier=self.identifier,
             expected_type=AssetWithOracles,
         )
 
     def resolve_to_fiat_asset(self) -> 'FiatAsset':
-        return AssetResolver().resolve_asset_to_class(
+        return AssetResolver.resolve_asset_to_class(
             identifier=self.identifier,
             expected_type=FiatAsset,
         )

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -339,8 +339,9 @@ class Inquirer:
         for chain_id, evm_manager in evm_managers:
             instance._evm_managers[chain_id] = evm_manager
 
-    def get_evm_manager(self, chain_id: ChainID) -> 'EvmManager':
-        evm_manager = self._evm_managers.get(chain_id)
+    @staticmethod
+    def get_evm_manager(chain_id: ChainID) -> 'EvmManager':
+        evm_manager = Inquirer._evm_managers.get(chain_id)
         assert evm_manager is not None, f'evm manager for chain id {chain_id} should have been injected'  # noqa: E501
         return evm_manager
 
@@ -638,7 +639,7 @@ class Inquirer:
 
         if isinstance(asset, FiatAsset):
             with suppress(RemoteError):
-                price, oracle = Inquirer._query_fiat_pair(base=asset, quote=instance.usd)
+                price, oracle = Inquirer._query_fiat_pair(base=asset, quote=Inquirer.usd)
                 return price, oracle, False
 
         # continue, asset isn't fiat or a price can be found by one of the oracles (CC for example)
@@ -653,7 +654,7 @@ class Inquirer:
 
             # Check if it is a special token
             if asset.identifier in Inquirer.special_tokens:
-                ethereum = Inquirer().get_evm_manager(chain_id=ChainID.ETHEREUM)
+                ethereum = Inquirer.get_evm_manager(chain_id=ChainID.ETHEREUM)
                 underlying_asset_price, oracle = get_underlying_asset_price(asset)
                 usd_price = handle_defi_price_query(
                     ethereum=ethereum.node_inquirer,  # type:ignore  # ethereum is an EthereumManager so the inquirer is of the expected type


### PR DESCRIPTION
- We were using instances of the Inquirer class to call staticmethods. This uses one extra method call and a check to see if there is already an instance for the singleton that are not needed.
- If we had evmtokens already resolved and called again resolve on them we would hit again the database. This happens some times in the decoders and is not really needed