### PR TITLE
Update usage_guide.rst to note hidden folder on macos

### DIFF
--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -2077,7 +2077,7 @@ Rotki data directory
 Rotki saves user data by default in a different directory per OS. For each OS data is stored in the respective standards compliant equivalent directory.
 
 - **Linux**: ``~/.local/share/rotki/data/``
-- **OSX**: ``~/Library/Application Support/rotki/data``
+- **OSX**: ``~/Library/Application Support/rotki/data`` - please note this folder is hidden by default
 - **Windows**: ``%LOCALAPPDATA%/rotki/data``
 
 Before v1.6.0 rotki was saving data in ``$USER/.rotkehlchen``. From v1.6.0 that directory got migrated to the OS equivalent standard directory and it should be safe for the users to delete the old directory as long as the new directory contains the migrated DB.


### PR DESCRIPTION
The folder "~/Library/Application Support/rotki/data" is hidden by default, which may confusion if come people (like me), go looking for the folder.

Detailing this here will prevent such people struggling, and seeking support.

Closes #(issue_number)

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

It is literally a docs change
