### PR TITLE
fix: check conditions on win32 exit to avoid unhandled error

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`8261` Windows users will no longer be greeted with an unhandled exception dialog when closing the application.
 * :bug:`8263` Fixes manual pagination not working.
 
 * :release:`1.34.0 <2024-07-12>`


### PR DESCRIPTION
Closes #8261

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
