### PR TITLE
Remove EvmTransaction serialize()

### DIFF
--- a/rotkehlchen/chain/optimism/types.py
+++ b/rotkehlchen/chain/optimism/types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTransaction, EVMTxHash, Timestamp
 
@@ -45,11 +45,6 @@ class OptimismTransaction(EvmTransaction):  # noqa: PLW1641  # hash implemented 
             nonce=nonce,
             db_id=db_id,
         )
-
-    def serialize(self) -> dict[str, Any]:
-        result = super().serialize()
-        result['l1_fee'] = str(result['l1_fee'])
-        return result
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, OptimismTransaction):

--- a/rotkehlchen/serialization/serialize.py
+++ b/rotkehlchen/serialization/serialize.py
@@ -52,7 +52,6 @@ from rotkehlchen.chain.ethereum.modules.yearn.vaults import (
 from rotkehlchen.chain.evm.accounting.structures import TxAccountingTreatment
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.types import NodeName, WeightedNode
-from rotkehlchen.chain.optimism.types import OptimismTransaction
 from rotkehlchen.db.settings import DBSettings
 from rotkehlchen.db.utils import DBAssetBalance, LocationData, SingleDBAssetBalance
 from rotkehlchen.exchanges.data_structures import Trade
@@ -75,7 +74,6 @@ from rotkehlchen.types import (
     ChainID,
     CostBasisMethod,
     EvmTokenKind,
-    EvmTransaction,
     ExchangeLocationID,
     Location,
     SupportedBlockchain,
@@ -143,8 +141,6 @@ def _process_entry(entry: Any) -> str | (list[Any] | (dict[str, Any] | Any)):
         return entry.serialize()
     if isinstance(entry, (
             Trade |
-            EvmTransaction |
-            OptimismTransaction |
             MakerdaoVault |
             DSRAccountReport |
             Balance |

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -1,6 +1,6 @@
 import typing
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import Enum, auto
 from typing import (
     TYPE_CHECKING,
@@ -342,20 +342,6 @@ class EvmTransaction:
     input_data: bytes
     nonce: int
     db_id: int = -1
-
-    def serialize(self) -> dict[str, Any]:
-        result = asdict(self)
-        result.pop('db_id')
-        result['tx_hash'] = result['tx_hash'].hex()
-        result['evm_chain'] = result.pop('chain_id').to_name()
-        result['input_data'] = '0x' + result['input_data'].hex()
-
-        # Most integers are turned to string to be sent via the API
-        result['value'] = str(result['value'])
-        result['gas'] = str(result['gas'])
-        result['gas_price'] = str(result['gas_price'])
-        result['gas_used'] = str(result['gas_used'])
-        return result
 
     def __hash__(self) -> int:
         return hash(self.identifier)


### PR DESCRIPTION
Since EvmTransaction objects are not serialized at all to the api, then we can remove this function. Can simply revert this commit if we ever bring it back

