### PR TITLE
Fix (Airdrops): Save coingecko and cryptocompare

### DIFF
--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -100,6 +100,8 @@ def edit_token_and_clean_cache(
         started: Timestamp | None,
         underlying_tokens: list[UnderlyingToken] | None,
         evm_inquirer: 'EvmNodeInquirer | None',
+        coingecko: str | None = None,
+        cryptocompare: str | None = None,
 ) -> None:
     """
     Update information regarding name and decimals for an ethereum token.
@@ -139,6 +141,14 @@ def edit_token_and_clean_cache(
 
     if underlying_tokens is not None and evm_token.underlying_tokens != underlying_tokens:
         object.__setattr__(evm_token, 'underlying_tokens', underlying_tokens)
+        updated_fields = True
+
+    if coingecko is not None and evm_token.coingecko != coingecko:
+        object.__setattr__(evm_token, 'coingecko', coingecko)
+        updated_fields = True
+
+    if cryptocompare is not None and evm_token.cryptocompare != cryptocompare:
+        object.__setattr__(evm_token, 'cryptocompare', cryptocompare)
         updated_fields = True
 
     # clean the cache if we need to update the token
@@ -190,6 +200,8 @@ def get_or_create_evm_token(
         underlying_tokens: list[UnderlyingToken] | None = None,
         evm_inquirer: Optional['EvmNodeInquirer'] = None,
         encounter: TokenEncounterInfo | None = None,
+        coingecko: str | None = None,
+        cryptocompare: str | None = None,
 ) -> EvmToken:
     """Given a token address return the <EvmToken>
 
@@ -231,6 +243,8 @@ def get_or_create_evm_token(
                 started=started,
                 underlying_tokens=underlying_tokens,
                 evm_inquirer=evm_inquirer,
+                coingecko=coingecko,
+                cryptocompare=cryptocompare,
             )
 
         except (UnknownAsset, DeserializationError):
@@ -272,6 +286,8 @@ def get_or_create_evm_token(
                 protocol=protocol if not is_spam_token else SPAM_PROTOCOL,
                 underlying_tokens=underlying_tokens,
                 started=started,
+                coingecko=coingecko,
+                cryptocompare=cryptocompare,
             )
             if asset_exists is True:
                 # This means that we need to update the information in the database with the

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -95,6 +95,8 @@ def _parse_airdrops(database: 'DBHandler', airdrops_data: dict[str, Any]) -> dic
                         decimals=new_asset_data['decimals'],
                         name=new_asset_data['name'],
                         symbol=new_asset_data['symbol'],
+                        coingecko=new_asset_data.get('coingecko'),
+                        cryptocompare=new_asset_data.get('cryptocompare'),
                     )
                 elif (asset := Asset(airdrop_data['asset_identifier'])).exists() is True:
                     crypto_asset = asset.resolve_to_crypto_asset()  # use the local values of user, if it pre-existed  # noqa: E501

--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -123,10 +123,14 @@ def _mock_airdrop_list(url: str, timeout: int = 0):  # pylint: disable=unused-ar
     'symbol': 'SHU',
     'chain_id': 1,
     'decimals': 18,
+    'coingecko': 'shutter',
+    'cryptocompare': 'SHUTTER',
 }, {
     'asset_type': 'SOLANA_TOKEN',  # test with non EVM token
     'name': 'Some Non EVM Token',
     'symbol': 'NONEVM',
+    'coingecko': 'nonevm',
+    'cryptocompare': 'NONEVM',
 }])
 @pytest.mark.parametrize('remove_global_assets', [['eip155:1/erc20:0xe485E2f1bab389C08721B291f6b59780feC83Fd7']])  # noqa: E501
 def test_check_airdrops(
@@ -225,11 +229,13 @@ def test_check_airdrops(
             data_dir=data_dir,
             tolerance_for_amount_check=tolerance_for_amount_check,
         )
-        with GlobalDBHandler().conn.read_ctx() as cursor:
-            assert cursor.execute(
-                'SELECT COUNT(*) FROM assets WHERE identifier=?',
-                (new_asset_identifier,),
-            ).fetchone()[0] == 1  # asset present after
+
+    # verify new asset's presence and details
+    new_found_asset = AssetResolver.resolve_asset(new_asset_identifier).resolve_to_crypto_asset()
+    assert new_found_asset.name == new_asset_data['name']
+    assert new_found_asset.symbol == new_asset_data['symbol']
+    assert new_found_asset.coingecko == new_asset_data['coingecko']
+    assert new_found_asset.cryptocompare == new_asset_data['cryptocompare']
 
     # Test data is returned for the address correctly
     assert len(data) == 3


### PR DESCRIPTION
## Checklist

- [x] Save coingecko and cryptocompare values for new EVM tokens found in remote airdrops' data.