### PR TITLE
style: change layout for the ETH2 form

### DIFF
--- a/frontend/app/src/components/accounts/blockchain/Eth2Input.vue
+++ b/frontend/app/src/components/accounts/blockchain/Eth2Input.vue
@@ -9,6 +9,7 @@ import {
 } from '@vuelidate/validators';
 import { isEmpty } from 'lodash-es';
 import { toMessages } from '@/utils/validation';
+import { consistOfNumbers } from '@/utils/text';
 import type { Eth2Validator } from '@/types/balances';
 import type { ValidationErrors } from '@/types/api/errors';
 
@@ -38,6 +39,12 @@ const { t } = useI18n();
 const rules = {
   validatorIndex: {
     requiredUnlessKey: requiredUnless(logicAnd(publicKey)),
+    consistOfNumbers: helpers.withMessage(
+      t('eth2_input.validator_index.validation'),
+      (value: string) =>
+        !value || consistOfNumbers(value)
+      ,
+    ),
   },
   publicKey: {
     requiredUnlessIndex: requiredUnless(logicAnd(validatorIndex)),
@@ -94,9 +101,10 @@ watch(
 <template>
   <div class="grid gap-4 grid-cols-3 mt-3">
     <div class="col-span-3 md:col-span-1">
-      <AmountInput
+      <RuiTextField
         v-model="validatorIndex"
-        outlined
+        variant="outlined"
+        color="primary"
         :disabled="disabled"
         :label="t('common.validator_index')"
         :error-messages="toMessages(v$.validatorIndex)"

--- a/frontend/app/src/components/accounts/blockchain/Eth2Input.vue
+++ b/frontend/app/src/components/accounts/blockchain/Eth2Input.vue
@@ -92,19 +92,8 @@ watch(
 </script>
 
 <template>
-  <div class="grid gap-4 grid-cols-2">
-    <div class="col-span-2">
-      <RuiTextField
-        v-model="publicKey"
-        variant="outlined"
-        color="primary"
-        :disabled="disabled"
-        :label="t('eth2_input.public_key')"
-        :error-messages="toMessages(v$.publicKey)"
-        @blur="v$.publicKey.$touch()"
-      />
-    </div>
-    <div class="col-span-2 md:col-span-1">
+  <div class="grid gap-4 grid-cols-3 mt-3">
+    <div class="col-span-3 md:col-span-1">
       <AmountInput
         v-model="validatorIndex"
         outlined
@@ -115,7 +104,21 @@ watch(
       />
     </div>
 
-    <div class="col-span-2 md:col-span-1">
+    <div class="col-span-3 md:col-span-2 flex gap-4">
+      <span class="mt-4">{{ t('common.or') }}</span>
+      <RuiTextField
+        v-model="publicKey"
+        class="grow"
+        variant="outlined"
+        color="primary"
+        :disabled="disabled"
+        :label="t('eth2_input.public_key')"
+        :error-messages="toMessages(v$.publicKey)"
+        @blur="v$.publicKey.$touch()"
+      />
+    </div>
+
+    <div class="col-span-3">
       <AmountInput
         v-model="ownershipPercentage"
         outlined

--- a/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
+++ b/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
@@ -105,6 +105,7 @@ onUnmounted(() => {
           v-if="isBitcoin"
           type="button"
           :value="InputMode.XPUB_ADD"
+          :disabled="loading"
         >
           <template #prepend>
             <RuiIcon name="key-line" />

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2113,6 +2113,9 @@
       "hint": "*Optional: By default it is 100%",
       "validation": "The value should be 0-100%"
     },
+    "validator_index": {
+      "validation": "Validator index can be filled with numeric value only."
+    },
     "ownership_percentage": "Ownership Percentage",
     "public_key": "Public Key"
   },

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1605,6 +1605,7 @@
     "no_premium": "No premium subscription detected. ",
     "notes": "Notes",
     "of": "of",
+    "or": "or",
     "price": "Price",
     "price_in_symbol": "Price in {symbol}",
     "priority": "Priority",


### PR DESCRIPTION
To improve the clarity, so the user doesn't get confused.
Make it clear that only one of `validatorIndex` or `publicKey` needed.

<img width="915" alt="image" src="https://github.com/rotki/rotki/assets/26648140/2844dd5f-e18e-492e-8b08-30605dfbf208">


