### PR TITLE
Chore (Migrations): Add 16th migration

### DIFF
--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -12,6 +12,7 @@ from rotkehlchen.data_migrations.migrations.migration_11 import data_migration_1
 from rotkehlchen.data_migrations.migrations.migrations_13 import data_migration_13
 from rotkehlchen.data_migrations.migrations.migrations_14 import data_migration_14
 from rotkehlchen.data_migrations.migrations.migrations_15 import data_migration_15
+from rotkehlchen.data_migrations.migrations.migrations_16 import data_migration_16
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 from .constants import LAST_DATA_MIGRATION
@@ -39,6 +40,7 @@ MIGRATION_LIST = [  # remember to bump LAST_DATA_MIGRATION if editing this
     MigrationRecord(version=13, function=data_migration_13),
     MigrationRecord(version=14, function=data_migration_14),
     MigrationRecord(version=15, function=data_migration_15),
+    MigrationRecord(version=16, function=data_migration_16),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migrations_16.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_16.py
@@ -1,0 +1,27 @@
+import logging
+from typing import TYPE_CHECKING
+
+from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+
+if TYPE_CHECKING:
+    from rotkehlchen.data_migrations.progress import MigrationProgressHandler
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+@enter_exit_debug_log()
+def data_migration_16(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:  # pylint: disable=unused-argument
+    """Introduced at v1.34.2
+
+    Removes the underlying token entries from the database that have themselves
+    as the underlying token."""
+    progress_handler.set_total_steps(1)
+    with GlobalDBHandler().conn.write_ctx() as write_cursor:
+        write_cursor.execute(
+            'DELETE FROM underlying_tokens_list WHERE identifier=parent_token_entry;',
+        )
+
+    progress_handler.new_step()


### PR DESCRIPTION
## Checklist

- [x] Add data migration 16 to remove the underlying tokens that have parent_token_entry == identifier