### PR TITLE
feat: allow download the accounting rules

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4047,7 +4047,7 @@ Get asset location mappings for a location
             "message": ""
         }
 
-    :resjson object entries: An array of mapping objects. Each entry is composed of the asset identifier under the ``"asset"`` key, its ticker symbol used in the location under the ``"location_symbol"`` key, and its location under the ``"location"`` key. 
+    :resjson object entries: An array of mapping objects. Each entry is composed of the asset identifier under the ``"asset"`` key, its ticker symbol used in the location under the ``"location_symbol"`` key, and its location under the ``"location"`` key.
     :resjson int entries_found: The number of entries found for the current filter. Ignores pagination.
     :resjson int entries_total: The number of total entries ignoring all filters.
     :resjson str message: Error message if any errors occurred.
@@ -5682,7 +5682,7 @@ Import PnL report debug data
 Export Accounting rules
 ============================
 
-.. http:post:: /api/(version)/accounting/rules/transfer
+.. http:post:: /api/(version)/accounting/rules/export
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
@@ -5713,7 +5713,7 @@ Export Accounting rules
           "message": ""
       }
 
-   :resjson bool result: Boolean denoting success or failure of the export
+   :resjson bool result: Boolean denoting success or failure of the export. If ``directory_path`` is not present, it will return the JSON data directly.
    :statuscode 200: File was exported successfully
    :statuscode 400: Provided JSON is in some way malformed.
    :statuscode 409: No user is currently logged in. No permissions to write in the given directory. Check error message.
@@ -5723,8 +5723,8 @@ Export Accounting rules
 Import Accounting rules
 ============================
 
-.. http:put:: /api/(version)/accounting/rules/transfer
-.. http:patch:: /api/(version)/accounting/rules/transfer
+.. http:put:: /api/(version)/accounting/rules/import
+.. http:patch:: /api/(version)/accounting/rules/import
 
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
@@ -8217,7 +8217,7 @@ Getting eth2 staking performance
       This endpoint is only available for premium users
 
    .. note::
-      This endpoint can also be queried asynchronously by using ``"async_query": true``	      
+      This endpoint can also be queried asynchronously by using ``"async_query": true``
 
    **Example Request**:
 
@@ -13311,7 +13311,7 @@ Managing calendar entries
          "message": ""
       }
 
-  :resjson object result: object with the identifier of the calendar entry created. 
+  :resjson object result: object with the identifier of the calendar entry created.
   :statuscode 200: Entry correctly stored.
   :statuscode 401: No user is currently logged in.
   :statuscode 409: Failed to validate the data.
@@ -13355,7 +13355,7 @@ Managing calendar entries
          "message": ""
       }
 
-  :resjson object result: object with the identifier of the calendar entry updated. 
+  :resjson object result: object with the identifier of the calendar entry updated.
   :statuscode 200: Entry correctly updated.
   :statuscode 401: No user is currently logged in.
   :statuscode 409: Failed to validate the data. Event not found.
@@ -13525,7 +13525,7 @@ Managing calendar reminders
          "message": ""
       }
 
-  :resjson object result: object with the identifier of the calendar reminder updated. 
+  :resjson object result: object with the identifier of the calendar reminder updated.
   :statuscode 200: Entry correctly updated.
   :statuscode 401: No user is currently logged in.
   :statuscode 409: Failed to validate the data. Event not found.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1664,11 +1664,14 @@ class RestAPI:
             return self._import_history_debug(async_query=async_query, filepath=filepath)  # pylint: disable=unexpected-keyword-arg  # pylint doesn't see the async decorator
 
     @async_api_call()
-    def export_accounting_rules(self, directory_path: Path) -> dict[str, Any]:
+    def export_accounting_rules(self, directory_path: Path | None) -> dict[str, Any]:
         """Exports all the accounting rules and linked properties into a json file
         in the given directory."""
         db_accounting = DBAccountingRules(self.rotkehlchen.data.db)
         rules_and_properties = db_accounting.get_accounting_rules_and_properties()
+
+        if directory_path is None:
+            return _wrap_in_ok_result(rules_and_properties)
 
         directory_path.mkdir(parents=True, exist_ok=True)
         try:

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1558,7 +1558,7 @@ class HistoryProcessingDebugResource(BaseMethodView):
 
         @require_loggedin_user()
         @use_kwargs(upload_schema, location='form_and_file')
-        def patch(self, async_query: bool, filepath: FileStorage) -> Response:
+        def patch(self, async_query: bool, filepath: Path) -> Response:
             return self.rest_api.import_history_debug(
                 async_query=async_query,
                 filepath=filepath,
@@ -1578,7 +1578,7 @@ class AccountingRulesImportResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(upload_schema, location='form_and_file')
-    def patch(self, async_query: bool, filepath: FileStorage) -> Response:
+    def patch(self, async_query: bool, filepath: Path) -> Response:
         return self.rest_api.import_accounting_rules(
             async_query=async_query,
             filepath=filepath,

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1622,7 +1622,12 @@ class AsyncFilePathSchema(AsyncQueryArgumentSchema):
             data: dict[str, Any],
             **_kwargs: Any,
     ) -> Any:
+        """
+        Change multipart/form-data to a file object if it's in that form,
+        so that it can be read with the same code
+        """
         if isinstance(data['filepath'], FileStorage):
+            # TODO cleanup: https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=65410141  # noqa: E501
             _, tmpfilepath = tempfile.mkstemp()
             data['filepath'].save(tmpfilepath)
             data['filepath'] = Path(tmpfilepath)

--- a/rotkehlchen/tests/api/blockchain/test_avalanche.py
+++ b/rotkehlchen/tests/api/blockchain/test_avalanche.py
@@ -11,10 +11,10 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.avalanche import AVALANCHE_ACC1_AVAX_ADDR, AVALANCHE_ACC2_AVAX_ADDR
@@ -73,7 +73,7 @@ def test_add_avax_blockchain_account(rotkehlchen_api_server: 'APIServer') -> Non
         'named_blockchain_balances_resource',
         blockchain=avalance_chain_key,
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # Check per account
     account_balances = result['per_account'][avalance_chain_key][AVALANCHE_ACC1_AVAX_ADDR]
@@ -111,7 +111,7 @@ def test_remove_avax_blockchain_account(rotkehlchen_api_server: 'APIServer') -> 
             'async_query': async_query,
         },
     )
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,

--- a/rotkehlchen/tests/api/blockchain/test_avalanche.py
+++ b/rotkehlchen/tests/api/blockchain/test_avalanche.py
@@ -11,11 +11,11 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
     wait_for_async_task,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.avalanche import AVALANCHE_ACC1_AVAX_ADDR, AVALANCHE_ACC2_AVAX_ADDR
 from rotkehlchen.tests.utils.substrate import SUBSTRATE_ACC1_DOT_ADDR
@@ -111,11 +111,11 @@ def test_remove_avax_blockchain_account(rotkehlchen_api_server: 'APIServer') -> 
             'async_query': async_query,
         },
     )
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     # Check per account
     avax_chain_key = SupportedBlockchain.AVALANCHE.serialize()

