### PR TITLE
Add a test that dead tasks log traceback

### DIFF
--- a/rotkehlchen/tests/api/test_errors.py
+++ b/rotkehlchen/tests/api/test_errors.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+import requests
+
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response
+
+
+def test_async_task_death_traceback(rotkehlchen_api_server, caplog):
+    """Test that the exception traceback appears in the logs for dead async tasks
+
+    Note that there still can be some tasks for which the task's gevent has saved
+    no exception info for some reason.
+    """
+    with patch('rotkehlchen.inquirer.Inquirer.find_usd_price', side_effect=ValueError('Boom')):
+        response = requests.get(
+            api_url_for(rotkehlchen_api_server, 'exchangeratesresource'),
+            json={'async_query': True, 'currencies': ['ETH']},
+        )
+
+    assert_proper_response(response)
+    assert ' Greenlet for task 0 dies with exception: Boom' in caplog.text
+    assert "Exception Name: <class 'ValueError'>" in caplog.text
+    assert 'Exception Info: Boom' in caplog.text
+    assert 'Traceback:' in caplog.text
+    tb_start = caplog.text.find('Traceback:')  # Check there is stuff after Traceack
+    file_count = caplog.text.count('File', tb_start)
+    assert file_count > 2, 'Traceback should involve more than 2 files'


### PR DESCRIPTION
Just a test that the functionality works. The test works. Problem is (probably) some greenlets for some errors can have no traceback.