### PR TITLE
feat(frontend): use mono font for address display

### DIFF
--- a/frontend/app/src/components/accounts/AccountGroupHeader.vue
+++ b/frontend/app/src/components/accounts/AccountGroupHeader.vue
@@ -84,10 +84,14 @@ const usdSum = computed<BigNumber>(() => balanceUsdValueSum(get(items)));
         <div class="font-medium">
           {{ t('account_group_header.xpub') }}
         </div>
-        <div :class="{ blur: !shouldShowAmount }">
+        <div
+          class="[&_*]:font-mono"
+          :class="{ blur: !shouldShowAmount }"
+        >
           <RuiTooltip
             :popper="{ placement: 'top' }"
             :open-delay="400"
+            tooltip-class="[&_*]:font-mono"
           >
             <template #activator>
               {{ displayXpub }}
@@ -116,7 +120,9 @@ const usdSum = computed<BigNumber>(() => balanceUsdValueSum(get(items)));
         <span class="font-medium">
           {{ t('account_group_header.derivation_path') }}:
         </span>
-        {{ xpub.data.derivationPath }}
+        <span class="font-mono">
+          {{ xpub.data.derivationPath }}
+        </span>
       </div>
       <TagDisplay
         small

--- a/frontend/app/src/components/helper/HashLink.vue
+++ b/frontend/app/src/components/helper/HashLink.vue
@@ -133,7 +133,7 @@ const { href, onLinkClick } = useLinks(url);
 </script>
 
 <template>
-  <div class="flex flex-row shrink items-center gap-1">
+  <div class="flex flex-row shrink items-center gap-1 text-sm">
     <template v-if="showIcon && !linkOnly && type === 'address'">
       <EnsAvatar
         :address="displayText"
@@ -154,14 +154,20 @@ const { href, onLinkClick } = useLinks(url);
         v-else
         :popper="{ placement: 'top' }"
         :open-delay="400"
+        tooltip-class="[&_*]:font-mono"
       >
         <template #activator>
-          <span :class="{ blur: !shouldShowAmount }">
-            <template v-if="truncatedAliasName">{{ truncatedAliasName }}</template>
+          <div
+            :class="{ blur: !shouldShowAmount }"
+            class="font-mono leading-6"
+          >
+            <template v-if="truncatedAliasName">
+              {{ truncatedAliasName }}
+            </template>
             <template v-else>
               {{ truncateAddress(displayText, truncateLength) }}
             </template>
-          </span>
+          </div>
         </template>
         <div
           v-if="aliasName && aliasName !== truncatedAliasName"

--- a/frontend/app/src/components/history/events/HistoryEventsList.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsList.vue
@@ -96,6 +96,7 @@ function handleMoreClick() {
   <div :class="{ 'pl-[3.125rem]': hasIgnoredEvent }">
     <DefineTable #default="{ data }">
       <HistoryEventsListTable
+        :event-group="eventGroup"
         :events="data"
         :total="events.length"
         :loading="loading"

--- a/frontend/app/src/components/history/events/HistoryEventsListTable.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsListTable.vue
@@ -15,6 +15,7 @@ interface DeleteEvent {
 const props = withDefaults(
   defineProps<{
     events: HistoryEventEntry[];
+    eventGroup: HistoryEventEntry;
     loading?: boolean;
     total?: number;
   }>(),
@@ -61,6 +62,8 @@ function getEventNoteAttrs(event: HistoryEventEntry) {
 
   if ('blockNumber' in event)
     data.blockNumber = event.blockNumber;
+  else if ('blockNumber' in props.eventGroup)
+    data.blockNumber = props.eventGroup.blockNumber;
 
   if ('counterparty' in event && event.counterparty)
     data.counterparty = event.counterparty;

--- a/frontend/app/src/utils/truncate.ts
+++ b/frontend/app/src/utils/truncate.ts
@@ -1,12 +1,12 @@
 import { XpubPrefix } from '@/utils/xpub';
 
 export const truncationPoints: Record<string, number> = {
-  'xs': 3,
+  'xs': 4,
   'sm': 6,
   'md': 10,
   'lg': 20,
-  'xl': 30,
-  '2xl': 40,
+  'xl': 20,
+  '2xl': 30,
 };
 
 export function findAddressKnownPrefix(address: string) {

--- a/frontend/app/tailwind.config.js
+++ b/frontend/app/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
     container: {
       center: true,
     },
+    fontFamily: {
+      mono: ['Roboto Mono'],
+    },
     extend: {},
   },
   // Classes for premium components


### PR DESCRIPTION
Use mono font for address display, for better readibility.
Also help us to calculate the width (since every character has same width), so we can truncate the address better.