### PR TITLE
Split test_ethereum_nodes_prune_and_archive_status

### DIFF
--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -54,13 +54,14 @@ def test_asset_data(session_coingecko):
         session_coingecko.asset_data(EvmToken('eip155:1/erc20:0x1844b21593262668B7248d0f57a220CaaBA46ab9').to_coingecko())  # PRL, a token without coingecko page  # noqa: E501
 
 
+@pytest.mark.vcr()
 def test_coingecko_historical_price(session_coingecko):
     price = session_coingecko.query_historical_price(
         from_asset=A_ETH,
         to_asset=A_EUR,
-        timestamp=1483056100,
+        timestamp=1704135600,
     )
-    assert price == Price(FVal('7.7478028375650725'))
+    assert price == Price(FVal('2065.603754353392'))
 
 
 def test_assets_with_icons(icon_manager):

--- a/rotkehlchen/tests/integration/test_price_history.py
+++ b/rotkehlchen/tests/integration/test_price_history.py
@@ -1,6 +1,7 @@
 import pytest
 
-from rotkehlchen.constants.assets import A_BTC, A_CORN, A_EUR, A_USD
+from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.constants.assets import A_BTC, A_EUR, A_USD
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -18,6 +19,7 @@ HISTORICAL_PRICE_ORACLES = [
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 @pytest.mark.parametrize('historical_price_oracles_order', [HISTORICAL_PRICE_ORACLES])
+@pytest.mark.vcr()
 def test_price_queries(price_historian, database):
     """Test some historical price queries. Make sure that we test some
     assets not in cryptocompare but in coigecko so the backup mechanism triggers and works"""
@@ -44,5 +46,6 @@ def test_price_queries(price_historian, database):
     price_historian.set_oracles_order(price_historian._oracles)
     assert price_historian.query_historical_price(A_DASH, A_USD, 1438387700) == FVal('10')
     # this should hit coingecko, since cornichon is not in cryptocompare
-    expected_price = FVal('0.07830444726516915')
-    assert price_historian.query_historical_price(A_CORN, A_USD, 1608854400) == expected_price
+    expected_price = FVal('0.5771301464712261')
+    yvecrv = EvmToken('eip155:1/erc20:0xc5bDdf9843308380375a611c18B50Fb9341f502A')
+    assert price_historian.query_historical_price(yvecrv, A_USD, 1704135600) == expected_price

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -14,6 +14,7 @@ from rotkehlchen.tests.utils.checks import assert_serialized_dicts_equal
 from rotkehlchen.tests.utils.ethereum import (
     ETHEREUM_FULL_TEST_PARAMETERS,
     ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED,
+    ETHEREUM_NODES_SET_WITH_PRUNED_AND_NOT_ARCHIVED,
     ETHEREUM_TEST_PARAMETERS,
     INFURA_ETH_NODE,
     wait_until_all_nodes_connected,
@@ -353,7 +354,7 @@ def test_ethereum_nodes_prune_and_archive_status(
     allow_playback_repeats=True,
     filter_query_parameters=['apikey'],
 )
-@pytest.mark.parametrize(*ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
+@pytest.mark.parametrize(*ETHEREUM_NODES_SET_WITH_PRUNED_AND_NOT_ARCHIVED)
 def test_get_pruned_nodes_behaviour_in_txn_queries(
         ethereum_inquirer,
         ethereum_manager_connect_at_start,

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -323,7 +323,7 @@ def test_get_blocknumber_by_time_etherscan(ethereum_inquirer):
     _test_get_blocknumber_by_time(ethereum_inquirer, True)
 
 
-@pytest.mark.vcr(match_on=['uri', 'method', 'raw_body'], allow_playback_repeats=True)
+@pytest.mark.vcr()
 @pytest.mark.parametrize(*ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 def test_ethereum_nodes_prune_and_archive_status(
         ethereum_inquirer,
@@ -342,8 +342,10 @@ def test_ethereum_nodes_prune_and_archive_status(
             assert not web3_node.is_pruned
             assert web3_node.is_archive
 
-    # excluding etherscan
-    assert len(ethereum_inquirer.web3_mapping) == len(ethereum_manager_connect_at_start) - 1
+    if ethereum_manager_connect_at_start[0].node_info.name == 'etherscan':
+        assert len(ethereum_inquirer.web3_mapping) == 0  # excluding etherscan
+    else:
+        assert len(ethereum_inquirer.web3_mapping) == 1
 
 
 @pytest.mark.vcr(

--- a/rotkehlchen/tests/utils/checks.py
+++ b/rotkehlchen/tests/utils/checks.py
@@ -113,6 +113,8 @@ def assert_serialized_dicts_equal(
                 ignore_keys=ignore_keys,
                 length_list_keymap=length_list_keymap,
             )
+        elif isinstance(a_val, bytes):
+            assert a_val.hex() == b[a_key]
         else:
             assert a_val == b[a_key], f"{a_key} doesn't match. {a_val} != {b[a_key]}"
 

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -118,12 +118,10 @@ INFURA_ETH_NODE = WeightedNode(
 ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED = (
     'ethereum_manager_connect_at_start',
     [
-        (
-            PRUNED_AND_NOT_ARCHIVED_NODE,
-            INFURA_ETH_NODE,
-            ETHEREUM_ETHERSCAN_NODE,
-            ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][2][0][0],
-        ),
+        (PRUNED_AND_NOT_ARCHIVED_NODE,),
+        (INFURA_ETH_NODE,),
+        (ETHEREUM_ETHERSCAN_NODE,),
+        (ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][2][0][0],),
     ],
 )
 
@@ -161,6 +159,7 @@ def wait_until_all_nodes_connected(
         timeout: int = NODE_CONNECTION_TIMEOUT,
 ):
     """Wait until all ethereum nodes are connected or until a timeout is hit"""
+    connect_at_start = [x for x in connect_at_start if x.node_info.name != evm_inquirer.etherscan_node_name]  # noqa: E501
     connected = [False] * len(connect_at_start)
     try:
         with gevent.Timeout(timeout):

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -125,6 +125,16 @@ ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED = (
     ],
 )
 
+ETHEREUM_NODES_SET_WITH_PRUNED_AND_NOT_ARCHIVED = (
+    'ethereum_manager_connect_at_start',
+    [(
+        PRUNED_AND_NOT_ARCHIVED_NODE,
+        INFURA_ETH_NODE,
+        ETHEREUM_ETHERSCAN_NODE,
+        ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][2][0][0],
+    )],
+)
+
 # Test with etherscan and infura
 ETHEREUM_TEST_PARAMETERS: tuple[str, list[tuple]]
 if 'GITHUB_WORKFLOW' in os.environ:  # TODO: Undo this if once all tests where it's used are mockable  # noqa: E501


### PR DESCRIPTION
## Checklist

- [x] Split `test_ethereum_nodes_prune_and_archive_status` for each node to avoid randomness in the order
- [x] Fixes non VCRed test where we were querying an unlisted asset in coingecko