### PR TITLE
Fix (Uniswap): NFT Contract data for other chains

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ Changelog
 * :feature:`7086` Added support for GMX v1 in Arbitrum.
 * :feature:`7281` rotki will now properly decode the transactions done on Aave v2 and v3 on all the supported chains.
 * :feature:`2698` Users can now manually link assets on their exchanges to assets recognized by Rotki, without having to wait for a new release.
-* :feature:`-` rotki will now properly decode the swaps done via Uniswap V3 on other supported chains.
+* :feature:`-` rotki will now properly decode the Uniswap V3 events on other supported chains.
 * :feature:`5978` rotki will now properly decode the swaps done via the 0x protocol.
 * :feature:`-` The claim event of the Degen airdrop 2 will be correctly decoded.
 * :bug:`-` Binance balances will now include funding wallet's balances.

--- a/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
@@ -5,10 +5,6 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
-from rotkehlchen.chain.evm.decoding.structures import (
-    FAILED_ENRICHMENT_OUTPUT,
-    TransferEnrichmentOutput,
-)
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.arbitrum_one_tx import DBArbitrumOneTx
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -21,7 +17,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.transactions import ArbitrumOneTransactions
     from rotkehlchen.chain.arbitrum_one.types import ArbitrumOneTransaction
     from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.db.dbhandler import DBHandler
 
 logger = logging.getLogger(__name__)
@@ -72,9 +67,6 @@ class ArbitrumOneTransactionDecoder(EVMTransactionDecoder):
             self.transaction_type_mappings[txtype].extend(rules)
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> TransferEnrichmentOutput:  # pylint: disable=unused-argument
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/base/decoding/decoder.py
+++ b/rotkehlchen/chain/base/decoding/decoder.py
@@ -2,10 +2,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
-from rotkehlchen.chain.evm.decoding.structures import (
-    FAILED_ENRICHMENT_OUTPUT,
-    TransferEnrichmentOutput,
-)
 from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.decoder import L2WithL1FeesTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
@@ -15,7 +11,6 @@ from rotkehlchen.types import ChecksumEvmAddress
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
     from rotkehlchen.chain.base.transactions import BaseTransactions
-    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.db.dbhandler import DBHandler
 
 logger = logging.getLogger(__name__)
@@ -47,9 +42,6 @@ class BaseTransactionDecoder(L2WithL1FeesTransactionDecoder):
         )
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> TransferEnrichmentOutput:  # pylint: disable=unused-argument
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -10,11 +10,8 @@ from rotkehlchen.chain.evm.decoding.base import BaseDecoderToolsWithDSProxy
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoderWithDSProxy
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
-    FAILED_ENRICHMENT_OUTPUT,
     ActionItem,
     DecodingOutput,
-    EnricherContext,
-    TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -165,23 +162,6 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
         return DEFAULT_DECODING_OUTPUT
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: EnricherContext) -> TransferEnrichmentOutput:
-        for enrich_call in self.rules.token_enricher_rules:
-            try:
-                transfer_enrich: TransferEnrichmentOutput = enrich_call(context)
-            except (UnknownAsset, WrongAssetType) as e:
-                log.error(
-                    f'Failed to enrich transfer due to unknown asset '
-                    f'{context.event.asset}. {e!s}',
-                )
-                # Don't try other rules since all of them will fail to resolve the asset
-                return FAILED_ENRICHMENT_OUTPUT
-
-            if transfer_enrich != FAILED_ENRICHMENT_OUTPUT:
-                return transfer_enrich
-
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:

--- a/rotkehlchen/chain/gnosis/decoding/decoder.py
+++ b/rotkehlchen/chain/gnosis/decoding/decoder.py
@@ -3,16 +3,11 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
-from rotkehlchen.chain.evm.decoding.structures import (
-    FAILED_ENRICHMENT_OUTPUT,
-    TransferEnrichmentOutput,
-)
 from rotkehlchen.constants.assets import A_XDAI
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.chain.gnosis.transactions import GnosisTransactions
     from rotkehlchen.db.dbhandler import DBHandler
