### PR TITLE
fix: remove notification tooltip

### DIFF
--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -180,7 +180,7 @@ const { href, onLinkClick } = useLinks(url);
           </RuiButton>
         </template>
 
-        {{ t('common.actions.copy') }}
+        {{ t('common.actions.copy_to_clipboard') }}
       </RuiTooltip>
 
       <RuiTooltip

--- a/frontend/app/src/components/status/notifications/Notification.vue
+++ b/frontend/app/src/components/status/notifications/Notification.vue
@@ -167,23 +167,14 @@ function buttonClicked() {
           {{ date }}
         </div>
       </div>
-      <RuiTooltip
-        :popper="{ placement: 'bottom', offsetDistance: 0 }"
-        :open-delay="400"
-        class="z-[9999]"
+      <RuiButton
+        variant="text"
+        icon
+        class="!p-2"
+        @click="dismiss(notification.id)"
       >
-        <template #activator>
-          <RuiButton
-            variant="text"
-            icon
-            class="!p-2"
-            @click="dismiss(notification.id)"
-          >
-            <RuiIcon name="close-line" />
-          </RuiButton>
-        </template>
-        <span>{{ t('notification.dismiss_tooltip') }}</span>
-      </RuiTooltip>
+        <RuiIcon name="close-line" />
+      </RuiButton>
     </div>
     <div
       class="mt-1 px-2 break-words text-rui-text-secondary text-body-2 leading-2 group"
@@ -244,29 +235,20 @@ function buttonClicked() {
           />
         </template>
       </RuiButton>
-      <RuiTooltip
-        :popper="{ placement: 'bottom', offsetDistance: 0 }"
-        :open-delay="400"
-        class="z-[9999]"
+      <RuiButton
+        color="primary"
+        variant="text"
+        size="sm"
+        @click="copy()"
       >
-        <template #activator>
-          <RuiButton
-            color="primary"
-            variant="text"
-            size="sm"
-            @click="copy()"
-          >
-            {{ t('notification.copy') }}
-            <template #append>
-              <RuiIcon
-                name="file-copy-line"
-                size="16"
-              />
-            </template>
-          </RuiButton>
+        {{ t('common.actions.copy') }}
+        <template #append>
+          <RuiIcon
+            name="file-copy-line"
+            size="16"
+          />
         </template>
-        <span> {{ t('notification.copy_tooltip') }}</span>
-      </RuiTooltip>
+      </RuiButton>
     </div>
   </RuiCard>
 </template>

--- a/frontend/app/src/locales/cn.json
+++ b/frontend/app/src/locales/cn.json
@@ -1399,7 +1399,8 @@
       "close": "关闭",
       "confirm": "确认",
       "continue": "继续",
-      "copy": "复制到剪贴板",
+      "copy": "复制",
+      "copy_to_clipboard": "复制到剪贴板",
       "create": "创建",
       "delete": "删除",
       "dismiss": "驳回",
@@ -3120,11 +3121,6 @@
       "in_this_page_tooltip": "专用于 \"{page}\" 部分的注释"
     },
     "tooltip": "注释"
-  },
-  "notification": {
-    "copy": "复制",
-    "copy_tooltip": "将消息复制到剪贴板",
-    "dismiss_tooltip": "关闭通知"
   },
   "notification_indicator": {
     "tooltip": "通知"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1651,7 +1651,8 @@
       "close": "Close",
       "confirm": "Confirm",
       "continue": "Continue",
-      "copy": "Copy to clipboard",
+      "copy": "Copy",
+      "copy_to_clipboard": "Copy to clipboard",
       "create": "Create",
       "delete": "Delete",
       "dismiss": "Dismiss",
@@ -3524,11 +3525,6 @@
       "in_this_page_tooltip": "Notes specialize for  \"{page}\" section"
     },
     "tooltip": "Notes"
-  },
-  "notification": {
-    "copy": "Copy",
-    "copy_tooltip": "Copy the message to clipboard",
-    "dismiss_tooltip": "Dismiss Notification"
   },
   "notification_indicator": {
     "tooltip": "Notifications"

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -1369,7 +1369,8 @@
       "close": "Close",
       "confirm": "Confirm",
       "continue": "Continue",
-      "copy": "Copy to clipboard",
+      "copy": "Copy",
+      "copy_to_clipboard": "Copy to clipboard",
       "create": "Crear",
       "delete": "Borrar",
       "dismiss": "Desestimar",
@@ -3032,11 +3033,6 @@
       "in_this_page_tooltip": "Notes specialize for  \"{page}\" section"
     },
     "tooltip": "Notes"
-  },
-  "notification": {
-    "copy": "Copiar",
-    "copy_tooltip": "Copy the message to clipboard",
-    "dismiss_tooltip": "Dismiss Notification"
   },
   "notification_indicator": {
     "tooltip": "Notificaciones"

--- a/frontend/app/src/locales/fr.json
+++ b/frontend/app/src/locales/fr.json
@@ -1552,7 +1552,8 @@
       "close": "Fermer",
       "confirm": "Confirmer",
       "continue": "Continuer",
-      "copy": "Copier dans le presse-papier",
+      "copy": "Copier",
+      "copy_to_clipboard": "Copier dans le presse-papier",
       "create": "Créer",
       "delete": "Supprimer",
       "dismiss": "Rejeter",
@@ -3387,11 +3388,6 @@
       "in_this_page_tooltip": "Notes spécialisées pour la section \"{page}\""
     },
     "tooltip": "Notes"
-  },
-  "notification": {
-    "copy": "Copier",
-    "copy_tooltip": "Copier le message dans le presse-papiers",
-    "dismiss_tooltip": "Rejeter la notification"
   },
   "notification_indicator": {
     "tooltip": "Notifications"

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -1374,7 +1374,8 @@
       "close": "Close",
       "confirm": "Confirm",
       "continue": "Continue",
-      "copy": "Copy to clipboard",
+      "copy": "Copy",
+      "copy_to_clipboard": "Copy to clipboard",
       "create": "Create",
       "delete": "Delete",
       "dismiss": "Dismiss",
@@ -3055,11 +3056,6 @@
       "in_this_page_tooltip": "Notes specialize for  \"{page}\" section"
     },
     "tooltip": "Notes"
-  },
-  "notification": {
-    "copy": "Copy",
-    "copy_tooltip": "Copy the message to clipboard",
-    "dismiss_tooltip": "Dismiss Notification"
   },
   "notification_indicator": {
     "tooltip": "Notifications"


### PR DESCRIPTION
Not sure if this entirely fix the notification issue, but at least I got some terrible experience with tooltip there (clicking the tooltip will close the navigation drawer), and we don't need anyway, since the action button is pretty straightforward
