### PR TITLE
Correctly calculate PnL for validators when exiting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,7 @@ Changelog
 * :bug:`-` Balances will get updated properly when removing a validator.
 * :feature:`-` Paladin bribe claiming events should now be properly decoded.
 * :bug:`8137` Uniswap V3 NFTs for positions that have been exited won't appear in the NFTs balances.
+* :bug:`8095` PnL will be correctly calculated for validators exiting with a balance above 32 ETH.
 * :bug:`-` Scroll decoders will now work as expected.
 * :bug:`-` Events claiming veCRV bribes from Gauge Bribe v2 will now be properly decoded.
 * :bug:`-` Complicated cowswap trades that were detected as part of another DEX should now be properly decoded.

--- a/rotkehlchen/history/events/structures/eth2.py
+++ b/rotkehlchen/history/events/structures/eth2.py
@@ -210,7 +210,7 @@ class EthWithdrawalEvent(EthStakingEvent):
     ) -> int:
         profit_amount = self.balance.amount
         if self.balance.amount >= 32:
-            profit_amount = 32 - self.balance.amount
+            profit_amount = self.balance.amount - 32
 
         # TODO: This is hacky and does not cover edge case where people mistakenly
         # double deposited for a validator. We can and should combine deposit and

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -206,7 +206,7 @@ def test_set_settings(rotkehlchen_api_server):
         elif setting == 'address_name_priority':
             value = ['hardcoded_mappings', 'ethereum_tokens']
         else:
-            raise AssertionError(f'Unexpected settting {setting} encountered')
+            raise AssertionError(f'Unexpected setting {setting} encountered')
 
         new_settings[setting] = value
 

--- a/rotkehlchen/tests/unit/accounting/test_staking.py
+++ b/rotkehlchen/tests/unit/accounting/test_staking.py
@@ -5,18 +5,22 @@ from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.chain.ethereum.constants import SHAPPELA_TIMESTAMP
-from rotkehlchen.chain.ethereum.modules.eth2.structures import ValidatorDailyStats
+from rotkehlchen.chain.ethereum.modules.eth2.structures import (
+    ValidatorDailyStats,
+    ValidatorDetails,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_ETH2
+from rotkehlchen.db.eth2 import DBEth2
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import HistoryEvent
-from rotkehlchen.history.events.structures.eth2 import EthBlockEvent
+from rotkehlchen.history.events.structures.eth2 import EthBlockEvent, EthWithdrawalEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.accounting import accounting_history_process, check_pnls_and_csv
 from rotkehlchen.tests.utils.history import prices
 from rotkehlchen.tests.utils.messages import no_message_errors
-from rotkehlchen.types import ChecksumEvmAddress, Location, Timestamp, TimestampMS
+from rotkehlchen.types import ChecksumEvmAddress, Eth2PubKey, Location, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now, ts_sec_to_ms
 
 
@@ -220,3 +224,42 @@ def test_mev_events(accountant: Accountant, ethereum_accounts: list[ChecksumEvmA
     processed_events = accountant.pots[0].processed_events
     assert processed_events[0].notes == 'Mev reward of 0.126458404824519798 for block 17508810'
     assert processed_events[1].notes == 'Kraken ETH staking'
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+@pytest.mark.parametrize('should_mock_price_queries', [True])
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+@pytest.mark.parametrize('use_dummy_pot', [True])
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+@pytest.mark.parametrize('db_settings', [{
+    'eth_staking_taxable_after_withdrawal_enabled': True,
+}])
+def test_validator_exit_pnl(
+        accountant: Accountant,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Regression test for https://github.com/rotki/rotki/issues/8095. Check that the PnL
+    is calculated correctly for validators exiting with a balance over 32 ETH"""
+    vindex1 = 45555
+    with accountant.db.conn.write_ctx() as write_cursor:
+        DBEth2(accountant.db).add_or_update_validators(write_cursor, validators=[
+            ValidatorDetails(
+                validator_index=vindex1,
+                public_key=Eth2PubKey('0xadd9843b2eb53ccaf5afb52abcc0a13223088320656fdfb162360ca53a71ebf8775dbebd0f1f1bf6c3e823d4bf2815f7'),
+            ),
+        ])
+    accountant.process_history(
+        start_ts=Timestamp(0),
+        end_ts=ts_now(),
+        events=[
+            EthWithdrawalEvent(
+                identifier=9,
+                validator_index=vindex1,
+                timestamp=TimestampMS(1666693607000),
+                balance=Balance(FVal(33)),
+                withdrawal_address=ethereum_accounts[0],
+                is_exit=True,
+            ),
+        ],
+    )
+    assert accountant.pots[0].pnls.taxable == ONE  # 1 ETH


### PR DESCRIPTION
Closes #8095. PnL will be calculated correctly since we were obtaining a negative PnL when balance was over 32 ETH

