### PR TITLE
Okx frozen balance bug fix #7915

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`7915` - Show OKX balances locked in active trades.
 * :bug:`-` Compound v2 transactions containing also flash loans of same asset type will now be properly decoded.
 
 * :release:`1.33.0 <2024-05-08>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`7915` - Show OKX balances locked in active trades.
+* :bug:`7915` Show OKX balances locked in active trades.
 * :bug:`-` Compound v2 transactions containing also flash loans of same asset type will now be properly decoded.
 
 * :release:`1.33.0 <2024-05-08>`

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -273,7 +273,7 @@ class Okx(ExchangeInterface):
                 continue
 
             try:
-                amount = deserialize_asset_amount(currency_data['availBal'])
+                amount = deserialize_asset_amount(currency_data['availBal']) + deserialize_asset_amount(currency_data['frozenBal'])  # noqa: E501
             except DeserializationError as e:
                 self.msg_aggregator.add_error(
                     f'Error processing {self.name} {asset.name} balance result due to inability '

--- a/rotkehlchen/tests/exchanges/test_okx.py
+++ b/rotkehlchen/tests/exchanges/test_okx.py
@@ -132,7 +132,7 @@ def test_okx_query_balances(mock_okx: Okx):
                "eq":"0.00000065312",
                "eqUsd":"0.00000065312",
                "fixedBal":"0",
-               "frozenBal":"0",
+               "frozenBal":"50",
                "interest":"",
                "isoEq":"0",
                "isoLiab":"",
@@ -173,7 +173,7 @@ def test_okx_query_balances(mock_okx: Okx):
     assert len(balances) == 3
     assert (balances[A_XMR.resolve_to_asset_with_oracles()]).amount == FVal('0.027846')
     assert (balances[A_SOL.resolve_to_asset_with_oracles()]).amount == FVal('299.9920000068')
-    assert (balances[A_USDT.resolve_to_asset_with_oracles()]).amount == FVal('6.5312E-7')
+    assert (balances[A_USDT.resolve_to_asset_with_oracles()]).amount == FVal('50.00000065312')
 
     warnings = mock_okx.msg_aggregator.consume_warnings()
     errors = mock_okx.msg_aggregator.consume_errors()


### PR DESCRIPTION
Closes https://github.com/rotki/rotki/issues/7915

I've fixed an issue where frozen balances were not displaying on OKX TR. After implementing the correction, I tested the changes and confirmed that everything is now working correctly.

Please review the changes at your convenience.


This pull request (7922) is a continuation of a previous pull request and I have opened it here again to address the issues identified there. By doing so, I aim to make it easier to track and manage the fixes made on top of the previous changes.
https://github.com/rotki/rotki/pull/7922
Thank you.
