### PR TITLE
ci: remove no-optional flag and disable cypress binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CYPRESS_INSTALL_BINARY=0
 WORKDIR /app
 COPY frontend/ .
 RUN if [ "$BUILDARCH" != "amd64" ]; then apt-get update && apt-get install -y build-essential python3 --no-install-recommends; fi
-RUN npm install -g pnpm@9 && pnpm install --no-optional --frozen-lockfile
+RUN npm install -g pnpm@9 && pnpm install --frozen-lockfile
 RUN pnpm run docker:build
 
 FROM python:3.11-buster as backend-build-stage

--- a/package.py
+++ b/package.py
@@ -96,6 +96,7 @@ class Environment:
         os.environ.pop(CERTIFICATE_KEY, None)
         os.environ.pop(APPLE_ID, None)
         os.environ.pop(APPLE_ID_PASS, None)
+        os.environ.setdefault('CYPRESS_INSTALL_BINARY', '0')
 
     def macos_sign_env(self) -> dict[str, str]:
         env = os.environ.copy()
@@ -1229,7 +1230,7 @@ class FrontendBuilder:
             f'Restoring dependencies using Node.js {node_version} and pnpm@{pnpm_version}',
         )
         ret_code = subprocess.call(
-            'pnpm install --no-optional --frozen-lockfile',
+            'pnpm install --frozen-lockfile',
             shell=True,
         )
         if ret_code != 0:


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
