### PR TITLE
ci: update macos runner to macos-12

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -85,7 +85,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.9
       CMAKE_OSX_ARCHITECTURES: 'x86_64;arm64'
     environment: macos_sign
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -170,7 +170,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.9
       CMAKE_OSX_ARCHITECTURES: 'x86_64;arm64'
     environment: macos_sign
-    runs-on: macos-11
+    runs-on: macos-12
     needs: create_draft
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/