### PR TITLE
Fix (Aave): Not notify when detecting v3 tokens

### DIFF
--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -231,6 +231,7 @@ def get_or_create_evm_token(
     existing token will still be silently returned
     Note2: This entire function is designed so that it does not context switch away from
     its calling greenlet so it should be safe to call from multiple greenlets.
+    Note3: If encounter is None, it will broadcast the `NEW_EVM_TOKEN_DETECTED` message by default.
 
     May raise:
     - NotERC20Conformant exception if an ethereum manager is given to query

--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.assets.types import AssetType
-from rotkehlchen.assets.utils import check_if_spam_token, get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    check_if_spam_token,
+    get_or_create_evm_token,
+)
 from rotkehlchen.chain.base.modules.aave.v3.constants import (
     AAVE_V3_DATA_PROVIDER as AAVE_V3_DATA_PROVIDER_BASE,
 )
@@ -337,6 +341,7 @@ def update_aave_v3_underlying_assets(chains_aggregator: 'ChainsAggregator') -> N
                             token_kind=EvmTokenKind.ERC20,
                             weight=ONE,
                         )],
+                        encounter=TokenEncounterInfo(should_notify=False),
                     )
                 except DeserializationError as e:
                     log.error(

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -609,6 +609,7 @@ def test_augmented_detection_pendle_transactions(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('max_tasks_num', [5])
+@pytest.mark.parametrize('function_scope_initialize_mock_rotki_notifier', [True])
 def test_maybe_update_aave_v3_underlying_assets(
         task_manager: TaskManager,
         globaldb: GlobalDBHandler,
@@ -672,6 +673,8 @@ def test_maybe_update_aave_v3_underlying_assets(
         assert task_manager.database.get_static_cache(
             cursor=cursor, name=DBCacheStatic.LAST_AAVE_V3_ASSETS_UPDATE,
         ) is not None
+
+    assert len(task_manager.database.msg_aggregator.rotki_notifier.messages) == 0  # type: ignore[union-attr]  # rotki_notifier is MockRotkiNotifier
 
 
 @pytest.mark.parametrize('max_tasks_num', [5])


### PR DESCRIPTION
## Checklist

- [x] Not sending `NEW_EVM_TOKEN_DETECTED` notification when detecting new Aave v3 tokens.
