### PR TITLE
Fix deletion of staking daily stats at validator refresh

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8671,7 +8671,7 @@ Getting tracked Eth2 validators
               "index":1532,
               "public_key":"0xa509dec619e5b3484bf4bc1c33baa4c2cdd5ac791876f4add6117f7eded966198ab77862ec2913bb226bdf855cc6d6ed",
               "ownership_percentage": "50",
-	      "activation_ts": 1701971000,
+	      "activation_timestamp": 1701971000,
 	      "status": "active"
             },
             {
@@ -8679,8 +8679,8 @@ Getting tracked Eth2 validators
               "public_key":"0xa64722f93f37c7da8da67ee36fd2a763103897efc274e3accb4cd172382f7a170f064b81552ae77cdbe440208a1b897e",
               "ownership_percentage": "25.75",
 	      "withdrawal_address": "0xfa13283f9e538a84d49139cd35c2fe0443caa34f",
-	      "activation_ts": 1701972000,
-	      "withdrawable_ts": 1702572000,
+	      "activation_timestamp": 1701972000,
+	      "withdrawable_timestamp": 1702572000,
 	      "status": "exited"
             }
           ],
@@ -8696,8 +8696,8 @@ Getting tracked Eth2 validators
    :resjson string status: The status of the validator. Can be one of ``"pending"``, ``"active"``, ``"exiting"`` and ``"exited"``.
    :resjson string[optional] ownership_percentage: The ownership percentage of the validator. If missing assume 100%.
    :resjson string[optional] withdrawal_address: The withdrawal address for the validator if set.
-   :resjson integer[optional] activation_ts: If existing this is the timestamp the validator will (or has been) activate/d. If not then this is a pending validator not yet fully deposited or not yet processed by the consensus layer.
-   :resjson integer[optional] withdrawable_ts: If existing this is the timestamp the validator will (or has been) able to be completely withdrawn. In other words from which point on a full exit will happen next time it's skimmed by withdrawals. If this key exists this mean we are dealing with a validator that is exiting or has exited.
+   :resjson integer[optional] activation_timestamp: If existing this is the timestamp the validator will (or has been) activate/d. If not then this is a pending validator not yet fully deposited or not yet processed by the consensus layer.
+   :resjson integer[optional] withdrawable_timestamp: If existing this is the timestamp the validator will (or has been) able to be completely withdrawn. In other words from which point on a full exit will happen next time it's skimmed by withdrawals. If this key exists this mean we are dealing with a validator that is exiting or has exited.
 
    :statuscode 200: Eth2 validator defaults successfully returned.
    :statuscode 401: User is not logged in.

--- a/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
@@ -238,8 +238,8 @@ class BeaconInquirer:
                 validator_index=deserialize_int(entry[index_key]),
                 public_key=Eth2PubKey(deserialize_str(valuegetter(entry, 'pubkey'))),
                 withdrawal_address=withdrawal_address,
-                activation_ts=activation_ts,
-                withdrawable_ts=withdrawable_ts,
+                activation_timestamp=activation_ts,
+                withdrawable_timestamp=withdrawable_ts,
             ))
 
         return details

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -408,7 +408,10 @@ class Eth2(EthereumModule):
         # pull data for newly detected validators and save them in the DB
         details = self.beacon_inquirer.get_validator_data(indices_or_pubkeys=list(untracked_validator_indices))  # noqa: E501
         with self.database.user_write() as write_cursor:
-            DBEth2(self.database).add_or_update_validators_except_ownership(write_cursor, validators=details)  # noqa: E501
+            DBEth2(self.database).add_or_update_validators_except_ownership(
+                write_cursor,
+                validators=details,
+            )
             self.database.set_dynamic_cache(
                 write_cursor=write_cursor,
                 name=DBCacheDynamic.WITHDRAWALS_TS,
@@ -475,7 +478,10 @@ class Eth2(EthereumModule):
             indices_or_pubkeys=[x.index if x.index is not None else x.public_key for x in validators_to_refresh],  # noqa: E501
         )
         with self.database.user_write() as write_cursor:
