### PR TITLE
Refactor (2698): Move Bitfinex currency_map to DB

### DIFF
--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -85,6 +85,7 @@ a = Entrypoint(
         ('rotkehlchen/data/populate_asset_collections.sql', 'rotkehlchen/data'),
         ('rotkehlchen/data/populate_multiasset_mappings.sql', 'rotkehlchen/data'),
         ('rotkehlchen/data/populate_location_asset_mappings.sql', 'rotkehlchen/data'),
+        ('rotkehlchen/data/populate_location_unsupported_assets.sql', 'rotkehlchen/data'),
         # TODO
         # We probably should have a better way to specify some data should be loaded
         # by a module in pyinstaller. Should be loaded dynamically by rotki and not

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -94,23 +94,23 @@ def asset_from_poloniex(poloniex_name: str) -> AssetWithOracles:
     ))
 
 
-def asset_from_bitfinex(
-        bitfinex_name: str,
-        currency_map: dict[str, str],
-) -> AssetWithOracles:
+def asset_from_bitfinex(bitfinex_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
     - UnsupportedAsset
     - UnknownAsset
 
-    Currency map coming from `<Bitfinex>._query_currency_map()` is already
-    updated with BITFINEX_TO_WORLD (prevent updating it on each call)
+    Currency map fetched in `<Bitfinex>._query_currency_map()` is already
+    inserted into location_asset_mappings (prevent updating it on each call)
     """
     if not isinstance(bitfinex_name, str):
         raise DeserializationError(f'Got non-string type {type(bitfinex_name)} for bitfinex asset')
 
-    symbol = currency_map.get(bitfinex_name, bitfinex_name)
-    return symbol_to_asset_or_token(symbol)
+    return symbol_to_asset_or_token(GlobalDBHandler.get_assetid_from_exchange_name(
+        exchange=Location.BITFINEX,
+        symbol=bitfinex_name,
+        default=bitfinex_name,
+    ))
 
 
 def asset_from_bitstamp(bitstamp_name: str) -> AssetWithOracles:

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -16,6 +16,7 @@ from requests.adapters import Response
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import BITFINEX_EXCHANGE_TEST_ASSETS, asset_from_bitfinex
+from rotkehlchen.assets.utils import symbol_to_asset_or_token
 from rotkehlchen.constants import ZERO
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import RemoteError
@@ -84,12 +85,6 @@ class CurrenciesResponse(NamedTuple):
     success: bool
     response: Response
     currencies: list[str]
-
-
-class CurrencyMapResponse(NamedTuple):
-    success: bool
-    response: Response
-    currency_map: dict[str, str]
 
 
 class ExchangePairsResponse(NamedTuple):
@@ -478,10 +473,7 @@ class Bitfinex(ExchangeInterface):
                 f'Unexpected bitfinex movement with status: {raw_result[5]}. '
                 f'Only completed movements are processed. Raw movement: {raw_result}',
             )
-        fee_asset = asset_from_bitfinex(
-            bitfinex_name=raw_result[1],
-            currency_map=self.currency_map,
-        )
+        fee_asset = asset_from_bitfinex(bitfinex_name=raw_result[1])
 
         amount = deserialize_asset_amount(raw_result[12])
         category = (
@@ -541,18 +533,9 @@ class Bitfinex(ExchangeInterface):
                 f'Raw trade: {raw_result}',
             )
 
-        base_asset = asset_from_bitfinex(
-            bitfinex_name=bfx_base_asset_symbol,
-            currency_map=self.currency_map,
-        )
-        quote_asset = asset_from_bitfinex(
-            bitfinex_name=bfx_quote_asset_symbol,
-            currency_map=self.currency_map,
-        )
-        fee_asset = asset_from_bitfinex(
-            bitfinex_name=raw_result[10],
-            currency_map=self.currency_map,
-        )
+        base_asset = asset_from_bitfinex(bitfinex_name=bfx_base_asset_symbol)
+        quote_asset = asset_from_bitfinex(bitfinex_name=bfx_quote_asset_symbol)
+        fee_asset = asset_from_bitfinex(bitfinex_name=raw_result[10])
 
         trade = Trade(
             timestamp=Timestamp(int(raw_result[2] / 1000)),
@@ -627,19 +610,18 @@ class Bitfinex(ExchangeInterface):
             currencies=currencies,
         )
 
-    def _query_currency_map(self) -> CurrencyMapResponse:
+    def _query_currency_map(self) -> None:
         """Query the list that maps standard currency symbols with the version
         of the Bitfinex API. If the request is successful and the list format
-        as well, return it as dict in `<CurrencyMapResponse>.currency_map`.
-        Otherwise populate <CurrencyMapResponse> with data that each endpoint
-        can process as an unsuccessful request.
+        as well, insert or ignore the mapping in location_asset_mappings.
 
         API result format is: [[[<bitfinex_symbol>, <symbol>], ...]]
 
-        May raise IndexError if the list is empty.
+        May raise:
+        - IndexError if the list is empty.
+        - RemoteError if the API returns an error response.
         """
         was_successful = True
-        currency_map = {}
         response = self._api_query('configs_map_currency_symbol')
 
         if response.status_code != HTTPStatus.OK:
@@ -653,24 +635,42 @@ class Bitfinex(ExchangeInterface):
                 log.error(
                     f'{self.name} currency map returned invalid JSON response. Check further logs',
                 )
-            else:
-                currency_map = {
-                    bfx_symbol: symbol for bfx_symbol, symbol in response_list[0]
-                    if bfx_symbol not in set(BITFINEX_EXCHANGE_TEST_ASSETS)
-                }
-                with GlobalDBHandler().conn.read_ctx() as cursor:
-                    cursor.execute(
-                        'SELECT exchange_symbol, local_id FROM location_asset_mappings WHERE location IS ? OR location IS NULL;',  # noqa: E501
-                        (Location.BITFINEX.serialize_for_db(),),
-                    )
-                    for bfx_symbol, asset_id in cursor:
-                        currency_map[bfx_symbol] = asset_id
+            else:  # add the mappings fetched from the API in globalDB, if they are not already there  # noqa: E501
+                test_assets = set(BITFINEX_EXCHANGE_TEST_ASSETS)
+                bfx_db_serialized = Location.BITFINEX.serialize_for_db()
+                bindings = []
+                for bfx_symbol, symbol in response_list[0]:
+                    if bfx_symbol in test_assets:
+                        continue  # skip test assets
+                    try:
+                        asset = symbol_to_asset_or_token(symbol)
+                    except UnknownAsset:
+                        log.info(f'Found new asset symbol {bfx_symbol} for {symbol} in Bitfinex. Support for it has to be added.')  # noqa: E501
+                        continue  # skip unknown assets
 
-        return CurrencyMapResponse(
-            success=was_successful,
-            response=response,
-            currency_map=currency_map,
-        )
+                    bindings.append((
+                        bfx_db_serialized,
+                        bfx_symbol,
+                        asset.serialize(),
+                        bfx_db_serialized,
+                        bfx_symbol,
+                    ))
+
+                # insert the mapping, and skip unsupported assets
+                with GlobalDBHandler().conn.write_ctx() as write_cursor:
+                    write_cursor.executemany(
+                        'INSERT OR IGNORE INTO location_asset_mappings (location, '
+                        'exchange_symbol, local_id) SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 '
+                        'FROM location_unsupported_assets WHERE location=? AND exchange_symbol=?)',
+                        bindings,
+                    )
+
+        if was_successful is False:
+            raise RemoteError(
+                f'bitfinex failed to request exchange currency map. '
+                f'Response status code: {response.status_code}. '
+                f'Response text: {response.text}.',
+            )
 
     def _query_exchange_pairs(self) -> ExchangePairsResponse:
         """Query and return the list of the exchange (trades) pairs in
@@ -796,6 +796,8 @@ class Bitfinex(ExchangeInterface):
 
         These data are stored in properties along with `pair_bfx_symbols_map`,
         a dict that maps a pair between the tickers of the base and quote assets.
+
+        May raise RemoteError if any API request fails.
         """
         if self.first_connection_made:
             return
@@ -816,13 +818,7 @@ class Bitfinex(ExchangeInterface):
                 f'Response text: {exchange_pairs_response.response.text}.',
             )
 
-        currency_map_response = self._query_currency_map()
-        if currency_map_response.success is False:
-            raise RemoteError(
-                f'bitfinex failed to request exchange currency map. '
-                f'Response status code: {currency_map_response.response.status_code}. '
-                f'Response text: {currency_map_response.response.text}.',
-            )
+        self._query_currency_map()
         # Generate a pair - tickers map. Bitfinex test assets have already been
         # removed from both 'pairs' and 'currencies' lists.
         pair_bfx_symbols_map: dict[str, tuple[str, str]] = {}
@@ -840,7 +836,6 @@ class Bitfinex(ExchangeInterface):
 
                 pair_bfx_symbols_map[bfx_pair] = (bfx_base_asset_symbol, bfx_quote_asset_symbol)
 
-        self.currency_map = currency_map_response.currency_map
         self.pair_bfx_symbols_map = pair_bfx_symbols_map
         self.first_connection_made = True
 
@@ -894,10 +889,7 @@ class Bitfinex(ExchangeInterface):
                 continue  # bitfinex can show small negative balances for some coins. Ignore
 
             try:
-                asset = asset_from_bitfinex(
-                    bitfinex_name=wallet[currency_index],
-                    currency_map=self.currency_map,
-                )
+                asset = asset_from_bitfinex(bitfinex_name=wallet[currency_index])
             except (UnknownAsset, UnsupportedAsset) as e:
                 asset_tag = 'unknown' if isinstance(e, UnknownAsset) else 'unsupported'
                 self.msg_aggregator.add_warning(

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -2112,8 +2112,7 @@ class GlobalDBHandler:
 
     @staticmethod
     def is_asset_symbol_unsupported(location: 'Location', asset_symbol: str) -> bool:
-        """Returns True if the asset with the given symbol is not supported in the given location.
-        Otherwise returns False."""
+        """Returns if the asset with the given symbol is not supported in the given location."""
         with GlobalDBHandler().conn.read_ctx() as cursor:
             return cursor.execute(
                 'SELECT COUNT(*) FROM location_unsupported_assets WHERE location=? AND exchange_symbol=?',  # noqa: E501

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -10,8 +10,8 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import BITFINEX_EXCHANGE_TEST_ASSETS, asset_from_bitfinex
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_GLM, A_LINK, A_USD, A_USDT, A_WBTC
-from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.bitfinex import (
     API_ERR_AUTH_NONCE_CODE,
     API_ERR_AUTH_NONCE_MESSAGE,
@@ -32,6 +32,7 @@ from rotkehlchen.types import (
     EvmTokenKind,
     Fee,
     Location,
+    LocationAssetMappingUpdateEntry,
     Price,
     Timestamp,
 )
@@ -69,18 +70,16 @@ def test_assets_are_known(mock_bitfinex, globaldb):
         ))
         pytest.xfail('Failed to request {mock_bitfinex.name} exchange pairs list')
 
-    currency_map_response = mock_bitfinex._query_currency_map()
-    if currency_map_response.success is False:
-        response = currency_map_response.response
+    try:
+        mock_bitfinex._query_currency_map()
+    except RemoteError as e:
         test_warnings.warn(UserWarning(
             f'Failed to request {mock_bitfinex.name} currency map. '
-            f'Response status code: {response.status_code}. '
-            f'Response text: {response.text}. Xfailing this test',
+            f'Xfailing this test. {e!s}',
         ))
         pytest.xfail('Failed to request {mock_bitfinex.name} currency map')
 
     test_assets = set(BITFINEX_EXCHANGE_TEST_ASSETS)
-    currency_map = currency_map_response.currency_map
     symbols = set()
     for symbol in currencies_response.currencies:
         if symbol in test_assets:
@@ -92,10 +91,7 @@ def test_assets_are_known(mock_bitfinex, globaldb):
 
     for symbol in symbols:
         try:
-            asset_from_bitfinex(
-                bitfinex_name=symbol,
-                currency_map=currency_map,
-            )
+            asset_from_bitfinex(bitfinex_name=symbol)
         except UnsupportedAsset:
             assert globaldb.is_asset_symbol_unsupported(Location.BITFINEX, symbol)
         except UnknownAsset as e:
@@ -105,17 +101,40 @@ def test_assets_are_known(mock_bitfinex, globaldb):
             ))
 
 
-def test_first_connection(mock_bitfinex):
-    """Test 'currency_map' and 'pair_bfx_symbols_map' contain the expected data.
+def test_first_connection(mock_bitfinex, globaldb):
+    """Test that 'pair_bfx_symbols_map' contain the expected data.
     """
     assert mock_bitfinex.first_connection_made is False
-    assert hasattr(mock_bitfinex, 'currency_map') is False
     assert hasattr(mock_bitfinex, 'pair_bfx_symbols_map') is False
+
+    bitfinex_db_serialized = Location.BITFINEX.serialize_for_db()
+    with globaldb.conn.read_ctx() as cursor:
+        mappings_before = set(cursor.execute(
+            'SELECT exchange_symbol, local_id FROM location_asset_mappings '
+            'WHERE location=?;',
+            (bitfinex_db_serialized,),
+        ).fetchall())
 
     mock_bitfinex.first_connection()
 
-    assert mock_bitfinex.currency_map['UST'] == ethaddress_to_identifier('0xdAC17F958D2ee523a2206206994597C13D831ec7')  # noqa: E501
-    assert mock_bitfinex.currency_map['WBT'] == ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599')  # noqa: E501
+    with globaldb.conn.read_ctx() as cursor:
+        mappings_after = set(cursor.execute(
+            'SELECT exchange_symbol, local_id FROM location_asset_mappings '
+            'WHERE location=?;',
+            (bitfinex_db_serialized,),
+        ).fetchall())
+
+    new_mappings = mappings_after - mappings_before
+    assert len(new_mappings) > 0
+
+    with globaldb.conn.read_ctx() as cursor:
+        for bfx_symbol, _ in new_mappings:
+            assert cursor.execute(
+                'SELECT COUNT(*) FROM location_unsupported_assets '
+                'WHERE location=? AND exchange_symbol=?;',
+                (bitfinex_db_serialized, bfx_symbol),
+            ).fetchone()[0] == 0  # no new mapping added for unsupported assets
+
     assert mock_bitfinex.pair_bfx_symbols_map['BTCUST'] == ('BTC', 'UST')
     assert mock_bitfinex.pair_bfx_symbols_map['UDCUSD'] == ('UDC', 'USD')
     assert mock_bitfinex.first_connection_made is True
@@ -170,7 +189,7 @@ def test_validate_api_key_invalid_key(mock_bitfinex):
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
-def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disable=unused-argument
+def test_query_balances_asset_balance(mock_bitfinex, inquirer, globaldb):  # pylint: disable=unused-argument
     """Test the balances of the assets are returned as expected.
 
     Also test the following logic:
@@ -180,12 +199,13 @@ def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disab
       - The asset ticker is standardized (e.g. WBT to WBTC, UST to USDT).
     """
     mock_bitfinex.first_connection = MagicMock()
-    mock_bitfinex.currency_map = {
-        'UST': ethaddress_to_identifier('0xdAC17F958D2ee523a2206206994597C13D831ec7'),
-        'GNT': 'GLM',
-        'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'),
-        'LINK': ethaddress_to_identifier('0x514910771AF9Ca656af840dff83E8264EcF986CA'),
-    }
+    globaldb.add_location_asset_mappings([
+        LocationAssetMappingUpdateEntry(
+            location=Location.BITFINEX,
+            location_symbol='GNT',
+            asset=A_GLM,
+        ),
+    ])
     balances_data = (
         """
         [
@@ -249,8 +269,6 @@ def test_query_balances_asset_balance(mock_bitfinex, inquirer):  # pylint: disab
 def test_api_query_paginated_stops_requesting(mock_bitfinex):
     """Test requests are stopped after retry limit is reached.
     """
-    mock_bitfinex.currency_map = {}
-
     def mock_api_query_response(endpoint, options):  # pylint: disable=unused-argument
         return MockResponse(
             HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -289,8 +307,6 @@ def test_api_query_paginated_retries_request(mock_bitfinex):
     JSON as a dict and later as a list (via `_process_unsuccessful_response()`)
     works as expected.
     """
-    mock_bitfinex.currency_map = {}
-
     def get_paginated_response():
         results = [
             f'{{"error":"{API_RATE_LIMITS_ERROR_MESSAGE}"}}',
@@ -327,10 +343,6 @@ def test_api_query_paginated_retries_request(mock_bitfinex):
 
 
 def test_deserialize_trade_buy(mock_bitfinex):
-    mock_bitfinex.currency_map = {
-        'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'),
-        'UST': ethaddress_to_identifier('0xdAC17F958D2ee523a2206206994597C13D831ec7'),
-    }
     mock_bitfinex.pair_bfx_symbols_map = {'WBTUST': ('WBT', 'UST')}
     raw_result = [
         399251013,
@@ -363,7 +375,6 @@ def test_deserialize_trade_buy(mock_bitfinex):
 
 
 def test_deserialize_trade_sell(mock_bitfinex):
-    mock_bitfinex.currency_map = {'UST': ethaddress_to_identifier('0xdAC17F958D2ee523a2206206994597C13D831ec7')}  # noqa: E501
     mock_bitfinex.pair_bfx_symbols_map = {'ETHUST': ('ETH', 'UST')}
     raw_result = [
         399251013,
@@ -407,7 +418,6 @@ def test_delisted_pair_trades_work(mock_bitfinex):
         chain_id=ChainID.ETHEREUM,
         token_kind=EvmTokenKind.ERC20,
     )
-    mock_bitfinex.currency_map = {}
     mock_bitfinex.pair_bfx_symbols_map = {}
     raw_result = [
         399251013,
@@ -457,10 +467,6 @@ def test_query_online_trade_history_case_1(mock_bitfinex):
     """
     api_limit = 2
     mock_bitfinex.first_connection = MagicMock()
-    mock_bitfinex.currency_map = {
-        'UST': ethaddress_to_identifier('0xdAC17F958D2ee523a2206206994597C13D831ec7'),
-        'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'),
-    }
     mock_bitfinex.pair_bfx_symbols_map = {
         'ETHUST': ('ETH', 'UST'),
         'WBTUSD': ('WBT', 'USD'),
@@ -679,10 +685,6 @@ def test_query_online_trade_history_case_2(mock_bitfinex):
     """
     api_limit = 2
     mock_bitfinex.first_connection = MagicMock()
-    mock_bitfinex.currency_map = {
-        'UST': ethaddress_to_identifier('0xdAC17F958D2ee523a2206206994597C13D831ec7'),
-        'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'),
-    }
     mock_bitfinex.pair_bfx_symbols_map = {
         'ETHUST': ('ETH', 'UST'),
         'WBTUSD': ('WBT', 'USD'),
@@ -840,7 +842,6 @@ def test_query_online_trade_history_case_2(mock_bitfinex):
 
 
 def test_deserialize_asset_movement_deposit(mock_bitfinex):
-    mock_bitfinex.currency_map = {'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599')}  # noqa: E501
     raw_result = [
         13105603,
         'WBT',
@@ -886,7 +887,6 @@ def test_deserialize_asset_movement_withdrawal(mock_bitfinex):
     """Test also both 'address' and 'transaction_id' are None for fiat
     movements.
     """
-    mock_bitfinex.currency_map = {}
     raw_result = [
         13105603,
         'EUR',
@@ -948,7 +948,6 @@ def test_query_online_deposits_withdrawals_case_1(mock_bitfinex):
     """
     api_limit = 2
     mock_bitfinex.first_connection = MagicMock()
-    mock_bitfinex.currency_map = {'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599')}  # noqa: E501
     # Deposit WBTC
     movement_1 = """
     [
@@ -1201,7 +1200,6 @@ def test_query_online_deposits_withdrawals_case_2(mock_bitfinex):
     """
     api_limit = 2
     mock_bitfinex.first_connection = MagicMock()
-    mock_bitfinex.currency_map = {'WBT': ethaddress_to_identifier('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599')}  # noqa: E501
     # Deposit WBTC
     movement_1 = """
     [


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=54770713

## Checklist

- [x] Use `location_asset_mappings` table of GlobalDB instead of in-memory `currency_map` for Bitfinex