### PR TITLE
Fix fee in kraken instant swaps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Fix an issue where kraken instant swaps could have an invalid type for fee events.
+
 * :release:`1.31.3 <2023-12-31>`
 * :bug:`-` The history events section will have correct pagination for free users, with all the events showing correct sub-events.
 * :bug:`7359` NFTs should be queried and displayed properly again.

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -2,7 +2,7 @@ from typing import Final
 
 from rotkehlchen.fval import FVal
 
-CURRENCYCONVERTER_API_KEY = 'a5a6494d168cb0bb93b3'
+CURRENCYCONVERTER_API_KEY = '4fc7223487de9ed243f6'
 
 ZERO = FVal(0)
 ONE = FVal(1)

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1189,7 +1189,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
                             usd_value=ZERO,
                         ),
                         notes=notes,
-                        event_type=event_type,
+                        event_type=event_type if event_type != HistoryEventType.RECEIVE else HistoryEventType.SPEND,  # in instant swaps @tewshi found that fees can also be in the receive part  # noqa: E501
                         event_subtype=HistoryEventSubType.FEE,
                     )))
                     # Increase the fee index to not have duplicates in the case of having a normal


### PR DESCRIPTION
It was found that the instant swaps can have the fee in the receive part and this was not properly handled in the logic.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
