### PR TITLE
Fix customized events fetching + zksync lite filtering

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -216,7 +216,6 @@ from rotkehlchen.types import (
     AVAILABLE_MODULES_MAP,
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
     EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
-    EVM_LOCATIONS,
     SPAM_PROTOCOL,
     SUPPORTED_BITCOIN_CHAINS,
     SUPPORTED_CHAIN_IDS,
@@ -3629,12 +3628,9 @@ class RestAPI:
                 entries_table='history_events',
                 group_by='event_identifier' if group_by_event_ids else None,
             )
-            location = filter_query.location
-            chain_id = ChainID(Location.to_chain_id(location)) if location in EVM_LOCATIONS else None  # noqa: E501
-
             customized_event_ids = dbevents.get_customized_event_identifiers(
                 cursor=cursor,
-                chain_id=chain_id,  # type: ignore
+                location=filter_query.location,
             )
             hidden_event_ids = dbevents.get_hidden_event_ids(cursor)
             ignored_ids_mapping = self.rotkehlchen.data.db.get_ignored_action_ids(

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -47,7 +47,7 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, EvmTransaction, EVMTxHash
+from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, EvmTransaction, EVMTxHash, Location
 from rotkehlchen.utils.misc import from_wei, hex_or_bytes_to_address, hex_or_bytes_to_int
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
@@ -625,7 +625,7 @@ class EVMTransactionDecoder(ABC):
                 self.dbevents.delete_events_by_tx_hash(
                     write_cursor=write_cursor,
                     tx_hashes=[transaction.tx_hash],
-                    chain_id=self.evm_inquirer.chain_id,
+                    location=Location.from_chain_id(self.evm_inquirer.chain_id),
                 )
                 write_cursor.execute(
                     'DELETE from evm_tx_mappings WHERE tx_id=? AND value=?',

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -31,6 +31,7 @@ from rotkehlchen.types import (
     EvmInternalTransaction,
     EvmTransaction,
     EVMTxHash,
+    Location,
     SupportedBlockchain,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -490,7 +491,7 @@ class DBEvmTx:
         dbevents.delete_events_by_tx_hash(
             write_cursor=write_cursor,
             tx_hashes=tx_hashes,
-            chain_id=chain_id,  # type: ignore[arg-type] # comes from SUPPORTED_EVM_CHAINS
+            location=Location.from_chain_id(chain_id),  # type: ignore[arg-type] # comes from SUPPORTED_EVM_CHAINS
         )
         write_cursor.execute(  # delete genesis tx events related to the provided address
             'DELETE FROM history_events WHERE identifier IN ('

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -35,6 +35,7 @@ from rotkehlchen.types import (
     EvmTransaction,
     EVMTxHash,
     ExternalService,
+    Location,
     SupportedBlockchain,
     Timestamp,
     deserialize_evm_tx_hash,
@@ -466,7 +467,7 @@ class Etherscan(ExternalServiceWithApiKey, ABC):
                             dbevents.delete_events_by_tx_hash(
                                 write_cursor=write_cursor,
                                 tx_hashes=[GENESIS_HASH],
-                                chain_id=self.chain.to_chain_id(),  # type: ignore[arg-type]
+                                location=Location.from_chain(self.chain),
                             )
                             write_cursor.execute(
                                 'DELETE from evm_tx_mappings WHERE tx_id=(SELECT identifier FROM '

--- a/rotkehlchen/tests/api/test_evmlike.py
+++ b/rotkehlchen/tests/api/test_evmlike.py
@@ -255,6 +255,11 @@ def test_decode_pending_evmlike(rotkehlchen_api_server: 'APIServer', zksync_lite
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),
     )
     result = assert_proper_response_with_result(response)
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+        json={'location': Location.ZKSYNC_LITE.serialize()},
+    )
+    assert assert_proper_response_with_result(response) == result, 'filtering by location should be same'  # noqa: E501
     assert len(result['entries']) == 17
     compare_events_without_id(result['entries'][0]['entry'], EvmEvent(
         event_identifier='zkl0xbd723b5a5f87e485a478bc7d1f365db79440b6e9305bff3b16a0e0ab83e51970',

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -26,14 +26,7 @@ from rotkehlchen.tests.utils.factories import (
     make_evm_address,
     make_evm_tx_hash,
 )
-from rotkehlchen.types import (
-    ChainID,
-    EVMTxHash,
-    Location,
-    Timestamp,
-    TimestampMS,
-    deserialize_evm_tx_hash,
-)
+from rotkehlchen.types import EVMTxHash, Location, Timestamp, TimestampMS, deserialize_evm_tx_hash
 
 
 def test_get_customized_event_identifiers(database):
@@ -93,9 +86,9 @@ def test_get_customized_event_identifiers(database):
         )
 
     with db.db.conn.read_ctx() as cursor:
-        assert db.get_customized_event_identifiers(cursor, chain_id=None) == [1, 4]
-        assert db.get_customized_event_identifiers(cursor, chain_id=ChainID.ETHEREUM) == [1]
-        assert db.get_customized_event_identifiers(cursor, chain_id=ChainID.OPTIMISM) == [4]
+        assert db.get_customized_event_identifiers(cursor, location=None) == [1, 4]
+        assert db.get_customized_event_identifiers(cursor, location=Location.ETHEREUM) == [1]
+        assert db.get_customized_event_identifiers(cursor, location=Location.OPTIMISM) == [4]
 
 
 def add_history_events_to_db(db: DBHistoryEvents, data: dict[int, tuple[str, TimestampMS, FVal, dict | None]]) -> None:  # noqa: E501

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -11,6 +11,7 @@ from typing import (
     NamedTuple,
     NewType,
     Optional,
+    TypeAlias,
     TypeVar,
     get_args,
 )
@@ -745,7 +746,7 @@ class Location(DBCharEnumMixIn):
     ZKSYNC_LITE = 47
 
     @staticmethod
-    def from_chain_id(chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE) -> 'Location':
+    def from_chain_id(chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE) -> 'EVM_LOCATIONS_TYPE':
         if chain_id == ChainID.ETHEREUM:
             return Location.ETHEREUM
 
@@ -788,13 +789,40 @@ class Location(DBCharEnumMixIn):
         assert self == Location.POLYGON_POS, 'should have only been polygon pos here'
         return ChainID.POLYGON_POS.value
 
+    @staticmethod
+    def from_chain(chain: SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE) -> 'BLOCKCHAIN_LOCATIONS_TYPE':
+        assert chain in SUPPORTED_EVM_EVMLIKE_CHAINS
+        match chain:
+            case SupportedBlockchain.ETHEREUM:
+                return Location.ETHEREUM
+            case SupportedBlockchain.OPTIMISM:
+                return Location.OPTIMISM
+            case SupportedBlockchain.POLYGON_POS:
+                return Location.POLYGON_POS
+            case SupportedBlockchain.ARBITRUM_ONE:
+                return Location.ARBITRUM_ONE
+            case SupportedBlockchain.BASE:
+                return Location.BASE
+            case SupportedBlockchain.GNOSIS:
+                return Location.GNOSIS
+            case SupportedBlockchain.SCROLL:
+                return Location.SCROLL
+            case SupportedBlockchain.ZKSYNC_LITE:
+                return Location.ZKSYNC_LITE
+            case _:  # should never happen
+                raise AssertionError(f'Got in Location.from_chain for {chain}')
 
-EVM_LOCATIONS_TYPE = Literal[Location.ETHEREUM, Location.OPTIMISM, Location.POLYGON_POS, Location.ARBITRUM_ONE, Location.BASE, Location.GNOSIS, Location.SCROLL, Location.ZKSYNC_LITE]  # noqa: E501
+
+EVM_LOCATIONS_TYPE = Literal[Location.ETHEREUM, Location.OPTIMISM, Location.POLYGON_POS, Location.ARBITRUM_ONE, Location.BASE, Location.GNOSIS, Location.SCROLL]  # noqa: E501
 EVM_LOCATIONS: tuple[EVM_LOCATIONS_TYPE, ...] = typing.get_args(EVM_LOCATIONS_TYPE)
 EVMLIKE_LOCATIONS_TYPE = Literal[Location.ZKSYNC_LITE]
 EVMLIKE_LOCATIONS: tuple[EVMLIKE_LOCATIONS_TYPE, ...] = typing.get_args(EVMLIKE_LOCATIONS_TYPE)
 EVM_EVMLIKE_LOCATIONS_TYPE = EVM_LOCATIONS_TYPE | EVMLIKE_LOCATIONS_TYPE
 EVM_EVMLIKE_LOCATIONS: tuple[EVM_EVMLIKE_LOCATIONS_TYPE, ...] = EVM_LOCATIONS + EVMLIKE_LOCATIONS
+
+# For now Location enum has only evmlike chains. This will change so keep separate variable
+BLOCKCHAIN_LOCATIONS_TYPE: TypeAlias = EVM_EVMLIKE_LOCATIONS_TYPE
+BLOCKCHAIN_LOCATIONS: Final = EVM_EVMLIKE_LOCATIONS
 
 
 class AssetMovementCategory(DBCharEnumMixIn):


### PR DESCRIPTION
- Fix the issue where zksync lite filtering in history events did not work
- Customized events should not be filtered by chain ID but by location as events exist in many places and not just evm chains.
