### PR TITLE
Monerium API only for premium

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -480,6 +480,8 @@ Getting or modifying external services API credentials
    for external services such as etherscan, cryptocompare e.t.c.
    If a credential already exists for a service it is overwritten.
 
+   Some credentials like monerium can't be input if the user is not premium.
+
    Returns external service entries after the additions.
 
    **Example Request**:
@@ -497,8 +499,8 @@ Getting or modifying external services API credentials
    :reqjson list services: The services parameter is a list of services along with their api keys.
    :reqjsonarr string name: Each entry in the list should have a name for the service. Valid ones are ``"etherscan"``, ``"cryptocompare"``, ``"beaconchain"``, ``"loopring"``, ``"opensea"``, ``blockscout``, ``monerium``.
    :reqjsonarr string[optional] api_key: Each entry in the list should have an api_key entry except for monerium.
-   :reqjsonarr string[optional] username: The monerium entry should have a username key
-   :reqjsonarr string[optional] password: The monerium entry should have a password key
+   :reqjsonarr string[optional] username: The monerium entry should have a username key. For monerium the user should have premium.
+   :reqjsonarr string[optional] password: The monerium entry should have a password key. For monerium the user should have premium.
 
    **Example Response**:
 
@@ -519,6 +521,7 @@ Getting or modifying external services API credentials
    :statuscode 200: Saving new external service credentials was successful
    :statuscode 400: Provided JSON is in some way malformed, of invalid value provided.
    :statuscode 401: There is no logged in user
+   :statuscode 403: Logged in user does not have premium and requested to add credentials that can only work for premium.
    :statuscode 500: Internal rotki error
 
 .. http:delete:: /api/(version)/external_services

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,6 @@ pytest-socket==0.6.0
 pytest-vcr==1.0.2
 vcrpy==5.1.0
 freezegun==1.4.0
-flaky==3.7.0
 
 
 # To test google spreadsheet uploading

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -592,6 +592,13 @@ class RestAPI:
         return self._return_external_services_response()
 
     def add_external_services(self, services: list[ExternalServiceApiCredentials]) -> Response:
+
+        if self.rotkehlchen.premium is None and ExternalService.MONERIUM in {x.service for x in services}:  # noqa: E501
+            return api_response(
+                wrap_in_fail_result('You can only use monerium with rotki premium'),
+                status_code=HTTPStatus.FORBIDDEN,
+            )
+
         self.rotkehlchen.data.db.add_external_service_credentials(services)
         return self._return_external_services_response()
 

--- a/rotkehlchen/externalapis/monerium.py
+++ b/rotkehlchen/externalapis/monerium.py
@@ -73,6 +73,9 @@ class Monerium:
         If some of those transactions have not yet been pulled do nothing. Since this
         processing has no pagination and all orders will be pulled again next time this runs.
 
+        This only runs for premium users. The check is on the caller which at
+        the moment of writing is the periodic task manager.
+
         May raise:
         - RemoteError if there is trouble contacting the api
         - KeyError if a key is missing

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -1397,8 +1397,8 @@ class GlobalDBHandler:
                 # Means foreign keys failure. Should not happen since is checked by marshmallow
                 raise InputError(f'Failed to add manual current price due to: {e!s}') from e
 
-            # invalidate the cached price for the assets using manual current as type and
-            # are connected to the asset used.
+            #  invalidate the cached price for the assets that are using manual current as type and
+            # and that are connected to the given asset
             write_cursor.execute(
                 'SELECT from_asset, to_asset FROM price_history WHERE source_type=? AND (from_asset=? OR to_asset=?)',  # noqa: E501
                 (HistoricalPriceOracle.MANUAL_CURRENT.serialize_for_db(), from_asset.identifier, from_asset.identifier),  # noqa: E501
@@ -1443,8 +1443,8 @@ class GlobalDBHandler:
     @staticmethod
     def delete_manual_latest_price(asset: Asset) -> set[Asset]:
         """
-        Deletes manual current price from globaldb and returns the set of assets
-        price pairs to be invalidated.
+        Deletes manual current price from globaldb and returns the set of assets to invalidate
+
         May raise:
         - InputError if asset was not found in the price_history table
         """

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -770,6 +770,9 @@ class TaskManager:
         )]
 
     def _maybe_query_monerium(self) -> Optional[list[gevent.Greenlet]]:
+        if self.chains_aggregator.premium is None:
+            return None  # should not run in free mode
+
         if should_run_periodic_task(self.database, DBCacheStatic.LAST_MONERIUM_QUERY_TS, HOUR_IN_SECONDS) is False:  # noqa: E501
             return None
 

--- a/rotkehlchen/tests/api/test_defi.py
+++ b/rotkehlchen/tests/api/test_defi.py
@@ -1,14 +1,12 @@
-import warnings as test_warnings
 
 import pytest
 import requests