--- a/rotkehlchen/tests/api/blockchain/test_base.py
+++ b/rotkehlchen/tests/api/blockchain/test_base.py
@@ -23,9 +23,9 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_proper_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.blockchain import (
     assert_btc_balances_result,
@@ -115,7 +115,7 @@ def test_query_bitcoin_blockchain_bech32_balances(
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_btc_balances_result(
         result=result,
         btc_accounts=btc_accounts,
@@ -153,7 +153,7 @@ def test_query_blockchain_balances(
             'named_blockchain_balances_resource',
             blockchain='ETH',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -176,7 +176,7 @@ def test_query_blockchain_balances(
             'named_blockchain_balances_resource',
             blockchain='BTC',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -196,7 +196,7 @@ def test_query_blockchain_balances(
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -250,7 +250,7 @@ def test_query_blockchain_balances_ignore_cache(
             'named_blockchain_balances_resource',
             blockchain='ETH',
         ))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert_eth_balances_result(
             rotki=rotki,
             result=result,
@@ -268,7 +268,7 @@ def test_query_blockchain_balances_ignore_cache(
             'named_blockchain_balances_resource',
             blockchain='ETH',
         ))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert_eth_balances_result(
             rotki=rotki,
             result=result,
@@ -286,7 +286,7 @@ def test_query_blockchain_balances_ignore_cache(
             'named_blockchain_balances_resource',
             blockchain='ETH',
         ), json={'ignore_cache': True})
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert_eth_balances_result(
             rotki=rotki,
             result=result,
@@ -352,7 +352,7 @@ def _add_blockchain_accounts_test_start(
             blockchain='ETH',
         ), json=data)
 
-        result = assert_maybe_async_response_with_result(
+        result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=api_server,
             async_query=async_query,
@@ -364,7 +364,7 @@ def _add_blockchain_accounts_test_start(
             api_server,
             'blockchainbalancesresource',
         ))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     assert_eth_balances_result(
         rotki=rotki,
@@ -389,7 +389,7 @@ def _add_blockchain_accounts_test_start(
             api_server,
             'blockchainbalancesresource',
         ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_eth_balances_result(
         rotki=rotki,
         result=result,
@@ -443,7 +443,7 @@ def test_add_blockchain_accounts(  # hard to VCR, the order of requests is not a
             'accounts': [{'address': UNIT_BTC_ADDRESS3}],
             'async_query': async_query,
         })
-        result = assert_maybe_async_response_with_result(
+        result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -454,7 +454,7 @@ def test_add_blockchain_accounts(  # hard to VCR, the order of requests is not a
             'blockchainbalancesresource',
             blockchain=SupportedBlockchain.BITCOIN.value,
         ))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     assert_btc_balances_result(
         result=result,
@@ -479,7 +479,7 @@ def test_add_blockchain_accounts(  # hard to VCR, the order of requests is not a
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -939,7 +939,7 @@ def test_add_blockchain_accounts_with_tags_and_label_and_querying_them(rotkehlch
         'blockchainsaccountsresource',
         blockchain='ETH',
     ))
-    response_data = assert_proper_response_with_result(response)
+    response_data = assert_proper_sync_response_with_result(response)
     assert len(response_data) == len(accounts_data)
     for entry in response_data:
         # find the corresponding account in accounts data
@@ -1025,7 +1025,7 @@ def test_edit_blockchain_accounts(
         blockchain='ETH',
     ), json=request_data)
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     expected_result = request_data['accounts'] + [
         {'address': ethereum_accounts[0]},
     ]
@@ -1037,7 +1037,7 @@ def test_edit_blockchain_accounts(
         'blockchainsaccountsresource',
         blockchain='ETH',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     compare_account_data(result, expected_result)
 
     # Edit 1 account so that both a label is edited but also a tag is removed and a tag is edited
@@ -1056,7 +1056,7 @@ def test_edit_blockchain_accounts(
         'blockchainsaccountsresource',
         blockchain='ETH',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for result_entry in result:  # order of return is not guaranteed
         if result_entry['address'] == ethereum_accounts[2]:
             assert result_entry['address'] == request_data['accounts'][0]['address']
@@ -1077,7 +1077,7 @@ def test_edit_blockchain_accounts(
         'blockchainsaccountsresource',
         blockchain='BTC',
     ), json=request_data)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 2
     # Assert the result is in the expected format and is edited
     standalone = result['standalone']
@@ -1442,7 +1442,7 @@ def _remove_blockchain_accounts_test_start(
             'blockchainsaccountsresource',
             blockchain='ETH',
         ), json={'accounts': removed_eth_accounts, 'async_query': async_query})
-        result = assert_maybe_async_response_with_result(
+        result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=api_server,
             async_query=async_query,
@@ -1478,7 +1478,7 @@ def _remove_blockchain_accounts_test_start(
             api_server,
             'blockchainbalancesresource',
         ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_eth_balances_result(
         rotki=rotki,
         result=result,
@@ -1537,7 +1537,7 @@ def test_remove_blockchain_accounts(
             'blockchainsaccountsresource',
             blockchain=SupportedBlockchain.BITCOIN.value,
         ), json={'accounts': [UNIT_BTC_ADDRESS1], 'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -1564,7 +1564,7 @@ def test_remove_blockchain_accounts(
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,

--- a/rotkehlchen/tests/api/blockchain/test_base.py
+++ b/rotkehlchen/tests/api/blockchain/test_base.py
@@ -23,10 +23,9 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response,
     assert_proper_response_with_result,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.blockchain import (
     assert_btc_balances_result,
@@ -154,15 +153,12 @@ def test_query_blockchain_balances(
             'named_blockchain_balances_resource',
             blockchain='ETH',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(
-                server=rotkehlchen_api_server,
-                task_id=task_id,
-                timeout=ASYNC_TASK_WAIT_TIMEOUT * 5,
-            )
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+            timeout=ASYNC_TASK_WAIT_TIMEOUT * 5,
+        )
 
     assert_eth_balances_result(
         rotki=rotki,
@@ -180,11 +176,11 @@ def test_query_blockchain_balances(
             'named_blockchain_balances_resource',
             blockchain='BTC',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
 
     assert_btc_balances_result(
         result=outcome,
@@ -200,15 +196,12 @@ def test_query_blockchain_balances(
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(
-                server=rotkehlchen_api_server,
-                task_id=task_id,
-                timeout=ASYNC_TASK_WAIT_TIMEOUT * 5,
-            )
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+            timeout=ASYNC_TASK_WAIT_TIMEOUT * 5,
+        )
 
     assert_eth_balances_result(
         rotki=rotki,
@@ -359,15 +352,12 @@ def _add_blockchain_accounts_test_start(
             blockchain='ETH',
         ), json=data)
 
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            result = wait_for_async_task_with_result(
-                api_server,
-                task_id,
-                timeout=ASYNC_TASK_WAIT_TIMEOUT * 4,
-            )
-        else:
-            result = assert_proper_response_with_result(response)
+        result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=api_server,
+            async_query=async_query,
+            timeout=ASYNC_TASK_WAIT_TIMEOUT * 4,
+        )
 
         assert result == new_eth_accounts
         response = requests.get(api_url_for(
@@ -453,11 +443,11 @@ def test_add_blockchain_accounts(  # hard to VCR, the order of requests is not a
             'accounts': [{'address': UNIT_BTC_ADDRESS3}],
             'async_query': async_query,
         })
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-        else:
-            result = assert_proper_response_with_result(response)
+        result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
         assert result == [UNIT_BTC_ADDRESS3]
         response = requests.get(api_url_for(
             rotkehlchen_api_server,
@@ -489,15 +479,12 @@ def test_add_blockchain_accounts(  # hard to VCR, the order of requests is not a
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(
-                server=rotkehlchen_api_server,
-                task_id=task_id,
-                timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
-            )
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+            timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
+        )
 
     assert_btc_balances_result(
         result=outcome,
@@ -1455,11 +1442,11 @@ def _remove_blockchain_accounts_test_start(
             'blockchainsaccountsresource',
             blockchain='ETH',
         ), json={'accounts': removed_eth_accounts, 'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            result = wait_for_async_task_with_result(api_server, task_id)
-        else:
-            result = assert_proper_response_with_result(response)
+        result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=api_server,
+            async_query=async_query,
+        )
 
     if query_balances_before_first_modification is True:
         assert_eth_balances_result(
@@ -1550,11 +1537,11 @@ def test_remove_blockchain_accounts(
             'blockchainsaccountsresource',
             blockchain=SupportedBlockchain.BITCOIN.value,
         ), json={'accounts': [UNIT_BTC_ADDRESS1], 'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
     assert_btc_balances_result(
         result=outcome,
         btc_accounts=btc_accounts_after_removal,
@@ -1577,15 +1564,12 @@ def test_remove_blockchain_accounts(
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(
-                server=rotkehlchen_api_server,
-                task_id=task_id,
-                timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
-            )
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+            timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
+        )
 
     assert_btc_balances_result(
         result=outcome,

--- a/rotkehlchen/tests/api/blockchain/test_evm.py
+++ b/rotkehlchen/tests/api/blockchain/test_evm.py
@@ -22,7 +22,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.avalanche import AVALANCHE_ACC1_AVAX_ADDR
@@ -80,7 +80,7 @@ def test_add_same_evm_account_for_multiple_chains(rotkehlchen_api_server):
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     for chain, native_token in ((SupportedBlockchain.ETHEREUM, A_ETH), (SupportedBlockchain.AVALANCHE, A_AVAX)):  # noqa: E501
         # Check per account
@@ -166,7 +166,7 @@ def test_adding_editing_ens_account_works(rotkehlchen_api_server):
         blockchain='ETH',
     ), json=request_data)
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [resolved_account]
     assert rotki.chains_aggregator.accounts.eth[-1] == resolved_account
 
@@ -191,7 +191,7 @@ def test_adding_editing_ens_account_works(rotkehlchen_api_server):
         'blockchainsaccountsresource',
         blockchain='ETH',
     ), json=request_data)
-    result = assert_proper_response_with_result(response)[0]
+    result = assert_proper_sync_response_with_result(response)[0]
     assert result['address'] == '0x9531C059098e3d194fF87FebB587aB07B30B1306'
     assert result['label'] == label
 
@@ -293,7 +293,7 @@ def test_add_multievm_accounts(rotkehlchen_api_server: 'APIServer'):
             'evmaccountsresource',
         ), json=request_data)
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     assert result == {
         'added': {
@@ -338,7 +338,7 @@ def test_add_multievm_accounts(rotkehlchen_api_server: 'APIServer'):
         'blockchainsaccountsresource',
         blockchain='ETH',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [
         {'address': contract_account, 'label': None, 'tags': None},
         {'address': common_account, 'label': label, 'tags': ['metamask']},
@@ -348,7 +348,7 @@ def test_add_multievm_accounts(rotkehlchen_api_server: 'APIServer'):
         'blockchainsaccountsresource',
         blockchain='AVAX',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [
         {'address': common_account, 'label': label, 'tags': ['metamask']},
     ]
@@ -357,7 +357,7 @@ def test_add_multievm_accounts(rotkehlchen_api_server: 'APIServer'):
         'blockchainsaccountsresource',
         blockchain='OPTIMISM',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [
         {'address': common_account, 'label': label, 'tags': ['metamask']},
     ]

--- a/rotkehlchen/tests/api/blockchain/test_optimism.py
+++ b/rotkehlchen/tests/api/blockchain/test_optimism.py
@@ -8,7 +8,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.types import SupportedBlockchain
 from rotkehlchen.utils.misc import ts_now
@@ -40,7 +40,7 @@ def test_add_optimism_blockchain_account(rotkehlchen_api_server):
         'named_blockchain_balances_resource',
         blockchain=optimism_chain_key,
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # Check per account
     account_balances = result['per_account'][optimism_chain_key][TEST_ADDY]
@@ -64,7 +64,7 @@ def test_add_optimism_blockchain_account(rotkehlchen_api_server):
             blockchain=optimism_chain_key,
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     optimism_tokens = {
         A_OP,
         Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
@@ -84,7 +84,7 @@ def test_add_optimism_blockchain_account(rotkehlchen_api_server):
             'ignore_cache': True,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # Check per account
     account_balances = result['per_account'][optimism_chain_key][TEST_ADDY]

--- a/rotkehlchen/tests/api/blockchain/test_substrate.py
+++ b/rotkehlchen/tests/api/blockchain/test_substrate.py
@@ -11,10 +11,10 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.ens import ENS_BRUNO, ENS_BRUNO_KSM_ADDR
@@ -83,7 +83,7 @@ def test_add_ksm_blockchain_account(rotkehlchen_api_server, kusama_manager_conne
         'named_blockchain_balances_resource',
         blockchain=kusama_chain_key,
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # Check per account
     account_balances = result['per_account'][kusama_chain_key][SUBSTRATE_ACC1_KSM_ADDR]
@@ -126,7 +126,7 @@ def test_remove_ksm_blockchain_account(rotkehlchen_api_server):
             'async_query': False,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # Check per account
     assert SUBSTRATE_ACC2_KSM_ADDR not in result['per_account'][kusama_chain_key]
@@ -194,7 +194,7 @@ def test_add_ksm_blockchain_account_ens_domain(rotkehlchen_api_server):
             'async_query': async_query,
         },
     )
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,

--- a/rotkehlchen/tests/api/blockchain/test_substrate.py
+++ b/rotkehlchen/tests/api/blockchain/test_substrate.py
@@ -11,11 +11,11 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
     wait_for_async_task,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.ens import ENS_BRUNO, ENS_BRUNO_KSM_ADDR
 from rotkehlchen.tests.utils.substrate import (
@@ -194,11 +194,11 @@ def test_add_ksm_blockchain_account_ens_domain(rotkehlchen_api_server):
             'async_query': async_query,
         },
     )
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert result == [ENS_BRUNO_KSM_ADDR]
     assert set(rotki.chains_aggregator.accounts.ksm) == {ENS_BRUNO_KSM_ADDR}

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -26,7 +26,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
@@ -97,7 +97,7 @@ def test_query_aave_balances(rotkehlchen_api_server: APIServer) -> None:
             'aavebalancesresource',
         ))
 
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         AAVE_BALANCESV1_TEST_ACC: {
             'lending': {
                 A_DAI.identifier: {
@@ -264,7 +264,7 @@ def test_query_aave_defi_borrowing(
         ))
 
     assert response is not None
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     account_data = result[addrs]
     assert len(account_data['lending']) == 1
     assert len(account_data['borrowing']) == 1
@@ -306,7 +306,7 @@ def test_events_aave_v2(rotkehlchen_api_server: 'APIServer') -> None:
         'modulestatsresource',
         module='aave',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {
         '0xe903fEed7c1098Ba92E4b7092ca77bBc48503d90': {
             'total_earned_interest': {

--- a/rotkehlchen/tests/api/test_accounting_rules.py
+++ b/rotkehlchen/tests/api/test_accounting_rules.py
@@ -1,4 +1,5 @@
 import json
+import random
 from http import HTTPStatus
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -22,6 +23,7 @@ from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
     assert_simple_ok_response,
 )
@@ -530,6 +532,7 @@ def test_cache_invalidation(rotkehlchen_api_server: APIServer):
 @pytest.mark.parametrize('initialize_accounting_rules', [True])
 def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
     """Test that exporting and importing accounting rules works fine."""
+    async_query = random.choice([True, False])
     with rotkehlchen_api_server.rest_api.rotkehlchen.data.db.conn.read_ctx() as cursor:
         initial_rules = cursor.execute(
             'SELECT * FROM accounting_rules WHERE identifier IN (1, 82);',
@@ -538,17 +541,34 @@ def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
 
     with TemporaryDirectory() as temp_directory:
         response = requests.post(
+            api_url_for(  # export the accounting rules as a response json
+                rotkehlchen_api_server,
+                'accountingrulesexportresource',
+            ), json={'async_query': async_query},
+        )
+        response_result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
+
+        response = requests.post(
             api_url_for(  # export the accounting rules into a json file
                 rotkehlchen_api_server,
                 'accountingrulesexportresource',
-            ), json={'directory_path': temp_directory},
+            ), json={'async_query': async_query, 'directory_path': temp_directory},
         )
-        assert_proper_response_with_result(response)
+        assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
 
         rules_file_path = Path(temp_directory) / 'accounting_rules.json'
         with open(rules_file_path, encoding='utf-8') as file:
             rules_data = json.load(file)
 
+        assert rules_data == response_result
         assert len(rules_data['accounting_rules']) == 82
         assert rules_data['accounting_rules']['1'] == {
             'event_type': 'deposit',
@@ -608,18 +628,26 @@ def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
             api_url_for(  # import the accounting rules from this json file
                 rotkehlchen_api_server,
                 'accountingrulesimportresource',
-            ), json={'filepath': rules_file_path.as_posix()},
+            ), json={'async_query': async_query, 'filepath': rules_file_path.as_posix()},
         )
-        assert_simple_ok_response(response)
+        response_result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
 
         with open(rules_file_path, encoding='utf-8') as file:
             response = requests.patch(
                 api_url_for(  # also as multipart/form-data
                     rotkehlchen_api_server,
                     'accountingrulesimportresource',
-                ), files={'filepath': file},
+                ), data={'async_query': async_query}, files={'filepath': file},
             )
-        assert_simple_ok_response(response)
+        response_result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
 
     # Check that the imported rules are in the DB
     with rotkehlchen_api_server.rest_api.rotkehlchen.data.db.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/api/test_accounting_rules.py
+++ b/rotkehlchen/tests/api/test_accounting_rules.py
@@ -23,8 +23,8 @@ from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
@@ -97,7 +97,7 @@ def test_query_rules(rotkehlchen_api_server):
             'counterparties': [None],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries_found'] == 1
     assert result['entries_total'] != 0
@@ -133,14 +133,14 @@ def test_manage_rules(rotkehlchen_api_server, db_settings):
             'accountingrulesresource',
         ), json=rule_1,
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
     response = requests.put(
         api_url_for(
             rotkehlchen_api_server,
             'accountingrulesresource',
         ), json=rule_2,
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
 
     # now try to query them
     rule_1_copy = rule_1.copy()
@@ -151,7 +151,7 @@ def test_manage_rules(rotkehlchen_api_server, db_settings):
             'accountingrulesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [
         {'identifier': 2, **rule_2},
         {'identifier': 1, **rule_1_copy, 'accounting_treatment': None},
@@ -168,7 +168,7 @@ def test_manage_rules(rotkehlchen_api_server, db_settings):
             'event_types': ['deposit', 'withdrawal'],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [
         {'identifier': 1, **rule_1, 'accounting_treatment': None},
     ]
@@ -184,7 +184,7 @@ def test_manage_rules(rotkehlchen_api_server, db_settings):
             'event_types': ['adjustment'],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == []
     assert result['entries_found'] == 0
     assert result['entries_total'] == 2
@@ -211,7 +211,7 @@ def test_manage_rules(rotkehlchen_api_server, db_settings):
             'accountingrulesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [
         {'identifier': 2, **rule_2},
         {'identifier': 1, **rule_1, 'accounting_treatment': None},
@@ -253,7 +253,7 @@ def test_manage_rules(rotkehlchen_api_server, db_settings):
             'accountingrulesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 1
     assert len(result['entries']) == 1
     assert result['entries_total'] == 1
@@ -266,7 +266,7 @@ def test_rules_info(rotkehlchen_api_server):
             'accountinglinkablepropertiesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert set(result.keys()) == set(get_args(LINKABLE_ACCOUNTING_PROPERTIES))
 
 
@@ -349,7 +349,7 @@ def test_listing_conflicts(
             'accountingrulesconflictsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [
         {
             'local_id': 2,
@@ -441,7 +441,7 @@ def test_cache_invalidation(rotkehlchen_api_server: APIServer):
             'historyeventresource',
         ), json={'event_identifiers': [events[0].event_identifier]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 2
     assert all(
         entry['event_accounting_rule_status'] == EventAccountingRuleStatus.NOT_PROCESSED.serialize()  # noqa: E501
@@ -471,7 +471,7 @@ def test_cache_invalidation(rotkehlchen_api_server: APIServer):
             'historyeventresource',
         ), json={'event_identifiers': [events[0].event_identifier]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 2
     assert result['entries'][0]['event_accounting_rule_status'] == EventAccountingRuleStatus.HAS_RULE.serialize()  # noqa: E501
     assert result['entries'][1]['event_accounting_rule_status'] == EventAccountingRuleStatus.NOT_PROCESSED.serialize()  # noqa: E501
@@ -500,7 +500,7 @@ def test_cache_invalidation(rotkehlchen_api_server: APIServer):
             'historyeventresource',
         ), json={'event_identifiers': [events[0].event_identifier]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 2
     assert result['entries'][0]['event_accounting_rule_status'] == EventAccountingRuleStatus.HAS_RULE.serialize()  # noqa: E501
     assert result['entries'][1]['event_accounting_rule_status'] == EventAccountingRuleStatus.PROCESSED.serialize()  # noqa: E501
@@ -521,7 +521,7 @@ def test_cache_invalidation(rotkehlchen_api_server: APIServer):
             'historyeventresource',
         ), json={'event_identifiers': [events[0].event_identifier]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 2
     all(
         entry['event_accounting_rule_status'] == EventAccountingRuleStatus.NOT_PROCESSED.serialize()  # noqa: E501
@@ -546,7 +546,7 @@ def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
                 'accountingrulesexportresource',
             ), json={'async_query': async_query},
         )
-        response_result = assert_maybe_async_response_with_result(
+        response_result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -558,7 +558,7 @@ def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
                 'accountingrulesexportresource',
             ), json={'async_query': async_query, 'directory_path': temp_directory},
         )
-        assert_maybe_async_response_with_result(
+        assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -630,7 +630,7 @@ def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
                 'accountingrulesimportresource',
             ), json={'async_query': async_query, 'filepath': rules_file_path.as_posix()},
         )
-        response_result = assert_maybe_async_response_with_result(
+        response_result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -643,7 +643,7 @@ def test_import_export_accounting_rules(rotkehlchen_api_server: 'APIServer'):
                     'accountingrulesimportresource',
                 ), data={'async_query': async_query}, files={'filepath': file},
             )
-        response_result = assert_maybe_async_response_with_result(
+        response_result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,

--- a/rotkehlchen/tests/api/test_addressbook.py
+++ b/rotkehlchen/tests/api/test_addressbook.py
@@ -16,7 +16,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.factories import (
     ADDRESS_ETH,
@@ -63,7 +63,7 @@ def test_get_addressbook(
             book_type=book_type,
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
     assert deserialized_entries == entries_set
     assert deserialized_entries != sorted(deserialized_entries, key=lambda x: x.name)  # not sorted
@@ -83,7 +83,7 @@ def test_get_addressbook(
             ],
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     assert result['entries_found'] == 3
     assert result['entries_total'] == len(entries_set)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
@@ -105,7 +105,7 @@ def test_get_addressbook(
             ],
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
     assert set(deserialized_entries) == {generated_entries[1]}
     assert result['entries_found'] == 1
@@ -123,7 +123,7 @@ def test_get_addressbook(
             'blockchain': SupportedBlockchain.ETHEREUM.serialize(),
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
     assert set(deserialized_entries) == {generated_entries[2]}
     assert result['entries_found'] == 1
@@ -142,7 +142,7 @@ def test_get_addressbook(
             'blockchain': SupportedBlockchain.ETHEREUM.serialize(),
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
     assert set(deserialized_entries) == {generated_entries[0]}
     assert result['entries_found'] == 2
@@ -161,7 +161,7 @@ def test_get_addressbook(
             'blockchain': SupportedBlockchain.ETHEREUM.serialize(),
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
     assert set(deserialized_entries) == {generated_entries[2]}
     assert result['entries_found'] == 2
@@ -176,7 +176,7 @@ def test_get_addressbook(
         ),
         json={'addresses': [{'address': KELSOS_ADDR}]},
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     assert AddressbookEntry.deserialize(data=result['entries'][0]) == KELSOS_BOOK_ENTRY
     assert result['entries_found'] == 1
     assert result['entries_total'] == len(entries_set)
@@ -195,7 +195,7 @@ def test_get_addressbook(
             ],
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     deserialized_entries = [AddressbookEntry.deserialize(data=raw_entry) for raw_entry in result['entries']]  # noqa: E501
     assert set(deserialized_entries) == set(generated_entries[0:3])
     assert result['entries_found'] == 3
@@ -214,7 +214,7 @@ def test_get_addressbook(
                 'ascending': [True],
             },
         )
-        result = assert_proper_response_with_result(response=response)
+        result = assert_proper_sync_response_with_result(response=response)
         entries = [raw_entry[attribute] for raw_entry in result['entries']]
         assert entries == sorted(entries)
 
@@ -305,7 +305,7 @@ def test_insert_into_addressbook(
             'addresses': [{'address': ADDRESS_MULTICHAIN}],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 2
 
     # insert the new entry replacing all the previous values stored
@@ -329,7 +329,7 @@ def test_insert_into_addressbook(
         ),
         json={'addresses': [{'address': ADDRESS_MULTICHAIN}]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [new_entry.serialize()]
 
     # try inserting a non checksummed address
@@ -347,7 +347,7 @@ def test_insert_into_addressbook(
         ),
         json={'entries': [new_entry.serialize()]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # check that in the database it was inserted checksummed
     with db_addressbook.read_ctx(book_type=book_type) as cursor:
@@ -667,7 +667,7 @@ def test_names_compilation(rotkehlchen_api_server: 'APIServer') -> None:
     ]
 
     response = names_request(publicly_known_addresses)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {AddressbookEntry.deserialize(x) for x in result} == set(publicly_known_expected)
 
     # now query names that are saved for all chains, but for a specific chain and see they appear
@@ -675,7 +675,7 @@ def test_names_compilation(rotkehlchen_api_server: 'APIServer') -> None:
         OptionalChainAddress(address_rotki, SupportedBlockchain.ETHEREUM),
         OptionalChainAddress(address_titan, SupportedBlockchain.ETHEREUM),
     ])
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {AddressbookEntry.deserialize(x) for x in result} == {
         AddressbookEntry(address=address_rotki, blockchain=SupportedBlockchain.ETHEREUM, name='rotki.eth'),  # noqa: E501
         AddressbookEntry(address=address_titan, blockchain=SupportedBlockchain.ETHEREUM, name='Titan Builder'),  # noqa: E501
@@ -701,7 +701,7 @@ def test_names_compilation(rotkehlchen_api_server: 'APIServer') -> None:
         AddressbookEntry(address=address_cody, blockchain=SupportedBlockchain.ETHEREUM, name='Cody'),  # noqa: E501
     }
     response = names_request(global_addressbook_addresses)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {AddressbookEntry.deserialize(x) for x in result} == global_addressbook_expected
 
     with db_handler.user_write() as cursor:
@@ -726,7 +726,7 @@ def test_names_compilation(rotkehlchen_api_server: 'APIServer') -> None:
         AddressbookEntry(address=address_cody, blockchain=SupportedBlockchain.ETHEREUM, name='Cody'),  # noqa: E501
     }
     response = names_request(labels_addresses)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {AddressbookEntry.deserialize(x) for x in result} == labels_expected
 
     with db_addressbook.write_ctx(book_type=AddressbookType.PRIVATE) as write_cursor:
@@ -753,7 +753,7 @@ def test_names_compilation(rotkehlchen_api_server: 'APIServer') -> None:
         AddressbookEntry(address=address_rose, blockchain=SupportedBlockchain.ETHEREUM, name='Rose'),  # noqa: E501
     }
     response = names_request(private_addressbook_addresses)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {AddressbookEntry.deserialize(x) for x in result} == private_addressbook_expected
 
 
@@ -785,7 +785,7 @@ def test_insert_into_addressbook_no_blockchain(
             'entries': [custom_name.serialize()],
         },
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
     response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
@@ -798,7 +798,7 @@ def test_insert_into_addressbook_no_blockchain(
             ],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [custom_name.serialize()]
 
     # now add the same name for all blockchains and see the value replaced
@@ -817,7 +817,7 @@ def test_insert_into_addressbook_no_blockchain(
             'entries': [custom_name.serialize()],
         },
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
     response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
@@ -830,7 +830,7 @@ def test_insert_into_addressbook_no_blockchain(
             ],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [custom_name.serialize()]
     if book_type == AddressbookType.PRIVATE:
         with database.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -31,7 +31,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.checks import assert_asset_result_order
 from rotkehlchen.tests.utils.constants import A_GNO, A_RDN
@@ -138,7 +138,7 @@ def test_query_owned_assets(
                 'ownedassetsresource',
             ),
         )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert set(result) == {'ETH', 'BTC', 'EUR', A_RDN, A_USDC}
 
 
@@ -155,7 +155,7 @@ def test_ignored_assets_modification(rotkehlchen_api_server):
             'ignoredassetsresource',
         ), json={'assets': ignored_assets},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     expected_ignored_assets = set(ignored_assets)
     assert expected_ignored_assets == set(result['successful'])
 
@@ -169,7 +169,7 @@ def test_ignored_assets_modification(rotkehlchen_api_server):
                 'ignoredassetsresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert expected_ignored_assets == set(result)
 
         # remove 2 assets from ignored assets
@@ -179,7 +179,7 @@ def test_ignored_assets_modification(rotkehlchen_api_server):
                 'ignoredassetsresource',
             ), json={'assets': [A_GNO.identifier, 'XMR']},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert set(result['successful']) == {A_GNO.identifier, 'XMR'}
         assert len(result['no_action']) == 0
 
@@ -193,7 +193,7 @@ def test_ignored_assets_modification(rotkehlchen_api_server):
                 'ignoredassetsresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert assets_after_deletion == set(result)
 
 
@@ -279,7 +279,7 @@ def test_ignored_assets_endpoint_errors(rotkehlchen_api_server, method):
                 'ignoredassetsresource',
             ), json={'assets': [asset]},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result == {
             'successful': [],
             'no_action': [asset],
@@ -303,7 +303,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) <= 20
     assert 'entries_found' in result
     assert 'entries_total' in result
@@ -326,7 +326,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'ascending': [False],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) <= 50
     assert 'entries_found' in result
     assert 'entries_total' in result
@@ -361,7 +361,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'ignored_assets_handling': 'exclude',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) <= 20
     assert 'entries_found' in result
     assert 'entries_total' in result
@@ -386,7 +386,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'show_user_owned_assets_only': True,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assets_names = {r['name'] for r in result['entries']}
     assets_chain = {r.get('evm_chain', None) for r in result['entries']}
     assert result['entries_found'] == 3
@@ -419,7 +419,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries'][0]['identifier'] == custom_asset_id
     assert result['entries'][0]['asset_type'] == 'custom asset'
@@ -440,7 +440,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'ignored_assets_handling': 'exclude',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert 50 >= len(result['entries']) > 2
     for entry in result['entries']:
         assert 'uniswap' in entry['name'].casefold()
@@ -474,7 +474,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'identifiers': [A_DAI.identifier],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'][0]['identifier'] == A_DAI
     assert 'address' in result['entries'][0]
     assert 'decimals' in result['entries'][0]
@@ -491,7 +491,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'identifiers': [A_BTC.identifier, A_USD.identifier, custom_asset_id],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'][0]['identifier'] == A_USD
     assert result['entries'][1]['identifier'] == custom_asset_id
     assert result['entries'][2]['identifier'] == A_BTC
@@ -504,7 +504,7 @@ def test_get_all_assets(rotkehlchen_api_server):
         ),
         json={'asset_type': 'evm token'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for entry in result['entries']:
         assert 'underlying_tokens' in entry
         assert entry['evm_chain'] in [x.to_name() for x in ChainID]
@@ -531,7 +531,7 @@ def test_get_all_assets(rotkehlchen_api_server):
         ),
         json={'evm_chain': 'ethereum', 'symbol': 'UNI'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert all(i['evm_chain'] == 'ethereum' and 'UNI' in i['symbol'].upper() for i in result['entries'])  # noqa: E501
 
     # check that filtering by address and evm_chain works.
@@ -545,7 +545,7 @@ def test_get_all_assets(rotkehlchen_api_server):
             'address': '0x6b175474e89094c44da98b954eedeac495271d0f',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries'][0]['address'] == '0x6B175474E89094C44Da98b954EedeAC495271d0F'
     assert result['entries'][0]['evm_chain'] == 'ethereum'
@@ -580,7 +580,7 @@ def test_get_assets_mappings(rotkehlchen_api_server):
         ),
         json={'identifiers': queried_assets},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assets = result['assets']
     assert len(assets) == len(queried_assets)
     for identifier, details in assets.items():
@@ -614,7 +614,7 @@ def test_get_assets_mappings(rotkehlchen_api_server):
         ),
         json={'identifiers': ['BTC', 'TRY', 'invalid']},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assets = result['assets']
     assert len(assets) == 2
     assert all(identifier in {'BTC', 'TRY'} for identifier in assets)
@@ -635,7 +635,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) <= 50
     for entry in result:
         assert 'bitcoin' in entry['name'].lower()
@@ -656,7 +656,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [False],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) <= 10
     for entry in result:
         assert 'eth' in entry['symbol'].lower()
@@ -677,7 +677,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 0
 
     # use the return_exact_matches flag
@@ -695,7 +695,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [False],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 4
     assert any(entry['name'] == 'Ethereum' for entry in result)
     for entry in result:
@@ -723,7 +723,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 4
     assert any(entry['name'] == 'Ethereum' for entry in result)
     for entry in result:
@@ -771,7 +771,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {asset['evm_chain'] for asset in result} == {
         'polygon_pos',
         'optimism',
@@ -797,7 +797,7 @@ def test_search_assets(rotkehlchen_api_server):
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert 50 >= len(result) > 10
     assert all(entry['evm_chain'] == 'ethereum' and 'DAI' in entry['symbol'] for entry in result)
     assert_asset_result_order(data=result, is_ascending=True, order_field='name')
@@ -833,7 +833,7 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server):
             'limit': 50,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) <= 50
     # check that Bitcoin(BTC) appears at the top of result.
     assert_asset_at_top_position('BTC', max_position_index=1, result=result)
@@ -868,7 +868,7 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server):
             'limit': 50,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) <= 50
     assert_substring_in_search_result(result, 'ETH')
     # check that Ethereum(ETH) appear at the top of result.
@@ -893,7 +893,7 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server):
             'limit': 50,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) <= 50
     assert_substring_in_search_result(result, 'ETH')
     # check that Ethereum(ETH) appears at the top of result.
@@ -911,7 +911,7 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server):
             'limit': 50,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 0
 
     # check that using evm_chain filter works.
@@ -926,7 +926,7 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server):
             'evm_chain': 'ethereum',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert 50 >= len(result) > 10
     assert all(entry['evm_chain'] == 'ethereum' and entry['asset_type'] != 'custom asset' and 'custom_asset_type' not in entry for entry in result)  # noqa: E501
 
@@ -958,7 +958,7 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server):
             'limit': 50,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_substring_in_search_result(result, 'my custom')
     assert all(custom_asset_id == entry['identifier'] and entry['asset_type'] == 'custom asset' and entry['custom_asset_type'] == 'random' for entry in result)  # noqa: E501
 
@@ -998,7 +998,7 @@ def test_search_nfts_with_levenshtein(rotkehlchen_api_server):
             'search_nfts': True,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [{
         'identifier': 'my-nft-identifier',
         'name': 'super-duper-nft',
@@ -1019,7 +1019,7 @@ def test_search_nfts_with_levenshtein(rotkehlchen_api_server):
             'limit': 50,
         },
     )
-    results_without_nfts = [x['identifier'] for x in assert_proper_response_with_result(response)]
+    results_without_nfts = [x['identifier'] for x in assert_proper_sync_response_with_result(response)]  # noqa: E501
 
     response = requests.post(
         api_url_for(
@@ -1032,7 +1032,7 @@ def test_search_nfts_with_levenshtein(rotkehlchen_api_server):
             'search_nfts': True,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     results_with_nfts = [x['identifier'] for x in result]
     assert set(results_with_nfts) - set(results_without_nfts) == {'my-nft-identifier'}
 
@@ -1072,7 +1072,7 @@ def test_only_ignored_assets(rotkehlchen_api_server):
             'ignored_assets_handling': 'show_only',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {entry['identifier'] for entry in result['entries']} == set(ignored_assets)
 
 
@@ -1122,7 +1122,7 @@ def test_false_positive(rotkehlchen_api_server: APIServer, globaldb: GlobalDBHan
 
     # check that we can query it from the api
     response = requests.get(api_url_for(rotkehlchen_api_server, 'falsepositivespamtokenresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert A_DAI in result
 
     # test that the filter in the search for assets works
@@ -1132,7 +1132,7 @@ def test_false_positive(rotkehlchen_api_server: APIServer, globaldb: GlobalDBHan
             'allassetsresource',
         ), json={'show_whitelisted_assets_only': True},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     with globaldb.conn.read_ctx() as cursor:
         assert result['entries_found'] == existing_whitelisted_count + 1
     assert A_DAI.identifier in {entry['identifier'] for entry in result['entries']}

--- a/rotkehlchen/tests/api/test_assets_updates.py
+++ b/rotkehlchen/tests/api/test_assets_updates.py
@@ -20,7 +20,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -152,7 +152,7 @@ INSERT INTO assets(identifier, name, type) VALUES("EUR", "Ευρώ", "A"); INSER
             result = outcome['result']
             assert outcome['message'] == ''
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
         assert result['local'] == 999999992
         assert result['remote'] == 999999996
         assert result['new_changes'] == 5  # 994 (3) + 995(2)
@@ -173,7 +173,7 @@ INSERT INTO assets(identifier, name, type) VALUES("EUR", "Ευρώ", "A"); INSER
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
         errors = rotki.msg_aggregator.consume_errors()
         warnings = rotki.msg_aggregator.consume_warnings()
@@ -278,7 +278,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0x1B175474E890
             result = outcome['result']
             assert outcome['message'] == ''
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
         assert result['local'] == 999999990
         assert result['remote'] == 999999991
         assert result['new_changes'] == 3
@@ -299,7 +299,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0x1B175474E890
             assert outcome['message'] == 'Found conflicts during assets upgrade'
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(
+            result = assert_proper_sync_response_with_result(
                 response,
                 message='Found conflicts during assets upgrade',
                 status_code=HTTPStatus.CONFLICT,
@@ -430,7 +430,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0x1B175474E890
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(
+            result = assert_proper_sync_response_with_result(
                 response,
                 message='',
                 status_code=HTTPStatus.OK,
@@ -550,7 +550,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0xa74476443119
             result = outcome['result']
             assert outcome['message'] == ''
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
         assert result['local'] == 999999990
         assert result['remote'] == 999999991
         assert result['new_changes'] == 2
@@ -571,7 +571,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0xa74476443119
             assert outcome['message'] == 'Found conflicts during assets upgrade'
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(
+            result = assert_proper_sync_response_with_result(
                 response,
                 message='Found conflicts during assets upgrade',
                 status_code=HTTPStatus.CONFLICT,
@@ -640,7 +640,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0xa74476443119
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(
+            result = assert_proper_sync_response_with_result(
                 response,
                 message='',
                 status_code=HTTPStatus.OK,
@@ -717,7 +717,7 @@ INSERT INTO evm_tokens(identifier, token_kind, chain, address, decimals, protoco
                 'assetupdatesresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['local'] == 0
         assert result['remote'] == 1
         assert result['new_changes'] == 2
@@ -728,7 +728,7 @@ INSERT INTO evm_tokens(identifier, token_kind, chain, address, decimals, protoco
                 'assetupdatesresource',
             ),
         )
-        result = assert_proper_response_with_result(
+        result = assert_proper_sync_response_with_result(
             response,
             message='Found conflicts during assets upgrade',
             status_code=HTTPStatus.CONFLICT,
@@ -788,7 +788,7 @@ INSERT INTO evm_tokens(identifier, token_kind, chain, address, decimals, protoco
             ),
             json={'conflicts': conflicts},
         )
-        result = assert_proper_response_with_result(
+        result = assert_proper_sync_response_with_result(
             response,
             message='',
             status_code=HTTPStatus.OK,

--- a/rotkehlchen/tests/api/test_async.py
+++ b/rotkehlchen/tests/api/test_async.py
@@ -10,7 +10,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.exchanges import mock_binance_balance_response, try_get_first_exchange
@@ -36,7 +36,7 @@ def test_query_async_tasks(rotkehlchen_api_server_with_exchanges):
 
     # Check querying the async task resource when no async task is scheduled
     response = requests.get(api_url_for(server, 'asynctasksresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'completed': [], 'pending': []}
 
     # Create an async task
@@ -50,7 +50,7 @@ def test_query_async_tasks(rotkehlchen_api_server_with_exchanges):
 
         # now check that there is a task
         response = requests.get(api_url_for(server, 'asynctasksresource'))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result == {'completed': [], 'pending': [task_id]}
 
         # now query for the task result and see it's still pending (test for task lists)
@@ -122,7 +122,7 @@ def test_query_async_task_that_died(rotkehlchen_api_server_with_exchanges):
 
     # now check that there is a task
     response = requests.get(api_url_for(server, 'asynctasksresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'completed': [task_id], 'pending': []}
 
     while True:
@@ -130,7 +130,7 @@ def test_query_async_task_that_died(rotkehlchen_api_server_with_exchanges):
         response = requests.get(
             api_url_for(server, 'specific_async_tasks_resource', task_id=task_id),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         if result['status'] == 'pending':
             # context switch so that the greenlet to query balances can operate
             gevent.sleep(1)
@@ -170,7 +170,7 @@ def test_cancel_async_task(rotkehlchen_api_server_with_exchanges):
 
     # now check that there is a task
     response = requests.get(api_url_for(server, 'asynctasksresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'completed': [], 'pending': [task_id]}
 
     response = requests.delete(api_url_for(server, 'specific_async_tasks_resource', task_id=666))
@@ -184,5 +184,5 @@ def test_cancel_async_task(rotkehlchen_api_server_with_exchanges):
 
     # now check that there is no task left
     response = requests.get(api_url_for(server, 'asynctasksresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'completed': [], 'pending': []}

--- a/rotkehlchen/tests/api/test_balancer.py
+++ b/rotkehlchen/tests/api/test_balancer.py
@@ -14,7 +14,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
@@ -94,7 +94,7 @@ def test_get_balances(rotkehlchen_api_server, ethereum_accounts):
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
     if len(result) != 1:
         test_warnings.warn(

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -21,10 +21,10 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
     wait_for_async_task_with_result,
 )
@@ -184,7 +184,7 @@ def test_query_all_balances(
                 'allbalancesresource',
             ), json={'async_query': async_query},
         )
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server_with_exchanges,
             async_query=async_query,
@@ -292,7 +292,7 @@ def test_query_all_balances_ignore_cache(
                 'allbalancesresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert_all_balances(
             result=result,
             db=rotki.data.db,
@@ -316,7 +316,7 @@ def test_query_all_balances_ignore_cache(
                 'allbalancesresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert_all_balances(
             result=result,
             db=rotki.data.db,
@@ -342,7 +342,7 @@ def test_query_all_balances_ignore_cache(
                 'allbalancesresource',
             ), json={'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert_all_balances(
             result=result,
             db=rotki.data.db,
@@ -442,7 +442,7 @@ def test_query_all_balances_with_manually_tracked_balances(
                 'allbalancesresource',
             ),
         )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_all_balances(
         result=result,
         db=rotki.data.db,
@@ -458,7 +458,7 @@ def test_query_all_balances_with_manually_tracked_balances(
                 'allbalancesresource',
             ),
         )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_all_balances(
         result=result,
         db=rotki.data.db,
@@ -520,7 +520,7 @@ def test_balance_snapshot_error_message(
             ),
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'assets': {}, 'liabilities': {}, 'location': {}, 'net_usd': '0'}
     websocket_connection.wait_until_messages_num(num=2, timeout=10)
     assert websocket_connection.messages_num() == 2
@@ -796,7 +796,7 @@ def test_query_avax_balances(rotkehlchen_api_server: 'APIServer') -> None:
             task_id = assert_ok_async_response(response)
             result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
     # Check per account
     account_1_balances = result['per_account'][avax_chain_key][AVALANCHE_ACC1_AVAX_ADDR]
@@ -839,7 +839,7 @@ def test_ethereum_tokens_detection(
                 'addresses': ethereum_accounts,
             },
         )
-        return assert_proper_response_with_result(response)
+        return assert_proper_sync_response_with_result(response)
 
     empty_tokens_result = {
         account: {
@@ -884,7 +884,7 @@ def test_balances_behaviour_with_manual_current_prices(rotkehlchen_api_server, e
                 'allbalancesresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         # (3 ETH) * (10 BTC per ETH) * (1,5 USD per BTC) = 45 USD of ETH
         eth_result = result['assets'][A_ETH.identifier]
         assert eth_result['amount'] == '3'
@@ -947,7 +947,7 @@ def test_blockchain_balances_refresh(rotkehlchen_api_server: 'APIServer', ethere
                     rotkehlchen_api_server,
                     'blockchainbalancesresource',
                 ), json={'async_query': False, 'blockchain': 'ETH', 'ignore_cache': True})
-                result = assert_proper_response_with_result(response)
+                result = assert_proper_sync_response_with_result(response)
             assert result is not None
             return result
 

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -21,6 +21,7 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
@@ -183,14 +184,11 @@ def test_query_all_balances(
                 'allbalancesresource',
             ), json={'async_query': async_query},
         )
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(
-                rotkehlchen_api_server_with_exchanges,
-                task_id,
-            )
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server_with_exchanges,
+            async_query=async_query,
+        )
 
     errors = rotki.msg_aggregator.consume_errors()
     assert len(errors) == 0

--- a/rotkehlchen/tests/api/test_bitcoin.py
+++ b/rotkehlchen/tests/api/test_bitcoin.py
@@ -10,7 +10,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2
@@ -148,7 +148,7 @@ def test_add_delete_xpub(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'blockchainbalancesresource',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     _check_xpub_addition_outcome(result, TEST_BITCOIN_XPUB_1)
 
     # Make sure that adding existing xpub fails
@@ -190,7 +190,7 @@ def test_add_delete_xpub(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'blockchainbalancesresource',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     _check_xpub_addition_outcome(result, TEST_BITCOIN_XPUB_1)
 
     # Also make sure that blockchain account data endpoint returns everything correctly
@@ -199,7 +199,7 @@ def test_add_delete_xpub(rotkehlchen_api_server):
         'blockchainsaccountsresource',
         blockchain='BTC',
     ))
-    outcome = assert_proper_response_with_result(response)
+    outcome = assert_proper_sync_response_with_result(response)
     assert len(outcome['standalone']) == 2
     for entry in outcome['standalone']:
         assert entry['address'] in (UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2)
@@ -359,7 +359,7 @@ def test_add_delete_xpub_multiple_chains(rotkehlchen_api_server):
         'blockchainsaccountsresource',
         blockchain='BTC',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     assert len(result['xpubs']) == 1
     xpub_return = result['xpubs'][0]
@@ -371,7 +371,7 @@ def test_add_delete_xpub_multiple_chains(rotkehlchen_api_server):
         'blockchainsaccountsresource',
         blockchain='BCH',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     assert len(result['xpubs']) == 1
     xpub_return = result['xpubs'][0]

--- a/rotkehlchen/tests/api/test_calendar.py
+++ b/rotkehlchen/tests/api/test_calendar.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+
 import pytest
 import requests
 
@@ -10,7 +11,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.types import ChecksumEvmAddress, SupportedBlockchain
 
@@ -45,7 +46,7 @@ def test_basic_calendar_operations(
         },
     )
 
-    data = assert_proper_response_with_result(response)
+    data = assert_proper_sync_response_with_result(response)
     assert data['entry_id'] == 1
 
     response = requests.put(
@@ -60,7 +61,7 @@ def test_basic_calendar_operations(
             'auto_delete': False,
         },
     )
-    data = assert_proper_response_with_result(response)
+    data = assert_proper_sync_response_with_result(response)
     assert data['entry_id'] == 2
 
     with database.conn.read_ctx() as cursor:
@@ -125,7 +126,7 @@ def test_basic_calendar_operations(
         api_url_for(rotkehlchen_api_server, 'calendarresource'),
         json=future_ts,
     )
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         'entries': [ens_json_event, curve_json_event],
         'entries_found': 2,
         'entries_total': 2,
@@ -137,7 +138,7 @@ def test_basic_calendar_operations(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
         json={'from_timestamp': 1977652400, 'to_timestamp': 1977652511},
     )
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         'entries': [ens_json_event],
         'entries_found': 1,
         'entries_total': 2,
@@ -151,7 +152,7 @@ def test_basic_calendar_operations(
             'accounts': [{'address': ethereum_accounts[0], 'blockchain': 'eth'}],
         } | future_ts,
     )
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         'entries': [ens_json_event],
         'entries_found': 1,
         'entries_total': 2,
@@ -163,7 +164,7 @@ def test_basic_calendar_operations(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
         json={'counterparty': CPT_CURVE} | future_ts,
     )
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         'entries': [curve_json_event],
         'entries_found': 1,
         'entries_total': 2,
@@ -175,7 +176,7 @@ def test_basic_calendar_operations(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
         json={'name': 'renewal'} | future_ts,
     )
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         'entries': [ens_json_event],
         'entries_found': 1,
         'entries_total': 2,
@@ -187,7 +188,7 @@ def test_basic_calendar_operations(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
         json={'name': 'Unlock'} | future_ts,
     )
-    assert assert_proper_response_with_result(response) == {
+    assert assert_proper_sync_response_with_result(response) == {
         'entries': [curve_json_event],
         'entries_found': 1,
         'entries_total': 2,
@@ -224,7 +225,7 @@ def test_basic_calendar_operations(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
         json={'accounts': [{'address': crv_event[4]}]} | future_ts,
     )
-    result = assert_proper_response_with_result(response)['entries']
+    result = assert_proper_sync_response_with_result(response)['entries']
     assert result[0]['blockchain'] == SupportedBlockchain.ETHEREUM.serialize()
     assert result[1]['blockchain'] == SupportedBlockchain.GNOSIS.serialize()
 
@@ -373,7 +374,7 @@ def test_reminder_operations(rotkehlchen_api_server: APIServer):
             'auto_delete': False,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     calendar_id = result['entry_id']
     assert calendar_id == 1
 
@@ -387,7 +388,7 @@ def test_reminder_operations(rotkehlchen_api_server: APIServer):
             'secs_before': DAY_IN_SECONDS * 3,
         }]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['success'] == [calendar_id]
     assert result['failed'] == [100]
 
@@ -396,7 +397,7 @@ def test_reminder_operations(rotkehlchen_api_server: APIServer):
         api_url_for(rotkehlchen_api_server, 'calendarremindersresource'),
         json={'identifier': calendar_id},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {
         'entries': [{
             'identifier': 1,
@@ -419,7 +420,7 @@ def test_reminder_operations(rotkehlchen_api_server: APIServer):
         api_url_for(rotkehlchen_api_server, 'calendarremindersresource'),
         json={'identifier': calendar_id},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {
         'entries': [{
             'identifier': 1,
@@ -436,5 +437,5 @@ def test_reminder_operations(rotkehlchen_api_server: APIServer):
         api_url_for(rotkehlchen_api_server, 'calendarremindersresource'),
         json={'identifier': calendar_id},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': []}

--- a/rotkehlchen/tests/api/test_compound.py
+++ b/rotkehlchen/tests/api/test_compound.py
@@ -18,7 +18,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.constants import CURRENT_PRICE_MOCK
@@ -60,7 +60,7 @@ def test_query_compound_balances(
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
     if len(result) != 1:
         test_warnings.warn(UserWarning(f'Test account {TEST_ACC1} has no compound balances'))
@@ -140,7 +140,7 @@ def test_query_compound_v3_balances(
             new=mock_extract_unique_borrowed_tokens,
         ),
     ):
-        result = assert_proper_response_with_result(requests.get(api_url_for(
+        result = assert_proper_sync_response_with_result(requests.get(api_url_for(
             rotkehlchen_api_server,
             'compoundbalancesresource',
         )))
@@ -249,7 +249,7 @@ def test_events_compound(rotkehlchen_api_server: 'APIServer') -> None:
         'modulestatsresource',
         module='compound',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {
         'interest_profit': {
             '0xF59D4937BF1305856C3a267bB07791507a3377Ee': {

--- a/rotkehlchen/tests/api/test_current_assets_price.py
+++ b/rotkehlchen/tests/api/test_current_assets_price.py
@@ -14,10 +14,9 @@ from rotkehlchen.inquirer import CurrentPriceOracle, Inquirer
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response,
     assert_proper_response_with_result,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.types import ChecksumEvmAddress, Price
 from rotkehlchen.utils.misc import timestamp_to_date
@@ -43,11 +42,11 @@ def test_get_current_assets_price_in_usd(rotkehlchen_api_server):
             'async_query': async_query,
         },
     )
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert len(result) == 3
     assert result['assets']['BTC'] == ['33183.98', CurrentPriceOracle.BLOCKCHAIN.value, False]
@@ -75,11 +74,11 @@ def test_get_current_assets_price_in_btc(rotkehlchen_api_server):
             'async_query': async_query,
         },
     )
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert len(result) == 3
     assert result['assets']['BTC'] == ['1', CurrentPriceOracle.BLOCKCHAIN.value, False]

--- a/rotkehlchen/tests/api/test_custom_assets.py
+++ b/rotkehlchen/tests/api/test_custom_assets.py
@@ -10,7 +10,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.checks import assert_asset_result_order
 
@@ -56,7 +56,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
             'customassetsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == len(TEST_CUSTOM_ASSETS)
     assert result['entries'] == [entry.to_dict(export_with_type=False) for entry in TEST_CUSTOM_ASSETS]  # noqa: E501
 
@@ -69,7 +69,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
         ),
         json={'name': 'goLD'},  # also check that case doesn't matter
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries_found'] == 1
     assert result['entries'][0] == TEST_CUSTOM_ASSETS[0].to_dict(export_with_type=False)
@@ -82,7 +82,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
         ),
         json={'custom_asset_type': 'ReAl EsTaTe'},  # also check that case doesn't matter
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 2
     assert result['entries_found'] == 2
     assert result['entries'] == [entry.to_dict(export_with_type=False) for entry in TEST_CUSTOM_ASSETS[1:3]]  # noqa: E501
@@ -95,7 +95,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
         ),
         json={'identifier': TEST_CUSTOM_ASSETS[3].identifier},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries_found'] == 1
     assert result['entries'][0] == TEST_CUSTOM_ASSETS[3].to_dict(export_with_type=False)
@@ -108,7 +108,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
         ),
         json={'name': 'idontexist'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 0
 
     # sort by custom asset type
@@ -122,7 +122,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 4
     assert_asset_result_order(
         data=result['entries'],
@@ -141,7 +141,7 @@ def test_get_custom_assets(rotkehlchen_api_server) -> None:
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 4
     assert_asset_result_order(
         data=result['entries'],
@@ -168,7 +168,7 @@ def test_add_custom_asset(rotkehlchen_api_server) -> None:
         ),
         json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries'][0]['name'] == data['name']
     assert result['entries'][0]['custom_asset_type'] == data['custom_asset_type']
@@ -223,7 +223,7 @@ def test_edit_custom_asset(rotkehlchen_api_server) -> None:
         ),
         json={'name': 'Milky Way'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries'][0] == data
 
@@ -275,7 +275,7 @@ def test_edit_custom_asset(rotkehlchen_api_server) -> None:
         ),
         json={'name': 'Land'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries'][0] == data
 
@@ -299,7 +299,7 @@ def test_delete_custom_asset(rotkehlchen_api_server) -> None:
             'customassetsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 3
     assert TEST_CUSTOM_ASSETS[0].identifier not in [entry['identifier'] for entry in result['entries']]  # noqa: E501
     assert TEST_CUSTOM_ASSETS[0].name not in [entry['name'] for entry in result['entries']]
@@ -326,7 +326,7 @@ def test_custom_asset_types(rotkehlchen_api_server) -> None:
             'customassetstypesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 0
 
     # add custom assets
@@ -337,6 +337,6 @@ def test_custom_asset_types(rotkehlchen_api_server) -> None:
             'customassetstypesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 3
     assert result == ['inheritance', 'real estate', 'stocks']

--- a/rotkehlchen/tests/api/test_data_import.py
+++ b/rotkehlchen/tests/api/test_data_import.py
@@ -12,7 +12,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.dataimport import (
@@ -84,7 +84,7 @@ def test_data_import_cointracking(rotkehlchen_api_server, file_upload):
                 ), json=json_data,
             )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_cointracking_import_results(rotki)
@@ -104,7 +104,7 @@ def test_data_import_cryptocom(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_cryptocom_import_results(rotki)
@@ -124,7 +124,7 @@ def test_data_import_cryptocom_special_types(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_cryptocom_special_events_import_results(rotki)
@@ -145,7 +145,7 @@ def test_data_import_bitmex_wallet_history(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_bitmex_import_wallet_history(rotki)
@@ -165,7 +165,7 @@ def test_data_import_blockfi_transactions(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_blockfi_transactions_import_results(rotki)
@@ -185,7 +185,7 @@ def test_data_import_blockfi_trades(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_blockfi_trades_import_results(rotki)
@@ -205,7 +205,7 @@ def test_data_import_nexo(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_nexo_results(rotki)
@@ -225,7 +225,7 @@ def test_data_import_shapeshift_trades(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_shapeshift_trades_import_results(rotki)
@@ -245,7 +245,7 @@ def test_data_import_uphold_transactions(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_uphold_transactions_import_results(rotki)
@@ -265,7 +265,7 @@ def test_data_import_bisq_transactions(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported successfully
     assert_bisq_trades_import_results(rotki)
@@ -468,7 +468,7 @@ def test_data_import_custom_format(rotkehlchen_api_server, file_upload):
                 ), json=json_data,
             )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     # And also assert data was imported succesfully
     assert_custom_cointracking(rotki)
@@ -487,7 +487,7 @@ def test_data_import_binance_history(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
     assert_binance_import_results(rotki)
 
@@ -505,7 +505,7 @@ def test_data_import_rotki_generic_trades(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_rotki_generic_trades_import_results(rotki)
 
     # check that passing `timestamp_format` does not break anything
@@ -520,7 +520,7 @@ def test_data_import_rotki_generic_trades(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_rotki_generic_trades_import_results(rotki)
 
 
@@ -537,7 +537,7 @@ def test_data_import_rotki_generic_events(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_rotki_generic_events_import_results(rotki)
 
 
@@ -560,7 +560,7 @@ def test_docker_async_import(rotkehlchen_api_server):
                 'file': infile,
             },
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         outcome = wait_for_async_task(rotkehlchen_api_server, result['task_id'])
     assert outcome['message'] == ''
     assert outcome['result'] is True
@@ -581,7 +581,7 @@ def test_bitcoin_tax_import(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_bitcoin_tax_trades_import_results(rotki, filepath.name)
 
     # Reimport the same csv file to test that no new events are created
@@ -593,7 +593,7 @@ def test_bitcoin_tax_import(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_bitcoin_tax_trades_import_results(rotki, filepath.name)
 
     # After the trades have been successfully imported, test a spending/income type csv import
@@ -605,7 +605,7 @@ def test_bitcoin_tax_import(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_bitcoin_tax_trades_import_results(rotki, filepath.name)
 
 
@@ -623,7 +623,7 @@ def test_bitstamp_import(rotkehlchen_api_server):
             'dataimportresource',
         ), json=json_data,
     )
-    assert assert_proper_response_with_result(response) is True
+    assert assert_proper_sync_response_with_result(response) is True
     assert_bitstamp_trades_import_results(rotki)
 
 
@@ -649,7 +649,7 @@ def test_bittrex_history_import(rotkehlchen_api_server):
                 'dataimportresource',
             ), json=json_data,
         )
-        assert assert_proper_response_with_result(response) is True
+        assert assert_proper_sync_response_with_result(response) is True
 
     assert_bittrex_import_results(rotki)
 
@@ -670,6 +670,6 @@ def test_kucoin_history_import(rotkehlchen_api_server):
                 'dataimportresource',
             ), json=json_data,
         )
-        assert assert_proper_response_with_result(response) is True
+        assert assert_proper_sync_response_with_result(response) is True
 
     assert_kucoin_import_results(rotki)

--- a/rotkehlchen/tests/api/test_database.py
+++ b/rotkehlchen/tests/api/test_database.py
@@ -12,7 +12,7 @@ from rotkehlchen.db.settings import ROTKEHLCHEN_DB_VERSION
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.utils.misc import ts_now
@@ -41,7 +41,7 @@ def test_query_db_info(
         db.conn.execute('PRAGMA wal_checkpoint;')  # flush the wal file
 
     response = requests.get(api_url_for(rotkehlchen_api_server, 'databaseinforesource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 2
     assert result['globaldb'] == {'globaldb_assets_version': 24, 'globaldb_schema_version': 8}
 
@@ -64,12 +64,12 @@ def test_create_download_delete_backup(
     """Test that creating, downloading and deleting a backup works fine"""
     start_ts = ts_now()
     response = requests.put(api_url_for(rotkehlchen_api_server, 'databasebackupsresource'))
-    filepath = Path(assert_proper_response_with_result(response))
+    filepath = Path(assert_proper_sync_response_with_result(response))
     assert filepath.exists()
     assert filepath.parent == data_dir / USERSDIR_NAME / username
 
     response = requests.get(api_url_for(rotkehlchen_api_server, 'databaseinforesource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     backups = result['userdb']['backups']
     assert len(backups) == 1
     assert backups[0]['time'] >= start_ts
@@ -99,7 +99,7 @@ def test_create_download_delete_backup(
     assert not filepath.exists()
     assert not second_filepath.exists()
     response = requests.get(api_url_for(rotkehlchen_api_server, 'databaseinforesource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     backups = result['userdb']['backups']
     assert len(backups) == 0
 
@@ -165,7 +165,7 @@ def test_delete_download_backup_errors(
     # test delete two files and only one exists
     undeletable_file.touch()
     response = requests.put(api_url_for(rotkehlchen_api_server, 'databasebackupsresource'))
-    filepath = Path(assert_proper_response_with_result(response))
+    filepath = Path(assert_proper_sync_response_with_result(response))
     response = requests.delete(
         api_url_for(
             rotkehlchen_api_server,

--- a/rotkehlchen/tests/api/test_defi.py
+++ b/rotkehlchen/tests/api/test_defi.py
@@ -3,7 +3,7 @@ import pytest
 import requests
 
 from rotkehlchen.tests.utils.aave import AAVE_TEST_ACC_1
-from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_sync_response_with_result
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -18,7 +18,7 @@ def test_query_defi_balances(rotkehlchen_api_server, ethereum_accounts):  # pyli
         rotkehlchen_api_server,
         'defibalancesresource',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     # assert some defi balances were detected
     first_entry = result[AAVE_TEST_ACC_1][0]

--- a/rotkehlchen/tests/api/test_ens.py
+++ b/rotkehlchen/tests/api/test_ens.py
@@ -11,7 +11,7 @@ from rotkehlchen.errors.misc import BlockchainQueryError, RemoteError
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.types import ChecksumEvmAddress, EnsMapping, Timestamp
 from rotkehlchen.utils.misc import ts_now
@@ -91,7 +91,7 @@ def test_reverse_ens(rotkehlchen_api_server):
             ),
             json={'ethereum_addresses': addrs_1},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         expected_resp_1 = {
             addrs_1[0]: 'rotki.eth',
             addrs_1[1]: 'lefteris.eth',
@@ -111,7 +111,7 @@ def test_reverse_ens(rotkehlchen_api_server):
             ),
             json={'ethereum_addresses': addrs_2},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         expected_resp_2 = {
             addrs_2[0]: 'rotki.eth',
             addrs_2[1]: 'abc.eth',
@@ -143,7 +143,7 @@ def test_reverse_ens(rotkehlchen_api_server):
             ),
             json={'ethereum_addresses': addrs_1 + addrs_2[1:], 'ignore_cache': True},
         )
-        assert_proper_response_with_result(response)
+        assert_proper_sync_response_with_result(response)
     db_changes_after = db_conn.total_changes
     # Check that we have 5 updates because we have 5 rows in ens_mappings table
     assert db_changes_after == 5 + db_changes_before

--- a/rotkehlchen/tests/api/test_erc20_info.py
+++ b/rotkehlchen/tests/api/test_erc20_info.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 
 
@@ -34,7 +34,7 @@ def test_query_token_with_info(rotkehlchen_api_server):
             'evm_chain': 'ethereum',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['decimals'] == 18
     assert result['symbol'] == 'DAI'
     assert result['name'] == 'Dai Stablecoin'
@@ -48,7 +48,7 @@ def test_query_token_with_info(rotkehlchen_api_server):
             'evm_chain': 'optimism',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['decimals'] == 6
     assert result['symbol'] == 'USDT'
     assert result['name'] == 'Tether USD'
@@ -64,7 +64,7 @@ def test_query_token_with_info(rotkehlchen_api_server):
         },
     )
 
-    result_2 = assert_proper_response_with_result(response_2)
+    result_2 = assert_proper_sync_response_with_result(response_2)
     assert_default_erc20_info_response(result_2)
 
     # Test an address that is not a contract
@@ -78,7 +78,7 @@ def test_query_token_with_info(rotkehlchen_api_server):
         },
     )
 
-    result_3 = assert_proper_response_with_result(response_3)
+    result_3 = assert_proper_sync_response_with_result(response_3)
     assert_default_erc20_info_response(result_3)
 
     # Test an address that is not valid (this one has extra chars)

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -31,10 +31,9 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
     assert_simple_ok_response,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
@@ -464,15 +463,12 @@ def test_eth2_add_eth1_account(rotkehlchen_api_server):
             blockchain='ETH',
         ), json=data)
 
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            result = wait_for_async_task_with_result(
-                rotkehlchen_api_server,
-                task_id,
-                timeout=ASYNC_TASK_WAIT_TIMEOUT * 4,
-            )
-        else:
-            result = assert_proper_response_with_result(response)
+        result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+            timeout=ASYNC_TASK_WAIT_TIMEOUT * 4,
+        )
 
         # now get all detected validators
         response = requests.get(
@@ -953,15 +949,12 @@ def test_query_eth2_balances(rotkehlchen_api_server, query_all_balances):
             blockchain='ETH2',
         ), json={'async_query': async_query})
 
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        outcome = wait_for_async_task_with_result(
-            server=rotkehlchen_api_server,
-            task_id=task_id,
-            timeout=ASYNC_TASK_WAIT_TIMEOUT * 5,
-        )
-    else:
-        outcome = assert_proper_response_with_result(response)
+    outcome = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+        timeout=ASYNC_TASK_WAIT_TIMEOUT * 5,
+    )
 
     assert len(outcome['per_account']) == 1  # only ETH2
     per_acc = outcome['per_account']['eth2']

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -31,8 +31,8 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
@@ -104,7 +104,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
             'eth2dailystatsresource',
         ), json={'only_cache': False},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     total_stats = len(result['entries'])
     assert total_stats == result['entries_total']
     assert total_stats == result['entries_found']
@@ -122,7 +122,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
             'eth2dailystatsresource',
         ), json={'only_cache': True, 'validator_indices': [CLEAN_HISTORY_VALIDATOR1, CLEAN_HISTORY_VALIDATOR3]},  # noqa: E501
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_total'] == total_stats
     assert result['entries_found'] == validator1_and_3_stats
     assert len(result['entries']) == validator1_and_3_stats
@@ -135,7 +135,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
             'eth2dailystatsresource',
         ), json={'only_cache': True, 'addresses': [CLEAN_HISTORY_WITHDRAWAL2]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_total'] == total_stats
     assert result['entries_found'] == validator_2_stats
     assert len(result['entries']) == validator_2_stats
@@ -148,7 +148,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
             'eth2dailystatsresource',
         ), json={'only_cache': True, 'status': 'exited'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_total'] == total_stats
     assert result['entries_found'] == validator_3_stats
     assert len(result['entries']) == validator_3_stats
@@ -162,7 +162,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
             'eth2dailystatsresource',
         ), json={'only_cache': True, 'validator_indices': queried_validators, 'from_timestamp': from_ts, 'to_timestamp': to_ts},  # noqa: E501
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_total'] == total_stats
     assert result['entries_found'] <= total_stats
     assert len(result['entries']) == result['entries_found']
@@ -192,7 +192,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
             'eth2dailystatsresource',
         ), json=json,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_total'] == total_stats
     assert result['entries_found'] <= total_stats
     assert len(result['entries']) == 5
@@ -221,7 +221,7 @@ def test_eth2_daily_stats(rotkehlchen_api_server):
         )
         assert scraper.call_count == 0
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     total_stats = len(result['entries'])
     assert total_stats == result['entries_total']
     assert total_stats == result['entries_found']
@@ -260,7 +260,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
         'blockchainsaccountsresource',
         blockchain='ETH',
     ), json=data)
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
 
     detected_validator = ValidatorDetailsWithStatus(
         activation_timestamp=Timestamp(1684036055),
@@ -284,7 +284,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [x.serialize() for x in (detected_validator, exited_validator)], 'entries_found': 2, 'entries_limit': -1}  # noqa: E501
 
     # Query withdrawals/block productions
@@ -304,7 +304,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'][1]['index'] == exited_validator.validator_index
     assert result['entries'][1]['status'] == 'exited'
 
@@ -321,7 +321,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
                 detected_validator.validator_index, exited_validator.validator_index,
             ]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     expected_validators_result = {
         'sums': {
@@ -362,7 +362,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
                     'eth2stakeperformanceresource',
                 ), json={'limit': 10, 'offset': 0 + page},
             )
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
             assert result['entries_found'] == total_validators
             assert result['entries_total'] == total_validators
             assert len(result['validators']) in (10, 2)
@@ -388,7 +388,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
                 'eth2stakeperformanceresource',
             ), json={'limit': 500, 'offset': 0, 'status': status},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['entries_found'] == expected_num
         assert len(result['validators']) == expected_num
         assert result['entries_total'] == total_validators
@@ -400,7 +400,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
             'eth2stakeperformanceresource',
         ), json={'limit': 500, 'offset': 0, 'from_timestamp': 1704063600, 'to_timestamp': 1706742000},  # noqa: E501
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 313
     assert len(result['validators']) == 313
     assert result['entries_total'] == total_validators
@@ -412,7 +412,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
             'eth2stakeperformanceresource',
         ), json={'limit': 500, 'offset': 0, 'addresses': [make_evm_address()]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 0
     assert len(result['validators']) == 0
     assert result['entries_total'] == total_validators
@@ -430,7 +430,7 @@ def test_staking_performance(rotkehlchen_api_server, ethereum_accounts):
             'validator_indices': [exited_validator.validator_index],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_validators_result
 
 
@@ -463,7 +463,7 @@ def test_eth2_add_eth1_account(rotkehlchen_api_server):
             blockchain='ETH',
         ), json=data)
 
-        result = assert_maybe_async_response_with_result(
+        result = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -477,7 +477,7 @@ def test_eth2_add_eth1_account(rotkehlchen_api_server):
                 'eth2validatorsresource',
             ),
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         # That address has only 1 validator. If that changes in the future this
         # test will fail and we will need to adjust the test
         validator_pubkey = '0x800199f8f3af15a22c42ccd7185948870eceeba2d06199ea30e7e28eb976a69284e393ba2f401e8983d011534b303a57'  # noqa: E501
@@ -494,7 +494,7 @@ def test_eth2_add_eth1_account(rotkehlchen_api_server):
             rotkehlchen_api_server,
             'blockchainbalancesresource',
         ))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         per_acc = result['per_account']
         assert FVal(per_acc['eth'][new_account]['assets'][A_ETH.identifier]['amount']) > ZERO
         assert FVal(per_acc['eth2'][validator_pubkey]['assets'][A_ETH2.identifier]['amount']) == ZERO  # exited # noqa: E501
@@ -545,7 +545,7 @@ def test_add_get_edit_delete_eth2_validators(rotkehlchen_api_server, start_with_
         ),
     )
     expected_limit = -1 if start_with_valid_premium else FREE_VALIDATORS_LIMIT
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [], 'entries_limit': expected_limit, 'entries_found': 0}
 
     validators = [ValidatorDetailsWithStatus(
@@ -610,7 +610,7 @@ def test_add_get_edit_delete_eth2_validators(rotkehlchen_api_server, start_with_
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [x.serialize() for x in validators], 'entries_limit': expected_limit, 'entries_found': 4}  # noqa: E501
 
     if start_with_valid_premium is False:
@@ -692,7 +692,7 @@ def test_add_get_edit_delete_eth2_validators(rotkehlchen_api_server, start_with_
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [validators[1].serialize()], 'entries_limit': expected_limit, 'entries_found': 1}  # noqa: E501
 
     # Try to add validator with a custom ownership percentage
@@ -741,7 +741,7 @@ def test_add_get_edit_delete_eth2_validators(rotkehlchen_api_server, start_with_
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [validator.serialize() for validator in custom_percentage_validators], 'entries_limit': expected_limit, 'entries_found': 2}  # noqa: E501
 
 
@@ -895,7 +895,7 @@ def test_query_eth2_balances(rotkehlchen_api_server, query_all_balances):
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [], 'entries_limit': -1, 'entries_found': 0}
 
     validators = [ValidatorDetailsWithStatus(
@@ -933,7 +933,7 @@ def test_query_eth2_balances(rotkehlchen_api_server, query_all_balances):
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'entries': [x.serialize() for x in validators], 'entries_limit': -1, 'entries_found': 2}  # noqa: E501
 
     async_query = random.choice([False, True])
@@ -949,7 +949,7 @@ def test_query_eth2_balances(rotkehlchen_api_server, query_all_balances):
             blockchain='ETH2',
         ), json={'async_query': async_query})
 
-    outcome = assert_maybe_async_response_with_result(
+    outcome = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -983,7 +983,7 @@ def test_query_eth2_balances(rotkehlchen_api_server, query_all_balances):
         'named_blockchain_balances_resource',
         blockchain='ETH2',
     ), json={'async_query': False, 'ignore_cache': True})
-    outcome = assert_proper_response_with_result(response)
+    outcome = assert_proper_sync_response_with_result(response)
 
     assert len(outcome['per_account']) == 1  # only ETH2
     per_acc = outcome['per_account']['eth2']
@@ -1055,7 +1055,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         ),
         json={'group_by_event_ids': True},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == result['entries_found'] == result['entries_total'] == 7
     event_identifier = None
     for entry in result['entries']:
@@ -1076,7 +1076,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         ),
         json={'group_by_event_ids': False, 'event_identifiers': [event_identifier]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == result['entries_found'] == 3
     assert result['entries_total'] == 12
     for outer_entry in result['entries']:
@@ -1116,7 +1116,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         ),
         json={'validator_indices': [vindex1, 42]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 8
     for entry in result['entries']:
         assert entry['entry']['entry_type'] == 'eth block event'
@@ -1131,7 +1131,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         ),
         json={'counterparties': [CPT_ETH2]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 11
     for entry in result['entries']:
         assert entry['entry']['entry_type'] == 'eth block event'
@@ -1149,7 +1149,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         ),
         json={'entry_types': entry_types_include_arg},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 11
     for outer_entry in result['entries']:
         entry = outer_entry['entry']
@@ -1168,7 +1168,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         ),
         json={'entry_types': entry_types_exclude_arg},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     for outer_entry in result['entries']:
         entry = outer_entry['entry']
@@ -1220,7 +1220,7 @@ def test_get_validators(rotkehlchen_api_server):
             'eth2validatorsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [validator1_data, validator2_data, validator3_data]
 
     response = requests.get(  # Check filtering by index works
@@ -1229,7 +1229,7 @@ def test_get_validators(rotkehlchen_api_server):
             'eth2validatorsresource',
         ), json={'validator_indices': [CLEAN_HISTORY_VALIDATOR1]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [validator1_data]
 
     response = requests.get(  # Check filtering by address works
@@ -1238,7 +1238,7 @@ def test_get_validators(rotkehlchen_api_server):
             'eth2validatorsresource',
         ), json={'addresses': [CLEAN_HISTORY_WITHDRAWAL2]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [validator2_data]
 
     response = requests.get(  # Check filtering by status works
@@ -1247,5 +1247,5 @@ def test_get_validators(rotkehlchen_api_server):
             'eth2validatorsresource',
         ), json={'status': 'exited'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [validator3_data]

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -34,7 +34,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
     wait_for_async_task,
 )
@@ -206,7 +206,7 @@ def query_events(server, json, expected_num_with_grouping, expected_totals_with_
         api_url_for(server, 'historyeventresource'),
         json=extra_json,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     entries = result['entries']
     assert result['entries_limit'] == entries_limit
     assert result['entries_found'] == expected_num_with_grouping
@@ -221,7 +221,7 @@ def query_events(server, json, expected_num_with_grouping, expected_totals_with_
                 api_url_for(server, 'historyeventresource'),
                 json=extra_json,
             )
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
             augmented_entries.extend(result['entries'])
         else:
             entry.pop('grouped_events_num')
@@ -502,7 +502,7 @@ def test_query_over_10k_transactions(rotkehlchen_api_server):
             json={'evm_chain': 'ethereum'},
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) >= expected_at_least
     assert result['entries_found'] >= expected_at_least
     assert result['entries_limit'] == -1
@@ -663,7 +663,7 @@ def test_query_transactions_removed_address(
         'blockchainsaccountsresource',
         blockchain='ETH',
     ), json={'accounts': [ethereum_accounts[0]]})
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
 
     # Check that only the 3 remaining transactions from the other account are returned
     dbevmtx = DBEvmTx(rotki.data.db)
@@ -959,7 +959,7 @@ def test_query_transactions_check_decoded_events(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),
         json={key: value for key, value in tx4_events[0]['entry'].items() if key != 'event_identifier'},  # noqa: E501
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     tx4_events[0]['entry']['identifier'] = result['identifier']
 
     # Also add a cache entry for a transaction
@@ -1323,7 +1323,7 @@ def test_no_value_eth_transfer(rotkehlchen_api_server: 'APIServer'):
         ),
         json={'tx_hashes': [tx_str]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'][0]['entry']['asset'] == A_ETH
     assert result['entries'][0]['entry']['balance']['amount'] == '0'
 
@@ -1350,7 +1350,7 @@ def test_decoding_missing_transactions(
             'evmpendingtransactionsdecodingresource',
         ), json={'async_query': False, 'chains': ['ethereum']},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['decoded_tx_number']['ethereum'] == len(transactions)
 
     websocket_connection.wait_until_messages_num(num=4, timeout=4)
@@ -1385,7 +1385,7 @@ def test_decoding_missing_transactions(
             'evmpendingtransactionsdecodingresource',
         ), json={'async_query': True},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     outcome = wait_for_async_task(rotkehlchen_api_server, result['task_id'])
     assert outcome['result']['decoded_tx_number'] == {}
 
@@ -1471,7 +1471,7 @@ def test_count_transactions_missing_decoding(rotkehlchen_api_server: 'APIServer'
         assert outcome['message'] == ''
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     assert result == {
         'base': {'undecoded': 1, 'total': 1},

--- a/rotkehlchen/tests/api/test_evm_transactions.py
+++ b/rotkehlchen/tests/api/test_evm_transactions.py
@@ -23,9 +23,9 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_async_response,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -105,7 +105,7 @@ def test_query_transactions(rotkehlchen_api_server: 'APIServer'):
         assert outcome['message'] == ''
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     assert result is True
 
@@ -175,7 +175,7 @@ def test_evm_transaction_hash_addition(rotkehlchen_api_server: 'APIServer') -> N
             'associated_address': ADDY,
         },
     )
-    assert assert_maybe_async_response_with_result(
+    assert assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=is_async_query,

--- a/rotkehlchen/tests/api/test_evm_transactions.py
+++ b/rotkehlchen/tests/api/test_evm_transactions.py
@@ -23,11 +23,10 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_async_response,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response_with_result,
-    assert_simple_ok_response,
     wait_for_async_task,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.types import (
@@ -176,12 +175,11 @@ def test_evm_transaction_hash_addition(rotkehlchen_api_server: 'APIServer') -> N
             'associated_address': ADDY,
         },
     )
-    if is_async_query is True:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-        assert result is True
-    else:
-        assert_simple_ok_response(response)
+    assert assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=is_async_query,
+    )
 
     # now see that the transaction is present in the db
     # and the transaction was decoded properly
@@ -254,7 +252,7 @@ def test_evm_transaction_hash_addition(rotkehlchen_api_server: 'APIServer') -> N
         },
     )
     if is_async_query:
-        task_id = assert_ok_async_response(response)  # type: ignore[unreachable]
+        task_id = assert_ok_async_response(response)
         response_data = wait_for_async_task(rotkehlchen_api_server, task_id)
         assert_error_async_response(response_data, f'{random_tx_hash} not found on chain.', status_code=HTTPStatus.NOT_FOUND)  # noqa: E501
     else:

--- a/rotkehlchen/tests/api/test_evmlike.py
+++ b/rotkehlchen/tests/api/test_evmlike.py
@@ -16,7 +16,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -107,7 +107,7 @@ def test_evmlike_blockchain_balances(
                 'blockchainbalancesresource',
             ), json={'async_query': False},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert balance_query.call_count == 1
         assert result == {
             'per_account': {
@@ -147,7 +147,7 @@ def test_evmlike_add_accounts(rotkehlchen_api_server: 'APIServer') -> None:
         'blockchainsaccountsresource',
         blockchain='ZKSYNC_LITE',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == []
 
     response = requests.put(api_url_for(
@@ -162,7 +162,7 @@ def test_evmlike_add_accounts(rotkehlchen_api_server: 'APIServer') -> None:
         'blockchainsaccountsresource',
         blockchain='ZKSYNC_LITE',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [{'address': addy_0, 'label': None, 'tags': None}]
     assert rotki.chains_aggregator.accounts.zksync_lite == (addy_0,)
 
@@ -178,7 +178,7 @@ def test_evmlike_add_accounts(rotkehlchen_api_server: 'APIServer') -> None:
         'blockchainsaccountsresource',
         blockchain='ZKSYNC_LITE',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {'address': addy_1, 'label': 'addy 1 label', 'tags': None} in result
     assert {'address': addy_0, 'label': None, 'tags': None} in result
 
@@ -197,7 +197,7 @@ def test_evmlike_add_accounts(rotkehlchen_api_server: 'APIServer') -> None:
         'blockchainsaccountsresource',
         blockchain='ZKSYNC_LITE',
     ), json={'accounts': [{'address': non_checksummed}]})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [checksummed]  # see it's returned/saved checksummed
 
     response = requests.get(api_url_for(
@@ -205,7 +205,7 @@ def test_evmlike_add_accounts(rotkehlchen_api_server: 'APIServer') -> None:
         'blockchainsaccountsresource',
         blockchain='ZKSYNC_LITE',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert {'address': checksummed, 'label': None, 'tags': None} in result
 
     response = requests.delete(api_url_for(  # delete non-checksummed address
@@ -252,7 +252,7 @@ def test_decode_pending_evmlike(rotkehlchen_api_server: 'APIServer', zksync_lite
             'evmlikependingtransactionsdecodingresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'zksync_lite': {'undecoded': 16, 'total': 16}}
 
     response = requests.post(
@@ -269,19 +269,19 @@ def test_decode_pending_evmlike(rotkehlchen_api_server: 'APIServer', zksync_lite
             'evmlikependingtransactionsdecodingresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {}
 
     response = requests.post(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),
     )
     assert_proper_response(response)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     response = requests.post(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),
         json={'location': Location.ZKSYNC_LITE.serialize()},
     )
-    assert assert_proper_response_with_result(response) == result, 'filtering by location should be same'  # noqa: E501
+    assert assert_proper_sync_response_with_result(response) == result, 'filtering by location should be same'  # noqa: E501
     assert len(result['entries']) == 17
     compare_events_without_id(result['entries'][0]['entry'], EvmEvent(
         event_identifier='zkl0xbd723b5a5f87e485a478bc7d1f365db79440b6e9305bff3b16a0e0ab83e51970',

--- a/rotkehlchen/tests/api/test_exchange_rates_query.py
+++ b/rotkehlchen/tests/api/test_exchange_rates_query.py
@@ -9,7 +9,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 
 
@@ -50,7 +50,7 @@ def test_querying_exchange_rates(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'exchangeratesresource') + '?currencies=' +
         ','.join(data['currencies']),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     expected_currencies = [A_EUR, A_USD, A_KRW, A_ETH]
     assert len(result) == len(expected_currencies)
     for currency in expected_currencies:
@@ -77,4 +77,4 @@ def test_querying_exchange_rates_errors(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'exchangeratesresource'), json=data,
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)

--- a/rotkehlchen/tests/api/test_exchanges.py
+++ b/rotkehlchen/tests/api/test_exchanges.py
@@ -34,12 +34,12 @@ from rotkehlchen.tests.utils.accounting import toggle_ignore_an_asset
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response,
     assert_proper_response_with_result,
     assert_simple_ok_response,
     wait_for_async_task,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.exchanges import (
     assert_binance_balances_result,
@@ -511,11 +511,11 @@ def test_exchange_query_balances(rotkehlchen_api_server_with_exchanges):
             'named_exchanges_balances_resource',
             location='binance',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(server, task_id)
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server_with_exchanges,
+            async_query=async_query,
+        )
     assert_binance_balances_result(outcome)
 
     # query balances of all setup exchanges
@@ -526,11 +526,11 @@ def test_exchange_query_balances(rotkehlchen_api_server_with_exchanges):
             api_url_for(server, 'exchangebalancesresource'),
             json={'async_query': async_query},
         )
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            result = wait_for_async_task_with_result(server, task_id)
-        else:
-            result = assert_proper_response_with_result(response)
+        result = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server_with_exchanges,
+            async_query=async_query,
+        )
 
     assert_binance_balances_result(result['binance'])
     assert_poloniex_balances_result(result['poloniex'])

--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -6,7 +6,7 @@ import requests
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 
 
@@ -19,7 +19,7 @@ def test_add_get_external_service(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {}
 
     # Now add some data and see that the response shows they are added
@@ -38,14 +38,14 @@ def test_add_get_external_service(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
         json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
     # Query again and see that the newly added services are returned
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
     # Test that we can replace a value of an already existing service
@@ -56,14 +56,14 @@ def test_add_get_external_service(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
         json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
     # Query again and see that the modified services are returned
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
 
@@ -83,7 +83,7 @@ def test_delete_external_service(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
         json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
     # Now try to delete an entry and see the response shows it's deleted
@@ -93,14 +93,14 @@ def test_delete_external_service(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
         json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
     # Query again and see that the modified services are returned
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == expected_result
 
     # Now try to delete an existing and a non-existing service to make sure
@@ -110,14 +110,14 @@ def test_delete_external_service(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
         json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {}
 
     # Query again and see that the modified services are returned
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {}
 
 

--- a/rotkehlchen/tests/api/test_historical_assets_price.py
+++ b/rotkehlchen/tests/api/test_historical_assets_price.py
@@ -11,8 +11,8 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 
@@ -56,7 +56,7 @@ def test_get_historical_assets_price(rotkehlchen_api_server):
             'async_query': async_query,
         },
     )
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -226,7 +226,7 @@ def test_manual_historical_price(rotkehlchen_api_server, globaldb):
             'from_asset': A_CRV.identifier,
         },
     )
-    data = assert_proper_response_with_result(response)
+    data = assert_proper_sync_response_with_result(response)
     _assert_expected_prices(data, after_deletion=False, crv_1611166340_price='1.50')
     # Check that calling PUT for an existing price replaces the price
     response = requests.put(
@@ -250,7 +250,7 @@ def test_manual_historical_price(rotkehlchen_api_server, globaldb):
             'from_asset': A_CRV.identifier,
         },
     )
-    data = assert_proper_response_with_result(response)
+    data = assert_proper_sync_response_with_result(response)
     _assert_expected_prices(data, after_deletion=False)
     # If we query against the to_asset we should get the same entry
     response = requests.get(
@@ -270,7 +270,7 @@ def test_manual_historical_price(rotkehlchen_api_server, globaldb):
             'historicalassetspriceresource',
         ),
     )
-    data = assert_proper_response_with_result(response)
+    data = assert_proper_sync_response_with_result(response)
     _assert_expected_prices(data, after_deletion=False)
     # Delete entry
     response = requests.delete(
@@ -294,7 +294,7 @@ def test_manual_historical_price(rotkehlchen_api_server, globaldb):
             'from_asset': A_CRV.identifier,
         },
     )
-    data = assert_proper_response_with_result(response)
+    data = assert_proper_sync_response_with_result(response)
     _assert_expected_prices(data, after_deletion=True)
     # Delete an entry that is not in database
     response = requests.delete(

--- a/rotkehlchen/tests/api/test_historical_assets_price.py
+++ b/rotkehlchen/tests/api/test_historical_assets_price.py
@@ -11,10 +11,9 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
     assert_simple_ok_response,
-    wait_for_async_task_with_result,
 )
 
 
@@ -57,11 +56,11 @@ def test_get_historical_assets_price(rotkehlchen_api_server):
             'async_query': async_query,
         },
     )
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert len(result) == 2
     assert result['assets']['BTC'] == {

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -27,11 +27,10 @@ from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
+    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response_with_result,
-    assert_simple_ok_response,
     wait_for_async_task,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.constants import ETH_ADDRESS1, ETH_ADDRESS2, ETH_ADDRESS3
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
@@ -429,15 +428,11 @@ def test_history_debug_import(rotkehlchen_api_server):
                 'async_query': async_query,
             },
         )
-        if async_query is True:
-            result = wait_for_async_task_with_result(
-                server=rotkehlchen_api_server,
-                task_id=response.json()['result']['task_id'],
-            )
-            assert result is True
-
-        else:
-            assert_simple_ok_response(response)
+        assert assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
     else:
         with open(str(filepath), encoding='utf8') as infile:
             response = requests.patch(
@@ -448,14 +443,11 @@ def test_history_debug_import(rotkehlchen_api_server):
                 files={'filepath': infile},
                 data={'async_query': async_query},
             )
-            if async_query is True:
-                result = wait_for_async_task_with_result(
-                    server=rotkehlchen_api_server,
-                    task_id=response.json()['result']['task_id'],
-                )
-                assert result is True
-            else:
-                assert_simple_ok_response(response)
+            assert assert_maybe_async_response_with_result(
+                response=response,
+                rotkehlchen_api_server=rotkehlchen_api_server,
+                async_query=async_query,
+            )
     assert_pnl_debug_import(
         filepath=filepath,
         database=rotkehlchen_api_server.rest_api.rotkehlchen.data.db,

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -27,9 +27,9 @@ from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_ok_async_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.constants import ETH_ADDRESS1, ETH_ADDRESS2, ETH_ADDRESS3
@@ -152,7 +152,7 @@ def test_query_history(rotkehlchen_api_server_with_exchanges, start_ts, end_ts):
             'historyactionableitemsresource',
         ),
     )
-    result = assert_proper_response_with_result(response=response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response=response, status_code=HTTPStatus.OK)
     assert len(result['missing_acquisitions']) == 9 if fees_in_cost_basis is False else 8
     assert len(result['missing_prices']) == 0
     assert result['report_id'] == 1
@@ -337,7 +337,7 @@ def test_query_pnl_report_events_pagination_filtering(
             report_id=report_id,
         ),
     )
-    events_result = assert_proper_response_with_result(response)
+    events_result = assert_proper_sync_response_with_result(response)
     master_events = events_result['entries']
 
     events = []
@@ -355,7 +355,7 @@ def test_query_pnl_report_events_pagination_filtering(
                 'ascending': [ascending_timestamp],
             },
         )
-        events_result = assert_proper_response_with_result(response)
+        events_result = assert_proper_sync_response_with_result(response)
         assert len(events_result['entries']) <= 10
         events.extend(events_result['entries'])
 
@@ -406,7 +406,7 @@ def test_history_debug_export(rotkehlchen_api_server: 'APIServer') -> None:
             'to_timestamp': now,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert tuple(result.keys()) == expected_keys
     assert result['pnl_settings'] == {'from_timestamp': Timestamp(0), 'to_timestamp': now}
     assert result['ignored_events_ids'] == {'history_event': [tx_id]}
@@ -428,7 +428,7 @@ def test_history_debug_import(rotkehlchen_api_server):
                 'async_query': async_query,
             },
         )
-        assert assert_maybe_async_response_with_result(
+        assert assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -443,7 +443,7 @@ def test_history_debug_import(rotkehlchen_api_server):
                 files={'filepath': infile},
                 data={'async_query': async_query},
             )
-            assert assert_maybe_async_response_with_result(
+            assert assert_proper_response_with_result(
                 response=response,
                 rotkehlchen_api_server=rotkehlchen_api_server,
                 async_query=async_query,
@@ -525,7 +525,7 @@ def test_missing_prices_in_pnl_report(rotkehlchen_api_server):
             'historyactionableitemsresource',
         ),
     )
-    result = assert_proper_response_with_result(response=response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response=response, status_code=HTTPStatus.OK)
     assert coingecko_api_calls == 2
     assert result['report_id'] == 1
     assert result['missing_prices'] == [{

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -22,7 +22,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.history_base_entry import (
@@ -116,7 +116,7 @@ def test_add_edit_delete_entries(rotkehlchen_api_server: 'APIServer'):
             api_url_for(rotkehlchen_api_server, 'historyeventresource'),
             json=json_data,
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert 'identifier' in result
         entry.identifier = result['identifier']
 
@@ -328,7 +328,7 @@ def test_event_with_details(rotkehlchen_api_server: 'APIServer'):
             'historyeventresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     events = result['entries']
     assert events[1]['has_details'] is True
 
@@ -365,7 +365,7 @@ def test_event_with_details(rotkehlchen_api_server: 'APIServer'):
             'eventdetailsresource',
         ), json={'identifier': events[1]['entry']['identifier']},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {SUB_SWAPS_DETAILS: event2.extra_data[SUB_SWAPS_DETAILS]}  # type: ignore[index]  # extra_data is not None here
 
 
@@ -390,7 +390,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
             'historyeventresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 9
     assert result['entries_limit'] == 100
     assert result['entries_total'] == 9
@@ -414,7 +414,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         ),
         json={'group_by_event_ids': True},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 6
     assert result['entries_limit'] == 100
     assert result['entries_total'] == 6
@@ -431,7 +431,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         ),
         json={'group_by_event_ids': True, 'offset': 1, 'limit': 1},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries_found'] == 6
     assert result['entries_limit'] == 100
@@ -445,7 +445,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         ),
         json={'group_by_event_ids': True, 'offset': 0, 'limit': 1, 'asset': 'ETH'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries_found'] == 4
     assert result['entries_limit'] == 100
@@ -459,7 +459,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         ),
         json={'location': Location.KRAKEN.serialize()},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert result['entries_found'] == 1
     assert result['entries_limit'] == 100
@@ -472,7 +472,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
         ),
         json={'location': Location.ETHEREUM.serialize()},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 8
     assert result['entries_found'] == 8
     assert result['entries_limit'] == 100
@@ -488,7 +488,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
             ),
             json={'group_by_event_ids': True, 'offset': 0, 'limit': 5, 'exclude_ignored_assets': exclude_ignored_assets},  # noqa: E501
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert len(result['entries']) == min(found, 5)
         assert result['entries_found'] == found
         assert result['entries_limit'] == 100
@@ -503,7 +503,7 @@ def test_get_events(rotkehlchen_api_server: 'APIServer'):
             ),
             json={'group_by_event_ids': False, 'offset': 0, 'limit': 5, 'exclude_ignored_assets': exclude_ignored_assets},  # noqa: E501
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert len(result['entries']) == min(sub_events_found, 5)
         assert result['entries_found'] == events_found
         assert result['entries_limit'] == 100

--- a/rotkehlchen/tests/api/test_icons.py
+++ b/rotkehlchen/tests/api/test_icons.py
@@ -17,7 +17,7 @@ from rotkehlchen.icons import ALLOWED_ICON_EXTENSIONS
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.constants import A_DOGE, A_GNO
@@ -53,7 +53,7 @@ def test_upload_custom_icon(rotkehlchen_api_server, file_upload, data_dir):
             ), json=json_data,
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'identifier': A_GNO.identifier}
     uploaded_icon = data_dir / IMAGESDIR_NAME / ASSETIMAGESDIR_NAME / CUSTOMASSETIMAGESDIR_NAME / f'{gno_id_quoted}.svg'  # noqa: E501
     assert uploaded_icon.is_file()

--- a/rotkehlchen/tests/api/test_liquity.py
+++ b/rotkehlchen/tests/api/test_liquity.py
@@ -17,9 +17,8 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.api import (
     api_url_for,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -48,11 +47,11 @@ def test_trove_position(rotkehlchen_api_server, inquirer):  # pylint: disable=un
         rotkehlchen_api_server,
         'liquitytrovesresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert LQTY_ADDR in result
     trove_data = result[LQTY_ADDR]
@@ -89,11 +88,11 @@ def test_trove_staking(rotkehlchen_api_server, inquirer):  # pylint: disable=unu
         rotkehlchen_api_server,
         'liquitystakingresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert LQTY_STAKING in result
     stake_data = result[LQTY_STAKING]
@@ -131,11 +130,11 @@ def test_account_without_info(rotkehlchen_api_server, inquirer):  # pylint: disa
         rotkehlchen_api_server,
         'liquitytrovesresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert ADDR_WITHOUT_TROVE not in result
 
@@ -152,11 +151,11 @@ def test_account_with_proxy(rotkehlchen_api_server, inquirer):  # pylint: disabl
         rotkehlchen_api_server,
         'liquitytrovesresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert LQTY_PROXY in result
     assert ADDR_WITHOUT_TROVE not in result
@@ -195,11 +194,11 @@ def test_stability_pool(rotkehlchen_api_server):
             'liquitystabilitypoolresource',
         ), json={'async_query': async_query})
 
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert JUSTIN in result
     assert LIQUITY_POOL_DEPOSITOR in result

--- a/rotkehlchen/tests/api/test_liquity.py
+++ b/rotkehlchen/tests/api/test_liquity.py
@@ -17,8 +17,8 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.api import (
     api_url_for,
-    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -47,7 +47,7 @@ def test_trove_position(rotkehlchen_api_server, inquirer):  # pylint: disable=un
         rotkehlchen_api_server,
         'liquitytrovesresource',
     ), json={'async_query': async_query})
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -88,7 +88,7 @@ def test_trove_staking(rotkehlchen_api_server, inquirer):  # pylint: disable=unu
         rotkehlchen_api_server,
         'liquitystakingresource',
     ), json={'async_query': async_query})
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -130,7 +130,7 @@ def test_account_without_info(rotkehlchen_api_server, inquirer):  # pylint: disa
         rotkehlchen_api_server,
         'liquitytrovesresource',
     ), json={'async_query': async_query})
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -151,7 +151,7 @@ def test_account_with_proxy(rotkehlchen_api_server, inquirer):  # pylint: disabl
         rotkehlchen_api_server,
         'liquitytrovesresource',
     ), json={'async_query': async_query})
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -194,7 +194,7 @@ def test_stability_pool(rotkehlchen_api_server):
             'liquitystabilitypoolresource',
         ), json={'async_query': async_query})
 
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -341,7 +341,7 @@ def test_staking_stats(rotkehlchen_api_server: APIServer, ethereum_accounts: lis
         'modulestatsresource',
         module='liquity',
     ), json={'async_query': False})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     global_stats = result['global_stats']
     address_0_data = result['by_address'][ethereum_accounts[0]]
