### PR TITLE
Fix (Airdrops): Optional icon_url

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8802,7 +8802,8 @@ Querying ethereum airdrops
                      "amount": "400",
                      "asset": "eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
                      "link": "https://app.uniswap.org/",
-                     "claimed": true
+                     "claimed": true,
+                     "icon_url": "https://raw.githubusercontent.com/rotki/data/main/airdrops/icons/uniswap.svg"
                   }
             },
             "message": ""
@@ -12799,7 +12800,8 @@ Getting Metadata For Airdrops
             {
                "identifier": "uniswap",
                "name": "Uniswap",
-               "icon": "uniswap.svg"
+               "icon": "uniswap.svg",
+               "icon_url": "https://raw.githubusercontent.com/rotki/data/main/airdrops/icons/uniswap.svg"
             },
             {
                "identifier": "1inch",

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4392,6 +4392,8 @@ class RestAPI:
                     'name': airdrop.name,
                     'icon': airdrop.icon,
                 })
+                if airdrop.icon_url is not None:
+                    result[-1]['icon_url'] = airdrop.icon_url
         except RemoteError as e:
             return api_response(wrap_in_fail_result(str(e)), status_code=HTTPStatus.BAD_GATEWAY)
         return api_response(result=_wrap_in_ok_result(result=result))

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -54,6 +54,7 @@ class Airdrop(NamedTuple):
     url: str
     name: str
     icon: str
+    icon_url: str | None = None
     cutoff_time: Timestamp | None = None
 
 
@@ -114,10 +115,13 @@ def _parse_airdrops(database: 'DBHandler', airdrops_data: dict[str, Any]) -> dic
 
             airdrops[protocol_name] = Airdrop(
                 asset=crypto_asset,
+                # combining the base data repo url for main/develop with the path to the CSV in that repo  # noqa: E501
                 csv_path=f"{AIRDROPS_REPO_BASE}/{airdrop_data['csv_path']}",
                 url=airdrop_data['url'],
                 name=airdrop_data['name'],
                 icon=airdrop_data['icon'],
+                # combining the base data repo url for main/develop with the path to the icon in that repo  # noqa: E501
+                icon_url=f"{AIRDROPS_REPO_BASE}/{airdrop_data['icon_path']}" if 'icon_path' in airdrop_data else None,  # noqa: E501
                 cutoff_time=airdrop_data.get('cutoff_time'),
             )
         except KeyError as e:
@@ -304,9 +308,11 @@ def check_airdrops(
                 found_data[addr][protocol_name] = {  # type: ignore
                     'amount': str(amount),
                     'asset': airdrop_data.asset,
-                    'link': airdrop_data[2],
+                    'link': airdrop_data.url,
                     'claimed': False,
                 }
+                if airdrop_data.icon_url is not None:
+                    found_data[addr][protocol_name]['icon_url'] = airdrop_data.icon_url  # type: ignore
                 airdrop_tuples.append(
                     AirdropClaimEventQueryParams(
                         event_type=claim_event_type,

--- a/rotkehlchen/tests/api/test_metadata.py
+++ b/rotkehlchen/tests/api/test_metadata.py
@@ -22,7 +22,7 @@ def test_metadata_endpoint(rotkehlchen_api_server: 'APIServer') -> None:
             'identifier': identifier,
             'name': airdrop.name,
             'icon': airdrop.icon,
-        }
+        } | ({'icon_url': airdrop.icon_url} if airdrop.icon_url is not None else {})
         for identifier, airdrop in fetch_airdrops_metadata(
             database=rotkehlchen_api_server.rest_api.rotkehlchen.data.db,
         )[0].items()

--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -55,6 +55,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
         'url': 'https://claim.harvest.finance/',
         'name': 'Grain',
         'icon': 'grain.png',
+        'icon_path': 'airdrops/icons/grain.svg',
     },
     'shapeshift': {
         'csv_path': 'airdrops/shapeshift.csv',
@@ -239,6 +240,7 @@ def test_check_airdrops(freezer, ethereum_accounts, database, new_asset_data):
         'asset': A_GRAIN,
         'link': 'https://claim.harvest.finance/',
         'claimed': False,
+        'icon_url': f'{AIRDROPS_REPO_BASE}/airdrops/icons/grain.svg',
     }
     assert data[TEST_ADDR2]['shutter'] == {
         'amount': '394857.029384576349787465',


### PR DESCRIPTION
## Checklist

- [x] Add optional field in response `icon_url`

**What problem does the PR solve?**
The problem is for the assets whose icons are not already present in the repo. If we add a new airdrop remotely for these assets, the frontend will have no way to show their icons.

**What was the approach taken?**
Now we can pass an optional `icon_path` (to their location in the data repo) in the metadata JSON for these new assets. When the backend receives them, it will convert them to full URLs and return them via the API. So, frontend will receive these new assets' icons' URLs which can be directly rendered from GitHub.

**What the frontend needs to do?**
When parsing the response from [GET /api/(version)/blockchains/eth/airdrops](https://rotki.readthedocs.io/en/latest/api.html#get--api-(version)-blockchains-eth-airdrops) or [GET /api/(version)/airdrops/metadata](https://rotki.readthedocs.io/en/latest/api.html#get--api-(version)-airdrops-metadata), also check if `icon_url` field is present in the response. If it is present use that URL instead of trying to use a packaged icon