### PR TITLE
Bump web3.py to 6.17.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gevent==24.2.1
 greenlet==3.0.3
 gevent-websocket==0.10.1  # like the below is abandoned
 wsaccel==0.6.6  # recommended for acceleration of gevent-websocket. But abandoned.
-web3==6.15.1
+web3==6.17.1
 content-hash==2.0.0
 rotki-pysqlcipher3==2024.1.2
 requests==2.31.0

--- a/rotkehlchen/chain/evm/contracts.py
+++ b/rotkehlchen/chain/evm/contracts.py
@@ -86,7 +86,7 @@ class EvmContract(NamedTuple):
 
     def encode(self, method_name: str, arguments: list[Any] | None = None) -> str:
         contract = WEB3.eth.contract(address=self.address, abi=self.abi)
-        return contract.encodeABI(method_name, args=arguments or [])
+        return contract.encode_abi(method_name, args=arguments or [])
 
     def decode(
             self,

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -629,7 +629,7 @@ class EvmNodeInquirer(ABC):
         """
         web3 = Web3()
         contract = web3.eth.contract(address=contract_address, abi=abi)
-        input_data = contract.encodeABI(method_name, args=arguments or [])
+        input_data = contract.encode_abi(method_name, args=arguments or [])
         result = self.etherscan.eth_call(
             to_address=contract_address,
             input_data=input_data,


### PR DESCRIPTION
Should fix also the damn eth-typing problems that suddenly hit us in the tests due to the improper pinning the old web3.py had.

