### PR TITLE
Feat (2698): Remote updates for the mappings

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2232,7 +2232,10 @@ class LocationAssetMappingUpdateEntrySchema(LocationAssetMappingsBaseSchema):
             data: dict[str, Any],
             **_kwargs: Any,
     ) -> LocationAssetMappingUpdateEntry:
-        return LocationAssetMappingUpdateEntry.deserialize(data)
+        try:
+            return LocationAssetMappingUpdateEntry.deserialize(data)
+        except DeserializationError as e:
+            raise ValidationError(f'Could not deserialize data: {e!s}') from e
 
 
 class LocationAssetMappingDeleteEntrySchema(LocationAssetMappingsBaseSchema):
@@ -2244,7 +2247,10 @@ class LocationAssetMappingDeleteEntrySchema(LocationAssetMappingsBaseSchema):
             data: dict[str, Any],
             **_kwargs: Any,
     ) -> LocationAssetMappingDeleteEntry:
-        return LocationAssetMappingDeleteEntry.deserialize(data)
+        try:
+            return LocationAssetMappingDeleteEntry.deserialize(data)
+        except DeserializationError as e:
+            raise ValidationError(f'Could not deserialize data: {e!s}') from e
 
 
 class LocationAssetMappingsUpdateSchema(LocationAssetMappingsBaseSchema):

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -34,6 +34,7 @@ class UpdateType(Enum):
     CONTRACTS = 'contracts'
     GLOBAL_ADDRESSBOOK = 'global_addressbook'
     ACCOUNTING_RULES = 'accounting_rules'
+    LOCATION_ASSET_MAPPINGS = 'location_asset_mappings'
 
     def serialize(self) -> str:
         """Serializes the update type for the DB and API"""

--- a/rotkehlchen/tests/api/test_location_asset_mappings.py
+++ b/rotkehlchen/tests/api/test_location_asset_mappings.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import requests
 
@@ -11,6 +11,8 @@ from rotkehlchen.tests.utils.api import (
 
 if TYPE_CHECKING:
     from rotkehlchen.api.server import APIServer
+
+NUM_ASSETS_MAPPINGS_V1_32: Final = 1500
 
 
 def _get_all_location_mappings(rotkehlchen_api_server: 'APIServer') -> Any:
@@ -28,7 +30,7 @@ def test_location_asset_mappings_query(rotkehlchen_api_server: 'APIServer') -> N
     """Test the location asset mappings API for querying the mappings."""
     # query all the mappings
     result = _get_all_location_mappings(rotkehlchen_api_server)
-    assert len(result['entries']) == result['entries_found'] == result['entries_total'] == 1500
+    assert len(result['entries']) == result['entries_found'] == result['entries_total'] == NUM_ASSETS_MAPPINGS_V1_32  # noqa: E501
 
     # query all common mappings
     response = requests.post(
@@ -103,7 +105,7 @@ def test_location_asset_mappings_add(rotkehlchen_api_server: 'APIServer') -> Non
     )
     result = assert_proper_response_with_result(response)
     all_mappings_after_addition = result['entries']
-    assert len(all_mappings_after_addition) == result['entries_found'] == 1502
+    assert len(all_mappings_after_addition) == result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32 + 2  # noqa: E501
     for new_mapping in added_mappings:
         assert new_mapping not in all_mappings
         assert new_mapping in all_mappings_after_addition
@@ -160,7 +162,7 @@ def test_location_asset_mappings_delete(rotkehlchen_api_server: 'APIServer') -> 
 
     result = _get_all_location_mappings(rotkehlchen_api_server)
     all_mappings_after_deletion = result['entries']
-    assert len(all_mappings_after_deletion) == result['entries_found'] == 1499
+    assert len(all_mappings_after_deletion) == result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32 - 1  # noqa: E501
     assert all_mappings[0] not in all_mappings_after_deletion
 
 
@@ -181,7 +183,7 @@ def test_location_asset_mappings_pagination(rotkehlchen_api_server: 'APIServer')
     )
     result = assert_proper_response_with_result(response=response)
     assert result['entries'] == [all_mappings[0]]
-    assert result['entries_found'] == 1500
+    assert result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32
 
     # pagination offset works
     response = requests.post(
@@ -196,7 +198,7 @@ def test_location_asset_mappings_pagination(rotkehlchen_api_server: 'APIServer')
     )
     result = assert_proper_response_with_result(response=response)
     assert result['entries'] == [all_mappings[1]]
-    assert result['entries_found'] == 1500
+    assert result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32
 
 
 def test_location_asset_mappings_errors(rotkehlchen_api_server: 'APIServer') -> None:

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -849,9 +849,15 @@ class LocationAssetMappingDeleteEntry:
     @classmethod
     def deserialize(cls: type['LocationAssetMappingDeleteEntry'], data: dict[str, Any]) -> 'LocationAssetMappingDeleteEntry':  # noqa: E501
         """May raise:
-        -KeyError if required keys are missing
+        -DeserializationError if required keys are missing
         """
-        return cls(**data)
+        try:
+            return cls(
+                location=data['location'],
+                location_symbol=data['location_symbol'],
+            )
+        except KeyError as e:
+            raise DeserializationError(f'Missing key {e!s}') from e
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
@@ -861,9 +867,16 @@ class LocationAssetMappingUpdateEntry(LocationAssetMappingDeleteEntry):
     @classmethod
     def deserialize(cls: type['LocationAssetMappingUpdateEntry'], data: dict[str, Any]) -> 'LocationAssetMappingUpdateEntry':  # noqa: E501
         """May raise:
-        -KeyError if required keys are missing
+        -DeserializationError if required keys are missing
         """
-        return cls(**data)
+        try:
+            return cls(
+                asset=data['asset'],
+                location=data['location'],
+                location_symbol=data['location_symbol'],
+            )
+        except KeyError as e:
+            raise DeserializationError(f'Missing key {e!s}') from e
 
 
 class OptionalChainAddress(NamedTuple):


### PR DESCRIPTION
Closes #2698

## Checklist

- [x] Allow remote updates for location_asset_mappings from data repo
- [x] Update `info.json` there: https://github.com/rotki/data/pull/69

It's a follow-up PR from https://github.com/rotki/rotki/pull/7547, where the hardcoded mappings are moved to the packaged GlobalDB. And, also an upgrade is made to move these mapping for already existing users.