### PR TITLE
Fixes wal issues

### DIFF
--- a/rotkehlchen/db/search_assets.py
+++ b/rotkehlchen/db/search_assets.py
@@ -55,7 +55,7 @@ def _search_only_assets_levenstein(
     globaldb.conn.execute('PRAGMA wal_checkpoint;')  # needed to have up to date information when attaching  # noqa: E501
     with db.conn.critical_section():  # needed due to ATTACH. Must not context switch out of this
         cursor.execute(
-            f'ATTACH DATABASE "file:{globaldb.filepath()!s}?more=ro" AS globaldb KEY "";',
+            f'ATTACH DATABASE "{globaldb.filepath()!s}" AS globaldb KEY "";',
         )
         try:
             query, bindings = filter_query.prepare('assets')

--- a/rotkehlchen/db/search_assets.py
+++ b/rotkehlchen/db/search_assets.py
@@ -55,7 +55,7 @@ def _search_only_assets_levenstein(
     globaldb.conn.execute('PRAGMA wal_checkpoint;')  # needed to have up to date information when attaching  # noqa: E501
     with db.conn.critical_section():  # needed due to ATTACH. Must not context switch out of this
         cursor.execute(
-            f'ATTACH DATABASE "{globaldb.filepath()!s}" AS globaldb KEY "";',
+            f'ATTACH DATABASE "file:{globaldb.filepath()!s}?more=ro" AS globaldb KEY "";',
         )
         try:
             query, bindings = filter_query.prepare('assets')

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -370,7 +370,7 @@ class GlobalDBHandler:
             globaldb = GlobalDBHandler()
             globaldb.conn.execute('PRAGMA wal_checkpoint;')  # needed to have up to date information when attaching  # noqa: E501
             cursor.execute(
-                f'ATTACH DATABASE "{globaldb.filepath()!s}" AS globaldb KEY "";',
+                f'ATTACH DATABASE "file:{globaldb.filepath()!s}?more=ro" AS globaldb KEY "";',
             )
             try:
                 # get all underlying tokens
@@ -481,7 +481,7 @@ class GlobalDBHandler:
         with db.conn.read_ctx() as cursor:
             treat_eth2_as_eth = db.get_settings(cursor).treat_eth2_as_eth
             cursor.execute(
-                f'ATTACH DATABASE "{globaldb.filepath()!s}" AS globaldb KEY "";',
+                f'ATTACH DATABASE "file:{globaldb.filepath()!s}?more=ro" AS globaldb KEY "";',
             )
             try:
                 cursor.execute(query, bindings)

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb.py
@@ -1302,3 +1302,16 @@ def test_assets_in_same_collection(globaldb: GlobalDBHandler):
 
     # check an asset with no related assets
     assert globaldb.get_assets_in_same_collection(identifier=A_ETH.identifier) == (A_ETH,)
+
+
+def test_check_wal_mode_of_package_db(globaldb: GlobalDBHandler) -> None:
+    """
+    If the packaged db is modified and the wal mode is activated users can have issues
+    when the database is in a read only device. To avoid such issues we need to ensure
+    that no new files are created and this is why we prevent from shipping the database
+    in WAL mode.
+    """
+    with globaldb.packaged_db_conn().cursor() as cursor:
+        journal_mode = cursor.execute('PRAGMA journal_mode').fetchone()[0]
+
+    assert journal_mode == 'delete'


### PR DESCRIPTION
We were getting autogenerated whl files in the packaged globaldb folder when running the dev app and errors when querying all the assets if several queries were attempted.

What I did was:

- The query won't fail if the database is lock. We were commiting the wal file since when we attach a database the attached database won't see everything unless it is commited. It happens that if we spawn several times the query very fast two queries lock the database
- To avoid creating the whl in the packaged db I changed the mode to remove the WAL mode in the packaged db ~one and I always attach it in read only mode what avoids changing the mode~ Edit: I was wrongly thinking that the packaged db was the one getting attached but it was the user db to the user globaldb. 

The diff of the database is empty since what I changed is the wal mode

```
PRAGMA journal_mode=DELETE
```


```
(rotki-main) ➜  rotki git:(fixes-wal) ✗ sqldiff ~/Downloads/global-wal.db rotkehlchen/data/global.db    
(rotki-main) ➜  rotki git:(fixes-wal) ✗ 
```