### PR TITLE
Fix (Binance): Lending APIs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Binance lending positions and rewards will get properly decoded and displayed again.
 * :bug:`7488` Show tags in multi-lines when multiple to avoid horizontal scroll.
 * :bug:`7497` In ETH staking view execution rewards should now be counted properly. MEV reward and block reward should not both be counted if recipient is not tracked.
 * :bug:`-` Invalid data in airdrops' CSVs or JSONs will now get ignored to show the rest of the valid data.

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -303,7 +303,7 @@ def test_query_all_balances_ignore_cache(
         )
         for fn in function_call_counters:
             if fn._mock_wraps == original_binance_query_dict:
-                assert fn.call_count == 3
+                assert fn.call_count == 2
             # addresses are not derived from xpubs when `ignore_cache` is False
             elif fn._mock_name == 'check_for_new_xpub_addresses':
                 assert fn.call_count == 0
@@ -328,7 +328,7 @@ def test_query_all_balances_ignore_cache(
         msg = 'call count should stay the same since cache should have been used'
         for fn in function_call_counters:
             if fn._mock_wraps == original_binance_query_dict:
-                assert fn.call_count == 3, msg
+                assert fn.call_count == 2, msg
             # addresses are not derived from xpubs when `ignore_cache` is False
             elif fn._mock_name == 'check_for_new_xpub_addresses':
                 assert fn.call_count == 0, msg
@@ -354,7 +354,7 @@ def test_query_all_balances_ignore_cache(
         msg = 'call count should increase since cache should have been ignored'
         for fn in function_call_counters:
             if fn._mock_wraps == original_binance_query_dict:
-                assert fn.call_count == 6, msg
+                assert fn.call_count == 4, msg
             # addresses are derived from xpubs when `ignore_cache` is True
             elif fn._mock_name == 'check_for_new_xpub_addresses':
                 assert fn.call_count == 2, msg  # 2 is for btc + bch
@@ -644,7 +644,7 @@ def test_multiple_balance_queries_not_concurrent(
             )
         assert eth.call_count == 1, 'eth balance query should only fire once'
         assert btc.call_count == 1, 'btc balance query should only happen once'
-        assert bn.call_count == 3, 'binance balance query should do 2 calls'
+        assert bn.call_count == 2, 'binance balance query should do 2 calls'
 
     assert_all_balances(
         result=outcome_all,

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -324,8 +324,7 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
                 'capital/deposit' in url or
                 'capital/withdraw' in url or
                 'fiat/orders' in url or
-                'fiat/payments' in url or
-                'lending/union/interestHistory' in url
+                'fiat/payments' in url
         ):
             payload = '[]'
         else:


### PR DESCRIPTION
## Checklist

- [x] [Switch](https://www.binance.com/en/support/announcement/updates-on-binance-simple-earn-sapi-endpoints-2023-09-21-8060cafe466b4d2c87c79a37a0757aeb) to new Simple Earn APIs and stop using `/sapi/v1/lending/union/*` endpoints
- [x] Update tests 