### PR TITLE
feat(aave): integrate native Aave V2 staking detection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`1633` rotki now supports AAVE staking.
 * :feature:`7568` Eigenlayer native restaking events are now properly decoded and balances in native restaking eigenpods or the delayed withdrawal system are automatically detected.
 * :feature:`6115` Now free users can filter history events too.
 * :feature:`7570` Users can choose whether to automatically force-push when a time discrepancy warning occurs during automatic database sync.

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -154,6 +154,8 @@ DEFI_PROTOCOLS_TO_SKIP_ASSETS = {
     # aTokens are already detected at token balance queries
     'Aave': True,  # True means all
     'Aave V2': True,  # True means all
+    # stkAAVE and staking incentives are already detected
+    'Aave • Staking': True,
     # cTokens are already detected at token balance queries
     'Compound': True,  # True means all
     # Curve balances are detected by our scan for ERC20 tokens

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -38,6 +38,7 @@ PROTOCOLS_WITH_BALANCES = Literal[
     'eigenlayer',
     'gmx',
     'compound-v3',
+    'aave',
 ]
 BalancesType = dict[ChecksumEvmAddress, dict[EvmToken, Balance]]
 BalancesSheetType = dict[ChecksumEvmAddress, BalanceSheet]

--- a/rotkehlchen/chain/ethereum/modules/aave/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/balances.py
@@ -1,0 +1,82 @@
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
+from rotkehlchen.chain.ethereum.modules.aave.constants import STK_AAVE_ADDR
+from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
+from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE
+from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.constants.assets import A_AAVE
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.history.events.structures.evm_event import EvmProduct
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.db.dbhandler import DBHandler
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class AaveBalances(ProtocolWithBalance):
+    def __init__(
+            self,
+            database: 'DBHandler',
+            evm_inquirer: 'EthereumInquirer',
+    ):
+        super().__init__(
+            database=database,
+            evm_inquirer=evm_inquirer,
+            counterparty=CPT_AAVE,
+            deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
+        )
+
+    def query_balances(self) -> 'BalancesSheetType':
+        """Queries and returns the balances sheet for staking events.
+
+        Retrieves deposit events and calls staking contract to get the total rewards balance."""
+        balances: BalancesSheetType = defaultdict(BalanceSheet)
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(products=[EvmProduct.STAKING]))) == 0:  # noqa: E501
+            return balances
+
+        staking_contract = self.evm_inquirer.contracts.contract(address=STK_AAVE_ADDR)
+        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        if len(staked_rewards := self.evm_inquirer.multicall(
+            calls=[(
+                staking_contract.address,
+                staking_contract.encode(
+                    method_name='getTotalRewardsBalance',
+                    arguments=[user],
+                ),
+            ) for user in addresses_with_deposits],
+            call_order=call_order,
+            calls_chunk_size=chunk_size,
+        )) == 0:
+            return balances
+
+        token_price = Inquirer.find_usd_price(A_AAVE)
+        for user, result in zip(addresses_with_deposits, staked_rewards, strict=True):
+            balance: int
+            if (balance := staking_contract.decode(
+                result=result,
+                method_name='getTotalRewardsBalance',
+                arguments=[user],
+            )[0]) == ZERO:
+                continue
+
+            if (balance_norm := token_normalized_value_decimals(
+                token_amount=balance,
+                token_decimals=DEFAULT_TOKEN_DECIMALS,
+            )) > ZERO:
+                balances[user].assets[A_AAVE] += Balance(
+                    amount=balance_norm,
+                    usd_value=token_price * balance_norm,
+                )
+
+        return balances

