### PR TITLE
fix setuptools

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -96,7 +96,8 @@ jobs:
           Get-ChildItem -Path $PYTHON_LOCATION
           (Get-Command python).Path
       - name: Install dependencies
-        run: |          
+        run: |
+          uv pip install --system 'setuptools<72'
           uv pip install --system --upgrade wheel pytest-cov
           uv pip install --system -r requirements_dev.txt
           uv pip install --system -e .


### PR DESCRIPTION
As documented here https://github.com/pypa/setuptools/issues/4519 setuptools has released a breaking change that removes a functionality used by some our dependencies breaking the install process. In our case is the VCR package that has been already notified https://github.com/kevin1024/vcrpy/pull/858

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
