### PR TITLE
Make oracle penalty settings  user-modifiable at the backend

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -611,6 +611,8 @@ Getting or modifying settings
               "ssf_graph_multiplier": 2,
               "non_sync_exchanges": [{"location": "binance", "name": "binance1"}],
               "cost_basis_method": "fifo",
+              "oracle_penalty_threshold_count": 5,
+              "oracle_penalty_duration": 1800,
               "address_name_priority": ["private_addressbook", "blockchain_account",
                                         "global_addressbook", "ethereum_tokens",
                                         "hardcoded_mappings", "ens_names"],
@@ -645,6 +647,8 @@ Getting or modifying settings
    :resjson int query_retry_limit: The number of times to retry a query to external services before giving up. Default is 5.
    :resjson int connect_timeout: The number of seconds to wait before giving up on establishing a connection to an external service. Default is 30.
    :resjson int read_timeout: The number of seconds to wait for the first byte after a connection to an external service has been established. Default is 30.
+   :resjson int oracle_penalty_threshold_count: The number of failures after which an oracle is penalized. Default is 5.
+   :resjson int oracle_penalty_duration: The duration in seconds for which an oracle is penalized. Default is 1800.
 
    :statuscode 200: Querying of settings was successful
    :statuscode 409: There is no logged in user
@@ -689,6 +693,8 @@ Getting or modifying settings
    :resjson int query_retry_limit: The number of times to retry a query to external services before giving up. Default is 5.
    :resjson int connect_timeout: The number of seconds to wait before giving up on establishing a connection to an external service. Default is 30.
    :resjson int read_timeout: The number of seconds to wait for the first byte after a connection to an external service has been established. Default is 30.
+   :resjson int oracle_penalty_threshold_count: The number of failures after which an oracle is penalized. Default is 5.
+   :resjson int oracle_penalty_duration: The duration in seconds for which an oracle is penalized. Default is 1800.
 
    **Example Response**:
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1261,6 +1261,20 @@ class ModifiableSettingsSchema(Schema):
         ),
         load_default=None,
     )
+    oracle_penalty_threshold_count = fields.Integer(
+        load_default=None,
+        validate=webargs.validate.Range(
+            min=1,
+            error='The count should be >= 1',
+        ),
+    )
+    oracle_penalty_duration = fields.Integer(
+        load_default=None,
+        validate=webargs.validate.Range(
+            min=1,
+            error='The penalty should be >= 1 seconds',
+        ),
+    )
 
     @validates_schema
     def validate_settings_schema(
@@ -1316,6 +1330,8 @@ class ModifiableSettingsSchema(Schema):
             query_retry_limit=data['query_retry_limit'],
             connect_timeout=data['connect_timeout'],
             read_timeout=data['read_timeout'],
+            oracle_penalty_threshold_count=data['oracle_penalty_threshold_count'],
+            oracle_penalty_duration=data['oracle_penalty_duration'],
         )
 
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -309,9 +309,6 @@ class Rotkehlchen:
         self.cryptocompare.set_database(self.data.db)
         Inquirer()._manualcurrent.set_database(database=self.data.db)
 
-        # Initialize the cached settings singleton
-        CachedSettings()
-
         # Anything that was set above here has to be cleaned in case of failure in the next step
         # by reset_after_failed_account_creation_or_login()
         try:
@@ -336,6 +333,7 @@ class Rotkehlchen:
 
         with self.data.db.conn.read_ctx() as cursor:
             settings = self.get_settings(cursor)
