### PR TITLE
Fix (accounting): order of processed fee events

### DIFF
--- a/rotkehlchen/tests/unit/accounting/evm/test_paraswap.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_paraswap.py
@@ -1,71 +1,66 @@
 from typing import TYPE_CHECKING
 
 import pytest
-from more_itertools import peekable
 
-from rotkehlchen.accounting.cost_basis.base import (
-    AssetAcquisitionEvent,
-    CostBasisInfo,
-    MatchedAcquisition,
-)
 from rotkehlchen.accounting.mixins.event import AccountingEventType
-from rotkehlchen.accounting.pnl import PNL
+from rotkehlchen.accounting.pnl import PNL, PnlTotals
 from rotkehlchen.accounting.structures.balance import Balance
-from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
 from rotkehlchen.chain.evm.decoding.paraswap.constants import CPT_PARASWAP
-from rotkehlchen.constants import ONE, ZERO
-from rotkehlchen.constants.assets import A_USDC, A_WBTC
+from rotkehlchen.constants import ZERO
+from rotkehlchen.constants.assets import A_ETH, A_WBTC
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.accounting import (
-    MOCKED_PRICES,
     TIMESTAMP_0_MS,
     TIMESTAMP_0_SEC,
     TIMESTAMP_1_MS,
     TIMESTAMP_1_SEC,
+    accounting_history_process,
+    assert_pnl_totals_close,
 )
 from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
+from rotkehlchen.tests.utils.messages import no_message_errors
 from rotkehlchen.types import Location, Price
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.accountant import Accountant
 
 
-@pytest.mark.parametrize('mocked_price_queries', [MOCKED_PRICES])
+@pytest.mark.parametrize('mocked_price_queries', [{
+    A_WBTC.identifier: {'EUR': {
+        TIMESTAMP_0_SEC: Price(FVal(5)),
+        TIMESTAMP_1_SEC: Price(FVal(10)),
+    }},
+    A_ETH.identifier: {'EUR': {
+        TIMESTAMP_0_SEC: Price(FVal(0.1)),
+        TIMESTAMP_1_SEC: Price(FVal(0.1)),
+    }},
+}])
 @pytest.mark.parametrize('accounting_initialize_parameters', [True])
-def test_paraswap_swap_with_fee(accountant: 'Accountant'):
+@pytest.mark.parametrize('db_settings', [
+    {'include_fees_in_cost_basis': True},
+    {'include_fees_in_cost_basis': False},
+])
+def test_paraswap_swap_with_fee(accountant: 'Accountant', db_settings: dict):
     """Test that the fee in paraswap is handled correctly during accounting"""
