### PR TITLE
Feat/cache: Move unrelated values from `settings` to `key_value_cache`

### DIFF
--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -44,6 +44,7 @@ from rotkehlchen.chain.substrate.utils import SUBSTRATE_NODE_CONNECTION_TIMEOUT
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_AVAX, A_BCH, A_BTC, A_DAI, A_DOT, A_ETH, A_ETH2, A_KSM
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
+from rotkehlchen.db.cache import DBCache
 from rotkehlchen.db.eth2 import DBEth2
 from rotkehlchen.db.filtering import Eth2DailyStatsFilterQuery
 from rotkehlchen.db.queried_addresses import QueriedAddresses
@@ -85,7 +86,6 @@ from rotkehlchen.utils.mixins.cacheable import CacheableMixIn, cache_response_ti
 from rotkehlchen.utils.mixins.lockable import LockableQueryMixIn, protect_with_lock
 
 from .balances import BlockchainBalances, BlockchainBalancesUpdate
-from .constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.manager import ArbitrumOneManager
@@ -1540,8 +1540,8 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
 
         with self.database.user_write() as cursor:
             cursor.execute(  # remember last time evm addresses were detected
-                'INSERT OR REPLACE INTO settings (name, value) VALUES (?, ?)',
-                (LAST_EVM_ACCOUNTS_DETECT_KEY, str(ts_now())),
+                'INSERT OR REPLACE INTO key_value_cache (name, value) VALUES (?, ?)',
+                (DBCache.LAST_EVM_ACCOUNTS_DETECT_TS.value, str(ts_now())),
             )
 
         return added_accounts

--- a/rotkehlchen/chain/constants.py
+++ b/rotkehlchen/chain/constants.py
@@ -1,5 +1,3 @@
-from typing import Final
-
 from rotkehlchen.types import SUPPORTED_BLOCKCHAIN_TO_CHAINID, SupportedBlockchain
 
 DEFAULT_EVM_RPC_TIMEOUT = 10
@@ -9,5 +7,3 @@ NON_BITCOIN_CHAINS = [
     SupportedBlockchain.ETHEREUM_BEACONCHAIN,
     SupportedBlockchain.KUSAMA,
 ] + list(SUPPORTED_BLOCKCHAIN_TO_CHAINID.keys())
-
-LAST_EVM_ACCOUNTS_DETECT_KEY: Final = 'last_evm_accounts_detect_ts'

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -33,8 +33,3 @@ ALLASSETIMAGESDIR_NAME: Final = 'all'
 CUSTOMASSETIMAGESDIR_NAME: Final = 'custom'
 MISCDIR_NAME: Final = 'misc'
 APPDIR_NAME: Final = 'app'
-
-LAST_SPAM_ASSETS_DETECT_KEY: Final = 'last_spam_assets_detect_key'
-LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY: Final = 'last_augmented_spam_assets_detect_key'
-
-LAST_OWNED_ASSETS_UPDATE: Final = 'last_owned_assets_update'

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -45,15 +45,14 @@ class DataMigrationManager:
 
     def maybe_migrate_data(self) -> None:
         with self.rotki.data.db.conn.read_ctx() as cursor:
-            settings = self.rotki.data.db.get_settings(cursor)
-        last_migration_version = settings.last_data_migration
+            last_migration_version = self.rotki.data.db.get_setting(cursor, 'last_data_migration')
 
         self.progress_handler = MigrationProgressHandler(
             messages_aggregator=self.rotki.msg_aggregator,
             target_version=LAST_DATA_MIGRATION,
         )
         for migration in MIGRATION_LIST:
