### PR TITLE
Fix (Airdrops): Update CSVs based on their hash

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` rotki will now automatically update the local airdrops' CSVs when needed, without manually deleting them.
 * :bug:`-` Fix the issue where an incorrect amount of ETH is displayed in the Loopring account table.
 * :bug:`-` Binance lending positions and rewards will get properly decoded and displayed again.
 * :bug:`7488` Show tags in multi-lines when multiple to avoid horizontal scroll.

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -1,13 +1,14 @@
 import csv
-import json
 import logging
 from collections import defaultdict
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any, Final, NamedTuple
 
 import requests
+from requests import Response
 
 from rotkehlchen.assets.asset import Asset, CryptoAsset
 from rotkehlchen.assets.types import AssetType
@@ -16,7 +17,6 @@ from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.misc import AIRDROPSDIR_NAME, AIRDROPSPOAPDIR_NAME, APPDIR_NAME
-from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset
@@ -24,7 +24,6 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import (
-    globaldb_get_unique_cache_last_queried_ts_by_key,
     globaldb_get_unique_cache_value,
     globaldb_set_unique_cache_value,
 )
@@ -42,6 +41,7 @@ log = RotkehlchenLogsAdapter(logger)
 SMALLEST_AIRDROP_SIZE: Final = 20900
 AIRDROPS_REPO_BASE: Final = f'https://raw.githubusercontent.com/rotki/data/{"main" if is_production() else "develop"}'  # noqa: E501
 AIRDROPS_INDEX: Final = f'{AIRDROPS_REPO_BASE}/airdrops/index_v1.json'
+ETAG_CACHE_KEY: Final = 'ETag'
 
 
 class Airdrop(NamedTuple):
@@ -52,6 +52,7 @@ class Airdrop(NamedTuple):
     website URL, name, and icon filename.
     """
     csv_path: str
+    csv_hash: str
     asset: CryptoAsset
     url: str
     name: str
@@ -121,6 +122,7 @@ def _parse_airdrops(database: 'DBHandler', airdrops_data: dict[str, Any]) -> dic
                 asset=crypto_asset,
                 # combining the base data repo url for main/develop with the path to the CSV in that repo  # noqa: E501
                 csv_path=f"{AIRDROPS_REPO_BASE}/{airdrop_data['csv_path']}",
+                csv_hash=airdrop_data['csv_hash'],
                 url=airdrop_data['url'],
                 name=airdrop_data['name'],
                 icon=airdrop_data['icon'],
@@ -141,11 +143,23 @@ def fetch_airdrops_metadata(database: 'DBHandler') -> tuple[dict[str, Airdrop], 
     """
     airdrops_data = None
     with GlobalDBHandler().conn.read_ctx() as cursor:
-        airdrops_metadata_cached_at = globaldb_get_unique_cache_last_queried_ts_by_key(
+        headers = {}
+        if (cached_etag := globaldb_get_unique_cache_value(
             cursor=cursor,
-            key_parts=(CacheType.AIRDROPS_METADATA,),
-        )
-        if ts_now() - airdrops_metadata_cached_at < HOUR_IN_SECONDS * 12:
+            key_parts=(CacheType.AIRDROPS_HASH, ETAG_CACHE_KEY),
+        )) is not None:
+            headers['If-None-Match'] = cached_etag.encode('utf-8')
+
+        try:
+            remote_metadata_res = requests.get(
+                url=AIRDROPS_INDEX,
+                timeout=CachedSettings().get_timeout_tuple(),
+                headers=headers,
+            )
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Airdrops Index request failed due to {e!s}') from e
+
+        if remote_metadata_res.status_code == HTTPStatus.NOT_MODIFIED:  # index is not modified, use cached index  # noqa: E501
             airdrops_metadata_cache = globaldb_get_unique_cache_value(
                 cursor=cursor,
                 key_parts=(CacheType.AIRDROPS_METADATA,),
@@ -153,18 +167,22 @@ def fetch_airdrops_metadata(database: 'DBHandler') -> tuple[dict[str, Airdrop], 
             if airdrops_metadata_cache is not None:
                 airdrops_data = jsonloads_dict(airdrops_metadata_cache)  # get cached response
 
-    if airdrops_data is None:  # query fresh data
-        try:
-            airdrops_data = requests.get(url=AIRDROPS_INDEX, timeout=CachedSettings().get_timeout_tuple()).json()  # noqa: E501
-        except requests.exceptions.RequestException as e:
-            raise RemoteError(f'Airdrops Index request failed due to {e!s}') from e
-
+    if airdrops_data is None:  # index has been modified, save new index
         with GlobalDBHandler().conn.write_ctx() as write_cursor:
             globaldb_set_unique_cache_value(
                 write_cursor=write_cursor,
-                key_parts=(CacheType.AIRDROPS_METADATA,),
-                value=json.dumps(airdrops_data),
+                key_parts=(CacheType.AIRDROPS_HASH, ETAG_CACHE_KEY),
+                value=remote_metadata_res.headers[ETAG_CACHE_KEY],
             )
+            globaldb_set_unique_cache_value(
+                write_cursor=write_cursor,
+                key_parts=(CacheType.AIRDROPS_METADATA,),
+                value=remote_metadata_res.text,
+            )
+            try:
+                airdrops_data = remote_metadata_res.json()
+            except JSONDecodeError as e:
+                raise RemoteError(f'Airdrops Index is not valid JSON {e!s}') from e
 
     return (
         _parse_airdrops(database=database, airdrops_data=airdrops_data['airdrops']),
@@ -172,30 +190,75 @@ def fetch_airdrops_metadata(database: 'DBHandler') -> tuple[dict[str, Airdrop], 
     )
 
 
-def get_airdrop_data(airdrop_csv_path: str, name: str, data_dir: Path) -> Iterator[list[str]]:
-    airdrops_dir = data_dir / APPDIR_NAME / AIRDROPSDIR_NAME
-    airdrops_dir.mkdir(parents=True, exist_ok=True)
-    filename = airdrops_dir / f'{name}.csv'
+def _maybe_get_updated_file(
+        data_dir: Path,
+        name: str,
+        file_hash: str,
+        remote_url: str,
+        process_response: Callable[[Response, Path], None],
+) -> Path:
+    """Downloads the file if cached hash is different and returns its path."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    filename = data_dir / f'{name}'
+
+    with GlobalDBHandler().conn.read_ctx() as cursor:
+        if (existing_csv_hash := globaldb_get_unique_cache_value(
+            cursor=cursor,
+            key_parts=(CacheType.AIRDROPS_HASH, name),
+        )) != file_hash:
+            log.info(
+                f'Found a new {name} airdrop file hash: {file_hash}. '
+                f'Removing the old file with hash: {existing_csv_hash}, and downloading new one.',
+            )
+            filename.unlink(missing_ok=True)
+
     if not filename.is_file():
         # if not cached, get it from the remote data repo
         try:
-            response = requests.get(url=airdrop_csv_path, timeout=(30, 100))  # a large read timeout is necessary because the queried data is quite large  # noqa: E501
+            response = requests.get(url=remote_url, timeout=(30, 100))  # a large read timeout is necessary because the queried data is quite large  # noqa: E501
         except requests.exceptions.RequestException as e:
             raise RemoteError(f'Airdrops CSV request failed due to {e!s}') from e
-        content = response.text
+        process_response(response, filename)
+
+        with GlobalDBHandler().conn.write_ctx() as write_cursor:
+            globaldb_set_unique_cache_value(
+                write_cursor=write_cursor,
+                key_parts=(CacheType.AIRDROPS_HASH, name),
+                value=file_hash,
+            )
+
+    return filename
+
+
+def get_airdrop_data(airdrop_data: Airdrop, name: str, data_dir: Path) -> Iterator[list[str]]:
+    """Yields the rows from airdrop's CSV file after downloading it locally for the first time.
+    If a new CSV is found in the index, it will be downloaded again to update the local CSV file
+    and yield new data."""
+    airdrops_dir = data_dir / APPDIR_NAME / AIRDROPSDIR_NAME
+
+    def _process_csv(response: Response, filename: Path) -> None:
         try:
             if (
-                not csv.Sniffer().has_header(content) or
+                not csv.Sniffer().has_header(response.text) or
                 len(response.content) < SMALLEST_AIRDROP_SIZE
             ):
                 raise csv.Error
             with open(filename, 'w', encoding='utf8') as f:
-                f.write(content)
+                f.write(response.text)
         except csv.Error as e:
-            log.debug(f'airdrop file {filename} contains invalid data {content}')
+            log.debug(f'airdrop file {filename} contains invalid data {response.text}')
             raise RemoteError(
                 f'File {filename} contains invalid data. Check logs.',
             ) from e
+
+    filename = _maybe_get_updated_file(
+        data_dir=airdrops_dir,
+        file_hash=airdrop_data.csv_hash,
+        name=f'{name}.csv',
+        remote_url=airdrop_data.csv_path,
+        process_response=_process_csv,
+    )
+
     # Verify the CSV file
     with open(filename, encoding='utf8') as csvfile:
         iterator = csv.reader(csvfile)
@@ -203,25 +266,29 @@ def get_airdrop_data(airdrop_csv_path: str, name: str, data_dir: Path) -> Iterat
         yield from iterator
 
 
-def get_poap_airdrop_data(poap_airdrop_path: str, name: str, data_dir: Path) -> dict[str, Any]:
+def get_poap_airdrop_data(airdrop_data: list[str], name: str, data_dir: Path) -> dict[str, Any]:
+    """Returns a dictionary of POAP airdrop data after downloading it locally for the first time.
+    If a new JSON is found in the index, it will be downloaded again to update the local JSON file
+    and return its data."""
     airdrops_dir = data_dir / APPDIR_NAME / AIRDROPSPOAPDIR_NAME
-    airdrops_dir.mkdir(parents=True, exist_ok=True)
-    filename = airdrops_dir / f'{name}.json'
-    if not filename.is_file():
-        # if not cached, get it from the remote data repo
-        try:
-            request = requests.get(url=f'{AIRDROPS_REPO_BASE}/{poap_airdrop_path}', timeout=CachedSettings().get_timeout_tuple())  # noqa: E501
-        except requests.exceptions.RequestException as e:
-            raise RemoteError(f'POAP airdrops JSON request failed due to {e!s}') from e
 
+    def _process_json(response: Response, filename: Path) -> None:
         try:
-            json_data = jsonloads_dict(request.content.decode('utf-8'))
+            json_data = jsonloads_dict(response.content.decode('utf-8'))
         except JSONDecodeError as e:
             log.error(f"POAP airdrop {name}'s JSON is invalid {e!s}")
-            return {}
+            json_data = {}
 
         with open(filename, 'w', encoding='utf8') as outfile:
             outfile.write(rlk_jsondumps(json_data))
+
+    filename = _maybe_get_updated_file(
+        data_dir=airdrops_dir,
+        file_hash=airdrop_data[3],
+        name=f'{name}.json',
+        remote_url=f'{AIRDROPS_REPO_BASE}/{airdrop_data[0]}',
+        process_response=_process_json,
+    )
 
     return jsonloads_dict(Path(filename).read_text(encoding='utf8'))
 
@@ -295,7 +362,7 @@ def check_airdrops(
         # temporarily store this protocol's data here
         temp_found_data: dict[ChecksumEvmAddress, dict] = defaultdict(lambda: defaultdict(dict))
         temp_airdrop_tuples = []
-        for row in get_airdrop_data(airdrop_data.csv_path, protocol_name, data_dir):
+        for row in get_airdrop_data(airdrop_data, protocol_name, data_dir):
             if len(row) < 2:
                 msg_aggregator.add_warning(f'Skipping airdrop CSV for {protocol_name} because it contains an invalid row: {row}')  # noqa: E501
                 break
@@ -338,7 +405,7 @@ def check_airdrops(
             for temp_addr, data in temp_found_data.items():
                 found_data[temp_addr].update(data)
 
-    asset_to_protocol = {item[1].identifier: protocol for protocol, item in airdrops.items()}
+    asset_to_protocol = {item.asset.identifier: protocol for protocol, item in airdrops.items()}
     claim_events_tuple = calculate_claimed_airdrops(
         airdrop_data=airdrop_tuples,
         database=database,
@@ -347,7 +414,7 @@ def check_airdrops(
         found_data[event_tuple[0]][asset_to_protocol[event_tuple[1]]]['claimed'] = True
 
     for protocol_name, poap_airdrop_data in poap_airdrops.items():
-        data_dict = get_poap_airdrop_data(poap_airdrop_data[0], protocol_name, data_dir)
+        data_dict = get_poap_airdrop_data(poap_airdrop_data, protocol_name, data_dir)
         for addr, assets in data_dict.items():
             # not doing to_checksum_address() here since the file addresses are checksummed
             # and doing to_checksum_address() so many times hits performance

--- a/rotkehlchen/tests/api/test_metadata.py
+++ b/rotkehlchen/tests/api/test_metadata.py
@@ -3,7 +3,6 @@ import pytest
 
 import requests
 
-from rotkehlchen.chain.ethereum.airdrops import fetch_airdrops_metadata
 from rotkehlchen.chain.ethereum.defi.protocols import DEFI_PROTOCOLS
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
 from rotkehlchen.types import SupportedBlockchain
@@ -16,22 +15,15 @@ if TYPE_CHECKING:
 def test_metadata_endpoint(rotkehlchen_api_server: 'APIServer') -> None:
     """Test that all the endpoints that query mappings or metadata from the backend work fine"""
 
-    # testing the airdrops metadata endpoint
-    airdrops_expected_result = [
-        {
-            'identifier': identifier,
-            'name': airdrop.name,
-            'icon': airdrop.icon,
-        } | ({'icon_url': airdrop.icon_url} if airdrop.icon_url is not None else {})
-        for identifier, airdrop in fetch_airdrops_metadata(
-            database=rotkehlchen_api_server.rest_api.rotkehlchen.data.db,
-        )[0].items()
-    ]
     airdrops_response = requests.get(
         api_url_for(rotkehlchen_api_server, 'airdropsmetadataresource'),
     )
     airdrops_result = assert_proper_response_with_result(airdrops_response)
-    assert airdrops_result == airdrops_expected_result
+    assert len(airdrops_result) == 18
+    for res in airdrops_result:
+        assert 'identifier' in res and isinstance(res['identifier'], str)
+        assert 'name' in res and isinstance(res['name'], str)
+        assert 'icon' in res and isinstance(res['icon'], str)
 
     # testing the defi metadata endpoint
     defi_expected_result = [

--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -1,11 +1,21 @@
 import datetime
+import json
+from copy import deepcopy
+from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.resolver import AssetResolver
-from rotkehlchen.chain.ethereum.airdrops import AIRDROPS_INDEX, AIRDROPS_REPO_BASE, check_airdrops
+from rotkehlchen.chain.ethereum.airdrops import (
+    AIRDROPS_INDEX,
+    AIRDROPS_REPO_BASE,
+    ETAG_CACHE_KEY,
+    _parse_airdrops,
+    check_airdrops,
+    fetch_airdrops_metadata,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_1INCH, A_GRAIN, A_SHU, A_UNI
 from rotkehlchen.constants.misc import AIRDROPSDIR_NAME, AIRDROPSPOAPDIR_NAME, APPDIR_NAME
@@ -13,7 +23,10 @@ from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
-from rotkehlchen.globaldb.cache import globaldb_get_unique_cache_value
+from rotkehlchen.globaldb.cache import (
+    globaldb_get_unique_cache_value,
+    globaldb_set_unique_cache_value,
+)
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -28,6 +41,7 @@ NOT_CSV_WEBPAGE = {
     'airdrops': {
         'test': {
             'csv_path': 'notavalidpath/yabirgb',
+            'csv_hash': 'd39fdc7913b4cbafc90cd0458c9e88656e951d9c216a9f4c0e973b7e7c6f1882',
             'asset_identifier': 'eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
             'url': 'https://github.com',
             'name': 'Yabirgb',
@@ -38,6 +52,7 @@ NOT_CSV_WEBPAGE = {
 MOCK_AIRDROP_INDEX = {'airdrops': {
     'uniswap': {
         'csv_path': 'airdrops/uniswap.csv',
+        'csv_hash': '87c81b0070d4a19ab87fd631b79247293031412706ec5414a859899572470ddf',
         'asset_identifier': 'eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
         'url': 'https://app.uniswap.org/',
         'name': 'Uniswap',
@@ -45,6 +60,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     '1inch': {
         'csv_path': 'airdrops/1inch.csv',
+        'csv_hash': '7f8a67b1fe7c2019bcac956777d306dd372ebe5bc2a9cd920129884170562108',
         'asset_identifier': 'eip155:1/erc20:0x111111111117dC0aa78b770fA6A738034120C302',
         'url': 'https://1inch.exchange/',
         'name': '1inch',
@@ -52,6 +68,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     'grain': {
         'csv_path': 'airdrops/grain_iou.csv',
+        'csv_hash': 'dff6b525931ac7ad321efd8efc419370a9d7a222e92b1aad7a985b7e61248121',
         'asset_identifier': 'eip155:1/erc20:0x6589fe1271A0F29346796C6bAf0cdF619e25e58e',
         'url': 'https://claim.harvest.finance/',
         'name': 'Grain',
@@ -60,6 +77,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     'shapeshift': {
         'csv_path': 'airdrops/shapeshift.csv',
+        'csv_hash': '97b599c62af4391a19c17b47bd020733801e28a443443ad7e1602c647c9ebfe2',
         'asset_identifier': 'eip155:1/erc20:0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
         'url': 'https://shapeshift.com/shapeshift-decentralize-airdrop',
         'name': 'ShapeShift',
@@ -67,6 +85,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     'cow_gnosis': {
         'csv_path': 'airdrops/cow_gnosis.csv',
+        'csv_hash': 'f7fea2a5806c67a27c15bb4e05c3fd6c0c1ab51f5bd2a23c29852fa2f95a7db3',
         'asset_identifier': 'eip155:100/erc20:0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB',
         'url': 'https://cowswap.exchange/#/claim',
         'name': 'COW (gnosis chain)',
@@ -74,6 +93,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     'diva': {
         'csv_path': 'airdrops/diva.csv',
+        'csv_hash': '50cf9f2bb2f769ae20dc699809b8bdca5f48ce695c792223ad93f8681ab8d0fc',
         'asset_identifier': 'eip155:1/erc20:0xBFAbdE619ed5C4311811cF422562709710DB587d',
         'url': 'https://claim.diva.community/',
         'name': 'DIVA',
@@ -81,6 +101,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     'shutter': {
         'csv_path': 'airdrops/shutter.csv',
+        'csv_hash': 'd4427f41181803df49901241ec89ed6a235b8b67cc4ef5cfdef1515dc84704d1',
         'asset_identifier': 'eip155:1/erc20:0xe485E2f1bab389C08721B291f6b59780feC83Fd7',
         'url': 'https://claim.shutter.network/',
         'name': 'SHU',
@@ -89,6 +110,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
     },
     'invalid': {
         'csv_path': 'airdrops/invalid.csv',
+        'csv_hash': 'a426abd9f7af3ec3138fe393e4735129a5884786b7bbda8de30002c134951aec',
         'asset_identifier': 'eip155:1/erc20:0xe485E2f1bab389C08721B291f6b59780feC83Fd7',
         'url': 'https://claim.invalid.community/',
         'name': 'INVALID',
@@ -99,13 +121,16 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
         'airdrops/poap/poap_aave_v2_pioneers.json',
         'https://poap.delivery/aave-v2-pioneers',
         'AAVE V2 Pioneers',
+        '388003b6c0dc589981ce9e962d6d8b6b2148c72ccf6ec3578ab32d63b547f903',
     ],
 }}
 
 
-def _mock_airdrop_list(url: str, timeout: int = 0):  # pylint: disable=unused-argument
+def _mock_airdrop_list(url: str, timeout: int = 0, headers: dict | None = None):  # pylint: disable=unused-argument
     mock_response = Mock()
     if url == AIRDROPS_INDEX:
+        mock_response.headers = {'ETag': 'etag'}
+        mock_response.text = json.dumps(NOT_CSV_WEBPAGE)
         mock_response.json = lambda: NOT_CSV_WEBPAGE
         return mock_response
     else:  # when CSV is queried, return invalid payload
@@ -137,6 +162,7 @@ def test_check_airdrops(
         freezer,
         ethereum_accounts,
         database,
+        globaldb,
         new_asset_data,
         data_dir,
         messages_aggregator,
@@ -167,6 +193,7 @@ def test_check_airdrops(
         ),
     ]
     MOCK_AIRDROP_INDEX['airdrops']['shutter']['new_asset_data'] = new_asset_data
+    mock_airdrop_index = deepcopy(MOCK_AIRDROP_INDEX)
 
     new_asset_identifier = MOCK_AIRDROP_INDEX['airdrops']['shutter']['asset_identifier']
     AssetResolver.assets_cache.clear()  # remove new asset from cache
@@ -175,13 +202,18 @@ def test_check_airdrops(
     with database.conn.write_ctx() as write_cursor:
         events_db.add_history_events(write_cursor, claim_events)
 
-    def mock_requests_get(url: str, timeout: int = 0):  # pylint: disable=unused-argument
+    def _prepare_mock_response(url: str, update_airdrop_index: bool = False):
         """Mocking the airdrop data is very convenient here because the airdrop data is quite large
         and read timeout errors can happen even with 90secs threshold. Vcr-ing it is not possible
         because the vcr yaml file is above the github limit of 100MB. The schema of AIRDROPS_INDEX
         is checked in the rotki/data repo."""
+        mock_response = Mock()
+        if update_airdrop_index is True:
+            mock_airdrop_index['airdrops']['diva']['csv_hash'] = 'updated_hash'
+            mock_airdrop_index['poap_airdrops']['aave_v2_pioneers'][3] = 'updated_hash'
+            mock_response.headers = {'ETag': 'updated_etag'}
         url_to_data_map = {
-            AIRDROPS_INDEX: MOCK_AIRDROP_INDEX,
+            AIRDROPS_INDEX: mock_airdrop_index,
             f'{AIRDROPS_REPO_BASE}/airdrops/uniswap.csv':
                 f'address,uni,is_lp,is_user,is_socks\n{TEST_ADDR1},400,False,True,False\n{TEST_ADDR2},400.050642,True,True,False\n',
             f'{AIRDROPS_REPO_BASE}/airdrops/1inch.csv':
@@ -201,14 +233,38 @@ def test_check_airdrops(
             f'{AIRDROPS_REPO_BASE}/airdrops/poap/poap_aave_v2_pioneers.json':
                 f'{{"{TEST_POAP1}": [\n566\n]}}',
         }
-        mock_response = Mock()
         if url == AIRDROPS_INDEX:
-            mock_response.json = lambda: url_to_data_map[AIRDROPS_INDEX]
+            mock_response.text = json.dumps(mock_airdrop_index)
+            mock_response.json = lambda: mock_airdrop_index
+            mock_response.headers = {'ETag': 'etag'}
         else:
             mock_response.text = url_to_data_map.get(url, 'address,tokens\n')  # Return the data from the dictionary or just a header if 'url' is not found  # noqa: E501
             assert isinstance(mock_response.text, str)
             mock_response.content = mock_response.text.encode('utf-8')
         return mock_response
+
+    def mock_requests_get(url: str, timeout: int = 0, headers: dict | None = None):  # pylint: disable=unused-argument
+        return _prepare_mock_response(url)
+
+    # invalid metadata index is already present
+    with globaldb.conn.write_ctx() as write_cursor:
+        globaldb_set_unique_cache_value(
+            write_cursor=write_cursor,
+            key_parts=(CacheType.AIRDROPS_METADATA,),
+            value='{"metadata": "invalid"}',
+        )
+
+    # no CSV hashes are present in the DB
+    with globaldb.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM unique_cache WHERE key LIKE ?', ('AIRDROPS_HASH%',),
+        ).fetchone()[0] == 0
+
+    # one CSV is already present with invalid content, but no cached hash in DB
+    csv_dir = data_dir / APPDIR_NAME / AIRDROPSDIR_NAME
+    csv_dir.mkdir(parents=True, exist_ok=True)
+    with open(csv_dir / 'shapeshift.csv', 'w', encoding='utf8') as f:
+        f.write('invalid,csv\n')
 
     # testing just on the cutoff time of shutter
     freezer.move_to(datetime.datetime.fromtimestamp(1721000000, tz=datetime.UTC))
@@ -229,6 +285,25 @@ def test_check_airdrops(
             data_dir=data_dir,
             tolerance_for_amount_check=tolerance_for_amount_check,
         )
+
+    # invalid metadata index is replaced by the valid one
+    with globaldb.conn.read_ctx() as cursor:
+        assert globaldb_get_unique_cache_value(
+            cursor=cursor,
+            key_parts=(CacheType.AIRDROPS_METADATA,),
+        ) == json.dumps(MOCK_AIRDROP_INDEX)
+
+    # new CSV hashes are saved in the DB
+    with globaldb.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM unique_cache WHERE key LIKE ?', ('AIRDROPS_HASH%',),
+        ).fetchone()[0] == 10
+        assert cursor.execute(
+            'SELECT value FROM unique_cache WHERE key=?', ('AIRDROPS_HASHdiva.csv',),
+        ).fetchone()[0] == MOCK_AIRDROP_INDEX['airdrops']['diva']['csv_hash']
+
+    # invalid CSV is also, updated
+    assert (csv_dir / 'shapeshift.csv').read_text(encoding='utf8') == f'address,tokens\n{TEST_ADDR1},200\n'  # noqa: E501
 
     # verify new asset's presence and details
     new_found_asset = AssetResolver.resolve_asset(new_asset_identifier).resolve_to_crypto_asset()
@@ -286,22 +361,6 @@ def test_check_airdrops(
     freezer.move_to(datetime.datetime.fromtimestamp(1721000001, tz=datetime.UTC))
     with (
         patch('rotkehlchen.chain.ethereum.airdrops.SMALLEST_AIRDROP_SIZE', 1),
-        patch('rotkehlchen.chain.ethereum.airdrops.requests.get') as mock_get,
-    ):
-        data = check_airdrops(
-            msg_aggregator=messages_aggregator,
-            addresses=[TEST_ADDR2],
-            database=database,
-            data_dir=data_dir,
-            tolerance_for_amount_check=tolerance_for_amount_check,
-        )
-        assert mock_get.call_count == 0  # not queried again because it was cached a second ago
-    assert len(data[TEST_ADDR2]) == 2
-    assert 'shutter' not in data[TEST_ADDR2]
-
-    freezer.move_to(datetime.datetime.fromtimestamp(1721000001 + 12 * HOUR_IN_SECONDS, tz=datetime.UTC))  # noqa: E501
-    with (
-        patch('rotkehlchen.chain.ethereum.airdrops.SMALLEST_AIRDROP_SIZE', 1),
         patch('rotkehlchen.chain.ethereum.airdrops.requests.get', side_effect=mock_requests_get) as mock_get,  # noqa: E501
     ):
         data = check_airdrops(
@@ -311,7 +370,33 @@ def test_check_airdrops(
             data_dir=data_dir,
             tolerance_for_amount_check=tolerance_for_amount_check,
         )
-        assert mock_get.call_count == 1  # queried again because it was cached 12 hours ago
+        assert mock_get.call_count == 1
+    assert len(data[TEST_ADDR2]) == 2
+    assert 'shutter' not in data[TEST_ADDR2]
+
+    def update_mock_requests_get(url: str, timeout: int = 0, headers: dict | None = None):  # pylint: disable=unused-argument
+        return _prepare_mock_response(url, update_airdrop_index=True)
+
+    freezer.move_to(datetime.datetime.fromtimestamp(1721000001 + 12 * HOUR_IN_SECONDS, tz=datetime.UTC))  # noqa: E501
+    with (
+        patch('rotkehlchen.chain.ethereum.airdrops.SMALLEST_AIRDROP_SIZE', 1),
+        patch('rotkehlchen.chain.ethereum.airdrops.requests.get', side_effect=update_mock_requests_get) as mock_get,  # noqa: E501
+    ):
+        data = check_airdrops(
+            msg_aggregator=messages_aggregator,
+            addresses=[TEST_ADDR2],
+            database=database,
+            data_dir=data_dir,
+            tolerance_for_amount_check=tolerance_for_amount_check,
+        )
+        # diva CSV and aave JSON were queried again because their hashes were updated
+        assert mock_get.call_count == 3
+
+    # new CSV hashes are saved in the DB
+    with globaldb.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT value FROM unique_cache WHERE key=?', ('AIRDROPS_HASHdiva.csv',),
+        ).fetchone()[0] == 'updated_hash'
 
     # Test cache file and row is created
     for protocol_name in MOCK_AIRDROP_INDEX['airdrops']:
@@ -322,7 +407,7 @@ def test_check_airdrops(
         assert globaldb_get_unique_cache_value(
             cursor=cursor,
             key_parts=(CacheType.AIRDROPS_METADATA,),
-        ) == rlk_jsondumps(MOCK_AIRDROP_INDEX)
+        ) == rlk_jsondumps(mock_airdrop_index)
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -337,3 +422,45 @@ def test_airdrop_fail(database, data_dir, messages_aggregator):
             database=database,
             data_dir=data_dir,
         )
+
+
+@pytest.mark.parametrize('remote_etag', ['etag', 'updated_etag'])
+@pytest.mark.parametrize('database_etag', [None, 'etag', 'updated_etag'])
+def test_fetch_airdrops_metadata(database, remote_etag, database_etag):
+    if database_etag is not None:
+        # if database_etag is present, add those values in DB
+        with GlobalDBHandler().conn.write_ctx() as write_cursor:
+            globaldb_set_unique_cache_value(
+                write_cursor=write_cursor,
+                key_parts=(CacheType.AIRDROPS_HASH, ETAG_CACHE_KEY),
+                value=database_etag,
+            )
+            globaldb_set_unique_cache_value(
+                write_cursor=write_cursor,
+                key_parts=(CacheType.AIRDROPS_METADATA,),
+                value=rlk_jsondumps(MOCK_AIRDROP_INDEX),
+            )
+
+    mock_airdrop_index = MOCK_AIRDROP_INDEX
+    if remote_etag != database_etag:  # if etag is different, update mock_airdrop_index
+        mock_airdrop_index['airdrops']['diva']['name'] = 'new_name'
+
+    def _mock_get(url: str, timeout: int = 0, headers: dict | None = None):  # pylint: disable=unused-argument
+        mock_response = Mock()
+        mock_response.headers = {'ETag': remote_etag}
+        if database_etag == remote_etag:  # not returning content in this case
+            mock_response.status_code = HTTPStatus.NOT_MODIFIED
+        else:
+            mock_response.status_code = HTTPStatus.OK
+            mock_response.text = rlk_jsondumps(mock_airdrop_index)
+            mock_response.json = lambda: mock_airdrop_index
+        return mock_response
+
+    with patch('rotkehlchen.chain.ethereum.airdrops.requests.get', side_effect=_mock_get):
+        metadata = fetch_airdrops_metadata(database)
+        assert metadata == (
+            _parse_airdrops(database=database, airdrops_data=mock_airdrop_index['airdrops']),
+            mock_airdrop_index['poap_airdrops'],
+        )
+        if remote_etag != database_etag:  # check if the value is updated
+            assert metadata[0]['diva'].name == 'new_name'

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -948,6 +948,7 @@ class CacheType(Enum):
     SPAM_ASSET_FALSE_POSITIVE = auto()  # assets that shouldn't be marked as spam automatically
     COINLIST = auto()  # coinlist / all coins cache for various oracles
     AIRDROPS_METADATA = auto()  # airdrops index fetched from rotki/data repo
+    AIRDROPS_HASH = auto()  # hash of airdrops csv file
 
     def serialize(self) -> str:
         # Using custom serialize method instead of SerializableEnumMixin since mixin replaces
@@ -969,6 +970,7 @@ UniqueCacheType = Literal[
     CacheType.CONVEX_POOL_NAME,
     CacheType.COINLIST,
     CacheType.AIRDROPS_METADATA,
+    CacheType.AIRDROPS_HASH,
 ]
 
 UNIQUE_CACHE_KEYS: tuple[UniqueCacheType, ...] = typing.get_args(UniqueCacheType)


### PR DESCRIPTION
## Checklist

- [x] Update the local CSVs if the index `csv_hash` is different from cached `csv_hash`
- [x] Add test to check if they're redownloaded
- [x] Update changelog