### PR TITLE
Catch exception when decoding token info

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ cryptography==41.0.7
 py-machineid==0.4.6
 more-itertools==10.1.0  # for peekable iterators
 regex==2023.12.25  # used for unicode information in detection of spam tokens
+eth-abi==5.0.1
 
 # For the rest api
 flask-cors==4.0.0

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 import requests
 from ens import ENS
-from eth_abi.exceptions import InsufficientDataBytes
+from eth_abi.exceptions import DecodingError
 from eth_typing import BlockNumber
 from requests import RequestException
 from web3 import HTTPProvider, Web3
@@ -1162,7 +1162,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
                 contract=contract,
                 token_kind=EvmTokenKind.ERC20,
             )
-        except (OverflowError, InsufficientDataBytes) as e:
+        except (OverflowError, DecodingError) as e:
             # This can happen when contract follows the ERC20 standard methods
             # but name and symbol return bytes instead of string. UNIV1 LP is such a case
             # It can also happen if the method is missing and they are all hitting
@@ -1254,7 +1254,7 @@ class EvmNodeInquirer(metaclass=ABCMeta):
                 contract=EvmContract(address=address, abi=self.contracts.erc721_abi, deployed_block=0),  # noqa: E501
                 token_kind=EvmTokenKind.ERC721,
             )
-        except (OverflowError, InsufficientDataBytes) as e:
+        except (OverflowError, DecodingError) as e:
             raise NotERC721Conformant(f'{address} token does not conform to the ERC721 spec') from e  # noqa: E501
 
         info: dict[str, Any] = {}
@@ -1278,7 +1278,8 @@ class EvmNodeInquirer(metaclass=ABCMeta):
         - `name` and `symbol` default to None.
         May raise:
         - OverflowError
-        - InsufficientDataBytes
+        - InsufficientDataBytes (subclass of eth_abi.exceptions.DecodingError)
+        - InvalidPointer (subclass of eth_abi.exceptions.DecodingError)
         """
         decoded_contract_info = []
         for method_name, method_value in zip(properties, output, strict=True):


### PR DESCRIPTION
eth-abi is a depenendy that we don't have fixed and in 5.0.1 a new exception can be raised for one of the cases that we cover in a test

https://github.com/ethereum/eth-abi/blob/main/docs/release_notes.rst#eth-abi-v501-2024-03-04

This was released recently and is not present in 5.0.0 that is what we have been using.

I didn't notice because pip had cached the dep. Doing a full reinstall showed it

```
 - eth-abi==5.0.0
 + eth-abi==5.0.1
```
