### PR TITLE
Fix filtering by customized events in the free version

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`7362` Filtering by customized events in the free version should work fine again.
 * :bug:`-` Premium sync failure will now appear in the toolbar indicator instead of showing a notification.
 * :bug:`-` Importing sell trades via rotki generic trades CSV import will now work properly again.
 * :bug:`-` All Gnosis bridge dai events from ethereum to gnosis chain should now be decoded properly.

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -856,7 +856,7 @@ class HistoryEventCustomizedOnlyJoinsFilter(DBFilter):
     def prepare(self) -> tuple[list[str], list[Any]]:
         query = (
             'INNER JOIN history_events_mappings '
-            'ON history_events_mappings.parent_identifier = history_events.identifier '
+            'ON history_events_mappings.parent_identifier = history_events_identifier '
             'WHERE history_events_mappings.name = ? AND history_events_mappings.value = ?'
         )
         bindings: list[str | int] = [HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED]

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -54,7 +54,8 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-HISTORY_BASE_ENTRY_FIELDS = 'entry_type, history_events.identifier, event_identifier, sequence_index, timestamp, location, location_label, asset, amount, usd_value, notes, type, subtype '  # noqa: E501
+# Giving a name for history_events.identifier since without it in the free version case https://github.com/rotki/rotki/issues/7362 we were hitting a no such column: history_events.identifier  # noqa: E501
+HISTORY_BASE_ENTRY_FIELDS = 'entry_type, history_events.identifier AS history_events_identifier, event_identifier, sequence_index, timestamp, location, location_label, asset, amount, usd_value, notes, type, subtype '  # noqa: E501
 HISTORY_BASE_ENTRY_LENGTH = 12
 
 EVM_EVENT_FIELDS = 'tx_hash, counterparty, product, address, extra_data'

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import pytest
+
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.accounting.structures.base import HistoryBaseEntryType, HistoryEvent
 from rotkehlchen.accounting.structures.eth2 import EthDepositEvent, EthWithdrawalEvent
@@ -217,7 +219,10 @@ def test_read_write_events_from_db(database):
                 assert event == expected_event
 
 
-def test_read_write_customized_events_from_db(database: DBHandler) -> None:
+@pytest.mark.parametrize(
+    ('has_premium', 'group_by_event_ids'), [(True, False), (True, True), (False, False), (False, True)],  # noqa: E501
+)
+def test_read_write_customized_events_from_db(database: DBHandler, has_premium: bool, group_by_event_ids: bool) -> None:  # noqa: E501
     """Tests filtering for fetching only the customized events"""
     db = DBHistoryEvents(database)
     history_data = {
@@ -261,14 +266,15 @@ def test_read_write_customized_events_from_db(database: DBHandler) -> None:
 
     with db.db.conn.read_ctx() as cursor:
         for (filtering_class, filter_args), expected_ids in zip(filter_query_args, expected_identifiers, strict=True):  # noqa: E501
-            events = db.get_history_events(
+            events = db.get_history_events(  # type: ignore
                 cursor=cursor,
                 filter_query=filtering_class.make(**filter_args),
-                has_premium=True,
-                group_by_event_ids=False,
+                has_premium=has_premium,
+                group_by_event_ids=group_by_event_ids,
             )
-            filtered_ids = [x.tx_hash if isinstance(x, EvmEvent) else x.event_identifier for x in events]  # noqa: E501
-            assert filtered_ids == expected_ids
+            if group_by_event_ids is False:  # don't check the grouping case. Just make sure no exception is raised  # noqa: E501
+                filtered_ids = [x.tx_hash if isinstance(x, EvmEvent) else x.event_identifier for x in events]  # noqa: E501
+                assert filtered_ids == expected_ids
 
 
 def test_delete_last_event(database):


### PR DESCRIPTION
Fix #7362 

Also add an exception `InvalidFilter` for invalid filter combinations. We may handle it in some places in the future, but unless I misunderstand completely it's not possible at the moment as the two places it's used is:

1. Customized Events filter when filtering History Events
2. Per account filter when filtering EVM Transactions

so atm there is no possibility of overlap