### PR TITLE
chore: introduce dev profiling parameters

### DIFF
--- a/frontend/app/src/subprocess-handler.ts
+++ b/frontend/app/src/subprocess-handler.ts
@@ -429,7 +429,12 @@ export class SubprocessHandler {
   }
 
   private startProcess(port: number, args: string[]) {
+    const profilingCmd = process.env.ROTKI_BACKEND_PROFILING_CMD;
+    const profilingArgs = process.env.ROTKI_BACKEND_PROFILING_ARGS;
+
     const defaultArgs: string[] = [
+      ...(profilingArgs ? profilingArgs.split(' ') : []),
+      ...(profilingCmd ? ['python'] : []),
       '-m',
       'rotkehlchen',
       '--rest-api-port',
@@ -449,11 +454,10 @@ export class SubprocessHandler {
     }
 
     const allArgs = defaultArgs.concat(args);
-    this.logToFile(
-      `Starting non-packaged rotki-core: python ${allArgs.join(' ')}`,
-    );
+    const cmd = profilingCmd || 'python';
+    this.logToFile(`Starting non-packaged rotki-core: ${cmd} ${allArgs.join(' ')}`);
 
-    this.childProcess = spawn('python', allArgs, { cwd: '../../' });
+    this.childProcess = spawn(cmd, allArgs, { cwd: '../../' });
 
     if (!isDevelopment) {
       this.colibriProcess = spawn('colibri');

--- a/frontend/scripts/start-dev.js
+++ b/frontend/scripts/start-dev.js
@@ -13,6 +13,20 @@ const BACKEND = 'backend';
 const scriptArgs = process.argv;
 const noElectron = scriptArgs.includes('--web');
 
+function getArg(flag) {
+  if (scriptArgs.includes(flag) && scriptArgs.length > scriptArgs.indexOf(flag) + 1)
+    return scriptArgs[scriptArgs.indexOf(flag) + 1];
+}
+
+const profilingArgs = getArg('--profiling-args');
+const profilingCmd = getArg('--profiling-cmd');
+
+if (profilingCmd)
+  process.env.ROTKI_BACKEND_PROFILING_CMD = profilingCmd;
+
+if (profilingArgs)
+  process.env.ROTKI_BACKEND_PROFILING_ARGS = profilingArgs;
+
 const colors = {
   magenta: msg => `\u001B[35m${msg}\u001B[0m`,
   green: msg => `\u001B[32m${msg}\u001B[0m`,
@@ -119,6 +133,8 @@ if (noElectron) {
     fs.mkdirSync(logDir);
 
   const args = [
+    ...(profilingArgs ? profilingArgs.split(' ') : []),
+    ...(profilingCmd ? ['python'] : []),
     '-m',
     'rotkehlchen',
     '--rest-api-port',
@@ -129,7 +145,7 @@ if (noElectron) {
     `${path.join(logDir, 'backend.log')}`,
   ];
 
-  startProcess('python', colors.yellow(BACKEND), BACKEND, args, {
+  startProcess(profilingCmd || 'python', colors.yellow(BACKEND), BACKEND, args, {
     cwd: path.join('..'),
   });
 }


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

@LefterisJP can you try it when you have some time let me know if this works for you?

`--profiling-cmd cmd` to replace the command
`--profiling-args "--arg value --arg2 value2"`

e.g. `pnpm run dev --profiling-cmd cmd --profiling-args "--arg value --arg2 value2"`
