### PR TITLE
Compound finance COMP claim when transfer after event

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Changelog
 * :bug:`-` Fix the issue where the popup notification breaks the experience when the notification sidebar is already open.
 * :bug:`-` Fixed an issue with the assets updates where conflicts couldn't be resolved for multiple changes in a single asset.
 * :bug:`-` Stakedao bribe claims older than January 2023 will now also be properly decoded.
+* :bug:`-` Compound finance COMP claim cases that were not decoded correctly should now appear fine.
 
 * :release:`1.33.1 <2024-05-29>`
 * :bug:`-` Fix the issue where airdrops aren't properly filtered by status.

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -365,6 +365,18 @@ class Compoundv2Decoder(DecoderInterface):
                 event.notes = f'Collect {event.balance.amount} COMP from compound'
                 break
 
+        else:  # not found, so transfer may come after
+            action_item = ActionItem(
+                action='transform',
+                from_event_type=HistoryEventType.RECEIVE,
+                from_event_subtype=HistoryEventSubType.NONE,
+                asset=A_COMP,
+                to_event_subtype=HistoryEventSubType.REWARD,
+                to_notes='Collect {amount} COMP from compound',  # amount set at actionitem process
+                to_counterparty=CPT_COMPOUND,
+            )
+            return DecodingOutput(action_items=[action_item])
+
         return DEFAULT_DECODING_OUTPUT
 
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -929,7 +929,11 @@ class EVMTransactionDecoder(ABC):
                 if action_item.to_event_subtype is not None:
                     transfer.event_subtype = action_item.to_event_subtype
                 if action_item.to_notes is not None:
-                    transfer.notes = action_item.to_notes if action_item.amount_error_tolerance is None else action_item.to_notes.format(amount=transfer.balance.amount)  # noqa: E501
+                    if '{amount}' in action_item.to_notes:
+                        transfer.notes = action_item.to_notes.format(amount=transfer.balance.amount)  # noqa: E501
+                    else:
+                        transfer.notes = action_item.to_notes
+
                 if action_item.to_counterparty is not None:
                     transfer.counterparty = action_item.to_counterparty
                 if action_item.extra_data is not None:

--- a/rotkehlchen/tests/unit/test_optimism_transactions.py
+++ b/rotkehlchen/tests/unit/test_optimism_transactions.py
@@ -5,6 +5,7 @@ from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.types import ChainID, deserialize_evm_tx_hash
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0xd6Ade875eEC93a7aAb7EfB7DBF13d1457443f95B']])
 def test_query_transactions_no_fee(optimism_transactions, optimism_accounts):
     """Test to query an optimism transaction with and without l1_fee existing in the DB.


### PR DESCRIPTION
Make sure decoder works for Compound finance COMP claim when the ERC20 transfer event comes after the claim event.

Part of https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=66951521

There is one more case with no event, not handled: https://etherscan.io/tx/0xc50cd2f79e33e0bfbb429d73a00c3745aba5116f05d86abd48e8532aa4c60d0d

But that is a bit trickier and seems to be a recent thing.