@@ -369,7 +369,7 @@ def test_proxy_info_is_shown(rotkehlchen_api_server, ethereum_accounts):
         'liquitystabilitypoolresource',
     ), json={'async_query': False})
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert 'gains' in result[user_address]['proxies']['0x33EAfDB72b69BFBe6b5911eDCbab41011e63C523']
 
     # check the other endpoint.
@@ -377,5 +377,5 @@ def test_proxy_info_is_shown(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         'liquitystakingresource',
     ), json={'async_query': False})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert 'staked' in result[user_address]['proxies']['0x33EAfDB72b69BFBe6b5911eDCbab41011e63C523']  # noqa: E501

--- a/rotkehlchen/tests/api/test_location_asset_mappings.py
+++ b/rotkehlchen/tests/api/test_location_asset_mappings.py
@@ -6,7 +6,7 @@ import requests
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ def _get_all_location_mappings(rotkehlchen_api_server: 'APIServer') -> Any:
             'locationassetmappingsresource',
         ),
     )
-    return assert_proper_response_with_result(response=response)
+    return assert_proper_sync_response_with_result(response=response)
 
 
 def test_location_asset_mappings_query(rotkehlchen_api_server: 'APIServer') -> None:
@@ -40,7 +40,7 @@ def test_location_asset_mappings_query(rotkehlchen_api_server: 'APIServer') -> N
         ),
         json={'location': None},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == result['entries_found'] == 33
 
     # query all common mappings
