### PR TITLE
Fix addressbook

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Fix an error introduced in 1.34.2 that was creating snapshots more frequently than expected.
+* :bug:`8350` Users will no longer be able to add duplicate names for an address for all evm chains to the address book.
 * :bug:`-` Eigenlayer native restaking exited balances residing in eigenpod will no longer be double counted.
 
 * :release:`1.34.2 <2024-08-09>`

--- a/rotkehlchen/data_migrations/constants.py
+++ b/rotkehlchen/data_migrations/constants.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-LAST_DATA_MIGRATION: Final = 16
+LAST_DATA_MIGRATION: Final = 17

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -13,6 +13,7 @@ from rotkehlchen.data_migrations.migrations.migrations_13 import data_migration_
 from rotkehlchen.data_migrations.migrations.migrations_14 import data_migration_14
 from rotkehlchen.data_migrations.migrations.migrations_15 import data_migration_15
 from rotkehlchen.data_migrations.migrations.migrations_16 import data_migration_16
+from rotkehlchen.data_migrations.migrations.migrations_17 import data_migration_17
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 from .constants import LAST_DATA_MIGRATION
@@ -41,6 +42,7 @@ MIGRATION_LIST = [  # remember to bump LAST_DATA_MIGRATION if editing this
     MigrationRecord(version=14, function=data_migration_14),
     MigrationRecord(version=15, function=data_migration_15),
     MigrationRecord(version=16, function=data_migration_16),
+    MigrationRecord(version=17, function=data_migration_17),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migrations_17.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_17.py
@@ -1,0 +1,45 @@
+import logging
+from typing import TYPE_CHECKING
+
+from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.types import ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE
+
+if TYPE_CHECKING:
+    from rotkehlchen.data_migrations.progress import MigrationProgressHandler
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+@enter_exit_debug_log()
+def data_migration_17(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:  # pylint: disable=unused-argument
+    """
+    Introduced at v1.34.3
+
+    For both the user db and the globaldb ensure that if there are duplicates in the
+    table for the address book we delete them except the one with the highest rowid
+    (latest inserted) and set the blockchain value with the constant
+    ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE to avoid having NULL values.
+    """
+    progress_handler.set_total_steps(2)
+
+    for conn in (rotki.data.db.conn, GlobalDBHandler().conn):
+        with conn.read_ctx() as cursor:
+            cursor.execute('SELECT address FROM address_book WHERE blockchain IS NULL GROUP BY address HAVING COUNT(address) > 1;')  # noqa: E501
+            invalid_addresses = [(x[0], x[0]) for x in cursor]
+
+        with conn.write_ctx() as write_cursor:
+            if len(invalid_addresses) != 0:
+                write_cursor.executemany(
+                    'DELETE FROM address_book WHERE address=? AND rowid NOT IN (SELECT MAX(rowid) FROM address_book WHERE blockchain IS NULL AND address=?);',  # noqa: E501
+                    invalid_addresses,
+                )
+
+            write_cursor.execute(
+                'UPDATE address_book SET blockchain=? WHERE blockchain IS NULL',
+                (ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE,),
+            )
+
+        progress_handler.new_step()

--- a/rotkehlchen/tests/api/test_addressbook.py
+++ b/rotkehlchen/tests/api/test_addressbook.py
@@ -25,6 +25,7 @@ from rotkehlchen.tests.utils.factories import (
     make_addressbook_entries,
 )
 from rotkehlchen.types import (
+    ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE,
     AddressbookEntry,
     AddressbookType,
     BTCAddress,
@@ -824,11 +825,7 @@ def test_insert_into_addressbook_no_blockchain(
             'addressbookresource',
             book_type=book_type,
         ),
-        json={
-            'addresses': [
-                {'address': test_address},
-            ],
-        },
+        json={'addresses': [{'address': test_address}]},
     )
     result = assert_proper_sync_response_with_result(response)
     assert result['entries'] == [custom_name.serialize()]
@@ -841,4 +838,4 @@ def test_insert_into_addressbook_no_blockchain(
             cursor.execute('SELECT * FROM address_book')
             result = cursor.fetchall()
 
-    assert result == [(test_address, None, 'my address')]
+    assert result == [(test_address, ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE, 'my address')]

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -33,6 +33,7 @@ from rotkehlchen.tests.utils.blockchain import setup_evm_addresses_activity_mock
 from rotkehlchen.tests.utils.exchanges import check_saved_events_for_exchange
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.types import (
+    ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
     ChainID,
     ChecksumEvmAddress,
@@ -622,6 +623,47 @@ def test_migration_16(rotkehlchen_api_server: 'APIServer', globaldb: 'GlobalDBHa
         assert cursor.execute(
             'SELECT COUNT(*) FROM underlying_tokens_list WHERE identifier=parent_token_entry',
         ).fetchone()[0] == 0
+
+
+@pytest.mark.parametrize('data_migration_version', [16])
+@pytest.mark.parametrize('perform_upgrades_at_unlock', [True])
+def test_migration_17(rotkehlchen_api_server: 'APIServer', globaldb: 'GlobalDBHandler') -> None:
+    """Test migration 17
+
+    - Test that address that appear more than once get de-duplicated and all
+    of them get the new "special" value for blockchain
+    """
+    bad_address, tether_address = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65', '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58'  # noqa: E501
+    inserted_rows = [
+        (bad_address, 'yabir.eth', None),
+        (bad_address, 'yabirgb.eth', None),
+        (tether_address, 'Black Tether', None),
+    ]
+
+    for conn in (
+        rotkehlchen_api_server.rest_api.rotkehlchen.data.db.conn,
+        globaldb.conn,
+    ):
+        with conn.write_ctx() as write_cursor:
+            write_cursor.executemany(
+                'INSERT INTO address_book (address, name, blockchain) VALUES (?, ?, ?)',
+                inserted_rows,
+            )
+
+    with patch(
+        'rotkehlchen.data_migrations.manager.MIGRATION_LIST',
+        new=[MIGRATION_LIST[10]],
+    ):
+        DataMigrationManager(rotkehlchen_api_server.rest_api.rotkehlchen).maybe_migrate_data()
+
+    with globaldb.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT * FROM address_book WHERE address IN (?, ?)',
+            (bad_address, tether_address),
+        ).fetchall() == [
+            (tether_address, ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE, 'Black Tether'),
+            (bad_address, ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE, 'yabirgb.eth'),
+        ]
 
 
 @pytest.mark.parametrize('perform_upgrades_at_unlock', [False])

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -719,12 +719,12 @@ def test_usd_price(inquirer: Inquirer, globaldb: GlobalDBHandler):
     """Check that price is queried for tokens in different chains using defillama"""
     inquirer.set_oracles_order(oracles=[CurrentPriceOracle.DEFILLAMA])
     globaldb.add_asset(EvmToken.initialize(
-        address=string_to_evm_address('0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000'),
+        address=string_to_evm_address('0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc'),
         chain_id=ChainID.BOBA,
         token_kind=EvmTokenKind.ERC20,
         decimals=18,
-        name='Wrapped Ether',
-        symbol='WETH',
+        name='USDC',
+        symbol='USDC',
     ))
     globaldb.add_asset(EvmToken.initialize(
         address=string_to_evm_address('0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7'),
@@ -762,7 +762,7 @@ def test_usd_price(inquirer: Inquirer, globaldb: GlobalDBHandler):
         Asset('eip155:8453/erc20:0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA'),  # base
         Asset('eip155:42161/erc20:0x5979D7b546E38E414F7E9822514be443A4800529'),  # arb
         Asset('eip155:43114/erc20:0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7'),  # avax
-        Asset('eip155:288/erc20:0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000'),  # boba
+        Asset('eip155:288/erc20:0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc'),  # boba
         Asset('eip155:1101/erc20:0xA8CE8aee21bC2A48a5EF670afCc9274C7bbbC035'),  # zkevm
     ):
         price = inquirer.find_usd_price(token)

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -910,6 +910,9 @@ class CostBasisMethod(SerializableEnumNameMixin):
     ACB = auto()
 
 
+ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE: Final = 'NONE'  # blockchain value used to mark in the DB that the address entry is valid for any blockchain  # noqa: E501
+
+
 class AddressbookEntry(NamedTuple):
     address: BlockchainAddress
     name: str
@@ -922,9 +925,8 @@ class AddressbookEntry(NamedTuple):
             'blockchain': self.blockchain.serialize() if self.blockchain is not None else None,
         }
 
-    def serialize_for_db(self) -> tuple[str, str, str | None]:
-        blockchain = self.blockchain.value if self.blockchain is not None else None
-        return (self.address, self.name, blockchain)
+    def serialize_for_db(self) -> tuple[str, str, str]:
+        return (self.address, self.name, self.blockchain.value if self.blockchain is not None else ANY_BLOCKCHAIN_ADDRESS_BOOK_VALUE)  # noqa: E501
 
     @classmethod
     def deserialize(cls: type['AddressbookEntry'], data: dict[str, Any]) -> 'AddressbookEntry':


### PR DESCRIPTION
Set the blockchain value to a constant string instead of None since the primary key of the table includes the nullable column.

This avoid having duplicated entries. Also ship a data migration for both the user db and the globaldb to update the tuples. In the case of duplicates we delete them except the one with the highest row id.

Related #8350

**NOTE**:

This is for bugfixes. In develop we need to issue a new db upgrade step where we mark the column as non nullable

