### PR TITLE
Add an explanatory sentence for RPC endpoint setting

### DIFF
--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -291,12 +291,14 @@ When rotki begins it tries to connect to a local kusama node running with an rpc
 Connecting to a Polkadot Client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Just like with kusama you can set the rpc endpoint of a Polkadot node you would like to connect to here.
+Just like with kusama you can set the RPC endpoint of a Polkadot node you would like to connect to here.
 
 Connecting to a ETH consensus layer beacon node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can set the RPC endpoint for the ethereum consensus layer beacon node to use when contacting the consensus layer. If it cannot be reached or if it is invalid, beaconcha.in will be used.
+
+If you are running a DAppNode Ethereum validator, you will find the RPC node setting that Rotki needs in the DAppNode Package for the Execution Client, where it is called the "Querying API".
 
 Price Oracle settings
 ---------------------


### PR DESCRIPTION
Update usage_guide.rst; add an explanatory sentence to help users find the RPC endpoint for an ETH validator if they are running a DAppNode.

Per @LefterisJP suggestion to this matter in the Rotki Discord `#support` channel [https://discord.com/channels/657906918408585217/745172610240872508/1212241893581131827](url) on 28 February 2024.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
