### PR TITLE
refactor: use deprecated dollar listeners to ease migration

### DIFF
--- a/frontend/app/src/components/CurrencyDropdown.vue
+++ b/frontend/app/src/components/CurrencyDropdown.vue
@@ -75,7 +75,7 @@ const calculateFontSize = (symbol: string) => {
           })
         "
         class-name="secondary--text text--lighten-4 currency-dropdown text-[1.375rem] font-bold"
-        :on-menu="on"
+        v-on="on"
       >
         {{ currency.unicodeSymbol }}
       </MenuTooltipButton>

--- a/frontend/app/src/components/GlobalSearch.vue
+++ b/frontend/app/src/components/GlobalSearch.vue
@@ -415,7 +415,7 @@ onBeforeMount(async () => {
             key
           }).toString()
         "
-        :on-menu="on"
+        v-on="on"
       >
         <RuiIcon name="search-line" />
       </MenuTooltipButton>

--- a/frontend/app/src/components/UserDropdown.vue
+++ b/frontend/app/src/components/UserDropdown.vue
@@ -47,7 +47,7 @@ const css = useCssModule();
         <MenuTooltipButton
           tooltip="Account"
           class-name="user-dropdown secondary--text text--lighten-4"
-          :on-menu="on"
+          v-on="on"
         >
           <RuiIcon name="account-circle-line" />
         </MenuTooltipButton>

--- a/frontend/app/src/components/accounts/AccountBalanceTable.vue
+++ b/frontend/app/src/components/accounts/AccountBalanceTable.vue
@@ -2,7 +2,7 @@
 import { type Balance } from '@rotki/common';
 import { Blockchain } from '@rotki/common/lib/blockchain';
 import { isEqual, some, sortBy } from 'lodash-es';
-import { type ComputedRef, type Ref, useListeners } from 'vue';
+import { type ComputedRef, type Ref } from 'vue';
 import { type DataTableHeader } from '@/types/vuetify';
 import { chainSection } from '@/types/blockchain';
 import { Section } from '@/types/status';
