### PR TITLE
Fix (Migration 15): Different db cursor from loop

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :release:`1.34.1 <2024-07-23>`
+* :release:`1.34.1 <2024-07-24>`
 * :bug:`-` Assets section will now show correct number of assets on any page when excluding ignored assets.
 * :bug:`-` Windows backend restart will no longer hang when users update their assets.
 * :bug:`8262` Prices of HOP LP tokens will now properly show up for all pools.

--- a/rotkehlchen/data_migrations/migrations/migrations_15.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_15.py
@@ -27,34 +27,38 @@ def data_migration_15(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
 
     Redecodes the distinct Add liquidity events for each Hop LP token."""
     progress_handler.set_total_steps(1)
-
     # find one Add liquidity event for each Hop LP token
-    event_data = []
-    with rotki.data.db.conn.write_ctx() as write_cursor:
-        for identifier, db_tx_hash, db_location in write_cursor.execute(
-            'SELECT EE.identifier, tx_hash, location FROM evm_events_info AS EE '
-            'LEFT JOIN history_events as HE on HE.identifier=EE.identifier '
-            'WHERE counterparty=? AND type=? AND subtype=? AND EE.identifier NOT IN ('
-            'SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?'
-            ') GROUP BY asset;', (
-                CPT_HOP,
-                HistoryEventType.RECEIVE.serialize(),
-                HistoryEventSubType.RECEIVE_WRAPPED.serialize(),
-                HISTORY_MAPPING_KEY_STATE,
-                HISTORY_MAPPING_STATE_CUSTOMIZED,
-            ),
-        ):
-            event_data.append((
+    with rotki.data.db.conn.read_ctx() as cursor:
+        event_data = [
+            (
+                identifier,
                 deserialize_evm_tx_hash(db_tx_hash),
                 Location.deserialize_from_db(db_location),
-            ))
+            )
+            for identifier, db_tx_hash, db_location in cursor.execute(
+                'SELECT EE.identifier, tx_hash, location FROM evm_events_info AS EE '
+                'LEFT JOIN history_events as HE on HE.identifier=EE.identifier '
+                'WHERE counterparty=? AND type=? AND subtype=? AND EE.identifier NOT IN ('
+                'SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?'
+                ') GROUP BY asset;', (
+                    CPT_HOP,
+                    HistoryEventType.RECEIVE.serialize(),
+                    HistoryEventSubType.RECEIVE_WRAPPED.serialize(),
+                    HISTORY_MAPPING_KEY_STATE,
+                    HISTORY_MAPPING_STATE_CUSTOMIZED,
+                ),
+            )
+        ]
+
+    with rotki.data.db.conn.write_ctx() as write_cursor:  # delete their events
+        for identifier, _, _ in event_data:
             write_cursor.execute('DELETE FROM history_events WHERE identifier=?', (identifier,))
             write_cursor.execute(
                 'DELETE from evm_tx_mappings WHERE tx_id=? AND value=?',
                 (identifier, HISTORY_MAPPING_STATE_DECODED),
             )
 
-    for tx_hash, location in event_data:
+    for _, tx_hash, location in event_data:  # redecode them
         chain_id: SUPPORTED_CHAIN_IDS = ChainID.deserialize(location.to_chain_id())  # type: ignore[assignment]  # db_location is already decoded, so it's supported
         chain_manager = rotki.chains_aggregator.get_evm_manager(chain_id=chain_id)
         try:


### PR DESCRIPTION
## Checklist

- [x] Fix to not use the same cursor in a loop for other queries in data migration 15