### PR TITLE
Fix (Compound v3): Remap the event decoders

### DIFF
--- a/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
@@ -2,9 +2,12 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
+from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
@@ -13,6 +16,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
     DecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -106,68 +110,6 @@ class Compoundv3CommonDecoder(DecoderInterface):
 
         return DEFAULT_DECODING_OUTPUT
 
-    def _decode_supply_or_withdraw_event(
-            self,
-            context: DecoderContext,
-            compound_token: EvmToken,
-    ) -> DecodingOutput:
-        """Decode a compound v3 supply or withdraw event. Takes decoder context and
-        the compound v3 wrapped token of the supplied/withdrawn underlying token"""
-        if (underlying_token := self._get_compound_underlying_token(compound_token)) is None:
-            log.error(
-                f'At compound v3 supply/withdraw decoding of tx '
-                f'{context.transaction.tx_hash.hex()} the underlying token was not found.',
-            )
-            return DEFAULT_DECODING_OUTPUT
-
-        amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data),
-            asset=underlying_token,
-        )
-        paired_event, action_from_event_type, action_to_event_subtype, action_to_notes = None, None, None, None  # noqa: E501
-        for event in context.decoded_events:
-            if (
-                event.event_subtype == HistoryEventSubType.NONE and
-                event.asset == underlying_token and amount == event.balance.amount
-            ):
-                if event.event_type == HistoryEventType.SPEND:
-                    event.event_type = HistoryEventType.DEPOSIT
-                    event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
-                    event.notes = f'Deposit {amount} {underlying_token.symbol} to compound v3'
-                    action_from_event_type = HistoryEventType.RECEIVE
-                    action_to_event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
-                    action_to_notes = f'Receive {{amount}} {compound_token.symbol} from compound v3'  # {amount} to be replaced in post decoding  # noqa: E501
-                else:
-                    event.event_type = HistoryEventType.WITHDRAWAL
-                    event.event_subtype = HistoryEventSubType.REMOVE_ASSET
-                    event.notes = f'Withdraw {amount} {underlying_token.symbol} from compound v3'
-                    action_from_event_type = HistoryEventType.SPEND
-                    action_to_event_subtype = HistoryEventSubType.RETURN_WRAPPED
-                    action_to_notes = f'Return {{amount}} {compound_token.symbol} to compound v3'
-
-                event.counterparty = CPT_COMPOUND_V3
-                paired_event = event
-                break
-        else:  # did not break/find anything
-            log.error(
-                'At compound v3 supply/withdraw decoding of tx '
-                f'{context.transaction.tx_hash.hex()} the action item data was not found.',
-            )
-            return DEFAULT_DECODING_OUTPUT
-
-        # also create an action item for the receive/return of the cTokens
-        action_item = ActionItem(
-            action='transform',
-            from_event_type=action_from_event_type,
-            from_event_subtype=HistoryEventSubType.NONE,
-            asset=compound_token,
-            to_event_subtype=action_to_event_subtype,
-            to_notes=action_to_notes,
-            to_counterparty=CPT_COMPOUND_V3,
-            paired_event_data=(paired_event, paired_event.event_type == HistoryEventType.DEPOSIT),
-        )
-        return DecodingOutput(action_items=[action_item])
-
     def _correct_supply_or_withdraw_event(
             self,
             decoded_events: list['EvmEvent'],
@@ -187,32 +129,210 @@ class Compoundv3CommonDecoder(DecoderInterface):
                 break
         return decoded_events
 
-    def _decode_repay_or_borrow_event(self, context: DecoderContext) -> DecodingOutput:
-        """Decode a compound v3 repay or borrow event. Takes only the decoder context."""
+    def _decode_supply_or_repay_event(
+            self,
+            context: DecoderContext,
+            compound_token: 'EvmToken',
+    ) -> DecodingOutput:
+        """Decode a compound v3 supply or repay event. Takes decoder context and
+        the compound v3 wrapped token of the supplied/withdrawn underlying token."""
+        if (underlying_token := self._get_compound_underlying_token(compound_token)) is None:
+            log.error(
+                f'At compound v3 supply/withdraw decoding of tx '
+                f'{context.transaction.tx_hash.hex()} the underlying token was not found.',
+            )
+            return DEFAULT_DECODING_OUTPUT
+
+        receiving_ctoken = False
+        for tx_log in context.all_logs:
+            if (
+                tx_log.address == compound_token.evm_address and
+                tx_log.topics[0] == ERC20_OR_ERC721_TRANSFER and
+                hex_or_bytes_to_address(tx_log.topics[1]) == ZERO_ADDRESS and  # from
+                hex_or_bytes_to_address(tx_log.topics[2]) == hex_or_bytes_to_address(context.tx_log.topics[2])  # to  # noqa: E501
+            ):
+                receiving_ctoken = True
+                break
+
+        amount = asset_normalized_value(
+            amount=hex_or_bytes_to_int(context.tx_log.data),
+            asset=underlying_token,
+        )
+        paired_event, action_from_event_type, action_to_event_subtype, action_to_notes = None, None, None, None  # noqa: E501
         for event in context.decoded_events:
             if (
+                event.event_type == HistoryEventType.SPEND and
                 event.event_subtype == HistoryEventSubType.NONE and
-                event.asset.identifier == evm_address_to_identifier(
-                    address=hex_or_bytes_to_address(context.tx_log.topics[3]),
-                    chain_id=self.evm_inquirer.chain_id,
-                    token_type=EvmTokenKind.ERC20,
-                )
+                event.asset == underlying_token and amount == event.balance.amount and
+                event.address == compound_token.evm_address
             ):
-                if event.event_type == HistoryEventType.SPEND:
+                event.counterparty = CPT_COMPOUND_V3
+                if receiving_ctoken:
+                    event.event_type = HistoryEventType.DEPOSIT
+                    event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                    event.notes = f'Deposit {amount} {underlying_token.symbol} into Compound v3'
+                    paired_event = event
+                    action_from_event_type = HistoryEventType.RECEIVE
+                    action_to_event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
+                    action_to_notes = f'Receive {{amount}} {compound_token.symbol} from Compound v3'  # {amount} to be replaced in post decoding  # noqa: E501
+                else:
+                    event.event_type = HistoryEventType.SPEND
                     event.event_subtype = HistoryEventSubType.PAYBACK_DEBT
-                    event.notes = f'Repay {event.balance.amount} {event.asset.symbol_or_name()} to compound v3'  # noqa: E501
+                    event.notes = f'Repay {amount} {underlying_token.symbol} on Compound v3'
+
+                break
+        else:  # did not break/find anything
+            log.error(
+                'At compound v3 supply/withdraw decoding of tx '
+                f'{context.transaction.tx_hash.hex()} the action item data was not found.',
+            )
+            return DEFAULT_DECODING_OUTPUT
+
+        action_items = []  # also create an action item for the receive of the cTokens
+        if paired_event is not None and action_from_event_type is not None:
+            action_items.append(ActionItem(
+                action='transform',
+                from_event_type=action_from_event_type,
+                from_event_subtype=HistoryEventSubType.NONE,
+                asset=compound_token,
+                to_event_subtype=action_to_event_subtype,
+                to_notes=action_to_notes,
+                to_counterparty=CPT_COMPOUND_V3,
+                paired_event_data=(paired_event, True),
+            ))
+
+        return DecodingOutput(action_items=action_items)
+
+    def _decode_withdraw_or_borrow_event(
+            self,
+            context: DecoderContext,
+            compound_token: EvmToken,
+    ) -> DecodingOutput:
+        """Decode a compound v3 withdraw or borrow event. Takes decoder context and
+        the compound v3 wrapped token of the withdrawn/borrowed underlying token."""
+        if (underlying_token := self._get_compound_underlying_token(compound_token)) is None:
+            log.error(
+                f'At compound v3 supply/withdraw decoding of tx '
+                f'{context.transaction.tx_hash.hex()} the underlying token was not found.',
+            )
+            return DEFAULT_DECODING_OUTPUT
+
+        sending_ctoken = False
+        for tx_log in context.all_logs:
+            if (
+                tx_log.address == compound_token.evm_address and
+                tx_log.topics[0] == ERC20_OR_ERC721_TRANSFER and
+                hex_or_bytes_to_address(tx_log.topics[1]) == hex_or_bytes_to_address(context.tx_log.topics[2]) and  # from  # noqa: E501
+                hex_or_bytes_to_address(tx_log.topics[2]) == ZERO_ADDRESS  # to
+            ):
+                sending_ctoken = True
+                break
+
+        paired_event, action_from_event_type, action_to_event_subtype, action_to_notes = None, None, None, None  # noqa: E501
+        for event in context.decoded_events:
+            if (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.asset.identifier == underlying_token.identifier and
+                event.address == compound_token.evm_address
+            ):
+                if sending_ctoken:
+                    event.event_type = HistoryEventType.WITHDRAWAL
+                    event.event_subtype = HistoryEventSubType.REMOVE_ASSET
+                    event.notes = f'Withdraw {event.balance.amount} {event.asset.symbol_or_name()} from Compound v3'  # noqa: E501
+                    paired_event = event
+                    action_from_event_type = HistoryEventType.SPEND
+                    action_to_event_subtype = HistoryEventSubType.RETURN_WRAPPED
+                    action_to_notes = f'Return {{amount}} {compound_token.symbol} to Compound v3'  # {amount} to be replaced in post decoding  # noqa: E501
                 else:
                     event.event_subtype = HistoryEventSubType.GENERATE_DEBT
-                    event.notes = f'Borrow {event.balance.amount} {event.asset.symbol_or_name()} from compound v3'  # noqa: E501
+                    event.notes = f'Borrow {event.balance.amount} {event.asset.symbol_or_name()} from Compound v3'  # noqa: E501
 
                 event.counterparty = CPT_COMPOUND_V3
                 break
         else:
             log.error(
-                f'Could not find any compound v3 repay or borrow event in tx '
+                f'Could not find any compound v3 withdraw or borrow event in tx '
                 f'{context.transaction.tx_hash.hex()}.',
             )
 
+        action_items = []  # also create an action item for the spend of the cTokens
+        if paired_event is not None and action_from_event_type is not None:
+            action_items.append(ActionItem(
+                action='transform',
+                from_event_type=action_from_event_type,
+                from_event_subtype=HistoryEventSubType.NONE,
+                asset=compound_token,
+                to_event_subtype=action_to_event_subtype,
+                to_notes=action_to_notes,
+                to_counterparty=CPT_COMPOUND_V3,
+                paired_event_data=(paired_event, False),
+            ))
+
+        return DecodingOutput(action_items=action_items)
+
+    def _decode_collateral_movemement(
+            self,
+            context: DecoderContext,
+            compound_token: EvmToken,
+    ) -> DecodingOutput:
+        """Decode compound v3 supply/withdraw collateral events"""
+        collateral_asset = EvmToken(evm_address_to_identifier(
+            address=hex_or_bytes_to_address(context.tx_log.topics[3]),
+            chain_id=self.evm_inquirer.chain_id,
+            token_type=EvmTokenKind.ERC20,
+        ))
+        collateral_amount = asset_normalized_value(
+            amount=hex_or_bytes_to_int(context.tx_log.data),
+            asset=collateral_asset,
+        )
+
+        for event in context.decoded_events:
+            if (
+                event.event_type in {HistoryEventType.SPEND, HistoryEventType.RECEIVE} and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.balance.amount == collateral_amount and
+                event.asset == collateral_asset and
+                event.address == compound_token.evm_address
+            ):
+                transfer_event = event
+                event.counterparty = CPT_COMPOUND_V3
+                if event.event_type == HistoryEventType.SPEND:
+                    notes_action = 'Enable'
+                    event.event_type = HistoryEventType.DEPOSIT
+                    event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                    event.notes = f'Deposit {collateral_amount} {collateral_asset.symbol} into Compound v3'  # noqa: E501
+                else:
+                    notes_action = 'Disable'
+                    event.event_type = HistoryEventType.WITHDRAWAL
+                    event.event_subtype = HistoryEventSubType.REMOVE_ASSET
+                    event.notes = f'Withdraw {collateral_amount} {collateral_asset.symbol} from Compound v3'  # noqa: E501
+
+                collateral_event = self.base.make_event_next_index(
+                    tx_hash=context.transaction.tx_hash,
+                    timestamp=context.transaction.timestamp,
+                    event_type=HistoryEventType.INFORMATIONAL,
+                    event_subtype=HistoryEventSubType.NONE,
+                    balance=Balance(),
+                    asset=event.asset,
+                    location_label=event.location_label,
+                    counterparty=event.counterparty,
+                    notes=f'{notes_action} {collateral_amount} {collateral_asset.symbol} as collateral on Compound v3',  # noqa: E501
+                    address=event.address,
+                )
+                break
+        else:
+            log.error(
+                f'Could not find any compound v3 supply/withdraw collateral event in tx '
+                f'{context.transaction.tx_hash.hex()}.',
+            )
+            return DEFAULT_DECODING_OUTPUT
+
+        context.decoded_events.append(collateral_event)
+        maybe_reshuffle_events(
+            events_list=context.decoded_events,
+            ordered_events=[transfer_event, collateral_event],
+        )
         return DEFAULT_DECODING_OUTPUT
 
     def decode_compound_token_movement(
@@ -232,13 +352,21 @@ class Compoundv3CommonDecoder(DecoderInterface):
         ):
             return DEFAULT_DECODING_OUTPUT
 
-        if context.tx_log.topics[0] in {COMPOUND_V3_SUPPLY, COMPOUND_V3_WITHDRAW}:
-            return self._decode_supply_or_withdraw_event(
+        if context.tx_log.topics[0] == COMPOUND_V3_SUPPLY:
+            return self._decode_supply_or_repay_event(
+                context=context,
+                compound_token=compound_token,
+            )
+        elif context.tx_log.topics[0] == COMPOUND_V3_WITHDRAW:
+            return self._decode_withdraw_or_borrow_event(
                 context=context,
                 compound_token=compound_token,
             )
         else:
-            return self._decode_repay_or_borrow_event(context=context)
+            return self._decode_collateral_movemement(
+                context=context,
+                compound_token=compound_token,
+            )
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/tests/api/test_compound.py
+++ b/rotkehlchen/tests/api/test_compound.py
@@ -2,13 +2,15 @@ import random
 import warnings as test_warnings
 from contextlib import ExitStack
 from http import HTTPStatus
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.api.server import APIServer
+from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.evm.decoding.compound.v3.balances import Compoundv3Balances
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_COMP
 from rotkehlchen.fval import FVal
@@ -19,8 +21,9 @@ from rotkehlchen.tests.utils.api import (
     assert_proper_response_with_result,
     wait_for_async_task,
 )
+from rotkehlchen.tests.utils.constants import CURRENT_PRICE_MOCK
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
-from rotkehlchen.types import ChecksumEvmAddress, deserialize_evm_tx_hash
+from rotkehlchen.types import ChecksumEvmAddress, Price, deserialize_evm_tx_hash
 
 TEST_ACC1 = '0x2bddEd18E2CA464355091266B7616956944ee7eE'
 
@@ -85,8 +88,10 @@ def test_query_compound_balances(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[
-    '0x478768685e023B8AF2815369b353b786713fDEa4', '0x3eab2E72fA768C3cB8ab071929AC3C8aed6CbFA6',
-    '0x1107F797c1af4982b038Eb91260b3f9A90eecee9', '0x8fFb5a2e5d9b5dB800354Dc4fa73c15a5d047328',
+    '0x478768685e023B8AF2815369b353b786713fDEa4',
+    '0x3eab2E72fA768C3cB8ab071929AC3C8aed6CbFA6',
+    '0x1107F797c1af4982b038Eb91260b3f9A90eecee9',
+    '0x577e1290fE9561A9654b7b42B1C10c7Ea90c8a07',
 ]])
 @pytest.mark.parametrize('have_decoders', [[True]])
 @pytest.mark.parametrize('ethereum_modules', [['compound']])
@@ -94,44 +99,72 @@ def test_query_compound_v3_balances(
         rotkehlchen_api_server: APIServer,
         ethereum_accounts: list[ChecksumEvmAddress],
 ) -> None:
-    """Check querying the compound v3 balances endpoint works. Uses real data."""
+    """Check querying the compound v3 balances endpoint works. Uses real data for borrowing,
+    mocked balances for lending to avoid randomness in the VCR."""
     chain_aggregator = rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator
-    tokens = chain_aggregator.ethereum.tokens
-    tokens.evm_inquirer.multicall = MagicMock(side_effect=tokens.evm_inquirer.multicall)  # type: ignore[method-assign]
-    tokens.detect_tokens(only_cache=False, addresses=ethereum_accounts)
+    c_usdc_v3 = EvmToken('eip155:1/erc20:0xc3d688B66703497DAA19211EEdff47f25384cdc3')
     chain_aggregator.ethereum.transactions_decoder.decode_transaction_hashes(
         ignore_cache=True,
         tx_hashes=[
-            deserialize_evm_tx_hash('0x4221dacc70b5505f40046d8c8de084a5d606a7b864d2dc37738b532d6d33a608'),  # Borrow 0.1 WBTC from cUSDCv3  # noqa: E501
-            deserialize_evm_tx_hash('0x0b52a63d1f9b3518d0d4525354c601e83e4814c0165f496223753b29ce4f2a29'),  # Borrow 0.957368573046591548 wstETH from cWETHv3  # noqa: E501
+            deserialize_evm_tx_hash('0x0c9276ed2a202b039d5fa6e9749fd19f631c62e8e4beccc2f4dc0358a4882bb1'),  # Borrow 3,500 USDC from cUSDCv3  # noqa: E501
+            deserialize_evm_tx_hash('0x13965c2a1ba75dafa060d0bdadd332c9330b9c5819a8fee7d557a937728fa22f'),  # Borrow 42.5043 USDC from USDCv3  # noqa: E501
         ],
     )
+    compound_v3_balances = Compoundv3Balances(
+        database=chain_aggregator.database,
+        evm_inquirer=chain_aggregator.ethereum.node_inquirer,
+    )
+    unique_borrows, underlying_tokens = compound_v3_balances._extract_unique_borrowed_tokens()
 
-    result = assert_proper_response_with_result(requests.get(api_url_for(
-        rotkehlchen_api_server,
-        'compoundbalancesresource',
-    )))
+    def mock_extract_unique_borrowed_tokens(
+            self: 'Compoundv3Balances',  # pylint: disable=unused-argument
+    ) -> tuple[dict[EvmToken, list['ChecksumEvmAddress']], dict['ChecksumEvmAddress', EvmToken]]:
+        return {
+            token: sorted(addresses, reverse=True)  # cast set to list to avoid randomness in VCR
+            for token, addresses in unique_borrows.items()
+        }, underlying_tokens
+
+    def mock_query_tokens(addresses):
+        return ({
+            ethereum_accounts[0]: {c_usdc_v3: FVal('333349.851793')},
+            ethereum_accounts[1]: {c_usdc_v3: FVal('0.32795')},
+        }, {c_usdc_v3: Price(CURRENT_PRICE_MOCK)}) if len(addresses) != 0 else ({}, {})
+
+    with (
+        patch(
+            target='rotkehlchen.chain.evm.tokens.EvmTokens.query_tokens_for_addresses',
+            side_effect=mock_query_tokens,
+        ),
+        patch(
+            target='rotkehlchen.chain.evm.decoding.compound.v3.balances.Compoundv3Balances._extract_unique_borrowed_tokens',
+            new=mock_extract_unique_borrowed_tokens,
+        ),
+    ):
+        result = assert_proper_response_with_result(requests.get(api_url_for(
+            rotkehlchen_api_server,
+            'compoundbalancesresource',
+        )))
 
     def get_balance(amount: str) -> dict[str, str]:
-        return Balance(amount=FVal(amount), usd_value=FVal(amount) * FVal(1.5)).serialize()
+        return Balance(amount=FVal(amount), usd_value=FVal(amount) * CURRENT_PRICE_MOCK).serialize()  # noqa: E501
 
     assert result == {
         ethereum_accounts[0]: {
             'lending': {
-                'eip155:1/erc20:0xc3d688B66703497DAA19211EEdff47f25384cdc3': {  # cUSDCv3
-                    'apy': '6.12%',
+                c_usdc_v3.identifier: {
+                    'apy': '6.42%',
                     'balance': get_balance('333349.851793'),
                 },
             }, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('2.207376'),
+                    'balance': get_balance('2.356445'),
                 },
             },
         }, ethereum_accounts[1]: {
             'lending': {
-                'eip155:1/erc20:0xc3d688B66703497DAA19211EEdff47f25384cdc3': {  # cUSDCv3
-                    'apy': '6.12%',
+                c_usdc_v3.identifier: {
+                    'apy': '6.42%',
                     'balance': get_balance('0.32795'),
                 },
             }, 'rewards': {
@@ -142,26 +175,26 @@ def test_query_compound_v3_balances(
             },
         }, ethereum_accounts[2]: {
             'borrowing': {
-                'eip155:1/erc20:0xc3d688B66703497DAA19211EEdff47f25384cdc3': {  # cUSDCv3
-                    'apy': '8.30%',
-                    'balance': get_balance('253005.684547'),
+                c_usdc_v3.identifier: {
+                    'apy': '8.63%',
+                    'balance': get_balance('166903.418564'),
                 },
             }, 'lending': {}, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('0.172652'),
+                    'balance': get_balance('0.22238'),
                 },
             },
         }, ethereum_accounts[3]: {
             'borrowing': {
-                'eip155:1/erc20:0xA17581A9E3356d9A858b789D68B4d866e593aE94': {  # cWETHv3
-                    'apy': '1.83%',
-                    'balance': get_balance('0.260768110605080777'),
+                c_usdc_v3.identifier: {
+                    'apy': '8.63%',
+                    'balance': get_balance('257.564495'),
                 },
             }, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('0.106294'),
+                    'balance': get_balance('0.000038'),
                 },
             },
         },


### PR DESCRIPTION
Signed-off-by: OjusWiZard <ojuswimail@gmail.com>

- [x] Decode seperate events for adding and removal of collateral assets.
- [x] Change the common decoding logic from `_decode_supply_or_withdraw_event` and `_decode_repay_or_borrow_event`  to `_decode_supply_or_repay_event` and `_decode_withdraw_or_borrow_event`
- [x] Fix ~an~ two underlying_asset mapping for `cUSDCv3` on arbitrum. ~Checking if any other is wrong...~
- [x] Adjust the test for wrongly decoded events

SQL diff for global.db
```sql
UPDATE underlying_tokens_list SET identifier='eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8' WHERE rowid=193;
UPDATE underlying_tokens_list SET identifier='eip155:8453/erc20:0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA' WHERE rowid=196;
```