### PR TITLE
Remove redundant use of `VIRTUAL_ENV=${Python_ROOT_DIR}`

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -199,7 +199,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Set up uv
         run: |
-          echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
           pip install --upgrade pip
           pip install --no-cache uv
       - name: Install dependencies


### PR DESCRIPTION
Hi! 

In the latest uv release, we no longer support this for using the system Python and you're already using the `--system` flag so it should have no effect here. You can see some more context on the change in support at https://github.com/astral-sh/uv/issues/3765 and https://github.com/inventree/InvenTree/pull/7317.

## Checklist

- ~[ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.~
