### PR TITLE
Fix sending EUR to SEPA or bridging with Monerium burnfrom signature

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Sending money to SEPA or bridging with the BurnFrom monerium signature will now be properly decoded by rotki.
 * :bug:`-` Fix issue where long label in manual balances breaks the alignment of chain names.
 * :bug:`-` If saving a setting fails, error messages will no longer disappear automatically.
 * :bug:`7532` Curve LP token price calculation should now be correct.

--- a/rotkehlchen/chain/evm/decoding/monerium/constants.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/constants.py
@@ -4,3 +4,4 @@ from typing import Final
 
 CPT_MONERIUM: Final = 'monerium'
 BURN_MONERIUM_SIGNATURE: Final = b'8#\xca\xec'
+BURNFROM_MONERIUM_SIGNATURE: Final = b'\xef1\xf7\xaa'

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
-from .constants import BURN_MONERIUM_SIGNATURE, CPT_MONERIUM
+from .constants import BURN_MONERIUM_SIGNATURE, BURNFROM_MONERIUM_SIGNATURE, CPT_MONERIUM
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -74,7 +74,7 @@ class MoneriumCommonDecoder(DecoderInterface):
 
         elif (
             to_address == ZERO_ADDRESS and
-            context.transaction.input_data.startswith(BURN_MONERIUM_SIGNATURE)
+            context.transaction.input_data.startswith((BURN_MONERIUM_SIGNATURE, BURNFROM_MONERIUM_SIGNATURE))  # noqa: E501
         ):
             # Create a burn event
             event = self.base.make_event_from_transaction(

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -2,7 +2,7 @@ from typing import Final
 
 from rotkehlchen.fval import FVal
 
-CURRENCYCONVERTER_API_KEY = '4fc7223487de9ed243f6'
+CURRENCYCONVERTER_API_KEY: Final = 'db4ae39e25e5f77f1671'
 
 ZERO: Final = FVal(0)
 ONE: Final = FVal(1)

--- a/rotkehlchen/tests/unit/decoders/test_monerium.py
+++ b/rotkehlchen/tests/unit/decoders/test_monerium.py
@@ -176,3 +176,31 @@ def test_burning_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
         ),
     ]
     assert events == expected_events
+
+
+@pytest.mark.vcr()
+@pytest.mark.parametrize('gnosis_accounts', [['0x39c185721fbe8b350363e6B49801305d32485A45']])
+def test_burnfrom_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
+    evmhash = deserialize_evm_tx_hash(val='0xf04a5d84e6749828ff63991fb3323944472346c3b2c421e51d9999283d18f1fd')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        database=database,
+        tx_hash=evmhash,
+    )
+    amount_str = '501.04'
+    expected_events = [
+        EvmEvent(
+            tx_hash=evmhash,
+            sequence_index=497,
+            timestamp=TimestampMS(1709969940000),
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_GNOSIS_EURE,
+            balance=Balance(amount=FVal(amount_str)),
+            location_label=gnosis_accounts[0],
+            notes=f'Burn {amount_str} EURe',
+            counterparty=CPT_MONERIUM,
+        ),
+    ]
+    assert events == expected_events


### PR DESCRIPTION
The burning of monerium EURe via the burnfrom signature should now be properly decoded as bridging or sending EUR to SEPA

