### PR TITLE
Fix the curve pool token price calculation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`7532` Curve LP token price calculation should now be correct.
+
 * :release:`1.32.1 <2024-02-23>`
 * :bug:`-` rotki will now automatically update the local airdrops' CSVs when needed, without manually deleting them.
 * :bug:`-` Fix the issue where an incorrect amount of ETH is displayed in the Loopring account table.


### PR DESCRIPTION
Fix #7532


Also @yabirgb I see many curve pools are missing from our global DB. Such as the `TryLSD` one: `0x2570f1bD5D2735314FC102eb12Fc1aFe9e6E7193`. And a looooot more.

Shouldn't these be autodetected and added to our shipped global DB periodically?

I see them in neither the packaged DB nor in my own one.