### PR TITLE
Fix price conversion when querying TCR for liquity

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -94,7 +94,7 @@ class Liquity(HasDSProxy):
             total_collateral_ratio = self.trove_manager_contract.call(
                 node_inquirer=self.ethereum,
                 method_name='getTCR',
-                arguments=[FVal(eth_price * 10**18).to_int(True)],
+                arguments=[FVal(eth_price * 10**18).to_int(exact=False)],
             )
 
         except RemoteError as e:

--- a/rotkehlchen/tests/api/test_yearn_vaults.py
+++ b/rotkehlchen/tests/api/test_yearn_vaults.py
@@ -48,6 +48,7 @@ def test_query_yearn_vault_balances(rotkehlchen_api_server):
         assert FVal(vault['underlying_value']['usd_value']) > ZERO
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_V2_ACC2]])
 @pytest.mark.parametrize('ethereum_modules', [['yearn_vaults_v2']])
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])

--- a/rotkehlchen/tests/unit/test_stats.py
+++ b/rotkehlchen/tests/unit/test_stats.py
@@ -108,7 +108,7 @@ def test_compound_events_stats(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [TEST_ACCOUNTS])
-def test_liquity_tcr(ethereum_inquirer: 'EthereumInquirer'):
+def test_liquity_tcr_non_exact_int(ethereum_inquirer: 'EthereumInquirer'):
     liquity = Liquity(
         ethereum_inquirer=ethereum_inquirer,
         database=ethereum_inquirer.database,


### PR DESCRIPTION
When the price had high precission the FVal couldn't be converted to int exactly and this was raising an unhandled error. We don't need such procession here
## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