--- a/rotkehlchen/chain/ethereum/modules/aave/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/constants.py
@@ -1,0 +1,8 @@
+from typing import Final
+
+from rotkehlchen.chain.evm.types import string_to_evm_address
+
+STK_AAVE_ADDR: Final = string_to_evm_address('0x4da27a545c0c5B758a6BA100e3a049001de870f5')
+STKAAVE_IDENTIFIER: Final = f'eip155:1/erc20:{STK_AAVE_ADDR}'
+STAKED_AAVE: Final = b"l\x86\xf3\xfdQ\x18\xb3\xaa\x8b\xb4\xf3\x89\xa6\x17\x04m\xe0\xa3\xd3\xd4w\xde\x1a\x16s\xd2'\xf8\x02\xf6\x16\xdc"  # noqa: E501
+REDEEM_AAVE: Final = b'?i?\xff\x03\x8b\xb8\xa0F\xaav\xd9Qa\x90\xactD\xf7\xd6\x9c\xf9R\xc4\xcb\xdc\x08o\xde\xf2\xd6\xfc'  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/aave/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/decoder.py
@@ -1,0 +1,125 @@
+from typing import Any
+
+from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
+from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE
+from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_DECODING_OUTPUT,
+    DecoderContext,
+    DecodingOutput,
+)
+from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
+from rotkehlchen.constants.assets import A_AAVE
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.types import ChecksumEvmAddress
+from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
+
+from .constants import REDEEM_AAVE, STAKED_AAVE, STK_AAVE_ADDR, STKAAVE_IDENTIFIER
+
+
+class AaveDecoder(DecoderInterface):
+    """Aave decoder for staking and unstaking events"""
+    def _decode_staking_events(self, context: DecoderContext) -> DecodingOutput:
+        """Decode aave staking unstaking events"""
+        if context.tx_log.topics[0] == STAKED_AAVE:
+            method = self._decode_stake
+        elif context.tx_log.topics[0] == REDEEM_AAVE:
+            method = self._decode_unstake
+        else:
+            return DEFAULT_DECODING_OUTPUT
+
+        from_address = hex_or_bytes_to_address(context.tx_log.topics[1])
+        to_address = hex_or_bytes_to_address(context.tx_log.topics[2])
+        if not self.base.any_tracked([from_address, to_address]):
+            return DEFAULT_DECODING_OUTPUT
+
+        amount = token_normalized_value_decimals(
+            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token_decimals=DEFAULT_TOKEN_DECIMALS,
+        )
+        return method(from_address=from_address, to_address=to_address, amount=amount, decoded_events=context.decoded_events)  # noqa: E501
+
+    def _decode_stake(
+            self,
+            from_address: ChecksumEvmAddress,
+            to_address: ChecksumEvmAddress,
+            amount: FVal,
+            decoded_events: list[EvmEvent],
+    ) -> DecodingOutput:
+        for event in decoded_events:
+            if (
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.asset == A_AAVE and
+                event.location_label == to_address and
+                event.balance.amount == amount
+            ):
+                event.event_type = HistoryEventType.STAKING
+                event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                event.notes = f'Stake {amount} AAVE'
+                if from_address != to_address:
+                    event.notes += f' for {to_address}'
+                event.product = EvmProduct.STAKING
+                event.counterparty = CPT_AAVE
+            elif (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.asset.identifier == STKAAVE_IDENTIFIER and
+                event.location_label == to_address and
+                event.balance.amount == amount
+            ):
+                event.counterparty = CPT_AAVE
+                event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
+                event.notes = f'Receive {event.balance.amount} stkAAVE from staking in Aave'
+
+        return DEFAULT_DECODING_OUTPUT
+
+    def _decode_unstake(
+            self,
+            from_address: ChecksumEvmAddress,
+            to_address: ChecksumEvmAddress,
+            amount: FVal,
+            decoded_events: list[EvmEvent],
+    ) -> DecodingOutput:
+        for event in decoded_events:
+            if (
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.asset.identifier == STKAAVE_IDENTIFIER and
+                event.location_label == to_address and
+                event.balance.amount == amount
+            ):
+                event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
+                event.notes = f'Unstake {amount} stkAAVE'
+                if from_address != to_address:
+                    event.notes += f' for {to_address}'
+                event.product = EvmProduct.STAKING
+                event.counterparty = CPT_AAVE
+            elif (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.asset == A_AAVE and
+                event.location_label == to_address and
+                event.balance.amount == amount
+            ):
+                event.counterparty = CPT_AAVE
+                event.event_type = HistoryEventType.STAKING
+                event.event_subtype = HistoryEventSubType.REMOVE_ASSET
+                event.notes = f'Receive {event.balance.amount} AAVE after unstaking from Aave'
+
+        return DEFAULT_DECODING_OUTPUT
+
+    # DecoderInterface method
+    def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
+        return {STK_AAVE_ADDR: (self._decode_staking_events,)}
+
+    @staticmethod
+    def counterparties() -> tuple[CounterpartyDetails, ...]:
+        return (CounterpartyDetails(
+            identifier=CPT_AAVE,
+            label=CPT_AAVE.capitalize(),
+            image='aave.svg',
+        ),)

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -23,8 +23,6 @@ ETH_TOKEN_EXCEPTIONS = {
     # since the SDK entry might return other tokens from sushi and we don't
     # fully support sushi now.
     string_to_evm_address('0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272'),
-    # Ignore stkAave since it's queried by defi SDK.
-    string_to_evm_address('0x4da27a545c0c5B758a6BA100e3a049001de870f5'),
     # Ignore the following tokens. They are old tokens of upgraded contracts which
     # duplicated the balances at upgrade instead of doing a token swap.
     # e.g.: https://github.com/rotki/rotki/issues/3548

--- a/rotkehlchen/chain/evm/decoding/aave/constants.py
+++ b/rotkehlchen/chain/evm/decoding/aave/constants.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-
+CPT_AAVE: Final = 'aave'
 CPT_AAVE_V1: Final = 'aave-v1'
 CPT_AAVE_V2: Final = 'aave-v2'
 CPT_AAVE_V3: Final = 'aave-v3'

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -41,6 +41,7 @@ ADDRESS_WITHOUT_GENESIS_TX = '0x4bBa290826C253BD854121346c370a9886d1bC26'
 def test_decoders_initialization(ethereum_transaction_decoder: EthereumTransactionDecoder):
     """Make sure that all decoders we have created are detected and initialized"""
     assert set(ethereum_transaction_decoder.decoders.keys()) == {
+        'Aave',
         'Aavev1',
         'Aavev2',
         'Aavev3',
@@ -142,6 +143,7 @@ def test_decoders_initialization(ethereum_transaction_decoder: EthereumTransacti
         'stakedao',
         'convex',
         'votium',
+        'aave',
         'aave-v1',
         'aave-v2',
         'aave-v3',


### PR DESCRIPTION
Closes #1633 

- Removed `stkAave` from ignored list since `getTotalRewardsBalance` only returns the reward balance.
- Updated `zerionsdk.py` to exclude Aave Staking.

`sqldiff rotkehlchen/data/develop.db rotkehlchen/data/global.db`
```sql
INSERT INTO contract_abi(id,value,name) VALUES(89,'[{"inputs":[{"internalType":"address","name":"staker","type":"address"}],"name":"getTotalRewardsBalance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]','AAVE_STAKING');
INSERT INTO contract_data(rowid,address,chain_id,abi,deployed_block) VALUES(167,'0x4da27a545c0c5B758a6BA100e3a049001de870f5',1,89,10927018);
```