### PR TITLE
Fix Eigenlayer pending withdrawal balances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :release:`1.34.1 <2024-07-24>`
+* :bug:`-` Eigenlayer LST pending withdrawals that have been completed should no longer count as user balance.
 * :bug:`-` Assets section will now show correct number of assets on any page when excluding ignored assets.
 * :bug:`-` Windows backend restart will no longer hang when users update their assets.
 * :bug:`8262` Prices of HOP LP tokens will now properly show up for all pools.

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1098,13 +1098,14 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         needs to be added to the total balance of the account. Examples of such protocols are
         Curve, Convex and Velodrome.
         """
-        chain: SUPPORTED_EVM_CHAINS_TYPE = ChainID.to_blockchain(chain_id)  # type: ignore[assignment]  # CHAIN_IDS_WITH_BALANCE_PROTOCOLS only contains SUPPORTED_EVM_CHAINS_TYPE
-        inquirer = self.get_chain_manager(chain).node_inquirer
+        chain: SUPPORTED_EVM_CHAINS_TYPE = ChainID.to_blockchain(chain_id)  # type: ignore  # CHAIN_IDS_WITH_BALANCE_PROTOCOLS only contains SUPPORTED_EVM_CHAINS_TYPE
+        chain_manager = self.get_evm_manager(chain_id)
         existing_balances: defaultdict[ChecksumEvmAddress, BalanceSheet] = self.balances.get(chain)
         for protocol in CHAIN_TO_BALANCE_PROTOCOLS[chain_id]:
             protocol_with_balance: ProtocolWithBalance = protocol(
                 database=self.database,
-                evm_inquirer=inquirer,
+                evm_inquirer=chain_manager.node_inquirer,
+                tx_decoder=chain_manager.transactions_decoder,
             )
             try:
                 protocol_balances = protocol_with_balance.query_balances()

--- a/rotkehlchen/chain/arbitrum_one/modules/gearbox/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gearbox/balances.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-
 from rotkehlchen.chain.arbitrum_one.modules.gearbox.constants import (
     GEAR_IDENTIFIER_ARB,
     GEAR_STAKING_CONTRACT,
@@ -8,15 +7,22 @@ from rotkehlchen.chain.arbitrum_one.modules.gearbox.constants import (
 from rotkehlchen.chain.evm.decoding.gearbox.balances import GearboxCommonBalances
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.arbitrum_one.decoding.decoder import ArbitrumOneTransactionDecoder
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
 
 class GearboxBalances(GearboxCommonBalances):
-    def __init__(self, database: 'DBHandler', evm_inquirer: 'ArbitrumOneInquirer') -> None:
+    def __init__(
+            self,
+            database: 'DBHandler',
+            evm_inquirer: 'ArbitrumOneInquirer',
+            tx_decoder: 'ArbitrumOneTransactionDecoder',
+    ) -> None:
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             staking_contract=GEAR_STAKING_CONTRACT,
             native_token_id=GEAR_IDENTIFIER_ARB,
         )

--- a/rotkehlchen/chain/arbitrum_one/modules/gmx/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gmx/balances.py
@@ -22,6 +22,7 @@ from rotkehlchen.utils.misc import get_chunks
 from .constants import CPT_GMX, GMX_READER, GMX_STAKING_REWARD, GMX_USD_DECIMALS, GMX_VAULT_ADDRESS
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.arbitrum_one.decoding.decoder import ArbitrumOneTransactionDecoder
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -30,10 +31,16 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class GmxBalances(ProtocolWithBalance):
-    def __init__(self, database: 'DBHandler', evm_inquirer: 'ArbitrumOneInquirer'):
+    def __init__(
+            self,
+            database: 'DBHandler',
+            evm_inquirer: 'ArbitrumOneInquirer',
+            tx_decoder: 'ArbitrumOneTransactionDecoder',
+    ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_GMX,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/arbitrum_one/modules/hop/constants.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/hop/constants.py
@@ -37,6 +37,8 @@ BRIDGES: Final = {
     ),
 }
 
+# Contracts from https://github.com/hop-protocol/hop/blob/92b1fb24f672c102e9fe557a2b8c2aa808a24e80/packages/frontend/src/config/addresses.ts  # noqa: E501
+# There is no on chain registry or api to check against it so they need to be manually updated
 REWARD_CONTRACTS: Final = {
     string_to_evm_address('0xb0CabFE930642AD3E7DECdc741884d8C3F7EbC70'),  # HOP (USDC.e)
     string_to_evm_address('0x9Dd8685463285aD5a94D2c128bda3c5e8a6173c8'),  # HOP (USDT)

--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
@@ -6,6 +6,7 @@ from rotkehlchen.chain.evm.decoding.thegraph.balances import ThegraphCommonBalan
 from rotkehlchen.constants.assets import A_GRT_ARB
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.arbitrum_one.decoding.decoder import ArbitrumOneTransactionDecoder
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -16,10 +17,12 @@ class ThegraphBalances(ThegraphCommonBalances):
             self,
             database: 'DBHandler',
             evm_inquirer: 'ArbitrumOneInquirer',
+            tx_decoder: 'ArbitrumOneTransactionDecoder',
     ) -> None:
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             native_asset=A_GRT_ARB,
             staking_contract=CONTRACT_STAKING,
         )

--- a/rotkehlchen/chain/base/decoding/decoder.py
+++ b/rotkehlchen/chain/base/decoding/decoder.py
@@ -40,6 +40,7 @@ class BaseTransactionDecoder(L2WithL1FeesTransactionDecoder):
             ),
             dbevmtx_class=DBL2WithL1FeesTx,
         )
+        self.evm_inquirer: BaseInquirer  # re-affirm type
 
     # -- methods that need to be implemented by child classes --
 

--- a/rotkehlchen/chain/base/modules/aerodrome/balances.py
+++ b/rotkehlchen/chain/base/modules/aerodrome/balances.py
@@ -5,6 +5,7 @@ from rotkehlchen.chain.evm.decoding.velodrome.constants import CPT_AERODROME
 from rotkehlchen.db.dbhandler import DBHandler
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.base.decoding.decoder import BaseTransactionDecoder
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
 
 
@@ -13,9 +14,11 @@ class AerodromeBalances(VelodromeLikeBalances):
             self,
             database: DBHandler,
             evm_inquirer: 'BaseInquirer',
+            tx_decoder: 'BaseTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_AERODROME,
         )

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -21,6 +21,7 @@ from rotkehlchen.types import ChecksumEvmAddress, Location
 from rotkehlchen.utils.misc import get_chunks
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -59,12 +60,14 @@ class ProtocolWithBalance(abc.ABC):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EVMTransactionDecoder',
             counterparty: PROTOCOLS_WITH_BALANCES,
             deposit_event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
     ):
         self.counterparty = counterparty
         self.event_db = DBHistoryEvents(database)
         self.evm_inquirer = evm_inquirer
+        self.tx_decoder = tx_decoder
         self.deposit_event_types = deposit_event_types
 
     def addresses_with_activity(
@@ -122,11 +125,12 @@ class ProtocolWithGauges(ProtocolWithBalance):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EVMTransactionDecoder',
             counterparty: PROTOCOLS_WITH_BALANCES,
             deposit_event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
             gauge_deposit_event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
     ):
-        super().__init__(database=database, evm_inquirer=evm_inquirer, counterparty=counterparty, deposit_event_types=deposit_event_types)  # noqa: E501
+        super().__init__(database=database, evm_inquirer=evm_inquirer, tx_decoder=tx_decoder, counterparty=counterparty, deposit_event_types=deposit_event_types)  # noqa: E501
         self.gauge_deposit_event_types = gauge_deposit_event_types
 
     def addresses_with_gauge_deposits(self) -> dict[ChecksumEvmAddress, list['EvmEvent']]:

--- a/rotkehlchen/chain/ethereum/modules/aave/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/balances.py
@@ -17,6 +17,7 @@ from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -29,10 +30,12 @@ class AaveBalances(ProtocolWithBalance):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EthereumInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_AAVE,
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/ethereum/modules/blur/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/blur/balances.py
@@ -19,6 +19,7 @@ from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.types import ChecksumEvmAddress
@@ -32,10 +33,12 @@ class BlurBalances(ProtocolWithBalance):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_BLUR,
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/ethereum/modules/convex/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/balances.py
@@ -18,7 +18,8 @@ from rotkehlchen.types import ChecksumEvmAddress
 from .constants import CPT_CONVEX, CVX_LOCKER_V2, CVX_REWARDS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
 logger = logging.getLogger(__name__)
@@ -31,11 +32,13 @@ class ConvexBalances(ProtocolWithGauges):
     def __init__(
             self,
             database: DBHandler,
-            evm_inquirer: 'EvmNodeInquirer',
+            evm_inquirer: 'EthereumInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_CONVEX,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
             gauge_deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/curve/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/balances.py
@@ -7,7 +7,8 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
 
@@ -17,10 +18,16 @@ class CurveBalances(ProtocolWithGauges):
     LP tokens are already queried by the normal token detection.
     """
 
