### PR TITLE
style: fix notifications overlapping in firefox

### DIFF
--- a/frontend/app/src/components/status/notifications/NotificationSidebar.vue
+++ b/frontend/app/src/components/status/notifications/NotificationSidebar.vue
@@ -174,6 +174,7 @@ watch([y, selectedTab, selectedNotifications], ([currentY, currSelectedTab, curr
             :key="item.id"
             :initial-appear="initialAppear"
             min-height="120px"
+            class="grow-0 shrink-0"
           >
             <Notification
               :notification="item"
@@ -222,7 +223,7 @@ watch([y, selectedTab, selectedNotifications], ([currentY, currSelectedTab, curr
 }
 
 .content {
-  @apply ps-3.5 pe-2 mt-2 grid grid-cols-1 gap-2;
+  @apply ps-3.5 pe-2 mt-2 flex flex-col gap-2;
   @apply overflow-y-auto #{!important};
 }
 </style>


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
