### PR TITLE
Add default order to logs queries

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
@@ -312,6 +312,7 @@ class MakerdaoVaults(HasDSProxy):
                 event_name='LogNote',
                 argument_filters=argument_filters,
                 from_block=gemjoin.deployed_block,
+                call_order=self.ethereum.default_call_order(),
             )
         except EventNotInABI:
             # for now let's ignore any non-gemjoin abis. The join adapters can unfortunately

--- a/rotkehlchen/chain/ethereum/transactions.py
+++ b/rotkehlchen/chain/ethereum/transactions.py
@@ -81,6 +81,7 @@ class EthereumTransactions(EvmTransactions):
                 argument_filters={'l2Delegator': address},
                 from_block=from_block,
                 to_block=to_block,
+                call_order=self.evm_inquirer.default_call_order(),
             )
 
             if len(events) == 0:


### PR DESCRIPTION
Logs queries default to etherscan if no default node is provided. Those calls required a list of nodes to be provided

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