-    def __init__(self, database: DBHandler, evm_inquirer: 'EvmNodeInquirer'):
+    def __init__(
+            self,
+            database: DBHandler,
+            evm_inquirer: 'EthereumInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
+    ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_CURVE,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
             gauge_deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
@@ -325,6 +325,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface):
                     notes=f'Complete eigenlayer withdrawal of {withdrawal_event.asset.resolve_to_asset_with_symbol().symbol}',  # noqa: E501
                     counterparty=CPT_EIGENLAYER,
                     address=context.tx_log.address,
+                    extra_data={'matched': True},
                 )
                 with self.base.database.user_write() as write_cursor:
                     dbevents.edit_event_extra_data(  # set withdrawal event as completed
@@ -352,7 +353,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface):
 
                 break  # completed the finding event logic
 
-        else:  # not found. Perhaps transaction and event not pulled for some reason?
+        else:  # not found. Perhaps transaction and event not pulled or timing issue. Is rechecked from time to time when doing balance queries.  # noqa: E501
             log.debug(f'When decoding eigenlayer WithdrawalCompleted could not find corresponding Withdrawal queued: {context.transaction.tx_hash.hex()}')  # noqa: E501
 
             new_event = self.base.make_event_next_index(  # so let's just keep minimal info

--- a/rotkehlchen/chain/ethereum/modules/gearbox/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/gearbox/balances.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-
 from rotkehlchen.chain.ethereum.modules.gearbox.constants import (
     GEAR_IDENTIFIER,
     GEAR_STAKING_CONTRACT,
@@ -8,15 +7,22 @@ from rotkehlchen.chain.ethereum.modules.gearbox.constants import (
 from rotkehlchen.chain.evm.decoding.gearbox.balances import GearboxCommonBalances
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
 
 class GearboxBalances(GearboxCommonBalances):
-    def __init__(self, database: 'DBHandler', evm_inquirer: 'EthereumInquirer') -> None:
+    def __init__(
+            self,
+            database: 'DBHandler',
+            evm_inquirer: 'EthereumInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
+    ) -> None:
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             staking_contract=GEAR_STAKING_CONTRACT,
             native_token_id=GEAR_IDENTIFIER,
         )

--- a/rotkehlchen/chain/ethereum/modules/octant/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/balances.py
@@ -16,6 +16,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from .constants import CPT_OCTANT, OCTANT_DEPOSITS
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 
 logger = logging.getLogger(__name__)
@@ -27,10 +28,12 @@ class OctantBalances(ProtocolWithBalance):
             self,
             database: DBHandler,
             evm_inquirer: 'EthereumInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_OCTANT,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/ethereum/modules/thegraph/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/balances.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
+
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType
-
-
 from rotkehlchen.chain.ethereum.modules.thegraph.constants import CONTRACT_STAKING
 from rotkehlchen.chain.evm.decoding.thegraph.balances import ThegraphCommonBalances
 from rotkehlchen.constants.assets import A_GRT
 from rotkehlchen.types import Location
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -18,10 +18,12 @@ class ThegraphBalances(ThegraphCommonBalances):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EthereumInquirer',
+            tx_decoder: 'EthereumTransactionDecoder',
     ) -> None:
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             native_asset=A_GRT,
             staking_contract=CONTRACT_STAKING,
         )

