### PR TITLE
Fix (Airdrops): Always include `has_decoder` field

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8563,7 +8563,8 @@ Querying ethereum airdrops
                      "amount": "675.55",
                      "asset": "eip155:1/erc20:0x111111111117dC0aa78b770fA6A738034120C302",
                      "link": "https://app.uniswap.org/",
-                     "claimed": false
+                     "claimed": false,
+                     "has_decoder": true
                   }
             },
             "0x0B89f648eEcCc574a9B7449B5242103789CCD9D7": {
@@ -8579,7 +8580,8 @@ Querying ethereum airdrops
                      "asset": "eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
                      "link": "https://app.uniswap.org/",
                      "claimed": true,
-                     "icon_url": "https://raw.githubusercontent.com/rotki/data/main/airdrops/icons/uniswap.svg"
+                     "icon_url": "https://raw.githubusercontent.com/rotki/data/main/airdrops/icons/uniswap.svg",
+                     "has_decoder": true
                   }
             },
             "message": ""

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -94,9 +94,7 @@ def _enrich_user_airdrop_data(
         protocol_name: str,
         airdrop_data: Airdrop,
 ) -> None:
-    """Modify user_data to add information about icons and if the decoder is missing"""
-    if airdrop_data.has_decoder is False:
-        user_data[protocol_name]['has_decoder'] = False
+    """Modify user_data to add information about icons"""
     if airdrop_data.icon_url is not None:
         user_data[protocol_name]['icon_url'] = airdrop_data.icon_url
 
@@ -442,6 +440,7 @@ def process_airdrop_with_api_data(
             'asset': airdrop_data.asset,
             'link': airdrop_data.url,
             'claimed': False,
+            'has_decoder': airdrop_data.has_decoder,
         }
         _enrich_user_airdrop_data(
             user_data=found_data[address],
@@ -520,6 +519,7 @@ def _process_csv_airdrop(
                 'asset': airdrop_data.asset,
                 'link': airdrop_data.url,
                 'claimed': False,
+                'has_decoder': airdrop_data.has_decoder,
             }
             _enrich_user_airdrop_data(
                 user_data=temp_found_data[addr],

--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -362,12 +362,14 @@ def test_check_airdrops(
         'asset': A_UNI,
         'link': 'https://app.uniswap.org/',
         'claimed': True,
+        'has_decoder': True,
     }
     assert data[TEST_ADDR1]['1inch'] == {
         'amount': '630.374421472277638654',
         'asset': A_1INCH,
         'link': 'https://1inch.exchange/',
         'claimed': False,
+        'has_decoder': True,
     }
     assert messages_aggregator.warnings[0] == 'Skipping airdrop CSV for invalid because it contains an invalid row: []'  # noqa: E501
 
@@ -377,6 +379,7 @@ def test_check_airdrops(
         'asset': A_UNI,
         'link': 'https://app.uniswap.org/',
         'claimed': False,
+        'has_decoder': True,
     }
     assert data[TEST_ADDR2]['grain'] == {
         'amount': '16301.717650649890035791',
@@ -384,12 +387,14 @@ def test_check_airdrops(
         'link': 'https://claim.harvest.finance/',
         'claimed': False,
         'icon_url': f'{AIRDROPS_REPO_BASE}/airdrops/icons/grain.svg',
+        'has_decoder': True,
     }
     assert data[TEST_ADDR2]['shutter'] == {
         'amount': '394857.029384576349787465',
         'asset': A_SHU,
         'link': 'https://claim.shutter.network/',
         'claimed': False,
+        'has_decoder': True,
     }
     assert data[TEST_ADDR2]['degen2_season1'] == {
         'amount': '394857.029384576349787465',
@@ -405,6 +410,7 @@ def test_check_airdrops(
         'link': 'https://eigenfoundation.org',
         'claimed': False,
         'icon_url': 'https://raw.githubusercontent.com/rotki/data/develop/airdrops/icons/eigen.svg',
+        'has_decoder': True,
     }
     assert len(data[TEST_POAP1]) == 1
     assert data[TEST_POAP1]['poap'] == [{


### PR DESCRIPTION
## Checklist

- [x] Always include `has_decoder` field in the metadata index, no matter if it's true or false
