### PR TITLE
1inch curve

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/aave/common.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/common.py
@@ -11,7 +11,6 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
-
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
@@ -74,7 +73,7 @@ def asset_to_atoken(asset: CryptoAsset, version: int) -> EvmToken | None:
         result = cursor.execute(
             'SELECT A.identifier from evm_tokens as A LEFT OUTER JOIN common_asset_details as B '
             'WHERE A.protocol==? AND A.identifier=B.identifier AND B.symbol=?',
-            (protocol, 'a' + asset.symbol),
+            (protocol, 'a' + asset.symbol.upper()),  # upper is needed since sUSD has aSUSD
         ).fetchall()
     if len(result) != 1:
         log.error(f'Could not derive atoken from {asset} since multiple or no results were returned')  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
@@ -9,6 +9,7 @@ from rotkehlchen.chain.ethereum.modules.oneinch.constants import CPT_ONEINCH_V4
 from rotkehlchen.chain.ethereum.modules.uniswap.v2.constants import (
     SWAP_SIGNATURE as UNISWAP_V2_SWAP_SIGNATURE,
 )
+from rotkehlchen.chain.evm.decoding.curve.constants import TOKEN_EXCHANGE
 from rotkehlchen.chain.evm.decoding.oneinch.decoder import OneinchCommonDecoder
 from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import ORDERFILLED_RFQ
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -56,6 +57,7 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
                 UNISWAP_V2_SWAP_SIGNATURE,  # uniswap v2 is also used by sushiswap
                 BALANCER_V2_SWAP_SIGNATURE,
                 ORDERFILLED_RFQ,
+                TOKEN_EXCHANGE,  # curve is also used by 1inch
             ],
             counterparty=counterparty,
         )


### PR DESCRIPTION
This makes oneinch swaps work with curve underneath too. Also fixed a bug where aSUSD aToken query was failing.


- [Make sure aToken DB query works for aSUSD](https://github.com/rotki/rotki/commit/a3a6a4855ae4fce7ac9b38e59913fa7c90a54d12)
- [Oneinch swaps can also use curve](https://github.com/rotki/rotki/commit/7de9cf4f68fff554c1931dfa3fc849d278e56c0d)

Both of them were discovered and are related to https://github.com/rotki/rotki/issues/8107 as that was a transaction I used as a test and came up with the problem.