### PR TITLE
Common filtering across the eth staking endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8357,7 +8357,7 @@ Getting eth2 staking performance
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "validator_indices": [0, 15, 23542], "only_cache": false, "limit": 10, "offset": 10}
+      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "validator_indices": [0, 15, 23542], "only_cache": false, "status": "all", "limit": 10, "offset": 10}
 
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
    :reqjson bool only_cache: If false then we skip any cached values
@@ -8445,7 +8445,7 @@ Getting Eth2 Staking daily stats
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
-      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "validator_indices": [0, 15, 23542], "addresses": ["0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12"],  "only_cache": false}
+      {"from_timestamp": 1451606400, "to_timestamp": 1571663098, "validator_indices": [0, 15, 23542], "addresses": ["0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12"],  "status": "all", "only_cache": false}
 
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
    :reqjson bool only_cache: If true then only the daily stats in the DB are queried.
@@ -8457,6 +8457,7 @@ Getting Eth2 Staking daily stats
    :reqjson int to_timestamp: The timestamp until which to query. Can be missing in which case we query until now.
    :reqjson list(string)[optional] validator_indices: Optionally filter entries validator indices. If missing data for all validators are returned.
    :reqjson list(string)[optional] addresses: The associated addresses for which to filter the results. These will associate with a validator if the address is a depositor, a withdrawal address or a fee recipient.
+   :reqjson string[optional] status: The status by which to filter. By default and if missing it's ``"all"`` validators. Can also fiter by ``"active"`` or ``"exited"``.
 
    **Example Response**:
 
@@ -8641,7 +8642,10 @@ Getting tracked Eth2 validators
       {"ignore_cache": true, "async_query": true}
 
    :reqjson bool async_query: Boolean denoting whether this is an asynchronous query or not
-   :param bool ignore_cache: Boolean denoting whether to ignore the DB cache and refresh all validator data.
+   :reqjson bool ignore_cache: Boolean denoting whether to ignore the DB cache and refresh all validator data.
+   :reqjson list(string)[optional] validator_indices: Optionally filter entries validator indices. If missing data for all validators are returned.
+   :reqjson list(string)[optional] addresses: The associated addresses for which to filter the results. These will associate with a validator if the address is a depositor, a withdrawal address or a fee recipient.
+   :reqjson string[optional] status: The status by which to filter. By default and if missing it's ``"all"`` validators. Can also fiter by ``"active"`` or ``"exited"``.
 
 
    **Example Response**:

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2167,9 +2167,16 @@ class RestAPI:
         return {'result': result, 'message': '', 'status_code': HTTPStatus.OK}
 
     @async_api_call()
-    def get_eth2_validators(self, ignore_cache: bool) -> dict[str, Any]:
+    def get_eth2_validators(
+            self,
+            ignore_cache: bool,
+            validator_indices: set[int] | None,
+    ) -> dict[str, Any]:
         try:
-            validators = self.rotkehlchen.chains_aggregator.get_eth2_validators(ignore_cache=ignore_cache)  # noqa: E501
+            validators = self.rotkehlchen.chains_aggregator.get_eth2_validators(
+                ignore_cache=ignore_cache,
+                validator_indices=validator_indices,
+            )
         except ModuleInactive as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.CONFLICT}
         except RemoteError as e:

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1251,7 +1251,11 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
 
         return stats
 
-    def get_eth2_validators(self, ignore_cache: bool) -> list['ValidatorDetailsWithStatus']:
+    def get_eth2_validators(
+            self,
+            ignore_cache: bool,
+            validator_indices: set[int] | None,
+    ) -> list['ValidatorDetailsWithStatus']:
         """May raise:
         - ModuleInactive if eth2 module is not activated
         """
@@ -1259,7 +1263,11 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         if eth2 is None:
             raise ModuleInactive('Cant get eth2 validators since the eth2 module is not active')
 
-        return eth2.get_validators(ignore_cache=ignore_cache, addresses=self.queried_addresses_for_module('eth2'))  # noqa: E501
+        return eth2.get_validators(
+            ignore_cache=ignore_cache,
+            addresses=self.queried_addresses_for_module('eth2'),
+            validator_indices=validator_indices,
+        )
 
     def edit_eth2_validator(self, validator_index: int, ownership_proportion: FVal) -> None:
         """Edit a validator to modify its ownership proportion. May raise:

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -481,16 +481,19 @@ class Eth2(EthereumModule):
             self,
             ignore_cache: bool,
             addresses: Sequence[ChecksumEvmAddress],
+            validator_indices: set[int] | None,
     ) -> list[ValidatorDetailsWithStatus]:
         """Go through the list of eth1 addresses and find all eth2 validators associated
         with them along with their details.
