### PR TITLE
chore: update release action to v2

### DIFF
--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
-        uses: rotki/action-gh-release@v1
+        uses: rotki/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

Synced the repo https://github.com/rotki/action-gh-release with upstream so it should not support node 20 properly
