### PR TITLE
Ensure that latest price is correctly queried for nfts

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10708,7 +10708,8 @@ Querying  NFTs
                 "background_color": null,
                 "image_url": "https://lh3.googleusercontent.com/kwF-39qZlluEalQnNv-yMxbntzNdc3g00pK2xALkpoir9ooWttVUO2hVFWOgPtOkJOHufYRajfn-nNFdjruRQ4YaMgOYHEB8E4CdjBk",
                 "external_link": "https://www.bastardganpunks.club/v2/8636",
-                "price_eth": "0.025",
+                "price_in_asset": "0.025",
+                "price_asset": "ETH",
                 "price_usd": "250",
                 "collection": {
                   "name": "BASTARD GAN PUNKS V2",
@@ -10735,7 +10736,8 @@ Querying  NFTs
    :resjson string name: [ Optional] The name of the NFT. Can be Null.
    :resjson string external_link: [Optional]. A link to the page of the creator of the NFT. Can be Null.
    :resjson string permalink: [Optional]. A link to the NFT in opensea.
-   :resjson string price_eth: The last known price of the NFT in ETH. Can be zero.
+   :resjson string price_in_asset: The last known price of the NFT in `price_asset`. Can be zero.
+   :resjson string price_asset: The identifier of the asset used for `price_in_asset`.
    :resjson string price_usd: The last known price of the NFT in USD. Can be zero.
    :statuscode 200: NFTs successfully queried
    :statuscode 400: Provided JSON is in some way malformed

--- a/rotkehlchen/chain/ethereum/modules/nft/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nft/nfts.py
@@ -232,7 +232,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
                 if uniswap_v3_lp is not None:
                     db_data.append((nft.token_identifier, nft.name, str(uniswap_v3_lp.user_balance.usd_value), 'USD', False, address, True, nft.image_url, collection_name))  # noqa: E501
                 else:
-                    db_data.append((nft.token_identifier, nft.name, str(nft.price_eth), 'ETH', False, address, False, nft.image_url, collection_name))  # noqa: E501
+                    db_data.append((nft.token_identifier, nft.name, str(nft.price_in_asset), nft.price_asset.identifier, False, address, False, nft.image_url, collection_name))  # noqa: E501
 
         # Update DB cache
         fresh_nfts_identifiers = [x[0] for x in db_data]

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -13,6 +13,7 @@ from rotkehlchen.chain.ethereum.modules.nft.structures import NftLpHandling
 from rotkehlchen.chain.ethereum.modules.uniswap.v3.types import NFTLiquidityPool
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
+from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.queried_addresses import QueriedAddresses
 from rotkehlchen.externalapis.opensea import NFT, Collection
 from rotkehlchen.fval import FVal
@@ -46,7 +47,8 @@ TEST_NFT_NEBOLAX_ETH = NFT(
     name='nebolax.eth',
     external_link='https://metadata.ens.domains/mainnet/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/73552724610198397480670284492690114609730214421511097849210414928326607694469',
     permalink='https://opensea.io/assets/ethereum/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/73552724610198397480670284492690114609730214421511097849210414928326607694469',
-    price_eth=FVal(0.0012),
+    price_in_asset=FVal(0.0012),
+    price_asset=A_ETH,
     price_usd=FVal(1.2379458),
     collection=Collection(
         name='ENS: Ethereum Name Service',
@@ -54,6 +56,7 @@ TEST_NFT_NEBOLAX_ETH = NFT(
         description='Ethereum Name Service (ENS) domains are secure domain names for the decentralized world. ENS domains provide a way for users to map human readable names to blockchain and non-blockchain resources, like Ethereum addresses, IPFS hashes, or website URLs. ENS domains can be bought and sold on secondary markets.',  # noqa: E501
         large_image='https://i.seadn.io/gae/BBj09xD7R4bBtg1lgnAAS9_TfoYXKwMtudlk-0fVljlURaK7BWcARCpkM-1LGNGTAcsGO6V1TgrtmQFvCo8uVYW_QEfASK-9j6Nr?w=500&auto=format',
         floor_price=FVal(0.00098),
+        floor_price_asset=A_ETH,
     ),
 )
 
@@ -64,7 +67,8 @@ TEST_NFT_YABIR_ETH = NFT(
     name='yabir.eth',
     external_link='https://metadata.ens.domains/mainnet/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/26612040215479394739615825115912800930061094786769410446114278812336794170041',
     permalink='https://opensea.io/assets/ethereum/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/26612040215479394739615825115912800930061094786769410446114278812336794170041',
-    price_eth=FVal(0.00098),
+    price_in_asset=FVal(0.00098),
+    price_asset=A_ETH,
     price_usd=FVal(1.2379458),
     collection=Collection(
         name='ENS: Ethereum Name Service',
@@ -72,6 +76,7 @@ TEST_NFT_YABIR_ETH = NFT(
         description='Ethereum Name Service (ENS) domains are secure domain names for the decentralized world. ENS domains provide a way for users to map human readable names to blockchain and non-blockchain resources, like Ethereum addresses, IPFS hashes, or website URLs. ENS domains can be bought and sold on secondary markets.',  # noqa: E501
         large_image='https://i.seadn.io/gae/BBj09xD7R4bBtg1lgnAAS9_TfoYXKwMtudlk-0fVljlURaK7BWcARCpkM-1LGNGTAcsGO6V1TgrtmQFvCo8uVYW_QEfASK-9j6Nr?w=500&auto=format',
         floor_price=FVal(0.00098),
+        floor_price_asset=A_ETH,
     ),
 )
 
@@ -114,7 +119,7 @@ def test_nft_query(rotkehlchen_api_server, start_with_valid_premium):
             assert entry['name'] == 'MoonCat #129: 0x0082206dcb'
             assert entry['external_link'] == 'https://api.mooncat.community/traits/129'
             assert 'image_url' in entry
-            assert FVal(entry['price_eth']) > ZERO
+            assert FVal(entry['price_in_asset']) > ZERO
             assert FVal(entry['price_usd']) > ZERO
             assert entry['collection']['name'] == 'MoonCats'
             assert entry['collection']['banner_image'].startswith('https://')
@@ -431,7 +436,8 @@ def test_edit_delete_nft(rotkehlchen_api_server):
             name='nebolax.eth',
             external_link='https://metadata.ens.domains/mainnet/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/73552724610198397480670284492690114609730214421511097849210414928326607694469',
             permalink='https://opensea.io/assets/ethereum/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/73552724610198397480670284492690114609730214421511097849210414928326607694469',
-            price_eth=FVal(0.5),
+            price_in_asset=FVal(0.5),
+            price_asset=A_ETH,
             price_usd=FVal(1.2379458),
             collection=Collection(
                 name='ENS: Ethereum Name Service',
@@ -662,7 +668,8 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
                     name='Uniswap - 0.3% - SHIB/WETH - 79010000<>166260000',
                     external_link=None,
                     permalink='https://opensea.io/assets/ethereum/0xc36442b4a4522e871399cd717abdd847ab11fe88/360762',
-                    price_eth=ZERO,
+                    price_in_asset=ZERO,
+                    price_asset=A_ETH,
                     price_usd=ZERO,
                     collection=Collection(
                         name='Uniswap V3 Positions',
@@ -679,7 +686,8 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
                     name='Uniswap - 0.3% - USDT/WETH - 224.56<>2445.5',
                     external_link=None,
                     permalink='https://opensea.io/assets/ethereum/0xc36442b4a4522e871399cd717abdd847ab11fe88/360680',
-                    price_eth=ZERO,
+                    price_in_asset=ZERO,
+                    price_asset=A_ETH,
                     price_usd=ZERO,
                     collection=Collection(
                         name='Uniswap V3 Positions',

--- a/rotkehlchen/tests/unit/test_nfts.py
+++ b/rotkehlchen/tests/unit/test_nfts.py
@@ -1,6 +1,10 @@
 import pytest
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.aggregator import ChainsAggregator
 
 from rotkehlchen.db.filtering import NFTFilterQuery
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import ChecksumEvmAddress
 
 TEST_ACC1 = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65'  # yabir.eth
 TEST_ACC2 = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'  # lefteris.eth
@@ -21,3 +25,23 @@ def test_addresses_queried_for_nfts(blockchain):
     )
     balances = nft_module.get_db_nft_balances(filter_query=NFTFilterQuery.make())['entries']
     assert any(x['name'] == 'yabir.eth' for x in balances)
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x1143fd695a33ac740C84B93fd57f1f8396C1Af05']])
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('ethereum_modules', [['nfts']])
+def test_nfts_floor_prices(
+        blockchain: ChainsAggregator,
+        ethereum_accounts: list[ChecksumEvmAddress],
+):
+    """Test that if the floor price is given in something else than ETH we correctly
+    represent it.
+    """
+    nft_module = blockchain.get_module('nfts')
+    assert nft_module is not None
+    nfts = nft_module.opensea.get_account_nfts(ethereum_accounts[0])
+    assert len(nfts) == 1
+    assert nfts[0].collection is not None
+    assert nfts[0].collection.floor_price == FVal(599)
+    assert nfts[0].collection.floor_price_asset == Asset('eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174')  # USDC.e on polygon # noqa: E501


### PR DESCRIPTION
the floor price can be given using an asset different than ETH and this was not correctly handled. Now we query the token and save the price using the correct asset.

**This PR requires a small frontend change and @lukicenturi  is already aware of that. Not including the changelog entry due to that** 
