### PR TITLE
Eigenlayer do not double count eigenpod

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Fix an error introduced in 1.34.2 that was creating snapshots more frequently than expected.
+* :bug:`-` Eigenlayer native restaking exited balances residing in eigenpod will no longer be double counted.
 
 * :release:`1.34.2 <2024-08-09>`
 * :bug:`-` Users will be able to filter by event subtype in the history events view.

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
@@ -185,8 +185,8 @@ class EigenlayerBalances(ProtocolWithBalance):
 
         return balances
 
-    def _query_eigenpod_balances(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':
-        """Queries the balance of ETH in the eigenpod and in the Delayed Withdrawal router"""
+    def _query_delayed_withdrawal_balances(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':  # noqa: E501
+        """Queries the balance of ETH in the Delayed Withdrawal router"""
         if len(eigenpod_data := self.addresses_with_activity(
             event_types={(HistoryEventType.INFORMATIONAL, HistoryEventSubType.CREATE)},
         )) == 0:
@@ -203,15 +203,7 @@ class EigenlayerBalances(ProtocolWithBalance):
 
                 owner_mapping[eigenpod] = owner
 
-        eth_price = Inquirer.find_usd_price(A_ETH)  # now query all eigenpod balances and add it
-        for eigenpod_address, amount in self.evm_inquirer.get_multi_balance(accounts=list(owner_mapping.keys())).items():  # noqa: E501
-            if amount > ZERO:
-                balances[owner_mapping[eigenpod_address]].assets[A_ETH] += Balance(
-                    amount=amount,
-                    usd_value=eth_price * amount,
-                )
-
-        # finally check the balance in the delayed withdrawal router for all eigenpod owners
+        eth_price = Inquirer.find_usd_price(A_ETH)  # check the balance in the delayed withdrawal router for all eigenpod owners  # noqa: E501
         contract = EvmContract(  # TODO: perhaps move this in the DB
             address=EIGENPOD_DELAYED_WITHDRAWAL_ROUTER,
             abi=EIGENPOD_DELAYED_WITHDRAWAL_ROUTER_ABI,
@@ -252,6 +244,6 @@ class EigenlayerBalances(ProtocolWithBalance):
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
         balances = self._query_lst_deposits(balances)
-        balances = self._query_eigenpod_balances(balances)
+        balances = self._query_delayed_withdrawal_balances(balances)
         balances = self._query_token_pending_withdrawals(balances)
         return balances

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -39,7 +39,6 @@ from rotkehlchen.constants.assets import (
     A_AAVE,
     A_ARB,
     A_CVX,
-    A_ETH,
     A_GLM,
     A_GMX,
     A_GRT,
@@ -423,35 +422,6 @@ def test_eigenlayer_balances(
     assert balances[ethereum_accounts[0]].assets[A_STETH.resolve_to_evm_token()] == Balance(
         amount=FVal('0.114063122816914142'),
         usd_value=FVal('0.1710946842253712130'),
-    )
-
-
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('ethereum_accounts', [['0x789E8DD02FfCCd7A753B048559d4FBeA1e1a1b7c']])
-def test_eigenpod_balances(
-        ethereum_inquirer: 'EthereumInquirer',
-        ethereum_transaction_decoder: 'EthereumTransactionDecoder',
-        ethereum_accounts: list[ChecksumEvmAddress],
-        inquirer: 'Inquirer',  # pylint: disable=unused-argument
-) -> None:
-    database = ethereum_transaction_decoder.database
-    tx_hex = deserialize_evm_tx_hash('0xb6fa282227916f9b16df953f79a5859ba80b8bc3b9c6adc01f262070d3c9e3d5')  # noqa: E501
-    events, tx_decoder = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
-        tx_hash=tx_hex,
-    )
-    assert len(events) == 2
-    balances_inquirer = EigenlayerBalances(
-        database=database,
-        evm_inquirer=ethereum_inquirer,
-        tx_decoder=tx_decoder,
-    )
-    eigenpod_balance, delayed_withdrawals = FVal('0.054506232'), FVal('0.007164493')
-    balances = balances_inquirer.query_balances()
-    assert balances[ethereum_accounts[0]].assets[A_ETH] == Balance(
-        amount=eigenpod_balance + delayed_withdrawals,
-        usd_value=FVal('1.5') * (eigenpod_balance + delayed_withdrawals),
     )
 
 

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -1084,7 +1084,7 @@ def test_deadlock_logout(
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 def test_snapshots_dont_happen_always(rotkehlchen_api_server: 'APIServer') -> None:
     """Regression test for an issue we had where the task for snapshots was
-    creating one for each run of the background task.
+    creating a snapshot for each run of the background task.
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     task_manager = cast(TaskManager, rotki.task_manager)


### PR DESCRIPTION
Eigenlayer native restaking exited balances residing in eigenpod will no longer be double counted.

