### PR TITLE
Bump ruff to 0.5.2

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -2,7 +2,7 @@ mypy==1.10.1
 mypy-extensions==1.0.0
 pylint==3.2.5
 astroid==3.2.3  # engine of pylint, upgrade them together
-ruff==0.4.7
+ruff==0.5.2
 double-indent-rotki==0.1.7  # our fork of double indent
 flake8==7.1.0
 flake8-commas==4.0.0

--- a/rotkehlchen/chain/evm/decoding/hop/balances.py
+++ b/rotkehlchen/chain/evm/decoding/hop/balances.py
@@ -63,8 +63,7 @@ class HopBalances(ProtocolWithBalance):
                     staked_contracts[event.address].add(user_address)
 
         hop_abi = self.evm_inquirer.contracts.abi('HOP_STAKING')
-        for contract_address in staked_contracts:
-            addresses = staked_contracts[contract_address]
+        for contract_address, addresses in staked_contracts.items():
             staking_contract = EvmContract(
                 address=contract_address,
                 abi=hop_abi,

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -443,7 +443,7 @@ class CryptocomImporter(BaseExchangeImporter):
 
         # Compute investments profit
         if len(investments_withdrawals) != 0:
-            for asset in investments_withdrawals:
+            for asset, withdrawals in investments_withdrawals.items():
                 asset_object = asset_from_cryptocom(asset)
                 if asset not in investments_deposits:
                     log.error(
@@ -453,7 +453,7 @@ class CryptocomImporter(BaseExchangeImporter):
                     continue
                 # Sort by date in ascending order
                 withdrawals_rows = sorted(
-                    investments_withdrawals[asset],
+                    withdrawals,
                     key=lambda x: deserialize_timestamp_from_date(
                         date=x['Timestamp (UTC)'],
                         formatstr=timestamp_format,

--- a/rotkehlchen/tests/api/blockchain/test_substrate.py
+++ b/rotkehlchen/tests/api/blockchain/test_substrate.py
@@ -48,7 +48,7 @@ def test_add_ksm_blockchain_account_invalid(rotkehlchen_api_server):
     )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('kusama_manager_connect_at_start', [(KusamaNodeName.OWN,)])
 @pytest.mark.parametrize('ksm_rpc_endpoint', [KUSAMA_TEST_RPC_ENDPOINT], ids=['KUSAMA_TEST_RPC_ENDPOINT'])  # setting ids to rename the argument to be processed by vcr since its value can contain characters that are illegal in windows. Affects all other similar fixtures in this file # noqa: E501
@@ -99,7 +99,7 @@ def test_add_ksm_blockchain_account(rotkehlchen_api_server, kusama_manager_conne
     assert FVal(total_ksm['usd_value']) >= ZERO
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('ksm_accounts', [[SUBSTRATE_ACC1_KSM_ADDR, SUBSTRATE_ACC2_KSM_ADDR]])
 @pytest.mark.parametrize('kusama_manager_connect_at_start', [(KusamaNodeName.OWN,)])

--- a/rotkehlchen/tests/api/test_caching.py
+++ b/rotkehlchen/tests/api/test_caching.py
@@ -113,7 +113,7 @@ def test_icons_and_avatars_cache_deletion(rotkehlchen_api_server):
     assert response.headers['Content-Type'] == 'image/png'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_general_cache_refresh(rotkehlchen_api_server: 'APIServer'):
     """Tests that refreshing the general cache works as expected"""
     with ExitStack() as stack:

--- a/rotkehlchen/tests/api/test_current_assets_price.py
+++ b/rotkehlchen/tests/api/test_current_assets_price.py
@@ -308,7 +308,7 @@ def test_remove_manual_current_price(rotkehlchen_api_server):
     assert (A_BTC, A_ETH) not in Inquirer()._cached_current_price
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_manual_current_prices_loop(inquirer: 'Inquirer'):
     """Check that if we got a loop of manual current prices
@@ -342,7 +342,7 @@ def test_manual_current_prices_loop(inquirer: 'Inquirer'):
     assert 'from ETH(Ethereum) to EUR(Euro) since your manual latest' in warnings[0]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ignore_mocked_prices_for', ['ETH'])
 def test_inquirer_oracles_does_not_affect_manual_price(inquirer):
     """Checks that change of oracles order does not affect manual current price usage.

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -80,7 +80,7 @@ def assert_csv_export_response(
         assert count == expected_count
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_history_export_download_csv(
         rotkehlchen_api_server_with_exchanges,

--- a/rotkehlchen/tests/api/test_makerdao_vaults.py
+++ b/rotkehlchen/tests/api/test_makerdao_vaults.py
@@ -887,7 +887,7 @@ def test_query_vaults_usdc_strange(rotkehlchen_api_server, ethereum_accounts):
     assert_serialized_lists_equal(expected_details, details)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDRESS_1]])
 @pytest.mark.parametrize('ethereum_modules', [['makerdao_vaults']])
 @pytest.mark.parametrize('mocked_proxies', [{

--- a/rotkehlchen/tests/api/test_metadata.py
+++ b/rotkehlchen/tests/api/test_metadata.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from rotkehlchen.api.server import APIServer
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_metadata_endpoint(rotkehlchen_api_server: 'APIServer') -> None:
     """Test that all the endpoints that query mappings or metadata from the backend work fine"""
     airdrops_response = requests.get(

--- a/rotkehlchen/tests/api/test_nfts.py
+++ b/rotkehlchen/tests/api/test_nfts.py
@@ -132,7 +132,7 @@ def test_nft_query(rotkehlchen_api_server, start_with_valid_premium):
 
 
 @requires_env([TestEnvironment.NIGHTLY, TestEnvironment.NFTS])
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[]])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('ethereum_modules', [['nfts']])
@@ -176,7 +176,7 @@ def test_nft_query_after_account_add(rotkehlchen_api_server):
 
 
 @requires_env([TestEnvironment.NIGHTLY, TestEnvironment.NFTS])
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ACC2, TEST_ACC3]])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('ethereum_modules', [['nfts']])

--- a/rotkehlchen/tests/api/test_substrate_manager.py
+++ b/rotkehlchen/tests/api/test_substrate_manager.py
@@ -6,7 +6,7 @@ from rotkehlchen.tests.utils.api import api_url_for, assert_proper_sync_response
 from rotkehlchen.tests.utils.substrate import KUSAMA_TEST_RPC_ENDPOINT
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.freeze_time('2023-10-12 09:00:00 GMT')
 def test_set_unset_own_rpc_endpoint(rotkehlchen_api_server):
     """Test that successfully setting/unsetting an own node (via `ksm_rpc_endpoint` setting)

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -104,7 +104,7 @@ if sys.platform == 'darwin':
         with suppress(AttributeError):
             delattr(request.config._tmpdirhandler, '_basetemp')
 
-    @pytest.fixture()
+    @pytest.fixture
     def tmpdir(request, tmpdir_factory):
         """Return a temporary directory path object
         which is unique to each test function invocation,

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -147,8 +147,7 @@ def detect_accounts_migration_check(
     assert set(accounts.eth) == set(current_evm_accounts)
     assert set(rotki.chains_aggregator.accounts.eth) == set(current_evm_accounts)
     chain_to_added_address = []
-    for chain in expected_detected_addresses_per_chain:
-        chain_addresses = expected_detected_addresses_per_chain[chain]
+    for chain, chain_addresses in expected_detected_addresses_per_chain.items():
         assert set(getattr(accounts, chain.get_key())) == set(chain_addresses)
         assert set(getattr(rotki.chains_aggregator.accounts, chain.get_key())) == set(chain_addresses)  # noqa: E501
         chain_to_added_address.extend(

--- a/rotkehlchen/tests/db/test_ens.py
+++ b/rotkehlchen/tests/db/test_ens.py
@@ -36,7 +36,7 @@ def _simple_ens_setup(database, freezer) -> tuple[DBEns, ChecksumEvmAddress, Che
     return dbens, addy1, addy2
 
 
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 def test_simple_ens_mapping(database, freezer):
     _simple_ens_setup(database, freezer)
 
@@ -48,7 +48,7 @@ def test_empty_addresses(database):
     assert res == {}
 
 
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 def test_update_ens_mapping(database, freezer):
     dbens, addy1, addy2 = _simple_ens_setup(database, freezer)
 
@@ -102,7 +102,7 @@ def test_update_ens_mapping(database, freezer):
     }
 
 
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 def test_multiple_ens_mapping_none(database, freezer):
     dbens, addy1, addy2 = _simple_ens_setup(database, freezer)
 
@@ -133,7 +133,7 @@ def test_multiple_ens_mapping_none(database, freezer):
     }
 
 
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 def test_conflict(database, freezer):
     dbens, addy1, addy2 = _simple_ens_setup(database, freezer)
     addy3 = make_evm_address()

--- a/rotkehlchen/tests/exchanges/test_bitmex.py
+++ b/rotkehlchen/tests/exchanges/test_bitmex.py
@@ -185,7 +185,7 @@ def test_bitmex_api_withdrawals_deposit_unexpected_data(sandbox_bitmex):
     query_bitmex_and_test(given_input, expected_warnings_num=0, expected_errors_num=1)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_bitmex_margin_history(sandbox_bitmex):
     result = sandbox_bitmex.query_margin_history(
         start_ts=1536492800,

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -650,7 +650,6 @@ def test_trade_from_kraken_unexpected_data(kraken):
 
     def query_kraken_and_test(input_trades, expected_warnings_num, expected_errors_num):
         # delete kraken history entries so they get requeried
-        cursor = kraken.history_events_db.db.conn.cursor()
         with kraken.history_events_db.db.user_write() as cursor:
             location = Location.KRAKEN
             cursor.execute(

--- a/rotkehlchen/tests/external_apis/test_bisq_market.py
+++ b/rotkehlchen/tests/external_apis/test_bisq_market.py
@@ -8,7 +8,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.bisq_market import get_bisq_market_price
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_market_request():
     """Test that we can query bisq for market prices"""
     price_in_btc = get_bisq_market_price(A_BSQ.resolve_to_crypto_asset())

--- a/rotkehlchen/tests/external_apis/test_blockscout.py
+++ b/rotkehlchen/tests/external_apis/test_blockscout.py
@@ -16,7 +16,7 @@ def fixture_blockscout(database, messages_aggregator):
     return Blockscout(database=database, msg_aggregator=messages_aggregator)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_query_withdrawals(blockscout, database):
     """Test the querying logic of eth withdrawal for blockscout"""
     address = '0xE12799BC799fc024db69E118fD2A6eA293DBFF7d'

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -31,7 +31,7 @@ def assert_coin_data_same(given, expected, compare_description=False):
     assert given.image_url == expected.image_url
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_asset_data(session_coingecko):
     expected_data = CoingeckoAssetData(
         identifier='bitcoin',
@@ -55,7 +55,7 @@ def test_asset_data(session_coingecko):
         session_coingecko.asset_data(EvmToken('eip155:1/erc20:0x1844b21593262668B7248d0f57a220CaaBA46ab9').to_coingecko())  # PRL, a token without coingecko page  # noqa: E501
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_coingecko_historical_price(session_coingecko):
     price = session_coingecko.query_historical_price(
         from_asset=A_ETH,

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -97,7 +97,7 @@ def check_cc_result(result: list, forward: bool):
 
 
 @pytest.mark.skip('They are updating their systems & cleaning inactive pairs. Check again soon')
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_cryptocompare_histohour_data_going_forward(database, freezer):
     """Test that the cryptocompare histohour data retrieval works properly
@@ -141,7 +141,7 @@ def test_cryptocompare_histohour_data_going_forward(database, freezer):
 
 
 @pytest.mark.skip('They are updating their systems & cleaning inactive pairs. Check again soon')
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_cryptocompare_histohour_data_going_backward(database, freezer):
     """Test that the cryptocompare histohour data retrieval works properly

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -62,7 +62,7 @@ def fixture_should_mock_price_queries():
     return True
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_mock_price_value() -> FVal | None:
     """Determines test behavior If a mock price is not found
 
@@ -74,7 +74,7 @@ def default_mock_price_value() -> FVal | None:
     return None
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_price_queries():
     return defaultdict(defaultdict)
 

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -122,7 +122,7 @@ def _init_database(
     return db
 
 
-@pytest.fixture()
+@pytest.fixture
 def database(
         globaldb,  # pylint: disable=unused-argument  # needed for init_database
         user_data_dir,

--- a/rotkehlchen/tests/fixtures/exchanges/binance.py
+++ b/rotkehlchen/tests/fixtures/exchanges/binance.py
@@ -9,7 +9,7 @@ def fixture_binance_location() -> Location:
     return Location.BINANCE
 
 
-@pytest.fixture()
+@pytest.fixture
 def function_scope_binance(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/bitcoinde.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitcoinde.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_bitcoinde
 
 
-@pytest.fixture()
+@pytest.fixture
 def function_scope_bitcoinde(
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,

--- a/rotkehlchen/tests/fixtures/exchanges/bitfinex.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitfinex.py
@@ -14,7 +14,7 @@ def fixture_bitfinex_api_secret():
     return make_api_secret()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_bitfinex(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/bitmex.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitmex.py
@@ -8,7 +8,7 @@ TEST_BITMEX_API_KEY = 'XY98JYVL15Zn-iU9f7OsJeVf'
 TEST_BITMEX_API_SECRET = b'671tM6f64bt6KhteDakj2uCCNBt7HhZVEE7H5x16Oy4zb1ag'
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_bitmex(
         database,
         inquirer,  # pylint: disable=unused-argument
@@ -22,7 +22,7 @@ def mock_bitmex(
     return bitmex
 
 
-@pytest.fixture()
+@pytest.fixture
 def sandbox_bitmex(database, inquirer):  # pylint: disable=unused-argument
     bitmex = Bitmex(
         name='bitmex',

--- a/rotkehlchen/tests/fixtures/exchanges/bitpanda.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitpanda.py
@@ -14,7 +14,7 @@ def fixture_bitpanda_api_secret():
     return make_api_secret()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_bitpanda(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/bitstamp.py
+++ b/rotkehlchen/tests/fixtures/exchanges/bitstamp.py
@@ -14,7 +14,7 @@ def fixture_bitstamp_api_secret():
     return make_api_secret()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_bitstamp(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/coinbase.py
+++ b/rotkehlchen/tests/fixtures/exchanges/coinbase.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_coinbase
 
 
-@pytest.fixture()
+@pytest.fixture
 def function_scope_coinbase(
         database,
         inquirer,  # pylint: disable=unused-argument,

--- a/rotkehlchen/tests/fixtures/exchanges/gemini.py
+++ b/rotkehlchen/tests/fixtures/exchanges/gemini.py
@@ -25,7 +25,7 @@ def fixture_gemini_test_base_uri():
     return 'https://api.sandbox.gemini.com'
 
 
-@pytest.fixture()
+@pytest.fixture
 def sandbox_gemini(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/iconomi.py
+++ b/rotkehlchen/tests/fixtures/exchanges/iconomi.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_iconomi
 
 
-@pytest.fixture()
+@pytest.fixture
 def function_scope_iconomi(
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,

--- a/rotkehlchen/tests/fixtures/exchanges/independentreserve.py
+++ b/rotkehlchen/tests/fixtures/exchanges/independentreserve.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.exchanges import create_test_independentreserve
 
 
-@pytest.fixture()
+@pytest.fixture
 def function_scope_independentreserve(
         inquirer,  # pylint: disable=unused-argument
         function_scope_messages_aggregator,

--- a/rotkehlchen/tests/fixtures/exchanges/kucoin.py
+++ b/rotkehlchen/tests/fixtures/exchanges/kucoin.py
@@ -24,7 +24,7 @@ def fixture_kucoin_passphrase():
     return make_random_uppercasenumeric_string(size=6)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_kucoin(
         database,
         inquirer,  # pylint: disable=unused-argument
@@ -65,7 +65,7 @@ def fixture_kucoin_sandbox_base_uri():
     return 'https://openapi-sandbox.kucoin.com'
 
 
-@pytest.fixture()
+@pytest.fixture
 def sandbox_kucoin(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/okx.py
+++ b/rotkehlchen/tests/fixtures/exchanges/okx.py
@@ -23,7 +23,7 @@ def fixture_okx_passphrase():
     return OKX_PASSPHRASE
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_okx(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/exchanges/woo.py
+++ b/rotkehlchen/tests/fixtures/exchanges/woo.py
@@ -14,7 +14,7 @@ def fixture_woo_api_secret():
     return make_api_secret()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_woo(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/history.py
+++ b/rotkehlchen/tests/fixtures/history.py
@@ -39,7 +39,7 @@ def fixture_force_no_price_found_for():
     return []
 
 
-@pytest.fixture()
+@pytest.fixture
 def price_historian(
         data_dir,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/fixtures/messages.py
+++ b/rotkehlchen/tests/fixtures/messages.py
@@ -53,7 +53,7 @@ def fixture_initialize_mock_rotki_notifier() -> bool:
     return False
 
 
-@pytest.fixture()
+@pytest.fixture
 def function_scope_messages_aggregator(function_scope_initialize_mock_rotki_notifier):
     msg_aggregator = MessagesAggregator()
     if function_scope_initialize_mock_rotki_notifier is True:

--- a/rotkehlchen/tests/fixtures/pylint.py
+++ b/rotkehlchen/tests/fixtures/pylint.py
@@ -2,6 +2,6 @@ import pytest
 from pylint.testutils.unittest_linter import UnittestLinter
 
 
-@pytest.fixture()
+@pytest.fixture
 def pylint_test_linter():
     return UnittestLinter()

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -585,7 +585,7 @@ def fixture_rotkehlchen_api_server(
     api_server.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def rotkehlchen_instance(
         uninitialized_rotkehlchen,
         start_with_logged_in_user,
@@ -673,7 +673,7 @@ def rotkehlchen_instance(
     return uninitialized_rotkehlchen
 
 
-@pytest.fixture()
+@pytest.fixture
 def rotkehlchen_api_server_with_exchanges(
         rotkehlchen_api_server,
         added_exchanges,

--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -12,18 +12,18 @@ def fixture_port_generator(request):
     return get_free_port('127.0.0.1', request.config.option.initial_port)
 
 
-@pytest.fixture()
+@pytest.fixture
 def db_password():
     return '123'
 
 
-@pytest.fixture()
+@pytest.fixture
 def rest_api_port(port_generator):
     port = next(port_generator)
     return port
 
 
-@pytest.fixture()
+@pytest.fixture
 def added_exchanges() -> Sequence[Location]:
     """A fixture determining which exchanges to add to a test rotkehlchen api server"""
     return (
@@ -38,7 +38,7 @@ def added_exchanges() -> Sequence[Location]:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def network_mocking(request):
     """Uses the --no-network-mocking argument. By default when not passed, the network
     is mocked in all tests that are aware of it (by using this fixture).

--- a/rotkehlchen/tests/integration/test_eth2.py
+++ b/rotkehlchen/tests/integration/test_eth2.py
@@ -133,7 +133,7 @@ def test_withdrawals(eth2: 'Eth2', database, ethereum_accounts, query_method):
     assert account1_events == 47
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2023-04-24 21:00:00 GMT')
 def test_block_production(eth2: 'Eth2', database):
@@ -275,7 +275,7 @@ def test_block_production(eth2: 'Eth2', database):
     )]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2023-11-19 16:30:00 GMT')
 def test_withdrawals_detect_exit(eth2: 'Eth2', database):

--- a/rotkehlchen/tests/integration/test_price_history.py
+++ b/rotkehlchen/tests/integration/test_price_history.py
@@ -19,7 +19,7 @@ HISTORICAL_PRICE_ORACLES = [
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 @pytest.mark.parametrize('historical_price_oracles_order', [HISTORICAL_PRICE_ORACLES])
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_price_queries(price_historian, database):
     """Test some historical price queries. Make sure that we test some
     assets not in cryptocompare but in coigecko so the backup mechanism triggers and works"""

--- a/rotkehlchen/tests/integration/test_transactions.py
+++ b/rotkehlchen/tests/integration/test_transactions.py
@@ -55,7 +55,7 @@ def test_get_transaction_receipt(
     assert results[0] == transactions[0]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
 @pytest.mark.parametrize('ethereum_accounts', [[ETH_ADDRESS1, ETH_ADDRESS2, ETH_ADDRESS3]])
 def test_get_or_create_transaction(ethereum_accounts, eth_transactions, database):

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -37,7 +37,7 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_1inchv1_swap(database, ethereum_inquirer):
     """Data taken from
@@ -108,7 +108,7 @@ def test_1inchv1_swap(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_1inchv2_swap_for_eth(database, ethereum_inquirer):
     """
@@ -180,7 +180,7 @@ def test_1inchv2_swap_for_eth(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_1inchv3_swap_for_eth(database, ethereum_inquirer, ethereum_accounts):
     """Test an 1inchv3 swap for ETH."""
@@ -351,7 +351,7 @@ def test_1inchv4_orderfilledrfq(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF92940216a808378bfFD05f444B7bF71d5A193Cd']])
 def test_1inchv4_swap_on_sushiswap(database, ethereum_inquirer):
     """
@@ -412,7 +412,7 @@ def test_1inchv4_swap_on_sushiswap(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x201b5Abfd44A8F9b75F0fE1BaE74CDaC7675E54B']])
 def test_1inchv4_multiple_swaps(database, ethereum_inquirer):
     """
@@ -485,7 +485,7 @@ def test_1inchv4_multiple_swaps(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xcA74F404E0C7bfA35B13B511097df966D5a65597']])
 def test_1inchv4_weth_eth_swap(database, ethereum_inquirer):
     """
@@ -546,7 +546,7 @@ def test_1inchv4_weth_eth_swap(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xdCB02829F91533Ab757b1B0e8B595D7c950AfBb8']])
 def test_1inchv4_eth_weth_swap(database, ethereum_inquirer):
     """
@@ -607,7 +607,7 @@ def test_1inchv4_eth_weth_swap(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_1inch_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
     """Data taken from
@@ -734,7 +734,7 @@ def test_1inch_gnosis_v5_swap(database, gnosis_inquirer, gnosis_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF']])
 def test_1inch_velodrome(database, optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3cb68ee7dae76c0ca6466e3a593b32144d25eabb27c1ba416c83f154627d84d8')  # noqa: E501
@@ -789,7 +789,7 @@ def test_1inch_velodrome(database, optimism_inquirer, optimism_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC5d494aa0CBabD7871af0Ef122fB410Fa25c3379']])
 def test_half_decoded_1inch_v5_swap(database, ethereum_inquirer, ethereum_accounts):
     """

--- a/rotkehlchen/tests/unit/decoders/test_aave_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v2.py
@@ -39,7 +39,7 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 ADDY2 = '0x5727c0481b90a129554395937612d8b9301D6c7b'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_aave_deposit_v1(database, ethereum_inquirer):
     """Data taken from
@@ -110,7 +110,7 @@ def test_aave_deposit_v1(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_aave_withdraw_v1(database, ethereum_inquirer):
     """Data taken from
@@ -182,7 +182,7 @@ def test_aave_withdraw_v1(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY2]])
 def test_aave_eth_withdraw_v1(database, ethereum_inquirer):
     """Data taken from
@@ -811,7 +811,7 @@ def test_aave_v2_repay(database, ethereum_inquirer, eth_transactions):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x1dB64086b4cdA94884E4FC296799a512dfc564CA']])
 def test_aave_v2_liquidation(
         database: 'DBHandler',
@@ -862,7 +862,7 @@ def test_aave_v2_liquidation(
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x8ca7ED9b02ec1E8bEee868a32495Ed5b157eeE08']])
 def test_aave_v1_liquidation(
         database: 'DBHandler',
@@ -914,7 +914,7 @@ def test_aave_v1_liquidation(
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xe903fEed7c1098Ba92E4b7092ca77bBc48503d90']])
 def test_aave_v2_supply_ether(database, ethereum_inquirer, ethereum_accounts):
     """
@@ -992,7 +992,7 @@ def test_aave_v2_supply_ether(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x572f60c0b887203324149D9C308574BcF2dfaD82']])
 def test_aave_v2_borrow_polygon(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x2c2777e24bc8a59171e33d54c2a87d846fc23e7f21a32b99d22397e64429b39c')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_aave_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v3.py
@@ -29,7 +29,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x93a208b0d7007f5733ea23F65bACF101Be8aC6cD']])
 def test_aave_v3_enable_collateral(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x867d09a777ca7c5cbccd281d197ffbed327b5a8f07153483e94f75d4e1d04413')  # noqa: E501
@@ -97,7 +97,7 @@ def test_aave_v3_enable_collateral(database, ethereum_inquirer, ethereum_account
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x203b2E862C57fbAc813c05c46B6e1242844724A2']])
 def test_aave_v3_disable_collateral(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1f7614ba2425f3345d02bf1518c81ab3aa46e888553b409f3c9a360259bc7988')  # noqa: E501
@@ -165,7 +165,7 @@ def test_aave_v3_disable_collateral(database, ethereum_inquirer, ethereum_accoun
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x08c14B32C8A48894E4b933090EBcC9CE33B21135']])
 def test_aave_v3_deposit(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x062bb6b01d4ac5fabd7b7783965d22589d289e44bb0227bb2fc0adaad7eb563b')  # noqa: E501
@@ -220,7 +220,7 @@ def test_aave_v3_deposit(database, ethereum_inquirer, ethereum_accounts) -> None
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xabE9e5d199E1E411098181b6a5Ab9f5f65d91389']])
 def test_aave_v3_withdraw(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xf184c285dab9ea6c72d18025c65202e3d9e5ec3181209a6cbedf88dfd4c8283f')  # noqa: E501
@@ -275,7 +275,7 @@ def test_aave_v3_withdraw(database, ethereum_inquirer, ethereum_accounts) -> Non
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x08c14B32C8A48894E4b933090EBcC9CE33B21135']])
 def test_aave_v3_borrow(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x44367976e841cde459d84aec984d5fae4466b2978b1d71c9cd916bb79792ee20')  # noqa: E501
@@ -330,7 +330,7 @@ def test_aave_v3_borrow(database, ethereum_inquirer, ethereum_accounts) -> None:
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9CBF099ff424979439dFBa03F00B5961784c06ce']])
 def test_aave_v3_repay(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x440dddaad9f8d9c6d99777494640520854cca8dd102fb557f1654f5746da5f7e')  # noqa: E501
@@ -385,7 +385,7 @@ def test_aave_v3_repay(database, ethereum_inquirer, ethereum_accounts) -> None:
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7420fA58bA44E1141d5E9ADB6903BE549f7cE0b5']])
 def test_aave_v3_liquidation(database, ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xc1a03e87f1c0446ddd5a77f7eb906831c72618a921a1f6f9f430f612edca0531')  # noqa: E501
@@ -455,7 +455,7 @@ def test_aave_v3_liquidation(database, ethereum_inquirer, ethereum_accounts) -> 
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xA55EaD17fa903b1218dc6a79c47b54C9370E20AB']])
 def test_aave_v3_enable_collateral_polygon(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x8002f1a3044bcdec645d512713724f09551c18a14c67509417c83961b230294b')  # noqa: E501
@@ -523,7 +523,7 @@ def test_aave_v3_enable_collateral_polygon(database, polygon_pos_inquirer, polyg
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x645C22593c232Ae78a7eCbaC93b38cbaC535ef12']])
 def test_aave_v3_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts) -> None:  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x09d5e6da511fb88e8a7db6f1209542610a9d3873048e405b88c7a766d7210d6f')  # noqa: E501
@@ -578,7 +578,7 @@ def test_aave_v3_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xaafc3e3C8B4fD93584256E6D49a9C364648E66cE']])
 def test_aave_v3_borrow_base(database, base_inquirer, base_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x92b6fef0623a3f56daa651968819f2e5b7a982037c19fed2166e4c00ba4d6350')  # noqa: E501
@@ -633,7 +633,7 @@ def test_aave_v3_borrow_base(database, base_inquirer, base_accounts) -> None:
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x91ed7A7fd3072885c1ec905C932717Df6A8aE2cA']])
 def test_aave_v3_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1f3cae37be928563d154c534c98f41eefe9201eb3d0129c99c1ecb51f83e5596')  # noqa: E501
@@ -688,7 +688,7 @@ def test_aave_v3_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts) -> 
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xdbD5D31B7f48adC13A0aB0c591F7e3D4f9642e69']])
 def test_aave_v3_borrow_optimism(database, optimism_inquirer, optimism_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xb043a7f28cccd6cb0392db47cea4607f8cf3b91b6510669a0a62588b66eb7fcf')  # noqa: E501
@@ -743,7 +743,7 @@ def test_aave_v3_borrow_optimism(database, optimism_inquirer, optimism_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x3E6B4598E5bfeEc911f344E546C9EbFe4A00d770']])
 def test_aave_v3_repay_scroll(database, scroll_inquirer, scroll_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x66010f353be60adaa004f839d37cecd22c35c580060eeaffb9a28ebe169e1692')  # noqa: E501
@@ -798,7 +798,7 @@ def test_aave_v3_repay_scroll(database, scroll_inquirer, scroll_accounts) -> Non
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x35E0091D67B5e213db857F605c2047cA29A8800d']])
 def test_non_aave_tx(database, ethereum_inquirer, ethereum_accounts) -> None:
     """Test that the non-aave transactions happened through flash loans are not decoded
@@ -883,7 +883,7 @@ def test_claim_incentives_reward(database, optimism_inquirer, optimism_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xfe46dCeb5d586DA13aBAA571613e20f5a61fa62e']])
 def test_aave_v3_events_with_approval(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x0aaca18a7e0ee29a247bd9bfab3b081acf469833105a9204251c5a4969a5fc29')  # noqa: E501
@@ -962,7 +962,7 @@ def test_aave_v3_events_with_approval(database, polygon_pos_inquirer, polygon_po
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x76111D2841b41B15e6F07fBae4796a82438D9c90']])
 def test_aave_v3_withdraw_eth(database, scroll_inquirer, scroll_accounts) -> None:
     """Test that withdrawing ETH from Aave gets decoded properly"""
@@ -1057,7 +1057,7 @@ def test_aave_v3_withdraw_eth(database, scroll_inquirer, scroll_accounts) -> Non
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x2013b74bdbd2Adf3eBF39E5112a9f794144Aeb15']])
 def test_aave_v3_withdraw_matic(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x301885bdc8998d0e6d5c0064b3b92f5ee34f81ebbd14ca2b796579981ff8df31')  # noqa: E501
@@ -1136,7 +1136,7 @@ def test_aave_v3_withdraw_matic(database, polygon_pos_inquirer, polygon_pos_acco
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x44ddBB35CfeBbafE98e402970517b33d8e925eB3']])
 def test_aave_v3_withdraw_xdai(database, gnosis_inquirer, gnosis_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x0154ef3042e93a632d654c86bff99f7d452681dba72f4f773806c9c26470f678')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_aerodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_aerodrome.py
@@ -49,7 +49,7 @@ WETH_BASE = Asset(evm_address_to_identifier(
 ))
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_AERODROME]])
 @pytest.mark.parametrize('base_accounts', [['0x514c4BA193c698100DdC998F17F24bDF59c7b6fB']])
 def test_add_liquidity(base_transaction_decoder, base_accounts, load_global_caches):
@@ -137,7 +137,7 @@ def test_add_liquidity(base_transaction_decoder, base_accounts, load_global_cach
     assert EvmToken(pool_token.identifier).protocol == AERODROME_POOL_PROTOCOL
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_AERODROME]])
 @pytest.mark.parametrize('base_accounts', [['0x514c4BA193c698100DdC998F17F24bDF59c7b6fB']])
 def test_stake_lp_token_to_gauge(base_accounts, base_transaction_decoder, load_global_caches):
@@ -197,7 +197,7 @@ def test_stake_lp_token_to_gauge(base_accounts, base_transaction_decoder, load_g
     assert EvmToken(pool_token.identifier).protocol == AERODROME_POOL_PROTOCOL
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_AERODROME]])
 @pytest.mark.parametrize('base_accounts', [['0x61D90de4fa8cfbBD7A7650Ae01A39fD1B1863503']])
 def test_remove_liquidity(base_accounts, base_transaction_decoder, load_global_caches):

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
@@ -19,7 +19,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4e7DF0FDa2d203f5DFbaa34b9FB64DDe5133196e']])
 def test_deposit_eth_from_ethereum_to_arbitrum_one(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xbe5b747193c68a7d1844053996e1a27a1279a4f1743f4b9a00e5a14152ee8641')  # noqa: E501
@@ -59,7 +59,7 @@ def test_deposit_eth_from_ethereum_to_arbitrum_one(database, ethereum_inquirer, 
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x4e7DF0FDa2d203f5DFbaa34b9FB64DDe5133196e']])
 def test_receive_eth_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x30505174f2f82a6513f21eb5177e59935a6da95d057e4c1972e65da90ea1c547')  # noqa: E501
@@ -87,7 +87,7 @@ def test_receive_eth_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_o
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x5EA45c8E36704d7F4053Bb0e23cDd96E4d8b80F7']])
 def test_withdraw_eth_from_arbitrum_one_to_ethereum(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
     evmhash = deserialize_evm_tx_hash('0xdb8e29f27a7b7b416f168e8135347703268a142b6776503e26419dbfc43bcabf')  # noqa: E501
@@ -127,7 +127,7 @@ def test_withdraw_eth_from_arbitrum_one_to_ethereum(database, arbitrum_one_inqui
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x5EA45c8E36704d7F4053Bb0e23cDd96E4d8b80F7']])
 def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x2698916bd8d658ce6cfe032e5526fa345b3656a849870e72b1e853d22efdd7ac')  # noqa: E501
@@ -167,7 +167,7 @@ def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xBEEC919d69FB1a5195964ee90959C413CDbACe28']])
 def test_deposit_erc20_from_ethereum_to_arbitrum_one(database, ethereum_inquirer, ethereum_accounts):  # noqa: E501
     evmhash = deserialize_evm_tx_hash('0x2eb4686e6b9857f02c1c8a035dc1ac7dcaf160fd52248b56a76de7774482390d')  # noqa: E501
@@ -221,7 +221,7 @@ def test_deposit_erc20_from_ethereum_to_arbitrum_one(database, ethereum_inquirer
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_receive_erc20_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x80e6c0835c3ead90dde524c3dfe49a067fd5b5cda93d5a223707e686d910d8a2')  # noqa: E501
@@ -249,7 +249,7 @@ def test_receive_erc20_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xbD91C9DF3C30F0e43B19b1dd05888CF9b647b781']])
 def test_withdraw_erc20_from_arbitrum_one_to_ethereum(database, arbitrum_one_inquirer, arbitrum_one_accounts, caplog):  # noqa: E501
     """Test that LPT withdrawals from arbitrum to L1 work fine"""
@@ -306,7 +306,7 @@ def test_withdraw_erc20_from_arbitrum_one_to_ethereum(database, arbitrum_one_inq
     assert '_decode_eth_withdraw_event failed due to Invalid ethereum address' not in caplog.text
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_withdraw_dai_from_arbitrum_one_to_ethereum(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
     """
@@ -350,7 +350,7 @@ def test_withdraw_dai_from_arbitrum_one_to_ethereum(database, arbitrum_one_inqui
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbD91C9DF3C30F0e43B19b1dd05888CF9b647b781']])
 def test_receive_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xa235be4bde09d215518485acf55a577ca0662f27ff4af2a33f6867e4847596b8')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_balancer.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer.py
@@ -190,7 +190,7 @@ def test_balancer_v1_exit(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x549C0421c69Be943A2A60e76B19b4A801682cBD3']])
 def test_deposit_with_excess_tokens(database, ethereum_inquirer, ethereum_accounts):
     """Verify that when a refund is made for a deposit in balancer v1 this is properly decoded"""

--- a/rotkehlchen/tests/unit/decoders/test_base_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_base_bridge.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc91FC9Dd7f1Bb6Ec429edDB577b9Ace6236B2147']])
 def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xbd58a2802a40659da35ff838017a00ba0e251dd0c96ae0c802bd41b5a999f366')  # noqa: E501
@@ -52,7 +52,7 @@ def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC8f9850e4862b62cCA7f87A81633c2Add9488743']])
 def test_withdraw_eth(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x6f62277e5fe0c7d8c613b66b6850dd4b6cf193f830b52486d7d9b79917441e46')  # noqa: E501
@@ -92,7 +92,7 @@ def test_withdraw_eth(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbAbE777e1a43053C273bd8A4e45D0cB6c20f8Fc6']])
 def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x9593200706ea6941eac1c8189b9648e9ebab5bd14504c4a493f5309f85e6cba6')  # noqa: E501
@@ -132,7 +132,7 @@ def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x0050F3427E5388E9cc458e977bC3444faf015618']])
 def test_withdraw_token(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x2d047f0b7a0f2052791359ef82eab317b6d6a685a3c24614f51e8775f4b60ef4')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_compound_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v2.py
@@ -152,7 +152,7 @@ def test_compound_ether_withdraw(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY2]])
 def test_compound_deposit_with_comp_claim(
         database,
@@ -227,7 +227,7 @@ def test_compound_deposit_with_comp_claim(
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY3]])
 def test_compound_multiple_comp_claim(database, ethereum_inquirer):
     """Test that a transaction with multiple comp claims decodes all of them as rewards
@@ -323,7 +323,7 @@ def test_compound_multiple_comp_claim(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xB8cCf257d32b134ffecb902e5Bef3042841B8A4A']])
 def test_compound_comp_claim_last_transfer(database, ethereum_inquirer, ethereum_accounts):
     """

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('function_scope_initialize_mock_rotki_notifier', [True])
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0xC960338B529e0353F570f62093Fd362B8FB55f0B')]])  # noqa: E501
 def test_booster_deposit(
@@ -101,7 +101,7 @@ def test_booster_deposit(
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x53913A03a065f685097f8E8f40284D58016bB0F9')]])  # noqa: E501
 def test_booster_withdraw(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = '0x79fcbafa4367e0563d3e614f774c5e4257c4e41f124ae8288980a310e2b2b547'
@@ -319,7 +319,7 @@ def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0xe81FC42336c9314A9Be1EDB3F50eA9e275C93df3')]])  # noqa: E501
 def test_cvxcrv_withdraw(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = '0x0a804804cc62f615b72dff55e8c245d9b69aa8f8ed3de549101ae128a4ae432b'
@@ -367,7 +367,7 @@ def test_cvxcrv_withdraw(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x2AcEcBF2Ee5BFc8eed599D58835EE9A7c45F3E2c')]])  # noqa: E501
 def test_cvxcrv_stake(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = '0x3cc0b25887e2f0dac7f86fabd81aaafb1e041e84dbe8167885073c443320ad5f'

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -779,7 +779,7 @@ def test_curve_remove_imbalanced(database, ethereum_transaction_decoder):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6Bb553FFC5716782051f51b564Bb149D9946f0d2']])
 def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -838,7 +838,7 @@ def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x66215D23B8A247C80c2D1B7beF4BefC2AB384bCE']])
 def test_gauge_vote(ethereum_accounts, ethereum_transaction_decoder) -> None:
     tx_hex = deserialize_evm_tx_hash('0xf67308b01613b3f75a71f2a3cea198acc063c987f17be4aaf5505a1ad70751ef')  # noqa: E501
@@ -882,7 +882,7 @@ def test_gauge_vote(ethereum_accounts, ethereum_transaction_decoder) -> None:
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('function_scope_initialize_mock_rotki_notifier', [True])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd289986c25Ae3f4644949e25bC369e9d8e0caeaD']])
@@ -942,7 +942,7 @@ def test_gauge_deposit(
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd80DF837766C8Edb6f11Bf7fD35703f87F2a31fB']])
 def test_gauge_withdraw(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
@@ -988,7 +988,7 @@ def test_gauge_withdraw(ethereum_transaction_decoder, ethereum_accounts, load_gl
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0E9Fed33f6a202146a615De0FA1985adFb461467']])
 def test_gauge_claim_rewards(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
@@ -1033,7 +1033,7 @@ def test_gauge_claim_rewards(ethereum_transaction_decoder, ethereum_accounts, lo
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xA8d7Fb04877C3FBf175DE76FA3D2fa66c770537F']])
 def test_curve_trade_token_to_token(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1092,7 +1092,7 @@ def test_curve_trade_token_to_token(ethereum_transaction_decoder, ethereum_accou
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x8a1B73A88E1854Dd3EeBEe4354Bd4DbA23861E3A']])
 def test_curve_trade_eth_to_token(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1151,7 +1151,7 @@ def test_curve_trade_eth_to_token(ethereum_transaction_decoder, ethereum_account
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x38abab9766e0b27d2912718a884292b8E7eb2803']])
 def test_curve_trade_exchange_underlying(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1210,7 +1210,7 @@ def test_curve_trade_exchange_underlying(ethereum_transaction_decoder, ethereum_
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3Da232a0c0A5C59918D7B5fF77bf1c8Fc93aeE1B']])
 def test_curve_swap_router(ethereum_transaction_decoder, ethereum_accounts):
     """Test that transactions made via curve swap router are decoded correctly"""
@@ -1267,7 +1267,7 @@ def test_curve_swap_router(ethereum_transaction_decoder, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xdE206bC0Fde2eF5C8BB6A1d552a64F82A2407Be4']])
 def test_curve_usdn_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1327,7 +1327,7 @@ def test_curve_usdn_add_liquidity(ethereum_transaction_decoder, ethereum_account
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6d84264A7bD2Cffa4A117BA2350403b3A9866949']])
 def test_curve_usdn_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1426,7 +1426,7 @@ def test_curve_usdn_remove_liquidity(ethereum_transaction_decoder, ethereum_acco
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xcbE942516AE7687d80a5fF94F8f9A203Be800713']])
 def test_3pool_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
@@ -1486,7 +1486,7 @@ def test_3pool_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, lo
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xC7BFb2ED20D14407C78cc1FC4a4Abe39f1964964']])
 def test_3pool_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1585,7 +1585,7 @@ def test_3pool_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts,
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x60b0f1919cf4ee46d1A8D63428276512814de570']])
 def test_remove_from_aave_pool(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1648,7 +1648,7 @@ def test_remove_from_aave_pool(ethereum_transaction_decoder, ethereum_accounts, 
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0550bED1C94AFBd468aa739852632D7e9b4c2F86']])
 def test_deposit_via_zap_in_metapool(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
@@ -1724,7 +1724,7 @@ def test_deposit_via_zap_in_metapool(ethereum_transaction_decoder, ethereum_acco
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd381e358d6b4E176559D3D76109985ED83259aEC']])
 def test_no_zap_event(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
@@ -1829,7 +1829,7 @@ def test_gauge_bribe_v2(ethereum_transaction_decoder, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x1c362DFE864a4c4b3311eC97bf0b8320CB0a4952']])
 def test_curve_deposit_polygon(database, polygon_pos_inquirer, polygon_pos_accounts, load_global_caches):  # noqa: E501
@@ -1898,7 +1898,7 @@ def test_curve_deposit_polygon(database, polygon_pos_inquirer, polygon_pos_accou
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('optimism_accounts', [['0x1CD90D091C5c13Bb7e7612a90485C6F38B826Fdd']])
 def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, load_global_caches):  # noqa: E501
@@ -1963,7 +1963,7 @@ def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, 
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xD4f9FE0039Da59e6DDb21bbb6E84e0C9e83D73eD']])
 def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_global_caches):
@@ -2028,7 +2028,7 @@ def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0x4113a3CB9004E193E9906131B632e280F5f9B61e']])
 def test_curve_swap_router_base(database, base_inquirer, base_accounts):
     """Test that transactions made via the new curve swap router are decoded correctly"""
@@ -2083,7 +2083,7 @@ def test_curve_swap_router_base(database, base_inquirer, base_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x8800AcEDF5571F35675CF8Aa1E3C16C7A8da0088']])
 def test_deposit_via_zap_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts, load_global_caches):  # noqa: E501
@@ -2279,7 +2279,7 @@ def test_vote_escrow_withdraw(ethereum_transaction_decoder, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_gauge_deposit_and_stake(database, gnosis_inquirer, gnosis_accounts, load_global_caches):
@@ -2335,7 +2335,7 @@ def test_gauge_deposit_and_stake(database, gnosis_inquirer, gnosis_accounts, loa
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_gauge_deposit_and_stake_multiple(database, gnosis_inquirer, gnosis_accounts, load_global_caches):  # noqa: E501
@@ -2406,7 +2406,7 @@ def test_gauge_deposit_and_stake_multiple(database, gnosis_inquirer, gnosis_acco
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_liquidity_withdrawal(database, gnosis_inquirer, gnosis_accounts, load_global_caches):

--- a/rotkehlchen/tests/unit/decoders/test_degen.py
+++ b/rotkehlchen/tests/unit/decoders/test_degen.py
@@ -23,7 +23,7 @@ from rotkehlchen.types import ChecksumEvmAddress, Location, TimestampMS, deseria
 DEGEN_TOKEN: Final = Asset(DEGEN_TOKEN_ID)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_claim_airdrop_2(
         base_accounts: list[ChecksumEvmAddress],

--- a/rotkehlchen/tests/unit/decoders/test_diva.py
+++ b/rotkehlchen/tests/unit/decoders/test_diva.py
@@ -14,7 +14,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_diva_delegate(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x806081bcc60a40db22bae2c1729f240f48de4b73e76b673fc4767bcee4f1c704')  # noqa: E501
@@ -56,7 +56,7 @@ def test_diva_delegate(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_diva_claim(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc66dd53da9837e5197f95d32065807706a118dc2ff326a5e3bf8844b8ee261c2')  # noqa: E501
@@ -113,7 +113,7 @@ def test_diva_claim(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_vote_cast(database, ethereum_inquirer, ethereum_accounts):
     """Test voting for DIVA governance"""

--- a/rotkehlchen/tests/unit/decoders/test_eas.py
+++ b/rotkehlchen/tests/unit/decoders/test_eas.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_attest_optimism(database, optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0xf843f6d09e8dec2ee2d1b5fdeade9a9744857f598cf593b6c259166c32dfd05a')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -28,7 +28,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbec0937E0E99425a886B99A3b956C7aC6C39aA12']])
 def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x716b15f5088ff469d7d31680535d35b085e1c3de25255c7849e5955a59df8d31')  # noqa: E501
@@ -84,7 +84,7 @@ def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x47E50634E32212F43713Bf4e4A86E6275AcD456d']])
 def test_withdraw(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x00bdab08d05bd68f8f863e35a8dbe435978481dcbf15faf7276da30a5bfee971')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_element_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_element_finance.py
@@ -15,7 +15,7 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_claim_airdrop(database, ethereum_inquirer):
     """Data taken from

--- a/rotkehlchen/tests/unit/decoders/test_ens.py
+++ b/rotkehlchen/tests/unit/decoders/test_ens.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_mint_ens_name(database, ethereum_inquirer, add_subgraph_api_key):  # pylint: disable=unused-argument
     tx_hash = deserialize_evm_tx_hash('0x74e72600c6cd5a1f0170a3ca38ecbf7d59edeb8ceb48adab2ed9b85d12cc2b99')  # noqa: E501
@@ -271,7 +271,7 @@ def test_set_resolver(database, ethereum_inquirer, ethereum_accounts, add_subgra
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbc2E9Df6281a8e853121dc52dBc8BCc8bBE3ed0e']])
 def test_set_attribute_v2(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test that setting ens text attribute using public resolver deployed in March 2023 works"""
@@ -315,7 +315,7 @@ def test_set_attribute_v2(database, ethereum_inquirer, ethereum_accounts, add_su
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA3B9E4b2C18eFB1C767542e8eb9419B840881467']])
 def test_register_v2(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test that registering an ens name using eth registar deployed in March 2023 works"""
@@ -401,7 +401,7 @@ def test_register_v2(database, ethereum_inquirer, ethereum_accounts, add_subgrap
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA01f6D0985389a8E106D3158A9441aC21EAC8D8c']])
 def test_renewal_with_refund_old_controller(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
     """
@@ -451,7 +451,7 @@ def test_renewal_with_refund_old_controller(database, ethereum_inquirer, ethereu
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_renewal_with_refund_new_controller(database, ethereum_inquirer, ethereum_accounts):
     """
@@ -501,7 +501,7 @@ def test_renewal_with_refund_new_controller(database, ethereum_inquirer, ethereu
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7277F7849966426d345D8F6B9AFD1d3d89183083']])
 def test_content_hash_changed(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
     """Test that transactions changing the content hash of an ENS are properly decoded"""
@@ -546,7 +546,7 @@ def test_content_hash_changed(database, ethereum_inquirer, ethereum_accounts, ad
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(('action', 'ethereum_accounts'), [
     ('Transfer', ['0x4bBa290826C253BD854121346c370a9886d1bC26', '0x34207C538E39F2600FE672bB84A90efF190ae4C7']),  # noqa: E501
     ('Send', ['0x4bBa290826C253BD854121346c370a9886d1bC26']),
@@ -625,7 +625,7 @@ def test_transfer_ens_name(database, ethereum_inquirer, action, ethereum_account
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x5f0eb172CaA67d45865AAd955FA77654Da33196F']])
 def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
     """Test for https://github.com/rotki/rotki/issues/6597 where some labelhashes
@@ -752,7 +752,7 @@ def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts,
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_vote_cast(database, ethereum_inquirer, ethereum_accounts):
     """Test voting for ENS governance"""
@@ -798,7 +798,7 @@ def test_vote_cast(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_vote_cast_abstain(database, ethereum_inquirer, ethereum_accounts):
     """Test voting for ENS (or any) governance as abstain"""
@@ -844,7 +844,7 @@ def test_vote_cast_abstain(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_set_attribute_for_non_primary_name(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
     """Test that setting ens text attribute for a name that is controlle by but not
@@ -890,7 +890,7 @@ def test_set_attribute_for_non_primary_name(database, ethereum_inquirer, ethereu
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF5d90Ac6747CB3352F05BF61f48b991ACeaE28eB']])
 def test_claim_airdrop(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     tx_hex = deserialize_evm_tx_hash('0xb892797f63943dbf75e9e8a86515e9a4a964dcb6930dad10e93b526a2a648e6d')  # noqa: E501
@@ -950,7 +950,7 @@ def test_invalid_ens_name(globaldb: 'GlobalDBHandler'):
             ).fetchone()[0] == 0
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_new_owner(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test assigning new owner to a subnode"""
@@ -995,7 +995,7 @@ def test_new_owner(database, ethereum_inquirer, ethereum_accounts, add_subgraph_
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_address_changed(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test address changed for a name"""

--- a/rotkehlchen/tests/unit/decoders/test_eth2.py
+++ b/rotkehlchen/tests/unit/decoders/test_eth2.py
@@ -13,7 +13,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Eth2PubKey, Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc66962Ff943449C90b457856D448Aa19D60CB033']])
 def test_deposit(database, ethereum_inquirer, ethereum_accounts):
     """Test a simple beacon chain deposit contract"""
@@ -56,7 +56,7 @@ def test_deposit(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3e5fd0244e13d82fC230f3Fc610bcd76b3c8217C']])
 def test_multiple_deposits(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x819fe4a07894cf044f5d8c63e5c1e2294e068d05bf91d9cfc3e7ae3e60528ae5')  # noqa: E501
@@ -124,7 +124,7 @@ def test_multiple_deposits(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfeF0E7635281eF8E3B705e9C5B86e1d3B0eAb397', '0xFbcE5F52fc21296AE42EE000dFdFdC7FecAaA2fD']])  # noqa: E501
 def test_deposit_with_anonymous_event(database, ethereum_inquirer, ethereum_accounts):
     """As seen here: https://twitter.com/LefterisJP/status/1671515625397669889

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin.py
@@ -15,7 +15,7 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_gitcoin_old_donation(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x811ba23a10c76111289133ec6f90d3c33a604baa50053739210e870687a456d9')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
@@ -11,7 +11,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_optimism_donation_received(database, optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0x08685669305ee26060a5a78ae70065aec76d9e62a35f0837c291fb1232f33601')  # noqa: E501
@@ -41,7 +41,7 @@ def test_optimism_donation_received(database, optimism_inquirer, optimism_accoun
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_ethereum_donation_received(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x71fc406467f342f5801560a326aa29ac424381daf17cc04b5573960425ba605b')  # noqa: E501
@@ -69,7 +69,7 @@ def test_ethereum_donation_received(database, ethereum_inquirer, ethereum_accoun
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[
     '0x1B274eaCc333F4a904D72b576B55A108532aB379',
     # also track a grantee to see we handle donating to self fine
@@ -137,7 +137,7 @@ def test_ethereum_make_donation(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_optimism_create_project(database, optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0xe59f04c693e91f1659bd8bc718c993158efeb9af02c9c6337f039c44d8a822f6')  # noqa: E501
@@ -192,7 +192,7 @@ def test_optimism_create_project(database, optimism_inquirer, optimism_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_ethereum_project_apply(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3e4639d97be450c6d32ce77a146898780b75781caaf004d3c40bae083dec07c7')  # noqa: E501
@@ -234,7 +234,7 @@ def test_ethereum_project_apply(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_ethereum_project_update(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xfe00fa198eb5395e1d809e017c6b416e882b0aef16e82bf00cd60ce5576bb122')  # noqa: E501
@@ -276,7 +276,7 @@ def test_ethereum_project_update(database, ethereum_inquirer, ethereum_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xd034Fd34eaEe5eC2c413C51936109E12873f4DA5']])
 def test_optimism_many_donations_different_strategies(database, optimism_inquirer, optimism_accounts):  # noqa: E501
     tx_hex = deserialize_evm_tx_hash('0x5d85b436f5f177de6019baa9ecebae285e0def4924546307fac40556bece4cd7')  # noqa: E501
@@ -328,7 +328,7 @@ def test_optimism_many_donations_different_strategies(database, optimism_inquire
         assert event.counterparty == CPT_GITCOIN
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_optimism_grant_payout(database, optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0x84110136c94ceb71c72afb27ccb517eb33f77a8a419d125101644e2c43294815')  # noqa: E501
@@ -356,7 +356,7 @@ def test_optimism_grant_payout(database, optimism_inquirer, optimism_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_ethereum_grant_payout(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x66ff5be7841f05cc9cb53fd0307460690f91203c52490f5bbfdeabe8462be50b')  # noqa: E501
@@ -384,7 +384,7 @@ def test_ethereum_grant_payout(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_donation_matic_received(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hex = deserialize_evm_tx_hash('0x32837e03ac3e9066f09c1ee0807c533aa1bef5e3119b98dcacdd1ca631bc7ca6')  # noqa: E501
@@ -414,7 +414,7 @@ def test_polygon_donation_matic_received(database, polygon_pos_inquirer, polygon
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_donation_token_received(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hex = deserialize_evm_tx_hash('0x17601356467af0cfcf3a62f93879b504695b8690545b2b8669da5ec0f3a2a91b')  # noqa: E501
@@ -444,7 +444,7 @@ def test_polygon_donation_token_received(database, polygon_pos_inquirer, polygon
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_apply_to_round(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hex = deserialize_evm_tx_hash('0x51c1909ce9268f453d4b7136b0fecb72d8da567f406c37014dd8ad8ed05c9a1f')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_gmx.py
+++ b/rotkehlchen/tests/unit/decoders/test_gmx.py
@@ -19,7 +19,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x22E798f9440F563B92AAE24E94C75DfA499e3d3E']])
 def test_swap_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x5969392c45eaf7e6e3453e2405afb23eb2424e8e4ba2d14e38943fdcdab55d5f')  # noqa: E501
@@ -89,7 +89,7 @@ def test_swap_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0C0e6d63A7933e1C2dE16E1d5E61dB1cA802BF51']])
 def test_long_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x99eed649e7845813353b29dba0ac248dc328253051a778ca895a0a6c34092798')  # noqa: E501
@@ -145,7 +145,7 @@ def test_long_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x3D4d8A52D5717b09CA1e1980393d244Ac258C6AA']])
 def test_decrease_short_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xa3dd437d57689479db67ce685c4b70ee9bdbfbcc53f99fc343f73c89edaafe7a')  # noqa: E501
@@ -190,7 +190,7 @@ def test_decrease_short_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_acc
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xB5E10681aA81cd65D74912015220999044b9520C']])
 def test_stake_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x682aa15cb8d49021ae5b12c89f6d0138387c4819b1a31b80f67b70aac55d199c')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_gnosis_sdai.py
+++ b/rotkehlchen/tests/unit/decoders/test_gnosis_sdai.py
@@ -19,7 +19,7 @@ A_GNOSIS_SDAI = evm_address_to_identifier(
 )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x78E87757861185Ec5e8C0EF6BF0C69Fa7832df6C']])
 def test_deposit_xdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
@@ -76,7 +76,7 @@ def test_deposit_xdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
     assert actual_events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x4fFAD6ac852c0Af0AA301376F4C5Dea3a928b120']])
 def test_withdraw_xdai_from_sdai(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
@@ -135,7 +135,7 @@ def test_withdraw_xdai_from_sdai(database, gnosis_inquirer, gnosis_accounts):
     assert actual_events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x5938852FE18Ad6963322FB98D1fDDA5c24DD8a0E']])
 def test_deposit_wxdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
@@ -192,7 +192,7 @@ def test_deposit_wxdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
     assert actual_events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x23727b54163F63CffdD8B7769e0eCb13Df253b4e']])
 def test_withdraw_wxdai_from_sdai(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_golem.py
+++ b/rotkehlchen/tests/unit/decoders/test_golem.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf264267DCaFC1539900bc96006879701fA053259']])
 def test_gnt_glm_migration(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x86baa45e4ab48d1db26df82da1a6f654fe96f1254ace5883b6397d7f55eb11a4')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_juicebox.py
+++ b/rotkehlchen/tests/unit/decoders/test_juicebox.py
@@ -14,7 +14,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_donation(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -85,7 +85,7 @@ def test_donation(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x15b850a67A6ceDd218e368f1Cab11403f45a42f4']])
 def test_fund_raising(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(

--- a/rotkehlchen/tests/unit/decoders/test_lido_eth.py
+++ b/rotkehlchen/tests/unit/decoders/test_lido_eth.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4C49d4Bd6a571827B4A556a0e1e3071DA6231B9D']])
 def test_lido_steth_staking(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x23a3ee601475424e91bdc0999a780afe57bf37cbcce6d1c09a4dfaaae1765451')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -19,7 +19,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9ba961989Dd6609Ed091f512bE947118c40F2291']])
 def test_deposit_eth_borrow_lusd(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xdb9a541a4af7d5d46d7ea5fe4a2a752dcb731d64d052f86f630e97362063602c')  # noqa: E501
@@ -86,7 +86,7 @@ def test_deposit_eth_borrow_lusd(database, ethereum_inquirer, ethereum_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648E180e246741363639B1496762763dd25649db']])
 def test_payback_lusd(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x40bb08427a3b99fb9896cf14858d82d361a6e7a8fb7dd6d2000511ac3dca5707')  # noqa: E501
@@ -127,7 +127,7 @@ def test_payback_lusd(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648E180e246741363639B1496762763dd25649db']])
 def test_remove_eth(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x6be5312c21855c3cc324b5b6ce9f9f65dbd488e270e84ac5e6fb96c74d83fe4e')  # noqa: E501
@@ -169,7 +169,7 @@ def test_remove_eth(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF04E6f2D27ED324917AD2098F96f5d4ac52e1684']])
 def test_stability_pool_deposit(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x1277cb6c2c8e151fe90118cdd738e46f894e18de04ab6af33d567e91597f322b')  # noqa: E501
@@ -223,7 +223,7 @@ def test_stability_pool_deposit(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF03639047f75204d00c9314611C2b24570db4405']])
 def test_stability_pool_collect_rewards(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xad077faf7976504615561ac7fd9fdddc934180f3237f216851136d2327d71196')  # noqa: E501
@@ -290,7 +290,7 @@ def test_stability_pool_collect_rewards(database, ethereum_inquirer, ethereum_ac
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x1b63708eafa610DFa81c6DB4A257570D78a6dF1c']])
 def test_increase_lqty_staking(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x4e2bbc53a75fbbc954fc305f7adf68be1fa3b1416c941b0350719cc484c9d8fb')  # noqa: E501
@@ -358,7 +358,7 @@ def test_increase_lqty_staking(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x58D9A499AC82D74b08b3Cb76E69d8f32e1395746']])
 def test_remove_liquity_staking(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x028397f0409042da26890ec27eb36d617e326c3ce476d823f181419bdd0ad860')  # noqa: E501
@@ -700,7 +700,7 @@ def test_ds_proxy_liquity_staking(database, ethereum_inquirer, ethereum_accounts
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF35da7a42d92c7919172195aA7BC7a0d43eC866c']])
 def test_ds_proxy_borrow_lusd(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xa7404dc759fdef08fde6dbb227d6c55276861853d274c9a739236488a123f794')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -796,7 +796,7 @@ def test_maybe_reshuffle_events():
     )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[
     '0xA1E4380A3B1f749673E270229993eE55F35663b4',
     '0x756F45E3FA69347A9A973A725E3C98bC4db0b5a0',
@@ -858,7 +858,7 @@ def test_genesis_transaction(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDRESS_WITHOUT_GENESIS_TX]])
 def test_genesis_transaction_no_address(database, ethereum_inquirer):
@@ -875,7 +875,7 @@ def test_genesis_transaction_no_address(database, ethereum_inquirer):
         )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_phising_zero_transfers(database, ethereum_inquirer):
     """Checks that zero transfer phishing transactions are marked as ignored."""

--- a/rotkehlchen/tests/unit/decoders/test_makerdao.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648aA14e4424e0825A5cE739C8C68610e143FB79']])
 def test_makerdao_simple_transaction(
         database,
@@ -59,7 +59,7 @@ def test_makerdao_simple_transaction(
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xa217BDa86b0EDb86eE7d4D6e34F493eDF1ea4F29']])
 def test_withdraw_dai_from_sdai(
         database,
@@ -118,7 +118,7 @@ def test_withdraw_dai_from_sdai(
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xa217BDa86b0EDb86eE7d4D6e34F493eDF1ea4F29']])
 def test_deposit_dai_to_sdai(
         database,

--- a/rotkehlchen/tests/unit/decoders/test_metamask.py
+++ b/rotkehlchen/tests/unit/decoders/test_metamask.py
@@ -34,7 +34,7 @@ A_OPTIMISM_USDC = Asset('eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097F
 A_POLYGON_USDC = Asset('eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174')
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7e6Ee5d52825B3A3d9C500E7B8b0a2BAa1c91545']])
 def test_metamask_swap_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -115,7 +115,7 @@ def test_metamask_swap_token_to_eth(database, ethereum_inquirer, ethereum_accoun
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4bc63637428B1cb65E646d6CF3216A4B4C84f446']])
 def test_metamask_swap_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -184,7 +184,7 @@ def test_metamask_swap_eth_to_token(database, ethereum_inquirer, ethereum_accoun
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4E2A6f9F27AC0B4bd4E1729640e06888F432030C']])
 def test_metamask_swap_usdt_to_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -253,7 +253,7 @@ def test_metamask_swap_usdt_to_token(database, ethereum_inquirer, ethereum_accou
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xDe0A989c715C594Eadc98a1b97a9aa65d3cECb48']])
 def test_metamask_swap_token_to_usdc(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -322,7 +322,7 @@ def test_metamask_swap_token_to_usdc(database, ethereum_inquirer, ethereum_accou
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x94c3951a05df16b2e744937574778fFeb10a51b2']])
 def test_metamask_swap_token_to_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -403,7 +403,7 @@ def test_metamask_swap_token_to_token(database, ethereum_inquirer, ethereum_acco
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x517725Caf62Fca000C0ea950497116933f813E38']])
 def test_metamask_swap_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -472,7 +472,7 @@ def test_metamask_swap_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_ac
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xc29067833665820b3505953a87F8265C9f1A517b']])
 def test_metamask_swap_optimism(database, optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash(
@@ -541,7 +541,7 @@ def test_metamask_swap_optimism(database, optimism_inquirer, optimism_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xB12897740478eeC7B86b9eBf14245cDAcBBa4F2f']])
 def test_metamask_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash(

--- a/rotkehlchen/tests/unit/decoders/test_monerium.py
+++ b/rotkehlchen/tests/unit/decoders/test_monerium.py
@@ -10,7 +10,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da']])
 def test_minting_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(val='0x4ed9db44c5ee4ba6a4cf3e8e9b386f0b857afebad8339a92666e175c747bdd74')  # noqa: E501
@@ -38,7 +38,7 @@ def test_minting_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x99a0618B846D43E29C15ac468Eae06d03C9243C7']])
 def test_burning_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(val='0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354')  # noqa: E501
@@ -66,7 +66,7 @@ def test_burning_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x762e5f511c219823eeC73C743C8245807A53E123']])
 def test_minting_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xb240acc158fb2cdcdebc7321ca4a96f71b371379e2a78a9a7f27d0718a2e3735')  # noqa: E501
@@ -94,7 +94,7 @@ def test_minting_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_a
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x0A251dF99A88A20a93876205Fb7f5Faf2E85A481']])
 def test_burning_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xeaed8e3e862a9b41189e9039c825ee57fb80385801b8ac5c3ed70339baf243e5')  # noqa: E501
@@ -122,7 +122,7 @@ def test_burning_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_a
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x9566E3e6F55D4378243E55DE8e037Ee8E6e4de7E']])
 def test_minting_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
     evmhash = deserialize_evm_tx_hash(val='0x31183d757f530f799872600e6fe8644e3c20a1f90d02de9e89d0463454b400fa')  # noqa: E501
@@ -150,7 +150,7 @@ def test_minting_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0xAf31992307AcBb6Ad8795261EeA31494e62A8e40']])
 def test_burning_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xae087f309231e4dc1fa84927888deb6c56b9980e63f9cc049cbe2d7d2bc503e6')  # noqa: E501
@@ -178,7 +178,7 @@ def test_burning_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x39c185721fbe8b350363e6B49801305d32485A45']])
 def test_burnfrom_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xf04a5d84e6749828ff63991fb3323944472346c3b2c421e51d9999283d18f1fd')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_optimism.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism.py
@@ -19,7 +19,7 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [[ADDY]])
 def test_optimism_airdrop_1_claim(database, optimism_inquirer):
     """Data taken from
@@ -63,7 +63,7 @@ def test_optimism_airdrop_1_claim(database, optimism_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x168FEB2E7de2aC0c37a239261D3F9e1b396F22a2']])
 def test_optimism_airdrop_4_claim(database, optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xb5b478b321a81ae03565dd72bd625fcb203a97f017670b28e306a893414ae83b')  # noqa: E501
@@ -104,7 +104,7 @@ def test_optimism_airdrop_4_claim(database, optimism_accounts, optimism_inquirer
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [[ADDY]])
 def test_optimism_delegate_change(database, optimism_inquirer):
     """Data taken from

--- a/rotkehlchen/tests/unit/decoders/test_optimism_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism_bridge.py
@@ -15,7 +15,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
 def test_deposit_erc20(database, ethereum_inquirer, ethereum_accounts):
     """Data is taken from
@@ -58,7 +58,7 @@ def test_deposit_erc20(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x18C22c88146B24a2c96E65c82666d976A4ba5a94']])
 def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
     """Data is taken from
@@ -101,7 +101,7 @@ def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
 def test_receive_erc20_on_optimism_legacy(database, optimism_inquirer, optimism_accounts):
     """Legacy bridge deposit to optimism. Where l1fee exists in receipt data"""
@@ -130,7 +130,7 @@ def test_receive_erc20_on_optimism_legacy(database, optimism_inquirer, optimism_
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_receive_erc20_on_optimism(database, optimism_inquirer, optimism_accounts):
     """Newer bridge deposit to optimism. Where l1fee is 0 and missing from receipt data"""
@@ -159,7 +159,7 @@ def test_receive_erc20_on_optimism(database, optimism_inquirer, optimism_account
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xfc399B17D1Ddf01a518DcaeE557ef776bf288f63']])
 def test_receive_eth_on_optimism(database, optimism_inquirer, optimism_accounts):
     """Data is taken from
@@ -190,7 +190,7 @@ def test_receive_eth_on_optimism(database, optimism_inquirer, optimism_accounts)
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x261FD12AF4c4bAbb30F44c1B0FE20a718A39b04C']])
 def test_withdraw_erc20(database, optimism_inquirer, optimism_accounts):
     """Data is taken from
@@ -233,7 +233,7 @@ def test_withdraw_erc20(database, optimism_inquirer, optimism_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xE232E72983E329757F02292322296f5B96dAfC8F']])
 def test_withdraw_eth(database, optimism_inquirer, optimism_accounts):
     """Data is taken from
@@ -276,7 +276,7 @@ def test_withdraw_eth(database, optimism_inquirer, optimism_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x261FD12AF4c4bAbb30F44c1B0FE20a718A39b04C']])
 def test_claim_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     """Data is taken from
@@ -319,7 +319,7 @@ def test_claim_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xE232E72983E329757F02292322296f5B96dAfC8F']])
 def test_claim_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     """Data is taken from
@@ -362,7 +362,7 @@ def test_claim_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC02ad7b9a9121fc849196E844DC869D2250DF3A6']])
 def test_prove_withdrawal(database, ethereum_inquirer, ethereum_accounts):
     """Test that withdrawal proving of the 2-step withdrawal is recognized properly

--- a/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_vote_cast(database, optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xeb9fb7b5047a30c4bb7e68343c6657ba4b0f0bcaf3d64972dcc01ccc3c10608b')  # noqa: E501
@@ -52,7 +52,7 @@ def test_vote_cast(database, optimism_inquirer, optimism_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_vote_cast_with_params(database, optimism_inquirer, optimism_accounts):
     """Data is taken from
@@ -95,7 +95,7 @@ def test_vote_cast_with_params(database, optimism_inquirer, optimism_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_vote_cast_with_reason(database, optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xced69de2a81814554b9f69a19240737f0728f94bd67d94c73f960d24f99343bd')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_paraswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap.py
@@ -47,7 +47,7 @@ A_POLYGON_POS_USDC = Asset('eip155:137/erc20:0x3c499c542cEF5E3811e1192ce70d8cC03
 A_POLYGON_POS_DAI = Asset('eip155:137/erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063')
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf8fa0bB0798489445577fA7387dcB2125C361c28']])
 def test_simple_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xeab04bca5abb6a794fd83e3c336b128824a2d3a72abf565d82a6ecd39d5929ef')  # noqa: E501
@@ -114,7 +114,7 @@ def test_simple_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x711ee578860F6f621401A6148b09F69c1F8508B2']])
 def test_simple_swap_eth_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xeeea20b39f157fe59fa4904fd4b62f8971188b53d05c6831e0ed67ee157e40c2')  # noqa: E501
@@ -181,7 +181,7 @@ def test_simple_swap_eth_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xd3669637F3C520d73eE922EA62D2C33F547F9Cd6']])
 def test_simple_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf4d28d1c46dde983fac73db8e651514fe7299edaf40870766462362b1b1a1d83')  # noqa: E501
@@ -261,7 +261,7 @@ def test_simple_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf84C3222D213e53a053A97E426738Cb12c50CBA5']])
 def test_simple_buy(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x695739b3eab8dc7e6ef7f9b362983cfd4d9b81592b0840bd0ca69b0b2e8e51f9')  # noqa: E501
@@ -315,7 +315,7 @@ def test_simple_buy(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x33e543cB6Be7b33fF95FAF61eA8106b384E74912']])
 def test_multi_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6f7313845874cb26cda5d63adcbf9899edf257f2e196a7ace641bdbb179947e7')  # noqa: E501
@@ -369,7 +369,7 @@ def test_multi_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xBc067f00652Ba0B3278a3d373431769F2805Bc27']])
 def test_multi_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0c55b3df325d145b82fbe4e135e88eeae9820b035842b2ec5e17ccb1357375c6')  # noqa: E501
@@ -436,7 +436,7 @@ def test_multi_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4e9B2f2B72F6A5B3735cD18357F0F0EF950D1Ba7']])
 def test_mega_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5c36bcfa67d3306a3fe21203b7279e589d26c9925d055b3174ac259b262345f3')  # noqa: E501
@@ -503,7 +503,7 @@ def test_mega_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x752921eAead738CFd1aEB8571a58480dB51e42C1']])
 def test_mega_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9c529e46976ce23d1caf3dc1c062ee3c9ec9c327014f5447761409788e842294')  # noqa: E501
@@ -570,7 +570,7 @@ def test_mega_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xe952e50D1F82bBfb5054311Ca689807e343a1ab8']])
 def test_swap_on_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6fa4a6a9c0d9c5aad831cc1ff149fb7683c0573db93571bc43acb5b4848314ae')  # noqa: E501
@@ -624,7 +624,7 @@ def test_swap_on_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts)
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4AE269b8e9116f8E44797D7424E8351286FCDfab']])
 def test_swap_on_uniswap_v2_fork_with_permit(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xaab04d564e1f065b350e6aa6fda9d0ff51082e8810520e691866fdade91ba9c4')  # noqa: E501
@@ -691,7 +691,7 @@ def test_swap_on_uniswap_v2_fork_with_permit(database, ethereum_inquirer, ethere
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA80F8ac7Fe79558854E26A49867D11f8cF9cC36B']])
 def test_buy_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x15df127374a04772df72b94685f60f71200da679e4bc2c334a12889fe2ab046c')  # noqa: E501
@@ -745,7 +745,7 @@ def test_buy_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xB855c4eBb5b6eB3F2033aecC4E543e27BC39465D']])
 def test_direct_uniswap_v3_swap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2b6e830d4b32c22b3c4c2a26dbdb9a17c3cc2962fc35d5b4cd5d56c58cbec68a')  # noqa: E501
@@ -799,7 +799,7 @@ def test_direct_uniswap_v3_swap(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xE93EB339C3d826F8A4d14Cc14CA008375915000F']])
 def test_direct_curve_v1_swap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5a601f524592627eaf3562e4cb1340880260a1bf627a984392308cdf79a828dc')  # noqa: E501
@@ -866,7 +866,7 @@ def test_direct_curve_v1_swap(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x6133de401FB609aACB767D8b379157731a09b66b']])
 def test_direct_curve_v2_swap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2ea92952050e9f5cbf9b46619355a3b34822286443e10a6f5405573330def118')  # noqa: E501
@@ -920,7 +920,7 @@ def test_direct_curve_v2_swap(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x23a49A9930f5b562c6B1096C3e6b5BEc133E8B2E']])
 def test_direct_balancer_v2_given_swap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x606413e4074e79e68ee0f79eee96c94cf091e7c061a551d2dd2a27044fb007e7')  # noqa: E501
@@ -1000,7 +1000,7 @@ def test_direct_balancer_v2_given_swap(database, ethereum_inquirer, ethereum_acc
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xFee285cf79719FC3552c5F7c540554f09DAdAD21']])
 def test_simple_buy_fee_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x92a422b746cc1ce14b795e5fc2239cdf3146482a5bc3c5278dccb1c3ccccdc17')  # noqa: E501
@@ -1080,7 +1080,7 @@ def test_simple_buy_fee_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_o
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0x66CF237A0D3505E80eF083E0F8D4Cad09Fd0BFe4']])
 def test_simple_swap_no_fee_base(database, base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf93a7211656753e841899b40edf3a9ccfded6b40b6d7b3538a4215362f9bd34f')  # noqa: E501
@@ -1134,7 +1134,7 @@ def test_simple_swap_no_fee_base(database, base_inquirer, base_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xDa2181fB19f2Fe365BeF6Ccb84209d6FDb0d1828']])
 def test_direct_curve_v1_swap_optimism(database, optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x83ac5abc6819fca458f614e4fdbca6fe324bbea8b7ce5fb072bf99407cd8c031')  # noqa: E501
@@ -1214,7 +1214,7 @@ def test_direct_curve_v1_swap_optimism(database, optimism_inquirer, optimism_acc
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xe03679B59AC0026036ba4518bc0d5e5F800Bd9c1']])
 def test_direct_uniswap_v3_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4f72cff63802c8eed51662e3d1e20bc7e86ac06cdc1aa490c26cfeee075b6018')  # noqa: E501
@@ -1281,7 +1281,7 @@ def test_direct_uniswap_v3_swap_polygon(database, polygon_pos_inquirer, polygon_
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x60A543647a1ecAccAADFc2DF27a2D1D74e60A39f']])
 def test_paraswap_fork_with_factory(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x90d9e615e808d5d9b62f6f072c783e9a9f8417c46fcc6665a4aadd927dc74fce')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_polygon.py
+++ b/rotkehlchen/tests/unit/decoders/test_polygon.py
@@ -15,7 +15,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x692C673814eDB9Fe6DB2a6F4227F40524240Cbec']])
 def test_matic_to_pol_migration(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6c30b202e7223ea93b9d1c898d7012b699d14bec5434e8839fc290858718f6a2')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_safe.py
+++ b/rotkehlchen/tests/unit/decoders/test_safe.py
@@ -13,7 +13,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [
     [
         '0x6C65fB326e7734Ba5508b5d043718288b43b9ed9',
@@ -64,7 +64,7 @@ def test_added_owner(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [
     [
         '0xafCD4572408b322adA9890253a7A42A9Fa4C2E40',
@@ -115,7 +115,7 @@ def test_removed_owner(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [
     [
         '0xa0DD8E6c5440a424cD19f5Ec30F8fa485E814247',
@@ -165,7 +165,7 @@ def test_changed_threshold(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_execution_success(database, ethereum_inquirer, ethereum_accounts):
     """
@@ -213,7 +213,7 @@ def test_execution_success(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7']])
 def test_execution_failure(database, ethereum_inquirer, ethereum_accounts):
     """
@@ -261,7 +261,7 @@ def test_execution_failure(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x96399Ddb62d833029fbEf774d1FE044AF33E98Ef']])
 def test_safe_creation(database, ethereum_inquirer, ethereum_accounts):
     """Test that creation of new safes is tracked"""
@@ -306,7 +306,7 @@ def test_safe_creation(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])  # yabir.eth  # noqa: E501
 def test_safe_spam(database, polygon_pos_inquirer, polygon_pos_accounts):
     """Test that a safe transaction if from an unrelated account, does not appear in events"""

--- a/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
@@ -26,7 +26,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfa8666aE51F5b136596248d9411b03AC9040fff0']])
 def test_deposit_eth_from_ethereum_to_scroll(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x1d924e2f2f63cf5a2d78ceaa6289658cf4743e968d23f78064d55c7428f78b60')  # noqa: E501
@@ -81,7 +81,7 @@ def test_deposit_eth_from_ethereum_to_scroll(database, ethereum_inquirer, ethere
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xfa8666aE51F5b136596248d9411b03AC9040fff0']])
 def test_receive_eth_on_scroll(database, scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0xd47e37dc8acb08b86bd90214d1df15549305e6d5fe126b97ff3b66a1b814b801')  # noqa: E501
@@ -111,7 +111,7 @@ def test_receive_eth_on_scroll(database, scroll_inquirer, scroll_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xEa72f0d67045b2cffbFB18E56744799f9F860CB7']])
 def test_withdraw_eth_from_scroll_to_ethereum(database, scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x87c44e16cf62a8aa8e56b9677e6c400041b6731a5c24f9b8ca2deb6e00202a42')  # noqa: E501
@@ -153,7 +153,7 @@ def test_withdraw_eth_from_scroll_to_ethereum(database, scroll_inquirer, scroll_
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xEa72f0d67045b2cffbFB18E56744799f9F860CB7']])
 def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xed4d0ddc99b88caa07d5d15faf376abade6cc06eaf6a28dce47eac66695503c4')  # noqa: E501
@@ -195,7 +195,7 @@ def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xD297a2E732537f9fFb2Da53816FC84c7A50a11C2']])
 def test_deposit_erc20_from_ethereum_to_scroll(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xd80e6894bce182c2976bb9fa64e162f1757a087057b00638b43fe0c5154cf1a6')  # noqa: E501
@@ -250,7 +250,7 @@ def test_deposit_erc20_from_ethereum_to_scroll(database, ethereum_inquirer, ethe
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xD297a2E732537f9fFb2Da53816FC84c7A50a11C2']])
 def test_receive_erc20_on_scroll(database, scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x630cd85723676d993f4afdd9f182cd2468444748eb7b1c6c0c8cc1db0d925c15')  # noqa: E501
@@ -280,7 +280,7 @@ def test_receive_erc20_on_scroll(database, scroll_inquirer, scroll_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x182A0c65bCB008adAaE404e30A813c9797BD717c']])
 def test_withdraw_erc20_from_scroll_to_ethereum(database, scroll_inquirer, scroll_accounts, caplog):  # noqa: E501
     """Test that USDT withdrawals from scroll to L1 work fine"""
@@ -326,7 +326,7 @@ def test_withdraw_erc20_from_scroll_to_ethereum(database, scroll_inquirer, scrol
     assert '_decode_eth_withdraw_event failed due to Invalid ethereum address' not in caplog.text
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xa6145DFB72ADBd7D018c30f611bde7D943EE2E17']])
 def test_withdraw_usdc_from_scroll_to_ethereum(database, scroll_inquirer, scroll_accounts):
     """
@@ -372,7 +372,7 @@ def test_withdraw_usdc_from_scroll_to_ethereum(database, scroll_inquirer, scroll
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x59ceD3eeB1cb01AfE92ADbC994D1CE78310E668E']])
 def test_receive_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xbe6e98db62ee719922c7d01b0b623e16c8ee162a2bf9143603f11eba3e3dd474')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_shapeshift.py
+++ b/rotkehlchen/tests/unit/decoders/test_shapeshift.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3800966F67ccBA1976F69D006374204fba56d240']])
 def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x6635d1e12fed1a95019a53e6f6495c586891bf7b41bccfc5838f9b1703a9c20c')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_shutter.py
+++ b/rotkehlchen/tests/unit/decoders/test_shutter.py
@@ -15,7 +15,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xCc60Eb2f64E7AD9b6924939B7985970D29A0108c']])
 def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3f20929de51baefdc688997a05bde1e32120cb7d4e0fda5da3963b1a620d0a8b')  # noqa: E501
@@ -59,7 +59,7 @@ def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x36bE40f9bd613dFf47294E7e10D4cae072E06A2D']])
 def test_shu_delegation(database, ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x46a476b09c85d2278f1ac889e943d7f47d029d0985719cc2a73d589a73cb2473')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_socket.py
+++ b/rotkehlchen/tests/unit/decoders/test_socket.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_optimism_to_arb_bridge(database, optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xe8c9cffe2a2bbccf81cf8dd34f9b89c01b00ae3f0ff74eab089de96f4624165c')  # noqa: E501
@@ -54,7 +54,7 @@ def test_optimism_to_arb_bridge(database, optimism_inquirer, optimism_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_bridge_eth(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xb1e29bebca0300ff02ee478dfa6c0c2197169761e1c0dcc87418c53a6530d3a5')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -26,7 +26,7 @@ ADDY_2 = string_to_evm_address('0x1F14bE60172b40dAc0aD9cD72F6f0f2C245992e8')
 ADDY_3 = string_to_evm_address('0x3D6a724247c4B133C3b279558e90EdD0c5d25751')
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_1]])
 def test_sushiswap_single_swap(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbfe3c8a13c325a32736beb34ea170053cdbbd1740a9c3ceca52060906b7f87bd')  # noqa: E501
@@ -93,7 +93,7 @@ def test_sushiswap_single_swap(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_2]])
 def test_sushiswap_v2_remove_liquidity(database, ethereum_inquirer):
     """This checks that removing liquidity to Sushiswap V2 pool is decoded properly"""
@@ -163,7 +163,7 @@ def test_sushiswap_v2_remove_liquidity(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_3]])
 def test_sushiswap_v2_add_liquidity(database, ethereum_inquirer):
     """This checks that adding liquidity to Sushiswap V2 pool is decoded properly"""

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -26,7 +26,7 @@ ADDY_USER_2_ARB = string_to_evm_address('0xec9342111098f8b4A293cD8033746d6f8E9e9
 ADDY_USER_3_ARB = string_to_evm_address('0xBe79986821637afD1406BF9278DA55cf9085cF8f')
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
 def test_thegraph_delegate(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x6ed3377db652151fb8e4794dd994a921a2d029ad317bd3f2a2916af239490fec')  # noqa: E501
@@ -98,7 +98,7 @@ def test_thegraph_delegate(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_ROTKI]])
 def test_thegraph_contract_deposit_gas(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xf254ac1bbfbf07ca21042edd3ff78dad7c3158c8218598b5359b6e415e0977b7')  # noqa: E501
@@ -142,7 +142,7 @@ def test_thegraph_contract_deposit_gas(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_ROTKI]])
 def test_thegraph_contract_transfer_approval(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbb8280cc9ca9de1d33e573a4381d88525a214fc45f84415129face03125ba22f')  # noqa: E501
@@ -184,7 +184,7 @@ def test_thegraph_contract_transfer_approval(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_ROTKI]])
 def test_thegraph_contract_delegation_transferred_to_l2_vested(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x48321bb00e5c5b67f080991864606dbc493051d20712735a579d7ae31eca3d78')  # noqa: E501
@@ -234,7 +234,7 @@ def test_thegraph_contract_delegation_transferred_to_l2_vested(database, ethereu
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER_2, ADDY_ROTKI]])
 def test_thegraph_contract_delegation_transferred_to_l2(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xed80711e4cb9c428790f0d9b51f79473bf5253d5d03c04d958d411e7fa34a92e')  # noqa: E501
@@ -294,7 +294,7 @@ def test_thegraph_contract_delegation_transferred_to_l2(database, ethereum_inqui
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
 def test_thegraph_undelegate(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x5ca5244868d9c0d8c30a1cad0feaf137bd28acd9c3f669a09a3a199fd75ad25a')  # noqa: E501
@@ -337,7 +337,7 @@ def test_thegraph_undelegate(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
 def test_thegraph_delegated_withdrawn(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x49307751de5ba4cf98fccbdd1ab8387fd60a7ce120800212c216bf0a6a04acfa')  # noqa: E501
@@ -380,7 +380,7 @@ def test_thegraph_delegated_withdrawn(database, ethereum_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_1_ARB]])
 def test_thegraph_delegate_arbitrum_one(database, arbitrum_one_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x3c846f305330969fb0ddb87c5ae411b4e9692f451a7ff3237b6f71020030c7d1')  # noqa: E501
@@ -451,7 +451,7 @@ def test_thegraph_delegate_arbitrum_one(database, arbitrum_one_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_2_ARB]])
 def test_thegraph_undelegate_arbitrum_one(database, arbitrum_one_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xc66ea685db10809b1765e8381175ada7b021b5a40f57572e220a8b94235c1f72')  # noqa: E501
@@ -509,7 +509,7 @@ def test_thegraph_undelegate_arbitrum_one(database, arbitrum_one_inquirer):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_3_ARB]])
 def test_thegraph_delegated_withdrawn_arbitrum_one(database, arbitrum_one_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xd6847bc02b65891118caaa8a2882cf5db6e0938c909db112e4fa6930929d8c39')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_velodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_velodrome.py
@@ -43,7 +43,7 @@ VELO_V1_TOKEN = evm_address_to_identifier(
 )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_add_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_global_caches):
@@ -130,7 +130,7 @@ def test_add_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_
     assert EvmToken(WETH_OP_LP_TOKEN).protocol == VELODROME_POOL_PROTOCOL
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0xE1343a4b5e64d47B0c0f208d05Fb4B5973443818']])
 def test_add_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_global_caches):
@@ -207,7 +207,7 @@ def test_add_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_
     assert EvmToken(lp_token_identifier).protocol == VELODROME_POOL_PROTOCOL
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_remove_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_global_caches):
@@ -300,7 +300,7 @@ def test_remove_liquidity_v2(optimism_transaction_decoder, optimism_accounts, lo
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0xe435BEbA6DEE3D6F99392ab9568777EB8165719d']])
 def test_remove_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_global_caches):
@@ -387,7 +387,7 @@ def test_remove_liquidity_v1(optimism_transaction_decoder, optimism_accounts, lo
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_swap_eth_to_token_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):
@@ -445,7 +445,7 @@ def test_swap_eth_to_token_v2(optimism_accounts, optimism_transaction_decoder, l
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0xB1D34002ee676516787fd8CDb9C549a415F68aA8']])
 def test_swap_eth_to_token_v1(optimism_accounts, optimism_transaction_decoder, load_global_caches):
@@ -503,7 +503,7 @@ def test_swap_eth_to_token_v1(optimism_accounts, optimism_transaction_decoder, l
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x2359497cc3F8F11A80d775715367d5CB3D0fD274']])
 def test_swap_token_to_eth_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):
@@ -573,7 +573,7 @@ def test_swap_token_to_eth_v2(optimism_accounts, optimism_transaction_decoder, l
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0xeEf53a1f4eb3846f33C3E549D6FDF130fa4f8b27']])
 def test_swap_token_to_eth_v1(optimism_accounts, optimism_transaction_decoder, load_global_caches):
@@ -631,7 +631,7 @@ def test_swap_token_to_eth_v1(optimism_accounts, optimism_transaction_decoder, l
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_swap_tokens_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):
@@ -701,7 +701,7 @@ def test_swap_tokens_v2(optimism_accounts, optimism_transaction_decoder, load_gl
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0xC6d5Ad3C4002A1b48d87b83939698660516ae142']])
 def test_swap_tokens_v1(optimism_accounts, optimism_transaction_decoder, load_global_caches):
@@ -759,7 +759,7 @@ def test_swap_tokens_v1(optimism_accounts, optimism_transaction_decoder, load_gl
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_stake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):  # noqa: E501
@@ -825,7 +825,7 @@ def test_stake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_deco
     assert EvmToken(WETH_OP_LP_TOKEN).protocol == VELODROME_POOL_PROTOCOL
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_unstake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):  # noqa: E501
@@ -871,7 +871,7 @@ def test_unstake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_de
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_VELODROME]])
 @pytest.mark.parametrize('optimism_accounts', [['0xf9AEb52bB4eF74E1987dd295E4Df326d41D0d0fF']])
 def test_get_reward_from_gauge_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_weth.py
+++ b/rotkehlchen/tests/unit/decoders/test_weth.py
@@ -36,7 +36,7 @@ WETH_MAINNET_ADDRESS = string_to_evm_address('0xC02aaA39b223FE8D0A0e5C4F27eAD908
 WETH_ARB_ADDRESS = string_to_evm_address('0x82aF49447D8a07e3bd95BD0d56f35241523fBab1')
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4B078a6A7026C32D2D6Aff763E2F37336cf552Dd']])
 def test_weth_deposit(database, ethereum_inquirer):
     """
@@ -105,7 +105,7 @@ def test_weth_deposit(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4b2975AfF4DeF34D3Cd4f4759b45faF738D790D3']])
 def test_weth_withdrawal(database, ethereum_inquirer):
     """
@@ -168,7 +168,7 @@ def test_weth_withdrawal(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC4DdFf531132d32b47eC938AcfA28E354769A806']])
 def test_weth_interaction_with_protocols_deposit(database, ethereum_inquirer):
     """
@@ -250,7 +250,7 @@ def test_weth_interaction_with_protocols_deposit(database, ethereum_inquirer):
     )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xDea6866A866C60d68fFDFc6178C12fCFdb9d0D47']])
 def test_weth_interaction_with_protocols_withdrawal(database, ethereum_inquirer):
     """
@@ -312,7 +312,7 @@ def test_weth_interaction_with_protocols_withdrawal(database, ethereum_inquirer)
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d']])
 def test_weth_interaction_errors(database, ethereum_inquirer):
     """
@@ -370,7 +370,7 @@ def test_weth_interaction_errors(database, ethereum_inquirer):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_wxdai_unwrap(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
@@ -428,7 +428,7 @@ def test_wxdai_unwrap(database, gnosis_inquirer, gnosis_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0xd6f585378F3232E440B165AD56658bFcA76D1B32']])
 def test_wxdai_wrap(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
@@ -486,7 +486,7 @@ def test_wxdai_wrap(database, gnosis_inquirer, gnosis_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xBE6660FBE96B61B72Bf35FFaB40eB2CA886A7f85']])
 def test_weth_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xc19c7e1e0af7819b1922a287d034540e8f8dba4e065317d6483d48ac27e727e9')  # noqa: E501
@@ -541,7 +541,7 @@ def test_weth_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_on
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x7aBAee8F04EFd689961115f7A28bAA2E73Be6703']])
 def test_weth_deposit_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x57cc837c6f3d84c8fa3db8a7405f7244f11d32152159edf5ba79f5a7c34919b8')  # noqa: E501
@@ -596,7 +596,7 @@ def test_weth_deposit_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x81aa5101D4c376cd6DC031EA62D7b64A9BAE10a0']])
 def test_weth_withdraw_optimism(database, optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0x4a6b47e1f622a8ad059bd0723c53f2c71f12e7b105d2ef2ff4dff07ac1f185c0')  # noqa: E501
@@ -651,7 +651,7 @@ def test_weth_withdraw_optimism(database, optimism_inquirer, optimism_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xD6f30247e6a8B8656a8B02Ea37247f5eb939c626']])
 def test_weth_deposit_optimism(database, optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0x42074e2228be1716f84888f1993fa62443f591945b21dfbf159a64ae467990c4')  # noqa: E501
@@ -706,7 +706,7 @@ def test_weth_deposit_optimism(database, optimism_inquirer, optimism_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x6247666Ea4C80083035214780978E9EBa4AA6Cf4']])
 def test_weth_withdraw_scroll(database, scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x88f49633073a7667f93eb888ec2151c26f449cc10afca565a15f8df68ee20f82')  # noqa: E501
@@ -761,7 +761,7 @@ def test_weth_withdraw_scroll(database, scroll_inquirer, scroll_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xdFd21F8aA81c5787160F9a4B39357F5FE1c743DC']])
 def test_weth_deposit_scroll(database, scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x1fa6d87801891fcea66a9be2d4fce1c52569c5ce30579fbe7de37eb05bd247f8')  # noqa: E501
@@ -816,7 +816,7 @@ def test_weth_deposit_scroll(database, scroll_inquirer, scroll_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0x44f29ebE386c409376C66ad268F9Ae595c8C3e76']])
 def test_weth_withdraw_base(database, base_inquirer, base_accounts):
     evmhash = deserialize_evm_tx_hash('0x8d54608c2f684d880ad40a16cf9b82525c51520798ae8875d543d3338327ddad')  # noqa: E501
@@ -871,7 +871,7 @@ def test_weth_withdraw_base(database, base_inquirer, base_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xf396e7dbb20489D47F2daBfDA013163223B892a0']])
 def test_weth_deposit_base(database, base_inquirer, base_accounts):
     evmhash = deserialize_evm_tx_hash('0x0d418e4a858ca5faf00c36b685561ca0fdac52ebd10364bf2cb6d7b5969e84e5')  # noqa: E501
@@ -926,7 +926,7 @@ def test_weth_deposit_base(database, base_inquirer, base_accounts):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x33C0Aae5b2b6Eae2a6286B3a6621B55DcC02dC9e']])
 def test_wmatic_deposit_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash('0xba581391d417a6dcc31031f1cf7cba6e63b701a8680828445ffdde73777843e1')  # noqa: E501
@@ -981,7 +981,7 @@ def test_wmatic_deposit_polygon_pos(database, polygon_pos_inquirer, polygon_pos_
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xdAA9E3CA7500d7Ba3855dF9d8BCCde229C13919e']])
 def test_wmatic_withdraw_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash('0xe90ed71875ff44ea45ea960d006ec4c0ccb86506cba494471aba4ba9dc86123f')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
@@ -15,7 +15,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4c1a316De360E08817eB88dD31A0E7305005fB65']])
 def test_bridge_dai_from_ethereum(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe17f61edb9fe278720679ecfd5498f75082e38bf4779e5e6403a551f5084ee23')  # noqa: E501
@@ -57,7 +57,7 @@ def test_bridge_dai_from_ethereum(database, ethereum_inquirer, ethereum_accounts
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfF025244b556F0CD4617FBfE67F7986D7292A3E4']])
 def test_bridge_dai_from_ethereum_nolog(database, ethereum_inquirer, ethereum_accounts):
     """Test the case where a simple transfer to the bridge is recognized as a bridging event"""
@@ -100,7 +100,7 @@ def test_bridge_dai_from_ethereum_nolog(database, ethereum_inquirer, ethereum_ac
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x07AD02e0C1FA0b09fC945ff197E18e9C256838c6']])
 def test_withdraw_dai_to_ethereum(database, ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
@@ -142,7 +142,7 @@ def test_withdraw_dai_to_ethereum(database, ethereum_inquirer, ethereum_accounts
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x07AD02e0C1FA0b09fC945ff197E18e9C256838c6']])
 def test_withdraw_dai_from_gnosis(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
@@ -184,7 +184,7 @@ def test_withdraw_dai_from_gnosis(database, gnosis_inquirer, gnosis_accounts):
     ]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x7DA9A33d15413F499299687cC9d81DE84684E28E']])
 def test_deposit_dai_to_gnosis(database, gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_yearn.py
+++ b/rotkehlchen/tests/unit/decoders/test_yearn.py
@@ -485,7 +485,7 @@ def test_withdraw_yearn_v1(database, ethereum_inquirer, eth_transactions):
     assert events == expected_events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfDb7EEc5eBF4c4aC7734748474123aC25C6eDCc8']])
 def test_deposit_yearn_full_amount(database, ethereum_inquirer, ethereum_accounts):
     """

--- a/rotkehlchen/tests/unit/decoders/test_ygov.py
+++ b/rotkehlchen/tests/unit/decoders/test_ygov.py
@@ -12,7 +12,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xB04a6DB13942b6d4416AbeC5A8327866375c17a4']])
 def test_ygov_stake(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1c596eb9189d124418d5bd060cb702acf20be8f7b18220fbec9b94a99b95c1d3')  # noqa: E501
@@ -56,7 +56,7 @@ def test_ygov_stake(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA7499Aa6464c078EeB940da2fc95C6aCd010c3Cc']])
 def test_ygov_get_reward(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9063899641457daf68518b7017a4df30a79a0630224528aee0f2c483db76fc58')  # noqa: E501
@@ -100,7 +100,7 @@ def test_ygov_get_reward(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3AA33a58BFD82EA119E36b8886BC7E36E6F7Aa29']])
 def test_ygov_exit(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x42787b2b175d7f09401c3fd68c92f78982de2deef2214196261a31258c68006b')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_zerox.py
+++ b/rotkehlchen/tests/unit/decoders/test_zerox.py
@@ -42,7 +42,7 @@ A_PENDLE: Final = Asset(strethaddress_to_identifier('0x808507121B80c02388fAd1472
 A_BULL: Final = Asset('eip155:137/erc20:0x9f95e17b2668AFE01F8fbD157068b0a4405Cc08D')
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xaE84961b9FA7412fEAEf209fD8f50C4F8Ef4D8fD']])
 def test_sell_to_uniswap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb9827174e182a1b8df3507d13c5cedccdc974c4edd5d66f59355f7e9758b9006')  # noqa: E501
@@ -95,7 +95,7 @@ def test_sell_to_uniswap(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc2aAd9386835C90deC9d669e35c128461E6102CA']])
 def test_sell_eth_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5b7719016f7d7d3d8ed9d4d86afd0e0079551d0a7795f70f01764ce5eaa44478')  # noqa: E501
@@ -148,7 +148,7 @@ def test_sell_eth_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereum_
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xed288d0261421C7cf36a56f23297cD5F4635A089']])
 def test_sell_token_for_eth_to_uniswap_v3(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x68416e19252c678cdf67ae9b7adff742d78f95cea3c3f0582d3dc930340e5bdf')  # noqa: E501
@@ -201,7 +201,7 @@ def test_sell_token_for_eth_to_uniswap_v3(database, ethereum_inquirer, ethereum_
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xCCD54C835d7199ceEE2AedA4722C69eeeA6E606D']])
 def test_sell_token_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6efe8a18de9ca3183bdb319be445f1b0b9041c0e8208fa04a58ee276b54574dd')  # noqa: E501
@@ -254,7 +254,7 @@ def test_sell_token_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereu
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xddb143606305559e6b69843c1f53f2689D2aB605']])
 def test_multiplex_batch_sell_eth_for_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa151bc4f1c69591598386eaa65761cefd706cbfe0a1a340d8856dbfe2c3bd8c5')  # noqa: E501
@@ -307,7 +307,7 @@ def test_multiplex_batch_sell_eth_for_token(database, ethereum_inquirer, ethereu
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xdf0093104D66509B35411815d7b29c40C16c9578']])
 def test_multiplex_batch_sell_token_for_eth(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf9b40a3bbbd92fe72099cff45564e099782fc9b0b4bd40c2d87484b43735b3b1')  # noqa: E501
@@ -360,7 +360,7 @@ def test_multiplex_batch_sell_token_for_eth(database, ethereum_inquirer, ethereu
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF6a17316821eD254EC0DFa270c6F9f0D3317f706']])
 def test_multiplex_batch_sell_token_for_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0f422be6e6904700181c3effb0600a8ed7e1616e70e6587d383b29290d6a7c1d')  # noqa: E501
@@ -413,7 +413,7 @@ def test_multiplex_batch_sell_token_for_token(database, ethereum_inquirer, ether
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA5a81a7Bf4A737dAbCd8a4C5fc2A36598c1943bF']])
 def test_multiplex_multihop_sell_token_for_token(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xceccb105d312df00105eca2560b8da4cd0e791bb0f0da4cebeb17ca46abf2ce4')  # noqa: E501
@@ -466,7 +466,7 @@ def test_multiplex_multihop_sell_token_for_token(database, ethereum_inquirer, et
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x773E123A1F1d5495a8Eaf4556a9f4e8aFDd9989C']])
 def test_0x415565b0_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
     """Test ETH to Token swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
@@ -520,7 +520,7 @@ def test_0x415565b0_eth_to_token(database, ethereum_inquirer, ethereum_accounts)
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x61Ead4d3e373332c2099e2DC63F916Dbe99f4B0c']])
 def test_0x415565b0_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
     """Test Token to ETH swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
@@ -574,7 +574,7 @@ def test_0x415565b0_token_to_eth(database, ethereum_inquirer, ethereum_accounts)
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x85A28E964FCF12E0a6db44B3432794B08aD2426d']])
 def test_0x415565b0_token_to_token(database, ethereum_inquirer, ethereum_accounts):
     """Test Token to Token swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
@@ -628,7 +628,7 @@ def test_0x415565b0_token_to_token(database, ethereum_inquirer, ethereum_account
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xE4BeF064c912BC95C404850019909efe8D357716']])
 def test_execute_meta_transaction_v2(database, ethereum_inquirer, ethereum_accounts):
     """Test meta transaction swaps done via the 0x protocol router contract."""
@@ -683,7 +683,7 @@ def test_execute_meta_transaction_v2(database, ethereum_inquirer, ethereum_accou
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3951970BA92CBFff00496e8C5Ebd675cEB614773']])
 def test_execute_meta_transaction_v2_multiplex(database, ethereum_inquirer, ethereum_accounts):
     """Test meta transaction multiplex swaps done via the 0x protocol router contract."""
@@ -738,7 +738,7 @@ def test_execute_meta_transaction_v2_multiplex(database, ethereum_inquirer, ethe
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2dcd7947973cb5CBf20e3dBF0663F566D1De9CdA']])
 def test_execute_meta_transaction_v2_flash(database, ethereum_inquirer, ethereum_accounts):
     """Test meta transaction swaps done via the 0x protocol using its flash contract."""
@@ -793,7 +793,7 @@ def test_execute_meta_transaction_v2_flash(database, ethereum_inquirer, ethereum
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x701D5a3344C98765b36014A8a71941f499A2Bc75']])
 def test_swap_on_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8e7c52d519d1ca0d1dfd8c8c21a2d2c34574e2bdada0ae7faafd49c1ddb8e8a6')  # noqa: E501
@@ -846,7 +846,7 @@ def test_swap_on_polygon_pos(database, polygon_pos_inquirer, polygon_pos_account
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xf06cc31757760CC9B8235C868ED90789f9c1E883']])
 def test_swap_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x355c18ab70fb5d17098b6bc8fd527ce00f0b25c8220d6fe29522a1fb64b711bc')  # noqa: E501
@@ -900,7 +900,7 @@ def test_swap_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_account
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x4Ea754349AcE5303c82f0d1D491041e042f2ad22']])
 def test_swap_optimism(database, optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6b2b2d8c0cf2e27bb9e6c8309fd9887a066f9b72139acfe13d7ca5c29ae6c0ff')  # noqa: E501
@@ -954,7 +954,7 @@ def test_swap_optimism(database, optimism_inquirer, optimism_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xF68D2BfCecd7895BBa05a7451Dd09A1749026454']])
 def test_swap_base(database, base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4a5eb8fac7ef1d6637ff1d54e67791e4a5a49effb141f30e5af90f5aba5d48a5')  # noqa: E501
@@ -1008,7 +1008,7 @@ def test_swap_base(database, base_inquirer, base_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA26B29a299c65D0F63A8568BA5663028347f5571']])
 def test_swap_on_pancakeswap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xcfb3b1587bb4d24a06d0f543493098ab285ae3763a489911da5bbea99bcb3499')  # noqa: E501
@@ -1061,7 +1061,7 @@ def test_swap_on_pancakeswap(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x74882149e6a43b8E69cAC6Aef92D753e96054B78']])
 def test_swap_on_curve(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x12d794e7ced93da02978aa9b46b59f27ceab49724fdb1b0c39963792af68fdf0')  # noqa: E501
@@ -1114,7 +1114,7 @@ def test_swap_on_curve(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfD1F67fDbA4F0C1952861345237463b39228F1C6']])
 def test_swap_on_sushiswap(database, ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x802f7d1c4b2f1b7ef48e5c3af92a3a166a91624b89e736f85b90df3dd7ce9d73')  # noqa: E501
@@ -1167,7 +1167,7 @@ def test_swap_on_sushiswap(database, ethereum_inquirer, ethereum_accounts):
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xb3Dd5Cdb7F73acD1177c96409412e0b326E9C457']])
 def test_swap_on_quickswap(database, polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7b1bef89b8890e060787924a279e040ce8d50aedd35337747af6d56024ce269e')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_zksync.py
+++ b/rotkehlchen/tests/unit/decoders/test_zksync.py
@@ -11,7 +11,7 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7277F7849966426d345D8F6B9AFD1d3d89183083']])
 def test_zksync_lite_legacy_deposit(database, ethereum_inquirer, ethereum_accounts):
     """
@@ -60,7 +60,7 @@ def test_zksync_lite_legacy_deposit(database, ethereum_inquirer, ethereum_accoun
     assert expected_events == events
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7277F7849966426d345D8F6B9AFD1d3d89183083']])
 def test_zksync_lite_deposit(database, ethereum_inquirer, ethereum_accounts):
     """Test a transaction with the Deposit event"""

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -238,7 +238,7 @@ def test_velodrome_cache(optimism_inquirer):
     assert mock_notify.call_args_list == [make_call_object(CPT_VELODROME, ChainID.OPTIMISM, 0, 0)]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_convex_cache(ethereum_inquirer):
     """Test convex pools querying and caching mechanism"""
     convex_expected_pools = {  # some expected pools

--- a/rotkehlchen/tests/unit/test_arbitrum_one_inquirer.py
+++ b/rotkehlchen/tests/unit/test_arbitrum_one_inquirer.py
@@ -5,7 +5,7 @@ from rotkehlchen.tests.utils.arbitrum_one import (
 )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*ARBITRUM_ONE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_arbitrum_one_nodes_prune_and_archive_status(

--- a/rotkehlchen/tests/unit/test_base_inquirer.py
+++ b/rotkehlchen/tests/unit/test_base_inquirer.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.base import BASE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*BASE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('base_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_base_nodes_prune_and_archive_status(

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -205,7 +205,7 @@ def test_protocol_balances(blockchain: 'ChainsAggregator') -> None:
     assert ETH_ADDRESS2 not in blockchain.balances.eth
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
 def test_native_token_balance(blockchain, polygon_pos_accounts):
     """

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -825,7 +825,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
     assert performance['validators'] == {}
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.freeze_time('2024-02-02 13:34:45 GMT')
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b', '0xF4fEae08C1Fa864B64024238E33Bfb4A3Ea7741d']])  # noqa: E501
@@ -986,7 +986,7 @@ def test_combine_block_with_tx_events(eth2, database):
         assert hidden_ids == [2]
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2023-04-30 21:52:55 GMT')
 def test_refresh_activated_validators_deposits(eth2, database):
@@ -1064,7 +1064,7 @@ def test_refresh_activated_validators_deposits(eth2, database):
         assert set(dbeth2.get_validators(cursor)) == {validator3, validator1, validator2}
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2024-02-04 09:00:00 GMT')
 def test_query_chunked_endpoint_with_offset_pagination(eth2):

--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -192,7 +192,7 @@ def _mock_airdrop_list(url: str, timeout: int = 0, headers: dict | None = None):
         return mock_response
 
 
-@pytest.mark.freeze_time()
+@pytest.mark.freeze_time
 @pytest.mark.parametrize('number_of_eth_accounts', [2])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('new_asset_data', [{

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -328,7 +328,7 @@ def test_get_blocknumber_by_time_etherscan(ethereum_inquirer):
     _test_get_blocknumber_by_time(ethereum_inquirer)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 def test_ethereum_nodes_prune_and_archive_status(
         ethereum_inquirer,

--- a/rotkehlchen/tests/unit/test_evm_names.py
+++ b/rotkehlchen/tests/unit/test_evm_names.py
@@ -116,7 +116,7 @@ def test_uses_sources_only_when_needed(evm_address, database: 'DBHandler'):
     assert names == [], 'No names should have been returned since the blockchain was None'
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @freeze_time('2023-05-12')  # freezing time just to make sure comparisons of timestamps won't fail
 def test_download_ens_avatar(ethereum_inquirer, opensea):
     """

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -233,7 +233,7 @@ def test_query_and_decode_transactions_works_with_different_chains(
     assert len(hashes) == 1
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[
     '0x756F45E3FA69347A9A973A725E3C98bC4db0b5a0',
     '0x9328D55ccb3FCe531f199382339f0E576ee840A3',

--- a/rotkehlchen/tests/unit/test_gnosis_inquirer.py
+++ b/rotkehlchen/tests/unit/test_gnosis_inquirer.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.gnosis import GNOSIS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*GNOSIS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('gnosis_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_gnosis_nodes_prune_and_archive_status(gnosis_manager_connect_at_start, gnosis_inquirer):

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -212,7 +212,7 @@ def test_parsing_forex_cache_works(
     assert inquirer._query_fiat_pair(A_EUR, A_JPY)[0] == price
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_fallback_to_coingecko(inquirer: Inquirer):
@@ -391,7 +391,7 @@ def test_price_underlying_tokens(inquirer, globaldb):
     assert price == FVal(67)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_uniswap_v2_lp_token_price(inquirer, ethereum_manager, globaldb):
@@ -409,7 +409,7 @@ def test_find_uniswap_v2_lp_token_price(inquirer, ethereum_manager, globaldb):
     assert price is not None
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_velodrome_v2_lp_token_price(inquirer, optimism_manager):
@@ -694,7 +694,7 @@ def test_find_protocol_price_falllback_to_oracle(inquirer_defi):
     assert price is not None and price != ZERO
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_cache_is_hit_for_collection(inquirer: Inquirer):
     """Test that the price for a collection is saved to cache and not query for every asset"""

--- a/rotkehlchen/tests/unit/test_makerdao.py
+++ b/rotkehlchen/tests/unit/test_makerdao.py
@@ -168,7 +168,7 @@ def test_get_vault_balance(
     assert vault.get_balance() == expected_result
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize('globaldb_upgrades', [[]])
 @pytest.mark.parametrize('run_globaldb_migrations', [False])
 @pytest.mark.parametrize('custom_globaldb', ['v4_global_before_migration1.db'])

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.tests.utils.optimism import OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('optimism_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_optimism_nodes_prune_and_archive_status(

--- a/rotkehlchen/tests/unit/test_polygon_pos_inquirer.py
+++ b/rotkehlchen/tests/unit/test_polygon_pos_inquirer.py
@@ -6,7 +6,7 @@ from rotkehlchen.tests.utils.polygon_pos import (
 )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*POLYGON_POS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_polygon_pos_nodes_prune_and_archive_status(

--- a/rotkehlchen/tests/unit/test_scroll_inquirer.py
+++ b/rotkehlchen/tests/unit/test_scroll_inquirer.py
@@ -8,7 +8,7 @@ from rotkehlchen.tests.utils.scroll import (
 )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 @pytest.mark.parametrize(*SCROLL_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('scroll_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_scroll_nodes_prune_and_archive_status(

--- a/rotkehlchen/tests/unit/test_search.py
+++ b/rotkehlchen/tests/unit/test_search.py
@@ -57,8 +57,8 @@ def test_db_persistence_after_search():
     - Add a manual price for the custom asset
     - Crash the application
     - Check that the manual price is still in the global database"""
-    rotki_process = subprocess.Popen(
-        [  # noqa: S607,S603  # is only used to execute rotki code here
+    rotki_process = subprocess.Popen(  # noqa: S603
+        [  # noqa: S607  # is only used to execute rotki code here
             'python',
             '-m'
             'rotkehlchen.tests.utils.crash_test',

--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -403,7 +403,7 @@ def test_jsonloads_list():
     assert 'Returned json is not a list' in str(e.value)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr
 def test_retrieve_old_erc20_token_info(ethereum_inquirer):
     info = ethereum_inquirer.get_erc20_contract_info('0x2C4Bd064b998838076fa341A83d007FC2FA50957')
     assert info['symbol'] == 'UNI-V1'


### PR DESCRIPTION
- Removes parentheses from fixtures with no args
- S603 different line
- Enforce using .items() to access value in dict iteration (https://docs.astral.sh/ruff/rules/dict-index-missing-items/)
