### PR TITLE
Process kraken rewards program events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :bug:`7497` In ETH staking view execution rewards should now be counted properly. MEV reward and block reward should not both be counted if recipient is not tracked.
 * :bug:`-` ETH withdrawal events should now be taxable again if the setting for their treatment after withdrawals enabled is on (which is by default).
 * :bug:`-` Invalid data in airdrops' CSVs or JSONs will now get ignored to show the rest of the valid data.
+* :bug:`-` Deposits to the kraken rewards program should be correctly processed now.
 
 * :release:`1.32.0 <2024-02-16>`
 * :feature:`7383` rotki will now update airdrops' data remotely without needing to update the app.

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -925,8 +925,9 @@ def asset_from_kraken(kraken_name: str) -> AssetWithOracles:
     if not isinstance(kraken_name, str):
         raise DeserializationError(f'Got non-string type {type(kraken_name)} for kraken asset')
 
-    if kraken_name.endswith(('.S', '.M', '.P')):
+    if kraken_name.endswith(('.S', '.M', '.P', '.F', '.B')):
         # this is a special staked/use coin. Map to the normal version
+        # https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M-
         kraken_name = kraken_name[:-2]
 
         if kraken_name != 'ETH2':


### PR DESCRIPTION
This PR addresses two issues:

- Handle .F assets comming from kraken
- Process deposits for the rewards program.

It is missing:

- the unstaking event since we don't have data. I requested @tewshi to unstake a little amount to generate an event and check but it takes 7 days

edit: I've created a ticket to kraken since it is a bit confusing and I'm waiting for a response