-            if last_migration_version < migration.version:
+            if last_migration_version is not None and last_migration_version < migration.version:
                 if self._perform_migration(migration) is False:
                     break  # a migration failed -- no point continuing
 

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -1,0 +1,30 @@
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.types import Timestamp
+from rotkehlchen.utils.mixins.enums import Enum
+
+
+class DBCache(Enum):
+    """It contains all the values that can be stored in the `key_value_cache` table of the DB"""
+    LAST_BALANCE_SAVE = 'last_balance_save'
+    LAST_DATA_UPLOAD_TS = 'last_data_upload_ts'
+    LAST_DATA_UPDATES_TS = 'last_data_updates_ts'
+    LAST_OWNED_ASSETS_UPDATE = 'last_owned_assets_update'
+    LAST_EVM_ACCOUNTS_DETECT_TS = 'last_evm_accounts_detect_ts'
+    LAST_SPAM_ASSETS_DETECT_KEY = 'last_spam_assets_detect_key'
+    LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY = 'last_augmented_spam_assets_detect_key'
+
+    @classmethod
+    def deserialize(cls: type['DBCache'], value: str) -> 'DBCache':
+        """The method to deserialize a string to an enum object"""
+        try:
+            return getattr(cls, value.upper())
+        except AttributeError as e:
+            raise DeserializationError(f'Failed to deserialize {cls.__name__} value {value}') from e  # noqa: E501
+
+
+def serialize_cache_for_api(cache: dict[DBCache, int]) -> dict[str, Timestamp]:
+    """Serialize the cache for /settings API consumption."""
+    return {
+        DBCache.LAST_DATA_UPLOAD_TS.value: Timestamp(cache.get(DBCache.LAST_DATA_UPLOAD_TS, 0)),
+        DBCache.LAST_BALANCE_SAVE.value: Timestamp(cache.get(DBCache.LAST_BALANCE_SAVE, 0)),
+    }

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Final, Literal
+from typing import Literal
 
 from rotkehlchen.errors.serialization import DeserializationError
 
@@ -15,8 +15,6 @@ HISTORY_MAPPING_STATE_CUSTOMIZED = 1
 
 EVM_ACCOUNTS_DETAILS_LAST_QUERIED_TS = 'last_queried_timestamp'
 EVM_ACCOUNTS_DETAILS_TOKENS = 'tokens'
