### PR TITLE
fix: location selector selection bug

### DIFF
--- a/frontend/app/src/components/helper/LocationSelector.vue
+++ b/frontend/app/src/components/helper/LocationSelector.vue
@@ -57,21 +57,20 @@ const locations = computed<TradeLocationData[]>(() => {
       $listeners
     "
   >
-    <template #item="{ item, attrs, on }">
+    <template #item="{ item, attrs }">
       <LocationIcon
         :id="`balance-location__${item.identifier}`"
         v-bind="attrs"
         horizontal
         :item="item.identifier"
-        v-on="on"
       />
     </template>
-    <template #selection="{ item, attrs, on }">
+    <template #selection="{ item, attrs }">
       <LocationIcon
+        class="pr-2"
         v-bind="attrs"
         horizontal
         :item="item.identifier"
-        v-on="on"
       />
     </template>
   </VAutocomplete>


### PR DESCRIPTION
Fix issue in the location selector where typing something as a location (e.g. "blockchain"), and then click it, it set the vallue as "external".

https://discord.com/channels/657906918408585217/1080778280807956490/1205687247199014942