@@ -51,7 +51,7 @@ def test_location_asset_mappings_query(rotkehlchen_api_server: 'APIServer') -> N
         ),
         json={'location': None},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == result['entries_found'] == 33
 
     # query all kraken mappings
@@ -62,7 +62,7 @@ def test_location_asset_mappings_query(rotkehlchen_api_server: 'APIServer') -> N
         ),
         json={'location': 'kraken'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == result['entries_found'] == 228
 
     # query by symbol all the kraken mappings
@@ -73,7 +73,7 @@ def test_location_asset_mappings_query(rotkehlchen_api_server: 'APIServer') -> N
         ),
         json={'location_symbol': 'eth', 'location': 'kraken'},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert all(entry['location'] == 'kraken' for entry in result['entries'])
     assert {'XETH', 'ETHW', 'WETH', 'ETH2'}.issubset(
         {entry['location_symbol'] for entry in result['entries']},
@@ -103,7 +103,7 @@ def test_location_asset_mappings_add(rotkehlchen_api_server: 'APIServer') -> Non
             'entries': added_mappings,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
 
     # check that the mappings were indeed added
@@ -117,7 +117,7 @@ def test_location_asset_mappings_add(rotkehlchen_api_server: 'APIServer') -> Non
             'limit': 2000,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     all_mappings_after_addition = result['entries']
     assert len(all_mappings_after_addition) == result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32 + 2  # noqa: E501
     for new_mapping in added_mappings:
@@ -143,7 +143,7 @@ def test_location_asset_mappings_update(rotkehlchen_api_server: 'APIServer') -> 
         ),
         json={'entries': [updated_mapping]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
 
     # check if the mappings is updated
@@ -171,7 +171,7 @@ def test_location_asset_mappings_delete(rotkehlchen_api_server: 'APIServer') -> 
             'entries': [deleted_mapping],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
 
     result = _get_all_location_mappings(rotkehlchen_api_server)
@@ -195,7 +195,7 @@ def test_location_asset_mappings_pagination(rotkehlchen_api_server: 'APIServer')
             'limit': 1,
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     assert result['entries'] == [all_mappings[0]]
     assert result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32
 
@@ -210,7 +210,7 @@ def test_location_asset_mappings_pagination(rotkehlchen_api_server: 'APIServer')
             'limit': 1,
         },
     )
