### PR TITLE
Feat (2698): Remote updates for unsupported assets

### DIFF
--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -35,6 +35,7 @@ class UpdateType(Enum):
     GLOBAL_ADDRESSBOOK = 'global_addressbook'
     ACCOUNTING_RULES = 'accounting_rules'
     LOCATION_ASSET_MAPPINGS = 'location_asset_mappings'
+    LOCATION_UNSUPPORTED_ASSETS = 'location_unsupported_assets'
 
     def serialize(self) -> str:
         """Serializes the update type for the DB and API"""


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=54767616

## Checklist

- [x] Support remote updates for unsupported asset mappings for locations
- [x] https://github.com/rotki/data/pull/71