### PR TITLE
Fix duplicate entries in globaldb conflicts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Fix the issue where the popup notification breaks the experience when the notification sidebar is already open.
+* :bug:`-` Fixed an issue with the assets updates where conflicts couldn't be resolved for multiple changes in a single asset.
 
 * :release:`1.33.1 <2024-05-29>`
 * :bug:`-` Fix the issue where airdrops aren't properly filtered by status.


### PR DESCRIPTION
When updating assets it can happen that two remote updates by mistake add the same token and maybe with extra data. Before this change the multiple conflicts were being returned causing errors in the logic for the api consumer since it was assumed uniqness.

This PR ensures that only the latest appearence is took as conflict

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