-    result = assert_proper_response_with_result(response=response)
+    result = assert_proper_sync_response_with_result(response=response)
     assert result['entries'] == [all_mappings[1]]
     assert result['entries_found'] == NUM_ASSETS_MAPPINGS_V1_32
 

--- a/rotkehlchen/tests/api/test_locations.py
+++ b/rotkehlchen/tests/api/test_locations.py
@@ -6,7 +6,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_EUR
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_sync_response_with_result
 from rotkehlchen.tests.utils.exchanges import mock_exchange_data_in_db
 from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TradeType
 
@@ -50,5 +50,5 @@ def test_get_associated_locations(
             'associatedlocations',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert set(result) == {'nexo', 'binance', 'poloniex'}

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -19,8 +19,8 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_proper_response,
+    assert_proper_response_with_result,
 )
 from rotkehlchen.tests.utils.checks import assert_serialized_lists_equal
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -460,7 +460,7 @@ def test_query_current_dsr_balance(
             rotkehlchen_api_server,
             'makerdaodsrbalanceresource',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,
@@ -555,7 +555,7 @@ def test_query_historical_dsr(
             rotkehlchen_api_server,
             'makerdaodsrhistoryresource',
         ), json={'async_query': async_query})
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=rotkehlchen_api_server,
             async_query=async_query,