-
-LAST_DATA_UPDATES_KEY: Final = 'last_data_updates_ts'
 
 NO_ACCOUNTING_COUNTERPARTY = 'NONE'
 LINKABLE_ACCOUNTING_SETTINGS_NAME = Literal[

--- a/rotkehlchen/db/upgrades/v40_v41.py
+++ b/rotkehlchen/db/upgrades/v40_v41.py
@@ -22,15 +22,49 @@ def _add_cache_table(write_cursor: 'DBCursor') -> None:
     log.debug('Exit _add_cache_table')
 
 
+def _move_non_settings_mappings_to_cache(write_cursor: 'DBCursor') -> None:
+    """Move the non-settings value from `settings` to a seperate `key_value_cache` table"""
+    log.debug('Enter _move_non_settings_mappings_to_cache')
+    settings_moved = (
+        'last_balance_save',
+        'last_data_upload_ts',
+        'last_data_updates_ts',
+        'last_owned_assets_update',
+        'last_evm_accounts_detect_ts',
+        'last_spam_assets_detect_key',
+        'last_augmented_spam_assets_detect_key',
+        'spam_assets_version',
+        'rpc_nodes_version',
+        'contracts_version',
+        'global_addressbook_version',
+        'accounting_rules_version',
+    )
+    movable_settings = write_cursor.execute(
+        f'SELECT name, value FROM settings WHERE name IN ({",".join(["?"] * len(settings_moved))});',  # noqa: E501
+        settings_moved,
+    ).fetchall()
+    write_cursor.executemany(
+        'INSERT OR IGNORE INTO key_value_cache(name, value) VALUES(?, ?);',
+        movable_settings,
+    )
+    write_cursor.execute(
+        f'DELETE FROM settings WHERE name IN ({",".join(["?"] * len(movable_settings))});',
+        [setting[0] for setting in movable_settings],
+    )
+    log.debug('Exit _move_non_settings_mappings_to_cache')
+
+
 def upgrade_v40_to_v41(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHandler') -> None:
     """Upgrades the DB from v40 to v41. This was in v1.32 release.
 
         - Create a new table for key-value cache
     """
     log.debug('Enter userdb v40->v41 upgrade')
-    progress_handler.set_total_steps(1)
+    progress_handler.set_total_steps(2)
     with db.user_write() as write_cursor:
         _add_cache_table(write_cursor)
+        progress_handler.new_step()
+        _move_non_settings_mappings_to_cache(write_cursor)
     progress_handler.new_step()
 
     log.debug('Finish userdb v40->v41 upgrade')

--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -8,11 +8,8 @@ from rotkehlchen.assets.types import AssetType
 from rotkehlchen.assets.utils import check_if_spam_token
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.constants.assets import A_USD
-from rotkehlchen.constants.misc import (
-    LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY,
-    LAST_SPAM_ASSETS_DETECT_KEY,
-)
 from rotkehlchen.constants.prices import ZERO_PRICE
+from rotkehlchen.db.cache import DBCache
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.drivers.gevent import DBCursor
 from rotkehlchen.db.evmtx import DBEvmTx
@@ -98,7 +95,7 @@ def autodetect_spam_assets_in_db(user_db: DBHandler) -> None:
         )
         write_cursor.execute(  # remember last time spam detection ran
             'INSERT OR REPLACE INTO settings (name, value) VALUES (?, ?)',
-            (LAST_SPAM_ASSETS_DETECT_KEY, str(ts_now())),
+            (DBCache.LAST_SPAM_ASSETS_DETECT_KEY.value, str(ts_now())),
         )
 
     for chain in chains_to_refresh:
@@ -205,8 +202,8 @@ def augmented_spam_detection(user_db: DBHandler) -> None:
             user_db_write_cursor=write_cursor,
         )
         write_cursor.execute(  # remember last time augmented spam detection ran
-            'INSERT OR REPLACE INTO settings (name, value) VALUES (?, ?)',
-            (LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY, str(ts_now())),
+            'INSERT OR REPLACE INTO key_value_cache (name, value) VALUES (?, ?)',
+            (DBCache.LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY.value, str(ts_now())),
         )
 
     for chain in chains_with_spam:  # let frontend know so they refresh balances

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -9,7 +9,6 @@ import gevent
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.chain.bitcoin.xpub import XpubManager
-from rotkehlchen.chain.constants import LAST_EVM_ACCOUNTS_DETECT_KEY
 from rotkehlchen.chain.ethereum.modules.eth2.constants import (
     LAST_PRODUCED_BLOCKS_QUERY_TS,
     LAST_WITHDRAWALS_EXIT_QUERY_TS,
@@ -20,11 +19,6 @@ from rotkehlchen.chain.ethereum.modules.makerdao.cache import (
 )
 from rotkehlchen.chain.ethereum.modules.yearn.utils import query_yearn_vaults
 from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
-from rotkehlchen.constants.misc import (
-    LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY,
-    LAST_OWNED_ASSETS_UPDATE,
-    LAST_SPAM_ASSETS_DETECT_KEY,
-)
 from rotkehlchen.constants.timing import (
     AUGMENTED_SPAM_ASSETS_DETECTION_REFRESH,
     DATA_UPDATES_REFRESH,
@@ -34,7 +28,7 @@ from rotkehlchen.constants.timing import (
     OWNED_ASSETS_UPDATE,
     SPAM_ASSETS_DETECTION_REFRESH,
 )
-from rotkehlchen.db.constants import LAST_DATA_UPDATES_KEY
+from rotkehlchen.db.cache import DBCache
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery, HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -667,7 +661,7 @@ class TaskManager:
         Function that schedules the data update task if either there is no data update
         cache yet or this cache is older than `DATA_UPDATES_REFRESH`
         """
-        if should_run_periodic_task(self.database, LAST_DATA_UPDATES_KEY, DATA_UPDATES_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCache.LAST_DATA_UPDATES_TS, DATA_UPDATES_REFRESH) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -682,7 +676,7 @@ class TaskManager:
         Function that schedules the EVM accounts detection task if there has been more than
         EVM_ACCOUNTS_DETECTION_REFRESH seconds since the last time it ran.
         """
-        if should_run_periodic_task(self.database, LAST_EVM_ACCOUNTS_DETECT_KEY, EVM_ACCOUNTS_DETECTION_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCache.LAST_EVM_ACCOUNTS_DETECT_TS, EVM_ACCOUNTS_DETECTION_REFRESH) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -711,7 +705,7 @@ class TaskManager:
         This function queries the globaldb looking for assets that look like spam tokens
         and ignores them in addition to marking them as spam tokens
         """
-        if should_run_periodic_task(self.database, LAST_SPAM_ASSETS_DETECT_KEY, SPAM_ASSETS_DETECTION_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCache.LAST_SPAM_ASSETS_DETECT_KEY, SPAM_ASSETS_DETECTION_REFRESH) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -728,7 +722,7 @@ class TaskManager:
         time consuming analysis on user's asset that involves external calls in order to find and
         detect potential spam tokens.
         """
-        if should_run_periodic_task(self.database, LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY, AUGMENTED_SPAM_ASSETS_DETECTION_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCache.LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY, AUGMENTED_SPAM_ASSETS_DETECTION_REFRESH) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -745,7 +739,7 @@ class TaskManager:
         This task is required to have a fresh status on the assets searches when the filter for
         owned assets is used.
         """
-        if should_run_periodic_task(self.database, LAST_OWNED_ASSETS_UPDATE, OWNED_ASSETS_UPDATE) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCache.LAST_OWNED_ASSETS_UPDATE, OWNED_ASSETS_UPDATE) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(

--- a/rotkehlchen/tasks/utils.py
+++ b/rotkehlchen/tasks/utils.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.constants.assets import A_USD
+from rotkehlchen.db.cache import DBCache
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.history.price import PriceHistorian
@@ -22,11 +23,11 @@ log = RotkehlchenLogsAdapter(logger)
 def should_run_periodic_task(
         database: 'DBHandler',
         key_name: Literal[
-            'last_data_updates_ts',
-            'last_evm_accounts_detect_ts',
-            'last_spam_assets_detect_key',
-            'last_augmented_spam_assets_detect_key',
-            'last_owned_assets_update',
+            DBCache.LAST_DATA_UPDATES_TS,
+            DBCache.LAST_EVM_ACCOUNTS_DETECT_TS,
+            DBCache.LAST_SPAM_ASSETS_DETECT_KEY,
+            DBCache.LAST_AUGMENTED_SPAM_ASSETS_DETECT_KEY,
+            DBCache.LAST_OWNED_ASSETS_UPDATE,
         ],
         refresh_period: int,
 ) -> bool:
@@ -35,7 +36,7 @@ def should_run_periodic_task(
     it again.
     """
     with database.conn.read_ctx() as cursor:
-        cursor.execute('SELECT value FROM settings WHERE name=?', (key_name,))
+        cursor.execute('SELECT value FROM key_value_cache WHERE name=?', (key_name.value,))
         timestamp_in_db = cursor.fetchone()
 
     if timestamp_in_db is None:

--- a/rotkehlchen/tests/api/test_periodic.py
+++ b/rotkehlchen/tests/api/test_periodic.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+from rotkehlchen.db.cache import DBCache
 
 from rotkehlchen.tests.utils.api import (
     api_url_for,
@@ -34,10 +35,10 @@ def test_query_periodic(rotkehlchen_api_server_with_exchanges):
     )
     result = assert_proper_response_with_result(response)
     assert len(result) == 3
-    assert result['last_balance_save'] >= start_ts
+    assert result[DBCache.LAST_BALANCE_SAVE.value] >= start_ts
     connected_nodes = result['connected_nodes']
     assert len(connected_nodes) == len(list(rotki.chains_aggregator.iterate_evm_chain_managers()))
     for evm_manager in rotki.chains_aggregator.iterate_evm_chain_managers():
         assert connected_nodes[evm_manager.node_inquirer.chain_name] == []
     # Non -1 value tests for these exist in test_history.py::test_query_history_timerange
-    assert result['last_data_upload_ts'] == 0
+    assert result[DBCache.LAST_DATA_UPLOAD_TS.value] == 0

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -13,6 +13,7 @@ from rotkehlchen.db.settings import (
     ROTKEHLCHEN_DB_VERSION,
     CachedSettings,
     DBSettings,
+    ModifiableDBSettings,
 )
 from rotkehlchen.tests.utils.api import (
     api_url_for,
@@ -124,15 +125,17 @@ def test_set_settings(rotkehlchen_api_server):
     response = requests.get(api_url_for(rotkehlchen_api_server, 'settingsresource'))
     assert_proper_response(response)
     json_data = response.json()
-    original_settings = json_data['result']
+    original_settings = {
+        name: value
+        for name, value in json_data['result'].items()
+        if name in ModifiableDBSettings._fields
+    }
     assert json_data['message'] == ''
     # Create new settings which modify all of the original ones
     new_settings = {}
     unmodifiable_settings = (
         'version',
         'last_write_ts',
-        'last_data_upload_ts',
-        'last_balance_save',
         'have_premium',
         'last_data_migration',
     )

--- a/rotkehlchen/tests/data/pnl_debug.json
+++ b/rotkehlchen/tests/data/pnl_debug.json
@@ -178,7 +178,6 @@
     "last_write_ts": 1656344880,
     "premium_should_sync": false,
     "include_crypto2crypto": true,
-    "last_data_upload_ts": 0,
     "ui_floating_precision": 2,
     "taxfree_after_period": 31536000,
     "balance_save_frequency": 24,
@@ -187,7 +186,6 @@
     "dot_rpc_endpoint": "",
     "main_currency": "USD",
     "date_display_format": "%d/%m/%Y %H:%M:%S %Z",
-    "last_balance_save": 0,
     "submit_usage_analytics": true,
     "active_modules": [
       "liquity",

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -124,7 +124,7 @@ def detect_accounts_migration_check(
     # set high version so that DB data updates don't get applied
     with rotki.data.db.conn.write_ctx() as write_cursor:
         write_cursor.executemany(
-            'INSERT OR REPLACE INTO settings(name, value) VALUES (?, ?)',
+            'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES (?, ?)',
             [
                 (UpdateType.SPAM_ASSETS.serialize(), 999),
                 (UpdateType.RPC_NODES.serialize(), 999),
@@ -266,8 +266,8 @@ def test_failed_migration(database):
         DataMigrationManager(rotki).maybe_migrate_data()
 
     with database.conn.read_ctx() as cursor:
-        settings = database.get_settings(cursor)
-    assert settings.last_data_migration == 0, 'no migration should have happened'
+        last_data_migration = database.get_setting(cursor=cursor, name='last_data_migration')
+    assert last_data_migration == 0, 'no migration should have happened'
     errors = rotki.msg_aggregator.consume_errors()
     warnings = rotki.msg_aggregator.consume_warnings()
     assert len(warnings) == 0

--- a/rotkehlchen/tests/unit/test_data_updates.py
+++ b/rotkehlchen/tests/unit/test_data_updates.py
@@ -302,7 +302,7 @@ def test_updates_run(data_updater: RotkiDataUpdater) -> None:
     assert all(patch.call_count == times for patch in patches)
     with data_updater.user_db.conn.read_ctx() as cursor:
         cursor.execute(  # make sure latest DB value is also changed
-            f'SELECT value from settings WHERE name IN({", ".join("?" * len(UpdateType))})',
+            f'SELECT value from key_value_cache WHERE name IN({", ".join("?" * len(UpdateType))})',
             [x.serialize() for x in UpdateType],
         )
         assert {x[0] for x in cursor} == {'2'}
@@ -313,7 +313,7 @@ def test_no_update_due_to_update_version(data_updater: RotkiDataUpdater) -> None
     # set a higher last version applied
     with data_updater.user_db.conn.write_ctx() as write_cursor:
         write_cursor.executemany(
-            'INSERT OR REPLACE INTO settings(name, value) VALUES (?, ?)',
+            'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES (?, ?)',
             [
                 (UpdateType.SPAM_ASSETS.serialize(), 999),
                 (UpdateType.RPC_NODES.serialize(), 999),
@@ -334,7 +334,7 @@ def test_no_update_due_to_update_version(data_updater: RotkiDataUpdater) -> None
     assert all(patch.call_count == 0 for patch in patches)
     with data_updater.user_db.conn.read_ctx() as cursor:
         cursor.execute(  # also make sure latest DB value is not changed
-            f'SELECT value from settings WHERE name IN({", ".join("?" * len(UpdateType))})',
+            f'SELECT value from key_value_cache WHERE name IN({", ".join("?" * len(UpdateType))})',
             [x.serialize() for x in UpdateType],
         )
         assert {x[0] for x in cursor} == {'999'}


### PR DESCRIPTION
## Checklist

- [x] Update `v40_v41` upgrade to move unrelated settings to the `key_value_cache` table
- [x] Update `/settings` API to keep returning old settings values from both tables now
- [x] Add `DBCache` class for serializing and deserializing
- [x] Clean some temporary settings' code for cache values
- [x] Update `settings` with `key_value_cache` in related parts of the codebase and tests