### PR TITLE
Remove atoken_to_asset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ test-assets:
 	python pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_okx.py::test_assets_are_known
 	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_assets.py::test_coingecko_identifiers_are_reachable
 	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_assets.py::test_cryptocompare_asset_support
-	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_aave.py::test_atoken_to_asset
 	python pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_independentreserve.py::test_assets_are_known
 	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_zerionsdk.py::test_protocol_names_are_known
 	python pytestgeventwrapper.py rotkehlchen/tests/unit/test_zerionsdk.py::test_query_all_protocol_balances_for_account

--- a/rotkehlchen/chain/ethereum/modules/aave/common.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/common.py
@@ -4,15 +4,12 @@ from typing import NamedTuple
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset, CryptoAsset, EvmToken
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
-from rotkehlchen.constants.assets import A_AETH_V1, A_AREP_V1, A_ETH, A_KNC, A_REP
-from rotkehlchen.constants.resolver import ethaddress_to_identifier
+from rotkehlchen.constants.assets import A_AETH_V1, A_ETH
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.tests.utils.aave import A_AKNC_V1, A_AKNC_V2
 from rotkehlchen.types import ChecksumEvmAddress
-
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -65,28 +62,6 @@ def asset_to_aave_reserve_address(asset: CryptoAsset) -> ChecksumEvmAddress | No
     token = EvmToken(asset.identifier)
     assert token, 'should not be a non token asset at this point'
     return token.evm_address
-
-
-def atoken_to_asset(atoken: EvmToken) -> CryptoAsset | None:
-    if atoken == A_AETH_V1:
-        return A_ETH.resolve_to_crypto_asset()
-    if atoken == A_AREP_V1:
-        return A_REP.resolve_to_crypto_asset()
-    if atoken in (A_AKNC_V1, A_AKNC_V2):
-        return A_KNC.resolve_to_crypto_asset()
-
-    asset_symbol = atoken.symbol[1:]
-    with GlobalDBHandler().conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT A.address from evm_tokens as A LEFT OUTER JOIN common_asset_details as B '
-            'ON A.identifier=B.identifier WHERE A.chain=? AND B.symbol=? COLLATE NOCASE',
-            (atoken.chain_id.serialize_for_db(), asset_symbol),
-        ).fetchall()
-    if len(result) != 1:
-        log.error(f'Could not find asset from {atoken} since multiple or no results were returned')
-        return None
-
-    return EvmToken(ethaddress_to_identifier(result[0][0]))
 
 
 def asset_to_atoken(asset: CryptoAsset, version: int) -> EvmToken | None:

--- a/rotkehlchen/tests/unit/test_aave.py
+++ b/rotkehlchen/tests/unit/test_aave.py
@@ -5,11 +5,7 @@ import pytest
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.ethereum.modules.aave.aave import Aave
-from rotkehlchen.chain.ethereum.modules.aave.common import (
-    AaveStats,
-    asset_to_aave_reserve_address,
-    atoken_to_asset,
-)
+from rotkehlchen.chain.ethereum.modules.aave.common import AaveStats, asset_to_aave_reserve_address
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
@@ -18,7 +14,7 @@ from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.premium.premium import Premium, PremiumCredentials
-from rotkehlchen.tests.utils.aave import ATOKENV1_TO_ASSET, ATOKENV2_ADDRESS_TO_RESERVE_ASSET
+from rotkehlchen.tests.utils.aave import ATOKENV1_TO_ASSET
 from rotkehlchen.types import ChainID, Timestamp, deserialize_evm_tx_hash
 from rotkehlchen.utils.misc import ts_now
 
@@ -40,25 +36,6 @@ def test_aave_reserve_mapping():
 
         assert EvmToken(ethaddress_to_identifier(underlying_asset.evm_address)) == underlying_asset
         assert asset_to_aave_reserve_address(underlying_asset) == underlying_asset.evm_address
-
-
-def test_atoken_to_asset():
-    cursor = GlobalDBHandler().conn.cursor()
-    result = cursor.execute(
-        'SELECT A.identifier from evm_tokens as A LEFT OUTER JOIN common_asset_details as B '
-        'WHERE A.identifier=B.identifier AND A.protocol IN (?, ?)',
-        ('aave', 'aave-v2'),
-    )
-    for entry in result:
-        atoken = EvmToken(entry[0])
-        reserve_asset = atoken_to_asset(atoken)
-        if atoken in ATOKENV1_TO_ASSET:
-            assert reserve_asset == ATOKENV1_TO_ASSET[atoken]
-        else:
-            assert reserve_asset == ATOKENV2_ADDRESS_TO_RESERVE_ASSET[atoken.evm_address]
-
-    for atokenv1, reserve_asset in ATOKENV1_TO_ASSET.items():
-        assert atoken_to_asset(atokenv1.resolve_to_evm_token()) == reserve_asset
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])


### PR DESCRIPTION
The function is not used at all, and was problematic if both v1 and v2 tokens were in the globalDB due to symbol conflict.
