### PR TITLE
Handle TypeError from web3

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -538,6 +538,7 @@ class EvmNodeInquirer(ABC, LockableQueryMixIn):
                     requests.exceptions.RequestException,
                     BlockchainQueryError,
                     Web3Exception,
+                    TypeError,  # happened at the web3 level calling `apply_result_formatters` when the RPC node returned `None` in the response's result # noqa: E501
                     ValueError,  # not removing yet due to possibility of raising from missing trie error  # noqa: E501
             ) as e:
                 log.warning(f'Failed to query {node_info} for {method!s} due to {e!s}')


### PR DESCRIPTION
mevblocker rpc returned `None` in the result and web3.py failed to process it.

```
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/evm/node_inquirer.py", line 706, in _call_contract
    result = method(*arguments or [])
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/contract/base_contract.py", line 1051, in call_function
    return fn(*args, **kwargs).call(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/contract/contract.py", line 305, in call
    return call_contract_function(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/contract/utils.py", line 96, in call_contract_function
    return_data = w3.eth.call(
      ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/eth/eth.py", line 260, in call
    return self._durin_call(transaction, block_identifier, state_override)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/eth/eth.py", line 279, in _durin_call
    return self._call(transaction, block_identifier, state_override)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/module.py", line 78, in caller
    return apply_result_formatters(result_formatters, result)
    ^^^^^^^^^^^^^^^^^
  File "cytoolz/functoolz.pyx", line 267, in cytoolz.functoolz.curry.__call__
    raise
  File "cytoolz/functoolz.pyx", line 263, in cytoolz.functoolz.curry.__call__
    return self.func(*args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/web3/module.py", line 49, in apply_result_formatters
    formatted_result = pipe(result, result_formatters)
    ^^^^^^^^^^^^^^^^^
  File "cytoolz/functoolz.pyx", line 680, in cytoolz.functoolz.pipe
    return c_pipe(data, funcs)
      ^^^^^^^^^^^^^^^^^
  File "cytoolz/functoolz.pyx", line 655, in cytoolz.functoolz.c_pipe
    data = func(data)
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/hexbytes/main.py", line 42, in __new__
    bytesval = to_bytes(val)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/.pyenv/versions/3.11.9/envs/rotki-main/lib/python3.11/site-packages/hexbytes/_utils.py", line 32, in to_bytes
    raise TypeError(f"Cannot convert {val!r} of type {type(val)} to bytes")
    ^^^^^^^^^^^^^^^^^
```

from

```
[23/07/2024 11:26:00 CEST] DEBUG web3.providers.HTTPProvider Getting response HTTP. URI: https://rpc.mevblocker.io/fast, Method: eth_call, Response: {'jsonrpc': '2.0', 'id': 13, 'result': None}
```

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