-            DBEth2(self.database).add_or_update_validators_except_ownership(write_cursor, validators=details)  # noqa: E501
+            DBEth2(self.database).add_or_update_validators_except_ownership(
+                write_cursor,
+                validators=details,
+            )
 
     def get_validators(
             self,
@@ -613,7 +619,7 @@ class Eth2(EthereumModule):
 
         needed_validators: list[tuple[int, Timestamp]] = []
         for entry in validator_data:
-            if entry.withdrawable_ts is None:
+            if entry.withdrawable_timestamp is None:
                 continue
 
             # this is a slashed/exited validator
@@ -621,7 +627,7 @@ class Eth2(EthereumModule):
                 log.error(f'An exited validator does not contain an index: {entry}. Should never happen.')  # noqa: E501
                 continue
 
-            needed_validators.append((entry.validator_index, entry.withdrawable_ts))
+            needed_validators.append((entry.validator_index, entry.withdrawable_timestamp))
 
         if len(needed_validators) == 0:
             return
@@ -631,7 +637,7 @@ class Eth2(EthereumModule):
                 dbeth2.set_validator_exit(
                     write_cursor=write_cursor,
                     index=index,
-                    withdrawable_ts=withdrawable_ts,
+                    withdrawable_timestamp=withdrawable_ts,
                 )
 
     def refresh_activated_validators_deposits(self) -> None:

--- a/rotkehlchen/chain/ethereum/modules/eth2/structures.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/structures.py
@@ -166,8 +166,8 @@ class ValidatorDetails:
     validator_index: int | None  # can be None if no index has yet been created due to not yet being seen by the consensys layer  # noqa: E501
     public_key: Eth2PubKey
     withdrawal_address: ChecksumEvmAddress | None = None  # only set if user has 0x1 credentials
-    activation_ts: Timestamp | None = None  # activation timestamp. None if not activated yet.
-    withdrawable_ts: Timestamp | None = None  # the timestamp from which on a full withdrawal can happen. None if not exited and fully withdrawable yet  # noqa: E501
+    activation_timestamp: Timestamp | None = None  # activation timestamp. None if not activated yet.  # noqa: E501
+    withdrawable_timestamp: Timestamp | None = None  # the timestamp from which on a full withdrawal can happen. None if not exited and fully withdrawable yet  # noqa: E501
     ownership_proportion: FVal = ONE  # [0, 1] proportion of ownership user has on the validator
 
     def __hash__(self) -> int:
@@ -181,7 +181,7 @@ class ValidatorDetails:
         if self.ownership_proportion != ONE:
             data['ownership_percentage'] = self.ownership_proportion.to_percentage(precision=2, with_perc_sign=False)  # noqa: E501
 
-        for name in ('activation_ts', 'withdrawable_ts', 'withdrawal_address'):
+        for name in ('activation_timestamp', 'withdrawable_timestamp', 'withdrawal_address'):
             if (value := getattr(self, name)) is not None:
                 data[name] = value
 
@@ -195,8 +195,8 @@ class ValidatorDetails:
             self.public_key,
             str(self.ownership_proportion),
             self.withdrawal_address,
-            self.activation_ts,
-            self.withdrawable_ts,
+            self.activation_timestamp,
+            self.withdrawable_timestamp,
         )
 
     @classmethod
@@ -206,8 +206,8 @@ class ValidatorDetails:
             public_key=result[1],
             ownership_proportion=FVal(result[2]),
             withdrawal_address=result[3],
-            activation_ts=result[4],
-            withdrawable_ts=result[5],
+            activation_timestamp=result[4],
+            withdrawable_timestamp=result[5],
         )
 
 
@@ -230,9 +230,9 @@ class ValidatorDetailsWithStatus(ValidatorDetails):
     def determine_status(self, exited_indices: set[int]) -> None:
         if self.validator_index in exited_indices:
             self.status = ValidatorStatus.EXITED
-        elif self.withdrawable_ts is not None:
+        elif self.withdrawable_timestamp is not None:
             self.status = ValidatorStatus.EXITING
-        elif self.activation_ts is not None:
+        elif self.activation_timestamp is not None:
             self.status = ValidatorStatus.ACTIVE
         else:
             self.status = ValidatorStatus.PENDING

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -263,18 +263,18 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
     assert_proper_response_with_result(response)
 
     detected_validator = ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1684036055),
+        activation_timestamp=Timestamp(1684036055),
         validator_index=624729,
         public_key=Eth2PubKey('0x96e3fcfa954d8fe64c2d8cac932f962d4906ff47d62875bad0b4aa2be4337dfde803004691e1cad5bd3676bcbad54123'),
         withdrawal_address=ethereum_accounts[0],
         status=ValidatorStatus.ACTIVE,
     )
     exited_validator = ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1663864919),
+        activation_timestamp=Timestamp(1663864919),
         validator_index=432840,
         public_key=Eth2PubKey('0x8007ace91d9a996e045caab473d3887b4fb11637e1cc12f4f4dcb3fc0e3707df5e960e067a891270247186590282960f'),
         withdrawal_address=ethereum_accounts[1],