--- a/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
@@ -20,6 +20,7 @@ from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind
 from .constants import CPT_COMPOUND_V3
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -34,10 +35,16 @@ class CompoundArguments(NamedTuple):
 
 
 class Compoundv3Balances(ProtocolWithBalance):
-    def __init__(self, database: 'DBHandler', evm_inquirer: 'EvmNodeInquirer'):
+    def __init__(
+            self,
+            database: 'DBHandler',
+            evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EVMTransactionDecoder',
+    ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_COMPOUND_V3,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/evm/decoding/gearbox/balances.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/balances.py
@@ -16,6 +16,7 @@ from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.types import ChecksumEvmAddress
@@ -29,12 +30,14 @@ class GearboxCommonBalances(ProtocolWithBalance):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EVMTransactionDecoder',
             staking_contract: 'ChecksumEvmAddress',
             native_token_id: str,
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_GEARBOX,
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/evm/decoding/hop/balances.py
+++ b/rotkehlchen/chain/evm/decoding/hop/balances.py
@@ -2,7 +2,6 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
@@ -22,6 +21,7 @@ from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -34,10 +34,12 @@ class HopBalances(ProtocolWithBalance):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EVMTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_HOP,
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/evm/decoding/thegraph/balances.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/balances.py
@@ -19,6 +19,7 @@ from rotkehlchen.types import Location
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
+    from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.types import ChecksumEvmAddress
@@ -32,12 +33,14 @@ class ThegraphCommonBalances(ProtocolWithBalance):
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            tx_decoder: 'EVMTransactionDecoder',
             native_asset: 'Asset',
             staking_contract: 'ChecksumEvmAddress',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_THEGRAPH,
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )

