### PR TITLE
Remove contract check in opensea api calls

### DIFF
--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -279,8 +279,6 @@ class Opensea(ExternalServiceWithApiKey):
         for entry in raw_result:
             options = {'collection_slug': entry['collection']}
             collection = self._query(endpoint='collection', options=options)
-            if len(collection['contracts']) == 0:
-                continue  # skip if no contract (opensea makes everything a collection of 1)
             slug = collection['collection']
             if slug in self.collections:
                 continue  # do not requery already queried collection


### PR DESCRIPTION
This check was avoiding some NFTs from being rendered because the collections weren't queried. I've checked with the v2 endpoint and I didn't find issues with this logic.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
