### PR TITLE
Fix (API): Case-insensitive validation

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2184,7 +2184,7 @@ class AssetsReplaceSchema(Schema):
                 field_name='source_identifier',
             )
 
-        if data['source_identifier'] == data['target_asset'].identifier:
+        if data['source_identifier'].lower() == data['target_asset'].identifier.lower():
             raise ValidationError(
                 message="Can't merge the same asset to itself",
                 field_name='source_identifier',

--- a/rotkehlchen/tests/api/test_user_assets.py
+++ b/rotkehlchen/tests/api/test_user_assets.py
@@ -677,6 +677,15 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
     )
     assert_simple_ok_response(response)
 
+    response = requests.put(
+        api_url_for(
+            rotkehlchen_api_server,
+            'assetsreplaceresource',
+        ),
+        json={'source_identifier': 'etc', 'target_asset': 'ETC'},
+    )
+    assert_error_response(response)  # same identifier with different casing, not allowed
+
     # after the replacement. Check that the manual balance is changed
     if not only_in_globaldb:
         response = requests.get(


### PR DESCRIPTION
## Checklist

- [x] Check asset identifier without case-sensitivity in `AssetsReplaceSchema`
- [x] Test the logic