### PR TITLE
Fix EVM RPC node deletion.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,8 @@ Changelog
 =========
 
 * :bug:`-` Fix a bug where the custom price is not applied in the balance view under the account table.
-* :bug:`-` Naira should be correctly detected in binance.
+* :bug:`-` Deleting an EVM RPC node will no longer fail sometimes with a "Can't delete etherscan node" error. Additionally non-mainnet etherscan nodes are no longer deletable.
+* :bug:`-` Nigerian Naira should be correctly detected in binance.
 * :bug:`-` Kraken balances in new yield-bearing products and automatic staking for new kraken users should now appear properly.
 
 * :release:`1.32.2 <2024-03-15>`

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -663,7 +663,11 @@ class RpcNodesResource(BaseMethodView):
         return RpcNodeEditSchema(
             dbhandler=self.rest_api.rotkehlchen.data.db,
         )
-    delete_schema = RpcNodeListDeleteSchema()
+
+    def make_delete_schema(self) -> RpcNodeListDeleteSchema:
+        return RpcNodeListDeleteSchema(
+            dbhandler=self.rest_api.rotkehlchen.data.db,
+        )
 
     @require_loggedin_user()
     @use_kwargs(get_schema, location='view_args')
@@ -719,7 +723,7 @@ class RpcNodesResource(BaseMethodView):
         return self.rest_api.update_rpc_node(node=node)
 
     @require_loggedin_user()
-    @use_kwargs(delete_schema, location='json_and_query_and_view_args')
+    @resource_parser.use_kwargs(make_delete_schema, location='json_and_query_and_view_args')
     def delete(
             self,
             blockchain: SupportedBlockchain,

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2948,15 +2948,19 @@ class RpcNodeListDeleteSchema(Schema):
     blockchain = BlockchainField(required=True, exclude_types=(SupportedBlockchain.ETHEREUM_BEACONCHAIN,))  # noqa: E501
     identifier = fields.Integer(required=True)
 
+    def __init__(self, dbhandler: 'DBHandler') -> None:
+        super().__init__()
+        self.dbhandler = dbhandler
+
     @validates_schema
     def validate_schema(
             self,
             data: dict[str, Any],
             **_kwargs: Any,
     ) -> None:
-        if data['identifier'] == 1:
+        if self.dbhandler.is_etherscan_node(data['identifier']):
             raise ValidationError(
-                message="Can't delete the etherscan node",
+                message="Can't delete an etherscan node",
                 field_name='identifier',
             )
 

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -369,6 +369,7 @@ def test_manage_nodes(rotkehlchen_api_server):
         },
     )
     assert_proper_response_with_result(response)
+
     response = requests.patch(  # test that editing optimism etherscan weight works
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain='OPTIMISM'),
         json={
@@ -381,6 +382,18 @@ def test_manage_nodes(rotkehlchen_api_server):
         },
     )
     assert_proper_response_with_result(response)
+
+    # try to delete normal etherscan and optimism etherscan and see it fails
+    for identifier in (1, 6):
+        response = requests.delete(
+            api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
+            json={'identifier': identifier},
+        )
+        assert_error_response(
+            response=response,
+            contained_in_msg="Can't delete an etherscan node",
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
 
     # and now let's replicate https://github.com/rotki/rotki/issues/4769 by
     # editing all nodes to have 0% weight.


### PR DESCRIPTION
Fix #7671

Deleting an EVM RPC node will no longer fail sometimes with a "Can't delete etherscan node" failure. Additionally non-mainnet etherscan nodes are no longer deletable.

