### PR TITLE
fix: show balances loading from beginning

### DIFF
--- a/frontend/app/src/components/dashboard/OverallBalances.vue
+++ b/frontend/app/src/components/dashboard/OverallBalances.vue
@@ -23,9 +23,12 @@ const { totalNetWorth } = storeToRefs(statistics);
 const frontendStore = useFrontendSettingsStore();
 const { visibleTimeframes } = storeToRefs(frontendStore);
 
-const { isLoading: isSectionLoading } = useStatusStore();
+const { shouldShowLoadingScreen, isLoading: isSectionLoading } = useStatusStore();
 
-const isLoading = isSectionLoading(Section.BLOCKCHAIN);
+const isLoading = logicOr(
+  shouldShowLoadingScreen(Section.BLOCKCHAIN),
+  isSectionLoading(Section.BLOCKCHAIN),
+);
 
 const adjustedTotalNetWorthFontSize = computed(() => {
   const digits = get(totalNetWorth)

--- a/frontend/app/src/store/status.ts
+++ b/frontend/app/src/store/status.ts
@@ -87,7 +87,7 @@ export const useStatusStore = defineStore('status', () => {
   const shouldShowLoadingScreen = (section: Section, subsection: string = defaultSection) => computed<boolean>(() => {
     const statuses = get(status)[section];
     if (!statuses)
-      return false;
+      return true;
 
     return matchesStatus(statuses, subsection, isInitialLoadingStatus);
   });


### PR DESCRIPTION
show loading for dashboard percentage and chart from beginning, to not show sudden decrease when balances is not loaded