-        withdrawable_ts=Timestamp(1706386007),
+        withdrawable_timestamp=Timestamp(1706386007),
         status=ValidatorStatus.EXITING,  # since we don't have withdrawals information yet
     )
     total_validators, active_validators, exited_validators = 402, 259, 143
@@ -285,7 +285,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert result == {'entries': [x.serialize() for x in (exited_validator, detected_validator)], 'entries_found': 2, 'entries_limit': -1}  # noqa: E501
+    assert result == {'entries': [x.serialize() for x in (detected_validator, exited_validator)], 'entries_found': 2, 'entries_limit': -1}  # noqa: E501
 
     # Query withdrawals/block productions
     for query_type in ('block_productions', 'eth_withdrawals'):
@@ -305,8 +305,8 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert result['entries'][0]['index'] == exited_validator.validator_index
-    assert result['entries'][0]['status'] == 'exited'
+    assert result['entries'][1]['index'] == exited_validator.validator_index
+    assert result['entries'][1]['status'] == 'exited'
 
     # now let's go for performance
     response = requests.put(
@@ -487,11 +487,11 @@ def test_eth2_add_eth1_account(rotkehlchen_api_server):
         validator_pubkey = '0x800199f8f3af15a22c42ccd7185948870eceeba2d06199ea30e7e28eb976a69284e393ba2f401e8983d011534b303a57'  # noqa: E501
         assert len(result['entries']) == 1
         assert result['entries'][0] == {
-            'activation_ts': 1630893527,
+            'activation_timestamp': 1630893527,
             'index': 227858,
             'public_key': validator_pubkey,
             'status': 'exiting',
-            'withdrawable_ts': 1682749271,
+            'withdrawable_timestamp': 1682749271,
             'withdrawal_address': '0x62359ea4199fD696a81beA27676EBCC832422479',
         }
         response = requests.get(api_url_for(
@@ -553,27 +553,27 @@ def test_add_get_edit_delete_eth2_validators(rotkehlchen_api_server, start_with_
     assert result == {'entries': [], 'entries_limit': expected_limit, 'entries_found': 0}
 
     validators = [ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1606824023),
+        activation_timestamp=Timestamp(1606824023),
         validator_index=4235,
         public_key=Eth2PubKey('0xadd548bb2e6962c255ec5420e40e6e506dfc936592c700d56718ada7dcc52e4295644ff8f94f4ef898aa8a5ad81a5b84'),
-        withdrawable_ts=Timestamp(1703014103),
+        withdrawable_timestamp=Timestamp(1703014103),
         withdrawal_address=string_to_evm_address('0x865c05C13d422310d9421E4Da915B73E5289A6B1'),
         status=ValidatorStatus.EXITING,
     ), ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1606824023),
+        activation_timestamp=Timestamp(1606824023),
         validator_index=5235,
         public_key=Eth2PubKey('0x827e0f30c3d34e3ee58957dd7956b0f194d64cc404fca4a7313dc1b25ac1f28dcaddf59d05fbda798fa5b894c91b84fb'),
         withdrawal_address=string_to_evm_address('0x347A70cb4Ff0297102DC549B044c41bD61e22718'),
         status=ValidatorStatus.ACTIVE,
     ), ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1607118167),
+        activation_timestamp=Timestamp(1607118167),
         validator_index=23948,
         public_key=Eth2PubKey('0x8a569c702a5b51894a25b261960f6b792aa35f8f67d9e1d96a52b15857cf0ee4fa30670b9bfca40e9a9dba81057ba4c7'),
-        withdrawable_ts=Timestamp(1682832983),
+        withdrawable_timestamp=Timestamp(1682832983),
         withdrawal_address=string_to_evm_address('0xf604d331d9109253fF63A00EA93DE5c0264314eF'),
         status=ValidatorStatus.EXITING,
     ), ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1609038167),
+        activation_timestamp=Timestamp(1609038167),
         validator_index=43948,
         public_key=Eth2PubKey('0x922127b0722e0fca3ceeffe78a6d2f91f5b78edff42b65cce438f5430e67f389ff9f8f6a14a26ee6467051ddb1cc21eb'),
         withdrawal_address=string_to_evm_address('0xfA7F89a14d005F057107755cA18345728E2E3938'),
