### PR TITLE
fix (#7176): add label for addresses in CSV export

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`7176` The exported CSV for PnL Report now contains a label of the address in notes, if available.
 * :feature:`7146` The exported CSV for PnL Report now contains an Asset column with symbols.
 * :feature:`6254` Users can now stop the execution of long-running queries.
 * :feature:`7092` Users of metamask swaps will now see them properly decoded in the history view and have them taken into account during accounting.

--- a/rotkehlchen/accounting/export/csv.py
+++ b/rotkehlchen/accounting/export/csv.py
@@ -307,6 +307,7 @@ class CSVExporter(CustomizableDateMixin):
         dict_event = event.to_exported_dict(
             ts_converter=self.timestamp_to_date,
             export_type=AccountingEventExportType.CSV,
+            database=self.database,
             evm_explorer=evm_explorer,
         )
         # For CSV also convert timestamp to date

--- a/rotkehlchen/chain/evm/constants.py
+++ b/rotkehlchen/chain/evm/constants.py
@@ -1,3 +1,4 @@
+import re
 from typing import Final
 
 from rotkehlchen.types import deserialize_evm_tx_hash
@@ -9,6 +10,7 @@ ZERO_ADDRESS = string_to_evm_address('0x0000000000000000000000000000000000000000
 ETH_SPECIAL_ADDRESS = string_to_evm_address('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE')
 ZERO_32_BYTES_HEX = '0x' + '0' * 64
 GENESIS_HASH = deserialize_evm_tx_hash(ZERO_32_BYTES_HEX)  # hash for transactions in genesis block
+EVM_ADDRESS_REGEX = re.compile(r'\b0x[a-fA-F0-9]{40}\b')
 
 # Fake receipt with values taken from ethereum mainnet, to emulate a receipt for the
 # genesis transactions

--- a/rotkehlchen/tests/unit/test_evm_misc.py
+++ b/rotkehlchen/tests/unit/test_evm_misc.py
@@ -1,3 +1,4 @@
+from rotkehlchen.chain.evm.constants import EVM_ADDRESS_REGEX
 from rotkehlchen.chain.evm.types import asset_id_is_evm_token, string_to_evm_address
 from rotkehlchen.types import ChainID
 
@@ -22,3 +23,20 @@ def test_asset_id_is_evm_token():
     assert asset_id_is_evm_token('ETH') is None
     assert asset_id_is_evm_token('BTC') is None
     assert asset_id_is_evm_token('eip155:125/erc721:0xC36442b4a4522E871399CD717aBDD847Ab11FE88') is None  # noqa: E501
+
+
+def test_address_regex() -> None:
+    cases: dict[str, bool] = {
+        '0x0F5D2fB29fb7d3CFeE444a200298f468908cC942': True,  # address
+        '0x9b675024d8648c3b590eff411fcf75a1199d10d1a3fe2ddbe50e166ce8b87cc9': False,  # transaction hash  # noqa: E501
+        'https://etherscan.io/address/0x0F5D2fB29fb7d3CFeE444a200298f468908cC942': True,  # etherscan link of an address  # noqa: E501
+        'https://etherscan.io/tx/0x9b675024d8648c3b590eff411fcf75a1199d10d1a3fe2ddbe50e166ce8b87cc9': False,  # etherscan link of a transaction  # noqa: E501
+        '0x0F5D2fB29fb7d3CFeE444a200298f468908cC942a': False,  # invalid address length
+        '0x0F5D2fB29fb7d3CFeE444a200298f468908zC942': False,  # invalid address characters
+        '0x0F5D2fB29fb7d3CFeE444a200298f468908cC942 Note with address at the start': True,
+        'Note with address in the end 0x0F5D2fB29fb7d3CFeE444a200298f468908cC942': True,
+        'A full stop after the address 0x0F5D2fB29fb7d3CFeE444a200298f468908cC942.': True,
+    }
+
+    for case, expected_result in cases.items():
+        assert (EVM_ADDRESS_REGEX.search(case) is not None) == expected_result


### PR DESCRIPTION
Closes #7176

## Checklist

- [x] Match EVM address regex in notes of exported CSV and add a label after them if present.
- [x] Add test for this functionality