### PR TITLE
Properly handle curve pool with a specific coin == underlying

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -97,7 +97,6 @@ jobs:
           (Get-Command python).Path
       - name: Install dependencies
         run: |
-          uv pip install --system 'setuptools<72'
           uv pip install --system --upgrade wheel pytest-cov
           uv pip install --system -r requirements_dev.txt
           uv pip install --system -e .

--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -179,6 +179,9 @@ def _ensure_curve_tokens_existence(
                     )
                     continue
 
+                if underlying_token_address == token_address:  # they are the same token. Stop here
+                    continue  # can happen for a pool to have token's underlying token as itself
+
                 try:
                     # and ensure token exists
                     get_or_create_evm_token(
@@ -204,7 +207,7 @@ def _ensure_curve_tokens_existence(
                     continue
         else:
             # Otherwise just ensure that coins and underlying coins exist in our assets database  # noqa: E501
-            for token_address in pool.coins + pool.underlying_coins:
+            for token_address in set(pool.coins + pool.underlying_coins):
                 if token_address == ETH_SPECIAL_ADDRESS:
                     continue
                 try:


### PR DESCRIPTION
So finally found that bug that made USDT and PAXUSD have themselves as underlying tokens and create an infinite price recursion loop.

Since for curve it can happen that for a given pool some coins in the list have their own underlying coins and some have themselves use a set in a for loop to not repeat ourselves

Example pools. 

https://etherscan.io/address/0x06364f10B501e868329afBc005b3492902d6C763#readContract
![2024-08-03_00-38](https://github.com/user-attachments/assets/27da8e98-7b29-405c-a70f-ff260cd392a1)


https://etherscan.io/address/0xA5407eAE9Ba41422680e2e00537571bcC53efBfD#readContract
![2024-08-03_01-03](https://github.com/user-attachments/assets/99c25b6d-dc5f-46d3-ad3d-610b0a07939c)
