### PR TITLE
Feat (API): Allow sorting in addressbook

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11667,6 +11667,8 @@ Get mappings from addressbook
 
     :reqjson int[optional] limit: This signifies the limit of records to return as per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
     :reqjson int[optional] offset: This signifies the offset from which to start the return of records per the `sql spec <https://www.sqlite.org/lang_select.html#limitoffset>`__.
+    :reqjson list[string] order_by_attributes: This is the list of attributes of the addressbook entries by which to order the results.
+    :reqjson list[bool] ascending: Should the order be ascending? This is the default. If set to false, it will be on descending order.
     :reqjson str[optional] name_substring: The substring to use as filter for the name to be found in the addressbook.
     :reqjson str[optional] blockchain: The blockchain in which to use the provided name.
     :reqjson object[optional] addresses: List of addresses that the backend should find names for.

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2830,6 +2830,7 @@ class QueryAddressbookSchema(
     BaseAddressbookSchema,
     OptionalAddressesWithBlockchainsListSchema,
     DBPaginationSchema,
+    DBOrderBySchema,
 ):
     """Schema for querying addressbook entries"""
     name_substring = fields.String(load_default=None)
@@ -2847,6 +2848,7 @@ class QueryAddressbookSchema(
             blockchain=data['blockchain'],
             substring_search=data['name_substring'],
             optional_chain_addresses=data['addresses'],
+            order_by_rules=create_order_by_rules_list(data=data),
         )
         return {
             'filter_query': filter_query,

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -1445,11 +1445,13 @@ class AddressbookFilterQuery(DBFilterQuery):
             blockchain: SupportedBlockchain | None = None,
             optional_chain_addresses: list[OptionalChainAddress] | None = None,
             substring_search: str | None = None,
+            order_by_rules: list[tuple[str, bool]] | None = None,
     ) -> 'AddressbookFilterQuery':
         filter_query = cls.create(
             and_op=and_op,
             limit=limit,
             offset=offset,
+            order_by_rules=order_by_rules,
         )
         filters: list[DBFilter] = []
         if substring_search is not None:


### PR DESCRIPTION
Closes #7423

## Checklist

- [x] Allow sorting by 'name' and 'address' in `/names/addressbook`