--- a/rotkehlchen/tests/api/test_makerdao_dsr.py
+++ b/rotkehlchen/tests/api/test_makerdao_dsr.py
@@ -19,10 +19,8 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response,
-    assert_proper_response_with_result,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.checks import assert_serialized_lists_equal
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -462,11 +460,11 @@ def test_query_current_dsr_balance(
             rotkehlchen_api_server,
             'makerdaodsrbalanceresource',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
 
     assert_dsr_current_result_is_correct(outcome, setup)
 
@@ -557,11 +555,11 @@ def test_query_historical_dsr(
             rotkehlchen_api_server,
             'makerdaodsrhistoryresource',
         ), json={'async_query': async_query})
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=rotkehlchen_api_server,
+            async_query=async_query,
+        )
 
     assert_dsr_history_result_is_correct(outcome, setup)
 

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -17,10 +17,9 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response,
     assert_proper_response_with_result,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.checks import (
     assert_serialized_dicts_equal,
@@ -223,15 +222,12 @@ def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         'makerdaovaultsresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        vaults = wait_for_async_task_with_result(
-            rotkehlchen_api_server,
-            task_id,
-            timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
-        )
-    else:
-        vaults = assert_proper_response_with_result(response)
+    vaults = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+        timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
+    )
 
     _check_vaults_values(vaults, ethereum_accounts[0])
 
@@ -239,15 +235,12 @@ def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         'makerdaovaultdetailsresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        details = wait_for_async_task_with_result(
-            rotkehlchen_api_server,
-            task_id,
-            timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
-        )
-    else:
-        details = assert_proper_response_with_result(response)
+    details = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+        timeout=ASYNC_TASK_WAIT_TIMEOUT * 3,
+    )
     _check_vault_details_values(
         details=details,
         total_interest_owed_list=[FVal('0.2810015984764')],

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -17,9 +17,9 @@ from rotkehlchen.tests.utils.api import (
     ASYNC_TASK_WAIT_TIMEOUT,
     api_url_for,
     assert_error_response,
-    assert_maybe_async_response_with_result,
     assert_proper_response,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.checks import (
     assert_serialized_dicts_equal,
@@ -222,7 +222,7 @@ def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         'makerdaovaultsresource',
     ), json={'async_query': async_query})
-    vaults = assert_maybe_async_response_with_result(
+    vaults = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -235,7 +235,7 @@ def test_query_vaults(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         'makerdaovaultdetailsresource',
     ), json={'async_query': async_query})
-    details = assert_maybe_async_response_with_result(
+    details = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,
@@ -263,7 +263,7 @@ def test_query_only_details_and_not_vaults(rotkehlchen_api_server, ethereum_acco
         rotkehlchen_api_server,
         'makerdaovaultdetailsresource',
     ))
-    details = assert_proper_response_with_result(response)
+    details = assert_proper_sync_response_with_result(response)
     _check_vault_details_values(
         details=details,
         total_interest_owed_list=[FVal('0.2810015984764')],
@@ -273,7 +273,7 @@ def test_query_only_details_and_not_vaults(rotkehlchen_api_server, ethereum_acco
         rotkehlchen_api_server,
         'makerdaovaultsresource',
     ))
-    vaults = assert_proper_response_with_result(response)
+    vaults = assert_proper_sync_response_with_result(response)
     _check_vaults_values(vaults, ethereum_accounts[0])
 
 
@@ -314,7 +314,7 @@ def test_query_vaults_details_liquidation(rotkehlchen_api_server, ethereum_accou
         rotkehlchen_api_server,
         'makerdaovaultsresource',
     ))
-    vaults = assert_proper_response_with_result(response)
+    vaults = assert_proper_sync_response_with_result(response)
     vault_6021 = {
         'identifier': 6021,
         'owner': ethereum_accounts[2],
@@ -414,7 +414,7 @@ def test_query_vaults_details_liquidation(rotkehlchen_api_server, ethereum_accou
             'tx_hash': '0xded0f9de641087692555d92a7fa94fa9fa7abf22744b2d16c20a66c5e48a8edf',
         }],
     }
-    details = assert_proper_response_with_result(response)
+    details = assert_proper_sync_response_with_result(response)
     assert len(details) >= 2
     assert_serialized_dicts_equal(vault_6021_details, details[0], ignore_keys=['stability_fee'])
     assert_serialized_dicts_equal(
@@ -445,7 +445,7 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
         'makerdaovaultsresource',
     ))
     # That proxy has 3 vaults. We only want to test 8913, which is closed/repaid so just keep that
-    vaults = [x for x in assert_proper_response_with_result(response) if x['identifier'] == 8913]
+    vaults = [x for x in assert_proper_sync_response_with_result(response) if x['identifier'] == 8913]  # noqa: E501
     vault_8913 = MakerdaoVault(
         identifier=8913,
         owner=ethereum_accounts[0],
@@ -512,7 +512,7 @@ def test_query_vaults_wbtc(rotkehlchen_api_server, ethereum_accounts):
             'tx_hash': '0x678c4da562173c102473f1904ff293a767ebac9ec6c7d728ef2fd41acf00a13a',
         }],  # way too many events in the vault, so no need to check them all
     }
-    details = assert_proper_response_with_result(response)
+    details = assert_proper_sync_response_with_result(response)
     assert len(details) == 1
     assert_serialized_dicts_equal(
         details[0],
@@ -537,7 +537,7 @@ def test_query_vaults_usdc(rotkehlchen_api_server, ethereum_accounts):
         rotkehlchen_api_server,
         'makerdaovaultsresource',
     ))
-    vaults = assert_proper_response_with_result(response)
+    vaults = assert_proper_sync_response_with_result(response)
     vault_7588 = MakerdaoVault(
         identifier=7588,
         owner=ethereum_accounts[0],
@@ -611,7 +611,7 @@ def test_query_vaults_usdc(rotkehlchen_api_server, ethereum_accounts):
             'tx_hash': '0x97462ebba7ce2467787bf6de25a25c24e538cf8a647919112c5f048b6a293408',
         }],
     }
-    details = assert_proper_response_with_result(response)
+    details = assert_proper_sync_response_with_result(response)
     expected_details = [vault_7588_details]
     assert_serialized_lists_equal(expected_details, details, ignore_keys=['liquidation_ratio'])
 
@@ -634,7 +634,7 @@ def test_two_vaults_same_account_same_collateral(rotkehlchen_api_server, ethereu
         rotkehlchen_api_server,
         'makerdaovaultsresource',
     ))
-    vaults = assert_proper_response_with_result(response)
+    vaults = assert_proper_sync_response_with_result(response)
     vault_8543 = {
         'identifier': 8543,
         'owner': ethereum_accounts[0],
@@ -780,7 +780,7 @@ def test_two_vaults_same_account_same_collateral(rotkehlchen_api_server, ethereu
             'tx_hash': '0x36bfa27e157c03393a8816f6c1e3e990474f8f7473413810d87e2f4981d58044',
         }],
     }
-    details = assert_proper_response_with_result(response)
+    details = assert_proper_sync_response_with_result(response)
     assert len(details) == 2
     assert_serialized_dicts_equal(details[0], vault_8543_details, ignore_keys=['stability_fee'])
     assert_serialized_dicts_equal(
@@ -816,7 +816,7 @@ def test_query_vaults_usdc_strange(rotkehlchen_api_server, ethereum_accounts):
         'makerdaovaultsresource',
     ))
     # That proxy has 3 vaults. We only want to test 7538, which is closed/repaid so just keep that
-    vaults = [x for x in assert_proper_response_with_result(response) if x['identifier'] == 7538]
+    vaults = [x for x in assert_proper_sync_response_with_result(response) if x['identifier'] == 7538]  # noqa: E501
     vault_7538 = MakerdaoVault(
         identifier=7538,
         owner=ethereum_accounts[0],
@@ -882,7 +882,7 @@ def test_query_vaults_usdc_strange(rotkehlchen_api_server, ethereum_accounts):
             'tx_hash': '0x678c4da562173c102473f1904ff293a767ebac9ec6c7d728ef2fd41acf00a13a',
         }],
     }
-    details = assert_proper_response_with_result(response)
+    details = assert_proper_sync_response_with_result(response)
     expected_details = [vault_7538_details]
     assert_serialized_lists_equal(expected_details, details)
 

--- a/rotkehlchen/tests/api/test_manually_tracked_balances.py
+++ b/rotkehlchen/tests/api/test_manually_tracked_balances.py
@@ -17,7 +17,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.constants import A_RDN
@@ -144,7 +144,7 @@ def _populate_initial_balances(api_server) -> list[dict[str, Any]]:
             'manuallytrackedbalancesresource',
         ), json={'balances': balances},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     expected_balances = []
     for new_id, balance in enumerate(balances, start=1):
         new_balance = balance.copy()
