### PR TITLE
Support Coinbase staking_reward tx type

### DIFF
--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -641,7 +641,7 @@ class Coinbase(ExchangeInterface):
                 if (trade := self._process_coinbase_trade(event=transaction)):
                     trades.append(trade)
             elif (
-                    tx_type in ('interest', 'inflation_reward') or
+                    tx_type in ('interest', 'inflation_reward', 'staking_reward') or
                     (
                         tx_type == 'send' and 'from' in transaction and
                         'resource' in transaction['from'] and

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -487,7 +487,7 @@ def test_coinbase_query_income_loss_expense(
     with patch.object(coinbase.session, 'get', side_effect=mock_normal_coinbase_query):
         events = coinbase.query_income_loss_expense(
             start_ts=0,
-            end_ts=1611426233,
+            end_ts=1612439233,
             only_cache=False,
         )
 
@@ -495,7 +495,7 @@ def test_coinbase_query_income_loss_expense(
     errors = coinbase.msg_aggregator.consume_errors()
     assert len(warnings) == 0
     assert len(errors) == 0
-    assert len(events) == 2
+    assert len(events) == 3
     expected_events = [
         HistoryEvent(
             identifier=1,
@@ -519,6 +519,17 @@ def test_coinbase_query_income_loss_expense(
             asset=asset_from_coinbase('ALGO'),
             balance=Balance(amount=FVal('0.000076'), usd_value=ZERO),
             notes='Received 0.000076 ALGO ($0.00) as inflation_reward',
+        ), HistoryEvent(
+            identifier=3,
+            event_identifier='CBE_id6',
+            sequence_index=0,
+            timestamp=TimestampMS(1611512633000),
+            location=Location.COINBASE,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=asset_from_coinbase('SOL'),
+            balance=Balance(amount=FVal('0.025412'), usd_value=ZERO),
+            notes='',
         ),
     ]
     assert expected_events == events

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -1146,8 +1146,18 @@ TRANSACTIONS_RESPONSE = """{
  "resource_path": "/v2/accounts/accountid-1/transactions/txid-2",
  "status": "completed",
  "type": "sell",
- "updated_at": "2021-12-08T01:18:26Z"}
-]}"""  # noqa: E501
+ "updated_at": "2021-12-08T01:18:26Z"
+},{
+ "amount": {"amount": "0.025412", "currency": "SOL"},
+ "created_at": "2021-01-24T18:23:53Z",
+ "updated_at": "2021-01-24T18:23:53Z",
+ "id": "id6",
+ "native_amount": {"amount": "0.31", "currency": "EUR"},
+ "resource": "transaction",
+ "resource_path": "/v2/accounts/accountid-1/transactions/id6",
+ "status": "completed",
+ "type": "staking_reward"
+}]}"""  # noqa: E501
 
 
 def mock_normal_coinbase_query(url, **kwargs):  # pylint: disable=unused-argument


### PR DESCRIPTION
When digging into coinbase API responses, I found that rotki ignored the `staking_reward` tx type. This PR adds support in the same way as `inflation_reward` and `interest`.

As a related note, I don't know why all three (`interest`, `inflation_reward` and `staking_reward`) are reported with Event Subtype NONE where they could be reported as REWARD. If you want me to change this as well with this PR, let me know.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
