### PR TITLE
fix: metamask error if other wallet is installed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`8334` Importing addresses from MetaMask should work when multiple browser wallets are installed.
 * :bug:`-` rotki will now properly run background tasks when logging out and logging in again.
 * :bug:`-` rotki will now detect new tokens right after finishing decoding new events.
 * :bug:`8169` Prevent a recursion error when querying the price of a token.

--- a/frontend/app/public/metamask/import.html
+++ b/frontend/app/public/metamask/import.html
@@ -185,7 +185,7 @@
         </div>
         <div id="missing" class="flex-column">
             <div class="alert warning flex-column">
-                MetaMask could not be detected
+                MetaMask could not be detected, or refresh this page
             </div>
             <div class="text small mt-8">
                 Here are the common cause:
@@ -213,7 +213,7 @@
     </div>
 </div>
 <script type="text/javascript">
-    let isMetamask = false
+    let isMetamask = false;
 
     let $$ = document.getElementById.bind(document);
 
@@ -236,12 +236,45 @@
         elem.innerText = text;
     }
 
+    async function getMetamaskProviderWithTimeout(timeout = 2000) {
+        return new Promise((resolve) => {
+            let provider;
+
+            const handleProviderAnnouncement = (event) => {
+                if (event.detail.info.rdns === 'io.metamask') {
+                    provider = event.detail.provider;
+                    cleanup();
+                    resolve(provider);
+                }
+            };
+
+            const cleanup = () => {
+                window.removeEventListener("eip6963:announceProvider", handleProviderAnnouncement);
+            };
+
+            window.addEventListener("eip6963:announceProvider", handleProviderAnnouncement);
+            window.dispatchEvent(new Event("eip6963:requestProvider"));
+
+            setTimeout(() => {
+                cleanup();
+                resolve(undefined);
+            }, timeout);
+        });
+    }
+
     async function onImport() {
         setText(errorMessageElem, '');
         hide(errorElem);
 
+        let provider = await getMetamaskProviderWithTimeout(2000);
+
+        if (!provider) {
+          showNotDetectedMessage();
+          return;
+        }
+
         try {
-            const permissions = await window.ethereum.request({
+            const permissions = await provider.request({
                 method: 'wallet_requestPermissions',
                 params: [{
                     'eth_accounts': {},
@@ -256,11 +289,9 @@
                 show(errorElem);
                 setText(errorMessageElem, 'Could not find the eth_accounts permission');
             } else {
-                const addresses = [];
-                accountPermission.caveats.map(permission => {
-                    if (permission.value) {
-                        addresses.push(...permission.value);
-                    }
+                const addresses = await provider.request({
+                  method: 'eth_requestAccounts',
+                  params: [],
                 });
 
                 if (addresses.length > 0) {
@@ -312,16 +343,19 @@
         isMetamask = window.ethereum.isMetaMask;
     }
 
+    function showNotDetectedMessage() {
+        hide(buttonElem);
+        show(missingElem);
+    }
+
     document.addEventListener("DOMContentLoaded", function(){
         if (!isMetamask) {
-            hide(buttonElem);
-            show(missingElem);
+            showNotDetectedMessage();
         }
 
         buttonElem.addEventListener('click', onImport);
         copyElem.addEventListener('click', onCopy);
     });
-
 </script>
 </body>
 </html>

--- a/frontend/app/src/types.d.ts
+++ b/frontend/app/src/types.d.ts
@@ -5,19 +5,12 @@ interface Request {
   readonly params: Record<string, any>[];
 }
 
-interface Caveat {
-  readonly name: string;
-  readonly value: string[];
-}
-
 interface Permission {
   readonly parentCapability: string;
-  readonly caveats: Caveat[];
 }
 
 interface Provider {
   readonly isMetaMask?: boolean;
-  readonly request: (request: Request) => Promise<Permission[]>;
 }
 
 declare global {
@@ -25,6 +18,45 @@ declare global {
     interop?: Interop;
     ethereum?: Provider;
   }
+
+  interface WindowEventMap {
+    'eip6963:announceProvider': CustomEvent;
+  }
+}
+
+// Handle Metamask and other wallet extension import
+export interface EIP6963ProviderInfo {
+  rdns: string;
+  uuid: string;
+  name: string;
+  icon: string;
+}
+
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: EIP1193Provider;
+}
+
+export interface EIP6963AnnounceProviderEvent {
+  detail: {
+    info: EIP6963ProviderInfo;
+    provider: Readonly<EIP1193Provider>;
+  };
+}
+
+export interface EIP1193Provider {
+  isStatus?: boolean;
+  host?: string;
+  path?: string;
+  sendAsync?: (
+    request: { method: string; params?: Array<unknown> },
+    callback: (error: Error | null, response: unknown) => void
+  ) => void;
+  send?: (
+    request: { method: string; params?: Array<unknown> },
+    callback: (error: Error | null, response: unknown) => void
+  ) => void;
+  request: (request: Request) => Promise<Permission[] | string[]>;
 }
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/frontend/app/src/utils/metamask.ts
+++ b/frontend/app/src/utils/metamask.ts
@@ -1,3 +1,5 @@
+import type { EIP1193Provider, EIP6963AnnounceProviderEvent } from '@/types';
+
 export function isMetaMaskSupported(): boolean {
   return (
     (!!window.interop || (window.ethereum && window.ethereum.isMetaMask))
@@ -5,11 +7,40 @@ export function isMetaMaskSupported(): boolean {
   );
 }
 
+function getMetamaskProviderWithTimeout(timeout = 2000): Promise<EIP1193Provider | undefined> {
+  return new Promise((resolve) => {
+    let provider;
+
+    const handleProviderAnnouncement = (event: EIP6963AnnounceProviderEvent) => {
+      if (event.detail.info.rdns === 'io.metamask') {
+        provider = event.detail.provider;
+        cleanup();
+        resolve(provider);
+      }
+    };
+
+    const cleanup = () => {
+      window.removeEventListener('eip6963:announceProvider', handleProviderAnnouncement);
+    };
+
+    window.addEventListener('eip6963:announceProvider', handleProviderAnnouncement);
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+
+    setTimeout(() => {
+      cleanup();
+      resolve(undefined);
+    }, timeout);
+  });
+}
+
 export async function getMetamaskAddresses(): Promise<string[]> {
   assert(window.ethereum);
   assert(window.ethereum.isMetaMask);
 
-  const permissions = await window.ethereum.request({
+  const provider = await getMetamaskProviderWithTimeout();
+  assert(provider);
+
+  const permissions = await provider.request({
     method: 'wallet_requestPermissions',
     params: [
       {
@@ -19,15 +50,20 @@ export async function getMetamaskAddresses(): Promise<string[]> {
   });
 
   const accountPermission = permissions.find(
-    permission => permission.parentCapability === 'eth_accounts',
+    permission => typeof permission !== 'string' && permission.parentCapability === 'eth_accounts',
   );
 
   assert(accountPermission);
 
+  const requestedAddresses = await provider.request({
+    method: 'eth_requestAccounts',
+    params: [],
+  });
+
   const addresses: string[] = [];
-  accountPermission.caveats.forEach((permission) => {
-    if (permission.value)
-      addresses.push(...permission.value);
+  requestedAddresses.forEach((item) => {
+    if (typeof item === 'string')
+      addresses.push(item);
   });
 
   assert(addresses);


### PR DESCRIPTION
Closes #8334

Fix issue that metamask showed error `Method not supported`, especially if `Rainbow wallet` is installed alongside with the Metamask
