### PR TITLE
Fix (Async tasks): No pending after logout

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` rotki will now properly run background tasks when logging out and logging in again.
 * :bug:`-` rotki will now detect new tokens right after finishing decoding new events.
 * :bug:`8169` Prevent a recursion error when querying the price of a token.
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -462,6 +462,7 @@ class RestAPI:
         gevent.wait(self.waited_greenlets)
         log.debug('Waited for greenlets. Killing all other greenlets')
         gevent.killall(self.rotkehlchen.api_task_greenlets)
+        self.rotkehlchen.api_task_greenlets.clear()
         log.debug('Shutdown completed')
         logging.shutdown()
         self.stop_event.set()
@@ -1239,6 +1240,7 @@ class RestAPI:
         # 2. Have an intricate stop() notification system for each greenlet, but
         #   that is going to get complicated fast.
         gevent.killall(self.rotkehlchen.api_task_greenlets)
+        self.rotkehlchen.api_task_greenlets.clear()
         with self.task_lock:
             self.task_results = {}
         self.rotkehlchen.logout()


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=72778103

## Checklist

- [x] Clear the tracked greenlets list after they are all killed at logout

I confirmed that they are all dead, but were still tracked after logout.