### PR TITLE
Update installation_guide.rst

### DIFF
--- a/docs/installation_guide.rst
+++ b/docs/installation_guide.rst
@@ -110,7 +110,7 @@ Troubleshooting
 
 If you get "The python backend crashed" or any other error please run the executable via the Command Prompt. Then provide us with the output that is visible in the prompt and this will help us debug your issue.
 
-You should also include all logs that can be found in ``<WindowsDrive>:\Users\<User>\Roaming\rotki\logs\`` (``%APPDATA%\rotki\logs``).
+You should also include all logs that can be found in ``<WindowsDrive>:\Users\<User>\AppData\Roaming\rotki\logs\`` (``%APPDATA%\rotki\logs``).
 
 Docker
 ================


### PR DESCRIPTION
Originally read: 

> You should also include all logs that can be found in ``<WindowsDrive>:\Users\<User>\Roaming\rotki\logs\`` (``%APPDATA%\rotki\logs``).

Added missing 'AppData' to the path:

You should also include all logs that can be found in ``<WindowsDrive>:\Users\<User>\AppData\Roaming\rotki\logs\`` (``%APPDATA%\rotki\logs``).

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
