### PR TITLE
Fix deletion of transactions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :bug:`7488` Show tags in multi-lines when multiple to avoid horizontal scroll.
 * :bug:`7497` In ETH staking view execution rewards should now be counted properly. MEV reward and block reward should not both be counted if recipient is not tracked.
 * :bug:`7522` Invalid ENS names shouldn't stop the decoding process anymore.
+* :bug:`-` Removing an address from one of the EVM chains won't affect the decoded events in other chains anymore.
 * :bug:`-` ETH withdrawal events should now be taxable again if the setting for their treatment after withdrawals enabled is on (which is by default).
 * :bug:`-` Invalid data in airdrops' CSVs or JSONs will now get ignored to show the rest of the valid data.
 

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -462,10 +462,10 @@ class DBEvmTx:
         # Get all tx_hashes that are touched by this address and no other address for the chain
         result = write_cursor.execute(
             'SELECT A.tx_hash, A.identifier from evmtx_address_mappings AS B INNER JOIN '
-            'evm_transactions AS A ON A.identifier=B.tx_id WHERE B.address=? AND B.tx_id NOT IN ( '
-            'SELECT tx_id from evmtx_address_mappings WHERE address!=? AND chain_id=?'
-            ')',
-            (address, address, chain_id_serialized),
+            'evm_transactions AS A ON A.identifier=B.tx_id WHERE B.address=? AND A.chain_id=? '
+            'AND B.tx_id NOT IN (SELECT tx_id from evmtx_address_mappings WHERE address!=? '
+            'AND chain_id=?)',
+            (address, chain_id_serialized, address, chain_id_serialized),
         )
         tx_hashes = []
         tx_ids = []

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -1,15 +1,23 @@
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from rotkehlchen.chain.evm.types import EvmAccount
-from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
+import pytest
+
+from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
+from rotkehlchen.db.evmtx import DBEvmTx
+from rotkehlchen.db.filtering import EvmEventFilterQuery, EvmTransactionsFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.tests.utils.factories import make_evm_address
-from rotkehlchen.types import ChainID
+from rotkehlchen.types import ChainID, Location, SupportedBlockchain, deserialize_evm_tx_hash
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
+    from rotkehlchen.db.dbhandler import DBHandler
+
 
 ADDR_1, ADDR_2, ADDR_3 = make_evm_address(), make_evm_address(), make_evm_address()
+YAB_ADDRESS = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
 
 
 def test_query_transactions_single_chain(eth_transactions: 'EthereumTransactions'):
@@ -39,3 +47,56 @@ def test_query_transactions_single_chain(eth_transactions: 'EthereumTransactions
         ))
 
     assert queried_addresses == [ADDR_2, ADDR_3]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [[YAB_ADDRESS]])
+@pytest.mark.parametrize('gnosis_accounts', [[YAB_ADDRESS]])
+def test_delete_transactions_by_chain(
+        database: 'DBHandler',
+        gnosis_accounts,
+        ethereum_inquirer,
+        gnosis_inquirer,
+) -> None:
+    """
+    Test that deleting transactions by chain doesn't delete events
+    for the same address in other chains.s
+    """
+    get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        database=database,
+        tx_hash=deserialize_evm_tx_hash('0xac02ba9db26eee16f72a4b155fd07517ead140a539b1c41b67ba5a52b85d9dcb'),
+        relevant_address=gnosis_accounts[0],
+    )
+    get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        database=database,
+        tx_hash=deserialize_evm_tx_hash('0xafce539bd7fb898c5f03fdccf4c34e2c5c9ca321d612142953a7baf2849caafd'),
+        relevant_address=gnosis_accounts[0],
+    )
+    dbevmtx = DBEvmTx(database)
+    with database.user_write() as write_cursor:
+        events = DBHistoryEvents(database).get_history_events(
+            cursor=write_cursor,
+            filter_query=EvmEventFilterQuery.make(),
+            has_premium=True,
+            group_by_event_ids=False,
+        )
+        assert len(events) == 5  # we have 3 ethereum events and 2 gnosis events
+
+    with database.conn.write_ctx() as write_cursor:
+        dbevmtx.delete_transactions(
+            write_cursor=write_cursor,
+            address=gnosis_accounts[0],
+            chain=SupportedBlockchain.GNOSIS,
+        )
+
+    with database.conn.read_ctx() as cursor:
+        events = DBHistoryEvents(database).get_history_events(
+            cursor=cursor,
+            filter_query=EvmEventFilterQuery.make(),
+            has_premium=True,
+            group_by_event_ids=False,
+        )
+        assert len(events) == 3
+        assert all(event.location == Location.ETHEREUM for event in events)

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -4,6 +4,7 @@ import random
 from typing import TYPE_CHECKING, Any
 
 import gevent
+from eth_typing import ChecksumAddress
 
 from rotkehlchen.chain.arbitrum_one.decoding.decoder import ArbitrumOneTransactionDecoder
 from rotkehlchen.chain.arbitrum_one.transactions import ArbitrumOneTransactions
@@ -342,11 +343,15 @@ def get_decoded_events_of_transaction(
         database: DBHandler,
         tx_hash: EVMTxHash,
         transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
 ) -> tuple[list['EvmEvent'], EVMTransactionDecoder]:
     """A convenience function to ask get transaction, receipt and decoded event for a tx_hash
 
     It also accepts `transactions` in case the caller whants to apply some mocks (like call_count)
     on that object.
+
+    If relevant_address is provided then the transactions add added linked to
+    the provided address.
 
     Returns the list of decoded events and the EVMTransactionDecoder
     """
@@ -365,6 +370,14 @@ def get_decoded_events_of_transaction(
         decoder = mappings_result[1](database, evm_inquirer, transactions)
     else:
         raise AssertionError('Unsupported chainID at tests')
+
+    if relevant_address is not None:
+        with evm_inquirer.database.conn.read_ctx() as cursor:
+            transactions.get_or_create_transaction(
+                cursor=cursor,
+                tx_hash=tx_hash,
+                relevant_address=relevant_address,
+            )
 
     transactions.get_or_query_transaction_receipt(tx_hash=tx_hash)
     with patch_decoder_reload_data():


### PR DESCRIPTION
When deleting transactions we were missing a parameter in the query deleting all the history events for an address if we were deleting only by one chain
