### PR TITLE
Add entry type mappings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12450,6 +12450,16 @@ Event Mappings
               "none":"send"
             }
           },
+          "entry_type_mappings":{
+            "eth withdrawal event":{
+              "staking":{
+                "remove asset":{
+                    "is_exit":"stake exit",
+                    "not_exit":"withdraw"
+                }
+              }
+            }
+          },
           "per_protocol_mappings":{
             "ethereum":{
               "aave":{
@@ -12516,6 +12526,7 @@ Event Mappings
       }
 
   :resjson object global_mappings: keys of this object are the history event types names and values are mappings of subtypes' names to the ``EventCategory`` name. Contains mappings that should be applied if there is no a specific protocol rule.
+  :resjson object type_mappings: the keys of this mapping are entry types and it contains the combinations of event type and subtype that would overwritte the information in ``global_mappings`` only for that entry type.
   :resjson object per_protocol_mappings: same as global_mappings but contains specific mappings per chain and protocol.
   :resjson object event_category_details: This is a mapping of ``EventCategory`` to its direction and mapping of counterparty to details. For all the ``EventCategoryDetails`` mapping there is a ``"default"`` key mapping to the default details. For some exceptions there is also other keys which are counterparties. Such as for spend/fee and counterparty gas.
   :resjon object accounting_events_icons: Mapping of accounting event type to its corresponding icon name.

--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -62,7 +62,7 @@ EVENT_CATEGORY_MAPPINGS = {  # possible combinations of types and subtypes mappe
     }, HistoryEventType.STAKING: {
         HistoryEventSubType.DEPOSIT_ASSET: EventCategory.STAKE_DEPOSIT,
         HistoryEventSubType.REWARD: EventCategory.STAKING_REWARD,
-        HistoryEventSubType.REMOVE_ASSET: EventCategory.STAKE_WITHDRAWAL,
+        HistoryEventSubType.REMOVE_ASSET: EventCategory.UNSTAKE,
         HistoryEventSubType.BLOCK_PRODUCTION: EventCategory.CREATE_BLOCK,
         HistoryEventSubType.MEV_REWARD: EventCategory.MEV_REWARD,
         HistoryEventSubType.FEE: EventCategory.FEE,
@@ -203,8 +203,11 @@ EVENT_CATEGORY_DETAILS = {
     )}, EventCategory.STAKE_DEPOSIT: {DEFAULT: EventCategoryDetails(
         label='Stake',
         icon='folder-add-line',
-    )}, EventCategory.STAKE_WITHDRAWAL: {DEFAULT: EventCategoryDetails(
+    )}, EventCategory.UNSTAKE: {DEFAULT: EventCategoryDetails(
         label='Unstake',
+        icon='folder-reduce-line',
+    )}, EventCategory.STAKE_EXIT: {DEFAULT: EventCategoryDetails(
+        label='exit',
         icon='folder-reduce-line',
     )}, EventCategory.ATTEST: {DEFAULT: EventCategoryDetails(
         label='Attest',

--- a/rotkehlchen/accounting/entry_type_mappings.py
+++ b/rotkehlchen/accounting/entry_type_mappings.py
@@ -1,0 +1,20 @@
+from typing import Final
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
+from rotkehlchen.history.events.structures.types import (
+    EventCategory,
+    HistoryEventSubType,
+    HistoryEventType,
+)
+
+# possible combinations of types and subtypes mapped to their event
+# category based on the entry type
+ENTRY_TYPE_MAPPINGS: Final = {
+    HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize(): {
+        HistoryEventType.STAKING: {
+            HistoryEventSubType.REMOVE_ASSET: {
+                'is_exit': EventCategory.STAKE_EXIT,
+                'not_exit': EventCategory.WITHDRAW,
+            },
+        },
+    },
+}

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -31,6 +31,7 @@ from rotkehlchen.accounting.constants import (
     FREE_REPORTS_LOOKUP_LIMIT,
 )
 from rotkehlchen.accounting.debugimporter.json import DebugHistoryImporter
+from rotkehlchen.accounting.entry_type_mappings import ENTRY_TYPE_MAPPINGS
 from rotkehlchen.accounting.export.csv import (
     FILENAME_HISTORY_EVENTS_CSV,
     FILENAME_SKIPPED_EXTERNAL_EVENTS_CSV,
@@ -4346,6 +4347,7 @@ class RestAPI:
     def get_types_mappings(self) -> Response:
         result = {
             'global_mappings': EVENT_CATEGORY_MAPPINGS,
+            'entry_type_mappings': ENTRY_TYPE_MAPPINGS,
             'event_category_details': {
                 category: {'counterparty_mappings': entries, 'direction': category.direction.serialize()}  # noqa: E501
                 for category, entries in EVENT_CATEGORY_DETAILS.items()

--- a/rotkehlchen/history/events/structures/types.py
+++ b/rotkehlchen/history/events/structures/types.py
@@ -152,8 +152,9 @@ class EventCategory(Enum):
     UPDATE_PROJECT = 33, EventDirection.NEUTRAL
     APPLY = 34, EventDirection.NEUTRAL
     STAKE_DEPOSIT = 35, EventDirection.OUT
-    STAKE_WITHDRAWAL = 36, EventDirection.IN
+    UNSTAKE = 36, EventDirection.IN
     ATTEST = 37, EventDirection.NEUTRAL
+    STAKE_EXIT = 38, EventDirection.IN
 
     @property
     def direction(self) -> EventDirection:

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -442,6 +442,16 @@ def test_events_mappings(rotkehlchen_api_server_with_exchanges):
     )
     result = assert_proper_response_with_result(response)
     assert 'global_mappings' in result
+    assert result['entry_type_mappings'] == {
+        'eth withdrawal event': {
+            'staking': {
+                'remove asset': {
+                    'is_exit': 'stake exit',
+                    'not_exit': 'withdraw',
+                },
+            },
+        },
+    }
     assert 'event_category_details' in result
     assert 'accounting_events_icons' in result
     received_accounting_event_types = {


### PR DESCRIPTION
I didn't use directly `EthWithdrawalEvent.entry_type` because `entry_type` is an instance method and making `entry_type` a classmethod disallows from using it as a property. Didn't want to set it as a class attrribute because is something that we need to change and don't want someone from forgetting of changing it.

Created a new file for this mappings since otherwise we get a import cycle due the usage of `HistoryBaseEntryType` (is the same error if using `EthWithdrawalEvent`)
