### PR TITLE
Clarify logs for no price and etherscan

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2976,7 +2976,7 @@ class RestAPI:
                     timestamp=timestamp,
                 )
             except (RemoteError, NoPriceForGivenTimestamp) as e:
-                log.error(
+                log.warning(
                     f'Could not query the historical {target_asset.identifier} price for '
                     f'{asset.identifier} at time {timestamp} due to: {e!s}. Using zero price',
                 )

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -507,8 +507,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                     timestamp = deserialize_timestamp(entry['timeStamp'])
                 except DeserializationError as e:
                     log.error(
-                        f"Failed to read transaction timestamp {entry['hash']} from etherscan for "
-                        f'{account} in the range {from_ts} to {to_ts}. {e!s}',
+                        f"Failed to read transaction timestamp {entry['hash']} from {self.chain} "
+                        f'etherscan for {account} in the range {from_ts} to {to_ts}. {e!s}',
                     )
                     continue
 
@@ -520,8 +520,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
                     hashes.add((deserialize_evm_tx_hash(entry['hash']), timestamp))
                 except DeserializationError as e:
                     log.error(
-                        f"Failed to read transaction hash {entry['hash']} from etherscan for "
-                        f'{account} in the range {from_ts} to {to_ts}. {e!s}',
+                        f"Failed to read transaction hash {entry['hash']} from {self.chain} "
+                        f'etherscan for {account} in the range {from_ts} to {to_ts}. {e!s}',
                     )
                     continue
 
@@ -688,8 +688,8 @@ class Etherscan(ExternalServiceWithApiKey, metaclass=ABCMeta):
             number = deserialize_int_from_str(result, 'etherscan getblocknobytime')
         except DeserializationError as e:
             raise RemoteError(
-                f'Could not read blocknumber from etherscan getblocknobytime '
-                f'result {result}',
+                f'Could not read blocknumber from {self.chain} etherscan '
+                f'getblocknobytime result {result}',
             ) from e
 
         self.timestamp_to_block_cache.add(key=ts, value=number)


### PR DESCRIPTION
- Failure to _get_historical_assets_price via the API should just log a warning. Not error.
- etherscan logs add the chain to missing logs

Makes it easier to read logs