--- a/rotkehlchen/chain/evm/decoding/velodrome/balances.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/balances.py
@@ -8,9 +8,10 @@ from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
 
-
 if TYPE_CHECKING:
+    from rotkehlchen.chain.base.decoding.decoder import BaseTransactionDecoder
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
+    from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
@@ -25,11 +26,13 @@ class VelodromeLikeBalances(ProtocolWithGauges):
             self,
             database: DBHandler,
             evm_inquirer: 'OptimismInquirer | BaseInquirer',
+            tx_decoder: 'OptimismTransactionDecoder | BaseTransactionDecoder',
             counterparty: PROTOCOLS_WITH_BALANCES,
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=counterparty,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
             gauge_deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},  # noqa: E501

--- a/rotkehlchen/chain/optimism/modules/gearbox/balances.py
+++ b/rotkehlchen/chain/optimism/modules/gearbox/balances.py
@@ -7,15 +7,22 @@ from rotkehlchen.chain.optimism.modules.gearbox.constants import (
 )
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.db.dbhandler import DBHandler
 
 
 class GearboxBalances(GearboxCommonBalances):
-    def __init__(self, database: 'DBHandler', evm_inquirer: 'OptimismInquirer') -> None:
+    def __init__(
+            self,
+            database: 'DBHandler',
+            evm_inquirer: 'OptimismInquirer',
+            tx_decoder: 'OptimismTransactionDecoder',
+    ) -> None:
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             staking_contract=GEAR_STAKING_CONTRACT,
             native_token_id=GEAR_IDENTIFIER_OPT,
         )

--- a/rotkehlchen/chain/optimism/modules/velodrome/balances.py
+++ b/rotkehlchen/chain/optimism/modules/velodrome/balances.py
@@ -5,6 +5,7 @@ from rotkehlchen.chain.evm.decoding.velodrome.constants import CPT_VELODROME
 from rotkehlchen.db.dbhandler import DBHandler
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
 
 
@@ -13,9 +14,11 @@ class VelodromeBalances(VelodromeLikeBalances):
             self,
             database: DBHandler,
             evm_inquirer: 'OptimismInquirer',
+            tx_decoder: 'OptimismTransactionDecoder',
     ):
         super().__init__(
             database=database,
             evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
             counterparty=CPT_VELODROME,
         )