@@ -701,14 +701,14 @@ def test_add_get_edit_delete_eth2_validators(rotkehlchen_api_server, start_with_
 
     # Try to add validator with a custom ownership percentage
     custom_percentage_validators = [ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1606824023),
+        activation_timestamp=Timestamp(1606824023),
         validator_index=5235,
         public_key=Eth2PubKey('0x827e0f30c3d34e3ee58957dd7956b0f194d64cc404fca4a7313dc1b25ac1f28dcaddf59d05fbda798fa5b894c91b84fb'),
         withdrawal_address=string_to_evm_address('0x347A70cb4Ff0297102DC549B044c41bD61e22718'),
         ownership_proportion=FVal(0.4025),
         status=ValidatorStatus.ACTIVE,
     ), ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1609038167),
+        activation_timestamp=Timestamp(1609038167),
         validator_index=43948,
         public_key=Eth2PubKey('0x922127b0722e0fca3ceeffe78a6d2f91f5b78edff42b65cce438f5430e67f389ff9f8f6a14a26ee6467051ddb1cc21eb'),
         withdrawal_address=string_to_evm_address('0xfA7F89a14d005F057107755cA18345728E2E3938'),
@@ -903,13 +903,13 @@ def test_query_eth2_balances(rotkehlchen_api_server, query_all_balances):
     assert result == {'entries': [], 'entries_limit': -1, 'entries_found': 0}
 
     validators = [ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1606824023),
+        activation_timestamp=Timestamp(1606824023),
         validator_index=5234,
         public_key=Eth2PubKey('0xb0456681ca4dc1a1276a9cab5915af9f9210f0eb104b4bd60164f59243b6159c3f3dab0d712cbae1360c7eb07af6a276'),
         withdrawal_address=string_to_evm_address('0x5675801e9346eA8165e7Eb80dcCD01dCa65c0f3A'),
         status=ValidatorStatus.ACTIVE,
     ), ValidatorDetailsWithStatus(
-        activation_ts=Timestamp(1606824023),
+        activation_timestamp=Timestamp(1606824023),
         validator_index=5235,
         public_key=Eth2PubKey('0x827e0f30c3d34e3ee58957dd7956b0f194d64cc404fca4a7313dc1b25ac1f28dcaddf59d05fbda798fa5b894c91b84fb'),
         withdrawal_address=string_to_evm_address('0x347A70cb4Ff0297102DC549B044c41bD61e22718'),
@@ -1200,26 +1200,26 @@ def test_get_validators(rotkehlchen_api_server):
     _prepare_clean_validators(rotkehlchen_api_server)
     # Check they are returned fine
     validator1_data = {
-        'activation_ts': 1704906839,
+        'activation_timestamp': 1704906839,
         'index': CLEAN_HISTORY_VALIDATOR1,
         'public_key': '0xb324c5869db5a524f9c3e2f3b82a786e7baa6ea150dc8f5c86a5342e6a7a5b4719ee1749c2f79e9e49d18a00f006118b',  # noqa: E501
         'status': 'active',
         'withdrawal_address': CLEAN_HISTORY_WITHDRAWAL1,
     }
     validator2_data = {
-        'activation_ts': 1704906839,
+        'activation_timestamp': 1704906839,
         'index': CLEAN_HISTORY_VALIDATOR2,
         'public_key': '0x874df4549e48da22326e3f5c59a2e4e2096861236c8fd9314068f9e142812c216d440ed022371cdc5c3fcc2afac11693',  # noqa: E501
         'status': 'active',
         'withdrawal_address': CLEAN_HISTORY_WITHDRAWAL2,
     }
     validator3_data = {
-        'activation_ts': 1680814295,
+        'activation_timestamp': 1680814295,
         'index': CLEAN_HISTORY_VALIDATOR3,
         'public_key': '0xa5de79a98e323f28de94fec045407324bbcd19bfddfe84b1cbc64df0f7bc77886f13c5bb639b2441238d2cd9c2b501d5',  # noqa: E501
         'status': 'exited',
         'withdrawal_address': CLEAN_HISTORY_WITHDRAWAL3,
-        'withdrawable_ts': 1706912087,
+        'withdrawable_timestamp': 1706912087,
     }
     response = requests.get(
         api_url_for(


### PR DESCRIPTION
During the DB upgrade we were adding new fields to the eth2_validators table and making the validator index being a UNIQUE key instead of a primary key.

When detecting new data for validators the code was doing INSERT OR REPLACE which essentially replaced the entire row with a new one.

The problem here is that daily stats is tied to eth2 validators via foreign key connection to the validator index.

This replacing dropped all eth daily stats. We now do a more complicated query to detect if it's a new validator addition in which case we have to insert it or if it's an old one in which case we have to update some keys. Then we need to find which keys to update.

