### PR TITLE
Update mappings with globaldb

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -2055,16 +2055,16 @@ class GlobalDBHandler:
             for entry in entries:
                 try:
                     cursor.execute(
-                        'INSERT INTO location_asset_mappings(local_id, location, exchange_symbol) VALUES(?, ?, ?)', (  # noqa: E501
+                        'INSERT OR IGNORE INTO location_asset_mappings(local_id, location, exchange_symbol) VALUES(?, ?, ?)', (  # noqa: E501
                             entry.asset.serialize(),
                             None if entry.location is None else entry.location.serialize_for_db(),
                             entry.location_symbol,
                         ),
                     )
-                except sqlite3.IntegrityError as e:
+                except sqlite3.OperationalError as e:
                     raise InputError(
                         f'Failed to add the location asset mapping of {entry.location_symbol} in '
-                        f'{entry.location} because it already exists in the DB.',
+                        f'{entry.location} due to {e}',
                     ) from e
 
     @staticmethod

--- a/rotkehlchen/globaldb/updates.py
+++ b/rotkehlchen/globaldb/updates.py
@@ -117,7 +117,7 @@ class AssetsUpdater:
 
     def __init__(self, msg_aggregator: 'MessagesAggregator') -> None:
         self.msg_aggregator = msg_aggregator
-        self.local_assets_version = GlobalDBHandler().get_setting_value(ASSETS_VERSION_KEY, 0)
+        self.local_assets_version = GlobalDBHandler.get_setting_value(ASSETS_VERSION_KEY, 0)
         self.last_remote_checked_version = -1  # integer value that represents no update
         self.conflicts: list[tuple[AssetData, AssetData]] = []
         self.assets_re = re.compile(r'.*INSERT +INTO +assets\( *identifier *, *name *, *type *\) *VALUES\(([^,]*?),([^,]*?),([^,]*?)\).*?')  # noqa: E501

--- a/tools/assets_database/populate_with_mappings.py
+++ b/tools/assets_database/populate_with_mappings.py
@@ -1,0 +1,54 @@
+"""
+Tool to create a globaldb with the remote updates in the asset repo and the updates in the
+data repo for location assets mappings and unsupported assets . This script extends
+the one named "main.py" in the same folder.
+
+This script is intended to be used when testing the mappings to ensure that all the updates
+are correctly applied. To call the script do:
+
+python -m tools.assets_database.populate_with_mappings \
+    --start-db 9 --target-version 24 --assets-branch develop --target-directory data
+"""
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from gevent import monkey
+
+monkey.patch_all()  # isort:skip
+
+from rotkehlchen.db.constants import UpdateType
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.updates import RotkiDataUpdater
+from rotkehlchen.user_messages import MessagesAggregator
+
+from .main import clean_folder, populate_db_with_assets
+
+
+def populate_location_mappings():
+    """Apply remote updates to query mappings for assets"""
+    msg_aggregator = MessagesAggregator()
+    with TemporaryDirectory() as tmp_dir:
+        user_db = DBHandler(  # the RotkiDataUpdater takes a user db argument but is not used for the UpdateTypes that we use.  # noqa: E501
+            user_data_dir=Path(tmp_dir),
+            password='123',
+            msg_aggregator=msg_aggregator,
+            initial_settings=None,
+            sql_vm_instructions_cb=0,
+            resume_from_backup=False,
+        )
+        rotki_updater = RotkiDataUpdater(msg_aggregator=msg_aggregator, user_db=user_db)
+        print('Applying remote updates')
+        rotki_updater.check_for_updates(updates=[
+            UpdateType.LOCATION_ASSET_MAPPINGS,
+            UpdateType.LOCATION_UNSUPPORTED_ASSETS,
+        ])
+
+
+def main():
+    globaldb, target_directory = populate_db_with_assets()
+    populate_location_mappings()
+    clean_folder(globaldb, target_directory)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When filling the mappings for the globaldb those need to be checked locally. Also when checking the assets in tests we need to have an updated version of the mappings. This PR:

- Introduces a new script to populate the generated globaldb with the remote mappings
- Ensure that the insertion of an already existing mapping doesn't error (if we pull remote updates in a packaged globaldb this can happen)
