### PR TITLE
feat(evm): add spam transaction caching

### DIFF
--- a/rotkehlchen/chain/evm/constants.py
+++ b/rotkehlchen/chain/evm/constants.py
@@ -13,6 +13,7 @@ ETH_SPECIAL_ADDRESS: Final = string_to_evm_address('0xEeeeeEeeeEeEeeEeEeEeeEEEee
 ZERO_32_BYTES_HEX: Final = '0x' + '0' * 64
 GENESIS_HASH: Final = deserialize_evm_tx_hash(ZERO_32_BYTES_HEX)  # hash for transactions in genesis block # noqa: E501
 EVM_ADDRESS_REGEX: Final = re.compile(r'\b0x[a-fA-F0-9]{40}\b')
+LAST_SPAM_TXS_CACHE: Final = 'SPAM_TXS'
 
 # Fake receipt with values taken from ethereum mainnet, to emulate a receipt for the
 # genesis transactions


### PR DESCRIPTION
Add new constant for spam transactions. Implement dynamic caching for last query timestamps to optimize spam detection logic.


Addresses: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=45914187