-    tx_hash, user_address, contract_address, aquired_from_address, swap_amount_str, fee_amount_str, receive_amount_str = make_evm_tx_hash(), make_evm_address(), make_evm_address(), make_evm_address(), '138.2851', '11.308417', '1190.359719'  # noqa: E501
-    events = [EvmEvent(
+    tx_hash, user_address, contract_address, acquired_from_address, swap_amount_str, fee_amount_str, receive_amount_str = make_evm_tx_hash(), make_evm_address(), make_evm_address(), make_evm_address(), '1', '1', '100'  # noqa: E501
+    events = [EvmEvent(  # this event is to create cost basis for wBTC
         tx_hash=tx_hash,
         sequence_index=0,
-        timestamp=TIMESTAMP_0_MS,  # half price at t=0
+        timestamp=TIMESTAMP_0_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.NONE,
         asset=A_WBTC,
         balance=Balance(amount=FVal(swap_amount_str)),
         location_label=user_address,
-        notes=f'Receive {swap_amount_str} WBTC from {aquired_from_address} to {user_address}',
-        counterparty=CPT_PARASWAP,
-        address=aquired_from_address,
+        notes=f'Receive {swap_amount_str} WBTC from {acquired_from_address} to {user_address}',
+        counterparty='0xrandomaddress',
+        address=acquired_from_address,
     ), EvmEvent(
         tx_hash=tx_hash,
         sequence_index=1,
-        timestamp=TIMESTAMP_0_MS,  # same price at t=0
-        location=Location.ETHEREUM,
-        event_type=HistoryEventType.RECEIVE,
-        event_subtype=HistoryEventSubType.NONE,
-        asset=A_USDC,
-        balance=Balance(amount=ONE),
-        location_label=user_address,
-        notes=f'Receive {ONE} USDC from {aquired_from_address} to {user_address}',
-        counterparty=CPT_PARASWAP,
-        address=aquired_from_address,
-    ), EvmEvent(
-        tx_hash=tx_hash,
-        sequence_index=2,
         timestamp=TIMESTAMP_1_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.TRADE,
@@ -78,130 +73,54 @@ def test_paraswap_swap_with_fee(accountant: 'Accountant'):
         address=contract_address,
     ), EvmEvent(
         tx_hash=tx_hash,
-        sequence_index=3,
+        sequence_index=2,
         timestamp=TIMESTAMP_1_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
-        asset=A_USDC,
+        asset=A_ETH,
         balance=Balance(amount=FVal(receive_amount_str)),
         location_label=user_address,
-        notes=f'Receive {receive_amount_str} USDC as the result of a swap in paraswap',
+        notes=f'Receive {receive_amount_str} ETH as the result of a swap in paraswap',
         counterparty=CPT_PARASWAP,
         address=contract_address,
     ), EvmEvent(
         tx_hash=tx_hash,
-        sequence_index=4,
+        sequence_index=3,
         timestamp=TIMESTAMP_1_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.FEE,
-        asset=A_USDC,
+        asset=A_ETH,
         balance=Balance(amount=FVal(fee_amount_str)),
         location_label=user_address,
-        notes=f'Spend {fee_amount_str} USDC as a paraswap fee',
+        notes=f'Spend {fee_amount_str} ETH as a paraswap fee',
         counterparty=CPT_PARASWAP,
         address=contract_address,
     )]
-    pot = accountant.pots[0]
-    events_iterator = peekable(events)
-    for event in events_iterator:
-        pot.events_accountant.process(event=event, events_iterator=events_iterator)  # type: ignore
 
-    extra_data = {
-        'group_id': '1' + tx_hash.hex() + '23',  # pylint: disable=no-member
-        'tx_hash': tx_hash.hex(),  # pylint: disable=no-member
-    }
-    wbtc_prices = MOCKED_PRICES[A_WBTC.identifier]['EUR']
-    aquisition_event = AssetAcquisitionEvent(
-        index=0,
-        timestamp=TIMESTAMP_0_SEC,
-        amount=FVal(swap_amount_str),
-        rate=wbtc_prices[TIMESTAMP_0_SEC],
+    accounting_history_process(
+        accountant=accountant,
+        start_ts=TIMESTAMP_0_SEC,
+        end_ts=TIMESTAMP_1_SEC,
+        history_list=events,
     )
-    aquisition_event.remaining_amount = ZERO  # since it's not settable at ctor
-    expected_processed_events = [
-        ProcessedAccountingEvent(
-            index=0,
-            event_type=AccountingEventType.TRANSACTION_EVENT,
-            notes=f'Receive {swap_amount_str} WBTC from {aquired_from_address} to {user_address}',
-            location=Location.ETHEREUM,
-            timestamp=TIMESTAMP_0_SEC,
-            asset=A_WBTC,
-            free_amount=ZERO,
-            taxable_amount=events[0].balance.amount,
-            price=wbtc_prices[TIMESTAMP_0_SEC],
-            pnl=PNL(taxable=events[0].balance.amount * wbtc_prices[TIMESTAMP_0_SEC], free=ZERO),
-            cost_basis=None,
-            extra_data={'tx_hash': tx_hash.hex()},  # pylint: disable=no-member
-        ),
-        ProcessedAccountingEvent(
-            index=1,
-            event_type=AccountingEventType.TRANSACTION_EVENT,
-            notes=f'Receive {ONE} USDC from {aquired_from_address} to {user_address}',
-            location=Location.ETHEREUM,
-            timestamp=TIMESTAMP_0_SEC,
-            asset=A_USDC,
-            free_amount=ZERO,
-            taxable_amount=ONE,
-            price=Price(ONE),
-            pnl=PNL(taxable=ONE, free=ZERO),
-            cost_basis=None,
-            extra_data={'tx_hash': tx_hash.hex()},  # pylint: disable=no-member
-        ),
-        ProcessedAccountingEvent(
-            index=2,
-            event_type=AccountingEventType.TRANSACTION_EVENT,
-            notes=f'Swap {swap_amount_str} WBTC in paraswap',
-            location=Location.ETHEREUM,
-            timestamp=TIMESTAMP_1_SEC,
-            asset=A_WBTC,
-            free_amount=ZERO,
-            taxable_amount=events[2].balance.amount,
-            price=Price(ONE),
-            pnl=PNL(taxable=events[2].balance.amount * wbtc_prices[TIMESTAMP_1_SEC] - aquisition_event.amount * wbtc_prices[TIMESTAMP_0_SEC], free=ZERO),  # noqa: E501
-            cost_basis=CostBasisInfo(
-                taxable_amount=events[2].balance.amount,
-                taxable_bought_cost=events[2].balance.amount * wbtc_prices[TIMESTAMP_1_SEC] - aquisition_event.amount * wbtc_prices[TIMESTAMP_0_SEC],  # noqa: E501
-                taxfree_bought_cost=ZERO,
-                is_complete=True,
-                matched_acquisitions=[MatchedAcquisition(
-                    taxable=True,
-                    amount=aquisition_event.amount,
-                    event=aquisition_event,
-                )],
-            ),
-            extra_data=extra_data,
-        ), ProcessedAccountingEvent(
-            index=3,
-            event_type=AccountingEventType.FEE,
-            notes=f'Spend {fee_amount_str} USDC as a paraswap fee',
-            location=Location.ETHEREUM,
-            timestamp=TIMESTAMP_1_SEC,
-            asset=A_USDC,
-            free_amount=ZERO,
-            taxable_amount=FVal(fee_amount_str),
-            price=Price((FVal(swap_amount_str) + FVal(fee_amount_str)) / FVal(receive_amount_str)),
-            pnl=PNL(taxable=ZERO, free=ZERO),
-            cost_basis=None,
-            extra_data=extra_data,
-        ), ProcessedAccountingEvent(
-            index=4,
-            event_type=AccountingEventType.TRANSACTION_EVENT,
-            notes=f'Receive {receive_amount_str} USDC as the result of a swap in paraswap',
-            location=Location.ETHEREUM,
-            timestamp=TIMESTAMP_1_SEC,
-            asset=A_USDC,
-            free_amount=FVal(receive_amount_str),
-            taxable_amount=ZERO,
-            price=Price((FVal(swap_amount_str) + FVal(fee_amount_str)) / FVal(receive_amount_str)),
-            pnl=PNL(taxable=ZERO, free=ZERO),
-            cost_basis=None,
-            extra_data=extra_data,
-        )]
-    expected_processed_events[0].count_cost_basis_pnl = True  # since it's not settable at ctor
-    expected_processed_events[1].count_cost_basis_pnl = True  # since it's not settable at ctor
-    expected_processed_events[2].count_cost_basis_pnl = True  # since it's not settable at ctor
-    assert pot.processed_events == expected_processed_events
-    assert pot.pnls[AccountingEventType.TRANSACTION_EVENT].taxable == events[0].balance.amount + events[1].balance.amount  # noqa: E501
-    assert pot.pnls[AccountingEventType.TRANSACTION_EVENT].total == events[0].balance.amount + events[1].balance.amount  # noqa: E501
+    no_message_errors(accountant.msg_aggregator)
+
+    fee_spent_event = accountant.pots[0].processed_events[4]
+    if db_settings['include_fees_in_cost_basis']:
+        expected_pnls = PnlTotals({
+            AccountingEventType.TRANSACTION_EVENT: PNL(taxable=FVal(10), free=ZERO),  # Get BTC(€5) + profit_from_selling_btc(€5)  # noqa: E501
+        })
+        assert fee_spent_event.price == Price(FVal(0.101))  # (Fee given(€0.1) + BTC swapped(€10)) / ETH received(100)  # noqa: E501
+        assert fee_spent_event.cost_basis is None  # Fee is not taxable, because it is not included in cost basis  # noqa: E501
+    else:
+        expected_pnls = PnlTotals({
+            AccountingEventType.TRANSACTION_EVENT: PNL(taxable=FVal(10), free=ZERO),  # Get BTC(€5) + profit_from_selling_btc(€5)  # noqa: E501
+            AccountingEventType.FEE: PNL(taxable=FVal(-0.1), free=ZERO),  # -one_eth_fee(0.1)
+        })
+        assert fee_spent_event.price == Price(FVal(0.1))  # BTC swapped(€10) / ETH received(€100)
+        assert fee_spent_event.cost_basis is not None  # Fee is taxable this time
+        assert fee_spent_event.cost_basis.taxable_amount == FVal(1)
+        assert fee_spent_event.cost_basis.taxable_bought_cost == FVal(0.1)  # BTC swapped(€10) / ETH received(€100)  # noqa: E501
+    assert_pnl_totals_close(expected_pnls, accountant.pots[0].pnls)

--- a/rotkehlchen/tests/unit/accounting/evm/test_paraswap.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_paraswap.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING
 import pytest
 from more_itertools import peekable
 
-from rotkehlchen.accounting.cost_basis.base import CostBasisInfo
+from rotkehlchen.accounting.cost_basis.base import (
+    AssetAcquisitionEvent,
+    CostBasisInfo,
+    MatchedAcquisition,
+)
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL
 from rotkehlchen.accounting.structures.balance import Balance
@@ -14,7 +18,13 @@ from rotkehlchen.constants.assets import A_USDC, A_WBTC
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.tests.utils.accounting import MOCKED_PRICES, TIMESTAMP_1_MS, TIMESTAMP_1_SEC
+from rotkehlchen.tests.utils.accounting import (
+    MOCKED_PRICES,
+    TIMESTAMP_0_MS,
+    TIMESTAMP_0_SEC,
+    TIMESTAMP_1_MS,
+    TIMESTAMP_1_SEC,
+)
 from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
 from rotkehlchen.types import Location, Price
 
@@ -26,10 +36,36 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize('accounting_initialize_parameters', [True])
 def test_paraswap_swap_with_fee(accountant: 'Accountant'):
     """Test that the fee in paraswap is handled correctly during accounting"""
-    tx_hash, user_address, contract_address, swap_amount_str, fee_amount_str, receive_amount_str = make_evm_tx_hash(), make_evm_address(), make_evm_address(), '138.2851', '11.308417', '1190.359719'  # noqa: E501
+    tx_hash, user_address, contract_address, aquired_from_address, swap_amount_str, fee_amount_str, receive_amount_str = make_evm_tx_hash(), make_evm_address(), make_evm_address(), make_evm_address(), '138.2851', '11.308417', '1190.359719'  # noqa: E501
     events = [EvmEvent(
         tx_hash=tx_hash,
+        sequence_index=0,
+        timestamp=TIMESTAMP_0_MS,  # half price at t=0
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_WBTC,
+        balance=Balance(amount=FVal(swap_amount_str)),
+        location_label=user_address,
+        notes=f'Receive {swap_amount_str} WBTC from {aquired_from_address} to {user_address}',
+        counterparty=CPT_PARASWAP,
+        address=aquired_from_address,
+    ), EvmEvent(
+        tx_hash=tx_hash,
         sequence_index=1,
+        timestamp=TIMESTAMP_0_MS,  # same price at t=0
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_USDC,
+        balance=Balance(amount=ONE),
+        location_label=user_address,
+        notes=f'Receive {ONE} USDC from {aquired_from_address} to {user_address}',
+        counterparty=CPT_PARASWAP,
+        address=aquired_from_address,
+    ), EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=2,
         timestamp=TIMESTAMP_1_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.TRADE,
@@ -42,7 +78,7 @@ def test_paraswap_swap_with_fee(accountant: 'Accountant'):
         address=contract_address,
     ), EvmEvent(
         tx_hash=tx_hash,
-        sequence_index=2,
+        sequence_index=3,
         timestamp=TIMESTAMP_1_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.TRADE,
@@ -55,7 +91,7 @@ def test_paraswap_swap_with_fee(accountant: 'Accountant'):
         address=contract_address,
     ), EvmEvent(
         tx_hash=tx_hash,
-        sequence_index=3,
+        sequence_index=4,
         timestamp=TIMESTAMP_1_MS,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.TRADE,
@@ -73,24 +109,71 @@ def test_paraswap_swap_with_fee(accountant: 'Accountant'):
         pot.events_accountant.process(event=event, events_iterator=events_iterator)  # type: ignore
 
     extra_data = {
-        'group_id': '1' + tx_hash.hex() + '12',  # pylint: disable=no-member
+        'group_id': '1' + tx_hash.hex() + '23',  # pylint: disable=no-member
         'tx_hash': tx_hash.hex(),  # pylint: disable=no-member
     }
+    wbtc_prices = MOCKED_PRICES[A_WBTC.identifier]['EUR']
+    aquisition_event = AssetAcquisitionEvent(
+        index=0,
+        timestamp=TIMESTAMP_0_SEC,
+        amount=FVal(swap_amount_str),
+        rate=wbtc_prices[TIMESTAMP_0_SEC],
+    )
+    aquisition_event.remaining_amount = ZERO  # since it's not settable at ctor
     expected_processed_events = [
         ProcessedAccountingEvent(
+            index=0,
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes=f'Receive {swap_amount_str} WBTC from {aquired_from_address} to {user_address}',
+            location=Location.ETHEREUM,
+            timestamp=TIMESTAMP_0_SEC,
+            asset=A_WBTC,
+            free_amount=ZERO,
+            taxable_amount=events[0].balance.amount,
+            price=wbtc_prices[TIMESTAMP_0_SEC],
+            pnl=PNL(taxable=events[0].balance.amount * wbtc_prices[TIMESTAMP_0_SEC], free=ZERO),
+            cost_basis=None,
+            extra_data={'tx_hash': tx_hash.hex()},  # pylint: disable=no-member
+        ),
+        ProcessedAccountingEvent(
+            index=1,
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes=f'Receive {ONE} USDC from {aquired_from_address} to {user_address}',
+            location=Location.ETHEREUM,
+            timestamp=TIMESTAMP_0_SEC,
+            asset=A_USDC,
+            free_amount=ZERO,
+            taxable_amount=ONE,
+            price=Price(ONE),
+            pnl=PNL(taxable=ONE, free=ZERO),
+            cost_basis=None,
+            extra_data={'tx_hash': tx_hash.hex()},  # pylint: disable=no-member
+        ),
+        ProcessedAccountingEvent(
+            index=2,
             event_type=AccountingEventType.TRANSACTION_EVENT,
             notes=f'Swap {swap_amount_str} WBTC in paraswap',
             location=Location.ETHEREUM,
             timestamp=TIMESTAMP_1_SEC,
             asset=A_WBTC,
             free_amount=ZERO,
-            taxable_amount=FVal(swap_amount_str),
+            taxable_amount=events[2].balance.amount,
             price=Price(ONE),
-            pnl=PNL(taxable=FVal(swap_amount_str), free=ZERO),
-            cost_basis=CostBasisInfo(taxable_amount=FVal(swap_amount_str), taxable_bought_cost=ZERO, taxfree_bought_cost=ZERO, matched_acquisitions=[], is_complete=False),  # noqa: E501
-            index=0,
+            pnl=PNL(taxable=events[2].balance.amount * wbtc_prices[TIMESTAMP_1_SEC] - aquisition_event.amount * wbtc_prices[TIMESTAMP_0_SEC], free=ZERO),  # noqa: E501
+            cost_basis=CostBasisInfo(
+                taxable_amount=events[2].balance.amount,
+                taxable_bought_cost=events[2].balance.amount * wbtc_prices[TIMESTAMP_1_SEC] - aquisition_event.amount * wbtc_prices[TIMESTAMP_0_SEC],  # noqa: E501
+                taxfree_bought_cost=ZERO,
+                is_complete=True,
+                matched_acquisitions=[MatchedAcquisition(
+                    taxable=True,
+                    amount=aquisition_event.amount,
+                    event=aquisition_event,
+                )],
+            ),
             extra_data=extra_data,
         ), ProcessedAccountingEvent(
+            index=3,
             event_type=AccountingEventType.FEE,
             notes=f'Spend {fee_amount_str} USDC as a paraswap fee',
             location=Location.ETHEREUM,
@@ -101,9 +184,9 @@ def test_paraswap_swap_with_fee(accountant: 'Accountant'):
             price=Price((FVal(swap_amount_str) + FVal(fee_amount_str)) / FVal(receive_amount_str)),
             pnl=PNL(taxable=ZERO, free=ZERO),
             cost_basis=None,
-            index=1,
             extra_data=extra_data,
         ), ProcessedAccountingEvent(
+            index=4,
             event_type=AccountingEventType.TRANSACTION_EVENT,
             notes=f'Receive {receive_amount_str} USDC as the result of a swap in paraswap',
             location=Location.ETHEREUM,
@@ -114,8 +197,11 @@ def test_paraswap_swap_with_fee(accountant: 'Accountant'):
             price=Price((FVal(swap_amount_str) + FVal(fee_amount_str)) / FVal(receive_amount_str)),
             pnl=PNL(taxable=ZERO, free=ZERO),
             cost_basis=None,
-            index=2,
             extra_data=extra_data,
         )]
     expected_processed_events[0].count_cost_basis_pnl = True  # since it's not settable at ctor
+    expected_processed_events[1].count_cost_basis_pnl = True  # since it's not settable at ctor
+    expected_processed_events[2].count_cost_basis_pnl = True  # since it's not settable at ctor
     assert pot.processed_events == expected_processed_events
+    assert pot.pnls[AccountingEventType.TRANSACTION_EVENT].taxable == events[0].balance.amount + events[1].balance.amount  # noqa: E501
+    assert pot.pnls[AccountingEventType.TRANSACTION_EVENT].total == events[0].balance.amount + events[1].balance.amount  # noqa: E501

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -14,7 +14,7 @@ from rotkehlchen.accounting.structures.processed_event import ProcessedAccountin
 from rotkehlchen.api.server import APIServer
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ONE, ZERO
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USDC, A_WBTC
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USDC, A_USDT, A_WBTC
 from rotkehlchen.db.filtering import ReportDataFilterQuery
 from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.exchanges.data_structures import Trade
@@ -30,16 +30,30 @@ if TYPE_CHECKING:
     from rotkehlchen.tests.fixtures.google import GoogleService
 
 
+TIMESTAMP_0_MS = TimestampMS(0)
+TIMESTAMP_0_SEC = Timestamp(0)
 TIMESTAMP_1_MS = TimestampMS(1000)
 TIMESTAMP_1_SEC = Timestamp(1)
 
-MOCKED_PRICES = {
+MOCKED_PRICES: dict[str, dict[str, dict[Timestamp, Price]]] = {
     A_WBTC.identifier: {
         'EUR': {
+            TIMESTAMP_0_SEC: Price(FVal(0.5)),
             TIMESTAMP_1_SEC: Price(ONE),
         },
     },
     A_USDC.identifier: {
+        'EUR': {
+            TIMESTAMP_0_SEC: Price(ONE),
+            TIMESTAMP_1_SEC: Price(ONE),
+        },
+    },
+    A_ETH.identifier: {
+        'EUR': {
+            TIMESTAMP_1_SEC: Price(FVal(100)),
+        },
+    },
+    A_USDT.identifier: {
         'EUR': {
             TIMESTAMP_1_SEC: Price(ONE),
         },

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -14,7 +14,7 @@ from rotkehlchen.accounting.structures.processed_event import ProcessedAccountin
 from rotkehlchen.api.server import APIServer
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ONE, ZERO
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USDC, A_USDT, A_WBTC
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USDC, A_WBTC
 from rotkehlchen.db.filtering import ReportDataFilterQuery
 from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.exchanges.data_structures import Trade
@@ -35,25 +35,13 @@ TIMESTAMP_0_SEC = Timestamp(0)
 TIMESTAMP_1_MS = TimestampMS(1000)
 TIMESTAMP_1_SEC = Timestamp(1)
 
-MOCKED_PRICES: dict[str, dict[str, dict[Timestamp, Price]]] = {
+MOCKED_PRICES = {
     A_WBTC.identifier: {
         'EUR': {
-            TIMESTAMP_0_SEC: Price(FVal(0.5)),
             TIMESTAMP_1_SEC: Price(ONE),
         },
     },
     A_USDC.identifier: {
-        'EUR': {
-            TIMESTAMP_0_SEC: Price(ONE),
-            TIMESTAMP_1_SEC: Price(ONE),
-        },
-    },
-    A_ETH.identifier: {
-        'EUR': {
-            TIMESTAMP_1_SEC: Price(FVal(100)),
-        },
-    },
-    A_USDT.identifier: {
         'EUR': {
             TIMESTAMP_1_SEC: Price(ONE),
         },


### PR DESCRIPTION
## Checklist

- [x] Add prior acquisition of the assets that are swapped in paraswap test
- [x] Fix order of processed events when fee asset == in asset
- [x] Test if the final PnLs and cost basis are correct, for `include_fees_in_cost_basis` = True/False