### PR TITLE
Add metadata for when an airdrop is missing a decoder

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8923,7 +8923,8 @@ Querying ethereum airdrops
                      "amount": "1823.23",
                      "asset": "eip155:1/erc20:0x111111111117dC0aa78b770fA6A738034120C302",
                      "link": "https://1inch.exchange/",
-                     "claimed": false
+                     "claimed": false,
+                     "missing_decoder": true
                   },
                   "uniswap": {
                      "amount": "400",

--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.chain.ethereum.airdrops import (
     AIRDROPS_INDEX,
@@ -116,6 +117,23 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
         'name': 'INVALID',
         'icon': 'invalid.svg',
     },
+    'degen2_season1': {
+        'csv_path': 'airdrops/degen2_season1.csv',
+        'csv_hash': '708ae1fcbe33a11a91fd05e1e7c4fa2d514b65cb1f8d3e4ce3556e7bdd8af2f5',
+        'asset_identifier': 'eip155:8453/erc20:0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed',
+        'url': 'https://www.degen.tips/airdrop2/season1',
+        'name': 'DEGEN',
+        'icon': 'degen.svg',
+        'icon_path': 'airdrops/icons/degen.svg',
+        'new_asset_data': {
+            'asset_type': 'EVM_TOKEN',
+            'address': '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed',
+            'name': 'Degen',
+            'symbol': 'DEGEN',
+            'chain_id': 8453,
+            'decimals': 18,
+        },
+    },
 }, 'poap_airdrops': {
     'aave_v2_pioneers': [
         'airdrops/poap/poap_aave_v2_pioneers.json',
@@ -123,7 +141,7 @@ MOCK_AIRDROP_INDEX = {'airdrops': {
         'AAVE V2 Pioneers',
         '388003b6c0dc589981ce9e962d6d8b6b2148c72ccf6ec3578ab32d63b547f903',
     ],
-}}
+}, 'airdrops_missing_decoders': ['degen2_season1']}
 
 
 def _mock_airdrop_list(url: str, timeout: int = 0, headers: dict | None = None):  # pylint: disable=unused-argument
@@ -232,6 +250,8 @@ def test_check_airdrops(
                 f'address,tokens\n{TEST_ADDR2},123\n{TEST_ADDR2},123\n\n',  # will be skipped because last row is empty  # noqa: E501
             f'{AIRDROPS_REPO_BASE}/airdrops/poap/poap_aave_v2_pioneers.json':
                 f'{{"{TEST_POAP1}": [\n566\n]}}',
+            f'{AIRDROPS_REPO_BASE}/airdrops/degen2_season1.csv':
+                f'address,tokens\n{TEST_ADDR2},394857.029384576349787465\n',
         }
         if url == AIRDROPS_INDEX:
             mock_response.text = json.dumps(mock_airdrop_index)
@@ -297,7 +317,7 @@ def test_check_airdrops(
     with globaldb.conn.read_ctx() as cursor:
         assert cursor.execute(
             'SELECT COUNT(*) FROM unique_cache WHERE key LIKE ?', ('AIRDROPS_HASH%',),
-        ).fetchone()[0] == 10
+        ).fetchone()[0] == 11
         assert cursor.execute(
             'SELECT value FROM unique_cache WHERE key=?', ('AIRDROPS_HASHdiva.csv',),
         ).fetchone()[0] == MOCK_AIRDROP_INDEX['airdrops']['diva']['csv_hash']
@@ -329,7 +349,7 @@ def test_check_airdrops(
     }
     assert messages_aggregator.warnings[0] == 'Skipping airdrop CSV for invalid because it contains an invalid row: []'  # noqa: E501
 
-    assert len(data[TEST_ADDR2]) == 3
+    assert len(data[TEST_ADDR2]) == 4
     assert data[TEST_ADDR2]['uniswap'] == {
         'amount': '400.050642',
         'asset': A_UNI,
@@ -348,6 +368,14 @@ def test_check_airdrops(
         'asset': A_SHU,
         'link': 'https://claim.shutter.network/',
         'claimed': False,
+    }
+    assert data[TEST_ADDR2]['degen2_season1'] == {
+        'amount': '394857.029384576349787465',
+        'asset': Asset('eip155:8453/erc20:0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed'),
+        'link': 'https://www.degen.tips/airdrop2/season1',
+        'claimed': False,
+        'missing_decoder': True,
+        'icon_url': 'https://raw.githubusercontent.com/rotki/data/develop/airdrops/icons/degen.svg',
     }
     assert len(data[TEST_POAP1]) == 1
     assert data[TEST_POAP1]['poap'] == [{
@@ -371,7 +399,7 @@ def test_check_airdrops(
             tolerance_for_amount_check=tolerance_for_amount_check,
         )
         assert mock_get.call_count == 1
-    assert len(data[TEST_ADDR2]) == 2
+    assert len(data[TEST_ADDR2]) == 3
     assert 'shutter' not in data[TEST_ADDR2]
 
     def update_mock_requests_get(url: str, timeout: int = 0, headers: dict | None = None):  # pylint: disable=unused-argument
@@ -461,6 +489,7 @@ def test_fetch_airdrops_metadata(database, remote_etag, database_etag):
         assert metadata == (
             _parse_airdrops(database=database, airdrops_data=mock_airdrop_index['airdrops']),
             mock_airdrop_index['poap_airdrops'],
+            {'degen2_season1'},
         )
         if remote_etag != database_etag:  # check if the value is updated
             assert metadata[0]['diva'].name == 'new_name'


### PR DESCRIPTION
a new key in the index file has been introduced that lists the airdrops for which we don't have a decoder. In the api we will return a new attribute `missing_decoder` of type bool always true when the airdrop doesn't have a decoder.

Part of https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=53148627
