### PR TITLE
Decode older stakedao bribes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`-` Fix the issue where the popup notification breaks the experience when the notification sidebar is already open.
 * :bug:`-` Fixed an issue with the assets updates where conflicts couldn't be resolved for multiple changes in a single asset.
+* :bug:`-` Stakedao bribe claims older than January 2023 will now also be properly decoded.
 
 * :release:`1.33.1 <2024-05-29>`
 * :bug:`-` Fix the issue where airdrops aren't properly filtered by status.

--- a/rotkehlchen/chain/ethereum/modules/stakedao/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/stakedao/constants.py
@@ -1,6 +1,13 @@
+from typing import Final
+
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
-CPT_STAKEDAO = 'stakedao'
+CPT_STAKEDAO: Final = 'stakedao'
 
-STAKEDAO_CLAIMER1 = string_to_evm_address('0x0000000BE1d98523B5469AfF51A1e7b4891c6225')
-STAKEDAO_CLAIMER2 = string_to_evm_address('0x0000000895cB182E6f983eb4D8b4E0Aa0B31Ae4c')
+STAKEDAO_CLAIMER1: Final = string_to_evm_address('0x0000000BE1d98523B5469AfF51A1e7b4891c6225')
+STAKEDAO_CLAIMER2: Final = string_to_evm_address('0x0000000895cB182E6f983eb4D8b4E0Aa0B31Ae4c')
+STAKEDAO_CLAIMER_OLD: Final = string_to_evm_address('0x9f8386001D2245F3052725Dd29da68D268B7F4bB')
+
+
+CLAIMED_WITH_BOUNTY: Final = b'o\x9c\x98&\xbeYv\xf3\xf8*4\x90\xc5*\x832\x8c\xe2\xec{\xe9\xe6-\xcb9\xc2m\xa5\x14\x8d|v'  # noqa: E501
+CLAIMED_WITH_BRIBE: Final = b'\xd7\x95\x91St\x02K\xe1\xf02\x04\xe0R\xbdXK3\xbb\x85\xc9\x12\x8e\xde\x9cT\xad\xbe\x0b\xbd\xc2 \x95'  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/stakedao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/stakedao/decoder.py
@@ -13,15 +13,19 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, Timestamp
 from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int, timestamp_to_date
 
-from .constants import CPT_STAKEDAO, STAKEDAO_CLAIMER1, STAKEDAO_CLAIMER2
+from .constants import (
+    CLAIMED_WITH_BOUNTY,
+    CLAIMED_WITH_BRIBE,
+    CPT_STAKEDAO,
+    STAKEDAO_CLAIMER1,
+    STAKEDAO_CLAIMER2,
+    STAKEDAO_CLAIMER_OLD,
+)
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
-
-
-CLAIMED = b'o\x9c\x98&\xbeYv\xf3\xf8*4\x90\xc5*\x832\x8c\xe2\xec{\xe9\xe6-\xcb9\xc2m\xa5\x14\x8d|v'
 
 
 class StakedaoDecoder(DecoderInterface):
@@ -38,15 +42,14 @@ class StakedaoDecoder(DecoderInterface):
             msg_aggregator=msg_aggregator,
         )
 
-    def _decode_events(self, context: DecoderContext) -> DecodingOutput:
-        if context.tx_log.topics[0] != CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
-
-        # we are not checking user address in the logs as user is not always
-        # the recipient according to the contract
-        reward_token_address = hex_or_bytes_to_address(context.tx_log.data[0:32])
-        amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
-        period = Timestamp(hex_or_bytes_to_int(context.tx_log.data[96:128]))
+    def _decode_claim(
+            self,
+            context: DecoderContext,
+            reward_token_address: ChecksumEvmAddress,
+            amount: int,
+            period: Timestamp,
+    ) -> DecodingOutput:
+        """Base functionality for claiming different types of stakedao votemarket bribes"""
         claimed_token = get_or_create_evm_token(
             userdb=self.base.database,
             evm_address=reward_token_address,
@@ -54,7 +57,6 @@ class StakedaoDecoder(DecoderInterface):
             evm_inquirer=self.evm_inquirer,
         )
         normalized_amount = token_normalized_value(amount, claimed_token)
-
         for event in context.decoded_events:
             if event.event_type == HistoryEventType.RECEIVE and event.event_subtype == HistoryEventSubType.NONE and event.asset == claimed_token and event.balance.amount == normalized_amount:  # noqa: E501
                 event.event_subtype = HistoryEventSubType.REWARD
@@ -64,12 +66,35 @@ class StakedaoDecoder(DecoderInterface):
 
         return DEFAULT_DECODING_OUTPUT
 
+    def _decode_claim_with_bounty(self, context: DecoderContext) -> DecodingOutput:
+        if context.tx_log.topics[0] != CLAIMED_WITH_BOUNTY:
+            return DEFAULT_DECODING_OUTPUT
+
+        # we are not checking user address in the logs as user is not always
+        # the recipient according to the contract
+        reward_token_address = hex_or_bytes_to_address(context.tx_log.data[0:32])
+        amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        period = Timestamp(hex_or_bytes_to_int(context.tx_log.data[96:128]))
+        return self._decode_claim(context=context, reward_token_address=reward_token_address, amount=amount, period=period)  # noqa: E501
+
+    def _decode_claim_with_bribe(self, context: DecoderContext) -> DecodingOutput:
+        if context.tx_log.topics[0] != CLAIMED_WITH_BRIBE:
+            return DEFAULT_DECODING_OUTPUT
+
+        # we are not checking user address in the logs as user is not always
+        # the recipient according to the contract
+        reward_token_address = hex_or_bytes_to_address(context.tx_log.topics[2])
+        amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        period = Timestamp(hex_or_bytes_to_int(context.tx_log.data[32:64]))
+        return self._decode_claim(context=context, reward_token_address=reward_token_address, amount=amount, period=period)  # noqa: E501
+
     # -- DecoderInterface methods
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {
-            STAKEDAO_CLAIMER1: (self._decode_events,),
-            STAKEDAO_CLAIMER2: (self._decode_events,),
+            STAKEDAO_CLAIMER1: (self._decode_claim_with_bounty,),
+            STAKEDAO_CLAIMER2: (self._decode_claim_with_bounty,),
+            STAKEDAO_CLAIMER_OLD: (self._decode_claim_with_bribe,),
         }
 
     @staticmethod


### PR DESCRIPTION
Stakedao bribes older than January 2023 were not decoded properly since it was a different contract and event format.

This PR fixes that and adds a test
