### PR TITLE
Fix airdrops queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Changelog
 * :feature:`1574` Interactions with the ygov.finance contract are now decoded.
 * :bug:`7276` Fix the issue where Uniswap v3 positions are counted twice for the net worth.
 * :bug:`7147` rotki should no longer query price multiple times for the same asset across different chains.
+* :bug:`-`  Whether an airdrop has been claimed or not will be properly detected again for the supported airdrops.
 * :feature:`7399` Transactions involving the Savings xDAI contract at gnosis will now be properly decoded.
 * :bug:`-` It should no longer be possible to merge the same asset to itself, thus botching the asset in your database.
 * :feature:`-` Transactions burning vested vCOW to claim COW tokens will now be properly decoded for both gnosis chain and ethereum mainnet.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -99,6 +99,7 @@ from rotkehlchen.constants.limits import (
     FREE_USER_NOTES_LIMIT,
 )
 from rotkehlchen.constants.misc import (
+    AIRDROPS_TOLERANCE,
     AVATARIMAGESDIR_NAME,
     DEFAULT_MAX_LOG_BACKUP_FILES,
     DEFAULT_MAX_LOG_SIZE_IN_MB,
@@ -2264,7 +2265,7 @@ class RestAPI:
             data = check_airdrops(
                 addresses=self.rotkehlchen.chains_aggregator.accounts.eth,
                 database=self.rotkehlchen.data.db,
-                tolerance_for_amount_check=FVal('0.00000000000001000'),
+                tolerance_for_amount_check=AIRDROPS_TOLERANCE,
             )
         except RemoteError as e:
             return wrap_in_fail_result(str(e), status_code=HTTPStatus.BAD_GATEWAY)

--- a/rotkehlchen/chain/ethereum/modules/ens/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/constants.py
@@ -1,1 +1,6 @@
-CPT_ENS = 'ens'
+from typing import Final
+from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
+
+
+CPT_ENS: Final = 'ens'
+ENS_CPT_DETAILS: Final = CounterpartyDetails(identifier=CPT_ENS, label='ens', image='ens.svg')

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -32,7 +32,7 @@ from rotkehlchen.types import CacheType, ChecksumEvmAddress, EvmTokenKind
 from rotkehlchen.utils.misc import from_wei, hex_or_bytes_to_address
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
-from .constants import CPT_ENS
+from .constants import CPT_ENS, ENS_CPT_DETAILS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -440,4 +440,4 @@ class EnsDecoder(GovernableDecoderInterface, CustomizableDateMixin):
 
     @staticmethod
     def counterparties() -> tuple[CounterpartyDetails, ...]:
-        return (CounterpartyDetails(identifier=CPT_ENS, label='ens', image='ens.svg'),)
+        return (ENS_CPT_DETAILS,)

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -4,9 +4,13 @@ from rotkehlchen.fval import FVal
 
 CURRENCYCONVERTER_API_KEY = 'a5a6494d168cb0bb93b3'
 
-ZERO = FVal(0)
-ONE = FVal(1)
-EXP18 = FVal(1e18)
+ZERO: Final = FVal(0)
+ONE: Final = FVal(1)
+EXP18: Final = FVal(1e18)
+# Tolerance used when querying claims in the database since we need to cast
+# to float and we can loose precision in SQL. With lower tolerance the ens
+# airdrop fails to get detected.
+AIRDROPS_TOLERANCE: Final = FVal(10e-13)
 
 # Could also try to extend HTTPStatus but looks complicated
 # https://stackoverflow.com/questions/45028991/best-way-to-extend-httpstatus-with-custom-value

--- a/rotkehlchen/tests/unit/decoders/test_shapeshift.py
+++ b/rotkehlchen/tests/unit/decoders/test_shapeshift.py
@@ -1,0 +1,41 @@
+import pytest
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.chain.ethereum.modules.airdrops.constants import CPT_SHAPESHIFT
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_FOX
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
+from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+
+
+@pytest.mark.vcr()
+@pytest.mark.parametrize('ethereum_accounts', [['0x3800966F67ccBA1976F69D006374204fba56d240']])
+def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
+    tx_hex = deserialize_evm_tx_hash('0x6635d1e12fed1a95019a53e6f6495c586891bf7b41bccfc5838f9b1703a9c20c')  # noqa: E501
+    tx_hash = deserialize_evm_tx_hash(tx_hex)
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        database=database,
+        tx_hash=tx_hex,
+    )
+    timestamp = TimestampMS(1634470709000)
+    expected_events = [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=243,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.AIRDROP,
+            asset=A_FOX,
+            balance=Balance(amount=FVal('100')),
+            location_label=ethereum_accounts[0],
+            notes='Claim 100 FOX from shapeshift airdrop',
+            counterparty=CPT_SHAPESHIFT,
+            address=string_to_evm_address('0x2977F92D5BaddfB411beb642F97d125aA55C000A'),
+        ),
+    ]
+    assert events == expected_events


### PR DESCRIPTION
There were several problems:

- Wrong assets in the decoding logic
- Query didn't use () and things got mixed with AND and OR
- FOX airdrop seems to have several token distributors. I got them all from the deployer
