### PR TITLE
Temporary fix for Eigenlayer validators exit/exiting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`-` Fix an error introduced in 1.34.2 that was creating snapshots more frequently than expected.
 * :bug:`8350` Users will no longer be able to add duplicate names for an address for all evm chains to the address book.
 * :bug:`-` Eigenlayer native restaking exited balances residing in eigenpod will no longer be double counted.
+* :bug:`8397` Active/exited validators will now be propely displayed and filtered for validators that are tracked but the withdrawal address is not. This applies to protocols such as eigenlayer.
 
 * :release:`1.34.2 <2024-08-09>`
 * :bug:`-` Users will be able to filter by event subtype in the history events view.

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -1104,6 +1104,7 @@ def test_get_active_validator_indices(database):
             ), ValidatorDetails(
                 validator_index=exited_index,
                 public_key=Eth2PubKey('0x800041b1eff8af7a583caa402426ffe8e5da001615f5ce00ba30ea8e3e627491e0aa7f8c0417071d5c1c7eb908962d8e'),
+                withdrawable_timestamp=Timestamp(1699801559),
             ), ValidatorDetails(
                 validator_index=noevents_index,
                 public_key=Eth2PubKey('0xb02c42a2cda10f06441597ba87e87a47c187cd70e2b415bef8dc890669efe223f551a2c91c3d63a5779857d3073bf288'),


### PR DESCRIPTION
This is the bugfixes part of https://github.com/rotki/rotki/issues/8397.

Essentially we no longer rely on history events processing to detect a validator has exited. That is due to the fact we may track a validator but not its exit event due to not tracking the withdrawal address directly. This happens for example in Eigenlayer native restaking.

This temporary fix is a hack considering that if "enough time" has passed since the exit was started (the time of withdrawable_ts) and now then we consider it exited.

Long term solution will happen in develop/1.35.0 as per the issue description