+            CachedSettings().initialize(settings)  # initialize with saved DB settings
             self.greenlet_manager.spawn_and_track(
                 after_seconds=None,
                 task_name='submit_usage_analytics',

--- a/rotkehlchen/tests/data/pnl_debug.json
+++ b/rotkehlchen/tests/data/pnl_debug.json
@@ -236,7 +236,9 @@
     "infer_zero_timed_balances": false,
     "query_retry_limit": 5,
     "connect_timeout": 30,
-    "read_timeout": 30
+    "read_timeout": 30,
+    "oracle_penalty_threshold_count": 5,
+    "oracle_penalty_duration": 1800
   },
   "ignored_events_ids": {
     "history_event": ["100x0xca0a482213c17ccb0471b02ffab40b92279ae7f25da53e426fda5e73e915509f"],

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -50,6 +50,8 @@ from rotkehlchen.db.settings import (
     DEFAULT_INFER_ZERO_TIMED_BALANCES,
     DEFAULT_LAST_DATA_MIGRATION,
     DEFAULT_MAIN_CURRENCY,
+    DEFAULT_ORACLE_PENALTY_DURATION,
+    DEFAULT_ORACLE_PENALTY_THRESHOLD_COUNT,
     DEFAULT_PNL_CSV_HAVE_SUMMARY,
     DEFAULT_PNL_CSV_WITH_FORMULAS,
     DEFAULT_QUERY_RETRY_LIMIT,
@@ -481,6 +483,8 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         'query_retry_limit': DEFAULT_QUERY_RETRY_LIMIT,
         'connect_timeout': DEFAULT_CONNECT_TIMEOUT,
         'read_timeout': DEFAULT_READ_TIMEOUT,
+        'oracle_penalty_threshold_count': DEFAULT_ORACLE_PENALTY_THRESHOLD_COUNT,
+        'oracle_penalty_duration': DEFAULT_ORACLE_PENALTY_DURATION,
     }
     assert len(expected_dict) == len(dataclasses.fields(DBSettings)), 'One or more settings are missing'  # noqa: E501
 
@@ -529,6 +533,10 @@ def test_settings_entry_types(database):
     assert res.active_modules == DEFAULT_ACTIVE_MODULES
     assert isinstance(res.frontend_settings, str)
     assert res.frontend_settings == ''
+    assert isinstance(res.oracle_penalty_threshold_count, int)
+    assert res.oracle_penalty_threshold_count == DEFAULT_ORACLE_PENALTY_THRESHOLD_COUNT
+    assert isinstance(res.oracle_penalty_duration, int)
+    assert res.oracle_penalty_duration == DEFAULT_ORACLE_PENALTY_DURATION
 
 
 def test_key_value_cache_entry_types(database):

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -42,6 +42,11 @@ from rotkehlchen.tests.utils.substrate import wait_until_all_substrate_nodes_con
 from rotkehlchen.types import AVAILABLE_MODULES_MAP, Location, SupportedBlockchain, Timestamp
 
 
+@pytest.fixture(name='should_mock_settings')
+def fixture_should_mock_settings():
+    return True
+
+
 @pytest.fixture(name='start_with_logged_in_user')
 def fixture_start_with_logged_in_user():
     return True
@@ -261,6 +266,7 @@ def initialize_mock_rotkehlchen_instance(
         add_accounts_to_db,
         latest_accounting_rules,
         initialize_accounting_rules,
+        should_mock_settings=True,
 ) -> None:
     if not start_with_logged_in_user:
         return
@@ -317,6 +323,7 @@ def initialize_mock_rotkehlchen_instance(
             use_custom_database=use_custom_database,
             new_db_unlock_actions=new_db_unlock_actions,
             perform_upgrades_at_unlock=perform_upgrades_at_unlock,
+            should_mock_settings=should_mock_settings,
         )
         rotki.unlock_user(
             user=username,
@@ -475,6 +482,7 @@ def fixture_rotkehlchen_api_server(
         add_accounts_to_db,
         latest_accounting_rules,
         initialize_accounting_rules,
+        should_mock_settings,
 ):
     """A partially mocked rotkehlchen server instance"""
 
@@ -482,7 +490,6 @@ def fixture_rotkehlchen_api_server(
         rotki=uninitialized_rotkehlchen,
         rest_port_number=rest_api_port,
     )
-
     initialize_mock_rotkehlchen_instance(
         rotki=api_server.rest_api.rotkehlchen,
         start_with_logged_in_user=start_with_logged_in_user,
@@ -520,6 +527,7 @@ def fixture_rotkehlchen_api_server(
         add_accounts_to_db=add_accounts_to_db,
         latest_accounting_rules=latest_accounting_rules,
         initialize_accounting_rules=initialize_accounting_rules,
+        should_mock_settings=should_mock_settings,
     )
     with ExitStack() as stack:
         if start_with_logged_in_user is True:

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -28,6 +28,7 @@ from rotkehlchen.constants.assets import (
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.constants.resolver import ethaddress_to_identifier, evm_address_to_identifier
 from rotkehlchen.db.custom_assets import DBCustomAssets
+from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import (
@@ -56,7 +57,6 @@ from rotkehlchen.types import (
     Timestamp,
 )
 from rotkehlchen.utils.misc import ts_now
-from rotkehlchen.utils.mixins.penalizable_oracle import ORACLE_PENALTY_TS
 
 UNDERLYING_ASSET_PRICES = {
     A_AAVE: FVal('100'),
@@ -559,15 +559,16 @@ def test_punishing_of_oracles_works(inquirer):
                 assert defillama_mock.called is True
 
         # move the current time forward and check that coingecko is still penalized
+        penalty_duration = CachedSettings().oracle_penalty_duration
         with freeze_time(datetime.datetime.fromtimestamp(
-                ts_now() + ORACLE_PENALTY_TS / 2,
+                ts_now() + penalty_duration / 2,
                 tz=datetime.UTC,
         )):
             assert inquirer._coingecko.is_penalized() is True
 
         # move the current time forward and check that coingecko is no longer penalized
         with freeze_time(datetime.datetime.fromtimestamp(
-                ts_now() + ORACLE_PENALTY_TS + 1,
+                ts_now() + penalty_duration + 1,
                 tz=datetime.UTC,
         )):
             assert inquirer._coingecko.is_penalized() is False


### PR DESCRIPTION
Approach:
- Added settings `oracle_penalty_threshold_count` and `oracle_penalty_duration` to replace the constants that were being used by the `PenalizablePriceOracleMixin`.
- Made the settings updateable via the REST API.
- Made the settings accessible from `CachedSettings`.

I noticed that the previously `CachedSettings` was getting initialized by default settings, and updated with any settings updated in the logged in session. However this means that the next time the user logs in, cached settings would have default values but not any saved custom settings.

Changed this so that `CachedSettings` is updated with saved settings when the user is unlocked, so that previously customized settings are also cached.



Closes #5143 

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
