### PR TITLE
Fix (7572): LAST_QUERY_ID query in Coinbase

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`7572` Fix issue where coinbase data query could result in an error popup.
 * :bug:`7611` USDT balances and trades in bitcoin.de should now work properly.
 * :bug:`-` Sending money to SEPA or bridging with the BurnFrom monerium signature will now be properly decoded by rotki.
 * :bug:`-` Fix issue where long label in manual balances breaks the alignment of chain names.


### PR DESCRIPTION
Closes #7572

## Checklist

- [x] Fix issue where the Coinbase Deposits & Withdrawals section was notifying an error.