+
+        Also optionally filter returned data by a set of validator_indices
 
         May raise RemoteError due to beaconcha.in or beacon node connection"""
         if ignore_cache:
             self.detect_and_refresh_validators(addresses)
 
         with self.database.conn.read_ctx() as cursor:
-            return DBEth2(self.database).get_validators_with_status(cursor)
+            return DBEth2(self.database).get_validators_with_status(cursor, validator_indices)
 
     def add_validator(
             self,

--- a/rotkehlchen/chain/ethereum/modules/eth2/structures.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/structures.py
@@ -239,6 +239,13 @@ class ValidatorDetailsWithStatus(ValidatorDetails):
 
 
 class PerformanceStatusFilter(StrEnum):
+    """A smaller subset of validator statuses used by the frontend filtering
+
+    Pending does not make sense for the places this is called as validators have no performance
+    or daily stats. And since this is where we filter for now we use this also
+    for the validators endpoint for consistency. If we want to filter by all statuses
+    we can do it in the future.
+    """
     ALL = auto()
     ACTIVE = auto()
     EXITED = auto()

--- a/rotkehlchen/chain/ethereum/modules/eth2/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/utils.py
@@ -108,6 +108,9 @@ def scrape_validator_daily_stats(
     May raise:
     - RemoteError if we can't query beaconcha.in or if the data is not in the expected format
     """
+    if exit_ts is not None and last_known_timestamp > exit_ts:
+        return []  # nothing new to add
+
     url = f'{BEACONCHAIN_ROOT_URL}/validator/{validator_index}/stats'
     response = _query_page(url, 'stats')
     log.debug(f'Got beaconcha.in stats results for {validator_index=}. Processing it.')
@@ -136,7 +139,7 @@ def scrape_validator_daily_stats(
                 except ValueError as e:
                     raise RemoteError(f'Failed to parse {date} to timestamp') from e
 
-                if timestamp <= last_known_timestamp or (exit_ts is not None and timestamp > exit_ts):  # noqa: E501
+                if timestamp <= last_known_timestamp:
                     return stats  # we are done
 
                 column_pos += 1

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -158,7 +158,11 @@ class DBEth2:
         )
         return [ValidatorDetails.deserialize_from_db(x) for x in cursor]
 
-    def get_validators_with_status(self, cursor: 'DBCursor') -> list[ValidatorDetailsWithStatus]:
+    def get_validators_with_status(
+            self,
+            cursor: 'DBCursor',
+            validator_indices: set[int] | None,
+    ) -> list[ValidatorDetailsWithStatus]:
         result: list[ValidatorDetailsWithStatus] = []
         exited_indices = self.get_exited_validator_indices(cursor)
         cursor.execute(
@@ -169,6 +173,9 @@ class DBEth2:
             validator = ValidatorDetailsWithStatus.deserialize_from_db(entry)
             validator.determine_status(exited_indices)
             result.append(validator)
+
+        if validator_indices is not None:
+            result = [x for x in result if x.validator_index is not None and x.validator_index in validator_indices]  # noqa: E501
 
         return result
 

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -525,13 +525,13 @@ class DBIgnoreValuesFilter(DBFilter):
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
 class DBEth2ValidatorIndicesFilter(DBFilter):
     """A filter for Eth2 validator indices"""
-    validators: list[int] | None
+    validators: set[int] | None
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         if self.validators is None:
             return [], []
         questionmarks = '?' * len(self.validators)
-        return [f'validator_index IN ({",".join(questionmarks)})'], self.validators
+        return [f'validator_index IN ({",".join(questionmarks)})'], list(self.validators)
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
@@ -770,7 +770,7 @@ class Eth2DailyStatsFilterQuery(DBFilterQuery, FilterWithTimestamp):
             offset: int | None = None,
             from_ts: Timestamp | None = None,
             to_ts: Timestamp | None = None,
-            validator_indices: list[int] | None = None,
+            validator_indices: set[int] | None = None,
     ) -> 'Eth2DailyStatsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('timestamp', True)]

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -551,11 +551,15 @@ def test_ownership_proportion(eth2: 'Eth2', database):
     with database.user_write() as write_cursor:
         dbeth2.add_or_update_validators(write_cursor, validators)
 
-    result = eth2.get_validators(ignore_cache=True, addresses=[ADDR1, ADDR2])
+    result = eth2.get_validators(ignore_cache=True, addresses=[ADDR1, ADDR2], validator_indices=None)  # noqa: E501
     assert result[0].validator_index == 9 and result[0].ownership_proportion == FVal(0.5), 'Proportion from the DB should be used'  # noqa: E501
     assert result[1].validator_index == 997 and result[1].ownership_proportion == ONE, 'Since this validator is new, the proportion should be ONE'  # noqa: E501
     assert result[2].validator_index == 1647 and result[2].ownership_proportion == FVal(0.7), 'Proportion from the DB should be used'  # noqa: E501
     assert result[3].validator_index == 1757 and result[3].ownership_proportion == FVal(0.9), 'Proportion from the DB should be used'  # noqa: E501
+
+    # also test filtering by index
+    result = eth2.get_validators(ignore_cache=True, addresses=[], validator_indices={9, 1757})
+    assert [x.validator_index for x in result] == [9, 1757]
 
 
 def test_deposits_pubkey_re(eth2: 'Eth2', database):


### PR DESCRIPTION
Now all eth staking endpoints accept a list of associated addresses, specific validator indices and a validator status filter.

Also fix a bug where if a validator had exited daily stats would not be pulled for it at all.

