### PR TITLE
Ensure consistency for number of pending tx to decode

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2878,11 +2878,12 @@ class RestAPI:
             undecoded = cursor.execute(
                 'SELECT COUNT(*) FROM zksynclite_transactions WHERE is_decoded=0',
             ).fetchone()[0]
-            total = cursor.execute('SELECT COUNT(*) FROM zksynclite_transactions').fetchone()[0]
-            result['zksync_lite'] = {
-                'undecoded': undecoded,
-                'total': total,
-            }
+            if undecoded != 0:
+                cursor.execute('SELECT COUNT(*) FROM zksynclite_transactions')
+                result['zksync_lite'] = {
+                    'undecoded': undecoded,
+                    'total': cursor.fetchone()[0],
+                }
 
         return _wrap_in_ok_result(result)
 

--- a/rotkehlchen/tests/api/test_evmlike.py
+++ b/rotkehlchen/tests/api/test_evmlike.py
@@ -245,6 +245,16 @@ def test_decode_pending_evmlike(rotkehlchen_api_server: 'APIServer', zksync_lite
         ), json={'async_query': False},
     )
     assert_simple_ok_response(response)
+
+    response = requests.get(  # get the number of decoded & undecoded transactions
+        api_url_for(
+            rotkehlchen_api_server,
+            'evmlikependingtransactionsdecodingresource',
+        ),
+    )
+    result = assert_proper_response_with_result(response)
+    assert result == {'zksync_lite': {'undecoded': 16, 'total': 16}}
+
     response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
@@ -260,7 +270,7 @@ def test_decode_pending_evmlike(rotkehlchen_api_server: 'APIServer', zksync_lite
         ),
     )
     result = assert_proper_response_with_result(response)
-    assert result == {'zksync_lite': {'undecoded': 0, 'total': 16}}
+    assert result == {}
 
     response = requests.post(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),


### PR DESCRIPTION
The evm like was returning always a result for all the chains while the evm endpoint skipped chains where all the txs were decoded

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