@@ -41,7 +41,6 @@ type IndexedBlockchainAccountWithBalance = BlockchainAccountWithBalance & {
 const { balances, blockchain, visibleTags, selected, loopring } = toRefs(props);
 
 const rootAttrs = useAttrs();
-const rootListeners = useListeners();
 
 const { isTaskRunning } = useTaskStore();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
@@ -431,7 +430,10 @@ defineExpose({
     data-cy="account-table"
     :data-location="blockchain"
     :group-by="isBtcNetwork ? ['xpub', 'derivationPath'] : undefined"
-    v-on="rootListeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
   >
     <template #header.accountSelection>
       <RuiCheckbox

--- a/frontend/app/src/components/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/components/dashboard/DashboardAssetTable.vue
@@ -190,7 +190,7 @@ const tableHeaders = computed<DataTableColumn[]>(() => {
           <MenuTooltipButton
             :tooltip="t('dashboard_asset_table.select_visible_columns')"
             class-name="dashboard-asset-table__column-filter__button"
-            :on-menu="on"
+            v-on="on"
           >
             <RuiIcon name="more-2-fill" />
           </MenuTooltipButton>

--- a/frontend/app/src/components/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/NftBalanceTable.vue
@@ -169,7 +169,7 @@ watch(loading, async (isLoading, wasLoading) => {
           <MenuTooltipButton
             :tooltip="t('dashboard_asset_table.select_visible_columns')"
             class-name="nft_balance_table__column-filter__button"
-            :on-menu="on"
+            v-on="on"
           >
             <RuiIcon name="more-2-fill" />
           </MenuTooltipButton>

--- a/frontend/app/src/components/dashboard/SnapshotActionButton.vue
+++ b/frontend/app/src/components/dashboard/SnapshotActionButton.vue
@@ -97,7 +97,7 @@ const importSnapshot = async () => {
         :tooltip="t('snapshot_action_button.menu_tooltip', premium ? 2 : 1)"
         :variant="!dark ? 'default' : 'text'"
         size="sm"
-        :on-menu="on"
+        v-on="on"
       >
         <slot name="button-icon">
           <RuiIcon name="screenshot-2-line" />

--- a/frontend/app/src/components/dashboard/liquity-provider/LiquidityProviderBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/liquity-provider/LiquidityProviderBalanceTable.vue
@@ -185,7 +185,7 @@ const getAssets = (assets: XswapAsset[]) => assets.map(({ asset }) => asset);
           <MenuTooltipButton
             :tooltip="t('dashboard_asset_table.select_visible_columns')"
             class-name="nft_balance_table__column-filter__button"
-            :on-menu="on"
+            v-on="on"
           >
             <RuiIcon name="more-2-fill" />
           </MenuTooltipButton>

--- a/frontend/app/src/components/helper/CopyTooltip.vue
+++ b/frontend/app/src/components/helper/CopyTooltip.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
-
 defineProps<{
   copied: boolean;
   tooltip?: string | null;
 }>();
 const { t } = useI18n();
-
-const listeners = useListeners();
 </script>
 
 <template>
@@ -15,7 +11,10 @@ const listeners = useListeners();
     :popper="{ placement: 'top' }"
     :open-delay="200"
     class="text-no-wrap cursor-pointer"
-    v-on="listeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
   >
     <template #activator>
       <slot />

--- a/frontend/app/src/components/helper/DataTable.vue
+++ b/frontend/app/src/components/helper/DataTable.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
 import { type DataTableHeader } from '@/types/vuetify';
 import { type TablePagination } from '@/types/pagination';
 
@@ -69,7 +68,6 @@ const props = withDefaults(
 const { t } = useI18n();
 
 const rootAttrs = useAttrs();
-const rootListeners = useListeners();
 const frontendSettingsStore = useFrontendSettingsStore();
 const { itemsPerPage: itemsPerPageFromFrontendSetting } = storeToRefs(
   frontendSettingsStore
@@ -205,7 +203,10 @@ const { dark } = useTheme();
       :loading-text="loadingText"
       :options="options"
       :custom-group="customGroup"
-      v-on="rootListeners"
+      v-on="
+        // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+        $listeners
+      "
       @update:items-per-page="onItemsPerPageChange($event)"
       @update:page="scrollToTop()"
     >

--- a/frontend/app/src/components/helper/LocationSelector.vue
+++ b/frontend/app/src/components/helper/LocationSelector.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
 import { type TradeLocationData } from '@/types/history/trade/location';
 
 const props = withDefaults(
@@ -17,7 +16,6 @@ const emit = defineEmits<{
 }>();
 
 const rootAttrs = useAttrs();
-const listeners = useListeners();
 
 const { items, excludes } = toRefs(props);
 
@@ -56,7 +54,10 @@ const locations = computed<TradeLocationData[]>(() => {
     item-text="name"
     auto-select-first
     @input="change($event)"
-    v-on="listeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
   >
     <template #item="{ item, attrs, on }">
       <LocationIcon

--- a/frontend/app/src/components/helper/MenuTooltipButton.vue
+++ b/frontend/app/src/components/helper/MenuTooltipButton.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { type ButtonProps } from '@rotki/ui-library-compat';
 
+defineOptions({
+  inheritAttrs: false
+});
+
 withDefaults(
   defineProps<{
     tooltip: string;
-    onMenu?: object;
     retainFocusOnClick?: boolean;
     className?: string;
     href?: string;
@@ -12,7 +15,6 @@ withDefaults(
     size?: ButtonProps['size'];
   }>(),
   {
-    onMenu: undefined,
     retainFocusOnClick: false,
     className: '',
     variant: 'text',
@@ -20,12 +22,6 @@ withDefaults(
     href: undefined
   }
 );
-
-const emit = defineEmits<{
-  (e: 'click'): void;
-}>();
-
-const click = () => emit('click');
 </script>
 
 <template>
@@ -44,12 +40,15 @@ const click = () => emit('click');
         :class="[className, !size && '!w-12 !h-12']"
         :size="size"
         :retain-focus-on-click="retainFocusOnClick"
-        @click="click()"
-        v-on="onMenu"
+        v-bind="$attrs"
+        v-on="
+          // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+          $listeners
+        "
       >
         <slot />
       </RuiButton>
     </template>
-    <span>{{ tooltip }}</span>
+    {{ tooltip }}
   </RuiTooltip>
 </template>

--- a/frontend/app/src/components/helper/TableStatusFilter.vue
+++ b/frontend/app/src/components/helper/TableStatusFilter.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
-
-const listeners = useListeners();
+defineOptions({
+  inheritAttrs: false
+});
 </script>
 
 <template>
-  <VMenu offset-y :close-on-content-click="false" v-on="listeners">
+  <VMenu
+    offset-y
+    :close-on-content-click="false"
+    v-bind="$attrs"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
+  >
     <template #activator="{ on }">
       <RuiButton
         class="py-2.5 px-3 !outline-rui-grey-500 dark:!outline-rui-grey-700 !text-rui-text-secondary"

--- a/frontend/app/src/components/inputs/AmountInput.vue
+++ b/frontend/app/src/components/inputs/AmountInput.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
 import IMask, { type InputMask } from 'imask';
 
 const props = withDefaults(
@@ -19,7 +18,6 @@ const emit = defineEmits<{
 
 const attrs = useAttrs();
 const slots = useSlots();
-const listeners = useListeners();
 
 const filteredListeners = (listeners: any) => ({
   ...listeners,
@@ -105,7 +103,10 @@ const onFocus = () => {
     ref="textInput"
     :value="currentValue"
     v-bind="attrs"
-    v-on="filteredListeners(listeners)"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      filteredListeners($listeners)
+    "
     @focus="onFocus()"
   >
     <!-- Pass on all named slots -->

--- a/frontend/app/src/components/inputs/AssetSelect.vue
+++ b/frontend/app/src/components/inputs/AssetSelect.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { type Ref, useListeners } from 'vue';
+import { type Ref } from 'vue';
 import { type AssetInfoWithId } from '@/types/asset';
 import { transformCase } from '@/utils/text';
 import { type NftAsset } from '@/types/nfts';
@@ -167,8 +167,6 @@ onMounted(async () => {
 watch(value, async () => {
   await checkValue();
 });
-
-const listeners = useListeners();
 </script>
 
 <template>
@@ -196,7 +194,10 @@ const listeners = useListeners();
     :outlined="outlined"
     no-filter
     :class="outlined ? 'asset-select--outlined' : null"
-    v-on="listeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
     @input="input($event)"
     @blur="blur()"
   >

--- a/frontend/app/src/components/inputs/ComboboxWithCustomInput.vue
+++ b/frontend/app/src/components/inputs/ComboboxWithCustomInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type ComputedRef, type Ref, useListeners } from 'vue';
+import { type ComputedRef, type Ref } from 'vue';
 
 const props = withDefaults(
   defineProps<{
@@ -40,7 +40,6 @@ const filteredItems: ComputedRef<any[]> = computed(() => {
 });
 
 const rootAttrs = useAttrs();
-const rootListeners = useListeners();
 const slots = useSlots();
 </script>
 
@@ -50,7 +49,10 @@ const slots = useSlots();
     v-bind="rootAttrs"
     :search-input.sync="search"
     :items="filteredItems"
-    v-on="rootListeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
     @input="input($event)"
   >
     <!-- Pass on all named slots -->

--- a/frontend/app/src/components/inputs/DateTimePicker.vue
+++ b/frontend/app/src/components/inputs/DateTimePicker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import dayjs from 'dayjs';
-import { type ComputedRef, type Ref, useListeners } from 'vue';
+import { type ComputedRef, type Ref } from 'vue';
 import IMask, {
   type AnyMaskedOptions,
   type InputMask,
@@ -335,8 +335,6 @@ const focus = () => {
   });
 };
 
-const listeners = useListeners();
-
 const filteredListeners = (listeners: any) => ({
   ...listeners,
   input: () => {}
@@ -356,7 +354,10 @@ const filteredListeners = (listeners: any) => ({
     :outlined="outlined"
     :error-messages="toMessages(v$.date)"
     @focus="focus()"
-    v-on="filteredListeners(listeners)"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      filteredListeners($listeners)
+    "
   >
     <template #append>
       <VMenu

--- a/frontend/app/src/components/settings/StatisticsGraphSettings.vue
+++ b/frontend/app/src/components/settings/StatisticsGraphSettings.vue
@@ -22,7 +22,7 @@ const showMenu: Ref<boolean> = ref(false);
       <MenuTooltipButton
         :tooltip="t('statistics_graph_settings.tooltip')"
         class-name="graph-period"
-        :on-menu="on"
+        v-on="on"
       >
         <RuiIcon name="settings-4-line" />
       </MenuTooltipButton>

--- a/frontend/app/src/components/settings/accounting/CostBasisMethodSettings.vue
+++ b/frontend/app/src/components/settings/accounting/CostBasisMethodSettings.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
-
 const rootAttrs = useAttrs();
-const rootListeners = useListeners();
 const { costBasisMethodData } = useCostBasisMethod();
 </script>
 
@@ -14,7 +11,10 @@ const { costBasisMethodData } = useCostBasisMethod();
     item-value="identifier"
     item-text="identifier"
     :items="costBasisMethodData"
-    v-on="rootListeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
   >
     <template #item="{ item, attrs, on }">
       <ListItem

--- a/frontend/app/src/components/settings/explorers/ExplorerInput.vue
+++ b/frontend/app/src/components/settings/explorers/ExplorerInput.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
-
 const props = defineProps<{
   value: string;
 }>();
@@ -22,7 +20,6 @@ const model = computed({
 });
 
 const attrs = useAttrs();
-const listeners = useListeners();
 
 const isValid = (entry: string | null): boolean =>
   !entry ? false : entry.length > 0;
@@ -41,7 +38,10 @@ const saveData = (value?: string) => {
       color="primary"
       clearable
       v-bind="attrs"
-      v-on="listeners"
+      v-on="
+        // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+        $listeners
+      "
       @click:clear="saveData()"
     />
     <RuiButton

--- a/frontend/app/src/components/settings/general/DateInputFormatSelector.vue
+++ b/frontend/app/src/components/settings/general/DateInputFormatSelector.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { useListeners } from 'vue';
 import { displayDateFormatter } from '@/data/date_formatter';
 import { DateFormat } from '@/types/date-format';
 
 const rootAttrs = useAttrs();
-const rootListeners = useListeners();
 
 const selections = [
   {
@@ -32,7 +30,10 @@ const { t } = useI18n();
     outlined
     persistent-hint
     :items="selections"
-    v-on="rootListeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
   >
     <template #item="{ item, attrs, on }">
       <ListItem

--- a/frontend/app/src/components/settings/general/amount/RoundingSelector.vue
+++ b/frontend/app/src/components/settings/general/amount/RoundingSelector.vue
@@ -1,9 +1,7 @@
 ﻿<script setup lang="ts">
 import { BigNumber } from '@rotki/common';
-import { useListeners } from 'vue';
 
 const rootAttrs = useAttrs();
-const rootListeners = useListeners();
 const { t } = useI18n();
 
 const selections = [
@@ -33,7 +31,10 @@ const selections = [
     outlined
     persistent-hint
     :items="selections"
-    v-on="rootListeners"
+    v-on="
+      // eslint-disable-next-line vue/no-deprecated-dollar-listeners-api
+      $listeners
+    "
   >
     <template #item="{ item, attrs, on }">
       <ListItem

--- a/frontend/app/src/components/status/sync/SyncIndicator.vue
+++ b/frontend/app/src/components/status/sync/SyncIndicator.vue
@@ -86,7 +86,7 @@ watch(isSyncing, (current, prev) => {
           <MenuTooltipButton
             :tooltip="t('sync_indicator.menu_tooltip')"
             class-name="secondary--text text--lighten-4"
-            :on-menu="on"
+            v-on="on"
           >
             <RuiIcon v-if="isSyncing" :name="icon" color="primary" />
             <RuiIcon v-else name="cloud-line" />


### PR DESCRIPTION
It's easier to search and replace v-on globally.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
