### PR TITLE
Improve spammed account detection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :bug:`-` rotki will now properly run background tasks when logging out and logging in again.
 * :bug:`-` The task to read new curve pools from the chain will be faster now.
 * :bug:`-` rotki will now detect new tokens right after finishing decoding new events.
+* :bug:`-` The detection of account activity in new evm chains has been improved to avoid false positives when the account has been only sent spam tokens.
 * :bug:`8169` Prevent a recursion error when querying the price of a token.
 
 * :release:`1.34.1 <2024-07-24>`


### PR DESCRIPTION
When a untracked token is found check the context of the transaction to know if the token is being spammed to different accounts and if so mark it as spam

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
