### PR TITLE
UTC offset part of test_iso8601ts_to_timestamp was wrong

### DIFF
--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from json.decoder import JSONDecodeError
 from unittest.mock import patch
 
@@ -64,9 +64,7 @@ def test_iso8601ts_to_timestamp():
     timezone_ts_str = '1997-07-16T22:30'
     timezone_ts_at_utc = 869092200
     assert iso8601ts_to_timestamp(timezone_ts_str + 'Z') == timezone_ts_at_utc
-    utc_now = datetime.now(UTC)  # Get current time in UTC
-    local_now = utc_now.astimezone()  # Get current time in local timezone
-    utc_offset = local_now.utcoffset().total_seconds()  # Calculate the UTC offset in seconds
+    utc_offset = datetime.fromtimestamp(timezone_ts_at_utc).astimezone().utcoffset().total_seconds()  # noqa: E501
     assert iso8601ts_to_timestamp(timezone_ts_str) == timezone_ts_at_utc - utc_offset
     assert iso8601ts_to_timestamp('1997-07-16T22:30+01:00') == 869088600
     assert iso8601ts_to_timestamp('1997-07-16T22:30:45+01:00') == 869088645


### PR DESCRIPTION
It was never failing in the CI since CI is in UTC. For local runs of the tests, it was counting UTC offset with a date in July, but counting it with current time. So whenever DST was off/on it was off by 1 hour.