--- a/rotkehlchen/tests/api/test_compound.py
+++ b/rotkehlchen/tests/api/test_compound.py
@@ -113,6 +113,7 @@ def test_query_compound_v3_balances(
     compound_v3_balances = Compoundv3Balances(
         database=chain_aggregator.database,
         evm_inquirer=chain_aggregator.ethereum.node_inquirer,
+        tx_decoder=chain_aggregator.ethereum.transactions_decoder,
     )
     unique_borrows, underlying_tokens = compound_v3_balances._extract_unique_borrowed_tokens()
 

--- a/rotkehlchen/tests/unit/decoders/test_degen.py
+++ b/rotkehlchen/tests/unit/decoders/test_degen.py
@@ -4,6 +4,7 @@ import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.base.decoding.decoder import BaseTransactionDecoder
 from rotkehlchen.chain.base.modules.degen.constants import (
     CLAIM_AIRDROP_2_CONTRACT,
     CLAIM_AIRDROP_3_CONTRACT,
@@ -12,7 +13,6 @@ from rotkehlchen.chain.base.modules.degen.constants import (
 )
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
-from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -27,7 +27,7 @@ DEGEN_TOKEN: Final = Asset(DEGEN_TOKEN_ID)
 @pytest.mark.parametrize('base_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_claim_airdrop_2(
         base_accounts: list[ChecksumEvmAddress],
-        base_transaction_decoder: EVMTransactionDecoder,
+        base_transaction_decoder: BaseTransactionDecoder,
 ):
     evmhash = deserialize_evm_tx_hash('0x885722ab252530e687212799080d5d158d767536b62e0d45a700091a5424bcaa ')  # noqa: E501
     user_address = base_accounts[0]
@@ -73,7 +73,7 @@ def test_claim_airdrop_2(
 @pytest.mark.parametrize('base_accounts', [['0x80c008A7c9ec056158cB1F64024e710C8398048A']])
 def test_claim_airdrop_3(
         base_accounts: list[ChecksumEvmAddress],
-        base_transaction_decoder: EVMTransactionDecoder,
+        base_transaction_decoder: BaseTransactionDecoder,
 ):
     evmhash = deserialize_evm_tx_hash('0x40920bf5416e9bd756d1c57f04e1b978e838efb42e7c2b07c4e9aaa8eb0da2ef ')  # noqa: E501
     user_address = base_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -396,7 +396,7 @@ def test_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_accoun
 @pytest.mark.parametrize('ethereum_accounts', [['0x02855536652F67cB936851D94c793Fb3Ba27F9bb']])
 def test_lst_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_accounts, inquirer):  # pylint: disable=unused-argument
     tx_hash = deserialize_evm_tx_hash('0x8c006f764e9264cd150b2583ba72205bb4575ace76ed3afa83689227e9fe461b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
+    events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=database,
         tx_hash=tx_hash,
@@ -454,6 +454,7 @@ def test_lst_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_ac
     balances_inquirer = EigenlayerBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[ethereum_accounts[0]].assets[A_STETH.resolve_to_evm_token()] == Balance(
@@ -472,7 +473,7 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
         tx_hash=queue_tx_hash,
     )  # and now get the actual withdrawal complete transaction a week later
     tx_hash = deserialize_evm_tx_hash('0x2c9a7caf78126fdfe43760dedbf3648c6a3255ee17a7bc312372dba26e16132b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
+    events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=database,
         tx_hash=tx_hash,
@@ -504,6 +505,7 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
         notes='Complete eigenlayer withdrawal of cbETH',
         counterparty=CPT_EIGENLAYER,
         address=EIGENLAYER_DELEGATION,
+        extra_data={'matched': True},
     ), EvmEvent(
         tx_hash=tx_hash,
         sequence_index=581,
@@ -545,6 +547,7 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
     balances_inquirer = EigenlayerBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[ethereum_accounts[0]].assets[cbeth] == Balance()

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
+    from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.inquirer import Inquirer
 
 
@@ -89,7 +90,7 @@ def test_curve_balances(
 ) -> None:
     database = ethereum_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0x09b67a0846ce2f6bea50221cfb5ac67f5b2f55b89300e45f58bf2f69dc589d43')  # noqa: E501
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -98,6 +99,7 @@ def test_curve_balances(
     curve_balances_inquirer = CurveBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     curve_balances = curve_balances_inquirer.query_balances()
     user_balance = curve_balances[ethereum_accounts[0]]
@@ -118,7 +120,7 @@ def test_convex_gauges_balances(
 ) -> None:
     database = ethereum_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0x0d8863fb26d57ca11dc11c694dbf6a13ef03920e39d0482081aa88b0b20ba61b')  # noqa: E501
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -126,6 +128,7 @@ def test_convex_gauges_balances(
     convex_balances_inquirer = ConvexBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     convex_balances = convex_balances_inquirer.query_balances()
     user_balance = convex_balances[ethereum_accounts[0]]
@@ -153,7 +156,7 @@ def test_convex_staking_balances(
         tx_hash=tx_hex,
     )
     tx_hex = deserialize_evm_tx_hash('0x679746961f731819e351f866b33bc2267dfb341e9d0b30ebccd012834ae3ffde')  # noqa: E501
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -161,6 +164,7 @@ def test_convex_staking_balances(
     convex_balances_inquirer = ConvexBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     convex_balances = convex_balances_inquirer.query_balances()
     user_balance = convex_balances[ethereum_accounts[0]]
@@ -187,7 +191,7 @@ def test_convex_staking_balances_without_gauges(
     """
     database = ethereum_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0x38bd199803e7cb065c809ce07957afc0647a41da4c0610d1209a843d9b045cd6')  # noqa: E501
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -195,6 +199,7 @@ def test_convex_staking_balances_without_gauges(
     convex_balances_inquirer = ConvexBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     convex_balances = convex_balances_inquirer.query_balances()
     user_balance = convex_balances[ethereum_accounts[0]]
@@ -217,7 +222,7 @@ def test_velodrome_v2_staking_balances(
     """Check that balances of velodrome v2 gauges are properly queried."""
     database = optimism_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0xed7e13e4941bba33edbbd70c4f48c734629fd67fe4eac43ce1bed3ef8f3da7df')  # transaction that interacts with the gauge address  # noqa: E501
-    get_decoded_events_of_transaction(  # decode events that interact with the gauge address
+    _, tx_decoder = get_decoded_events_of_transaction(  # decode events that interact with the gauge address  # noqa: E501
         evm_inquirer=optimism_inquirer,
         database=optimism_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -226,6 +231,7 @@ def test_velodrome_v2_staking_balances(
     balances_inquirer = VelodromeBalances(
         database=database,
         evm_inquirer=optimism_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()  # queries the gauge balance of the address if the address has interacted with a known gauge  # noqa: E501
     user_balance = balances[optimism_accounts[0]]
@@ -251,7 +257,7 @@ def test_thegraph_balances(
     """Check that balances of GRT currently delegated to indexers are properly detected."""
     tx_hex = deserialize_evm_tx_hash('0x81cdf7a4201d3e89c9f3a8d3ae18e3cb7ae0e06a5cbc514f1e41504b9b263667')  # noqa: E501
     amount = '6626.873960369737'
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -259,6 +265,7 @@ def test_thegraph_balances(
     thegraph_balances_inquirer = ThegraphBalances(
         database=ethereum_transaction_decoder.database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     thegraph_balances = thegraph_balances_inquirer.query_balances()
     user_balance = thegraph_balances[ethereum_accounts[0]]
@@ -285,7 +292,7 @@ def test_thegraph_balances_arbitrum_one(
     )
     amount = FVal('25.607552758075613')
     tx_hex = deserialize_evm_tx_hash('0x3c846f305330969fb0ddb87c5ae411b4e9692f451a7ff3237b6f71020030c7d1')  # noqa: E501
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
         database=arbitrum_one_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -293,6 +300,7 @@ def test_thegraph_balances_arbitrum_one(
     thegraph_balances_inquirer = ThegraphBalancesArbitrumOne(
         database=arbitrum_one_transaction_decoder.database,
         evm_inquirer=arbitrum_one_inquirer,
+        tx_decoder=tx_decoder,
     )
     thegraph_balances = thegraph_balances_inquirer.query_balances()
     user_balance = thegraph_balances[arbitrum_one_accounts[0]]
@@ -309,6 +317,7 @@ def test_thegraph_balances_arbitrum_one(
 def test_thegraph_balances_vested_arbitrum_one(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_transaction_decoder: 'ArbitrumOneTransactionDecoder',
+        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
         arbitrum_one_manager_connect_at_start,
@@ -327,7 +336,7 @@ def test_thegraph_balances_vested_arbitrum_one(
     ):
         get_decoded_events_of_transaction(
             evm_inquirer=ethereum_inquirer,
-            database=arbitrum_one_transaction_decoder.database,
+            database=database,
             tx_hash=deserialize_evm_tx_hash(
                 tx_hash,
             ),
@@ -354,6 +363,7 @@ def test_thegraph_balances_vested_arbitrum_one(
         thegraph_balances_inquirer = ThegraphBalancesArbitrumOne(
             database=arbitrum_one_transaction_decoder.database,
             evm_inquirer=arbitrum_one_inquirer,
+            tx_decoder=arbitrum_one_transaction_decoder,
         )
         thegraph_balances = thegraph_balances_inquirer.query_balances()
     asset = A_GRT_ARB.resolve_to_evm_token()
@@ -373,7 +383,7 @@ def test_octant_balances(
 ) -> None:
     """Check that balances of locked GLM in Octant are properly detected"""
     tx_hex = deserialize_evm_tx_hash('0x29944efad254413b5eccdd5f13f14642ab830dbf51d5f2cfc59cf4957f33671a')  # noqa: E501
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -381,6 +391,7 @@ def test_octant_balances(
     octant_balances_inquirer = OctantBalances(
         database=ethereum_transaction_decoder.database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     octant_balances = octant_balances_inquirer.query_balances()
     user_balance = octant_balances[ethereum_accounts[0]]
@@ -397,7 +408,7 @@ def test_eigenlayer_balances(
 ) -> None:
     database = ethereum_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0x89981857ab9f31369f954ae332ffd910e1f3c8efe531efde5f26666316855591')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
+    events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -406,6 +417,7 @@ def test_eigenlayer_balances(
     balances_inquirer = EigenlayerBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[ethereum_accounts[0]].assets[A_STETH.resolve_to_evm_token()] == Balance(
@@ -424,7 +436,7 @@ def test_eigenpod_balances(
 ) -> None:
     database = ethereum_transaction_decoder.database
     tx_hex = deserialize_evm_tx_hash('0xb6fa282227916f9b16df953f79a5859ba80b8bc3b9c6adc01f262070d3c9e3d5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
+    events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -433,6 +445,7 @@ def test_eigenpod_balances(
     balances_inquirer = EigenlayerBalances(
         database=database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     eigenpod_balance, delayed_withdrawals = FVal('0.054506232'), FVal('0.007164493')
     balances = balances_inquirer.query_balances()
@@ -456,7 +469,7 @@ def test_eigenpod_balances(
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
 def test_gmx_balances(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-        arbitrum_one_transaction_decoder: 'OptimismTransactionDecoder',
+        arbitrum_one_transaction_decoder: 'ArbitrumOneTransactionDecoder',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
 ) -> None:
@@ -470,7 +483,7 @@ def test_gmx_balances(
         '0xf14d5a3f3fa4a4c324f95b70db81502f3d7c1910782381ed82f3580da64b093f',  # long eth
     ):
         tx_hex = deserialize_evm_tx_hash(tx_hash)
-        get_decoded_events_of_transaction(
+        _, tx_decoder = get_decoded_events_of_transaction(
             evm_inquirer=arbitrum_one_inquirer,
             database=arbitrum_one_transaction_decoder.database,
             tx_hash=tx_hex,
@@ -479,6 +492,7 @@ def test_gmx_balances(
     balances_inquirer = GmxBalances(
         database=arbitrum_one_transaction_decoder.database,
         evm_inquirer=arbitrum_one_inquirer,
+        tx_decoder=tx_decoder,
     )
 
     # we mock the function call for the user positions since the function returns a set and
@@ -527,7 +541,7 @@ def test_gmx_balances(
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_gmx_balances_staking(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-        arbitrum_one_transaction_decoder: 'OptimismTransactionDecoder',
+        arbitrum_one_transaction_decoder: 'ArbitrumOneTransactionDecoder',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
         arbitrum_one_manager_connect_at_start,
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
@@ -539,7 +553,7 @@ def test_gmx_balances_staking(
         connect_at_start=arbitrum_one_manager_connect_at_start,
         evm_inquirer=arbitrum_one_inquirer,
     )
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
         database=arbitrum_one_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0x25160bf17e5a77935c7661933c045739dba44606859a20f00f187ef291e56a8f'),
@@ -547,6 +561,7 @@ def test_gmx_balances_staking(
     balances_inquirer = GmxBalances(
         database=arbitrum_one_transaction_decoder.database,
         evm_inquirer=arbitrum_one_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[arbitrum_one_accounts[0]].assets == {
@@ -568,7 +583,7 @@ def test_aave_balances_staking(
     """Test the balance query for staked AAVE balances. It adds a staking event
     and then queries the balances for that address."""
     amount = FVal('0.134274348203440352')
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0xfaf96358784483a96a61db6aa4ecf4ac87294b841671ca208de6b5d8f83edf17'),
@@ -576,6 +591,7 @@ def test_aave_balances_staking(
     balances_inquirer = AaveBalances(
         database=ethereum_transaction_decoder.database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[ethereum_accounts[0]].assets == {
@@ -691,6 +707,7 @@ def test_compound_v3_token_balances_liabilities(
     compound_v3_balances = Compoundv3Balances(
         database=blockchain.database,
         evm_inquirer=blockchain.ethereum.node_inquirer,
+        tx_decoder=blockchain.ethereum.transactions_decoder,
     )
     unique_borrows, underlying_tokens = compound_v3_balances._extract_unique_borrowed_tokens()
 
@@ -737,7 +754,7 @@ def test_blur_balances(
     """Check that staked balances of Blur are properly detected."""
     tx_hex = deserialize_evm_tx_hash('0x09b9d311c62dadc69a06f39daa5206760f38ef48d9e8473f27a9cf2d599133c9')  # noqa: E501
     amount = FVal('6350.3577325406')
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -745,6 +762,7 @@ def test_blur_balances(
     blur_balances_inquirer = BlurBalances(
         database=ethereum_transaction_decoder.database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     blur_balances = blur_balances_inquirer.query_balances()
     user_balance = blur_balances[ethereum_accounts[0]]
@@ -765,7 +783,7 @@ def test_hop_balances_staking(
     """Test the balance query for staked hop lp balances. It adds a staking event
     and then queries the balances for that address."""
     lp_amount, reward_amount = FVal('0.005676129314105837'), FVal('0.06248913329652552')
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
         database=arbitrum_one_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0x6329984b82cb85903fee9fef61fb77cdf848ff6344056156da2e66676ad91473'),
@@ -773,6 +791,7 @@ def test_hop_balances_staking(
     balances_inquirer = HopBalances(
         database=arbitrum_one_transaction_decoder.database,
         evm_inquirer=arbitrum_one_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[arbitrum_one_accounts[0]].assets == {
@@ -796,7 +815,7 @@ def test_hop_balances_staking_2(
     """Test the balance query for staked hop lp balances. It adds a staking event
     and then queries the balances for that address."""
     lp_amount, reward_amount = FVal('0.005676129314105837'), FVal('0.008945843949587174')
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
         database=arbitrum_one_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0xe0c1f6f152422784a4e4346d84af7d32fda95eab17da257f3fdc5121f4a6fbc8'),
@@ -804,6 +823,7 @@ def test_hop_balances_staking_2(
     balances_inquirer = HopBalances(
         database=arbitrum_one_transaction_decoder.database,
         evm_inquirer=arbitrum_one_inquirer,
+        tx_decoder=tx_decoder,
     )
     balances = balances_inquirer.query_balances()
     assert balances[arbitrum_one_accounts[0]].assets == {
@@ -827,7 +847,7 @@ def test_gearbox_balances(
     """Check that staked balances of Gearbox are properly detected."""
     tx_hex = deserialize_evm_tx_hash('0x5de7647a4c8f8ca1e5434725dd09b27ce05e41954d72c3f1f4d639c8b7019f4a')  # noqa: E501
     amount = FVal('260.869836197270890866')
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -835,6 +855,7 @@ def test_gearbox_balances(
     protocol_balances_inquirer = GearboxBalances(
         database=ethereum_transaction_decoder.database,
         evm_inquirer=ethereum_inquirer,
+        tx_decoder=tx_decoder,
     )
     protocol_balances = protocol_balances_inquirer.query_balances()
     user_balance = protocol_balances[ethereum_accounts[0]]
@@ -855,7 +876,7 @@ def test_gearbox_balances_arb(
     """Check that staked balances of Gearbox are properly detected."""
     tx_hex = deserialize_evm_tx_hash('0xd6abdbf2e57c37e191c5e93b9b99d1c70acdca000b2fd9e8236093a0b359221e')  # noqa: E501
     amount = FVal('139896.73226582730792446')
-    get_decoded_events_of_transaction(
+    _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
         database=arbitrum_one_transaction_decoder.database,
         tx_hash=tx_hex,
@@ -863,6 +884,7 @@ def test_gearbox_balances_arb(
     protocol_balances_inquirer = GearboxBalancesArbitrumOne(
         database=arbitrum_one_transaction_decoder.database,
         evm_inquirer=arbitrum_one_inquirer,
+        tx_decoder=tx_decoder,
     )
     protocol_balances = protocol_balances_inquirer.query_balances()
     user_balance = protocol_balances[arbitrum_one_accounts[0]]

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import random
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import gevent
 from eth_typing import ChecksumAddress
@@ -42,7 +42,14 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
+    from rotkehlchen.chain.base.node_inquirer import BaseInquirer
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+    from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
+    from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
+    from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
+    from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
 NODE_CONNECTION_TIMEOUT = 10
@@ -343,6 +350,90 @@ def setup_ethereum_transactions_test(
                 dbevmtx.add_or_ignore_receipt_data(cursor, ChainID.ETHEREUM, txreceipt_to_data(expected_receipt2))  # noqa: E501
 
     return transactions, [expected_receipt1, expected_receipt2]
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'EthereumInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], EthereumTransactionDecoder]:
+    ...
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'OptimismInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], OptimismTransactionDecoder]:
+    ...
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'ArbitrumOneInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], ArbitrumOneTransactionDecoder]:
+    ...
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'BaseInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], BaseTransactionDecoder]:
+    ...
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'GnosisInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], GnosisTransactionDecoder]:
+    ...
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'PolygonPOSInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], PolygonPOSTransactionDecoder]:
+    ...
+
+
+@overload
+def get_decoded_events_of_transaction(
+        evm_inquirer: 'ScrollInquirer',
+        database: DBHandler,
+        tx_hash: EVMTxHash,
+        transactions: EvmTransactions | None = None,
+        relevant_address: ChecksumAddress | None = None,
+        load_global_caches: list[str] | None = None,
+) -> tuple[list['EvmEvent'], ScrollTransactionDecoder]:
+    ...
 
 
 def get_decoded_events_of_transaction(


### PR DESCRIPTION
If the timing of the eigenlayer pending withdrawal completion came before the saving of the start of pending withdrawal was in the DB, then the pending withdrawal was never marked as complete.

This resulted in those cases of completed withdrawals counting again in the balances.

This commit fixes this by forcing redecoding of completion if a completed withdrawal is found without having a match to a pending withdrawal whenever eigenlayer balances are queried.
