### PR TITLE
refactor: extracts balance sorting composables

### DIFF
--- a/frontend/app/.eslintrc-auto-import.json
+++ b/frontend/app/.eslintrc-auto-import.json
@@ -257,8 +257,6 @@
     "toRefs": true,
     "toSentenceCase": true,
     "toSnakeCase": true,
-    "toSortedAssetBalanceArray": true,
-    "toSortedAssetBalanceWithPrice": true,
     "toUnit": true,
     "totalCollateral": true,
     "transformEntryWithMeta": true,
@@ -732,6 +730,7 @@
     "isOfEventType": true,
     "isTaskCancelled": true,
     "useAssetWhitelistApi": true,
-    "useWhitelistedAssetsStore": true
+    "useWhitelistedAssetsStore": true,
+    "useBalanceSorting": true
   }
 }

--- a/frontend/app/src/auto-imports.d.ts
+++ b/frontend/app/src/auto-imports.d.ts
@@ -364,6 +364,7 @@ declare global {
   const useBackendMessagesStore: typeof import('./store/backend-messages')['useBackendMessagesStore']
   const useBackupApi: typeof import('./composables/api/backup')['useBackupApi']
   const useBalancePricesStore: typeof import('./store/balances/prices')['useBalancePricesStore']
+  const useBalanceSorting: typeof import('./composables/balances/sorting')['useBalanceSorting']
   const useBalancerApi: typeof import('./composables/api/defi/balancer')['useBalancerApi']
   const useBalancerStore: typeof import('./store/defi/balancer/index')['useBalancerStore']
   const useBalances: typeof import('./composables/balances/index')['useBalances']
@@ -1005,8 +1006,6 @@ declare module 'vue' {
     readonly toRem: UnwrapRef<typeof import('./utils/data')['toRem']>
     readonly toSentenceCase: UnwrapRef<typeof import('./utils/text')['toSentenceCase']>
     readonly toSnakeCase: UnwrapRef<typeof import('./utils/text')['toSnakeCase']>
-    readonly toSortedAssetBalanceArray: UnwrapRef<typeof import('./utils/balances')['toSortedAssetBalanceArray']>
-    readonly toSortedAssetBalanceWithPrice: UnwrapRef<typeof import('./utils/balances')['toSortedAssetBalanceWithPrice']>
     readonly toUnit: UnwrapRef<typeof import('./utils/calculation')['toUnit']>
     readonly toValue: UnwrapRef<typeof import('vue')['toValue']>
     readonly totalCollateral: UnwrapRef<typeof import('./utils/total-collateral')['totalCollateral']>
@@ -1094,6 +1093,7 @@ declare module 'vue' {
     readonly useBackendMessagesStore: UnwrapRef<typeof import('./store/backend-messages')['useBackendMessagesStore']>
     readonly useBackupApi: UnwrapRef<typeof import('./composables/api/backup')['useBackupApi']>
     readonly useBalancePricesStore: UnwrapRef<typeof import('./store/balances/prices')['useBalancePricesStore']>
+    readonly useBalanceSorting: UnwrapRef<typeof import('./composables/balances/sorting')['useBalanceSorting']>
     readonly useBalancerApi: UnwrapRef<typeof import('./composables/api/defi/balancer')['useBalancerApi']>
     readonly useBalancerStore: UnwrapRef<typeof import('./store/defi/balancer/index')['useBalancerStore']>
     readonly useBalances: UnwrapRef<typeof import('./composables/balances/index')['useBalances']>
@@ -1728,8 +1728,6 @@ declare module '@vue/runtime-core' {
     readonly toRem: UnwrapRef<typeof import('./utils/data')['toRem']>
     readonly toSentenceCase: UnwrapRef<typeof import('./utils/text')['toSentenceCase']>
     readonly toSnakeCase: UnwrapRef<typeof import('./utils/text')['toSnakeCase']>
-    readonly toSortedAssetBalanceArray: UnwrapRef<typeof import('./utils/balances')['toSortedAssetBalanceArray']>
-    readonly toSortedAssetBalanceWithPrice: UnwrapRef<typeof import('./utils/balances')['toSortedAssetBalanceWithPrice']>
     readonly toUnit: UnwrapRef<typeof import('./utils/calculation')['toUnit']>
     readonly toValue: UnwrapRef<typeof import('vue')['toValue']>
     readonly totalCollateral: UnwrapRef<typeof import('./utils/total-collateral')['totalCollateral']>
@@ -1817,6 +1815,7 @@ declare module '@vue/runtime-core' {
     readonly useBackendMessagesStore: UnwrapRef<typeof import('./store/backend-messages')['useBackendMessagesStore']>
     readonly useBackupApi: UnwrapRef<typeof import('./composables/api/backup')['useBackupApi']>
     readonly useBalancePricesStore: UnwrapRef<typeof import('./store/balances/prices')['useBalancePricesStore']>
+    readonly useBalanceSorting: UnwrapRef<typeof import('./composables/balances/sorting')['useBalanceSorting']>
     readonly useBalancerApi: UnwrapRef<typeof import('./composables/api/defi/balancer')['useBalancerApi']>
     readonly useBalancerStore: UnwrapRef<typeof import('./store/defi/balancer/index')['useBalancerStore']>
     readonly useBalances: UnwrapRef<typeof import('./composables/balances/index')['useBalances']>

--- a/frontend/app/src/composables/balances/account-details.ts
+++ b/frontend/app/src/composables/balances/account-details.ts
@@ -13,6 +13,7 @@ export const useAccountDetails = (
   const { balances: ethBalances, loopring } = storeToRefs(ethBalancesStore);
   const { balances: chainBalances } = storeToRefs(useChainBalancesStore());
   const { isAssetIgnored } = useIgnoredAssetsStore();
+  const { toSortedAssetBalanceArray } = useBalanceSorting();
 
   const balances: ComputedRef<BlockchainAssetBalances> = computed(() => {
     const chain = get(blockchain);

--- a/frontend/app/src/composables/balances/aggregated.ts
+++ b/frontend/app/src/composables/balances/aggregated.ts
@@ -15,6 +15,8 @@ export const useAggregatedBalances = () => {
     useManualAssetBalances();
 
   const { getAssociatedAssetIdentifier } = useAssetInfoRetrieval();
+  const { toSortedAssetBalanceWithPrice } = useBalanceSorting();
+  const { lpAggregatedBalances } = useLiquidityPosition();
 
   const balances = (
     hideIgnored = true,
@@ -70,7 +72,6 @@ export const useAggregatedBalances = () => {
         return asset;
       });
 
-      const { lpAggregatedBalances } = useLiquidityPosition();
       const lpBalances = get(lpAggregatedBalances(false));
       const lpAssets = lpBalances
         .map(item => item.asset)

--- a/frontend/app/src/composables/balances/breakdown.ts
+++ b/frontend/app/src/composables/balances/breakdown.ts
@@ -20,6 +20,7 @@ export const useBalancesBreakdown = () => {
     useBlockchainAggregatedBalances();
   const { toSelectedCurrency, assetPrice } = useBalancePricesStore();
   const { isAssetIgnored } = useIgnoredAssetsStore();
+  const { toSortedAssetBalanceWithPrice } = useBalanceSorting();
 
   const assetBreakdown = (asset: string): ComputedRef<AssetBreakdown[]> =>
     computed(() =>

--- a/frontend/app/src/composables/balances/sorting.ts
+++ b/frontend/app/src/composables/balances/sorting.ts
@@ -1,0 +1,98 @@
+import { groupBy } from 'lodash-es';
+import type {
+  AssetBalance,
+  AssetBalanceWithPrice,
+  Balance,
+  BigNumber
+} from '@rotki/common';
+import type { AssetBalances } from '@/types/balances';
+
+export const useBalanceSorting = () => {
+  const { assetInfo } = useAssetInfoRetrieval();
+  const { fetchedAssetCollections } = storeToRefs(useAssetCacheStore());
+
+  const toSortedAndGroupedArray = <T extends Balance>(
+    ownedAssets: AssetBalances,
+    isIgnored: (asset: string) => boolean,
+    groupMultiChain: boolean,
+    map: (asset: string) => T & { asset: string }
+  ): T[] => {
+    const data = Object.keys(ownedAssets)
+      .filter(asset => !isIgnored(asset))
+      .map(map);
+
+    if (!groupMultiChain) {
+      return data.sort((a, b) => sortDesc(a.usdValue, b.usdValue));
+    }
+
+    const groupedBalances = groupBy(data, balance => {
+      const info = get(assetInfo(balance.asset));
+
+      if (info?.collectionId) {
+        return `collection-${info.collectionId}`;
+      }
+
+      return balance.asset;
+    });
+
+    const mapped: T[] = [];
+
+    Object.keys(groupedBalances).forEach(key => {
+      const grouped = groupedBalances[key];
+      const isAssetCollection = key.startsWith('collection-');
+      const collectionKey = key.split('collection-')[1];
+      const assetCollectionInfo = !isAssetCollection
+        ? false
+        : get(fetchedAssetCollections)?.[collectionKey];
+
+      if (assetCollectionInfo && grouped.length > 1) {
+        const sumBalance = grouped.reduce(
+          (accumulator, currentBalance) =>
+            balanceSum(accumulator, currentBalance),
+          zeroBalance()
+        );
+
+        const parent: T = {
+          ...grouped[0],
+          ...sumBalance,
+          breakdown: grouped
+        };
+
+        mapped.push(parent);
+      } else {
+        mapped.push(...grouped);
+      }
+    });
+
+    return mapped.sort((a, b) => sortDesc(a.usdValue, b.usdValue));
+  };
+
+  const toSortedAssetBalanceWithPrice = (
+    ownedAssets: AssetBalances,
+    isIgnored: (asset: string) => boolean,
+    getPrice: (asset: string) => ComputedRef<BigNumber | null | undefined>,
+    groupMultiChain = true
+  ): AssetBalanceWithPrice[] =>
+    toSortedAndGroupedArray(ownedAssets, isIgnored, groupMultiChain, asset => ({
+      asset,
+      amount: ownedAssets[asset].amount,
+      usdValue: ownedAssets[asset].usdValue,
+      usdPrice: get(getPrice(asset)) ?? NoPrice
+    }));
+
+  const toSortedAssetBalanceArray = (
+    ownedAssets: AssetBalances,
+    isIgnored: (asset: string) => boolean,
+    groupMultiChain = false
+  ): AssetBalance[] =>
+    toSortedAndGroupedArray(ownedAssets, isIgnored, groupMultiChain, asset => ({
+      asset,
+      amount: ownedAssets[asset].amount,
+      usdValue: ownedAssets[asset].usdValue
+    }));
+
+  return {
+    toSortedAssetBalanceArray,
+    toSortedAssetBalanceWithPrice
+  };
+};

--- a/frontend/app/src/composables/blockchain/balances/aggregated.ts
+++ b/frontend/app/src/composables/blockchain/balances/aggregated.ts
@@ -19,6 +19,8 @@ export const useBlockchainAggregatedBalances = () => {
     useChainBalancesStore()
   );
   const { assetPrice } = useBalancePricesStore();
+  const { toSortedAssetBalanceWithPrice, toSortedAssetBalanceArray } =
+    useBalanceSorting();
 
   const totals: ComputedRef<AssetBalances> = computed(() => {
     const balances: AssetBalances = {};

--- a/frontend/app/src/store/balances/exchanges.ts
+++ b/frontend/app/src/store/balances/exchanges.ts
@@ -35,6 +35,7 @@ export const useExchangeBalancesStore = defineStore(
       getExchangeSavings,
       getExchangeSavingsTask
     } = useExchangeApi();
+    const { toSortedAssetBalanceWithPrice } = useBalanceSorting();
 
     const exchanges: ComputedRef<ExchangeInfo[]> = computed(() => {
       const balances = get(exchangeBalances);


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

- Moved a composable initialization out of the middle of a computed property
- Moved balance sorting from utils to a composable since this created issues in vue 3