-from flaky import flaky
 
 from rotkehlchen.tests.utils.aave import AAVE_TEST_ACC_1
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
 
 
-@flaky(max_runs=3, min_passes=1)  # failed in a flaky way sometimes in the CI due to etherscan
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[AAVE_TEST_ACC_1]])
 def test_query_defi_balances(rotkehlchen_api_server, ethereum_accounts):  # pylint: disable=unused-argument
     """Check querying the defi balances endpoint works. Uses real data.
@@ -22,14 +20,10 @@ def test_query_defi_balances(rotkehlchen_api_server, ethereum_accounts):  # pyli
     ))
     result = assert_proper_response_with_result(response)
 
-    # Since we can't really be sure of latest balance of a non-test account just check
-    # for correctness of result if there is any balance
-    if len(result[AAVE_TEST_ACC_1]) != 0:
-        first_entry = result[AAVE_TEST_ACC_1][0]
-        assert first_entry['protocol'] is not None
-        assert first_entry['protocol']['name'] is not None
-        assert first_entry['balance_type'] in {'Asset', 'Debt'}
-        assert first_entry['base_balance'] is not None
-        assert first_entry['underlying_balances'] is not None
-    else:
-        test_warnings.warn(UserWarning(f'Test account {AAVE_TEST_ACC_1} has no DeFi balances'))
+    # assert some defi balances were detected
+    first_entry = result[AAVE_TEST_ACC_1][0]
+    assert first_entry['protocol'] is not None
+    assert first_entry['protocol']['name'] is not None
+    assert first_entry['balance_type'] in {'Asset', 'Debt'}
+    assert first_entry['base_balance'] is not None
+    assert first_entry['underlying_balances'] is not None

--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -12,6 +12,7 @@ from rotkehlchen.tests.utils.api import (
 
 @pytest.mark.parametrize('include_etherscan_key', [False])
 @pytest.mark.parametrize('include_cryptocompare_key', [False])
+@pytest.mark.parametrize('start_with_valid_premium', [True])  # for monerium
 def test_add_get_external_service(rotkehlchen_api_server):
     """Tests that adding and retrieving external service credentials works"""
     # With no data an empty response should be returned
@@ -238,6 +239,19 @@ def test_add_external_services_errors(rotkehlchen_api_server):
         response=response,
         contained_in_msg='monerium needs a username and password"',
         status_code=HTTPStatus.BAD_REQUEST,
+    )
+
+    # monerium without premium
+    rotkehlchen_api_server.rest_api.rotkehlchen.premium = None
+    data = {'services': [{'name': 'monerium', 'username': 'Ben', 'password': 'secure'}]}
+    response = requests.put(
+        api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
+        json=data,
+    )
+    assert_error_response(
+        response=response,
+        contained_in_msg='You can only use monerium with rotki premium',
+        status_code=HTTPStatus.FORBIDDEN,
     )
 
 

--- a/rotkehlchen/tests/api/test_liquity.py
+++ b/rotkehlchen/tests/api/test_liquity.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import pytest
 import requests
-from flaky import flaky
 
 from rotkehlchen.api.server import APIServer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -30,7 +29,7 @@ JUSTIN = string_to_evm_address('0x3DdfA8eC3052539b6C9549F12cEA2C295cfF5296')
 LIQUITY_POOL_DEPOSITOR = string_to_evm_address('0xFBcAFB005695afa660836BaC42567cf6917911ac')
 
 
-@flaky(max_runs=3, min_passes=1)  # etherscan may occasionally time out
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[LQTY_ADDR]])
 @pytest.mark.parametrize('ethereum_modules', [['liquity']])
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
@@ -112,6 +111,7 @@ def test_trove_staking(rotkehlchen_api_server, inquirer):  # pylint: disable=unu
     }
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDR_WITHOUT_TROVE]])
 @pytest.mark.parametrize('ethereum_modules', [['liquity']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -132,6 +132,7 @@ def test_account_without_info(rotkehlchen_api_server, inquirer):  # pylint: disa
     assert ADDR_WITHOUT_TROVE not in result
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[LQTY_PROXY, ADDR_WITHOUT_TROVE, LQTY_ADDR]])
 @pytest.mark.parametrize('ethereum_modules', [['liquity']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 import requests
-from flaky import flaky
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.chain.ethereum.modules.makerdao.vaults import MakerdaoVault
@@ -256,7 +255,6 @@ def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@flaky(max_runs=3, min_passes=1)  # some makerdao vault tests take long time and may time out
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDRESS_1]])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -532,7 +530,6 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@flaky(max_runs=3, min_passes=1)  # some makerdao vault tests take long time and may time out
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDRESS_1]])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -627,7 +624,6 @@ def test_query_vaults_usdc(rotkehlchen_api_server, ethereum_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@flaky(max_runs=3, min_passes=1)  # some makerdao vault tests take long time and may time out
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDRESS_1]])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/external_apis/test_monerium.py
+++ b/rotkehlchen/tests/external_apis/test_monerium.py
@@ -31,6 +31,7 @@ def mock_monerium_and_run_periodic_task(task_manager, contents):
         return MockResponse(200, contents)
 
     timeout = 4
+    task_manager.chains_aggregator.premium = object()  # mock premium existence for monerium
     task_manager.potential_tasks = [task_manager._maybe_query_monerium]
     with gevent.Timeout(timeout), patch('requests.Session.get', side_effect=mock_monerium):
         try:


### PR DESCRIPTION
Backend work.

- Monerium credentials can only be given to rotki if user has an active premium
- The task to query the monerium API and decorate all related transactions with the banking information will now only run if the user has an active premium.

