### PR TITLE
Bugfix: compound v2, add check of the event address in mint and borrow logic

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` compound_v2 decoder will now check that the event address is a compound one for the borrow and mint event decoding. This fixes a bug with decoding transactions containing also flash loans of same asset type.
+
 * :release:`1.33.0 <2024-05-08>`
 * :feature:`7798` rotki now accurately decodes transactions on the Kyber swap aggregator across all supported chains. 
 * :feature:`-` Users will now be able to delete transactions and the associated events in history events.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`-` compound_v2 decoder will now check that the event address is a compound one for the borrow and mint event decoding. This fixes a bug with decoding transactions containing also flash loans of same asset type.
+* :bug:`-` Compound v2 transactions containing also flash loans of same asset type will now be properly decoded.
 
 * :release:`1.33.0 <2024-05-08>`
 * :feature:`7798` rotki now accurately decodes transactions on the Kyber swap aggregator across all supported chains. 

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -87,7 +87,8 @@ class Compoundv2Decoder(DecoderInterface):
             if (
                 event.event_type == HistoryEventType.SPEND and
                 event.asset == underlying_asset and
-                event.balance.amount == mint_amount
+                event.balance.amount == mint_amount and
+                event.address == compound_token.evm_address
             ):
                 event.event_type = HistoryEventType.DEPOSIT
                 event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
@@ -183,7 +184,8 @@ class Compoundv2Decoder(DecoderInterface):
             if (
                 event.event_type == HistoryEventType.RECEIVE and
                 event.asset.identifier == underlying_asset and
-                event.balance.amount == amount
+                event.balance.amount == amount and
+                event.address == compound_token.evm_address
             ):
                 event.event_subtype = HistoryEventSubType.GENERATE_DEBT
                 event.counterparty = CPT_COMPOUND

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -84,7 +84,11 @@ class Compoundv2Decoder(DecoderInterface):
         out_event = None
         for event in decoded_events:
             # Find the transfer event which should have come before the minting
-            if event.event_type == HistoryEventType.SPEND and event.asset == underlying_asset and event.balance.amount == mint_amount:  # noqa: E501
+            if (
+                event.event_type == HistoryEventType.SPEND and
+                event.asset == underlying_asset and
+                event.balance.amount == mint_amount
+            ):
                 event.event_type = HistoryEventType.DEPOSIT
                 event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
                 event.counterparty = CPT_COMPOUND
@@ -176,16 +180,26 @@ class Compoundv2Decoder(DecoderInterface):
         amount = asset_normalized_value(amount_raw, underlying_asset)
         for event in decoded_events:
             # Find the transfer event which should have come before the redeeming
-            if event.event_type == HistoryEventType.RECEIVE and event.asset.identifier == underlying_asset and event.balance.amount == amount:  # noqa: E501
+            if (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.asset.identifier == underlying_asset and
+                event.balance.amount == amount
+            ):
                 event.event_subtype = HistoryEventSubType.GENERATE_DEBT
                 event.counterparty = CPT_COMPOUND
                 event.notes = f'Borrow {amount} {underlying_asset.symbol} from compound'
-            elif event.event_type == HistoryEventType.RECEIVE and event.location_label == payer and event.asset == A_COMP and event.address == COMPTROLLER_PROXY_ADDRESS:  # noqa: E501
+            elif (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.location_label == payer and
+                event.asset == A_COMP and
+                event.address == COMPTROLLER_PROXY_ADDRESS
+            ):
                 event.event_subtype = HistoryEventSubType.REWARD
                 event.counterparty = CPT_COMPOUND
                 event.notes = f'Collect {event.balance.amount} COMP from compound'
             elif (
-                event.event_type == HistoryEventType.SPEND and event.balance.amount == amount and
+                event.event_type == HistoryEventType.SPEND and
+                event.balance.amount == amount and
                 (
                     (underlying_asset == self.eth and event.address == MAXIMILLION_ADDR) or
                     (event.location_label == payer and event.address == compound_token.evm_address)


### PR DESCRIPTION
Fix of an issue noticed in the decoding of atomic transactions containing interactions with other protocols as flash loan operations:
Flash loan borrowing from other protocols was detected as borrowing from compound.

Changelog:
Added the check of event.address in borrow logic: it must be the ctoken address.
Added the same check in mint operation, because it sounds as a safe check.
