### PR TITLE
Prevent queries to cc based on symbol

### DIFF
--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -258,13 +258,12 @@ class AssetWithOracles(AssetWithSymbol, abc.ABC):
         May raise:
             - UnsupportedAsset if the asset is not supported by cryptocompare
         """
-        cryptocompare_str = self.symbol if self.cryptocompare is None else self.cryptocompare
         # There is an asset which should not be queried in cryptocompare
-        if cryptocompare_str is None or cryptocompare_str == '':
+        if self.cryptocompare is None or self.cryptocompare == '':
             raise UnsupportedAsset(f'{self.identifier} is not supported by cryptocompare')
 
         # Seems cryptocompare capitalizes everything. So cDAI -> CDAI
-        return cryptocompare_str.upper()  # pylint: disable=no-member
+        return self.cryptocompare.upper()  # pylint: disable=no-member
 
     def to_coingecko(self) -> str:
         """

--- a/rotkehlchen/chain/ethereum/modules/yearn/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/utils.py
@@ -74,7 +74,7 @@ def _maybe_reset_yearn_cache_timestamp(data: list[dict[str, Any]] | None) -> boo
 
 
 def _merge_data_yearn_vaults() -> tuple[list[dict[str, Any]] | None, str | None]:
-    """At the moment of writing this logic ydemon doesn't support yearn v1 so we
+    """At the moment of writing the logic of ydemon doesn't support yearn v1 so we
     need to aggregate the information from two different apis and remove duplicates.
     """
     msg = None
@@ -160,7 +160,7 @@ def query_yearn_vaults(db: 'DBHandler', ethereum_inquirer: 'EthereumInquirer') -
 
             log.error(
                 f'Failed to store token information for yearn {vault_type} vault due to '
-                f'{msg}. Vault: {vault}. Skipping...',
+                f'{msg}. Vault: {vault}. Continuing without vault start timestamp.',
             )
             block_timestamp = None  # ydemon api doesn't provide this information
 

--- a/rotkehlchen/tests/api/test_assets_updates.py
+++ b/rotkehlchen/tests/api/test_assets_updates.py
@@ -328,7 +328,7 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0x1B175474E890
                 'evm_chain': 'ethereum',
                 'token_kind': 'erc20',
                 'decimals': 18,
-                'cryptocompare': None,
+                'cryptocompare': 'DAI',
                 'coingecko': 'dai',
                 'protocol': None,
             },

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -26,7 +26,7 @@ from rotkehlchen.externalapis.cryptocompare import (
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
-from rotkehlchen.tests.utils.constants import A_DAO, A_SNGLS, A_XMR
+from rotkehlchen.tests.utils.constants import A_SNGLS, A_XMR
 from rotkehlchen.types import Price, Timestamp
 
 
@@ -185,22 +185,6 @@ def test_cryptocompare_histohour_data_going_backward(database, freezer):
     data_range = globaldb.get_historical_price_range(A_BTC, A_USD, HistoricalPriceOracle.CRYPTOCOMPARE)  # noqa: E501
     assert data_range[0] == btc_start_ts
     assert data_range[1] == 1301540400  # that's the closest ts to now_ts cc returns
-
-
-def test_cryptocompare_dao_query(cryptocompare):
-    """
-    Test that querying the DAO token for cryptocompare historical prices works. At some point
-    it got accidentaly removed from cryptocompare. Then it got fixed.
-    This test will show us if this happens again.
-
-    Regression test for https://github.com/rotki/rotki/issues/548
-    """
-    price = cryptocompare.query_historical_price(
-        from_asset=A_DAO,
-        to_asset=A_USD,
-        timestamp=1468886400,
-    )
-    assert price is not None
 
 
 @pytest.mark.skipif(

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb.py
@@ -393,7 +393,7 @@ def test_get_all_asset_data_specific_ids(globaldb):
         chain_id=None,
         token_kind=None,
         decimals=None,
-        cryptocompare=None,
+        cryptocompare='BTC',
         coingecko='bitcoin',
         protocol=None,
     )
@@ -409,7 +409,7 @@ def test_get_all_asset_data_specific_ids(globaldb):
         chain_id=None,
         token_kind=None,
         decimals=None,
-        cryptocompare=None,
+        cryptocompare='ETH',
         coingecko='ethereum',
         protocol=None,
     )

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -783,3 +783,19 @@ def test_connect_rpc_with_hex_chainid(ethereum_inquirer: EthereumInquirer):
         ),
     )
     assert success is True and msg == ''
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_fake_symbol_doesnt_query_cc(inquirer: 'Inquirer'):
+    """Test that a token that has the symbol of another token (like USDC) doesn't trigger
+    a price query"""
+    inquirer.set_oracles_order(oracles=[CurrentPriceOracle.CRYPTOCOMPARE])
+    token = EvmToken.initialize(
+        address=string_to_evm_address('0x9fca10428566808CC9175412491dF4681cF39cE4'),
+        chain_id=ChainID.GNOSIS,
+        token_kind=EvmTokenKind.ERC20,
+        name='Fake USDC',
+        symbol='USDC',
+        decimals=18,
+    )
+    assert inquirer.find_usd_price(token) == ZERO


### PR DESCRIPTION
Avoid calling cc using the symbol of the token to avoid spam tokens from getting a price

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