@@ -177,7 +177,7 @@ def test_add_and_query_manually_tracked_balances(
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     assert result['balances'] == [], 'In the beginning we should have no entries'
 
     balances = _populate_initial_balances(rotkehlchen_api_server)
@@ -194,7 +194,7 @@ def test_add_and_query_manually_tracked_balances(
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     assert_balances_match(expected_balances=balances, returned_balances=result['balances'])
 
     now = ts_now()
@@ -213,7 +213,7 @@ def test_add_and_query_manually_tracked_balances(
             outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
     assets = result['assets']
     assert len(assets) == 5
@@ -269,7 +269,7 @@ def test_add_manually_tracked_balances_no_price(rotkehlchen_api_server):
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     expected_balances = []
     for new_id, balance in enumerate(balances, start=1):
         new_balance = balance.copy()
@@ -292,7 +292,7 @@ def test_add_manually_tracked_balances_no_price(rotkehlchen_api_server):
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     assert_balances_match(
         expected_balances=expected_balances,
         returned_balances=result['balances'],
@@ -324,7 +324,7 @@ def test_edit_manually_tracked_balances(rotkehlchen_api_server):
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     expected_balances = balances_to_edit + balances[3:]
     assert_balances_match(
@@ -344,7 +344,7 @@ def test_edit_manually_tracked_balances(rotkehlchen_api_server):
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     assert_balances_match(
         expected_balances=expected_balances,
         returned_balances=result['balances'],
@@ -682,7 +682,7 @@ def test_delete_manually_tracked_balances(rotkehlchen_api_server):
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     assert_balances_match(
         expected_balances=expected_balances,
         returned_balances=result['balances'],
@@ -700,7 +700,7 @@ def test_delete_manually_tracked_balances(rotkehlchen_api_server):
         outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
     assert_balances_match(
         expected_balances=expected_balances,
         returned_balances=result['balances'],
@@ -795,7 +795,7 @@ def test_update_manual_balance_label(rotkehlchen_api_server):
             'balances': [balance_to_patch_1, balance_to_patch_2],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_balances_match(
         expected_balances=expected_balances,
         returned_balances=result['balances'],
@@ -807,7 +807,7 @@ def test_update_manual_balance_label(rotkehlchen_api_server):
             'manuallytrackedbalancesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_balances_match(
         expected_balances=expected_balances,
         returned_balances=result['balances'],

--- a/rotkehlchen/tests/api/test_messages.py
+++ b/rotkehlchen/tests/api/test_messages.py
@@ -4,7 +4,7 @@ import requests
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.history import mock_history_processing_and_exchanges
 from rotkehlchen.types import Location
@@ -27,7 +27,7 @@ def test_query_messages(rotkehlchen_api_server_with_exchanges):
     response = requests.get(
         api_url_for(rotkehlchen_api_server_with_exchanges, 'messagesresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     errors = result['errors']
     warnings = result['warnings']
     assert len(errors) == 0

--- a/rotkehlchen/tests/api/test_metadata.py
+++ b/rotkehlchen/tests/api/test_metadata.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
-import pytest
 
+import pytest
 import requests
 
 from rotkehlchen.chain.ethereum.defi.protocols import DEFI_PROTOCOLS
-from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_sync_response_with_result
 from rotkehlchen.types import SupportedBlockchain
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ def test_metadata_endpoint(rotkehlchen_api_server: 'APIServer') -> None:
     airdrops_response = requests.get(
         api_url_for(rotkehlchen_api_server, 'airdropsmetadataresource'),
     )
-    airdrops_result = assert_proper_response_with_result(airdrops_response)
+    airdrops_result = assert_proper_sync_response_with_result(airdrops_response)
     assert len(airdrops_result) == 22
     for res in airdrops_result:
         assert 'identifier' in res and isinstance(res['identifier'], str)
@@ -34,14 +34,14 @@ def test_metadata_endpoint(rotkehlchen_api_server: 'APIServer') -> None:
         for identifier, protocol in DEFI_PROTOCOLS.items()
     ]
     defi_response = requests.get(api_url_for(rotkehlchen_api_server, 'defimetadataresource'))
-    defi_result = assert_proper_response_with_result(defi_response)
+    defi_result = assert_proper_sync_response_with_result(defi_response)
     assert defi_result == defi_expected_result
 
     # testing the supported chains endpoint
     supported_chains_response = requests.get(
         api_url_for(rotkehlchen_api_server, 'supportedchainsresource'),
     )
-    supported_chains_result = assert_proper_response_with_result(supported_chains_response)
+    supported_chains_result = assert_proper_sync_response_with_result(supported_chains_response)
     for entry in SupportedBlockchain:
         for result_entry in supported_chains_result:
             if (

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -18,7 +18,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.types import ChainID, Location, SupportedBlockchain
 from rotkehlchen.utils.misc import get_system_spec
@@ -76,7 +76,7 @@ def test_query_info_version_when_up_to_date(rotkehlchen_api_server):
             ),
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == generate_expected_info(expected_version, rotki.data_dir)
 
     with version_patch, release_patch:
@@ -90,7 +90,7 @@ def test_query_info_version_when_up_to_date(rotkehlchen_api_server):
             },
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == generate_expected_info(expected_version, rotki.data_dir, latest_version=expected_version)  # noqa: E501
 
     with version_patch, release_patch, patch.dict(os.environ, {'ROTKI_ACCEPT_DOCKER_RISK': 'whatever'}):  # noqa: E501
@@ -101,7 +101,7 @@ def test_query_info_version_when_up_to_date(rotkehlchen_api_server):
             ),
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == generate_expected_info(
         expected_version=expected_version,
         data_dir=rotki.data_dir,
@@ -148,7 +148,7 @@ def test_query_version_when_update_required(rotkehlchen_api_server):
             },
         )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     our_version = get_system_spec()['rotkehlchen']
     assert result == generate_expected_info(
         expected_version=our_version,
@@ -168,7 +168,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 5
     for node in result:
         if node['name'] != ETHEREUM_ETHERSCAN_NODE_NAME:
@@ -188,7 +188,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert not any(node['name'] == 'cloudflare' for node in result)
 
     # now try to add it again
@@ -206,7 +206,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for node in result:
         if node['name'] == 'cloudflare':
             assert FVal(node['weight']) == 20
@@ -267,7 +267,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for node in result:
         if node['identifier'] == 4:
             assert FVal(node['weight']) == 20
@@ -294,7 +294,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for node in result:
         if node['identifier'] == 4:
             assert FVal(node['weight']) == 20
@@ -332,7 +332,7 @@ def test_manage_nodes(rotkehlchen_api_server):
             'active': True,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     # set owned to false and see that we have the expected amount of nodes
     response = requests.patch(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
@@ -349,7 +349,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     # Check that the rebalancing didn't get affected by the owned node
     for node in result:
         if node['name'] == 'anchor':
@@ -368,7 +368,7 @@ def test_manage_nodes(rotkehlchen_api_server):
             'active': True,
         },
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
 
     response = requests.patch(  # test that editing optimism etherscan weight works
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain='OPTIMISM'),
@@ -381,7 +381,7 @@ def test_manage_nodes(rotkehlchen_api_server):
             'active': True,
         },
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
 
     # try to delete normal etherscan and optimism etherscan and see it fails
     for identifier in (1, 6):
@@ -400,7 +400,7 @@ def test_manage_nodes(rotkehlchen_api_server):
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=blockchain_key),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for node in result:
         response = requests.patch(
             api_url_for(rotkehlchen_api_server, 'rpcnodesresource', blockchain=node['blockchain']),
@@ -420,7 +420,7 @@ def test_manage_nodes(rotkehlchen_api_server):
 def test_configuration(rotkehlchen_api_server):
     """Test that the configuration endpoint returns the expected information"""
     response = requests.get(api_url_for(rotkehlchen_api_server, 'configurationsresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['max_size_in_mb_all_logs']['value'] == 659
     assert result['max_size_in_mb_all_logs']['is_default'] is False
     assert result['max_logfiles_num']['is_default'] is True
@@ -431,7 +431,7 @@ def test_configuration(rotkehlchen_api_server):
 
 def test_query_all_chain_ids(rotkehlchen_api_server):
     response = requests.get(api_url_for(rotkehlchen_api_server, 'allevmchainsresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for chain in ChainID:
         name, label = chain.name_and_label()
         assert {'id': chain.value, 'name': name, 'label': label} in result
@@ -453,7 +453,7 @@ def test_events_mappings(rotkehlchen_api_server_with_exchanges):
             'typesmappingsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert 'global_mappings' in result
     assert result['entry_type_mappings'] == {
         'eth withdrawal event': {
@@ -479,7 +479,7 @@ def test_events_mappings(rotkehlchen_api_server_with_exchanges):
             'locationresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     excluded_locations = {Location.TOTAL}
     valid_locations = {location.serialize() for location in Location if location not in excluded_locations}  # noqa: E501
     assert set(result['locations'].keys()) == valid_locations
@@ -492,7 +492,7 @@ def test_events_mappings(rotkehlchen_api_server_with_exchanges):
             'evmproductsresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['mappings'][CPT_CONVEX] == [EvmProduct.GAUGE.serialize(), EvmProduct.STAKING.serialize()]  # noqa: E501
     assert result['mappings'][CPT_CURVE] == [EvmProduct.GAUGE.serialize()]
     assert result['products'] == [product.serialize() for product in EvmProduct]
@@ -507,7 +507,7 @@ def test_counterparties(rotkehlchen_api_server_with_exchanges):
             'evmcounterpartiesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for counterparty_details in result:
         assert 'identifier' in counterparty_details
         assert 'label' in counterparty_details

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -21,7 +21,7 @@ from rotkehlchen.tests.conftest import TestEnvironment, requires_env
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -149,7 +149,7 @@ def test_nft_query_after_account_add(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsresource',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     if len(result['addresses']) == 0:
         test_warnings.warn(UserWarning(f'Test account {TEST_ACC1} has no NFTs'))
@@ -170,7 +170,7 @@ def test_nft_query_after_account_add(rotkehlchen_api_server):
             'nftsresource',
         ), json={'ignore_cache': True},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert TEST_ACC1 in result['addresses']
     assert TEST_ACC2 in result['addresses']
 
@@ -187,7 +187,7 @@ def test_nft_ids_are_unique(rotkehlchen_api_server):
         'nftsresource',
     ), json={'async_query': False})
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     # get the ids from the query result
     ids_1 = [nft['token_identifier'] for nft in result['addresses'][TEST_ACC2]]
     ids_2 = [nft['token_identifier'] for nft in result['addresses'][TEST_ACC3]]
@@ -211,13 +211,13 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': False})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [], 'nothing should be returned with ignore_cache=False until nfts are queried'  # noqa: E501
     response = requests.get(api_url_for(
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': True})
-    result_ignored_cache = assert_proper_response_with_result(response)
+    result_ignored_cache = assert_proper_sync_response_with_result(response)
     assert result_ignored_cache['entries_found'] == 6
     for nft_balance in result_ignored_cache['entries']:
         if nft_balance['id'] == NFT_ID_FOR_TEST_ACC4:
@@ -257,7 +257,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': False})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == result_ignored_cache, 'after querying nfts should be returned even with ignore_cache=False'  # noqa: E501
 
     # Check that search by name works
@@ -265,7 +265,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': False, 'name': 'nebolax'})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 1
     assert result['entries'][0]['id'] == NFT_ID_FOR_TEST_ACC5
 
@@ -280,7 +280,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         'limit': 2,
         'offset': 2,
     })
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 6
     assert result['entries_total'] == 6
 
@@ -302,8 +302,8 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': True, 'ignored_assets_handling': 'none'})
-    result_with_cache = assert_proper_response_with_result(response_with_cache)
-    result_ignored_cache = assert_proper_response_with_result(response_ignored_cache)
+    result_with_cache = assert_proper_sync_response_with_result(response_with_cache)
+    result_ignored_cache = assert_proper_sync_response_with_result(response_ignored_cache)
     assert result_with_cache == result_ignored_cache
 
     # Check that filtering ignored nfts works
@@ -323,12 +323,12 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': False, 'ignored_assets_handling': 'exclude'})
-    result_with_cache = assert_proper_response_with_result(response_with_cache)
+    result_with_cache = assert_proper_sync_response_with_result(response_with_cache)
     response_ignored_cache = requests.get(api_url_for(
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': False, 'ignored_assets_handling': 'exclude'})
-    result_ignored_cache = assert_proper_response_with_result(response_ignored_cache)
+    result_ignored_cache = assert_proper_sync_response_with_result(response_ignored_cache)
     assert result_with_cache == result_ignored_cache
 
     # Check that the response is correct
@@ -340,7 +340,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftsbalanceresource',
     ), json={'async_query': False, 'ignore_cache': False, 'ignored_assets_handling': 'show only'})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 3
     assert result['entries_total'] == 6
     assert {entry['id'] for entry in result['entries']} == {
@@ -353,7 +353,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftspricesresource',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for nft in result:
         if nft['asset'] == NFT_ID_FOR_TEST_ACC5:
             expected_result = {
@@ -374,7 +374,7 @@ def test_nft_balances_and_prices(rotkehlchen_api_server):
     ), json={
         'identifiers': [NFT_ID_FOR_TEST_ACC4],
     })
-    result = assert_proper_response_with_result(response)['assets'][NFT_ID_FOR_TEST_ACC4]
+    result = assert_proper_sync_response_with_result(response)['assets'][NFT_ID_FOR_TEST_ACC4]
     assert result == {
         'name': 'yabir.eth',
         'asset_type': 'nft',
@@ -411,7 +411,7 @@ def test_edit_delete_nft(rotkehlchen_api_server):
             ),
             json={'async_query': False, 'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['entries_found'] == 2
         assert result['entries'][1]['price_in_asset'] == '0.0012'
         assert result['entries'][1]['image_url'] == 'https://openseauserdata.com/files/8fd18b22e4c81aff3998956e7a712d93.svg'
@@ -454,7 +454,7 @@ def test_edit_delete_nft(rotkehlchen_api_server):
             ),
             json={'async_query': False, 'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['entries_found'] == 2
         assert result['entries'][1]['price_in_asset'] == '0.5'
         assert result['entries'][1]['image_url'] == 'https://openseauserdata.com/files/3f7c0c7d1ba51e61fe05ef53875f9f7e.svg'
@@ -481,7 +481,7 @@ def test_edit_delete_nft(rotkehlchen_api_server):
             ),
             json={'async_query': False, 'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['entries_found'] == 1 and result['entries'][0]['name'] == 'yabir.eth'
 
         # Also check that db was updated properly
@@ -513,7 +513,7 @@ def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
         ),
         json={'assets': [NFT_ID_FOR_TEST_ACC4]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert NFT_ID_FOR_TEST_ACC4 in result['successful']
 
     # query the nfts endpoint and verify that the nft is not present
@@ -525,7 +525,7 @@ def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
             ),
             json={'async_query': False},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         if endpoint == 'nftsresource':
             all_nfts_ids = {nft['token_identifier'] for nft in result['addresses'][TEST_ACC4]}
             assert NFT_ID_FOR_TEST_ACC4 not in all_nfts_ids
@@ -545,7 +545,7 @@ def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
         ),
         json={'assets': [NFT_ID_FOR_TEST_ACC4]},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['successful'] == [NFT_ID_FOR_TEST_ACC4]
 
     # query the nfts endpoint again and verify that the nft is present
@@ -557,7 +557,7 @@ def test_nfts_ignoring_works(rotkehlchen_api_server, endpoint):
             ),
             json={'async_query': False, 'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         if endpoint == 'nftsresource':
             all_nfts_ids = {nft['token_identifier'] for nft in result['addresses'][TEST_ACC4]}
         else:
@@ -628,7 +628,7 @@ def test_nft_no_price(rotkehlchen_api_server):
                 'nftsbalanceresource',
             ), json={'ignore_cache': True},
         )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {
         'entries': [
             {
@@ -781,7 +781,7 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
             ),
             json={'async_query': False, 'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['entries_found'] == 4
 
     # test that only lp works
@@ -796,7 +796,7 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
             'lps_handling': NftLpHandling.ONLY_LPS.serialize(),
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 2
     for entry in result['entries']:
         assert entry['is_lp'] is True
@@ -814,7 +814,7 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
             'name': 'yabir',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 1
 
     # test the handling in the prices endpoint
@@ -822,7 +822,7 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftspricesresource',
     ), json={'lps_handling': NftLpHandling.ONLY_LPS.serialize()})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     for nft in result:
         assert nft['asset'] in (NFT_ID_FOR_TEST_ACC6_1, NFT_ID_FOR_TEST_ACC6_2)
 
@@ -830,7 +830,7 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftspricesresource',
     ), json={'lps_handling': NftLpHandling.EXCLUDE_LPS.serialize()})
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 2
     for nft in result:
         assert nft['asset'] not in (NFT_ID_FOR_TEST_ACC6_1, NFT_ID_FOR_TEST_ACC6_2)
@@ -839,7 +839,7 @@ def test_lp_nfts_filtering(rotkehlchen_api_server):
         rotkehlchen_api_server,
         'nftspricesresource',
     ))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 4
 
 
@@ -869,7 +869,7 @@ def test_customized_queried_addresses(rotkehlchen_api_server):
             ),
             json={'async_query': False, 'ignore_cache': True},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['entries_found'] == 2
 
     # Make NFTs queried for only one of the addresses
@@ -884,5 +884,5 @@ def test_customized_queried_addresses(rotkehlchen_api_server):
         ),
         json={'async_query': False, 'ignore_cache': False},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1 and result['entries'][0]['name'] == TEST_NFT_NEBOLAX_ETH.name  # noqa: E501

--- a/rotkehlchen/tests/api/test_periodic.py
+++ b/rotkehlchen/tests/api/test_periodic.py
@@ -1,11 +1,11 @@
 import pytest
 import requests
-from rotkehlchen.db.cache import DBCacheStatic
 
+from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
 from rotkehlchen.types import Location
@@ -33,7 +33,7 @@ def test_query_periodic(rotkehlchen_api_server_with_exchanges):
     response = requests.get(
         api_url_for(rotkehlchen_api_server_with_exchanges, 'periodicdataresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 3
     assert result[DBCacheStatic.LAST_BALANCE_SAVE.value] >= start_ts
     connected_nodes = result['connected_nodes']

--- a/rotkehlchen/tests/api/test_pickle.py
+++ b/rotkehlchen/tests/api/test_pickle.py
@@ -3,7 +3,7 @@ import random
 import pytest
 import requests
 
-from rotkehlchen.tests.utils.api import api_url_for, assert_maybe_async_response_with_result
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
 
 PICKLE_ADDR = '0x5c4D8CEE7dE74E31cE69E76276d862180545c307'
 
@@ -23,7 +23,7 @@ def test_pickle_dill(
         rotkehlchen_api_server,
         'pickledillresource',
     ), json={'async_query': async_query})
-    result = assert_maybe_async_response_with_result(
+    result = assert_proper_response_with_result(
         response=response,
         rotkehlchen_api_server=rotkehlchen_api_server,
         async_query=async_query,

--- a/rotkehlchen/tests/api/test_pickle.py
+++ b/rotkehlchen/tests/api/test_pickle.py
@@ -3,12 +3,7 @@ import random
 import pytest
 import requests
 
-from rotkehlchen.tests.utils.api import (
-    api_url_for,
-    assert_ok_async_response,
-    assert_proper_response_with_result,
-    wait_for_async_task_with_result,
-)
+from rotkehlchen.tests.utils.api import api_url_for, assert_maybe_async_response_with_result
 
 PICKLE_ADDR = '0x5c4D8CEE7dE74E31cE69E76276d862180545c307'
 
@@ -28,11 +23,11 @@ def test_pickle_dill(
         rotkehlchen_api_server,
         'pickledillresource',
     ), json={'async_query': async_query})
-    if async_query:
-        task_id = assert_ok_async_response(response)
-        result = wait_for_async_task_with_result(rotkehlchen_api_server, task_id)
-    else:
-        result = assert_proper_response_with_result(response)
+    result = assert_maybe_async_response_with_result(
+        response=response,
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=async_query,
+    )
 
     assert PICKLE_ADDR in result
     data = result[PICKLE_ADDR]

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -19,7 +19,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.constants import A_JPY
@@ -538,7 +538,7 @@ def test_queried_addresses_per_protocol(rotkehlchen_api_server):
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'queriedaddressesresource'), json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'aave': [address1]}
 
     address2 = make_evm_address()
@@ -546,7 +546,7 @@ def test_queried_addresses_per_protocol(rotkehlchen_api_server):
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'queriedaddressesresource'), json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_queried_addresses_match(result, {
         'aave': [address1],
         'makerdao_vaults': [address2],
@@ -557,7 +557,7 @@ def test_queried_addresses_per_protocol(rotkehlchen_api_server):
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'queriedaddressesresource'), json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_queried_addresses_match(result, {
         'aave': [address1, address2],
         'makerdao_vaults': [address2],
@@ -580,7 +580,7 @@ def test_queried_addresses_per_protocol(rotkehlchen_api_server):
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'queriedaddressesresource'), json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_queried_addresses_match(result, {
         'aave': [address1, address2],
         'makerdao_vaults': [address2],
@@ -590,7 +590,7 @@ def test_queried_addresses_per_protocol(rotkehlchen_api_server):
     response = requests.delete(
         api_url_for(rotkehlchen_api_server, 'queriedaddressesresource'), json=data,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_queried_addresses_match(result, {
         'aave': [address1, address2],
         'makerdao_vaults': [address2],
@@ -609,7 +609,7 @@ def test_queried_addresses_per_protocol(rotkehlchen_api_server):
 
     # test that getting the queried addresses per module works
     response = requests.get(api_url_for(rotkehlchen_api_server, 'queriedaddressesresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert_queried_addresses_match(result, {
         'aave': [address1, address2],
         'makerdao_vaults': [address2],

--- a/rotkehlchen/tests/api/test_skipped_events.py
+++ b/rotkehlchen/tests/api/test_skipped_events.py
@@ -12,7 +12,7 @@ from rotkehlchen.assets.types import AssetType
 from rotkehlchen.constants import ONE
 from rotkehlchen.tests.utils.api import (
     api_url_for,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.exchanges import try_get_first_exchange
@@ -96,7 +96,7 @@ def test_skipped_external_events(rotkehlchen_api_server_with_exchanges, globaldb
             'stakingresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 0
 
     with rotki.data.db.user_write() as write_cursor:
@@ -122,7 +122,7 @@ def test_skipped_external_events(rotkehlchen_api_server_with_exchanges, globaldb
             'to_timestamp': 1640493378,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     events = result['entries']
     assert len(events) == 1, 'only 1 event should have been found now and rest written to skipped'
 
@@ -130,7 +130,7 @@ def test_skipped_external_events(rotkehlchen_api_server_with_exchanges, globaldb
     response = requests.get(
         api_url_for(server, 'historyskippedexternaleventresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['total'] == 6  # 5 is due to +2 unknown assets set up during fixture
     assert result['locations']['kraken'] == 6
     assert len(result['locations']) == 1
@@ -171,13 +171,13 @@ def test_skipped_external_events(rotkehlchen_api_server_with_exchanges, globaldb
     response = requests.post(
         api_url_for(server, 'historyskippedexternaleventresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['total'] == 6
     assert result['successful'] == 4
     response = requests.get(
         api_url_for(server, 'historyskippedexternaleventresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['total'] == 2, 'only 2 skipped events should be left'
     assert result['locations']['kraken'] == 2, 'only 2 skipped events should be left'
     assert len(result['locations']) == 1
@@ -193,6 +193,6 @@ def test_skipped_external_events(rotkehlchen_api_server_with_exchanges, globaldb
             'to_timestamp': 1640493378,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     events = result['entries']
     assert len(events) == 3

--- a/rotkehlchen/tests/api/test_snapshots.py
+++ b/rotkehlchen/tests/api/test_snapshots.py
@@ -28,7 +28,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.types import Location, Timestamp
@@ -723,7 +723,7 @@ def test_get_snapshot_json(rotkehlchen_api_server):
             timestamp=ts,
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['balances_snapshot']) == 2
     assert len(result['location_data_snapshot']) == 3
 
@@ -789,7 +789,7 @@ def test_edit_snapshot(rotkehlchen_api_server):
             timestamp=ts,
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['balances_snapshot']) == 2
     assert len(result['location_data_snapshot']) == 2
     assert result == snapshot_payload
@@ -838,7 +838,7 @@ def test_edit_snapshot(rotkehlchen_api_server):
             timestamp=ts,
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['balances_snapshot']) == 2
     assert len(result['location_data_snapshot']) == 2
     assert result == snapshot_payload

--- a/rotkehlchen/tests/api/test_statistics.py
+++ b/rotkehlchen/tests/api/test_statistics.py
@@ -15,7 +15,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.balances import get_asset_balance_total
 from rotkehlchen.tests.utils.constants import A_RDN
@@ -59,7 +59,7 @@ def test_query_statistics_netvalue(
         ),
     )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result) == 2
     assert len(result['times']) == 1
     assert len(result['data']) == 1
@@ -102,7 +102,7 @@ def test_query_statistics_asset_balance(
         json={'asset': 'ETH'},
     )
     if start_with_valid_premium:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert len(result) == 1
         entry = result[0]
         assert len(entry) == 4
@@ -125,7 +125,7 @@ def test_query_statistics_asset_balance(
         ), json={'from_timestamp': 0, 'to_timestamp': start_time + 60000, 'asset': 'BTC'},
     )
     if start_with_valid_premium:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert len(result) == 1
         entry = result[0]
         assert len(entry) == 4
@@ -148,7 +148,7 @@ def test_query_statistics_asset_balance(
         ), json={'from_timestamp': 0, 'to_timestamp': start_time - 1, 'asset': 'BTC'},
     )
     if start_with_valid_premium:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert len(result) == 0
     else:
         assert_error_response(
@@ -271,7 +271,7 @@ def test_query_statistics_value_distribution(
     def assert_okay_by_location(response):
         """Helper function to run next query and its assertion twice"""
         if start_with_valid_premium:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
             assert len(result) == 6
             locations = {'poloniex', 'binance', 'banks', 'blockchain', 'total', 'kraken'}
             for entry in result:
@@ -313,7 +313,7 @@ def test_query_statistics_value_distribution(
         ), json={'distribution_by': 'asset'},
     )
     if start_with_valid_premium:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         if db_settings['treat_eth2_as_eth'] is True:
             assert len(result) == 4
             totals = {
@@ -415,7 +415,7 @@ def test_query_statistics_renderer(rotkehlchen_api_server, start_with_valid_prem
             ),
         )
     if start_with_valid_premium:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result == 'codegoeshere'
     else:
         assert_error_response(

--- a/rotkehlchen/tests/api/test_substrate_manager.py
+++ b/rotkehlchen/tests/api/test_substrate_manager.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 
 from rotkehlchen.chain.substrate.types import KusamaNodeName
-from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_sync_response_with_result
 from rotkehlchen.tests.utils.substrate import KUSAMA_TEST_RPC_ENDPOINT
 
 
@@ -30,7 +30,7 @@ def test_set_unset_own_rpc_endpoint(rotkehlchen_api_server):
     )
 
     # Check settings response
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['ksm_rpc_endpoint'] == KUSAMA_TEST_RPC_ENDPOINT
 
     # Check SubstrateManager instance
@@ -47,7 +47,7 @@ def test_set_unset_own_rpc_endpoint(rotkehlchen_api_server):
     )
 
     # Check settings response
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['ksm_rpc_endpoint'] == ''
 
     # Check SubstrateManager instance

--- a/rotkehlchen/tests/api/test_sushiswap.py
+++ b/rotkehlchen/tests/api/test_sushiswap.py
@@ -14,7 +14,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.ethereum import INFURA_ETH_NODE, get_decoded_events_of_transaction
@@ -74,7 +74,7 @@ def test_get_balances(
         assert outcome['message'] == ''
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     address_balances = result[ethereum_accounts[0]]
     for lp in address_balances:
@@ -160,7 +160,7 @@ def test_get_events_history_filtering_by_timestamp(rotkehlchen_api_server: 'APIS
         assert outcome['message'] == ''
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     events_balances = result[TEST_EVENTS_ADDRESS_1]
 

--- a/rotkehlchen/tests/api/test_tags.py
+++ b/rotkehlchen/tests/api/test_tags.py
@@ -7,7 +7,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, UNIT_BTC_ADDRESS2
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
@@ -744,7 +744,7 @@ def test_delete_all_tags(rotkehlchen_api_server):
             blockchain='BTC',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['standalone'][0]['tags'] is None  # Should have been deleted
     with rotki.data.db.conn.read_ctx() as cursor:
         # Also check that the tag mapping is gone from the db

--- a/rotkehlchen/tests/api/test_uniswap.py
+++ b/rotkehlchen/tests/api/test_uniswap.py
@@ -18,7 +18,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.constants import A_DOLLAR_BASED
@@ -99,7 +99,7 @@ def test_get_balances(
         assert outcome['message'] == ''
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     address_balances = result[LP_HOLDER_ADDRESS]
     for lp in address_balances:
@@ -211,7 +211,7 @@ def test_get_events_history_filtering_by_timestamp(
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
     events_balances = result[ethereum_accounts[0]]
     assert len(events_balances) == 1
@@ -235,7 +235,7 @@ def test_get_v3_balances_premium(rotkehlchen_api_server):
             version='3',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     if LP_V3_HOLDER_ADDRESS not in result or len(result[LP_V3_HOLDER_ADDRESS]) == 0:
         test_warnings.warn(
@@ -288,7 +288,7 @@ def test_get_v3_balances_no_premium(rotkehlchen_api_server):
             version='3',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
 
     if LP_V3_HOLDER_ADDRESS not in result or len(result[LP_V3_HOLDER_ADDRESS]) == 0:
         test_warnings.warn(

--- a/rotkehlchen/tests/api/test_user_assets.py
+++ b/rotkehlchen/tests/api/test_user_assets.py
@@ -29,7 +29,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_response,
     assert_ok_async_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
     wait_for_async_task,
 )
@@ -59,7 +59,7 @@ def test_add_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist):  # p
         ),
         json=user_asset1,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset1_id = result['identifier']
 
     data = globaldb.get_asset_data(identifier=user_asset1_id, form_with_incomplete_data=False)
@@ -86,7 +86,7 @@ def test_add_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist):  # p
         ),
         json=user_asset2,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset2_id = result['identifier']
 
     data = globaldb.get_asset_data(identifier=user_asset2_id, form_with_incomplete_data=False)
@@ -251,7 +251,7 @@ def test_editing_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist): 
         ),
         json=user_asset1,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset1_id = result['identifier']
 
     data = globaldb.get_asset_data(identifier=user_asset1_id, form_with_incomplete_data=False)
@@ -279,7 +279,7 @@ def test_editing_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist): 
         ),
         json=user_asset1_v2,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result is True
 
     data = globaldb.get_asset_data(identifier=user_asset1_id, form_with_incomplete_data=False)
@@ -444,7 +444,7 @@ def test_deleting_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist):
         ),
         json=user_asset1,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset1_id = result['identifier']
 
     user_asset2 = {
@@ -464,7 +464,7 @@ def test_deleting_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist):
         ),
         json=user_asset2,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset2_id = result['identifier']
 
     user_asset3 = {
@@ -479,7 +479,7 @@ def test_deleting_user_assets(rotkehlchen_api_server, globaldb, cache_coinlist):
         ),
         json=user_asset3,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset3_id = result['identifier']
 
     # Delete user asset 3 and assert it works
@@ -551,7 +551,7 @@ def test_user_asset_delete_guard(rotkehlchen_api_server):
         ),
         json=user_asset1,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset1_id = result['identifier']
     with user_db.user_write() as cursor:
         user_db.add_manually_tracked_balances(cursor, [ManuallyTrackedBalance(
@@ -589,7 +589,7 @@ def test_query_asset_types(rotkehlchen_api_server):
             'assetstypesresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == [str(x) for x in AssetType if x not in ASSET_TYPES_EXCLUDED_FOR_USERS]
     assert all(isinstance(AssetType.deserialize(x), AssetType) for x in result)
 
@@ -617,7 +617,7 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
         ),
         json=user_asset1,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset1_id = result['identifier']
 
     if only_in_globaldb:
@@ -642,7 +642,7 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
                 'manuallytrackedbalancesresource',
             ), json={'async_query': False, 'balances': balances},
         )
-        assert_proper_response_with_result(response)
+        assert_proper_sync_response_with_result(response)
 
     # before the replacement. Check that we got a globaldb entry in owned assets
     global_cursor = globaldb.conn.cursor()
@@ -661,7 +661,7 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
                 'manuallytrackedbalancesresource',
             ), json={'async_query': False},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result['balances'] == expected_balances
         assert cursor.execute(
             'SELECT COUNT(*) from manually_tracked_balances WHERE asset=?;',
@@ -694,7 +694,7 @@ def test_replace_asset(rotkehlchen_api_server, globaldb, only_in_globaldb):
                 'manuallytrackedbalancesresource',
             ), json={'async_query': False},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         expected_balances[0]['asset'] = 'ICP'
         assert result['balances'] == expected_balances
         # check the previous asset is not in userdb anymore
@@ -764,7 +764,7 @@ def test_replace_asset_not_in_globaldb(rotkehlchen_api_server, globaldb):
             'manuallytrackedbalancesresource',
         ), json={'async_query': False},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['balances'] == [{
         'identifier': 1,
         'asset': 'ICP',
@@ -826,7 +826,7 @@ def test_replace_asset_edge_cases(rotkehlchen_api_server, globaldb):
         ),
         json=user_asset,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     user_asset_id = result['identifier']
 
     # Test that trying to replace an asset that's used as a foreign key elsewhere in
@@ -845,7 +845,7 @@ def test_replace_asset_edge_cases(rotkehlchen_api_server, globaldb):
             'manuallytrackedbalancesresource',
         ), json={'async_query': False, 'balances': balances},
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
     global_cursor = globaldb.conn.cursor()
 
     def assert_db() -> None:
@@ -975,7 +975,7 @@ def test_exporting_user_assets_list(
             )
 
         if with_custom_path:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
             if with_custom_path:
                 assert path in result['file']
             zip_file = ZipFile(result['file'])
@@ -1017,7 +1017,7 @@ def test_exporting_user_assets_list(
                 'userassetsresource',
             ), json={'action': 'download', 'destination': path},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
@@ -1062,7 +1062,7 @@ def test_importing_user_assets_list(
     errors = rotki.msg_aggregator.consume_errors()
     assert len(errors) == 0
 
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
     stinch = EvmToken('eip155:1/erc20:0xA0446D8804611944F1B527eCD37d7dcbE442caba')
     assert stinch.symbol == 'st1INCH'
     assert len(stinch.underlying_tokens) == 1

--- a/rotkehlchen/tests/api/test_user_evm_tokens.py
+++ b/rotkehlchen/tests/api/test_user_evm_tokens.py
@@ -18,7 +18,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.constants import A_MKR
 from rotkehlchen.tests.utils.factories import make_evm_address
@@ -60,7 +60,7 @@ def test_query_user_tokens(rotkehlchen_api_server):
         ),
         json={'address': user_token_address1, 'evm_chain': ChainID.ETHEREUM.to_name()},
     )
-    result = assert_proper_response_with_result(response)['entries'][0]
+    result = assert_proper_sync_response_with_result(response)['entries'][0]
     expected_result = expected_tokens[0].to_dict()
     expected_result['identifier'] = ethaddress_to_identifier(user_token_address1)
     assert result == expected_result
@@ -73,7 +73,7 @@ def test_query_user_tokens(rotkehlchen_api_server):
         ),
         json={'asset_type': 'evm token'},
     )
-    result = assert_proper_response_with_result(response)['entries']
+    result = assert_proper_sync_response_with_result(response)['entries']
     expected_result = [x.to_dict() for x in expected_tokens]
     assert_token_entry_exists_in_result(result, expected_result)
     # This check is to make sure the sqlite query works correctly and queries only for tokens
@@ -88,7 +88,7 @@ def test_query_user_tokens(rotkehlchen_api_server):
         ),
         json={'address': unknown_address, 'evm_chain': ChainID.ETHEREUM.to_name()},
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 0
 
 
@@ -114,7 +114,7 @@ def test_adding_user_tokens(rotkehlchen_api_server, cache_coinlist):  # pylint: 
         ),
         json=serialized_token,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result == {'identifier': USER_TOKEN3.identifier}
 
     response = requests.post(
@@ -124,7 +124,7 @@ def test_adding_user_tokens(rotkehlchen_api_server, cache_coinlist):  # pylint: 
         ),
         json={'asset_type': 'evm token'},
     )
-    result = assert_proper_response_with_result(response)['entries']
+    result = assert_proper_sync_response_with_result(response)['entries']
     expected_tokens = expected_tokens.copy() + [
         USER_TOKEN3,
         EvmToken.initialize(
@@ -339,7 +339,7 @@ def test_editing_user_tokens(rotkehlchen_api_server, cache_coinlist):  # pylint:
         ),
         json={'asset_type': 'evm token'},
     )
-    result = assert_proper_response_with_result(response)['entries']
+    result = assert_proper_sync_response_with_result(response)['entries']
     expected_tokens = deepcopy(expected_tokens)
     object.__setattr__(expected_tokens[0], 'name', new_name)
     object.__setattr__(expected_tokens[0], 'symbol', new_symbol)
@@ -444,7 +444,7 @@ def test_deleting_user_tokens(rotkehlchen_api_server):
         ),
         json={'asset_type': 'evm token'},
     )