@@ -45,9 +40,6 @@ class GnosisTransactionDecoder(EVMTransactionDecoder):
         )
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> TransferEnrichmentOutput:  # pylint: disable=unused-argument
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/optimism/decoding/decoder.py
+++ b/rotkehlchen/chain/optimism/decoding/decoder.py
@@ -2,10 +2,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderToolsWithDSProxy
-from rotkehlchen.chain.evm.decoding.structures import (
-    FAILED_ENRICHMENT_OUTPUT,
-    TransferEnrichmentOutput,
-)
 from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.decoder import L2WithL1FeesTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
@@ -13,7 +9,6 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.chain.optimism.transactions import OptimismTransactions
     from rotkehlchen.db.dbhandler import DBHandler
@@ -47,9 +42,6 @@ class OptimismTransactionDecoder(L2WithL1FeesTransactionDecoder):
         )
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> TransferEnrichmentOutput:  # pylint: disable=unused-argument
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/polygon_pos/decoding/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/decoding/decoder.py
@@ -3,16 +3,11 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
-from rotkehlchen.chain.evm.decoding.structures import (
-    FAILED_ENRICHMENT_OUTPUT,
-    TransferEnrichmentOutput,
-)
 from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.chain.polygon_pos.transactions import PolygonPOSTransactions
     from rotkehlchen.db.dbhandler import DBHandler
@@ -45,9 +40,6 @@ class PolygonPOSTransactionDecoder(EVMTransactionDecoder):
         )
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> TransferEnrichmentOutput:  # pylint: disable=unused-argument
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:  # pylint: disable=unused-argument

--- a/rotkehlchen/chain/scroll/decoding/decoder.py
+++ b/rotkehlchen/chain/scroll/decoding/decoder.py
@@ -2,17 +2,12 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
-from rotkehlchen.chain.evm.decoding.structures import (
-    FAILED_ENRICHMENT_OUTPUT,
-    TransferEnrichmentOutput,
-)
 from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.decoder import L2WithL1FeesTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.chain.scroll.transactions import ScrollTransactions
     from rotkehlchen.db.dbhandler import DBHandler
@@ -45,9 +40,6 @@ class ScrollTransactionDecoder(L2WithL1FeesTransactionDecoder):
         )
 
     # -- methods that need to be implemented by child classes --
-
-    def _enrich_protocol_tranfers(self, context: 'EnricherContext') -> TransferEnrichmentOutput:  # pylint: disable=unused-argument
-        return FAILED_ENRICHMENT_OUTPUT
 
     @staticmethod
     def _is_non_conformant_erc721(address: ChecksumEvmAddress) -> bool:  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/unit/test_evm_contracts.py
+++ b/rotkehlchen/tests/unit/test_evm_contracts.py
@@ -20,7 +20,7 @@ def test_evm_contracts_data(globaldb):
             assert is_checksum_address(entry[0])
             assert isinstance(entry[1], int) and entry[1] in serialized_chain_ids
             assert isinstance(entry[2], int)
-            assert isinstance(entry[3], int) and entry[3] > 0
+            assert isinstance(entry[3], int) and entry[3] >= 0
 
 
 def test_evm_abi_data(globaldb):


### PR DESCRIPTION

## Checklist

- [x] Add contract data for Uniswap NFT manager in global.db
- [x] Enable enricher in other chains' decoders
- [x] Test for optimism

SQL diff for `global.db`:
```sql
INSERT INTO contract_data(rowid,address,chain_id,abi,deployed_block) VALUES(162,'0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1',8453,15,1371714);
INSERT INTO contract_data(rowid,address,chain_id,abi,deployed_block) VALUES(163,'0xC36442b4a4522E871399CD717aBDD847Ab11FE88',42161,15,173);
INSERT INTO contract_data(rowid,address,chain_id,abi,deployed_block) VALUES(164,'0xC36442b4a4522E871399CD717aBDD847Ab11FE88',10,15,0);
INSERT INTO contract_data(rowid,address,chain_id,abi,deployed_block) VALUES(165,'0xC36442b4a4522E871399CD717aBDD847Ab11FE88',137,15,22760586);
```