### PR TITLE
Fix (count_with_limit): Make grouping configurable

### DIFF
--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -628,12 +628,15 @@ class DBHistoryEvents:
             )
 
             free_query_group_by = maybe_filter_ignore_asset(query_filter)
+            group_by_query = ''
+            if group_by_event_ids:
+                group_by_query = 'GROUP BY event_identifier ORDER BY timestamp DESC, sequence_index ASC LIMIT ?'  # noqa: E501
+                bindings.insert(0, entries_limit)  # add limit's binding before prepared_query's bindings  # noqa: E501
             count_with_limit = cursor.execute(
                 f'SELECT COUNT(*) FROM ('
                 f'SELECT {query_filter.get_columns()} {query_filter.get_join_query()}{free_query_group_by}'  # we take the groups before the limit has been applied  # noqa: E501
-                'GROUP BY event_identifier ORDER BY timestamp DESC, sequence_index ASC LIMIT ?'
-                f'){prepared_query}',
-                [entries_limit] + bindings,  # add limit's binding before prepared_query's bindings
+                f'{group_by_query}){prepared_query}',
+                bindings,
             ).fetchone()[0]
             return count_without_limit, count_with_limit
 

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -391,7 +391,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert result['entries_found'] == 6
+    assert result['entries_found'] == 9
     assert result['entries_limit'] == 100
     assert result['entries_total'] == 9
     for event in result['entries']:
@@ -474,7 +474,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
     )
     result = assert_proper_response_with_result(response)
     assert len(result['entries']) == 8
-    assert result['entries_found'] == 5
+    assert result['entries_found'] == 8
     assert result['entries_limit'] == 100
     assert result['entries_total'] == 9
 
@@ -495,7 +495,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         assert result['entries_total'] == 6
 
     # test pagination and exclude_ignored_assets without group by event ids works
-    for exclude_ignored_assets, events_found, sub_events_found in ((True, 2, 3), (False, 6, 9)):
+    for exclude_ignored_assets, events_found, sub_events_found in ((True, 3, 3), (False, 9, 9)):
         response = requests.post(
             api_url_for(
                 rotkehlchen_api_server,


### PR DESCRIPTION
## Checklist

- [x] For counting with limit, only do the group by sub-query if `group_by_event_ids` is True.