-    result = assert_proper_response_with_result(response)['entries']
+    result = assert_proper_sync_response_with_result(response)['entries']
     expected_tokens = initial_expected_tokens[:-1]
     expected_result = [x.to_dict() for x in expected_tokens]
     assert_token_entry_exists_in_result(result, expected_result)
@@ -500,7 +500,7 @@ def test_deleting_user_tokens(rotkehlchen_api_server):
         ),
         json={'address': initial_tokens[0].evm_address, 'evm_chain': ChainID.ETHEREUM.to_name()},
     )
-    result = assert_proper_response_with_result(response)['entries'][0]
+    result = assert_proper_sync_response_with_result(response)['entries'][0]
     assert result['swapped_for'] == A_MKR.identifier
 
     # test that trying to delete a token (MKR) that is used as swapped_for
@@ -534,7 +534,7 @@ def test_deleting_user_tokens(rotkehlchen_api_server):
         ),
         json={'asset_type': 'evm token'},
     )
-    result = assert_proper_response_with_result(response)['entries']
+    result = assert_proper_sync_response_with_result(response)['entries']
     expected_tokens = initial_expected_tokens[2:-1]
     expected_result = [x.to_dict() for x in expected_tokens]
     assert_token_entry_exists_in_result(result, expected_result)
@@ -607,7 +607,7 @@ def test_add_non_ethereum_token(rotkehlchen_api_server):
             'underlying_tokens': None,
         },
     )
-    identifier = assert_proper_response_with_result(response)['identifier']
+    identifier = assert_proper_sync_response_with_result(response)['identifier']
     assert identifier == 'eip155:56/erc20:0xC88eA7a5df3A7BA59C72393C5b2dc2CE260ff04D'
     token = EvmToken(identifier)
     assert token.name == 'Some random name'
@@ -692,7 +692,7 @@ def test_adding_evm_token_with_underlying_token(rotkehlchen_api_server, cache_co
         ),
         json=payload,
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['identifier'] == token_identifier
 
     response = requests.post(
@@ -704,7 +704,7 @@ def test_adding_evm_token_with_underlying_token(rotkehlchen_api_server, cache_co
             'identifiers': [token_identifier],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     underlying_tokens = [
         {
             'address': '0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4',
@@ -749,7 +749,7 @@ def test_adding_evm_token_with_underlying_token(rotkehlchen_api_server, cache_co
             'limit': 2,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 2
     assert result['entries'][1]['underlying_tokens'] == underlying_tokens
     assert len(result['entries'][0]['underlying_tokens']) == 2
@@ -767,7 +767,7 @@ def test_adding_evm_token_with_underlying_token(rotkehlchen_api_server, cache_co
             'ascending': [True],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 2
     assert result['entries'][0]['underlying_tokens'] == [
         {

--- a/rotkehlchen/tests/api/test_user_notes.py
+++ b/rotkehlchen/tests/api/test_user_notes.py
@@ -9,7 +9,7 @@ from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
     assert_proper_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
 )
 from rotkehlchen.tests.utils.factories import make_random_user_notes, make_user_notes_entries
@@ -28,7 +28,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
             'is_pinned': True,
         },
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert result == 1
 
     # try adding more user notes
@@ -44,7 +44,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
             'is_pinned': False,
         },
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert result == 2
     response = requests.put(
         api_url_for(
@@ -58,7 +58,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
             'is_pinned': True,
         },
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert result == 3
 
     # check that a total of user notes are in the db.
@@ -68,7 +68,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
             'usernotesresource',
         ),
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert len(result['entries']) == 3
 
     # check that filtering by title substring works
@@ -79,7 +79,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
         ),
         json={'title_substring': '3'},
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert result['entries_found'] == 1
     assert len(result['entries']) == 1
 
@@ -91,7 +91,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
         ),
         json={'location': 'trades'},
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert result['entries_found'] == 1
     assert result['entries_total'] == 3
     assert result['entries'][0]['location'] == 'trades'
@@ -107,7 +107,7 @@ def test_add_get_user_notes(rotkehlchen_api_server):
             'ascending': [False, True],
         },
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert len(result['entries']) == 3
     assert result['entries'][0]['title'] == '#1'
     assert result['entries'][1]['title'] == '#3'
@@ -206,7 +206,7 @@ def test_delete_user_notes(rotkehlchen_api_server):
             'usernotesresource',
         ),
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
     assert result['entries_found'] == 2
 
     # check that deleting a user note that is deleted already fails.
@@ -248,7 +248,7 @@ def test_premium_limits(rotkehlchen_api_server, start_with_valid_premium):
             'ascending': [False, True],
         },
     )
-    result = assert_proper_response_with_result(response, status_code=HTTPStatus.OK)
+    result = assert_proper_sync_response_with_result(response, status_code=HTTPStatus.OK)
 
     if start_with_valid_premium is False:
         assert result['entries_limit'] == FREE_USER_NOTES_LIMIT

--- a/rotkehlchen/tests/api/test_users.py
+++ b/rotkehlchen/tests/api/test_users.py
@@ -23,7 +23,7 @@ from rotkehlchen.tests.utils.api import (
     assert_error_async_response,
     assert_error_response,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     assert_simple_ok_response,
     wait_for_async_task,
     wait_for_async_task_with_result,
@@ -59,7 +59,7 @@ def check_user_status(api_server: APIServer) -> dict[str, str]:
     response = requests.get(
         api_url_for(api_server, 'usersresource'),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     return result
 
 
@@ -70,7 +70,7 @@ def test_loggedin_user_querying(rotkehlchen_api_server: APIServer, username: str
     user_dir.mkdir(exist_ok=True)
     (user_dir / USERDB_NAME).touch()
     response = requests.get(api_url_for(rotkehlchen_api_server, 'usersresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result[username] == 'loggedin'
     assert result['another_user'] == 'loggedout'
     assert len(result) == 2
@@ -92,7 +92,7 @@ def test_not_loggedin_user_querying(
     (user_dir / USERDB_NAME).touch()
 
     response = requests.get(api_url_for(rotkehlchen_api_server, 'usersresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result[username] == 'loggedout'
     assert result['another_user'] == 'loggedout'
     assert len(result) == 2
@@ -117,13 +117,13 @@ def test_user_creation(rotkehlchen_api_server, data_dir):
                 outcome = wait_for_async_task(rotkehlchen_api_server, task_id)
                 result = outcome['result']
             else:
-                result = assert_proper_response_with_result(response)
+                result = assert_proper_sync_response_with_result(response)
 
         check_proper_unlock_result(result, {'submit_usage_analytics': True})
 
         # Query users and make sure the new user is logged in
         response = requests.get(api_url_for(rotkehlchen_api_server, 'usersresource'))
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert result[username] == 'loggedin'
         assert len(result) == idx + 1
 
@@ -155,12 +155,12 @@ def test_user_creation_with_no_analytics(rotkehlchen_api_server, data_dir):
     with ExitStack() as stack:
         patch_no_op_unlock(rotki, stack, should_mock_settings=False)
         response = requests.put(api_url_for(rotkehlchen_api_server, 'usersresource'), json=data)
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         check_proper_unlock_result(result, {'submit_usage_analytics': False})
 
     # Query users and make sure the new user is logged in
     response = requests.get(api_url_for(rotkehlchen_api_server, 'usersresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result[username] == 'loggedin'
     assert len(result) == 1
 
@@ -221,12 +221,12 @@ def test_user_creation_with_premium_credentials(rotkehlchen_api_server, data_dir
     with patched_premium_at_start, ExitStack() as stack:
         patch_no_op_unlock(rotki, stack)
         response = requests.put(api_url_for(rotkehlchen_api_server, 'usersresource'), json=data)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     check_proper_unlock_result(result)
 
     # Query users and make sure the new user is logged in
     response = requests.get(api_url_for(rotkehlchen_api_server, 'usersresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result[username] == 'loggedin'
     assert len(result) == 1
 
@@ -305,12 +305,12 @@ def test_user_creation_with_invalid_premium_credentials(rotkehlchen_api_server, 
     with ExitStack() as stack:
         patch_no_op_unlock(rotki, stack)
         response = requests.put(api_url_for(rotkehlchen_api_server, 'usersresource'), json=data)
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     check_proper_unlock_result(result)
 
     # Query users and make sure the new user is logged in
     response = requests.get(api_url_for(rotkehlchen_api_server, 'usersresource'))
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result[username] == 'loggedin'
     assert len(result) == 2
 

--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -10,7 +10,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_ok_async_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
     wait_for_async_task,
 )
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
@@ -38,7 +38,7 @@ def test_query_yearn_vault_balances(rotkehlchen_api_server):
         assert outcome['message'] == ''
         result = outcome['result']
     else:
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
 
     for vault in result[TEST_ACC1].values():
         assert '%' in vault['roi']
@@ -79,7 +79,7 @@ def test_query_yearn_vault_v2_balances(rotkehlchen_api_server, ethereum_accounts
             assert outcome['message'] == ''
             result = outcome['result']
         else:
-            result = assert_proper_response_with_result(response)
+            result = assert_proper_sync_response_with_result(response)
 
     for vault in result[TEST_V2_ACC2].values():
         assert '%' in vault['roi']

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -46,7 +46,7 @@ from rotkehlchen.serialization.deserialize import deserialize_timestamp_from_flo
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
-    assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.constants import (
     A_AUD,
@@ -837,7 +837,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'stakingresource',
         ),
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 0
 
     with rotki.data.db.user_write() as write_cursor:
@@ -863,7 +863,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
         },
     )
 
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     events = result['entries']
 
     assert len(events) == 3
@@ -899,7 +899,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'limit': 1,
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 1
     assert set(result['assets']) == {'ETH', 'ETH2', 'XTZ'}
 
@@ -915,7 +915,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'asset': 'ETH2',
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 1
     assert len(result['received']) == 1
 
@@ -931,7 +931,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'event_subtypes': ['reward'],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 3
 
     response = requests.post(
@@ -948,7 +948,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             ],
         },
     )
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == 4
 
     # test that sorting for a non-existing column is handled correctly
@@ -987,7 +987,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
             'order_by_attributes': ['event_type'],
         },
     )
-    assert_proper_response_with_result(response)
+    assert_proper_sync_response_with_result(response)
 
     _, without_eth2_staking_report_result, _ = query_api_create_and_get_report(
         server=rotkehlchen_api_server_with_exchanges,

--- a/rotkehlchen/tests/utils/accounting.py
+++ b/rotkehlchen/tests/utils/accounting.py
@@ -19,7 +19,7 @@ from rotkehlchen.db.filtering import ReportDataFilterQuery
 from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_sync_response_with_result
 from rotkehlchen.types import AssetAmount, Fee, Location, Price, Timestamp, TimestampMS, TradeType
 from rotkehlchen.utils.version_check import get_current_version
 
@@ -371,7 +371,7 @@ def toggle_ignore_an_asset(
                 'ignoredassetsresource',
             ), json={'assets': [asset_to_ignore.identifier]},
         )
-        result = assert_proper_response_with_result(response)
+        result = assert_proper_sync_response_with_result(response)
         assert asset_to_ignore.identifier not in result
 
         with rotki.data.db.conn.read_ctx() as cursor:
@@ -387,7 +387,7 @@ def toggle_ignore_an_asset(
         ), json={'assets': [asset_to_ignore.identifier]},
     )
     assert response.status_code == 200
-    result = assert_proper_response_with_result(response)
+    result = assert_proper_sync_response_with_result(response)
     assert asset_to_ignore.identifier in result['successful']
 
     with rotki.data.db.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -78,7 +78,7 @@ def assert_simple_ok_response(response: requests.Response) -> None:
     assert data['message'] == ''
 
 
-def assert_proper_response_with_result(
+def assert_proper_sync_response_with_result(
         response: requests.Response | None,
         message: str | None = None,
         status_code: HTTPStatus = HTTPStatus.OK,
@@ -93,7 +93,7 @@ def assert_proper_response_with_result(
     return data['result']
 
 
-def assert_maybe_async_response_with_result(
+def assert_proper_response_with_result(
         response: requests.Response,
         rotkehlchen_api_server: APIServer,
         async_query: bool = False,
@@ -104,7 +104,7 @@ def assert_maybe_async_response_with_result(
         server=rotkehlchen_api_server,
         task_id=assert_ok_async_response(response),
         timeout=timeout,
-    ) if async_query else assert_proper_response_with_result(response)
+    ) if async_query else assert_proper_sync_response_with_result(response)
 
 
 def _check_error_response_properties(

--- a/rotkehlchen/tests/utils/api.py
+++ b/rotkehlchen/tests/utils/api.py
@@ -93,6 +93,20 @@ def assert_proper_response_with_result(
     return data['result']
 
 
+def assert_maybe_async_response_with_result(
+        response: requests.Response,
+        rotkehlchen_api_server: APIServer,
+        async_query: bool = False,
+        timeout: int = ASYNC_TASK_WAIT_TIMEOUT,
+) -> Any:
+    """Asserts that the response (sync or async) is okay and returns the result."""
+    return wait_for_async_task_with_result(
+        server=rotkehlchen_api_server,
+        task_id=assert_ok_async_response(response),
+        timeout=timeout,
+    ) if async_query else assert_proper_response_with_result(response)
+
+
 def _check_error_response_properties(
         response_data: dict[str, Any],
         contained_in_msg: str | list[str] | None,

--- a/rotkehlchen/tests/utils/pnl_report.py
+++ b/rotkehlchen/tests/utils/pnl_report.py
@@ -5,9 +5,8 @@ import requests
 
 from rotkehlchen.tests.utils.api import (
     api_url_for,
-    assert_ok_async_response,
+    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
-    wait_for_async_task_with_result,
 )
 from rotkehlchen.tests.utils.history import prepare_rotki_for_history_processing_test
 from rotkehlchen.types import Timestamp
@@ -42,11 +41,11 @@ def query_api_create_and_get_report(
             api_url_for(server, 'historyprocessingresource'),
             json={'from_timestamp': start_ts, 'to_timestamp': end_ts, 'async_query': async_query},
         )
-        if async_query:
-            task_id = assert_ok_async_response(response)
-            outcome = wait_for_async_task_with_result(server, task_id)
-        else:
-            outcome = assert_proper_response_with_result(response)
+        outcome = assert_maybe_async_response_with_result(
+            response=response,
+            rotkehlchen_api_server=server,
+            async_query=async_query,
+        )
 
     report_id = outcome
     response = requests.get(

--- a/rotkehlchen/tests/utils/pnl_report.py
+++ b/rotkehlchen/tests/utils/pnl_report.py
@@ -5,8 +5,8 @@ import requests
 
 from rotkehlchen.tests.utils.api import (
     api_url_for,
-    assert_maybe_async_response_with_result,
     assert_proper_response_with_result,
+    assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.history import prepare_rotki_for_history_processing_test
 from rotkehlchen.types import Timestamp
@@ -41,7 +41,7 @@ def query_api_create_and_get_report(
             api_url_for(server, 'historyprocessingresource'),
             json={'from_timestamp': start_ts, 'to_timestamp': end_ts, 'async_query': async_query},
         )
-        outcome = assert_maybe_async_response_with_result(
+        outcome = assert_proper_response_with_result(
             response=response,
             rotkehlchen_api_server=server,
             async_query=async_query,
@@ -51,7 +51,7 @@ def query_api_create_and_get_report(
     response = requests.get(
         api_url_for(server, 'per_report_resource', report_id=report_id),
     )
-    report_result = assert_proper_response_with_result(response)
+    report_result = assert_proper_sync_response_with_result(response)
 
     response = requests.post(
         api_url_for(server, 'per_report_data_resource', report_id=report_id),
@@ -62,5 +62,5 @@ def query_api_create_and_get_report(
             'ascending': [events_ascending_timestamp],
         },
     )
-    events_result = assert_proper_response_with_result(response)
+    events_result = assert_proper_sync_response_with_result(response)
     return report_id, report_result, events_result


### PR DESCRIPTION
## Checklist

- [x] Allow exporting accounting rules from response JSON, when not passing the `directory_path`
- [x] Fix the PATCH API for importing accounting rules, when `async_query` is `true`

discord thread https://discord.com/channels/657906918408585217/1245296485411717151
