### PR TITLE
Use default nodes when querying logs

### DIFF
--- a/rotkehlchen/chain/gnosis/transactions.py
+++ b/rotkehlchen/chain/gnosis/transactions.py
@@ -67,6 +67,7 @@ class GnosisTransactions(EvmTransactions):
             argument_filters={'receiver': addresses[0]} if len(addresses) == 1 else {},
             from_block=from_block,
             to_block='latest',
+            call_order=self.evm_inquirer.default_call_order(),
         )
 
         expected_topics = ['0x000000000000000000000000' + x.lower()[2:] for x in addresses]


### PR DESCRIPTION
By default we were using only owned nodes and etherscan and this was triggering a rate limit in gnosiscan when querying withdrawal logs

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
