### PR TITLE
Prevent deadlock with globaldb

### DIFF
--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -2183,3 +2183,17 @@ class GlobalDBHandler:
                 'SELECT protocol FROM evm_tokens WHERE identifier=?;',
                 (asset_identifier,),
             ).fetchone()) is not None else None
+
+    def clear_locks(self) -> None:
+        """release the locks in the globaldb.
+
+        We saw that when killing a greenlet the locks are not released and has to
+        be done manually.
+        It won't raise errors if the lock is over-released
+        https://www.gevent.org/api/gevent.lock.html#gevent.lock.Semaphore.release
+        The killall that happens in this logic can trigger a greenlet switch as per
+        https://github.com/gevent/gevent/issues/1473#issuecomment-548327614
+        """
+        self.packaged_db_lock.release()
+        self.conn.transaction_lock.release()
+        self.conn.in_callback.release()

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -516,10 +516,7 @@ class Rotkehlchen:
         if not self.user_is_logged_in:
             return
         user = self.data.username
-        log.info(
-            'Logging out user',
-            user=user,
-        )
+        log.info('Logging out user', user=user)
 
         self.deactivate_premium_status()
         self.greenlet_manager.clear()
@@ -537,13 +534,15 @@ class Rotkehlchen:
         # Make sure no messages leak to other user sessions
         self.msg_aggregator.consume_errors()
         self.msg_aggregator.consume_warnings()
+        self.task_manager.clear()  # type: ignore  # task_manager is not None here
         self.task_manager = None
 
+        # We have locks in the chain aggregator that gets removed in this
+        # function and in the db connections. The user db gets replaced but the globaldb
+        # needs to be released.
+        GlobalDBHandler().clear_locks()
         self.user_is_logged_in = False
-        log.info(
-            'User successfully logged out',
-            user=user,
-        )
+        log.info('User successfully logged out', user=user)
 
     def logout(self) -> None:
         if self.task_manager is None:  # no user logged in?

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -957,3 +957,10 @@ class TaskManager:
 
         with self.schedule_lock:
             self._schedule()
+
+    def clear(self) -> None:
+        """Ensure that no task is kept referenced. Used when removing the task manager"""
+        for task_list in self.running_greenlets.values():
+            gevent.killall(task_list)
+
+        self.running_greenlets.clear()


### PR DESCRIPTION
Prevent killed task from having locks of the globaldb

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
