### PR TITLE
Add default for ERC20 properties of curve gauges

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`8334` Importing addresses from MetaMask should work when multiple browser wallets are installed.
 * :bug:`-` rotki will now properly run background tasks when logging out and logging in again.
+* :bug:`-` The task to read new curve pools from the chain will be faster now.
 * :bug:`-` rotki will now detect new tokens right after finishing decoding new events.
 * :bug:`8169` Prevent a recursion error when querying the price of a token.
 

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -278,7 +278,10 @@ def get_or_create_evm_token(
             except UnknownAsset:
                 asset_exists = False
 
-            if evm_inquirer is not None:
+            if (
+                None in (name, symbol, decimals) and
+                evm_inquirer is not None
+            ):
                 try:
                     name, symbol, decimals = _query_or_get_given_token_info(
                         evm_inquirer=evm_inquirer,

--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -251,6 +251,10 @@ def _ensure_curve_tokens_existence(
 
         if pool.gauge_address is not None:
             try:
+                # Old gauges don't have the name/symbol/decimals methods. They use 18 decimals but
+                # the name and symbol differ and in the latest versions it is configurable. To be
+                # in sync with the onchain name we use the contract values and only
+                # if they are missing we resort to the fallback name and symbol.
                 get_or_create_evm_token(
                     userdb=evm_inquirer.database,
                     evm_address=pool.gauge_address,
@@ -265,7 +269,7 @@ def _ensure_curve_tokens_existence(
                         token_kind=EvmTokenKind.ERC20,
                         weight=ONE,
                     )],
-                    fallback_decimals=18,  # all gauges have 18 decimals https://t.me/curvefi/654915. Hard code since some contracts have no name/symbol/decimals.  # noqa: E501
+                    fallback_decimals=18,  # all gauges have 18 decimals https://t.me/curvefi/654915  # noqa: E501
                     fallback_name=f'{pool_lp_token.name} Gauge Deposit',
                     fallback_symbol=f'{pool_lp_token.symbol}-gauge',
                 )

--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -231,7 +231,7 @@ def _ensure_curve_tokens_existence(
         # finally ensure lp token and gauge token exists in the globaldb. Since they are created
         # by curve, they should always be an ERC20
         try:
-            get_or_create_evm_token(
+            pool_lp_token = get_or_create_evm_token(
                 userdb=evm_inquirer.database,
                 evm_address=pool.lp_token_address,
                 chain_id=evm_inquirer.chain_id,
@@ -265,6 +265,9 @@ def _ensure_curve_tokens_existence(
                         token_kind=EvmTokenKind.ERC20,
                         weight=ONE,
                     )],
+                    decimals=18,  # 18 is the default for old gauges that don't implement the decimals method https://t.me/curvefi/654915  # noqa: E501
+                    name=f'{pool_lp_token.name} Gauge Deposit',
+                    symbol=f'{pool_lp_token.symbol}-gauge',
                 )
             except NotERC20Conformant:
                 log.warning(f'Curve gauge {pool.gauge_address} is not a valid ERC20 token.')

--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -28,7 +28,7 @@ from rotkehlchen.errors.misc import (
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.globaldb.cache import (
-    globaldb_get_general_cache_like,
+    compute_cache_key,
     globaldb_get_general_cache_values,
     globaldb_get_unique_cache_value,
     globaldb_set_general_cache_values,
@@ -265,9 +265,9 @@ def _ensure_curve_tokens_existence(
                         token_kind=EvmTokenKind.ERC20,
                         weight=ONE,
                     )],
-                    decimals=18,  # 18 is the default for old gauges that don't implement the decimals method https://t.me/curvefi/654915  # noqa: E501
-                    name=f'{pool_lp_token.name} Gauge Deposit',
-                    symbol=f'{pool_lp_token.symbol}-gauge',
+                    fallback_decimals=18,  # all gauges have 18 decimals https://t.me/curvefi/654915. Hard code since some contracts have no name/symbol/decimals.  # noqa: E501
+                    fallback_name=f'{pool_lp_token.name} Gauge Deposit',
+                    fallback_symbol=f'{pool_lp_token.symbol}-gauge',
                 )
             except NotERC20Conformant:
                 log.warning(f'Curve gauge {pool.gauge_address} is not a valid ERC20 token.')
@@ -333,7 +333,7 @@ def save_curve_data_to_cache(
 
 def _query_curve_data_from_api(
         chain_id: ChainID,
-        existing_pools: list[ChecksumEvmAddress],
+        existing_pools: set[ChecksumEvmAddress],
 ) -> list[CurvePoolData]:
     """
     Query all curve information(lp tokens, pools, gagues, pool coins) from curve api.
@@ -385,7 +385,7 @@ def _query_curve_data_from_api(
 
 def _query_curve_data_from_chain(
         evm_inquirer: 'EvmNodeInquirer',
-        existing_pools: list[ChecksumEvmAddress],
+        existing_pools: set[ChecksumEvmAddress],
         msg_aggregator: 'MessagesAggregator',
 ) -> list[CurvePoolData] | None:
     """
@@ -484,7 +484,7 @@ def _query_curve_data_from_chain(
 
 def query_curve_data(
         inquirer: 'EvmNodeInquirer',
-        cache_type: Literal[CacheType.CURVE_LP_TOKENS],
+        cache_type: Literal[CacheType.CURVE_POOL_ADDRESS],
         msg_aggregator: 'MessagesAggregator',
 ) -> list[CurvePoolData] | None:
     """Query curve lp tokens, curve pools and curve gauges.
@@ -496,13 +496,14 @@ def query_curve_data(
     curve api returns "Curve.fi DAI/USDC/USDT" while metaregistry returns "3pool".
     TODO: think of how to make pool names uniform."""
     with GlobalDBHandler().conn.read_ctx() as cursor:
-        existing_pools = [
-            string_to_evm_address(address)
-            for address in globaldb_get_general_cache_like(
-                cursor=cursor,
-                key_parts=(cache_type, str(inquirer.chain_id.serialize_for_db())),
+        existing_pools = {  # query the pools that we already have in the db
+            string_to_evm_address(address[0])
+            for address in cursor.execute(
+                'SELECT value FROM unique_cache WHERE key LIKE ?',
+                (f'{compute_cache_key((cache_type, str(inquirer.chain_id.serialize_for_db())))}%',),  # noqa: E501
             )
-        ]
+        }
+
     try:
         pools_data: list[CurvePoolData] | None = _query_curve_data_from_api(
             chain_id=inquirer.chain_id,

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -87,7 +87,7 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
         ReloadablePoolsAndGaugesDecoderMixin.__init__(
             self,
             evm_inquirer=evm_inquirer,
-            cache_type_to_check_for_freshness=CacheType.CURVE_LP_TOKENS,
+            cache_type_to_check_for_freshness=CacheType.CURVE_POOL_ADDRESS,
             query_data_method=query_curve_data,
             save_data_to_cache_method=save_curve_data_to_cache,
             read_data_from_cache_method=read_curve_pools_and_gauges,

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -53,7 +53,7 @@ CACHE_QUERY_METHOD_TYPE = (
         ],
         list['VelodromePoolData'] | None] |
     Callable[
-        ['EthereumInquirer', Literal[CacheType.CURVE_LP_TOKENS], 'MessagesAggregator'],
+        ['EthereumInquirer', Literal[CacheType.CURVE_POOL_ADDRESS], 'MessagesAggregator'],
         list | None,
     ] |
     Callable[

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -377,7 +377,6 @@ def test_curve_cache(rotkehlchen_instance, use_curve_api, globaldb):
 
     assert mock_notify.call_args_list == [
         make_call_object(CPT_CURVE, ChainID.ETHEREUM, processed=1, total=2),
-        make_call_object(CPT_CURVE, ChainID.ETHEREUM, processed=1, total=2),
     ] if use_curve_api else [
         make_call_object(CPT_CURVE, ChainID.ETHEREUM, processed=0, total=0),
         make_call_object(CPT_CURVE, ChainID.ETHEREUM, processed=1, total=2),

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -452,7 +452,7 @@ def test_find_curve_lp_token_price(inquirer: 'Inquirer', blockchain: 'ChainsAggr
 
     def mock_query_curve_data_from_api(
             chain_id: ChainID,
-            existing_pools: list[ChecksumEvmAddress],
+            existing_pools: set[ChecksumEvmAddress],
     ) -> list[CurvePoolData]:
         for pool in _query_curve_data_from_api(
             chain_id=chain_id,

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -269,9 +269,9 @@ def test_flaky_binding_parameter_zero(
 
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
 def test_old_curve_gauge(ethereum_inquirer: 'EthereumInquirer'):
-    """Test that querying new and old gauges get the data correctly
-    Old one should peak the default values provided and the new one should
-    get values on chain
+    """Test that querying new and old gauges get the data correctly.
+    Old one should pick the default values provided and the new one should
+    get the values from the chain
     """
     # old gauge
     gauge_address = string_to_evm_address('0xC2b1DF84112619D190193E48148000e3990Bf627')
@@ -308,3 +308,32 @@ def test_old_curve_gauge(ethereum_inquirer: 'EthereumInquirer'):
     assert gauge_token.name == 'Curve.fi steCRV Gauge Deposit'
     assert gauge_token.symbol == 'steCRV-gauge'
     assert gauge_token.decimals == 18
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [1])
+def test_chain_is_not_queried_when_details(ethereum_inquirer: 'EthereumInquirer'):
+    """Test that if we provide the values of name, decimals and symbol we don't query
+    the chain without need
+    """
+    lido_address = string_to_evm_address('0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32')
+    with suppress(InputError):
+        GlobalDBHandler.delete_evm_token(lido_address, chain_id=ChainID.ETHEREUM)
+
+    with patch(
+        'rotkehlchen.assets.utils._query_or_get_given_token_info',
+        side_effect=_query_or_get_given_token_info,
+    ) as patched_query:
+        new_token = get_or_create_evm_token(
+            userdb=ethereum_inquirer.database,
+            evm_address=lido_address,
+            chain_id=ethereum_inquirer.chain_id,
+            evm_inquirer=ethereum_inquirer,
+            decimals=17,
+            name='new LDO',
+            symbol='nLDO',
+        )
+        assert patched_query.call_count == 0
+
+    assert new_token.name == 'new LDO'
+    assert new_token.symbol == 'nLDO'
+    assert new_token.decimals == 17


### PR DESCRIPTION
Old curve gauges don't have the symbol, name, decimals methods. I asked in telegram and the default is 18. This PR sets default values for this attributes to avoid errors at the moment of populating the curve cache

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
