### PR TITLE
Allow to set an asset as spam when ignoring it

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10011,9 +10011,14 @@ Dealing with ignored assets
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"assets": ["eip155:1/erc20:0x6810e776880C02933D47DB1b9fc05908e5386b96"]}
+      {"assets": [{
+         "asset": "eip155:1/erc20:0x6810e776880C02933D47DB1b9fc05908e5386b96",
+         "is_spam": true
+      }]}
 
-   :reqjson list assets: A list of asset symbols to add to the ignored assets.
+   :reqjson list assets: A list of assets to be ignored
+   :reqjson string asset: The id of the asset to be ignored
+   :reqjson bool is_spam: True if the asset should also be marked as spam in addition to putting to the ignore list.
 
    **Example Response**:
 
@@ -10035,7 +10040,7 @@ Dealing with ignored assets
 
 .. http:delete:: /api/(version)/assets/ignored/
 
-   Doing a DELETE on the ignored assets endpoint will remove the given assets from the ignored assets list. Returns the new list without the removed assets in the response.
+   Doing a DELETE on the ignored assets endpoint will remove the given assets from the ignored assets list. It will also remove the assets from the spam list. Returns the new list without the removed assets in the response.
 
 
    **Example Request**:

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -28,6 +28,7 @@ from rotkehlchen.api.v1.schemas import (
     AccountingReportsSchema,
     AccountingRuleConflictsPagination,
     AccountingRulesQuerySchema,
+    AddIgnoredAssetsSchema,
     AddressbookAddressesSchema,
     AddressbookUpdateSchema,
     AllBalancesQuerySchema,
@@ -65,6 +66,7 @@ from rotkehlchen.api.v1.schemas import (
     CurrentAssetsPriceSchema,
     CustomAssetsQuerySchema,
     DataImportSchema,
+    DeleteIgnoredAssetsSchema,
     DetectTokensSchema,
     EditAccountingRuleSchema,
     EditHistoryEventSchema,
@@ -104,7 +106,6 @@ from rotkehlchen.api.v1.schemas import (
     HistoryProcessingExportSchema,
     HistoryProcessingSchema,
     IgnoredActionsModifySchema,
-    IgnoredAssetsSchema,
     IntegerIdentifierSchema,
     ManuallyTrackedBalancesAddSchema,
     ManuallyTrackedBalancesDeleteSchema,
@@ -1714,19 +1715,20 @@ class BTCXpubResource(BaseMethodView):
 
 class IgnoredAssetsResource(BaseMethodView):
 
-    modify_schema = IgnoredAssetsSchema()
+    put_schema = AddIgnoredAssetsSchema()
+    post_schema = DeleteIgnoredAssetsSchema()
 
     @require_loggedin_user()
     def get(self) -> Response:
         return self.rest_api.get_ignored_assets()
 
     @require_loggedin_user()
-    @use_kwargs(modify_schema, location='json')
-    def put(self, assets: list[Asset]) -> Response:
-        return self.rest_api.add_ignored_assets(assets=assets)
+    @use_kwargs(put_schema, location='json')
+    def put(self, assets: list[tuple[Asset, bool]]) -> Response:
+        return self.rest_api.add_ignored_assets(assets_to_ignore=assets)
 
     @require_loggedin_user()
-    @use_kwargs(modify_schema, location='json')
+    @use_kwargs(post_schema, location='json')
     def delete(self, assets: list[Asset]) -> Response:
         return self.rest_api.remove_ignored_assets(assets=assets)
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1968,7 +1968,24 @@ class BlockchainAccountsDeleteSchema(AsyncQueryArgumentSchema):
         return data
 
 
-class IgnoredAssetsSchema(Schema):
+class IgnoreSingleAsset(Schema):
+    asset = AssetField(expected_type=Asset)
+    is_spam = fields.Boolean(load_default=False)
+
+
+class AddIgnoredAssetsSchema(Schema):
+    assets = fields.List(fields.Nested(IgnoreSingleAsset), required=True)
+
+    @post_load
+    def make_list_of_tuples(
+            self,
+            data: dict[str, Any],
+            **_kwargs: Any,
+    ) -> dict[str, Any]:
+        return {'assets': [tuple(entry.values()) for entry in data['assets']]}
+
+
+class DeleteIgnoredAssetsSchema(Schema):
     assets = fields.List(AssetField(expected_type=Asset), required=True)
 
 

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -278,7 +278,12 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
             rotkehlchen_api_server,
             'ignoredassetsresource',
         ),
-        json={'assets': [NFT_ID_FOR_TEST_ACC4, NFT_ID_FOR_TEST_ACC6_2]},
+        json={
+            'assets': [
+                {'asset': NFT_ID_FOR_TEST_ACC4},
+                {'asset': NFT_ID_FOR_TEST_ACC6_2},
+            ],
+        },
     )
 
     # Make sure that ignoring cache doesn't remove any NFTs from the app
@@ -495,7 +500,7 @@ def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
             rotkehlchen_api_server,
             'ignoredassetsresource',
         ),
-        json={'assets': [NFT_ID_FOR_TEST_ACC4]},
+        json={'assets': [{'asset': NFT_ID_FOR_TEST_ACC4}]},
     )
     result = assert_proper_response_with_result(response)
     assert NFT_ID_FOR_TEST_ACC4 in result

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -385,7 +385,7 @@ def toggle_ignore_an_asset(
         api_url_for(
             rotkehlchen_api_server,
             'ignoredassetsresource',
-        ), json={'assets': [asset_to_ignore.identifier]},
+        ), json={'assets': [{'asset': asset_to_ignore.identifier}]},
     )
     assert response.status_code == 200
     response_result = response.json().get('result', [])


### PR DESCRIPTION
This commit allows to send a `is_spam` field that will set the protocol to spam for evm tokens when ignoring them

Backend part of #7124

