### PR TITLE
refactor: Remove unused airdrops_list from accountants

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/accountant.py
+++ b/rotkehlchen/chain/arbitrum_one/accountant.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.arbitrum_one.modules.airdrops.decoder import AirdropsDecoder
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregator
 
 if TYPE_CHECKING:
@@ -20,5 +19,4 @@ class ArbitrumOneAccountingAggregator(EVMAccountingAggregator):
             node_inquirer=node_inquirer,
             msg_aggregator=msg_aggregator,
             modules_path='rotkehlchen.chain.arbitrum_one.modules',
-            airdrops_list=AirdropsDecoder.counterparties(),
         )

--- a/rotkehlchen/chain/ethereum/accountant.py
+++ b/rotkehlchen/chain/ethereum/accountant.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.ethereum.modules.airdrops.decoder import AirdropsDecoder
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregator
 
 if TYPE_CHECKING:
@@ -20,5 +19,4 @@ class EthereumAccountingAggregator(EVMAccountingAggregator):
             node_inquirer=node_inquirer,
             msg_aggregator=msg_aggregator,
             modules_path='rotkehlchen.chain.ethereum.modules',
-            airdrops_list=AirdropsDecoder.counterparties(),
         )

--- a/rotkehlchen/chain/evm/accounting/aggregator.py
+++ b/rotkehlchen/chain/evm/accounting/aggregator.py
@@ -1,12 +1,10 @@
 import importlib
 import logging
 import pkgutil
-from collections.abc import Sequence
 from contextlib import suppress
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.errors.misc import ModuleLoadingError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.user_messages import MessagesAggregator
@@ -36,12 +34,10 @@ class EVMAccountingAggregator:
             node_inquirer: 'EvmNodeInquirer',
             msg_aggregator: MessagesAggregator,
             modules_path: str,
-            airdrops_list: Sequence[CounterpartyDetails] | None = None,
     ) -> None:
         self.node_inquirer = node_inquirer
         self.msg_aggregator = msg_aggregator
         self.accountants: dict[str, ModuleAccountantInterface] = {}
-        self.airdrops_list = airdrops_list
         self.modules_path = modules_path
         self.initialize_all_accountants()
 
@@ -69,15 +65,9 @@ class EVMAccountingAggregator:
                         if class_name in self.accountants:
                             raise ModuleLoadingError(f'Accountant with name {class_name} already loaded')  # noqa: E501
 
-                        kwargs = {}
-                        if class_name == 'airdrops':
-                            assert self.airdrops_list, 'If accountant exists, list should exist'
-                            kwargs['airdrops_list'] = self.airdrops_list
-
                         self.accountants[class_name] = submodule_accountant(
                             node_inquirer=self.node_inquirer,
                             msg_aggregator=self.msg_aggregator,
-                            **kwargs,
                         )
 
                 self._recursively_initialize_accountants(full_name)

--- a/rotkehlchen/chain/gnosis/accountant.py
+++ b/rotkehlchen/chain/gnosis/accountant.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregator
-from rotkehlchen.chain.gnosis.modules.airdrops.decoder import AirdropsDecoder
 
 if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
@@ -20,5 +19,4 @@ class GnosisAccountingAggregator(EVMAccountingAggregator):
             node_inquirer=node_inquirer,
             msg_aggregator=msg_aggregator,
             modules_path='rotkehlchen.chain.gnosis.modules',
-            airdrops_list=AirdropsDecoder.counterparties(),
         )

--- a/rotkehlchen/chain/optimism/accountant.py
+++ b/rotkehlchen/chain/optimism/accountant.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregator
-from rotkehlchen.chain.optimism.modules.airdrops.decoder import AirdropsDecoder
 
 if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
@@ -20,5 +19,4 @@ class OptimismAccountingAggregator(EVMAccountingAggregator):
             node_inquirer=node_inquirer,
             msg_aggregator=msg_aggregator,
             modules_path='rotkehlchen.chain.optimism.modules',
-            airdrops_list=AirdropsDecoder.counterparties(),
         )

--- a/rotkehlchen/chain/scroll/accountant.py
+++ b/rotkehlchen/chain/scroll/accountant.py
@@ -19,5 +19,4 @@ class ScrollAccountingAggregator(EVMAccountingAggregator):
             node_inquirer=node_inquirer,
             msg_aggregator=msg_aggregator,
             modules_path='rotkehlchen.chain.scroll.modules',
-            airdrops_list=[],
         )


### PR DESCRIPTION
I noticed this code is not used, and the tests seems to pass without it. Is there a reason why this was made? I guess if there is need for this code, there should be at least tests for it.