### PR TITLE
Forbid merging same asset to itself

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Changelog
 * :bug:`7276` Fix the issue where Uniswap v3 positions are counted twice for the net worth.
 * :bug:`7147` rotki should no longer query price multiple times for the same asset across different chains.
 * :feature:`7399` Transactions involving the Savings xDAI contract at gnosis will now be properly decoded.
+* :bug:`-` It should no longer be possible to merge the same asset to itself, thus botching the asset in your database.
 
 * :release:`1.31.3 <2023-12-31>`
 * :bug:`-` The history events section will have correct pagination for free users, with all the events showing correct sub-events.

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2180,7 +2180,13 @@ class AssetsReplaceSchema(Schema):
     ) -> None:
         if data['source_identifier'].startswith(EVM_CHAIN_DIRECTIVE):
             raise ValidationError(
-                message="Can't merge two evm tokens",
+                message="Can't replace an evm token",
+                field_name='source_identifier',
+            )
+
+        if data['source_identifier'] == data['target_asset'].identifier:
+            raise ValidationError(
+                message="Can't merge the same asset to itself",
                 field_name='source_identifier',
             )
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2622,7 +2622,12 @@ class DBHandler:
 
     def replace_asset_identifier(self, source_identifier: str, target_asset: Asset) -> None:
         """Replaces a given source identifier either both in the global or the local
-        user DB with another given asset.
+        user DB with another given asset. There is some limitations/checks for the
+        source and target. This is not checked here but at the api level. The limitations are:
+        - source and target should not both be EVM assets
+        - source and target should not be the same
+
+        DO NOT call this without these checks as it will put the DBs in an inconsistent state.
 
         May raise:
         - UnknownAsset if the source_identifier can be found nowhere


### PR DESCRIPTION
Before this commit you could replace/merge an asset by itself, which killed the DB logic and effectively deleted the asset from your global DB and some parts of user DB.

Result was a botched DB which needed manual intervention. This should no longer be allowed by the API.
