### PR TITLE
ci: use pre-build miniupnpc wheel for windows

### DIFF
--- a/package.py
+++ b/package.py
@@ -13,7 +13,6 @@ from collections.abc import Callable, Generator
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Literal
-from zipfile import ZipFile
 
 from setuptools_scm import get_version
 
@@ -328,7 +327,6 @@ class WindowsPackaging:
         """
         Downloads miniupnpc and extracts the dll in the virtual environment.
         """
-        miniupnc = 'miniupnpc_64bit_py39-2.2.24.zip'
         python_dir = Path(
             subprocess.check_output(
                 'python -c "import os, sys; print(os.path.dirname(sys.executable))"',
@@ -348,25 +346,18 @@ class WindowsPackaging:
 
         build_dir = self.__storage.build_directory
         os.chdir(build_dir)
-        zip_path = build_dir / miniupnc
-        extraction_dir = build_dir / 'miniupnpc'
-        extraction_dir.mkdir(exist_ok=True)
 
-        url = f'https://github.com/mrx23dot/miniupnp/releases/download/miniupnpd_2_2_24/{miniupnc}'
-        urllib.request.urlretrieve(url, zip_path)  # noqa: S310
+        dll_file = build_dir / dll_filename
 
-        with ZipFile(zip_path, 'r') as zip_ref:
-            zip_ref.extractall(extraction_dir)
+        url = f'https://github.com/rotki/rotki-build/raw/main/miniupnpc/dll/2.2.6/{dll_filename}'
+        urllib.request.urlretrieve(url, dll_file)  # noqa: S310
 
-        dll_file = extraction_dir / dll_filename
         logger.info(f'moving {dll_file} to {python_dir}')
 
         shutil.move(
             src=dll_file,
             dst=python_dir,
         )
-        zip_path.unlink(missing_ok=True)
-        shutil.rmtree(extraction_dir)
 
     @log_group('certificates')
     def import_signing_certificates(self) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ substrate-interface==1.7.5
 beautifulsoup4==4.12.2
 maxminddb==2.5.1
 miniupnpc==2.0.2; sys_platform != 'win32'
-miniupnpc==2.2.3; sys_platform == 'win32'
+miniupnpc @ https://github.com/rotki/rotki-build/raw/main/miniupnpc/miniupnpc-2.2.6-cp311-cp311-win_amd64.whl ; sys_platform == 'win32'
 cryptography==41.0.7
 py-machineid==0.4.6
 more-itertools==10.1.0  # for peekable iterators


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
