### PR TITLE
Fix macos 11 builds

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -171,11 +171,10 @@ jobs:
         id: packaging
         run: |
           echo "::group::packaging dependencies"
-          pip3 install --upgrade uv
           pip3 install virtualenv
           python3 -m virtualenv ~/venv
           source ~/venv/bin/activate
-          uv pip install -r requirements_packaging.txt
+          pip3 install -r requirements_packaging.txt
           echo "::endgroup::"
           ./package.py --build full
         env:

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -259,11 +259,10 @@ jobs:
         id: packaging
         run: |
           echo "::group::packaging dependencies"
-          pip3 install --upgrade uv
           pip3 install virtualenv
           python3 -m virtualenv ~/venv
           source ~/venv/bin/activate
-          uv pip install --system -r requirements_packaging.txt
+          pip3 install -r requirements_packaging.txt
           echo "::endgroup::"
           ./package.py --build full
         env:


### PR DESCRIPTION
uv removed support for macos 11 in the latest release and we still use it to make the builds. For this reason we are changing back to pip instead of uv for macos

