### PR TITLE
History event export move amount/usd value to a sensible position

### DIFF
--- a/rotkehlchen/history/events/structures/base.py
+++ b/rotkehlchen/history/events/structures/base.py
@@ -248,9 +248,14 @@ class HistoryBaseEntry(AccountingEventMixin, ABC):
         """Serialize event data for CSV export"""
         entry = self.serialize()
         balance = entry.pop('balance')
-        entry['balance_amount'] = balance['amount']
-        entry['balance_usd_value'] = balance['usd_value']
-        return entry
+        new_dict = {}
+        for key, value in entry.items():
+            new_dict[key] = value
+            if key == 'asset':  # input the amount/usd value right after the asset
+                new_dict['amount'] = balance['amount']
+                new_dict['usd_value'] = balance['usd_value']
+
+        return new_dict
 
     def serialize_for_api(
             self,

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -37,16 +37,17 @@ def assert_csv_export_response(
         assert data['result'] is True
 
     base_headers = (
-        'location',
         'identifier',
         'entry_type',
         'event_identifier',
         'sequence_index',
         'timestamp',
+        'location',
         'asset',
-        'balance_amount',
-        'balance_usd_value',
+        'amount',
+        'usd_value',
         'event_type',
+        'event_subtype',
         'location_label',
         'notes',
     )
@@ -67,6 +68,8 @@ def assert_csv_export_response(
         reader = csv.DictReader(csvfile)
         count = 0
         for row in reader:
+            assert tuple(row.keys())[:len(base_headers)] == base_headers, 'order of columns does not match'  # noqa: E501
+
             for attr in base_headers:
                 assert row[attr] is not None
             if includes_extra_headers:


### PR DESCRIPTION
It should not be as the last column and does not need to be prepended with `balance_`. Looked really weird when exported and used by an accountant. Amount and usd value should go right after the asset.

