### PR TITLE
Remove argument not needed

### DIFF
--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -1035,7 +1035,6 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         assert cursor.execute('SELECT COUNT(*) FROM eth2_validators').fetchone() == (2,)
     _, _ = get_decoded_events_of_transaction(
         evm_inquirer=rotki.chains_aggregator.ethereum.node_inquirer,
-        database=rotki.data.db,
         tx_hash=tx_hash,
     )
 

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1455,7 +1455,6 @@ def test_count_transactions_missing_decoding(rotkehlchen_api_server: 'APIServer'
 
     get_decoded_events_of_transaction(
         evm_inquirer=rotki.chains_aggregator.ethereum.node_inquirer,
-        database=rotki.data.db,
         tx_hash=eth_transactions[0].tx_hash,
     )  # decode 1 transaction in ethereum
 
@@ -1500,7 +1499,6 @@ def test_repulling_transaction_with_internal_txs(rotkehlchen_api_server: 'APISer
     ethereum_inquirer = rotki.chains_aggregator.ethereum
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer.node_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
 

--- a/rotkehlchen/tests/api/test_sushiswap.py
+++ b/rotkehlchen/tests/api/test_sushiswap.py
@@ -53,10 +53,8 @@ def test_get_balances(
     """
     tx_hex = deserialize_evm_tx_hash('0xbc99e10c1e48969f4a580229abebc97f7a358b7ba8365dca1f829f9c387bec51')  # noqa: E501
     ethereum_inquirer = rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator.ethereum.node_inquirer  # noqa: E501
-    database = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     async_query = random.choice([False, True])
@@ -128,10 +126,8 @@ def test_get_events_history_filtering_by_timestamp(rotkehlchen_api_server: 'APIS
     """
     tx_hex = deserialize_evm_tx_hash('0xb226ddb8cbb286a7a998a35263ad258110eed5f923488f03a8d890572cd4608e')  # noqa: E501
     ethereum_inquirer = rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator.ethereum.node_inquirer  # noqa: E501
-    database = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     # Call time range

--- a/rotkehlchen/tests/api/test_uniswap.py
+++ b/rotkehlchen/tests/api/test_uniswap.py
@@ -74,10 +74,8 @@ def test_get_balances(
     """
     tx_hex = deserialize_evm_tx_hash('0x856a5b5d95623f85923938e1911dfda6ad1dd185f45ab101bac99371aeaed329')  # noqa: E501
     ethereum_inquirer = rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator.ethereum.node_inquirer  # noqa: E501
-    database = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     async_query = random.choice([False, True])
@@ -163,8 +161,6 @@ def test_get_events_history_filtering_by_timestamp(
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     ethereum_inquirer = rotki.chains_aggregator.ethereum.node_inquirer
-    database = rotki.data.db
-
     expected_events_balances_1 = [
         LiquidityPoolEventsBalance(
             pool_address=string_to_evm_address('0x55111baD5bC368A2cb9ecc9FBC923296BeDb3b89'),
@@ -181,7 +177,6 @@ def test_get_events_history_filtering_by_timestamp(
     for tx_hex in (tx_hex_1, tx_hex_2):
         get_decoded_events_of_transaction(
             evm_inquirer=ethereum_inquirer,
-            database=database,
             tx_hash=tx_hex,
         )
 

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -39,16 +39,12 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_1inchv1_swap(database, ethereum_inquirer):
+def test_1inchv1_swap(ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0x8b8652c502e80ce7c5441cdedc9184ea8f07a9c13b4c3446a47ae08c6c1d6efa
     """
     tx_hash = deserialize_evm_tx_hash('0x8b8652c502e80ce7c5441cdedc9184ea8f07a9c13b4c3446a47ae08c6c1d6efa')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     chispender_addy = string_to_evm_address('0xed04A060050cc289d91779A8BB3942C3A6589254')
     oneinch_contract = string_to_evm_address('0x11111254369792b2Ca5d084aB5eEA397cA8fa48B')
     timestamp = TimestampMS(1594500575000)
@@ -110,7 +106,7 @@ def test_1inchv1_swap(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_1inchv2_swap_for_eth(database, ethereum_inquirer):
+def test_1inchv2_swap_for_eth(ethereum_inquirer):
     """
     Test an 1inchv2 swap for ETH.
 
@@ -118,11 +114,7 @@ def test_1inchv2_swap_for_eth(database, ethereum_inquirer):
     https://etherscan.io/tx/0x5edc23d5a05e347afc60e64a4d5831ed2551985c21dceb85d267926ca2e2c13e
     """
     tx_hash = deserialize_evm_tx_hash('0x5edc23d5a05e347afc60e64a4d5831ed2551985c21dceb85d267926ca2e2c13e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1608498702000)
     expected_events = [
         EvmEvent(
@@ -182,14 +174,10 @@ def test_1inchv2_swap_for_eth(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_1inchv3_swap_for_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_1inchv3_swap_for_eth(ethereum_inquirer, ethereum_accounts):
     """Test an 1inchv3 swap for ETH."""
     tx_hash = deserialize_evm_tx_hash('0xc9403f8010c78cec3036fd502103b78566f9b50eae57068538735527b59435ae')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1618011137000)
     expected_events = [
@@ -238,7 +226,7 @@ def test_1inchv3_swap_for_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x312419eEC9C4632155904D9440dc1EeeafFBb280']])
-def test_1inchv4_swap_on_uniswapv3(database, ethereum_inquirer):
+def test_1inchv4_swap_on_uniswapv3(ethereum_inquirer):
     """
     Test an 1inch v4 swap for ETH via Uniswap v3.
 
@@ -246,11 +234,7 @@ def test_1inchv4_swap_on_uniswapv3(database, ethereum_inquirer):
     https://etherscan.io/tx/0xd02bbee01f92d778af8c2d159fb269ad31425b32703da568abb427ac14547e6d
     """
     tx_hash = deserialize_evm_tx_hash('0xd02bbee01f92d778af8c2d159fb269ad31425b32703da568abb427ac14547e6d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1687361999000)
     user_address = '0x312419eEC9C4632155904D9440dc1EeeafFBb280'
     expected_events = [
@@ -299,11 +283,10 @@ def test_1inchv4_swap_on_uniswapv3(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x456325F2AC7067234dD71E01bebe032B0255e039']])
-def test_1inchv4_orderfilledrfq(database, ethereum_inquirer, ethereum_accounts):
+def test_1inchv4_orderfilledrfq(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7e98fc61cdec43a7b886a9d045264bcc9292b2a34f8c466e4270ee6671684b69')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user_address, gas, amount_out, amount_in = TimestampMS(1683201803000), ethereum_accounts[0], '0.010777074', '1457.408044', '634.912997630527012864'  # noqa: E501
@@ -353,7 +336,7 @@ def test_1inchv4_orderfilledrfq(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF92940216a808378bfFD05f444B7bF71d5A193Cd']])
-def test_1inchv4_swap_on_sushiswap(database, ethereum_inquirer):
+def test_1inchv4_swap_on_sushiswap(ethereum_inquirer):
     """
     Test an 1inch v4 swap for ETH via Sushiswap.
 
@@ -363,7 +346,6 @@ def test_1inchv4_swap_on_sushiswap(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x396f57534e5deff9b530357bda8dcd31b80892ba7ce3de6f6593b0225bba3d0f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1687551611000)
@@ -414,7 +396,7 @@ def test_1inchv4_swap_on_sushiswap(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x201b5Abfd44A8F9b75F0fE1BaE74CDaC7675E54B']])
-def test_1inchv4_multiple_swaps(database, ethereum_inquirer):
+def test_1inchv4_multiple_swaps(ethereum_inquirer):
     """
     Test an 1inch v4 swap via multiple pools.
 
@@ -424,7 +406,6 @@ def test_1inchv4_multiple_swaps(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xeeefe25741462f0832183925ac4b1b840b819fbacd95cfc635496d853b7022bd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1687762727000)
@@ -487,7 +468,7 @@ def test_1inchv4_multiple_swaps(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xcA74F404E0C7bfA35B13B511097df966D5a65597']])
-def test_1inchv4_weth_eth_swap(database, ethereum_inquirer):
+def test_1inchv4_weth_eth_swap(ethereum_inquirer):
     """
     Test an 1inch v4 WETH to ETH swap via the WETH contract.
 
@@ -497,7 +478,6 @@ def test_1inchv4_weth_eth_swap(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x7097e7e9ef2b8bb096ed98950875b4512a833d41ceb3246903e06b61665cd5cd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1687870007000)
@@ -548,7 +528,7 @@ def test_1inchv4_weth_eth_swap(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xdCB02829F91533Ab757b1B0e8B595D7c950AfBb8']])
-def test_1inchv4_eth_weth_swap(database, ethereum_inquirer):
+def test_1inchv4_eth_weth_swap(ethereum_inquirer):
     """
     Test an 1inch v4 ETH to WETH swap via the WETH contract.
 
@@ -558,7 +538,6 @@ def test_1inchv4_eth_weth_swap(database, ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x6446f928148dc9f7e1ad719730d661d6d3409a9c62293ca8e8c259d06c6bd004')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1688039855000)
@@ -609,14 +588,13 @@ def test_1inchv4_eth_weth_swap(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_1inch_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_1inch_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     """Data taken from
     https://polygonscan.com/tx/0xe13e0ebab7a6abc0c0a22fcf0766b9a585a430415c88f3f90328b310119a85af
     """
     tx_hash = deserialize_evm_tx_hash('0xe13e0ebab7a6abc0c0a22fcf0766b9a585a430415c88f3f90328b310119a85af')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_addy = polygon_pos_accounts[0]
@@ -681,11 +659,10 @@ def test_1inch_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_1inch_gnosis_v5_swap(database, gnosis_inquirer, gnosis_accounts):
+def test_1inch_gnosis_v5_swap(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4b1fcb8836d7cc323015c0d019f595273d176bd6024f7b59b4b15d3f7071ef71')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_addy = gnosis_accounts[0]
@@ -736,11 +713,10 @@ def test_1inch_gnosis_v5_swap(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF']])
-def test_1inch_velodrome(database, optimism_inquirer, optimism_accounts):
+def test_1inch_velodrome(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3cb68ee7dae76c0ca6466e3a593b32144d25eabb27c1ba416c83f154627d84d8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_addy = optimism_accounts[0]
@@ -791,7 +767,7 @@ def test_1inch_velodrome(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC5d494aa0CBabD7871af0Ef122fB410Fa25c3379']])
-def test_half_decoded_1inch_v5_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_half_decoded_1inch_v5_swap(ethereum_inquirer, ethereum_accounts):
     """
     Test that if a swap using 1inch v5 has been  half decoded by other decoder (uniswap) first
     then the two legs of the swap are properly handled by the 1inch decoder.
@@ -799,7 +775,6 @@ def test_half_decoded_1inch_v5_swap(database, ethereum_inquirer, ethereum_accoun
     tx_hash = deserialize_evm_tx_hash('0x0a86fef1df2e7f186cf7239083f67c424c735f91461388c5b23e01c4d6a4e7d8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1701001727000)
@@ -863,11 +838,10 @@ def test_half_decoded_1inch_v5_swap(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_1inch_base_v6_swap(database, base_inquirer, base_accounts):
+def test_1inch_base_v6_swap(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5b41c094c49462cd97fc19dc898ef23c24f859b46dbd38ecf5d34d3d0fd291f5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, swap_amount, receive_amount = TimestampMS(1716833467000), '0.000019908608867869', '311804', '0.002362174980374604'  # noqa: E501
@@ -929,11 +903,10 @@ def test_1inch_base_v6_swap(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_1inchv4_swap_on_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_1inchv4_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4c1fcbc20fdd397229d9e3e88411fea589e7ceb901e770f6af2e70e89008d5fa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user, gas, amount_in, amount_out = TimestampMS(1653476213000), polygon_pos_accounts[0], '0.015694020167926014', '174.218999', '174.206'  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_aave_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v2.py
@@ -33,7 +33,6 @@ from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
 
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 ADDY2 = '0x5727c0481b90a129554395937612d8b9301D6c7b'
@@ -41,17 +40,13 @@ ADDY2 = '0x5727c0481b90a129554395937612d8b9301D6c7b'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_aave_deposit_v1(database, ethereum_inquirer):
+def test_aave_deposit_v1(ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410
     """
     tx_hash = deserialize_evm_tx_hash('0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410')  # noqa: E501
     timestamp = TimestampMS(1595376667000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '2507.675873220870275072'
     expected_events = [
         EvmEvent(
@@ -112,17 +107,13 @@ def test_aave_deposit_v1(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_aave_withdraw_v1(database, ethereum_inquirer):
+def test_aave_withdraw_v1(ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486
     """
     tx_hash = deserialize_evm_tx_hash('0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486')  # noqa: E501
     timestamp = TimestampMS(1598217272000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '7968.408929477087756071'
     interest = '88.663672238882760399'
     expected_events = [
@@ -184,16 +175,12 @@ def test_aave_withdraw_v1(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY2]])
-def test_aave_eth_withdraw_v1(database, ethereum_inquirer):
+def test_aave_eth_withdraw_v1(ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0xbd333bdd5784c10630aac5683e63f703e660a78d06f95b2ff2a8788a8dade787
     """
     tx_hash = deserialize_evm_tx_hash('0xbd333bdd5784c10630aac5683e63f703e660a78d06f95b2ff2a8788a8dade787')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '1.000240847792940067'
     interest = '0.000240847792940067'
     expected_events = [
@@ -551,13 +538,9 @@ def test_aave_v2_deposit(database, ethereum_inquirer, eth_transactions):
     '0x2715273613632226985186221669179813245119',
     '0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44',
 ]])
-def test_aave_v2_withdraw(database, ethereum_inquirer, ethereum_accounts):
+def test_aave_v2_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8fe440f37fd0fa1467067a195ea862db1f96c40634ea7bb3782cc3c3431e9b5c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, user_address = TimestampMS(1660809759000), '0.0217873', ethereum_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -624,13 +607,9 @@ def test_aave_v2_withdraw(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x00000000000Cd56832cE5dfBcBFf02e7eC639BC9']])
-def test_aave_v2_borrow(database, ethereum_inquirer, ethereum_accounts):
+def test_aave_v2_borrow(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6c8af2a4157632e33fac9d94a03619f54d318ce1254998aabc5384053eb98ffb')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1622302530000)
     gas_amount = '0.014311845'
     user_address = ethereum_accounts[0]
@@ -806,7 +785,6 @@ def test_aave_v2_repay(database, ethereum_inquirer, eth_transactions):
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x1dB64086b4cdA94884E4FC296799a512dfc564CA']])
 def test_aave_v2_liquidation(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
 ) -> None:
@@ -814,11 +792,7 @@ def test_aave_v2_liquidation(
     https://etherscan.io/tx/0x2077a54ecae4a06c553f96c120acc0237887fdd1fc2596aab103f6681712974d
     """
     tx_hash = deserialize_evm_tx_hash('0x2077a54ecae4a06c553f96c120acc0237887fdd1fc2596aab103f6681712974d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1684738775000)
     user_address = ethereum_accounts[0]
     expected_events = [
@@ -857,7 +831,6 @@ def test_aave_v2_liquidation(
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x8ca7ED9b02ec1E8bEee868a32495Ed5b157eeE08']])
 def test_aave_v1_liquidation(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
 ) -> None:
@@ -865,11 +838,7 @@ def test_aave_v1_liquidation(
     https://etherscan.io/tx/0x75ef28b5593efd3f0f9eff338e234f59b2bd34a7148a90ce020122900722a832
     """
     tx_hash = deserialize_evm_tx_hash('0x75ef28b5593efd3f0f9eff338e234f59b2bd34a7148a90ce020122900722a832')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1659244817000)
     user_address = ethereum_accounts[0]
     expected_events = [
@@ -908,17 +877,13 @@ def test_aave_v1_liquidation(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xe903fEed7c1098Ba92E4b7092ca77bBc48503d90']])
-def test_aave_v2_supply_ether(database, ethereum_inquirer, ethereum_accounts):
+def test_aave_v2_supply_ether(ethereum_inquirer, ethereum_accounts):
     """
     Test deposit in aave using the eth wrapper contract. Data taken from
     https://etherscan.io/tx/0xefc9040c100829a391a636f02eb96a9361bd0bc2ca5e8e5f97bbc4a1831cdec9
     """
     tx_hash = deserialize_evm_tx_hash('0xefc9040c100829a391a636f02eb96a9361bd0bc2ca5e8e5f97bbc4a1831cdec9')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -986,11 +951,10 @@ def test_aave_v2_supply_ether(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x572f60c0b887203324149D9C308574BcF2dfaD82']])
-def test_aave_v2_borrow_polygon(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:
+def test_aave_v2_borrow_polygon(polygon_pos_inquirer, polygon_pos_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x2c2777e24bc8a59171e33d54c2a87d846fc23e7f21a32b99d22397e64429b39c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1711437462000)
@@ -1041,14 +1005,10 @@ def test_aave_v2_borrow_polygon(database, polygon_pos_inquirer, polygon_pos_acco
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6A61Ea7832f84C3096c70f042aB88D9a56732D7B']])
-def test_aave_stake(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_aave_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     """Test that the decoder can decode the stake event from Aave"""
     tx_hash = deserialize_evm_tx_hash('0xfaf96358784483a96a61db6aa4ecf4ac87294b841671ca208de6b5d8f83edf17')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, staked, gas_fees, approval_amount = TimestampMS(1716118019000), '5.126267078394001645', '0.000367527', '115792089237316195423570985008687907853269984665640564038985.825837738726184306'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1109,15 +1069,11 @@ def test_aave_stake(database, ethereum_inquirer: 'EthereumInquirer', ethereum_ac
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xeD62616a7c1DD354801f4E72389299a81493e004']])
-def test_aave_stake_behalfof(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_aave_stake_behalfof(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     """Test that the decoder can decode the stake event from Aave from 2022
     The implementation of the proxy contract was different back then."""
     tx_hash = deserialize_evm_tx_hash('0x5532a19bdd4aa26656dc5099d80862a5218cbaf7c96f30cae4a8bb0d19803bfc')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, staked, gas_fees, approval_amount = TimestampMS(1684566515000), '58.469937', '0.011340746321963024', '115792089237316195423570985008687907853269984665640564039399.114070913129639935'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1178,14 +1134,10 @@ def test_aave_stake_behalfof(database, ethereum_inquirer: 'EthereumInquirer', et
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x201B93778C36Aad0510d96c0a3733A6Efa9d0bC5']])
-def test_aave_unstake(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_aave_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     """Test that the decoder can decode the unstake/redeem event from Aave"""
     tx_hash = deserialize_evm_tx_hash('0xaaef5990d08a0f4cb83b0f98b995f734c96ab6dca41bf7de54c3719fe463ce24')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, unstaked, gas_fees = TimestampMS(1716216731000), '2.71357', '0.001456740929488432'
     expected_events = [
         EvmEvent(
@@ -1234,14 +1186,10 @@ def test_aave_unstake(database, ethereum_inquirer: 'EthereumInquirer', ethereum_
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x76d098850ff14b5922774d156a2D3eb842d88B4a']])
-def test_aave_unstake_old(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_aave_unstake_old(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     """Test that the decoder can decode the unstake/redeem event from Aave back in 2022"""
     tx_hash = deserialize_evm_tx_hash('0x4d28e34be9ccc8a64d0fe9bc30982700b042cd0bdbe7c3bc3968107dce6471e3')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, unstaked, gas_fees = TimestampMS(1648296289000), '31.703464134297535778', '0.006477313887656742'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1290,14 +1238,10 @@ def test_aave_unstake_old(database, ethereum_inquirer: 'EthereumInquirer', ether
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9C836687964D89B52Ae80E3e941745Ddd67e5222']])
-def test_stake_reward(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_stake_reward(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     """Test that the decoder can decode aave reward claiming"""
     tx_hash = deserialize_evm_tx_hash('0xc8ed217572a15a81891ad6480a56150d5b2721c9e517564c3e8ead4439cdcb62')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_fees, amount = TimestampMS(1712099315000), '0.002299167729873168', '0.724507060516081735'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1333,15 +1277,11 @@ def test_stake_reward(database, ethereum_inquirer: 'EthereumInquirer', ethereum_
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6Cf9AA65EBaD7028536E353393630e2340ca6049']])
-def test_stake_reward_from_incentives(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_stake_reward_from_incentives(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     """Test that the decoder can decode aave staking reward claiming in the old way ~2022
     which takes it from the aave incentives"""
     tx_hash = deserialize_evm_tx_hash('0x376c51a492f3f309c408b00278fbb77e54adcbb883f9e0fc190c5478fc153bbf')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_fees, amount = TimestampMS(1649141661000), '0.03959433', '14.159467670600490614'
     expected_events = [
         EvmEvent(
@@ -1376,11 +1316,10 @@ def test_stake_reward_from_incentives(database, ethereum_inquirer: 'EthereumInqu
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9131C96c791A5aAd3dF4F8C85Acc755a8dD487Ed']])
-def test_polygon_incentives(database, polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_pos_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_polygon_incentives(polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_pos_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x6ebaa1502335caa7aa9b6589169885d0361e96bab9ed3b1264308a716d6524c3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user, gas_fees, amount = TimestampMS(1677815446000), polygon_pos_accounts[0], '0.010600028218383051', '2.703388364402691276'  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_aave_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v3.py
@@ -31,13 +31,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x93a208b0d7007f5733ea23F65bACF101Be8aC6cD']])
-def test_aave_v3_enable_collateral(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_enable_collateral(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x867d09a777ca7c5cbccd281d197ffbed327b5a8f07153483e94f75d4e1d04413')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711029839000)
     deposit_amount, gas_fees = '99503', '0.007154122119159412'
     expected_events = [
@@ -99,13 +95,9 @@ def test_aave_v3_enable_collateral(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x203b2E862C57fbAc813c05c46B6e1242844724A2']])
-def test_aave_v3_disable_collateral(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_disable_collateral(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1f7614ba2425f3345d02bf1518c81ab3aa46e888553b409f3c9a360259bc7988')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711028735000)
     returned_amount, withdraw_amount, gas_fees = '0.3', '0.30005421', '0.005234272941346752'
     expected_events = [
@@ -167,13 +159,9 @@ def test_aave_v3_disable_collateral(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x08c14B32C8A48894E4b933090EBcC9CE33B21135']])
-def test_aave_v3_deposit(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_deposit(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x062bb6b01d4ac5fabd7b7783965d22589d289e44bb0227bb2fc0adaad7eb563b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711030499000)
     deposit_amount, gas_fees = '71657.177259074315114745', '0.009902467860617334'
     expected_events = [
@@ -222,13 +210,9 @@ def test_aave_v3_deposit(database, ethereum_inquirer, ethereum_accounts) -> None
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xabE9e5d199E1E411098181b6a5Ab9f5f65d91389']])
-def test_aave_v3_withdraw(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_withdraw(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xf184c285dab9ea6c72d18025c65202e3d9e5ec3181209a6cbedf88dfd4c8283f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711030631000)
     return_amount, withdraw_amount, gas_fees = '6770.796829', '6779.85', '0.00692900756596481'
     expected_events = [
@@ -277,13 +261,9 @@ def test_aave_v3_withdraw(database, ethereum_inquirer, ethereum_accounts) -> Non
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x08c14B32C8A48894E4b933090EBcC9CE33B21135']])
-def test_aave_v3_borrow(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_borrow(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x44367976e841cde459d84aec984d5fae4466b2978b1d71c9cd916bb79792ee20')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711030571000)
     borrowed_amount, gas_fees = '79931.500229', '0.011111128567338506'
     expected_events = [
@@ -332,13 +312,9 @@ def test_aave_v3_borrow(database, ethereum_inquirer, ethereum_accounts) -> None:
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9CBF099ff424979439dFBa03F00B5961784c06ce']])
-def test_aave_v3_repay(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_repay(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x440dddaad9f8d9c6d99777494640520854cca8dd102fb557f1654f5746da5f7e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711030643000)
     return_amount, repay_amount, gas_fees = '123942.602894', '123961.452987', '0.00646693553105336'
     expected_events = [
@@ -387,13 +363,9 @@ def test_aave_v3_repay(database, ethereum_inquirer, ethereum_accounts) -> None:
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7420fA58bA44E1141d5E9ADB6903BE549f7cE0b5']])
-def test_aave_v3_liquidation(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_aave_v3_liquidation(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xc1a03e87f1c0446ddd5a77f7eb906831c72618a921a1f6f9f430f612edca0531')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1692320627000)
     payback_amount, liquidation_amount, fee_amount = '23.378156', '0.01887243880551005', '0.000090391508992915'  # noqa: E501
     expected_events = [
@@ -457,11 +429,10 @@ def test_aave_v3_liquidation(database, ethereum_inquirer, ethereum_accounts) -> 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xA55EaD17fa903b1218dc6a79c47b54C9370E20AB']])
-def test_aave_v3_enable_collateral_polygon(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:  # noqa: E501
+def test_aave_v3_enable_collateral_polygon(polygon_pos_inquirer, polygon_pos_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x8002f1a3044bcdec645d512713724f09551c18a14c67509417c83961b230294b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1711448176000)
@@ -525,11 +496,10 @@ def test_aave_v3_enable_collateral_polygon(database, polygon_pos_inquirer, polyg
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x645C22593c232Ae78a7eCbaC93b38cbaC535ef12']])
-def test_aave_v3_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts) -> None:  # noqa: E501
+def test_aave_v3_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x09d5e6da511fb88e8a7db6f1209542610a9d3873048e405b88c7a766d7210d6f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1711450245000)
@@ -580,13 +550,9 @@ def test_aave_v3_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xaafc3e3C8B4fD93584256E6D49a9C364648E66cE']])
-def test_aave_v3_borrow_base(database, base_inquirer, base_accounts) -> None:
+def test_aave_v3_borrow_base(base_inquirer, base_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x92b6fef0623a3f56daa651968819f2e5b7a982037c19fed2166e4c00ba4d6350')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711452273000)
     borrowed_amount, gas_fees = '0.181', '0.000090985761072991'
     expected_events = [
@@ -635,13 +601,9 @@ def test_aave_v3_borrow_base(database, base_inquirer, base_accounts) -> None:
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x91ed7A7fd3072885c1ec905C932717Df6A8aE2cA']])
-def test_aave_v3_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts) -> None:
+def test_aave_v3_withdraw_gnosis(gnosis_inquirer, gnosis_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1f3cae37be928563d154c534c98f41eefe9201eb3d0129c99c1ecb51f83e5596')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711453785000)
     withdraw_amount, gas_fees = '4300', '0.000876816'
     expected_events = [
@@ -690,13 +652,9 @@ def test_aave_v3_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts) -> 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xdbD5D31B7f48adC13A0aB0c591F7e3D4f9642e69']])
-def test_aave_v3_borrow_optimism(database, optimism_inquirer, optimism_accounts) -> None:
+def test_aave_v3_borrow_optimism(optimism_inquirer, optimism_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xb043a7f28cccd6cb0392db47cea4607f8cf3b91b6510669a0a62588b66eb7fcf')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711455941000)
     borrowed_amount, gas_fees = '2000', '0.000018093759776472'
     expected_events = [
@@ -745,13 +703,9 @@ def test_aave_v3_borrow_optimism(database, optimism_inquirer, optimism_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x3E6B4598E5bfeEc911f344E546C9EbFe4A00d770']])
-def test_aave_v3_repay_scroll(database, scroll_inquirer, scroll_accounts) -> None:
+def test_aave_v3_repay_scroll(scroll_inquirer, scroll_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x66010f353be60adaa004f839d37cecd22c35c580060eeaffb9a28ebe169e1692')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1711456958000)
     return_amount, repay_amount, gas_fees = '14459.999417', '14460.008663', '0.000386215421959661'
     expected_events = [
@@ -800,15 +754,11 @@ def test_aave_v3_repay_scroll(database, scroll_inquirer, scroll_accounts) -> Non
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x35E0091D67B5e213db857F605c2047cA29A8800d']])
-def test_non_aave_tx(database, ethereum_inquirer, ethereum_accounts) -> None:
+def test_non_aave_tx(ethereum_inquirer, ethereum_accounts) -> None:
     """Test that the non-aave transactions happened through flash loans are not decoded
     as aave events."""
     tx_hash = deserialize_evm_tx_hash('0xf5b4c6f3b4e5bce1f91f7e7eab6185b6d1518e63dea637c79d7f1bbb97edda67')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, multisig, gas_fees = TimestampMS(1713496487000), '0x35542F2c7D18716401A38cc7f08Bf5Bf61f371cc', '0.018530645755598298'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -843,14 +793,10 @@ def test_non_aave_tx(database, ethereum_inquirer, ethereum_accounts) -> None:
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_claim_incentives_reward(database, optimism_inquirer, optimism_accounts) -> None:
+def test_claim_incentives_reward(optimism_inquirer, optimism_accounts) -> None:
     """Test that claim rewards for incentives works"""
     tx_hash = deserialize_evm_tx_hash('0xa2860ca34ea7558240c44f3d0895a9cf832bd0dd952b2b27d3ae34ba6d45697c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, gas, user, amount = TimestampMS(1666883965000), '0.000198192753532852', optimism_accounts[0], '558.228460248737908186'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -885,11 +831,10 @@ def test_claim_incentives_reward(database, optimism_inquirer, optimism_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xfe46dCeb5d586DA13aBAA571613e20f5a61fa62e']])
-def test_aave_v3_events_with_approval(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:  # noqa: E501
+def test_aave_v3_events_with_approval(polygon_pos_inquirer, polygon_pos_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x0aaca18a7e0ee29a247bd9bfab3b081acf469833105a9204251c5a4969a5fc29')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, deposit_amount, approval_amount, gas_fees = TimestampMS(1718134876000), '72.227367', '115792089237316195423570985008687907853269984665640564039457584007903019.443007', '0.006703085584530904'  # noqa: E501
@@ -964,14 +909,10 @@ def test_aave_v3_events_with_approval(database, polygon_pos_inquirer, polygon_po
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x76111D2841b41B15e6F07fBae4796a82438D9c90']])
-def test_aave_v3_withdraw_eth(database, scroll_inquirer, scroll_accounts) -> None:
+def test_aave_v3_withdraw_eth(scroll_inquirer, scroll_accounts) -> None:
     """Test that withdrawing ETH from Aave gets decoded properly"""
     tx_hash = deserialize_evm_tx_hash('0x65cd06fd54a10052c3d9084d14d28c06e2bb328b1ec39730fab9284cb529d068')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     timestamp, gained_amount, withdrawn_amount, gas_fees = TimestampMS(1716738746000), '0.000000021776581852', '0.010000021776581852', '0.000058164147479909'  # noqa: E501
     weth_gateway = string_to_evm_address('0xFF75A4B698E3Ec95E608ac0f22A03B8368E05F5D')
     expected_events = [
@@ -1059,11 +1000,10 @@ def test_aave_v3_withdraw_eth(database, scroll_inquirer, scroll_accounts) -> Non
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x2013b74bdbd2Adf3eBF39E5112a9f794144Aeb15']])
-def test_aave_v3_withdraw_matic(database, polygon_pos_inquirer, polygon_pos_accounts) -> None:
+def test_aave_v3_withdraw_matic(polygon_pos_inquirer, polygon_pos_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x301885bdc8998d0e6d5c0064b3b92f5ee34f81ebbd14ca2b796579981ff8df31')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gained_amount, withdrawn_amount, gas_fees, gateway_address, approval_amount = TimestampMS(1720447017000), '0.94342753415979831', '4000', '0.013616476612010713', string_to_evm_address('0xC1E320966c485ebF2A0A2A6d3c0Dc860A156eB1B'), FVal('115792089237316195423570985008687907853269984665640564032456.584007913129639935')  # noqa: E501
@@ -1138,13 +1078,9 @@ def test_aave_v3_withdraw_matic(database, polygon_pos_inquirer, polygon_pos_acco
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x44ddBB35CfeBbafE98e402970517b33d8e925eB3']])
-def test_aave_v3_withdraw_xdai(database, gnosis_inquirer, gnosis_accounts) -> None:
+def test_aave_v3_withdraw_xdai(gnosis_inquirer, gnosis_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x0154ef3042e93a632d654c86bff99f7d452681dba72f4f773806c9c26470f678')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gained_amount, withdrawn_amount, gas_fees, gateway_address, approval_amount = TimestampMS(1720459795000), '0.076355892637370336', '5.076355892637370336', '0.0008300288', string_to_evm_address('0xfE76366A986B72c3f2923e05E6ba07b7de5401e4'), FVal('115792089237316195423570985008687907853269984665640564039452.507652020492269599')  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_aerodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_aerodrome.py
@@ -57,7 +57,6 @@ def test_add_liquidity(base_transaction_decoder, base_accounts, load_global_cach
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        database=base_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -145,7 +144,6 @@ def test_stake_lp_token_to_gauge(base_accounts, base_transaction_decoder, load_g
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        database=base_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -205,7 +203,6 @@ def test_remove_liquidity(base_accounts, base_transaction_decoder, load_global_c
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        database=base_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one.py
@@ -19,14 +19,13 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0c5b7A89b3689d86Ed473caE4E7CB00381949861']])
 @pytest.mark.parametrize('arbitrum_one_manager_connect_at_start', [(get_arbitrum_allthatnode(ONE),)])  # noqa: E501
-def test_arbitrum_airdrop_claim(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_arbitrum_airdrop_claim(arbitrum_one_inquirer, arbitrum_one_accounts):
     """Data taken from
     https://arbiscan.io/tx/0xa230fc4d5e61db1d9be044215b00cb6ad1775b413a240ea23a98117153f6264e
     """
     tx_hash = deserialize_evm_tx_hash('0xa230fc4d5e61db1d9be044215b00cb6ad1775b413a240ea23a98117153f6264e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user_address = TimestampMS(1689935876000), arbitrum_one_accounts[0]
@@ -62,11 +61,10 @@ def test_arbitrum_airdrop_claim(database, arbitrum_one_inquirer, arbitrum_one_ac
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_vote_cast(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_vote_cast(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x10b9c5adb845151365bf6977d76b728fad60b64372ce0bde6ae52602b01c282b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user_address = TimestampMS(1707677598000), arbitrum_one_accounts[0]
@@ -102,11 +100,10 @@ def test_vote_cast(database, arbitrum_one_inquirer, arbitrum_one_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_vote_cast_2(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_vote_cast_2(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf58c9b1ee6643d6af1fd3b5edbfb311bd86eb3417da561fd1650f12be775d71a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas = TimestampMS(1713188011000), '0.00000252921'
@@ -143,11 +140,10 @@ def test_vote_cast_2(database, arbitrum_one_inquirer, arbitrum_one_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_vote_cast_treasury(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_vote_cast_treasury(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8f5eed6ec89eeccbdfa141b91129118a8294d35a1b44f9e7d570945d17f42765')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas = TimestampMS(1717152106000), '0.00000270109'

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
@@ -21,13 +21,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4e7DF0FDa2d203f5DFbaa34b9FB64DDe5133196e']])
-def test_deposit_eth_from_ethereum_to_arbitrum_one(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_eth_from_ethereum_to_arbitrum_one(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xbe5b747193c68a7d1844053996e1a27a1279a4f1743f4b9a00e5a14152ee8641')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -61,11 +57,10 @@ def test_deposit_eth_from_ethereum_to_arbitrum_one(database, ethereum_inquirer, 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x4e7DF0FDa2d203f5DFbaa34b9FB64DDe5133196e']])
-def test_receive_eth_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_receive_eth_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x30505174f2f82a6513f21eb5177e59935a6da95d057e4c1972e65da90ea1c547')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -89,11 +84,10 @@ def test_receive_eth_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_o
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x5EA45c8E36704d7F4053Bb0e23cDd96E4d8b80F7']])
-def test_withdraw_eth_from_arbitrum_one_to_ethereum(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
+def test_withdraw_eth_from_arbitrum_one_to_ethereum(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xdb8e29f27a7b7b416f168e8135347703268a142b6776503e26419dbfc43bcabf')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -129,13 +123,9 @@ def test_withdraw_eth_from_arbitrum_one_to_ethereum(database, arbitrum_one_inqui
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x5EA45c8E36704d7F4053Bb0e23cDd96E4d8b80F7']])
-def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_receive_eth_on_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x2698916bd8d658ce6cfe032e5526fa345b3656a849870e72b1e853d22efdd7ac')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -169,13 +159,9 @@ def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xBEEC919d69FB1a5195964ee90959C413CDbACe28']])
-def test_deposit_erc20_from_ethereum_to_arbitrum_one(database, ethereum_inquirer, ethereum_accounts):  # noqa: E501
+def test_deposit_erc20_from_ethereum_to_arbitrum_one(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x2eb4686e6b9857f02c1c8a035dc1ac7dcaf160fd52248b56a76de7774482390d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -223,11 +209,10 @@ def test_deposit_erc20_from_ethereum_to_arbitrum_one(database, ethereum_inquirer
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
-def test_receive_erc20_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_receive_erc20_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x80e6c0835c3ead90dde524c3dfe49a067fd5b5cda93d5a223707e686d910d8a2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -251,12 +236,11 @@ def test_receive_erc20_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xbD91C9DF3C30F0e43B19b1dd05888CF9b647b781']])
-def test_withdraw_erc20_from_arbitrum_one_to_ethereum(database, arbitrum_one_inquirer, arbitrum_one_accounts, caplog):  # noqa: E501
+def test_withdraw_erc20_from_arbitrum_one_to_ethereum(arbitrum_one_inquirer, arbitrum_one_accounts, caplog):  # noqa: E501
     """Test that LPT withdrawals from arbitrum to L1 work fine"""
     evmhash = deserialize_evm_tx_hash('0x90ca8a767118c27aa4f6370bc06d9f952ab88a9219431f68d8e2d33b4a15b395')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     gateway_address = '0x6D2457a4ad276000A615295f7A80F79E48CcD318'
@@ -308,14 +292,13 @@ def test_withdraw_erc20_from_arbitrum_one_to_ethereum(database, arbitrum_one_inq
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_withdraw_dai_from_arbitrum_one_to_ethereum(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
+def test_withdraw_dai_from_arbitrum_one_to_ethereum(arbitrum_one_inquirer, arbitrum_one_accounts):
     """
     Test that DAI withdrawals from arbitrum to L1 work fine. This is just to test that
     our code is not token/gateway specific"""
     evmhash = deserialize_evm_tx_hash('0xb425d3f1bfeb5438930115345ad2e3a4fb415db76f845e652d9b5ba945a484e2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
 
@@ -352,13 +335,9 @@ def test_withdraw_dai_from_arbitrum_one_to_ethereum(database, arbitrum_one_inqui
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbD91C9DF3C30F0e43B19b1dd05888CF9b647b781']])
-def test_receive_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_receive_erc20_on_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xa235be4bde09d215518485acf55a577ca0662f27ff4af2a33f6867e4847596b8')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_balancer.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer.py
@@ -16,13 +16,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x20A1CF262Cd3A42a50D226fD728104119e6fD0a1']])
-def test_balancer_v2_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_balancer_v2_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x35dd639ba80940cb14d79c965002a11ea2aef17bbf1f1b85cc03c336da1ddebe')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1669622603000), '0.001085530186197622'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -69,13 +65,9 @@ def test_balancer_v2_swap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x7716a99194d758c8537F056825b75Dd0C8FDD89f']])
-def test_balancer_v1_join(database, ethereum_inquirer, ethereum_accounts):
+def test_balancer_v1_join(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb9dff9df4e3838c75d354d62c4596d94e5eb8904e07cee07a3b7ffa611c05544')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1597144247000), '0.0141724'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -123,13 +115,9 @@ def test_balancer_v1_join(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x7716a99194d758c8537F056825b75Dd0C8FDD89f']])
-def test_balancer_v1_exit(database, ethereum_inquirer, ethereum_accounts):
+def test_balancer_v1_exit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xfa1dfeb83480e51a15137a93cb0eba9ac92c1b6b0ee0bd8551a422c1ed83695b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1597243001000), '0.03071222'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -192,14 +180,10 @@ def test_balancer_v1_exit(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x549C0421c69Be943A2A60e76B19b4A801682cBD3']])
-def test_deposit_with_excess_tokens(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_with_excess_tokens(ethereum_inquirer, ethereum_accounts):
     """Verify that when a refund is made for a deposit in balancer v1 this is properly decoded"""
     tx_hash = deserialize_evm_tx_hash('0x22162f5c71261421db82a03ba4ad13725ef4fe9639c62bf6702538f980fbe7ba')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp = ethereum_accounts[0], TimestampMS(1593186380000)
     expected_events = [
         EvmEvent(
@@ -299,14 +283,10 @@ def test_deposit_with_excess_tokens(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xAB12253171A0d73df64B115cD43Fe0A32Feb9dAA']])
-def test_balancer_trade(database, ethereum_inquirer, ethereum_accounts):
+def test_balancer_trade(ethereum_inquirer, ethereum_accounts):
     """Test a balancer trade of token to token"""
     tx_hash = deserialize_evm_tx_hash('0xc9e8094d4435c3786bbb28b64546ecdf8a1f384057319e715eab7f28cfb01e4f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1643362575000), '0.01196446449981698'  # noqa: E501
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_base_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_base_bridge.py
@@ -14,13 +14,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc91FC9Dd7f1Bb6Ec429edDB577b9Ace6236B2147']])
-def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_eth(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xbd58a2802a40659da35ff838017a00ba0e251dd0c96ae0c802bd41b5a999f366')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -54,13 +50,9 @@ def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC8f9850e4862b62cCA7f87A81633c2Add9488743']])
-def test_withdraw_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_withdraw_eth(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x6f62277e5fe0c7d8c613b66b6850dd4b6cf193f830b52486d7d9b79917441e46')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -94,13 +86,9 @@ def test_withdraw_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbAbE777e1a43053C273bd8A4e45D0cB6c20f8Fc6']])
-def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_token(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x9593200706ea6941eac1c8189b9648e9ebab5bd14504c4a493f5309f85e6cba6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -134,13 +122,9 @@ def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x0050F3427E5388E9cc458e977bC3444faf015618']])
-def test_withdraw_token(database, ethereum_inquirer, ethereum_accounts):
+def test_withdraw_token(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x2d047f0b7a0f2052791359ef82eab317b6d6a685a3c24614f51e8775f4b60ef4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_blur.py
+++ b/rotkehlchen/tests/unit/decoders/test_blur.py
@@ -25,13 +25,8 @@ if TYPE_CHECKING:
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_blur_claim_and_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list[ChecksumEvmAddress]):  # noqa: E501
-    database = ethereum_inquirer.database
     tx_hash = deserialize_evm_tx_hash('0x09b9d311c62dadc69a06f39daa5206760f38ef48d9e8473f27a9cf2d599133c9')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, stake_amount, gas_fees = TimestampMS(1702156943000), '6350.3577325406', '0.005302886935404245'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -81,13 +76,8 @@ def test_blur_claim_and_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_ac
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x76107ad6A0c2AefDC5c19ee047add3D72aFb4984']])
 def test_blur_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list[ChecksumEvmAddress]):  # noqa: E501
-    database = ethereum_inquirer.database
     tx_hash = deserialize_evm_tx_hash('0xdae4c4cc02aea1a4063295aabf75c7fd30618a4fb364209270d215d2d33b7221')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, stake_amount, gas_fees = TimestampMS(1715478947000), '903.93', '0.000533750631510369'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -124,13 +114,8 @@ def test_blur_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xC60dC16A1bBaEb6dB99912aE8AD2359565BC5423']])
 def test_blur_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list[ChecksumEvmAddress]):  # noqa: E501
-    database = ethereum_inquirer.database
     tx_hash = deserialize_evm_tx_hash('0x494259cae7bf1d68c185f5d35ad5991e28a20089b44f30453da6967dd5a5270a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, unstake_amount, gas_fees = TimestampMS(1716377543000), '2333.05', '0.000802495016237112'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_cctp.py
+++ b/rotkehlchen/tests/unit/decoders/test_cctp.py
@@ -21,22 +21,16 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd0Adc5d079Cc486b58F1B9A28B973355C4ec9e6f']])
 def test_deposit_usdc_from_ethereum_to_arbitrum_one(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list[ChecksumEvmAddress],
 ):
     tx_hash = deserialize_evm_tx_hash('0xac7bb45701a4311a2c662377a4764ac694a8f6438270c1ee8a4100d4a000a511')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, deposit_amount = TimestampMS(1716588659000), '0.000649402467435812', '1839.726596'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -72,14 +66,12 @@ def test_deposit_usdc_from_ethereum_to_arbitrum_one(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xd0Adc5d079Cc486b58F1B9A28B973355C4ec9e6f']])
 def test_receive_usdc_on_arbitrum_one_from_ethereum(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
     tx_hash = deserialize_evm_tx_hash('0x9da8beb8e9ad2428ad2de132d920d27c2d6c7e0604d2977669aab219e51fd323')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, deposit_amount = TimestampMS(1716589968000), '0.00000196702', '1839.726596'
@@ -117,14 +109,12 @@ def test_receive_usdc_on_arbitrum_one_from_ethereum(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x75F3785B330aadbA5DB31535995568583EA8DEA8']])
 def test_deposit_usdc_from_polygon_to_arbitrum_one(
-        database: 'DBHandler',
         polygon_pos_inquirer: 'PolygonPOSInquirer',
         polygon_pos_accounts: list[ChecksumEvmAddress],
 ):
     tx_hash = deserialize_evm_tx_hash('0x90128b2988d709e7719dc157aaf08ea76792934cac4e47fa01e93c80d21d30fd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, deposit_amount = TimestampMS(1716970880000), '0.00404958204', '4253.283606'
@@ -162,14 +152,12 @@ def test_deposit_usdc_from_polygon_to_arbitrum_one(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x75F3785B330aadbA5DB31535995568583EA8DEA8']])
 def test_receive_usdc_on_arbitrum_one_from_polygon(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
     tx_hash = deserialize_evm_tx_hash('0xad6aa5691bde79c4c97be04871d92e1cc2fa8e43984834716d09001da309dce0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, deposit_amount = TimestampMS(1716971722000), '0.00000345289', '4253.283606'
@@ -207,14 +195,12 @@ def test_receive_usdc_on_arbitrum_one_from_polygon(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xFc99f58A8974A4bc36e60E2d490Bb8D72899ee9f']])
 def test_receive_usdc_on_arbitrum_one_from_polygon_2(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
     tx_hash = deserialize_evm_tx_hash('0xd067d3d8ed104af374b7cf101b8dea72ee4d9cf11a3b18dea9b2de4bb4d1e362')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, deposit_amount = TimestampMS(1716978796000), '1.541124'

--- a/rotkehlchen/tests/unit/decoders/test_clrfund.py
+++ b/rotkehlchen/tests/unit/decoders/test_clrfund.py
@@ -15,12 +15,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_ethstaker_matching_claim(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_ethstaker_matching_claim(arbitrum_one_inquirer, arbitrum_one_accounts):
     """Whats interesting here is that someone else claimed funds and not the recipient address"""
     tx_hash = deserialize_evm_tx_hash('0x5236f217873582446398c9b427a80a669be90b8a17fb5ed842f8d5d2925f3e7f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user, amount = TimestampMS(1654833348000), arbitrum_one_accounts[0], '39566.332611058195231384'  # noqa: E501
@@ -45,11 +44,10 @@ def test_ethstaker_matching_claim(database, arbitrum_one_inquirer, arbitrum_one_
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_add_recipient(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_add_recipient(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x52f8b96df94af89566fb6048026d10411928f8cf1518788b2d3d0ef6623bafe2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     gas, timestamp, user, amount = '0.00483736114768445', TimestampMS(1650384723000), arbitrum_one_accounts[0], '0.005'  # noqa: E501
@@ -86,11 +84,10 @@ def test_add_recipient(database, arbitrum_one_inquirer, arbitrum_one_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x506498abf98C157eFE8B226E5EcAa0093aB77F04']])
-def test_voted(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_voted(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf2fa4e67b28a20e49fe69fe83c0848557141b852bf84367f260f285e38bef5c5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     gas, timestamp, user = '0.003010415219175718', TimestampMS(1653433014000), arbitrum_one_accounts[0]  # noqa: E501
@@ -127,11 +124,10 @@ def test_voted(database, arbitrum_one_inquirer, arbitrum_one_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x017dc108b35495f627B9F991AA34C982Ae1047Fb']])
-def test_contribution(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_contribution(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x527e008a0fd9f0e0146eb842dfe7c47e2830e9cc05f07ca9908b23be1f8a18b8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     gas, timestamp, amount, user = '0.000313841956638943', TimestampMS(1653433994000), '8', arbitrum_one_accounts[0]  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_compound_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v2.py
@@ -29,7 +29,6 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
 
 ADDY = '0x5727c0481b90a129554395937612d8b9301D6c7b'
 ADDY2 = '0x87Dd56068Af560B0D8472C4EF41CB902FCbF5ebE'
@@ -42,16 +41,12 @@ ADDR_REPAYS_ETH = '0x18c42014Fb0aeD3E35515eb45DF8498Af67773a4'
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_compound_ether_deposit(database, ethereum_inquirer):
+def test_compound_ether_deposit(ethereum_inquirer):
     """Data taken from:
     https://etherscan.io/tx/0x06a8b9f758b0471886186c2a48dea189b3044916c7f94ee7f559026fefd91c39
     """
     tx_hash = deserialize_evm_tx_hash('0x06a8b9f758b0471886186c2a48dea189b3044916c7f94ee7f559026fefd91c39')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1598639099000)
     expected_events = [
         EvmEvent(
@@ -98,16 +93,12 @@ def test_compound_ether_deposit(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_compound_ether_withdraw(database, ethereum_inquirer):
+def test_compound_ether_withdraw(ethereum_inquirer):
     """Data taken from:
     https://etherscan.io/tx/0x024bd402420c3ba2f95b875f55ce2a762338d2a14dac4887b78174254c9ab807
     """
     tx_hash = deserialize_evm_tx_hash('0x024bd402420c3ba2f95b875f55ce2a762338d2a14dac4887b78174254c9ab807')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1598813490000)
     expected_events = [
         EvmEvent(
@@ -154,19 +145,12 @@ def test_compound_ether_withdraw(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY2]])
-def test_compound_deposit_with_comp_claim(
-        database,
-        ethereum_inquirer,
-):
+def test_compound_deposit_with_comp_claim(ethereum_inquirer):
     """Data taken from:
     https://etherscan.io/tx/0xfdbfe6e9ce822bd988054945c86f2dff1fac6a12b4acb0b68c8805b5aa3b30ba
     """
     tx_hash = deserialize_evm_tx_hash('0xfdbfe6e9ce822bd988054945c86f2dff1fac6a12b4acb0b68c8805b5aa3b30ba')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1607572696000)
     amount = FVal('14309.930911242041089052')
     wrapped_amount = FVal('687371.5068874')
@@ -229,18 +213,14 @@ def test_compound_deposit_with_comp_claim(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY3]])
-def test_compound_multiple_comp_claim(database, ethereum_inquirer):
+def test_compound_multiple_comp_claim(ethereum_inquirer):
     """Test that a transaction with multiple comp claims decodes all of them as rewards
     This is to test against a regression of a bug that decoded the last reward claim
     as a simple receive.
     """
     tx_hash = deserialize_evm_tx_hash('0x25d341421044fa27006c0ec8df11067d80f69b2d2135065828f1992fa6868a49')  # noqa: E501
     timestamp = TimestampMS(1622430975000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -325,18 +305,14 @@ def test_compound_multiple_comp_claim(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xB8cCf257d32b134ffecb902e5Bef3042841B8A4A']])
-def test_compound_comp_claim_last_transfer(database, ethereum_inquirer, ethereum_accounts):
+def test_compound_comp_claim_last_transfer(ethereum_inquirer, ethereum_accounts):
     """
     Test comp claim case that was not decoded properly before due to
     the transfer being last the last event
     """
     tx_hash = deserialize_evm_tx_hash('0xbd2dcb1121bf230a855788a77aa054dc1aae7a898cb4a7d7c45c5866f3f887ac')  # noqa: E501
     timestamp = TimestampMS(1622430975000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, amount = TimestampMS(1672433507000), '0.0041468661739364', '12.817402848098541218'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -369,19 +345,12 @@ def test_compound_comp_claim_last_transfer(database, ethereum_inquirer, ethereum
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDR_BORROWS]])
-def test_compound_borrow(
-        database: 'DBHandler',
-        ethereum_inquirer: 'EthereumInquirer',
-) -> None:
+def test_compound_borrow(ethereum_inquirer: 'EthereumInquirer') -> None:
     """Data taken from:
     https://etherscan.io/tx/0x036338316a076590a496791a729d3459934a89d6eb512f765cf0e28f9eb8b50c
     """
     tx_hash = deserialize_evm_tx_hash('0x036338316a076590a496791a729d3459934a89d6eb512f765cf0e28f9eb8b50c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -415,19 +384,12 @@ def test_compound_borrow(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDR_REPAYS]])
-def test_compound_payback(
-        database: 'DBHandler',
-        ethereum_inquirer: 'EthereumInquirer',
-) -> None:
+def test_compound_payback(ethereum_inquirer: 'EthereumInquirer') -> None:
     """Data taken from:
     https://etherscan.io/tx/0x000da925508a1a2f322f6fb74592baf9a75bb9f971cb3a72a5deb0526d39757d
     """
     tx_hash = deserialize_evm_tx_hash('0x000da925508a1a2f322f6fb74592baf9a75bb9f971cb3a72a5deb0526d39757d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -474,19 +436,12 @@ def test_compound_payback(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDR_BORROWS_ETH]])
-def test_compound_borrow_eth(
-        database: 'DBHandler',
-        ethereum_inquirer: 'EthereumInquirer',
-) -> None:
+def test_compound_borrow_eth(ethereum_inquirer: 'EthereumInquirer') -> None:
     """Data taken from:
     https://etherscan.io/tx/0x00035065f364453ca4585ab5d4ee7dacc59a3f7acc305644c334fdfff3a2527f
     """
     tx_hash = deserialize_evm_tx_hash('0x00035065f364453ca4585ab5d4ee7dacc59a3f7acc305644c334fdfff3a2527f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -520,19 +475,12 @@ def test_compound_borrow_eth(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDR_REPAYS_ETH]])
-def test_compound_repays_eth(
-        database: 'DBHandler',
-        ethereum_inquirer: 'EthereumInquirer',
-) -> None:
+def test_compound_repays_eth(ethereum_inquirer: 'EthereumInquirer') -> None:
     """Data taken from:
     https://etherscan.io/tx/0x0007416c8caa441ce07c61dbf2455b3068d21d9bffbfbbfca9f1016d7c3ca33f
     """
     tx_hash = deserialize_evm_tx_hash('0x0007416c8caa441ce07c61dbf2455b3068d21d9bffbfbbfca9f1016d7c3ca33f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -567,7 +515,6 @@ def test_compound_repays_eth(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9bf62c518ffe86bD43D57c7026aA1A4fBeA83b15']])
 def test_compound_liquidate(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts,
 ) -> None:
@@ -575,11 +522,7 @@ def test_compound_liquidate(
     Decode a liquidation happening to the position of 0x9bf62c518ffe86bD43D57c7026aA1A4fBeA83b15
     """
     tx_hash = deserialize_evm_tx_hash('0x0001a89e439c3673b8264f880730784ebd698502bb9dd62949d42a66a4129f23')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert events == [
         EvmEvent(
             tx_hash=tx_hash,
@@ -601,7 +544,6 @@ def test_compound_liquidate(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xD911560979B78821D7b045C79E36E9CbfC2F6C6F']])
 def test_compound_liquidator_side(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts,
 ) -> None:
@@ -609,11 +551,7 @@ def test_compound_liquidator_side(
     Decode liquidation made by 0xD911560979B78821D7b045C79E36E9CbfC2F6C6F
     """
     tx_hash = deserialize_evm_tx_hash('0x0001a89e439c3673b8264f880730784ebd698502bb9dd62949d42a66a4129f23')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert events == [
         EvmEvent(
             tx_hash=tx_hash,
@@ -650,17 +588,12 @@ def test_compound_liquidator_side(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xC440f3C87DC4B6843CABc413916220D4f4FeD117']])
 def test_compound_liquidation_eth(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts,
 ) -> None:
     """Test that repaying a compound loan in a liquidation using ETH is correctly decoded"""
     tx_hash = deserialize_evm_tx_hash('0x160c0e6db0df5ea0c1cc9b1b31bd90c842ef793c9b2ab496efdc62bdd80eeb52')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert events == [
         EvmEvent(
             tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_compound_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v3.py
@@ -21,23 +21,17 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x373aDc79FF63d5076D0685cA35031339d4E0Da82']])
 def test_compound_v3_claim_comp(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts,
 ) -> None:
     """Test that claiming comp reward for v3 works fine"""
     tx_hash = deserialize_evm_tx_hash('0x89b189f36989aba504c77e686cb52691fdb147873f72ef9c64c31f39bf355fc8')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1700653367000)
     gas_str = '0.002927949668742244'
@@ -75,13 +69,9 @@ def test_compound_v3_claim_comp(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xc1f8d0c485eC00B9A3A54c3B9BbeB5D7a2B4265a']])
-def test_compound_v3_supply(database, ethereum_inquirer, ethereum_accounts):
+def test_compound_v3_supply(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xcac67d0ca139b9418673f04dcc18fe7805b1242566489bf2e9c99a2fea4ee01c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1712239823000)
     gas_fees, supply_amount, position_amount = '0.003305489949685846', '15000', '14999.999998'
     expected_events = [
@@ -129,13 +119,9 @@ def test_compound_v3_supply(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xD7ca0E0238E3fDAB2a33646348207AB945d55df7']])
-def test_compound_v3_withdraw(database, ethereum_inquirer, ethereum_accounts):
+def test_compound_v3_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd8ba70d3e993cae4b89a68d5b991d0a85dd9888c0e6a07814c9ddd2ff4ba93d2')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1712239703000)
     gas_fees, withdraw_amount = '0.002760840922152728', '8158.266856'
     expected_events = [
@@ -183,13 +169,9 @@ def test_compound_v3_withdraw(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x274B56e812b7951B737e450a22e849860C8adA11']])
-def test_compound_v3_withdraw_collateral(database, ethereum_inquirer, ethereum_accounts):
+def test_compound_v3_withdraw_collateral(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x70aca19e6ac5285a586ad9e6a6d38bb4e4a682386901e987c7f7a30ea8c2431c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1712235011000)
     gas_fees, collateral_amount = '0.003503372063979697', '30'
     expected_events = [
@@ -237,13 +219,9 @@ def test_compound_v3_withdraw_collateral(database, ethereum_inquirer, ethereum_a
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x048C013be418178cBf35Fc7102d80298506e82E8']])
-def test_compound_v3_deposit_collateral(database, ethereum_inquirer, ethereum_accounts):
+def test_compound_v3_deposit_collateral(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2e362252c9c96669eb0801cd431d6b36bdea63968e5781d33ea58efc528ac205')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1712238731000)
     gas_fees, collateral_amount = '0.00267689111806624', '15'
     expected_events = [
@@ -291,11 +269,10 @@ def test_compound_v3_deposit_collateral(database, ethereum_inquirer, ethereum_ac
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xD350663eB2615FF8aDa1Db2A2c810129003142f1']])
-def test_polygon_pos_withdraw(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_polygon_pos_withdraw(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb747e7075a5f4d1b4b60da150da7fb0bce7759e36d2753fed47f0f6ecbda780c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1712676523000)
@@ -345,11 +322,10 @@ def test_polygon_pos_withdraw(database, polygon_pos_inquirer, polygon_pos_accoun
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xb453dE1360cEcf95bD9717CB9DEB6Fb961b7010D']])
-def test_arbitrum_one_borrow(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_arbitrum_one_borrow(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xaabe8666d515f5fa97cf31a5ac43c3f56af062ff3a077ef79dbc2480b33b7802')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1714561431000)
@@ -386,11 +362,10 @@ def test_arbitrum_one_borrow(database, arbitrum_one_inquirer, arbitrum_one_accou
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0xBD1eefb658C2B80c297493A0D4298B16941eff85']])
-def test_base_repay(database, base_inquirer, base_accounts):
+def test_base_repay(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x455761ce3e1076eb03a3af1a90b935b42a703336e08aacf218afe76102d8d171')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1714564377000)
@@ -428,11 +403,10 @@ def test_base_repay(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('scroll_accounts', [['0xe53Ca0bB4E6F22514Aa1c1ABFd9634d52A808546']])
-def test_scroll_withdraw(database, scroll_inquirer, scroll_accounts):
+def test_scroll_withdraw(scroll_inquirer, scroll_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0ec09157328bba439e276c83a2c3364c390d430b5bc0bddf3169d475b6fbfdee')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=scroll_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1712739257000)

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -47,7 +47,6 @@ def test_booster_deposit(
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     mocked_notifier = database.msg_aggregator.rotki_notifier
@@ -103,17 +102,11 @@ def test_booster_deposit(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x53913A03a065f685097f8E8f40284D58016bB0F9')]])  # noqa: E501
-def test_booster_withdraw(database, ethereum_inquirer, ethereum_accounts):
-    tx_hex = '0x79fcbafa4367e0563d3e614f774c5e4257c4e41f124ae8288980a310e2b2b547'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+def test_booster_withdraw(ethereum_inquirer, ethereum_accounts):
+    evmhash = deserialize_evm_tx_hash('0x79fcbafa4367e0563d3e614f774c5e4257c4e41f124ae8288980a310e2b2b547')  # noqa: E501
     user_address = ethereum_accounts[0]
     timestmap = TimestampMS(1655877898000)
-    evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -316,17 +309,11 @@ def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0xe81FC42336c9314A9Be1EDB3F50eA9e275C93df3')]])  # noqa: E501
-def test_cvxcrv_withdraw(database, ethereum_inquirer, ethereum_accounts):
-    tx_hex = '0x0a804804cc62f615b72dff55e8c245d9b69aa8f8ed3de549101ae128a4ae432b'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+def test_cvxcrv_withdraw(ethereum_inquirer, ethereum_accounts):
+    evmhash = deserialize_evm_tx_hash('0x0a804804cc62f615b72dff55e8c245d9b69aa8f8ed3de549101ae128a4ae432b')  # noqa: E501
     user_address = ethereum_accounts[0]
     timestmap = TimestampMS(1655747494000)
-    evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -364,17 +351,11 @@ def test_cvxcrv_withdraw(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x2AcEcBF2Ee5BFc8eed599D58835EE9A7c45F3E2c')]])  # noqa: E501
-def test_cvxcrv_stake(database, ethereum_inquirer, ethereum_accounts):
-    tx_hex = '0x3cc0b25887e2f0dac7f86fabd81aaafb1e041e84dbe8167885073c443320ad5f'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+def test_cvxcrv_stake(ethereum_inquirer, ethereum_accounts):
+    evmhash = deserialize_evm_tx_hash('0x3cc0b25887e2f0dac7f86fabd81aaafb1e041e84dbe8167885073c443320ad5f')  # noqa: E501
     user_address = ethereum_accounts[0]
     timestmap = TimestampMS(1655750059000)
-    evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -426,8 +407,7 @@ def test_cvxcrv_stake(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x5B186c93A50D3CB435fE2933427d36E6Dc688e4b')]])  # noqa: E501
 def test_cvx_stake(database, ethereum_inquirer, eth_transactions):
-    tx_hex = '0xc33246acb86798b81fe650061061d32751c53879d46ece6991fb4a3eda808103'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+    evmhash = deserialize_evm_tx_hash('0xc33246acb86798b81fe650061061d32751c53879d46ece6991fb4a3eda808103')  # noqa: E501
     user_address = string_to_evm_address('0x5B186c93A50D3CB435fE2933427d36E6Dc688e4b')
     transaction = EvmTransaction(
         tx_hash=evmhash,
@@ -542,8 +522,7 @@ def test_cvx_stake(database, ethereum_inquirer, eth_transactions):
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x95c5582D781d507A084c9E5f885C77BabACf8EeA')]])  # noqa: E501
 def test_cvx_get_reward(database, ethereum_inquirer, eth_transactions):
-    tx_hex = '0xdaead2f96859462b5800584ecdcf30f2b83a1ca2c36c49a838b23e43c61d803f'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+    evmhash = deserialize_evm_tx_hash('0xdaead2f96859462b5800584ecdcf30f2b83a1ca2c36c49a838b23e43c61d803f')  # noqa: E501
     user_address = '0x95c5582D781d507A084c9E5f885C77BabACf8EeA'
     transaction = EvmTransaction(
         tx_hash=evmhash,
@@ -670,8 +649,7 @@ def test_cvx_get_reward(database, ethereum_inquirer, eth_transactions):
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x84BCE169c271e1c1777715bb0dd38Ad9e6381BAa')]])  # noqa: E501
 def test_cvx_withdraw(database, ethereum_inquirer, eth_transactions):
-    tx_hex = '0xe725bd6e00b840f4fb8f73cd7286bfa18b04a24ca9278cac7249218ee9f420a8'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+    evmhash = deserialize_evm_tx_hash('0xe725bd6e00b840f4fb8f73cd7286bfa18b04a24ca9278cac7249218ee9f420a8')  # noqa: E501
     user_address = string_to_evm_address('0x84BCE169c271e1c1777715bb0dd38Ad9e6381BAa')
     transaction = EvmTransaction(
         tx_hash=evmhash,
@@ -762,8 +740,7 @@ def test_cvx_withdraw(database, ethereum_inquirer, eth_transactions):
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x999EcCEa3C4f9219B1B1B42b4830e62c26004B40')]])  # noqa: E501
 def test_claimzap_abracadabras(database, ethereum_inquirer, eth_transactions):
-    tx_hex = '0xe03d27127fda879144ea4cc587470bd37040be9921ff6a90f48d4efd0cb4fe13'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+    evmhash = deserialize_evm_tx_hash('0xe03d27127fda879144ea4cc587470bd37040be9921ff6a90f48d4efd0cb4fe13')  # noqa: E501
     user_address = string_to_evm_address('0x999EcCEa3C4f9219B1B1B42b4830e62c26004B40')
     transaction = EvmTransaction(
         tx_hash=evmhash,
@@ -846,8 +823,7 @@ def test_claimzap_abracadabras(database, ethereum_inquirer, eth_transactions):
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x0C3Cc503EaE928Ed6B5b01B8a9EE8de2855d03Ac')]])  # noqa: E501
 def test_claimzap_cvx_locker(database, ethereum_inquirer, eth_transactions):
-    tx_hex = '0x53e092e6f25e540d6323af851a1e889276096d58ec25495aef4500467ef2753c'
-    evmhash = deserialize_evm_tx_hash(tx_hex)
+    evmhash = deserialize_evm_tx_hash('0x53e092e6f25e540d6323af851a1e889276096d58ec25495aef4500467ef2753c')  # noqa: E501
     user_address = string_to_evm_address('0x0C3Cc503EaE928Ed6B5b01B8a9EE8de2855d03Ac')
     transaction = EvmTransaction(
         tx_hash=evmhash,
@@ -940,7 +916,7 @@ def test_claimzap_cvx_locker(database, ethereum_inquirer, eth_transactions):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('load_global_caches', [[CPT_CONVEX]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x983488580460155d43B6b82096eE17C640A7DCac']])
-def test_convex_claim_pending_rewards(database, ethereum_inquirer, ethereum_accounts, load_global_caches):  # noqa: E501
+def test_convex_claim_pending_rewards(ethereum_inquirer, ethereum_accounts, load_global_caches):
     """
     Tests a transaction that collects pending rewards but also compounds the pending CRV
     in the pool. In this case the user is rewarded for performing this action.
@@ -949,7 +925,6 @@ def test_convex_claim_pending_rewards(database, ethereum_inquirer, ethereum_acco
     evmhash = deserialize_evm_tx_hash('0xf3b8bbb2996515bc276626378ad85bc241051cac5d09c709ae9447665a3babd6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -988,18 +963,14 @@ def test_convex_claim_pending_rewards(database, ethereum_inquirer, ethereum_acco
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xD18327BB6D6de9241Bed63bb5E78459325FbbD70']])
-def test_convex_withdraw_expired_lock(database, ethereum_inquirer, ethereum_accounts):
+def test_convex_withdraw_expired_lock(ethereum_inquirer, ethereum_accounts):
     """
     Tests a transaction that collects pending rewards but also compounds the pending CRV
     in the pool. In this case the user is rewarded for performing this action.
     """
     user_address = ethereum_accounts[0]
     evmhash = deserialize_evm_tx_hash('0x4b707540ec6eebf5e787c88df149e8141d2c295cda8a514da6d6111cf2deca40')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1704839507000)
     gas_str, amount_str = '0.008929295372796715', '26633.698252368450151266'
     expected_events = [

--- a/rotkehlchen/tests/unit/decoders/test_cowswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_cowswap.py
@@ -28,15 +28,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x31b6020CeF40b72D1e53562229c1F9200d00CC12']])
-def test_swap_token_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xd4d16ea74bbf806715f5f0e799fd5e8befbf369a9e5461fa9c0ed88d72bd06e4')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1676976635000)
     full_amount = FVal('0.15463537')
     raw_amount = '0.15395918'
@@ -89,15 +85,11 @@ def test_swap_token_to_token(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x34938Bd809BDf57178df6DF523759B4083A29190']])
-def test_swap_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xd4d16ea74bbf806715f5f0e799fd5e8befbf369a9e5461fa9c0ed88d72bd06e4')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1676976635000)
     full_amount = FVal('99.99')
     raw_amount = '89.682951'
@@ -150,17 +142,13 @@ def test_swap_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_swap_token_to_eth_with_other_trade(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_token_to_eth_with_other_trade(ethereum_inquirer, ethereum_accounts):
     """This was not decoded properly before since the FLT swap was first detectedd
     as part of uniswap and then the cowswap decoder was not picking it up. This fixes that"""
     tx_hex = deserialize_evm_tx_hash('0x31051b28d2b0a0365c2b518778af91180355f130f1fcf2b199faecd256093cc9')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, approval, amount_out, amount_in = TimestampMS(1718357603000), '115792089237316195423570985008687907853269984665640564039457.584007913129639935', '5000', '0.861165556733956932'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -208,15 +196,11 @@ def test_swap_token_to_eth_with_other_trade(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xcFeA48Cf6Ba36e0328a6Ead0fdB4C2642D21c59d']])
-def test_swap_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xe2d6aa636623989061f1d762b19ca6fe6bc0edb5a890cf5a934a8fc6d42dcaca')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1676987243000)
     full_amount = FVal('24.311042505395616962')
     raw_amount = '24.304521595868826446'
@@ -272,19 +256,14 @@ def test_swap_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
     '0x0D2f07876685bEcd81DDa1C897f2D6Cacc733fc1',
     '0x34938Bd809BDf57178df6DF523759B4083A29190',
 ]])
-def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
+def test_2_decoded_swaps(ethereum_inquirer, ethereum_accounts):
     """
     Tests that if a user has 2 tracked addresses from a cowswap settlement transaction
     both swaps are decoded correctly.
     """
     tx_hex = deserialize_evm_tx_hash('0xd4d16ea74bbf806715f5f0e799fd5e8befbf369a9e5461fa9c0ed88d72bd06e4')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address_1, user_address_2 = ethereum_accounts
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
 
     timestamp = TimestampMS(1676976635000)
     asset_fund = Asset('eip155:1/erc20:0xe9B076B476D8865cDF79D1Cf7DF420EE397a7f75')
@@ -299,7 +278,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
 
     expected_events = [
         EvmEvent(  # approval
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=9,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -312,7 +291,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
             address='0xC92E8bdf79f0507f65a392b0ab4667716BFE0110',
 
         ), EvmEvent(  # 1st swap with FUND
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=11,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -325,7 +304,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=12,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -338,7 +317,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=13,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -351,7 +330,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ), EvmEvent(  # 2nd swap with USDT
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=14,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -364,7 +343,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=15,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -377,7 +356,7 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=16,
             timestamp=timestamp,
             location=Location.ETHEREUM,
@@ -396,18 +375,13 @@ def test_2_decoded_swaps(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xcFeA48Cf6Ba36e0328a6Ead0fdB4C2642D21c59d']])
-def test_place_eth_order(database, ethereum_inquirer, ethereum_accounts):
+def test_place_eth_order(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3619cc8d8f60541df0ea7d96d923efa4c783f53491af0d3ed1ed31de9fe15bcf')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=0,
             timestamp=TimestampMS(1676987159000),
             location=Location.ETHEREUM,
@@ -419,7 +393,7 @@ def test_place_eth_order(database, ethereum_inquirer, ethereum_accounts):
             notes='Burned 0.001768460133875456 ETH for gas',
             counterparty=CPT_GAS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=1,
             timestamp=TimestampMS(1676987159000),
             location=Location.ETHEREUM,
@@ -438,18 +412,13 @@ def test_place_eth_order(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_place_xdai_order(database, gnosis_inquirer, gnosis_accounts):
+def test_place_xdai_order(gnosis_inquirer, gnosis_accounts):
     tx_hex = deserialize_evm_tx_hash('0x0fa7c5936310a7fefa2b62597aea88fd152f73e736eee805d26e9337f461bc4f')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = gnosis_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=0,
             timestamp=TimestampMS(1691568565000),
             location=Location.GNOSIS,
@@ -461,7 +430,7 @@ def test_place_xdai_order(database, gnosis_inquirer, gnosis_accounts):
             notes='Burned 0.0000901568 XDAI for gas',
             counterparty=CPT_GAS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=1,
             timestamp=TimestampMS(1691568565000),
             location=Location.GNOSIS,
@@ -480,18 +449,13 @@ def test_place_xdai_order(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xdc4CaDC65123Ebd371887CaD59Cc8c6F8F6fC29c']])
-def test_invalidate_eth_order(database, ethereum_inquirer, ethereum_accounts):
+def test_invalidate_eth_order(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x5769b4634ae26ec93aebc80a50e0676b0793af485041b249652bd7ee6703a9f5')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=0,
             timestamp=TimestampMS(1677040511000),
             location=Location.ETHEREUM,
@@ -503,7 +467,7 @@ def test_invalidate_eth_order(database, ethereum_inquirer, ethereum_accounts):
             notes='Burned 0.001171136978414093 ETH for gas',
             counterparty=CPT_GAS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=1,
             timestamp=TimestampMS(1677040511000),
             location=Location.ETHEREUM,
@@ -522,18 +486,13 @@ def test_invalidate_eth_order(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xb0e83C2D71A991017e0116d58c5765Abc57384af']])
-def test_invalidate_gnosis_order(database, gnosis_inquirer, gnosis_accounts):
+def test_invalidate_gnosis_order(gnosis_inquirer, gnosis_accounts):
     tx_hex = deserialize_evm_tx_hash('0x68927e822317242ac1c0a0c71f2303725fc998164f1bb812f61b3053ef2a9a02')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = gnosis_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=0,
             timestamp=TimestampMS(1697119590000),
             location=Location.GNOSIS,
@@ -545,7 +504,7 @@ def test_invalidate_gnosis_order(database, gnosis_inquirer, gnosis_accounts):
             notes='Burned 0.000369223819835234 XDAI for gas',
             counterparty=CPT_GAS,
         ), EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=1,
             timestamp=TimestampMS(1697119590000),
             location=Location.GNOSIS,
@@ -564,18 +523,13 @@ def test_invalidate_gnosis_order(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x4DD2a258130673a2d4242FaC1C5E5f82d1A0888d']])
-def test_refund_eth_order(database, ethereum_inquirer, ethereum_accounts):
+def test_refund_eth_order(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x424f29ad7b865d764d89fe28767a7f34d177cad71cc123a2a8c0209aa0b70fda')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=0,
             timestamp=TimestampMS(1677055175000),
             location=Location.ETHEREUM,
@@ -594,18 +548,13 @@ def test_refund_eth_order(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x402633Ec0283F58415bcbe5b48e7F44338a349eb']])
-def test_refund_gnosis_order(database, gnosis_inquirer, gnosis_accounts):
+def test_refund_gnosis_order(gnosis_inquirer, gnosis_accounts):
     tx_hex = deserialize_evm_tx_hash('0xb37be7c154ef4fb0fd291c647c21013abb10428181e64ba1c6305b77df929d0e')  # noqa: E501
-    evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = gnosis_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
-            tx_hash=evmhash,
+            tx_hash=tx_hex,
             sequence_index=0,
             timestamp=TimestampMS(1696381750000),
             location=Location.GNOSIS,
@@ -624,15 +573,11 @@ def test_refund_gnosis_order(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_swap_gnosis_tokens(database, gnosis_inquirer, gnosis_accounts):
+def test_swap_gnosis_tokens(gnosis_inquirer, gnosis_accounts):
     tx_hex = deserialize_evm_tx_hash('0x024e1da9dc2bf7ff88dd22643857979fcd954103860698203257b6db27778482')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = gnosis_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1691567755000)
     full_amount = FVal('59.848803')
     raw_amount = '59.847255'
@@ -685,13 +630,9 @@ def test_swap_gnosis_tokens(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xf393fb8C4BbF7e37f583D0593AD1d1b2443E205c']])
-def test_ethereum_claim_airdrop(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_claim_airdrop(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8d33a6f1c37da1e2b77a4595425360361b6db79ec8811ff2eef810ebb9942044')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1644614818000)
     amount = FVal('15922.558465644366037906')
@@ -728,14 +669,10 @@ def test_ethereum_claim_airdrop(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_gnosis_claim_airdrop(database, gnosis_inquirer, gnosis_accounts):
+def test_gnosis_claim_airdrop(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x85540c0cb716efa6027ff9415c700ecb36d382aafa18749b9e66c67e66f47b8d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1644617690000)
     amount = FVal('34.73918333042108124')
     assert events == [
@@ -771,13 +708,9 @@ def test_gnosis_claim_airdrop(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x773d161310d07CaFC6f767Ca24f43e52163b9BE6']])
-def test_ethereum_vested_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_vested_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb6b58ea77542bfeec311c2df5707fe002b62c5a5d648aa17892d680f4e0d6e07')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704960791000)
     gas, amount = '0.001562177312628784', '4278.42414719412947787'
@@ -826,13 +759,9 @@ def test_ethereum_vested_claim(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_gnosis_vested_claim(database, gnosis_inquirer, gnosis_accounts):
+def test_gnosis_vested_claim(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x57ecb8f87eed5548cb375ea695531d6849843d6217771a5c25c957058a460243')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address = gnosis_accounts[0]
     timestamp = TimestampMS(1707738405000)
     gas, amount = '0.000520287498374868', '99.807039723201809834'
@@ -881,14 +810,10 @@ def test_gnosis_vested_claim(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x4eF72636664E3348791357588b7d3BF61d29f4DF']])
-def test_gnosis_claim_airdrop_with_xdai_payment(database, gnosis_inquirer, gnosis_accounts):
+def test_gnosis_claim_airdrop_with_xdai_payment(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x1b82f080f70f00d63be3da2bed93834c254517640406aec949126020f7deb4c4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, payment_amount, claim_amount = TimestampMS(1644614725000), '0.00012231000065232', '864.055299539170506912', '5760.36866359447004608'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -936,14 +861,10 @@ def test_gnosis_claim_airdrop_with_xdai_payment(database, gnosis_inquirer, gnosi
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x0b297C31d2DA6d959Bc911413990653e19F0e283']])
-def test_gnosis_claim_airdrop_with_gno_payment(database, gnosis_inquirer, gnosis_accounts):
+def test_gnosis_claim_airdrop_with_gno_payment(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xdae21fd2a64756326ba0bf119b8ee33cf41480fb758d0d7f17168fcc01622da1')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, claim1_amount, payment_amount, claim2_amount = TimestampMS(1645776935000), '0.000259548002076384', '3559.387459031416241036', '2.085578589276220452', '3559.387459031416239786'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -1005,13 +926,12 @@ def test_gnosis_claim_airdrop_with_gno_payment(database, gnosis_inquirer, gnosis
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_swap_token_to_token_arb(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_swap_token_to_token_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hex = deserialize_evm_tx_hash('0xd1b5ca7b7616f827216d4fd541f87b5c4571e568754f1d05ad87370975d4c69a')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = arbitrum_one_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     swapped_amount, received_amount, timestamp = '0.219694007376947474', '0.228831', TimestampMS(1717523107000)  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -767,7 +767,6 @@ def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -825,7 +824,6 @@ def test_gauge_vote(ethereum_accounts, ethereum_transaction_decoder) -> None:
     timestamp = TimestampMS(1685562071000)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=cast(EthereumInquirer, ethereum_transaction_decoder.evm_inquirer),
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     expected_events = [
@@ -875,7 +873,6 @@ def test_gauge_deposit(
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=cast(EthereumInquirer, ethereum_transaction_decoder.evm_inquirer),
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -929,7 +926,6 @@ def test_gauge_withdraw(ethereum_transaction_decoder, ethereum_accounts, load_gl
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -975,7 +971,6 @@ def test_gauge_claim_rewards(ethereum_transaction_decoder, ethereum_accounts, lo
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1021,7 +1016,6 @@ def test_curve_trade_token_to_token(ethereum_transaction_decoder, ethereum_accou
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1080,7 +1074,6 @@ def test_curve_trade_eth_to_token(ethereum_transaction_decoder, ethereum_account
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1139,7 +1132,6 @@ def test_curve_trade_exchange_underlying(ethereum_transaction_decoder, ethereum_
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1197,7 +1189,6 @@ def test_curve_swap_router(ethereum_transaction_decoder, ethereum_accounts):
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     expected_events = [
@@ -1255,7 +1246,6 @@ def test_curve_usdn_add_liquidity(ethereum_transaction_decoder, ethereum_account
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1315,7 +1305,6 @@ def test_curve_usdn_remove_liquidity(ethereum_transaction_decoder, ethereum_acco
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1414,7 +1403,6 @@ def test_3pool_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, lo
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1474,7 +1462,6 @@ def test_3pool_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts,
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1576,7 +1563,6 @@ def test_remove_from_aave_pool(ethereum_transaction_decoder, ethereum_accounts, 
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1639,7 +1625,6 @@ def test_deposit_via_zap_in_metapool(ethereum_transaction_decoder, ethereum_acco
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -1715,7 +1700,6 @@ def test_no_zap_event(ethereum_transaction_decoder, ethereum_accounts, load_glob
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -1772,7 +1756,6 @@ def test_gauge_bribe_v2(ethereum_transaction_decoder, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1680736307000), '0.007331605001682333', '14.752122471808652238'  # noqa: E501
@@ -1810,11 +1793,10 @@ def test_gauge_bribe_v2(ethereum_transaction_decoder, ethereum_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x1c362DFE864a4c4b3311eC97bf0b8320CB0a4952']])
-def test_curve_deposit_polygon(database, polygon_pos_inquirer, polygon_pos_accounts, load_global_caches):  # noqa: E501
+def test_curve_deposit_polygon(polygon_pos_inquirer, polygon_pos_accounts, load_global_caches):
     tx_hash = deserialize_evm_tx_hash('0x6cb9d7ceb55a1063c17b58cb643e699525ca6037e711c34283cf0f3d6e81716e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -1892,7 +1874,6 @@ def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, 
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -1957,7 +1938,6 @@ def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -2008,14 +1988,10 @@ def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0x4113a3CB9004E193E9906131B632e280F5f9B61e']])
-def test_curve_swap_router_base(database, base_inquirer, base_accounts):
+def test_curve_swap_router_base(base_inquirer, base_accounts):
     """Test that transactions made via the new curve swap router are decoded correctly"""
     tx_hash = deserialize_evm_tx_hash('0x6fee2438337aefe297a69d4361ff4d743865ef7fce6637e9e3e544af0c19184f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1718096041000), '0.01702', '59.996794', '0.000001665983350053'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -2064,11 +2040,10 @@ def test_curve_swap_router_base(database, base_inquirer, base_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x8800AcEDF5571F35675CF8Aa1E3C16C7A8da0088']])
-def test_deposit_via_zap_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts, load_global_caches):  # noqa: E501
+def test_deposit_via_zap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts, load_global_caches):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x5a72b9be1302cc4b9e1d79e61134b0b7f225b3a4aa723c27c557a672c29791ce')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -2138,7 +2113,6 @@ def test_fee_distributor(ethereum_transaction_decoder, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1697289611000), '0.002010414684866136', '112.875618618497828084'  # noqa: E501
@@ -2180,7 +2154,6 @@ def test_vote_escrow_deposit(ethereum_transaction_decoder, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     user_address, timestamp, gas, amount, locktime = ethereum_accounts[0], TimestampMS(1671946199000), '0.002774219663106188', '128.808146476393839874', Timestamp(1778112000)  # noqa: E501
@@ -2222,7 +2195,6 @@ def test_vote_escrow_withdraw(ethereum_transaction_decoder, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1671887987000), '0.002702199385335098', '1.872144205854855426'  # noqa: E501
@@ -2260,12 +2232,11 @@ def test_vote_escrow_withdraw(ethereum_transaction_decoder, ethereum_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_gauge_deposit_and_stake(database, gnosis_inquirer, gnosis_accounts, load_global_caches):
+def test_gauge_deposit_and_stake(gnosis_inquirer, gnosis_accounts, load_global_caches):
     tx_hash = deserialize_evm_tx_hash('0x52141e28c55744cdfddaa1ab5614642f61459d7624a51981e21ec06176c8f65c')  # noqa: E501
     timestamp, gauge_address, deposited_amount, gas_fees, received_amount = TimestampMS(1717744880000), string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00'), '834.517942394847767492', '0.0023483922', '431.905365995549947348'  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -2316,13 +2287,12 @@ def test_gauge_deposit_and_stake(database, gnosis_inquirer, gnosis_accounts, loa
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_gauge_deposit_and_stake_multiple(database, gnosis_inquirer, gnosis_accounts, load_global_caches):  # noqa: E501
+def test_gauge_deposit_and_stake_multiple(gnosis_inquirer, gnosis_accounts, load_global_caches):
     tx_hash = deserialize_evm_tx_hash('0xcbeaaee59405d5f7fd456dc510f1b841cc1329cd9624255ce64c894ac6643bd7')  # noqa: E501
     timestamp, gauge_address, gas_fees, received_amount = TimestampMS(1719684750000), string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00'), '0.0023626991', '0.567442277824060065'  # noqa: E501
     deposited_eur, deposited_usdc = '0.551864219634212696', '0.593161'
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -2387,14 +2357,13 @@ def test_gauge_deposit_and_stake_multiple(database, gnosis_inquirer, gnosis_acco
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_liquidity_withdrawal(database, gnosis_inquirer, gnosis_accounts, load_global_caches):
+def test_liquidity_withdrawal(gnosis_inquirer, gnosis_accounts, load_global_caches):
     """Test that a withdrawal in the case of pools that have underlying pools
     is correctly decoded"""
     tx_hash = deserialize_evm_tx_hash('0x7645bfeb43a1ccacd3f8eb29c496823bd73586498ff7b79be5a3a48145f1c4b4')  # noqa: E501
     timestamp, pool_address, gas_fees, removed_amount, returned_amount = TimestampMS(1719046465000), string_to_evm_address('0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a'), '0.000813878', '1656.600276747801451581', '850'  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )

--- a/rotkehlchen/tests/unit/decoders/test_defisaver.py
+++ b/rotkehlchen/tests/unit/decoders/test_defisaver.py
@@ -13,12 +13,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd312551890858CC313Bf1718F502FF9fcDB2e6ff']])
-def test_subscribe(database, ethereum_inquirer, ethereum_accounts):
+def test_subscribe(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x6c9e1aac8818eb5d40761f8c65041a227aec8d4d140b7e1684be80259b0f2138')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     user_address, timestamp, gas = ethereum_accounts[0], TimestampMS(1676641271000), '0.02686452'
@@ -56,12 +55,11 @@ def test_subscribe(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd312551890858CC313Bf1718F502FF9fcDB2e6ff']])
-def test_deactivate_sub(database, ethereum_inquirer, ethereum_accounts):
+def test_deactivate_sub(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x646352346021b3747143dfff704b6b61b736fd86479b5c1bdb0145c92e5d92a0')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     user_address, timestamp, gas = ethereum_accounts[0], TimestampMS(1677329195000), '0.00099726'

--- a/rotkehlchen/tests/unit/decoders/test_degen.py
+++ b/rotkehlchen/tests/unit/decoders/test_degen.py
@@ -33,7 +33,6 @@ def test_claim_airdrop_2(
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        database=base_transaction_decoder.database,
         tx_hash=evmhash,
     )
     timestamp, gas_amount, claimed_amount = TimestampMS(1709555247000), '0.000443147649294366', '100'  # noqa: E501
@@ -79,7 +78,6 @@ def test_claim_airdrop_3(
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        database=base_transaction_decoder.database,
         tx_hash=evmhash,
     )
     timestamp, gas_amount, claimed_amount = TimestampMS(1715696797000), '0.000016768741928411', '1649'  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_diva.py
+++ b/rotkehlchen/tests/unit/decoders/test_diva.py
@@ -16,12 +16,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_diva_delegate(database, ethereum_inquirer, ethereum_accounts):
+def test_diva_delegate(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x806081bcc60a40db22bae2c1729f240f48de4b73e76b673fc4767bcee4f1c704')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1690964039000)
@@ -58,14 +57,10 @@ def test_diva_delegate(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_diva_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_diva_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc66dd53da9837e5197f95d32065807706a118dc2ff326a5e3bf8844b8ee261c2')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1688847971000)
     expected_events = [
         EvmEvent(
@@ -115,16 +110,12 @@ def test_diva_claim(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_vote_cast(database, ethereum_inquirer, ethereum_accounts):
+def test_vote_cast(ethereum_inquirer, ethereum_accounts):
     """Test voting for DIVA governance"""
     tx_hex = deserialize_evm_tx_hash('0x640818700732a7345f085d14377adf285098ae33747da21444e594a64c905d41')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1694557811000)
     gas_str = '0.00074796777559248'
     expected_events = [

--- a/rotkehlchen/tests/unit/decoders/test_dripsv1.py
+++ b/rotkehlchen/tests/unit/decoders/test_dripsv1.py
@@ -14,14 +14,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_project_collect_and_split(database, ethereum_inquirer, ethereum_accounts):
+def test_project_collect_and_split(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xb116dfdef772f79ff7f28823cdb3f9f9eb61b8e774d038346d576f817572af0a')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas, amount, timestamp = '0.0013334084', '1575.363922839504794511', TimestampMS(1660127734000)
     expected_events = [
         EvmEvent(
@@ -86,14 +82,10 @@ def test_project_collect_and_split(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x5e4D630C35ef5c23ac57cF6bf8f2267D9E3CB78F']])
-def test_enduser_collect(database, ethereum_inquirer, ethereum_accounts):
+def test_enduser_collect(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x38b957eaa21ba7a35c8713559680329f4b6b04bd46db00b54217c9d590c1a514')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas, amount, timestamp = '0.0003162699', '125.835582561728229714', TimestampMS(1660733511000)
     expected_events = [
         EvmEvent(
@@ -128,14 +120,10 @@ def test_enduser_collect(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_splits_updated(database, ethereum_inquirer, ethereum_accounts):
+def test_splits_updated(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x2de9986920477923868559fc8b2a341972cb58c0824c46065d9ec2e11e4f9cad')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas, amount, timestamp = '0.00449242', '149.99999999999904', TimestampMS(1655506732000)
     assert events[0] == EvmEvent(
         tx_hash=tx_hash,
@@ -223,14 +211,10 @@ def test_splits_updated(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xbf55cd696C7D6dD9974Bec0de03162dCAEfA7c55']])
-def test_give(database, ethereum_inquirer, ethereum_accounts):
+def test_give(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x104b65d6b29a133b6eb7950da6abed747c3a806356da5a351a94bbb73ca2271e')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas, amount, timestamp = '0.001515204384196608', '1', TimestampMS(1660666663000)
     expected_events = [
         EvmEvent(
@@ -265,14 +249,10 @@ def test_give(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x1007A39088C22A4dfe54032F08fC47A7303603Df']])
-def test_set_drips(database, ethereum_inquirer, ethereum_accounts):
+def test_set_drips(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x86b8ea87f33cc6ac11286d229840e75f9328380f1b2b2c50ba93f173a97762dc')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, decoder = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, decoder = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)  # noqa: E501
     gas, amount, timestamp, per_sec_amount, end_ts = '0.005778677878564032', '50', TimestampMS(1654597232000), '0.000001929012345679', 1667557232  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_eas.py
+++ b/rotkehlchen/tests/unit/decoders/test_eas.py
@@ -14,15 +14,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_attest_optimism(database, optimism_inquirer, optimism_accounts):
+def test_attest_optimism(optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0xf843f6d09e8dec2ee2d1b5fdeade9a9744857f598cf593b6c259166c32dfd05a')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = optimism_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1700569289000)
     gas_amount_str = '0.000136427902240075'
     expected_events = [

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -30,13 +30,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbec0937E0E99425a886B99A3b956C7aC6C39aA12']])
-def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x716b15f5088ff469d7d31680535d35b085e1c3de25255c7849e5955a59df8d31')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount = TimestampMS(1702926167000), '0.049006058268043653'
     deposited_amount = '5.740516176725108094'
     strategy_addr = string_to_evm_address('0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6')
@@ -86,13 +82,9 @@ def test_deposit_token(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x47E50634E32212F43713Bf4e4A86E6275AcD456d']])
-def test_withdraw(database, ethereum_inquirer, ethereum_accounts):
+def test_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x00bdab08d05bd68f8f863e35a8dbe435978481dcbf15faf7276da30a5bfee971')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount = TimestampMS(1707668387000), '0.004606768190817408'
     withdrawn_amount = '0.407049270448991651'
     strategy_addr = string_to_evm_address('0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6')
@@ -128,13 +120,9 @@ def test_withdraw(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xabe8430e3f0BeCa32915dA84E530f81A01379953']])
-def test_airdrop_claim_s1_phase1(database, ethereum_inquirer, ethereum_accounts):
+def test_airdrop_claim_s1_phase1(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0a72c7bf0fe1808035f8df466a70453f29c6b57d0bec46913d993a19ef72265c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, claim_amount = TimestampMS(1715680739000), '0.00074757962836592', '110'
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -168,13 +156,9 @@ def test_airdrop_claim_s1_phase1(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xf6d3d6B6cee9991900Bf53261e1bb213A3d54Fec']])
-def test_airdrop_claim_s1_phase2(database, ethereum_inquirer, ethereum_accounts):
+def test_airdrop_claim_s1_phase2(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7896ca761e9e2fd53dbec28c946d5dbc2e0802a3700641d26d61bc79afaac1a5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, claim_amount = TimestampMS(1720527731000), '0.000428532817567424', '110'
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -208,13 +192,9 @@ def test_airdrop_claim_s1_phase2(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x65151A6343b16c38286f31fcC93e20246629cF8c']])
-def test_stake_eigen(database, ethereum_inquirer, ethereum_accounts):
+def test_stake_eigen(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4da63226965a8b0584f137efa934106cd0cb7a15b536d6f659945cfd4c260b4e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, staked_amount = TimestampMS(1715684387000), '0.00141296787957222', '110'
     a_eigen, strategy_addr = Asset(EIGEN_TOKEN_ID), '0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7'
     expected_events = [EvmEvent(
@@ -262,13 +242,9 @@ def test_stake_eigen(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x80B7EDA1Baa2290478205786615F65052c80882f']])
-def test_deploy_eigenpod(database, ethereum_inquirer, ethereum_accounts):
+def test_deploy_eigenpod(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x910087fb1be44dbf2d89363579c162e70d5666f16182c9015d635c4f81ac07b6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, eigenpod_address = TimestampMS(1715733143000), '0.00133529055565527', '0x664BFef14A62F316175d39D355809D04D2Cb7a23'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -302,13 +278,9 @@ def test_deploy_eigenpod(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x15646dDb42Ee60B26A0BA727CFeB4E8b1A319cdE', '0x24557b5D264757A3fCe2B55b257709D9f8C5aE94']])  # noqa: E501
-def test_deploy_eigenpod_via_safe(database, ethereum_inquirer, ethereum_accounts):
+def test_deploy_eigenpod_via_safe(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x449447b417019f9d8617e41c735c206d94669e91e066bd3cb0dd609fcd8faff7')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, eigenpod_address, user_address, safe_address = TimestampMS(1715601779000), '0.002212107522528736', '0x081aC22eb8582eF9f5ae596A5E8Df42b451b28b7', ethereum_accounts[0], ethereum_accounts[1]  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -355,13 +327,9 @@ def test_deploy_eigenpod_via_safe(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd007058e9b58E74C33c6bF6fbCd38BaAB813cBB6']])
-def test_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_accounts):
+def test_create_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd054c9f07b880ac8e587c725b0427dde2b4c2633250f6f84a5c803fa665fe307')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, withdrawal_amount = TimestampMS(1715768063000), '0.036853617070145433', '0.021045998'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -398,7 +366,6 @@ def test_lst_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_ac
     tx_hash = deserialize_evm_tx_hash('0x8c006f764e9264cd150b2583ba72205bb4575ace76ed3afa83689227e9fe461b')  # noqa: E501
     events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address, timestamp, gas_amount, amount = ethereum_accounts[0], TimestampMS(1718731823000), '0.001066996197578511', '0.501457627266872814'  # noqa: E501
@@ -469,15 +436,10 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
     queue_tx_hash = deserialize_evm_tx_hash('0xeab48010e80d50b7d35fd43a886448ffca1e798b641baf7c8877fc04075d972b')  # noqa: E501
     get_decoded_events_of_transaction(  # just decode the events of the withdrawal queuing
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=queue_tx_hash,
     )  # and now get the actual withdrawal complete transaction a week later
     tx_hash = deserialize_evm_tx_hash('0x2c9a7caf78126fdfe43760dedbf3648c6a3255ee17a7bc312372dba26e16132b')  # noqa: E501
-    events, tx_decoder = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, tx_decoder = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address, timestamp, gas_amount, amount, cbeth_strategy = ethereum_accounts[0], TimestampMS(1718879927000), '0.000880395253730733', '0.108703837292797063', string_to_evm_address('0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc')  # noqa: E501
     cbeth = Asset('eip155:1/erc20:0xBe9895146f7AF43049ca1c1AE358B0541Ea49704')
     expected_events = [EvmEvent(
@@ -555,13 +517,9 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xCd2bCdE423F36E1B81a25168D5373f908546c9BE', '0xf17606D3FFbd5B07454542146a74712Eb797Ac0a']])  # noqa: E501
-def test_claim_delayed_withdrawals(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc5d38c05567f5a4d51e686225dfc461ddf177eefa7c531822656b2ed9560ab12')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, withdrawal_amount, user_address, safe_address = TimestampMS(1716123995000), '0.000369830372847984', '0.004538247', ethereum_accounts[0], ethereum_accounts[1]  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -607,13 +565,9 @@ def test_claim_delayed_withdrawals(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x78524bEeAc12368e600457478738c233f436e9f6']])
-def test_native_restake_delegate(database, ethereum_inquirer, ethereum_accounts):
+def test_native_restake_delegate(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd857a09084c1dfc1d2df83cbeed70e99b79b1e3a74c7385df7dc7065a79e184c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, eth_restaked = TimestampMS(1715866679000), '160'
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_element_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_element_finance.py
@@ -17,17 +17,13 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_claim_airdrop(database, ethereum_inquirer):
+def test_claim_airdrop(ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b
     """
     tx_hash = deserialize_evm_tx_hash('0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b')  # noqa: E501
     timestamp = TimestampMS(1652910214000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_ens.py
+++ b/rotkehlchen/tests/unit/decoders/test_ens.py
@@ -47,11 +47,10 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_mint_ens_name(database, ethereum_inquirer, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_mint_ens_name(ethereum_inquirer, add_subgraph_api_key):  # pylint: disable=unused-argument
     tx_hash = deserialize_evm_tx_hash('0x74e72600c6cd5a1f0170a3ca38ecbf7d59edeb8ceb48adab2ed9b85d12cc2b99')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     expires_timestamp = 2142055301
@@ -140,7 +139,7 @@ def test_mint_ens_name(database, ethereum_inquirer, add_subgraph_api_key):  # py
     ]
     assert expected_events == events[0:6]
     erc721_asset = get_or_create_evm_token(  # TODO: Better way to test than this for ERC721 ...?
-        userdb=database,
+        userdb=ethereum_inquirer.database,
         evm_address=string_to_evm_address('0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'),
         chain_id=ChainID.ETHEREUM,
         token_kind=EvmTokenKind.ERC721,
@@ -176,11 +175,7 @@ def test_text_changed_old_name(database, ethereum_inquirer, ethereum_accounts, a
     tx_hex = deserialize_evm_tx_hash('0xaa59cb2029651d2ed2c0d1ee34b9b88f0b90278fc6da5b51446d4abf24d7f598')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1664548859000)
     gas_str = '0.00655101156241161'
     expected_events = [EvmEvent(
@@ -219,14 +214,10 @@ def test_text_changed_old_name(database, ethereum_inquirer, ethereum_accounts, a
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
-def test_set_resolver(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_set_resolver(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     tx_hex = deserialize_evm_tx_hash('0xae2cd848ce02c425bc50a8f46f8430eec32234475efb6fcff28315d2791329f6')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     user_address, timestamp, gas_str, ens_old_reverse_registrar = ethereum_accounts[0], TimestampMS(1660047719000), '0.001069480808983134', '0x084b1c3C81545d370f3634392De611CaaBFf8148'  # noqa: E501
 
     expected_events = [EvmEvent(
@@ -273,16 +264,12 @@ def test_set_resolver(database, ethereum_inquirer, ethereum_accounts, add_subgra
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbc2E9Df6281a8e853121dc52dBc8BCc8bBE3ed0e']])
-def test_set_attribute_v2(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_set_attribute_v2(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test that setting ens text attribute using public resolver deployed in March 2023 works"""
     tx_hex = deserialize_evm_tx_hash('0x6b354e4da21cfb06a8eb4cb5b7efd20558ae3be6a7a7c563f318e041fb3bfdd9')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -317,14 +304,13 @@ def test_set_attribute_v2(database, ethereum_inquirer, ethereum_accounts, add_su
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA3B9E4b2C18eFB1C767542e8eb9419B840881467']])
-def test_register_v2(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_register_v2(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test that registering an ens name using eth registar deployed in March 2023 works"""
     tx_hex = deserialize_evm_tx_hash('0x5150f6e1c76b74fa914e06df9e56577cdeec0faea11f9949ff529daeb16b1c76')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1681220435000)
@@ -403,7 +389,7 @@ def test_register_v2(database, ethereum_inquirer, ethereum_accounts, add_subgrap
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA01f6D0985389a8E106D3158A9441aC21EAC8D8c']])
-def test_renewal_with_refund_old_controller(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
+def test_renewal_with_refund_old_controller(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
     """
     Check that if there was a refund during a renewal, the refund is subtracted from the
     spent amount. Check a refund using the old ENS registrar controller. That contract
@@ -414,7 +400,6 @@ def test_renewal_with_refund_old_controller(database, ethereum_inquirer, ethereu
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     expires_timestamp = Timestamp(2310615949)
@@ -453,7 +438,7 @@ def test_renewal_with_refund_old_controller(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_renewal_with_refund_new_controller(database, ethereum_inquirer, ethereum_accounts):
+def test_renewal_with_refund_new_controller(ethereum_inquirer, ethereum_accounts):
     """
     Check that if there was a refund during a renewal, the refund is subtracted from the
     spent amount. Check a refund using the new ENS registrar controller. That contract
@@ -464,7 +449,6 @@ def test_renewal_with_refund_new_controller(database, ethereum_inquirer, ethereu
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     expires_timestamp = Timestamp(1849443293)
@@ -503,16 +487,12 @@ def test_renewal_with_refund_new_controller(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7277F7849966426d345D8F6B9AFD1d3d89183083']])
-def test_content_hash_changed(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
+def test_content_hash_changed(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test that transactions changing the content hash of an ENS are properly decoded"""
     tx_hex = deserialize_evm_tx_hash('0x21fa4ef7a4c20f2548cc010ba00974632cca9e55edea4d50b3fb2c00c7f2080b')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1686304523000)
     expected_events = [
         EvmEvent(
@@ -581,11 +561,7 @@ def test_transfer_ens_name(database, ethereum_inquirer, action, ethereum_account
         from_address = '0x34207C538E39F2600FE672bB84A90efF190ae4C7'
         to_address = '0x4bBa290826C253BD854121346c370a9886d1bC26'
 
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1687771811000)
     gas_event = EvmEvent(
         tx_hash=evmhash,
@@ -627,7 +603,7 @@ def test_transfer_ens_name(database, ethereum_inquirer, action, ethereum_account
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x5f0eb172CaA67d45865AAd955FA77654Da33196F']])
-def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
+def test_for_truncated_labelhash(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test for https://github.com/rotki/rotki/issues/6597 where some labelhashes
     had their leading 0s truncated and lead to graph failures
     """
@@ -636,7 +612,6 @@ def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts,
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1603662139000)
@@ -644,7 +619,7 @@ def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts,
     register_fee_str = '0.122618417748598345'
     expires_timestamp = Timestamp(1919231659)
     erc721_asset = get_or_create_evm_token(  # TODO: Better way to test than this for ERC721 ...?
-        userdb=database,
+        userdb=ethereum_inquirer.database,
         evm_address=string_to_evm_address('0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'),
         chain_id=ChainID.ETHEREUM,
         token_kind=EvmTokenKind.ERC721,
@@ -754,16 +729,12 @@ def test_for_truncated_labelhash(database, ethereum_inquirer, ethereum_accounts,
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_vote_cast(database, ethereum_inquirer, ethereum_accounts):
+def test_vote_cast(ethereum_inquirer, ethereum_accounts):
     """Test voting for ENS governance"""
     tx_hex = deserialize_evm_tx_hash('0x4677ffa104b011d591ae0c056ba651a978db982c0dfd131520db74c1b46ff564')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1695935903000)
     gas_str = '0.000916189648966683'
     expected_events = [
@@ -800,16 +771,12 @@ def test_vote_cast(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_vote_cast_abstain(database, ethereum_inquirer, ethereum_accounts):
+def test_vote_cast_abstain(ethereum_inquirer, ethereum_accounts):
     """Test voting for ENS (or any) governance as abstain"""
     tx_hex = deserialize_evm_tx_hash('0xc16e94a93480fd499373283ee973b34d18525c3b67ea81b248530d8158944ff2')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1720220639000)
     gas_str = '0.000255411223579504'
     expected_events = [
@@ -846,17 +813,13 @@ def test_vote_cast_abstain(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_set_attribute_for_non_primary_name(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
+def test_set_attribute_for_non_primary_name(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument  # noqa: E501
     """Test that setting ens text attribute for a name that is controlle by but not
     set as the primary name of the address works correctly"""
     tx_hex = deserialize_evm_tx_hash('0x07aa7d1ac61fc03f6416a25c0d6cf96f286e2ce84e9b350dd2a9a1bd6426aef2')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas_str = '0.00054662131669239'
     timestamp = TimestampMS(1694558075000)
     expected_events = [
@@ -892,15 +855,11 @@ def test_set_attribute_for_non_primary_name(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF5d90Ac6747CB3352F05BF61f48b991ACeaE28eB']])
-def test_claim_airdrop(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_claim_airdrop(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     tx_hex = deserialize_evm_tx_hash('0xb892797f63943dbf75e9e8a86515e9a4a964dcb6930dad10e93b526a2a648e6d')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas_str, claimed_amount = '0.014281582073130576', '88.217476134335168512'
     timestamp = TimestampMS(1637313773000)
     expected_events = [
@@ -952,16 +911,12 @@ def test_invalid_ens_name(globaldb: 'GlobalDBHandler'):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_new_owner(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_new_owner(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test assigning new owner to a subnode"""
     tx_hex = deserialize_evm_tx_hash('0x56bb5b09757fadfbb376b207fe5f340df9931f8169b2e852679d57885f9ae1c1')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str = TimestampMS(1669498319000), '0.0004635496'
     expected_events = [
         EvmEvent(
@@ -997,16 +952,12 @@ def test_new_owner(database, ethereum_inquirer, ethereum_accounts, add_subgraph_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_address_changed(database, ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
+def test_address_changed(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test address changed for a name"""
     tx_hex = deserialize_evm_tx_hash('0x67cbfebb9027a004d341b6f57976ba970fae9af8be7f32161a93224cefbb3e83')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str = TimestampMS(1669498439000), '0.000402353718699768'
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_eth2.py
+++ b/rotkehlchen/tests/unit/decoders/test_eth2.py
@@ -27,11 +27,7 @@ def test_deposit(database, ethereum_inquirer, ethereum_accounts):
 
     evmhash = deserialize_evm_tx_hash('0xb3658f940cab23f95273bb7c199eec5c71424a8bf2f111201f5cc2a1491d3471')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     assert events == [
         EvmEvent(
             tx_hash=evmhash,
@@ -61,11 +57,7 @@ def test_deposit(database, ethereum_inquirer, ethereum_accounts):
 def test_multiple_deposits(database, ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x819fe4a07894cf044f5d8c63e5c1e2294e068d05bf91d9cfc3e7ae3e60528ae5')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     dbeth2 = DBEth2(database)
     validators = [
         ValidatorDetails(
@@ -143,11 +135,7 @@ def test_deposit_with_anonymous_event(database, ethereum_inquirer, ethereum_acco
     evmhash = deserialize_evm_tx_hash('0xd455d892453de3c5b06a00ebedc1994b8d66eeba69e6b08bd20508281e690e80')  # noqa: E501
     user_address = ethereum_accounts[0]
     proxy_address = ethereum_accounts[1]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1669806275000)
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_fluence.py
+++ b/rotkehlchen/tests/unit/decoders/test_fluence.py
@@ -17,14 +17,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc04e88de26d3466e64a243c15db181342152d0b771b0e8e224920ea9b28fe7e0')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1712868707000)
     gas_amount_str, claimed_amount = '0.00203104493516988', '5000'
     expected_events = [
@@ -60,14 +56,10 @@ def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_airdrop_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_airdrop_swap(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x1db2028d68fbdc19e770307dd968c24c8fa4211b26eb512a938223f89d11450a')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_amount_str, claimed_amount = TimestampMS(1718357447000), '0.00059501796565782', '5000'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_gearbox.py
+++ b/rotkehlchen/tests/unit/decoders/test_gearbox.py
@@ -20,14 +20,12 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x3630220f243288E3EAC4C5676fC191CFf5756431']])
 def test_gearbox_deposit(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -35,7 +33,6 @@ def test_gearbox_deposit(
     tx_hash = deserialize_evm_tx_hash('0x04e3bcebf71873a5de1c4d9b40f1c97631a3958ef0d8d743a1a1b4d50361855d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -88,7 +85,6 @@ def test_gearbox_deposit(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xb99a2c4C1C4F1fc27150681B740396F6CE1cBcF5']])
 def test_gearbox_deposit_usdc(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -96,7 +92,6 @@ def test_gearbox_deposit_usdc(
     tx_hash = deserialize_evm_tx_hash('0x92d178bbe5152cad47029b0c130450848ee46084e72addd09ba955631af1325b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -161,7 +156,6 @@ def test_gearbox_deposit_usdc(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9167B9d55BA7E7D6163bAAa97C099dfE3d1D9420']])
 def test_gearbox_withdraw(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -169,7 +163,6 @@ def test_gearbox_withdraw(
     tx_hash = deserialize_evm_tx_hash('0xb286e618ec2e5961c696df1855006dea0343fb635c7f199621f8592db342dfba')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -222,7 +215,6 @@ def test_gearbox_withdraw(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_gearbox_deposit_arbitrum(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -230,7 +222,6 @@ def test_gearbox_deposit_arbitrum(
     tx_hash = deserialize_evm_tx_hash('0x00db27b8c09c9ec4478f27da7e40b90afbb577cfb4822536eab5a52dcae321e6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -283,7 +274,6 @@ def test_gearbox_deposit_arbitrum(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_gearbox_deposit_arbitrum_lp(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -291,7 +281,6 @@ def test_gearbox_deposit_arbitrum_lp(
     tx_hash = deserialize_evm_tx_hash('0x7dbb02839dab23bc87ed6f4f5899fc77986c576e6fedf16cfbd9751fbe09e2eb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -344,7 +333,6 @@ def test_gearbox_deposit_arbitrum_lp(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x3a212d3d7504dC4A39E21C731d0E80b114A2108b']])
 def test_gearbox_withdraw_arbitrum(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'EthereumInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -352,7 +340,6 @@ def test_gearbox_withdraw_arbitrum(
     tx_hash = deserialize_evm_tx_hash('0x9b3f388e53c6b0f2eb12c323aebb05d47e27f6d9f511bd1176ed826a351c6c06')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -405,7 +392,6 @@ def test_gearbox_withdraw_arbitrum(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x7b007E8c0f77B50bEC8009f0e97F523DBa6FE506']])
 def test_gearbox_deposit_usdc_arbitrum(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -413,7 +399,6 @@ def test_gearbox_deposit_usdc_arbitrum(
     tx_hash = deserialize_evm_tx_hash('0xc7a3b95862eba49a86b8eefe81837ea141037feda8c0da236d9c3adb370fdfb3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -490,7 +475,6 @@ def test_gearbox_deposit_usdc_arbitrum(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('optimism_accounts', [['0xb8150a1B6945e75D05769D685b127b41E6335Bbc']])
 def test_gearbox_deposit_optimism(
-        database: 'DBHandler',
         optimism_inquirer: 'OptimismInquirer',
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -498,7 +482,6 @@ def test_gearbox_deposit_optimism(
     tx_hash = deserialize_evm_tx_hash('0x1dc1803865e909909bf20a82b0d88b476bcac13c7a0efa57c531baa06b0cb27e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -551,7 +534,6 @@ def test_gearbox_deposit_optimism(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('optimism_accounts', [['0xb8150a1B6945e75D05769D685b127b41E6335Bbc']])
 def test_gearbox_deposit_usdc_optimism(
-        database: 'DBHandler',
         optimism_inquirer: 'OptimismInquirer',
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -559,7 +541,6 @@ def test_gearbox_deposit_usdc_optimism(
     tx_hash = deserialize_evm_tx_hash('0x25baef6edb2fae8fde18b7ee49dbba94bdaa500db1388cc5b22bdb4ba953d7b4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -624,7 +605,6 @@ def test_gearbox_deposit_usdc_optimism(
 @pytest.mark.parametrize('load_global_caches', [[CPT_GEARBOX]])
 @pytest.mark.parametrize('optimism_accounts', [['0x42ccF4f456D7c7fEBF274242CACcD74AAa0a53d7']])
 def test_gearbox_withdraw_optimism_usdc(
-        database: 'DBHandler',
         optimism_inquirer: 'OptimismInquirer',
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
@@ -632,7 +612,6 @@ def test_gearbox_withdraw_optimism_usdc(
     tx_hash = deserialize_evm_tx_hash('0x03569fa219dd445c120a38eb294a21feee8da7f0e1d3b6aed1d87a3ca519b16d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hash,
         load_global_caches=load_global_caches,
     )
@@ -684,16 +663,11 @@ def test_gearbox_withdraw_optimism_usdc(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_gearbox_staking(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x5de7647a4c8f8ca1e5434725dd09b27ce05e41954d72c3f1f4d639c8b7019f4a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, stake_amount = TimestampMS(1718177819000), '0.0008970313372218', '260.869836197270890866'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -754,16 +728,11 @@ def test_gearbox_staking(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xe4283e107fB8E96F3175955EC7269afb51ECa6ea']])
 def test_gearbox_unstaking(
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0xb50badadb71b7c8c4ab2d0f9691931396322b2395da2396bee1ed65755e3882a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, stake_amount = TimestampMS(1717241039000), '0.000287410296179888', '1210105.252774990252868034'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin.py
@@ -17,13 +17,9 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_gitcoin_old_donation(database, ethereum_inquirer):
+def test_gitcoin_old_donation(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x811ba23a10c76111289133ec6f90d3c33a604baa50053739210e870687a456d9')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas = TimestampMS(1569924574000), '0.000055118'
     expected_events = [
         EvmEvent(
@@ -71,13 +67,9 @@ def test_gitcoin_old_donation(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_bulkcheckout_receive_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_bulkcheckout_receive_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6ed7d6c156fa3a8e73c3726d9179f139abcf7e7d3845efe9c5b70e6b4222c0be')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, user_address, amount, donor = TimestampMS(1670831003000), ethereum_accounts[0], '0.000799', '0xC8CA7F1C1a391CAfE43cf7348a2E54930648a0D4'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -98,13 +90,9 @@ def test_bulkcheckout_receive_eth(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x81facc69908D9C1188280fBB2793567De39f8f9B']])
-def test_bulkcheckout_send_token(database, ethereum_inquirer, ethereum_accounts):
+def test_bulkcheckout_send_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x89f8f62f7b1a8af0f8de685b676dac94088833442db93a9c4d896817b9f5099d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, user_address, amount1, amount2, dst1, dst2 = TimestampMS(1671869867000), '0.000883451092980928', ethereum_accounts[0], '25', '1.25', '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3', '0xde21F729137C5Af1b01d73aF1dC21eFfa2B8a0d6'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -152,11 +140,10 @@ def test_bulkcheckout_send_token(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_polygon_bulkcheckout_receive_matic(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_polygon_bulkcheckout_receive_matic(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe2d9464020f45ea2a69c93156976c1323a16e390550e0fe9af749e88e234e06b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, user_address, amount, donor = TimestampMS(1667285686000), polygon_pos_accounts[0], '2', '0x6e08E6e2D0deeb294fd53e9708f53b0fBedc06d5'  # noqa: E501
@@ -179,14 +166,10 @@ def test_polygon_bulkcheckout_receive_matic(database, polygon_pos_inquirer, poly
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_gitcoin_vote_cast(database, ethereum_inquirer):
+def test_gitcoin_vote_cast(ethereum_inquirer):
     """Test the old vote cast that gitcoin governor has"""
     tx_hash = deserialize_evm_tx_hash('0x068a954e8c8eda8942e972977d252997bd9de766c7b59230377ebdb9351e0183')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas = TimestampMS(1659375478000), '0.001115205340736039'
     expected_events = [
         EvmEvent(
@@ -221,13 +204,9 @@ def test_gitcoin_vote_cast(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xB1b3751834646fb999EDd18CA62C69663071cF43']])
-def test_gitcoin_gr15_matching_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_gitcoin_gr15_matching_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc7ba01598f7fee42bb3923af95355d676ad38ec0aebdcdf49eaf7cb74d2150b2')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, user, amount = TimestampMS(1666139015000), '0.00118573107792279', ethereum_accounts[0], '1719.1187865411025'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -262,13 +241,9 @@ def test_gitcoin_gr15_matching_claim(database, ethereum_inquirer, ethereum_accou
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd31b671F1a398B519222FdAba5aB5464B9F2a3Fa']])
-def test_gitcoin_payout_claimed_matching_gr12(database, ethereum_inquirer, ethereum_accounts):
+def test_gitcoin_payout_claimed_matching_gr12(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5acb6ddac6b72fc6ff45e6a387cf8316c1478dfbaff513918c4cc8731858b362')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, user, amount = TimestampMS(1643262544000), '0.00327700462232052', ethereum_accounts[0], '793.606553162524960498'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -303,14 +278,10 @@ def test_gitcoin_payout_claimed_matching_gr12(database, ethereum_inquirer, ether
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x28BE0996b15149aA011C84f09cE3389cbC719Fa6']])
-def test_gitcoin_payout_claimed_matching_gr11(database, ethereum_inquirer, ethereum_accounts):
+def test_gitcoin_payout_claimed_matching_gr11(ethereum_inquirer, ethereum_accounts):
     """Test of the PayoutClaimed event with both recipiend and amount in data (non-indexed args)"""
     tx_hash = deserialize_evm_tx_hash('0x3a069b8cef0d25068fbd2ae4e46ddd552451ed1bbe3737fbaaca05eeb87d9425')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, user, amount = TimestampMS(1648056902000), '0.00206346594437105', ethereum_accounts[0], '2618.692525999999816121'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
@@ -13,13 +13,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_optimism_donation_received(database, optimism_inquirer, optimism_accounts):
+def test_optimism_donation_received(optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0x08685669305ee26060a5a78ae70065aec76d9e62a35f0837c291fb1232f33601')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1692176477000)
@@ -43,14 +42,10 @@ def test_optimism_donation_received(database, optimism_inquirer, optimism_accoun
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_ethereum_donation_received(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_donation_received(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x71fc406467f342f5801560a326aa29ac424381daf17cc04b5573960425ba605b')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     amount_str = '0.001'
     expected_events = [EvmEvent(
         tx_hash=evmhash,
@@ -75,16 +70,12 @@ def test_ethereum_donation_received(database, ethereum_inquirer, ethereum_accoun
     # also track a grantee to see we handle donating to self fine
     '0xB352bB4E2A4f27683435f153A259f1B207218b1b',
 ]])
-def test_ethereum_make_donation(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_make_donation(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xd8d55b66f19a6dbf260d171fbb0c4c146f00c90919f1215cf691d7f0684771c6')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
     tracked_grant = ethereum_accounts[1]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1683676595000)
     amount_str = '0.0006'
     gas_str = '0.011086829409239852'
@@ -139,15 +130,11 @@ def test_ethereum_make_donation(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_optimism_create_project(database, optimism_inquirer, optimism_accounts):
+def test_optimism_create_project(optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0xe59f04c693e91f1659bd8bc718c993158efeb9af02c9c6337f039c44d8a822f6')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = optimism_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1691697693000)
     gas_str = '0.000085459641651569'
     expected_events = [EvmEvent(
@@ -194,15 +181,11 @@ def test_optimism_create_project(database, optimism_inquirer, optimism_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_ethereum_project_apply(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_project_apply(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3e4639d97be450c6d32ce77a146898780b75781caaf004d3c40bae083dec07c7')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1673472803000)
     gas_str = '0.000645250895735256'
     expected_events = [EvmEvent(
@@ -236,15 +219,11 @@ def test_ethereum_project_apply(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_ethereum_project_update(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_project_update(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xfe00fa198eb5395e1d809e017c6b416e882b0aef16e82bf00cd60ce5576bb122')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1681330523000)
     gas_str = '0.001464795019471285'
     expected_events = [EvmEvent(
@@ -278,15 +257,11 @@ def test_ethereum_project_update(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xd034Fd34eaEe5eC2c413C51936109E12873f4DA5']])
-def test_optimism_many_donations_different_strategies(database, optimism_inquirer, optimism_accounts):  # noqa: E501
+def test_optimism_many_donations_different_strategies(optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0x5d85b436f5f177de6019baa9ecebae285e0def4924546307fac40556bece4cd7')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = optimism_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1692300843000)
     gas_str = '0.004506208027331091'
     op_dai = Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1')
@@ -330,14 +305,10 @@ def test_optimism_many_donations_different_strategies(database, optimism_inquire
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_optimism_grant_payout(database, optimism_inquirer, optimism_accounts):
+def test_optimism_grant_payout(optimism_inquirer, optimism_accounts):
     tx_hex = deserialize_evm_tx_hash('0x84110136c94ceb71c72afb27ccb517eb33f77a8a419d125101644e2c43294815')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hex)
     amount_str = '1228.529999999999934464'
     expected_events = [EvmEvent(
         tx_hash=evmhash,
@@ -358,14 +329,10 @@ def test_optimism_grant_payout(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_ethereum_grant_payout(database, ethereum_inquirer, ethereum_accounts):
+def test_ethereum_grant_payout(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x66ff5be7841f05cc9cb53fd0307460690f91203c52490f5bbfdeabe8462be50b')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     amount_str = '20000'
     expected_events = [EvmEvent(
         tx_hash=evmhash,
@@ -386,13 +353,12 @@ def test_ethereum_grant_payout(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_polygon_donation_matic_received(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_polygon_donation_matic_received(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hex = deserialize_evm_tx_hash('0x32837e03ac3e9066f09c1ee0807c533aa1bef5e3119b98dcacdd1ca631bc7ca6')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = polygon_pos_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1700595622000)
@@ -416,13 +382,12 @@ def test_polygon_donation_matic_received(database, polygon_pos_inquirer, polygon
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_polygon_donation_token_received(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_polygon_donation_token_received(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hex = deserialize_evm_tx_hash('0x17601356467af0cfcf3a62f93879b504695b8690545b2b8669da5ec0f3a2a91b')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = polygon_pos_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1700593336000)
@@ -446,13 +411,12 @@ def test_polygon_donation_token_received(database, polygon_pos_inquirer, polygon
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_polygon_apply_to_round(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_polygon_apply_to_round(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hex = deserialize_evm_tx_hash('0x51c1909ce9268f453d4b7136b0fecb72d8da567f406c37014dd8ad8ed05c9a1f')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = polygon_pos_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1699442294000)

--- a/rotkehlchen/tests/unit/decoders/test_gmx.py
+++ b/rotkehlchen/tests/unit/decoders/test_gmx.py
@@ -21,11 +21,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x22E798f9440F563B92AAE24E94C75DfA499e3d3E']])
-def test_swap_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_swap_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x5969392c45eaf7e6e3453e2405afb23eb2424e8e4ba2d14e38943fdcdab55d5f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -91,11 +90,10 @@ def test_swap_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0C0e6d63A7933e1C2dE16E1d5E61dB1cA802BF51']])
-def test_long_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_long_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x99eed649e7845813353b29dba0ac248dc328253051a778ca895a0a6c34092798')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -147,11 +145,10 @@ def test_long_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x3D4d8A52D5717b09CA1e1980393d244Ac258C6AA']])
-def test_decrease_short_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_decrease_short_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xa3dd437d57689479db67ce685c4b70ee9bdbfbcc53f99fc343f73c89edaafe7a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -192,11 +189,10 @@ def test_decrease_short_in_gmx(database, arbitrum_one_inquirer, arbitrum_one_acc
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xB5E10681aA81cd65D74912015220999044b9520C']])
-def test_stake_gmx(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_stake_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x682aa15cb8d49021ae5b12c89f6d0138387c4819b1a31b80f67b70aac55d199c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_gnosis_sdai.py
+++ b/rotkehlchen/tests/unit/decoders/test_gnosis_sdai.py
@@ -21,12 +21,11 @@ A_GNOSIS_SDAI = evm_address_to_identifier(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x78E87757861185Ec5e8C0EF6BF0C69Fa7832df6C']])
-def test_deposit_xdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
+def test_deposit_xdai_to_sdai(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x1342646cab122d58f0b7dfae404dad5235d42224de881099dc05e59477bb93aa')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1707169525000)
@@ -78,13 +77,12 @@ def test_deposit_xdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x4fFAD6ac852c0Af0AA301376F4C5Dea3a928b120']])
-def test_withdraw_xdai_from_sdai(database, gnosis_inquirer, gnosis_accounts):
+def test_withdraw_xdai_from_sdai(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     receive_address = '0xD499b51fcFc66bd31248ef4b28d656d67E591A94'
     tx_hash = deserialize_evm_tx_hash('0xe23ee1ac52b8981723c737b01781691b965c5819cccccdb98e7c8cb5894dddbb')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1707070975000)
@@ -137,12 +135,11 @@ def test_withdraw_xdai_from_sdai(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x5938852FE18Ad6963322FB98D1fDDA5c24DD8a0E']])
-def test_deposit_wxdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
+def test_deposit_wxdai_to_sdai(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xd406f40ecd2538d41adb2e645c8fb6d32cec5485510798bfed5d991c258d4b1d')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1706794335000)
@@ -194,12 +191,11 @@ def test_deposit_wxdai_to_sdai(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x23727b54163F63CffdD8B7769e0eCb13Df253b4e']])
-def test_withdraw_wxdai_from_sdai(database, gnosis_inquirer, gnosis_accounts):
+def test_withdraw_wxdai_from_sdai(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xd7e2123adc6c8f4fd8ced74733010cf47dba2bd4e0e5c468d63d53942b9e2dd3')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1706699405000)

--- a/rotkehlchen/tests/unit/decoders/test_golem.py
+++ b/rotkehlchen/tests/unit/decoders/test_golem.py
@@ -14,14 +14,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf264267DCaFC1539900bc96006879701fA053259']])
-def test_gnt_glm_migration(database, ethereum_inquirer, ethereum_accounts):
+def test_gnt_glm_migration(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x86baa45e4ab48d1db26df82da1a6f654fe96f1254ace5883b6397d7f55eb11a4')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1646777828000)
     gas_str = '0.00560851737819982'
     amount_str = '5920'

--- a/rotkehlchen/tests/unit/decoders/test_harvest_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_harvest_finance.py
@@ -19,14 +19,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x7F248e4301F5A16B2a8289989584A509f7157845']])
-def test_claim_grain(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_grain(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x5d0464be1198872d88507a3da2a876fe32c9d4427fb9ba7254c29fef0a94698c')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, amount_str = TimestampMS(1613015691000), '0.007051027', '1373.104541023509385198'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_hop.py
+++ b/rotkehlchen/tests/unit/decoders/test_hop.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.inquirer import Inquirer
 
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
@@ -49,13 +48,9 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_hop_l2_deposit(database, ethereum_inquirer):
+def test_hop_l2_deposit(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xd46640417a686b399b2f2a920b0c58a35095759365cbe7b795bddec34b8c5eee')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1653219722000)
     expected_events = [
         EvmEvent(
@@ -89,13 +84,9 @@ def test_hop_l2_deposit(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xD8245043a3f339400dcfFFc7A9E6F22a264b933D']])
-def test_hop_l2_deposit_usdc(database, ethereum_inquirer, ethereum_accounts):
+def test_hop_l2_deposit_usdc(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xac42ca2d88194c0ee219f6c71c98fe566667151a1dc235d17d993b6985342062')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_fee, bridge_amount = TimestampMS(1710955643000), '0.005802319111323689', '3700'
     expected_events = [
         EvmEvent(
@@ -130,16 +121,12 @@ def test_hop_l2_deposit_usdc(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [[ADDY]])
-def test_hop_optimism_eth_receive(database, optimism_inquirer):
+def test_hop_optimism_eth_receive(optimism_inquirer):
     """Data taken from
     https://optimistic.etherscan.io/tx/0x8394c39e1f030a04aa8359f0322257632282a7dfa419b3c9ffc8ab61205a815d
     """
     tx_hash = deserialize_evm_tx_hash('0x8394c39e1f030a04aa8359f0322257632282a7dfa419b3c9ffc8ab61205a815d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -160,18 +147,14 @@ def test_hop_optimism_eth_receive(database, optimism_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
-def test_hop_optimism_eth_receive_no_event(database, optimism_inquirer, optimism_accounts):
+def test_hop_optimism_eth_receive_no_event(optimism_inquirer, optimism_accounts):
     """Data taken from
     https://optimistic.etherscan.io/tx/0x3e18e3a0220857ecce91ad79065f10a663128926854b6087161fd0364c7f76f5
 
     Test that HOP bridge events that have no TRANSFER_FROM_L1_COMPLETED event are decoded.
     """
     tx_hash = deserialize_evm_tx_hash('0x3e18e3a0220857ecce91ad79065f10a663128926854b6087161fd0364c7f76f5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     bridge_amount, timestamp, user_address = '0.03958480553397407', TimestampMS(1666977475000), optimism_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -194,13 +177,9 @@ def test_hop_optimism_eth_receive_no_event(database, optimism_inquirer, optimism
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xc009D690942DbAaC8d5b15B20EFb24fCbFF77Ddd']])
-def test_hop_usdc_bridge(database, ethereum_inquirer, ethereum_accounts):
+def test_hop_usdc_bridge(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xdca89892d6a738c2ea278d93a5e1757b2f946f4e24c4aa02d59a0abf6a8e5f4b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1715038763000), '9006.683634', ethereum_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -223,13 +202,9 @@ def test_hop_usdc_bridge(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_hop_eth_bridge_optimism(database, optimism_inquirer, optimism_accounts):
+def test_hop_eth_bridge_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4f1e95506c10f061ddfe28a7437f3b651959ff17f1e2a7a148c8896147ee357e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1643122781000), '0.10392672200478311', optimism_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -252,13 +227,9 @@ def test_hop_eth_bridge_optimism(database, optimism_inquirer, optimism_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc5DE997A4809c15b64560b04E1141416B1a2A71e']])
-def test_hop_eth_bridge_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
+def test_hop_eth_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8765cf6596ff1794679509fcc0ecd5adf921464859f08992944f6d6a7e905d98')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1715179605000), '0.008909890056139906', gnosis_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -281,13 +252,9 @@ def test_hop_eth_bridge_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gnos
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x0B8B3648060b97447C023E9EE227BB92E35B30FE']])
-def test_hop_usdc_bridge_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
+def test_hop_usdc_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd00e4cd1223d962ef841c16977142856c1f54d4e87fae417c58520270e3a9420')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1710961255000), '23.482715', gnosis_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -310,13 +277,9 @@ def test_hop_usdc_bridge_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gno
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x3b6a814bFbfdae6649Bc3753018e746B8e605342']])
-def test_hop_hop_bridge_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
+def test_hop_hop_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x93a644818341e6ac22e499ac1ab73c11b6d8e55ff52ecc529125dc28790d7df1')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1697084045000), '6854.931542581763573457', gnosis_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -339,11 +302,10 @@ def test_hop_hop_bridge_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gnos
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x8f7043fF95c088b5727bF7889b4d868DF92F6a58']])
-def test_hop_eth_bridge_polygon_pos(database, polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_pos_accounts):  # noqa: E501
+def test_hop_eth_bridge_polygon_pos(polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_pos_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xcb26a59c87d41de4d6dd688a9ff8400b4e981f7e38d25787616ec0f81b4dccca')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, bridge_amount, user_address = TimestampMS(1715182468000), '0.00371160659018274', polygon_pos_accounts[0]  # noqa: E501
@@ -368,11 +330,10 @@ def test_hop_eth_bridge_polygon_pos(database, polygon_pos_inquirer: 'PolygonPOSI
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0xC0b263b8315FAABC27BC0479a5A547281c049C1c']])
-def test_hop_eth_bridge_base(database, base_inquirer: 'BaseInquirer', base_accounts):
+def test_hop_eth_bridge_base(base_inquirer: 'BaseInquirer', base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd78eb0f79fa4af1e140641ef260499a6e138b6398d2c4cdcd2e7c488ee8cb20e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, bridge_amount, user_address = TimestampMS(1715184391000), '0.895370313537560075', base_accounts[0]  # noqa: E501
@@ -397,11 +358,10 @@ def test_hop_eth_bridge_base(database, base_inquirer: 'BaseInquirer', base_accou
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x32C885EcE06EBC8F6bEf6C2052E400226C087e08']])
-def test_hop_eth_bridge_l2_to_l1_arbitrum_one(database, arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
+def test_hop_eth_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x4fb91812763e6af24465ee014a306b8322beb612aa51f26b657772447744ae94')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1715614190000)
@@ -452,13 +412,9 @@ def test_hop_eth_bridge_l2_to_l1_arbitrum_one(database, arbitrum_one_inquirer: '
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x32C885EcE06EBC8F6bEf6C2052E400226C087e08']])
-def test_hop_eth_bridge_l2_to_l1_ethereum(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts):  # noqa: E501
+def test_hop_eth_bridge_l2_to_l1_ethereum(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x15704d966705b423b1f747d9413a474f35647e676a5f7ec2bed5ae83bf4f5e38')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1715614211000), '0.194877831029822766', ethereum_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -481,11 +437,10 @@ def test_hop_eth_bridge_l2_to_l1_ethereum(database, ethereum_inquirer: 'Ethereum
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0a6c69327d517568E6308F1E1CD2fD2B2b3cd4BF']])
-def test_hop_magic_bridge_l2_to_l1_arbitrum_one(database, arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
+def test_hop_magic_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x05c2c5f18e9acc193f34c611e176d9e65f34d420ba80c7546e0ba0c124d510e3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1715564239000)
@@ -549,13 +504,9 @@ def test_hop_magic_bridge_l2_to_l1_arbitrum_one(database, arbitrum_one_inquirer:
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xebe61c49901a46c954e37B8945Bfb87D238F8f45']])
-def test_hop_usdc_bridge_l2_to_l1_ethereum(database, ethereum_inquirer: 'EthereumInquirer', ethereum_accounts):  # noqa: E501
+def test_hop_usdc_bridge_l2_to_l1_ethereum(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xc76dbb99825d1e53488426b5cf93f7ff71b5fd1fccd41259537e84824a950cc9')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, user_address = TimestampMS(1715208275000), '60786.713495', ethereum_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -578,13 +529,9 @@ def test_hop_usdc_bridge_l2_to_l1_ethereum(database, ethereum_inquirer: 'Ethereu
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xebe61c49901a46c954e37B8945Bfb87D238F8f45']])
-def test_hop_usdc_bridge_l2_to_l1_gnosis(database, gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):  # noqa: E501
+def test_hop_usdc_bridge_l2_to_l1_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0c6084399c873b06407f073acec89ffd9693ac0c7df4befd9e45e4178b5ae869')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, bridge_amount, gas_fees, user_address = TimestampMS(1715204760000), '60786.713495', '0.0001299435', gnosis_accounts[0]  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -619,13 +566,10 @@ def test_hop_usdc_bridge_l2_to_l1_gnosis(database, gnosis_inquirer: 'GnosisInqui
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D', '0xA63734db2c674122EEd383aea7698C68aAbf749e']])  # noqa: E501
-def test_hop_eth_bridge_arbitrum_custom_recipient(
-        database, arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts,
-):
+def test_hop_eth_bridge_arbitrum_custom_recipient(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x88b6fce15afacab9fa77caaf8d42d30d7a517f9f5ae6b7d6c37795309ac90383')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, bridge_amount, hop_fee, user_address = TimestampMS(1715946201000), '0.00000266018', '0.000880551717232904', '0.000118862618614123', arbitrum_one_accounts[0]  # noqa: E501
@@ -677,18 +621,13 @@ def test_hop_eth_bridge_arbitrum_custom_recipient(
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('base_accounts', [['0xAE70bC0Cbe03ceF2a14eCA507a2863441C6Df7A1']])
 def test_hop_add_liquidity(
-        database: 'DBHandler',
         inquirer: 'Inquirer',
         base_manager: 'BaseManager',
         base_inquirer: 'BaseInquirer',
         base_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0xa50286f6288ca13452a490d766aaf969d20cce7035b514423a7b1432fd329cc5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp, gas, lp_amount, lp_token_amount = TimestampMS(1714582939000), '0.000013783759721971', '0.025', '0.023220146656543904'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -750,14 +689,12 @@ def test_hop_add_liquidity(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_hop_add_liquidity_2(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x52ab27e8f15148c0f41df0114429321d2a1e9411f2ea2fe7c8fb9c663bc09ecb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, lp_amount, lp_amount_2, lp_token_amount, approval_amount_1, approval_amount_2 = TimestampMS(1716391406000), '0.00000298668', '0.001', '0.005129453530970625', '0.005676129314105837', '115792089237316195423570985008687907853269984665640564039457.583007913129639935', '115792089237316195423570985008687907853269984665640564039457.57887845959866931'  # noqa: E501
@@ -845,16 +782,11 @@ def test_hop_add_liquidity_2(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0xA38b8E0cA73916fD611Bbf9E854FDBB25865e42a']])
 def test_hop_remove_liquidity(
-        database: 'DBHandler',
         base_inquirer: 'BaseInquirer',
         base_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0xc3662d3d68f845dd848c9df2aef4efedf9c9a01580872619a2f4eaafdbf98feb')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp, gas, lp_amount, withdrawn = TimestampMS(1714729295000), '0.000019101983974486', '0.75', '0.807405509354959205'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -915,16 +847,11 @@ def test_hop_remove_liquidity(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0x8Df3480a31B5a32508Cd1E29A6Ff84fd03b96430']])
 def test_hop_remove_liquidity_2(
-        database: 'DBHandler',
         base_inquirer: 'BaseInquirer',
         base_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x4995c8896bb845ab506b759530d35e306d6ef5418630b60bbf26ca0fae90fcaa')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp, gas, lp_amount, withdrawn_1, withdrawn_2 = TimestampMS(1716298905000), '0.000020283535960823', '0.014812373943526529', '0.008484007194088721', '0.007520340659511852'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -998,16 +925,11 @@ def test_hop_remove_liquidity_2(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xCe0945D35cCc4ccA674e13D3cc2918843C4B56d6']])
 def test_hop_remove_liquidity_usdc_gnosis(
-        database: 'DBHandler',
         gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x5833d34d7f20ee4e71b902dac85a025f40739a1d646091553104a3e345a38f81')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gas, lp_amount, withdrawn, withdrawn_2, approval_amount = TimestampMS(1716258450000), '0.000645488318952488', '2.138240168467212015', '0.258527', '2.026586', '0.861759831532787985'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1082,7 +1004,6 @@ def test_hop_remove_liquidity_usdc_gnosis(
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_hop_stake(
-        database: 'DBHandler',
         inquirer: 'Inquirer',
         arbitrum_one_manager: 'ArbitrumOneManager',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
@@ -1091,12 +1012,10 @@ def test_hop_stake(
     tx_hash = deserialize_evm_tx_hash('0x6329984b82cb85903fee9fef61fb77cdf848ff6344056156da2e66676ad91473')  # noqa: E501
     get_decoded_events_of_transaction(  # decode the deposit tx to process the LP token
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=deserialize_evm_tx_hash('0x52ab27e8f15148c0f41df0114429321d2a1e9411f2ea2fe7c8fb9c663bc09ecb'),
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, stake_amount, approval_amount = TimestampMS(1716391575000), '0.00000183398', '0.005676129314105837', '115792089237316195423570985008687907853269984665640564039457.578331783815534098'  # noqa: E501
@@ -1149,14 +1068,12 @@ def test_hop_stake(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_hop_stake_2(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0xe0c1f6f152422784a4e4346d84af7d32fda95eab17da257f3fdc5121f4a6fbc8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, stake_amount, approval_amount = TimestampMS(1718269403000), '0.00000199918', '0.005676129314105837', '115792089237316195423570985008687907853269984665640564039457.578331783815534098'  # noqa: E501
@@ -1207,14 +1124,12 @@ def test_hop_stake_2(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x73F809c0B3cF18d40463D05Ba4b95067cb51393B']])
 def test_hop_claim_rewards(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x905c1f8cf4b94d49b18f14fc7c403df653f731999ef5262b6aa92dbe5ad0423f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, reward_amount = TimestampMS(1716445828000), '0.00000098192', '1.556162863261353191'  # noqa: E501
@@ -1252,14 +1167,12 @@ def test_hop_claim_rewards(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xA252bd92293B0eb9BEB1C2cF72F794F8a3a54348']])
 def test_hop_claim_rewards_2(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x85b7ca62b27f78f59bcb9fd52ab18c05f3f143ff4df00c70d4f9a3edfa5eea19')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, reward_amount = TimestampMS(1718278937000), '0.00000171746', '1.305947476028639625'  # noqa: E501
@@ -1297,14 +1210,12 @@ def test_hop_claim_rewards_2(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x73F809c0B3cF18d40463D05Ba4b95067cb51393B']])
 def test_hop_unstake(
-        database: 'DBHandler',
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x4bdf31c7bbe27ccbb9a5d381596b6f4d8cf9583d111af43d5b0b5d76bb8f6751')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, gas, unstake_amount, reward_amount = TimestampMS(1716446062000), '0.00000160545', '0.000958469117996842', '0.000025838435799823'  # noqa: E501
@@ -1355,16 +1266,11 @@ def test_hop_unstake(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x5d58727c200E96347235a907d9b856A1B0089D86']])
 def test_hop_stake_gnosis(
-        database: 'DBHandler',
         gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0xf3b00cb365594bf9b2894af0edf852d04411db49b5fe9c07708186f75bce5385')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gas, stake_amount, approval_amount = TimestampMS(1710600070000), '0.00017891077758659', '1.927208027730675426', '115792089237316195423570985008687907853269984665640564039453.729591857668289083'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1413,16 +1319,11 @@ def test_hop_stake_gnosis(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x5d58727c200E96347235a907d9b856A1B0089D86']])
 def test_hop_claim_rewards_gnosis(
-        database: 'DBHandler',
         gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x5ad3d5050d43ec08883c76116d9328b6bf61dd8478c082bfe21bd97eb237c4b1')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gas, reward_amount = TimestampMS(1710597650000), '0.000149113056096078', '0.001269493516433091'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1458,16 +1359,11 @@ def test_hop_claim_rewards_gnosis(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x95e62E8FF84ed8456fDc9739eE4A9597Bb6E4c1f']])
 def test_hop_unstake_gnosis(
-        database: 'DBHandler',
         gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x10e32923be7fd7beda4551badb4fb3ca1a708268884e540d92c73b88596f3ac4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp, gas, unstake_amount, reward_amount = TimestampMS(1708463325000), '0.000669895628651568', '30000', '0.91583970339645'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -1515,13 +1411,9 @@ def test_hop_unstake_gnosis(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_vote_cast(database, ethereum_inquirer):
+def test_vote_cast(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xc6116ef064b0a713eb50cb55a1e76ef947ebdba9cbfba9a71498dacb6b75ba0e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas = TimestampMS(1671494483000), '0.00186503943913884'
     expected_events = [
         EvmEvent(
@@ -1556,16 +1448,11 @@ def test_vote_cast(database, ethereum_inquirer):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_hop_add_liquidity_optimism_usdc(
-        database: 'DBHandler',
         optimism_inquirer: 'BaseInquirer',
         optimism_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x891d2b68a1ecc36b1c14943ddaece1ee50d0d895ca20b9ad61640aa531b8755e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, gas, lp_amount, lp_token_amount, approval_amount = TimestampMS(1670628821000), '0.00006011384375604', '11208.995146', '10843.63570237678072025', '115792089237316195423570985008687907853269984665640564039457584007901920.644789'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_juicebox.py
+++ b/rotkehlchen/tests/unit/decoders/test_juicebox.py
@@ -16,15 +16,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_donation(database, ethereum_inquirer, ethereum_accounts):
+def test_donation(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0xf7873b900aa9bb0453b70bc57c7eef54af37346c58edfd4768eb74567279e06e',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1706095919000)
     donated_amount, gas_fees = '2', '0.00306450894012447'
@@ -87,15 +83,11 @@ def test_donation(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x15b850a67A6ceDd218e368f1Cab11403f45a42f4']])
-def test_fund_raising(database, ethereum_inquirer, ethereum_accounts):
+def test_fund_raising(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0xd4b8b0857d4cce83f0ce7310a0ed1a8f6360bae331bb4e8bd9217b1370b05bee',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1706711399000)
     paid_amount, gas_fees = '0.4', '0.003792515741532086'

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -18,18 +18,14 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6d379cb5BA04c09293b21Bf314E7aba3FfEAaF5b']])
-def test_kyber_legacy_old_contract(database, ethereum_inquirer, ethereum_accounts):
+def test_kyber_legacy_old_contract(ethereum_inquirer, ethereum_accounts):
     """
     Data for trade taken from
     https://etherscan.io/tx/0xe9cc9f27ef2a09fe23abc886a0a0f7ae19d9e2eb73663e1e41e07a3e0c011b87
     """
     tx_hex = deserialize_evm_tx_hash('0xe9cc9f27ef2a09fe23abc886a0a0f7ae19d9e2eb73663e1e41e07a3e0c011b87')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
 
     assert len(events) == 3
     expected_events = [
@@ -83,17 +79,13 @@ def test_kyber_legacy_old_contract(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x5340F6faff9BF55F66C16Db6Bf9E020d987F87D0']])
-def test_kyber_legacy_new_contract(database, ethereum_inquirer):
+def test_kyber_legacy_new_contract(ethereum_inquirer):
     """Data for trade taken from
     https://etherscan.io/tx/0xe80928d5e21f9628c047af1f8b191cbffbb6b8b9945adb502cfb3af152552f22
     """
     tx_hex = deserialize_evm_tx_hash('0xe80928d5e21f9628c047af1f8b191cbffbb6b8b9945adb502cfb3af152552f22')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
 
     assert len(events) == 3
     expected_events = [
@@ -145,13 +137,9 @@ def test_kyber_legacy_new_contract(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xceD462398bDFBb1B45d75b7F2c61172643a18009']])
-def test_kyber_aggregator_swap_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_kyber_aggregator_swap_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x82205817d573da45a2f6da6e5e9623739bd4cdbce5f9b65d48450805bce0bdff')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1714563455000)
     gas, approval_amount = '0.00199568430867988', '20.819823166790499332'
     spend_amount, receive_amount = '20', '21.100486952910759139'
@@ -214,11 +202,10 @@ def test_kyber_aggregator_swap_ethereum(database, ethereum_inquirer, ethereum_ac
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
-def test_kyber_aggregator_swap_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
+def test_kyber_aggregator_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xbcc690fb11b0a6b0f3b1e5bed6abb5c3e93d5b4855472f94adea824bfa2be6ed')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1714517062000)
@@ -270,13 +257,9 @@ def test_kyber_aggregator_swap_arbitrum_one(database, arbitrum_one_inquirer, arb
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0x8a8162b86A3179a9F7A2F46FFd7029B669876B75']])
-def test_kyber_aggregator_swap_base(database, base_inquirer, base_accounts):
+def test_kyber_aggregator_swap_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x27b040b725caa995343f98ca16fabebfbd2116063488761cbbdc1f99a2bf8619')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1714588063000)
     gas, spend_amount, receive_amount = '0.000057116139238782', '10076.279107426212183073', '19.725836184026980754'  # noqa: E501
     a_dog = Asset('eip155:8453/erc20:0xAfb89a09D82FBDE58f18Ac6437B3fC81724e4dF6')
@@ -339,13 +322,9 @@ def test_kyber_aggregator_swap_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x1961425eB7467330380ea268d4b909C7975f79c6']])
-def test_kyber_aggregator_swap_optimism(database, optimism_inquirer, optimism_accounts):
+def test_kyber_aggregator_swap_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc50282f437bacfbeef00baf4dae0785a259f87294089b96f7a6363ad4928570e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1714589233000)
     gas, spend_amount, receive_amount = '0.000018524563536246', '1.404275039033980017', '1.633943151167508706'  # noqa: E501
     a_wsteth_op = Asset('eip155:10/erc20:0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
@@ -407,11 +386,10 @@ def test_kyber_aggregator_swap_optimism(database, optimism_inquirer, optimism_ac
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x686e14AFb1AB9eb5aB89593ddE9fCe9389cA8C35']])
-def test_kyber_aggregator_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_kyber_aggregator_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0xfd32220a3dfad3a74b0e172b88f0052670cd60b72f4b0cf19ded4a4145ba4a2b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1714589685000)
@@ -464,13 +442,9 @@ def test_kyber_aggregator_swap_polygon(database, polygon_pos_inquirer, polygon_p
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('scroll_accounts', [['0x8C6270BB0D3d95Dad8581D6e9795Bb7089A34123']])
-def test_kyber_aggregator_swap_scroll(database, scroll_inquirer, scroll_accounts):
+def test_kyber_aggregator_swap_scroll(scroll_inquirer, scroll_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd5c9011e2edd8b724eb3f0a691f5657eb7adb0d943be01b54b52a22b82df7062')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1714590811000)
     gas, spend_amount, receive_amount = '0.00014495886763554', '327.431697', '0.109956490224557286'
     a_usdc_scroll = Asset('eip155:534352/erc20:0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4')

--- a/rotkehlchen/tests/unit/decoders/test_lido_eth.py
+++ b/rotkehlchen/tests/unit/decoders/test_lido_eth.py
@@ -14,14 +14,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4C49d4Bd6a571827B4A556a0e1e3071DA6231B9D']])
-def test_lido_steth_staking(database, ethereum_inquirer, ethereum_accounts):
+def test_lido_steth_staking(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x23a3ee601475424e91bdc0999a780afe57bf37cbcce6d1c09a4dfaaae1765451')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, amount_deposited, amount_minted = TimestampMS(1710486191000), '0.002846110430778206', '1.12137397', '1.121373969999999999'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -21,14 +21,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x9ba961989Dd6609Ed091f512bE947118c40F2291']])
-def test_deposit_eth_borrow_lusd(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_eth_borrow_lusd(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xdb9a541a4af7d5d46d7ea5fe4a2a752dcb731d64d052f86f630e97362063602c')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1650878514000)
     gas_str, fee_str, debt_str = '0.013622314246080246', '23.795404790091371686', '4751.162005820150243344'  # noqa: E501
     expected_events = [EvmEvent(
@@ -88,14 +84,10 @@ def test_deposit_eth_borrow_lusd(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648E180e246741363639B1496762763dd25649db']])
-def test_payback_lusd(database, ethereum_inquirer, ethereum_accounts):
+def test_payback_lusd(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x40bb08427a3b99fb9896cf14858d82d361a6e7a8fb7dd6d2000511ac3dca5707')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1650746429000)
     gas_str, amount_str = '0.006264200693494173', '118184.07'
     expected_events = [EvmEvent(
@@ -129,15 +121,11 @@ def test_payback_lusd(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648E180e246741363639B1496762763dd25649db']])
-def test_remove_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_remove_eth(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x6be5312c21855c3cc324b5b6ce9f9f65dbd488e270e84ac5e6fb96c74d83fe4e')  # noqa: E501
     user_address = ethereum_accounts[0]
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1650998125000)
     gas_str, amount_str = '0.016981969690997082', '32'
     expected_events = [EvmEvent(
@@ -171,14 +159,10 @@ def test_remove_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF04E6f2D27ED324917AD2098F96f5d4ac52e1684']])
-def test_stability_pool_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_stability_pool_deposit(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x1277cb6c2c8e151fe90118cdd738e46f894e18de04ab6af33d567e91597f322b')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1665994475000)
     gas_str, amount_str, fee_str = '0.003626058925730277', '120', '4.970574827214596312'
     expected_events = [EvmEvent(
@@ -225,14 +209,10 @@ def test_stability_pool_deposit(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF03639047f75204d00c9314611C2b24570db4405']])
-def test_stability_pool_collect_rewards(database, ethereum_inquirer, ethereum_accounts):
+def test_stability_pool_collect_rewards(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xad077faf7976504615561ac7fd9fdddc934180f3237f216851136d2327d71196')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1665913919000)
     gas_str, eth_str, got_lqty_str, fee_lqty_str = '0.00249609940900398', '0.0211265398269', '1308.878062778294406909', '13.810598430718930388'  # noqa: E501
     expected_events = [EvmEvent(
@@ -292,14 +272,10 @@ def test_stability_pool_collect_rewards(database, ethereum_inquirer, ethereum_ac
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x1b63708eafa610DFa81c6DB4A257570D78a6dF1c']])
-def test_increase_lqty_staking(database, ethereum_inquirer, ethereum_accounts):
+def test_increase_lqty_staking(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x4e2bbc53a75fbbc954fc305f7adf68be1fa3b1416c941b0350719cc484c9d8fb')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1667784263000)
     gas_str, eth_str, lqty_str, lusd_str = '0.001329619874685459', '0.000047566872899089', '89.99999999999997', '1.134976028981709316'  # noqa: E501
     expected_events = [EvmEvent(
@@ -360,15 +336,11 @@ def test_increase_lqty_staking(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x58D9A499AC82D74b08b3Cb76E69d8f32e1395746']])
-def test_remove_liquity_staking(database, ethereum_inquirer, ethereum_accounts):
+def test_remove_liquity_staking(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x028397f0409042da26890ec27eb36d617e326c3ce476d823f181419bdd0ad860')  # noqa: E501
     user_address = string_to_evm_address('0x58D9A499AC82D74b08b3Cb76E69d8f32e1395746')
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1667817419000)
     gas_str, eth_str, lqty_str, lusd_str = '0.001768189006455498', '0.000215197741630696', '372.883717436930835121', '2.476877599503048728'  # noqa: E501
     expected_events = [EvmEvent(
@@ -429,14 +401,10 @@ def test_remove_liquity_staking(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x5DD596C901987A2b28C38A9C1DfBf86fFFc15d77']])
-def test_stability_pool_withdrawal(database, ethereum_inquirer, ethereum_accounts):
+def test_stability_pool_withdrawal(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     evmhash = deserialize_evm_tx_hash('0xca9acc377ba5eb020dd5f113961016ac1c652617b0e5c71f31a7fb32e188858d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1677402143000)
     gas_str, lqty_fee_str, lqty_amount_str, withdraw_str = '0.00719440411023624', '1.028279761898401648', '1.3168840890645', '500000'  # noqa: E501
     expected_events = [EvmEvent(
@@ -496,14 +464,10 @@ def test_stability_pool_withdrawal(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0c3ce74FCB2B93F9244544919572818Dc2AC0641']])
-def test_ds_proxy_liquity_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_ds_proxy_liquity_deposit(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     evmhash = deserialize_evm_tx_hash('0x83e9930bee6a993204ade072ac6753249f9773b0da243b7efdb6cbba1e0bff6c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -549,14 +513,10 @@ def test_ds_proxy_liquity_deposit(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0c3ce74FCB2B93F9244544919572818Dc2AC0641']])
-def test_ds_proxy_liquity_withdraw(database, ethereum_inquirer, ethereum_accounts):
+def test_ds_proxy_liquity_withdraw(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     evmhash = deserialize_evm_tx_hash('0xdac8d9273a17b00fb81e89839d0c974e393db406a641552051419646b902c4b3')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -616,14 +576,10 @@ def test_ds_proxy_liquity_withdraw(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xEa00FC641a817e5F3eded4743aac7AB08dbf74b0']])
-def test_ds_proxy_liquity_staking(database, ethereum_inquirer, ethereum_accounts):
+def test_ds_proxy_liquity_staking(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     evmhash = deserialize_evm_tx_hash('0x48aa71f1af847d93601f03777ba960281bc9405bbdcc2fdb8c64f2a3350f354a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -702,14 +658,10 @@ def test_ds_proxy_liquity_staking(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF35da7a42d92c7919172195aA7BC7a0d43eC866c']])
-def test_ds_proxy_borrow_lusd(database, ethereum_inquirer, ethereum_accounts):
+def test_ds_proxy_borrow_lusd(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xa7404dc759fdef08fde6dbb227d6c55276861853d274c9a739236488a123f794')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1704486503000)
     gas_str, debt_str, fee_str = '0.006847541539452045', '50000', '300.21680310311845'
     expected_events = [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_llamazip.py
+++ b/rotkehlchen/tests/unit/decoders/test_llamazip.py
@@ -21,13 +21,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0xbF79b07d1311DF96CdDC53C71397271Ae8a2B0E9']])
-def test_llamazip_optimism_swap_token_to_eth(database, optimism_inquirer, optimism_accounts):
+def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa6271df026c97691148b0bcd53096cdbec91394b74f93e6e86ab046852f4a115')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724034205000), '0.000000114027950239', '1.653522515434244221', '0.000626208109106399'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -74,13 +70,9 @@ def test_llamazip_optimism_swap_token_to_eth(database, optimism_inquirer, optimi
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0xa521E425f37aCC731651565B41Ce3E5022274F4F']])
-def test_llamazip_optimism_swap_eth_to_token(database, optimism_inquirer, optimism_accounts):
+def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6caae7d1a32abecf9dcc23c89e11fecfb9fccd2b21e718c0f62c6f001eb7a626')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724081427000), '0.000000754413255739', '0.005', '12.918744'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -127,13 +119,9 @@ def test_llamazip_optimism_swap_eth_to_token(database, optimism_inquirer, optimi
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x1D84C9Ab259372Ab07BEE9549a6aCF28DC111001']])
-def test_llamazip_optimism_swap_token_to_token(database, optimism_inquirer, optimism_accounts):
+def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x92e9af072a20b74d730037b80a96bf7ab02168679624bc87de8b3427e88882fd')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724074841000), '0.000000292773423793', '24.786522600837181987', '24.780601'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -180,11 +168,10 @@ def test_llamazip_optimism_swap_token_to_token(database, optimism_inquirer, opti
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x635Cb8149C292Ff96F71a1a49120D04053c7eE7A']])
-def test_llamazip_arbitrum_swap_token_to_eth(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
+def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5a3e6748dd62b943918508a7495df0dc481a054af9dc607a7b85f167a9cc54c2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, fee_amount, spend_amount, receive_amount, a_usdce = TimestampMS(1679552792000), '0.0000306163', '36', '0.020467522941555658', Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8')  # noqa: E501
@@ -245,11 +232,10 @@ def test_llamazip_arbitrum_swap_token_to_eth(database, arbitrum_one_inquirer, ar
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x5Ef3D4F41791f0B9f1CEe6D739d77748f81FCa3A']])
-def test_llamazip_arbitrum_swap_eth_to_token(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
+def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd75a0b795e0748dffdedc80b731710e9596f6af5fbc77274482cc785ed4c1cd3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1679521589000), '0.0000419029', '0.125', '215.453696'  # noqa: E501
@@ -298,11 +284,10 @@ def test_llamazip_arbitrum_swap_eth_to_token(database, arbitrum_one_inquirer, ar
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9fAe1b2Be0A8D7e64780fd740F8AD05188E8170A']])
-def test_llamazip_arbitrum_swap_token_to_token(database, arbitrum_one_inquirer, arbitrum_one_accounts):  # noqa: E501
+def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb1f65779afe9b92edd791af3b95ea36c46d6a6e8f8cc60f4740bb11b79993a92')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, fee_amount, spend_amount, receive_amount, a_weth = TimestampMS(1679511150000), '0.0000360038', '0.071985413648931875', '0.00454144', Asset('eip155:42161/erc20:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1')  # noqa: E501
@@ -363,11 +348,10 @@ def test_llamazip_arbitrum_swap_token_to_token(database, arbitrum_one_inquirer, 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xa716c2ef62B60cF82B8119947030ea7E26A39908']])
-def test_llamazip_arbitrum_swap_eth_to_arb(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_llamazip_arbitrum_swap_eth_to_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf9d2cb0f7593181f3a296647205a184f820dcba36273a4e8486cad545ad1bf39')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724091866000), '0.00000154191', '0.0001', '0.487303878224941508'  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_lockedgno.py
+++ b/rotkehlchen/tests/unit/decoders/test_lockedgno.py
@@ -18,15 +18,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xfcA5BDce638Fb8b80438bdb41F5CedcAA8893bc7']])
-def test_lock_gno(database, ethereum_inquirer, ethereum_accounts):
+def test_lock_gno(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xe74bd8d81a057942d734d16303d74b9ae01dcd5659488f7955c36d6be5b107fe')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1643833498000)
     amount_str = '5.207408513473562376'
     expected_events = [
@@ -76,15 +72,11 @@ def test_lock_gno(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xc62b361FdC14210dA59b9F5c3Ba7FAa7d61893a4']])
-def test_unlock_gno(database, ethereum_inquirer, ethereum_accounts):
+def test_unlock_gno(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x60b03b2bf3861c68a508f54a233d9ed742ddcd57899e730c57cc10f2939b0df0')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1682246147000)
     amount_str = '7.232204655685847974'
     expected_events = [

--- a/rotkehlchen/tests/unit/decoders/test_makerdao.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao.py
@@ -14,20 +14,13 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648aA14e4424e0825A5cE739C8C68610e143FB79']])
-def test_makerdao_simple_transaction(
-        database,
-        ethereum_inquirer,
-):
+def test_makerdao_simple_transaction(ethereum_inquirer):
     """Data taken from
     https://etherscan.io/tx/0x95de47059bcc084ebb8bdd60f48fbcf05619c2af84bf612fdc27a6bbf9b5097e
     """
     tx_hash = deserialize_evm_tx_hash('0x95de47059bcc084ebb8bdd60f48fbcf05619c2af84bf612fdc27a6bbf9b5097e')  # noqa: E501
     # We don't need any events here, we just check that no errors occured during decoding
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert events == [
         EvmEvent(
             tx_hash=tx_hash,
@@ -61,17 +54,9 @@ def test_makerdao_simple_transaction(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xa217BDa86b0EDb86eE7d4D6e34F493eDF1ea4F29']])
-def test_withdraw_dai_from_sdai(
-        database,
-        ethereum_inquirer,
-        ethereum_accounts,
-):
+def test_withdraw_dai_from_sdai(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6b2a1f836cfc7c28002e4ac60297daa6d79fcde892d9c3b9ca723dea2f21af5c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1695854591000)
     sdai = A_SDAI.resolve_to_evm_token()
@@ -120,18 +105,10 @@ def test_withdraw_dai_from_sdai(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xa217BDa86b0EDb86eE7d4D6e34F493eDF1ea4F29']])
-def test_deposit_dai_to_sdai(
-        database,
-        ethereum_inquirer,
-        ethereum_accounts,
-):
+def test_deposit_dai_to_sdai(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x27bd72a2ccd999a44c2a7aaed9090572f34045d62e153362a34715a70ca7a6a7')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1695089927000)
     address = A_SDAI.resolve_to_evm_token().evm_address
     assert events == [

--- a/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
@@ -2199,7 +2199,6 @@ def test_makerdao_sai_cdp_migration(ethereum_transaction_decoder, ethereum_accou
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=evmhash,
     )
     expected_events = [
@@ -2330,7 +2329,6 @@ def test_sai_dai_migration(ethereum_transaction_decoder, ethereum_accounts):
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=evmhash,
     )
     timestamp = TimestampMS(1575726133000)

--- a/rotkehlchen/tests/unit/decoders/test_metamask.py
+++ b/rotkehlchen/tests/unit/decoders/test_metamask.py
@@ -36,15 +36,11 @@ A_POLYGON_USDC = Asset('eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7e6Ee5d52825B3A3d9C500E7B8b0a2BAa1c91545']])
-def test_metamask_swap_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_metamask_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0x9b675024d8648c3b590eff411fcf75a1199d10d1a3fe2ddbe50e166ce8b87cc9',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1696160411000)
     approval_amount, swap_amount, received_amount, gas_fees, metamask_fee = '115792089237316195423570985008687907853269984665640564032906.862642668551001919', '6550.721365244578638016', '0.017595546435556104', '0.001533786820220988', '0.000153961031311116'  # noqa: E501
@@ -117,15 +113,11 @@ def test_metamask_swap_token_to_eth(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4bc63637428B1cb65E646d6CF3216A4B4C84f446']])
-def test_metamask_swap_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_metamask_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0xf1ac0081467b2f758758d2ff6afc7149b7937efa1f79904082c4c6d4a810e57b',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1702292675000)
     swap_amount, received_amount, gas_fees, fee_amount = '0.0495625', '2595.147664794130524115', '0.004927174848537517', '0.0004375'  # noqa: E501
@@ -186,15 +178,11 @@ def test_metamask_swap_eth_to_token(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4E2A6f9F27AC0B4bd4E1729640e06888F432030C']])
-def test_metamask_swap_usdt_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_metamask_swap_usdt_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0xc31b87085cf0195c63d536bbfd2fc42194d27462cfc1cdf7a8eaa885ce6dff38',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1702376699000)
     swap_amount, received_amount, gas_fees, fee_amount = '568.614655', '157279690809.103532500734254552', '0.007519637280969888', '5.019297'  # noqa: E501
@@ -255,15 +243,11 @@ def test_metamask_swap_usdt_to_token(database, ethereum_inquirer, ethereum_accou
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xDe0A989c715C594Eadc98a1b97a9aa65d3cECb48']])
-def test_metamask_swap_token_to_usdc(database, ethereum_inquirer, ethereum_accounts):
+def test_metamask_swap_token_to_usdc(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0x17e8c0e123081c77b5bb553bd3cf553d4031547f5d8884b31c8d74bb76057add',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1702376675000)
     swap_amount, received_amount, gas_fees, fee_amount = '52000000000', '2837.148343', '0.01015815871814444', '24.824308'  # noqa: E501
@@ -324,15 +308,11 @@ def test_metamask_swap_token_to_usdc(database, ethereum_inquirer, ethereum_accou
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x94c3951a05df16b2e744937574778fFeb10a51b2']])
-def test_metamask_swap_token_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_metamask_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0x5f67ce35264b7c9313cb626b133c0d99e38fcd5fd40518920aa2deb4ea67303c',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1702399619000)
     swap_amount, received_amount, gas_fees, fee_amount, approval_amount = '89.301543595802992849', '323.028598123743886055', '0.036588478688486165', '0.788286009042397163', '90071443.400914235154609988'  # noqa: E501
@@ -405,13 +385,12 @@ def test_metamask_swap_token_to_token(database, ethereum_inquirer, ethereum_acco
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x517725Caf62Fca000C0ea950497116933f813E38']])
-def test_metamask_swap_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_metamask_swap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0x91733fb94bbb2de9d7fccfd87e41d5498245b74583902ddf02debe8c70a44d7e',
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -474,15 +453,11 @@ def test_metamask_swap_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_ac
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xc29067833665820b3505953a87F8265C9f1A517b']])
-def test_metamask_swap_optimism(database, optimism_inquirer, optimism_accounts):
+def test_metamask_swap_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0x9c5debedbbd19fdcb1701e9905a2f0ebf31159eb8073f66de62ffda5680d1d14',
     )
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     user_address = optimism_accounts[0]
     timestamp = TimestampMS(1702469285000)
     swap_amount, received_amount, gas_fees, fee_amount = '148.6875', '148.608467', '0.000354333259086529', '1.3125'  # noqa: E501
@@ -543,13 +518,12 @@ def test_metamask_swap_optimism(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xB12897740478eeC7B86b9eBf14245cDAcBBa4F2f']])
-def test_metamask_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_metamask_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash(
         '0x9862e755e27b5e88f8b782c8264b0a8f55934084dd57d97753be8d540ee8ec67',
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address = polygon_pos_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_monerium.py
+++ b/rotkehlchen/tests/unit/decoders/test_monerium.py
@@ -12,13 +12,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da']])
-def test_minting_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_minting_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(val='0x4ed9db44c5ee4ba6a4cf3e8e9b386f0b857afebad8339a92666e175c747bdd74')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     amount_str = '1500'
     expected_events = [
         EvmEvent(
@@ -40,13 +36,9 @@ def test_minting_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x99a0618B846D43E29C15ac468Eae06d03C9243C7']])
-def test_burning_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_burning_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash(val='0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     amount_str = '1161210.84'
     expected_events = [
         EvmEvent(
@@ -68,11 +60,10 @@ def test_burning_monerium_on_eth(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x762e5f511c219823eeC73C743C8245807A53E123']])
-def test_minting_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_minting_monerium_on_matic(polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xb240acc158fb2cdcdebc7321ca4a96f71b371379e2a78a9a7f27d0718a2e3735')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     amount_str = '95'
@@ -96,11 +87,10 @@ def test_minting_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_a
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x0A251dF99A88A20a93876205Fb7f5Faf2E85A481']])
-def test_burning_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_burning_monerium_on_matic(polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xeaed8e3e862a9b41189e9039c825ee57fb80385801b8ac5c3ed70339baf243e5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     amount_str = '208.93'
@@ -124,11 +114,10 @@ def test_burning_monerium_on_matic(database, polygon_pos_inquirer, polygon_pos_a
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x9566E3e6F55D4378243E55DE8e037Ee8E6e4de7E']])
-def test_minting_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
+def test_minting_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
     evmhash = deserialize_evm_tx_hash(val='0x31183d757f530f799872600e6fe8644e3c20a1f90d02de9e89d0463454b400fa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     amount_str = '66'
@@ -152,13 +141,9 @@ def test_minting_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0xAf31992307AcBb6Ad8795261EeA31494e62A8e40']])
-def test_burning_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
+def test_burning_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xae087f309231e4dc1fa84927888deb6c56b9980e63f9cc049cbe2d7d2bc503e6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=evmhash)
     amount_str = '1'
     expected_events = [
         EvmEvent(
@@ -180,13 +165,9 @@ def test_burning_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x39c185721fbe8b350363e6B49801305d32485A45']])
-def test_burnfrom_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts):
+def test_burnfrom_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
     evmhash = deserialize_evm_tx_hash(val='0xf04a5d84e6749828ff63991fb3323944472346c3b2c421e51d9999283d18f1fd')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=evmhash)
     amount_str = '501.04'
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_octant.py
+++ b/rotkehlchen/tests/unit/decoders/test_octant.py
@@ -17,15 +17,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_lock_glm(database, ethereum_inquirer, ethereum_accounts):
+def test_lock_glm(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x29944efad254413b5eccdd5f13f14642ab830dbf51d5f2cfc59cf4957f33671a')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1697572739000)
     gas_str = '0.000721453620442015'
     approval_str = '199999000'
@@ -75,15 +71,11 @@ def test_lock_glm(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xa8258ED271BB9be9d7E16c5818E45eF6F2577d92']])
-def test_unlock_glm(database, ethereum_inquirer, ethereum_accounts):
+def test_unlock_glm(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x6705075bef0c3d9167c95a4a6c4911d6cc4055365e12fc445acd1039b157b1ab')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1697527487000)
     gas_str = '0.000482531053547631'
     amount_str = '500'
@@ -120,15 +112,11 @@ def test_unlock_glm(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd1B8dB70Ded72dB850713b2ce7e1A4FfAfAD95d1']])
-def test_claim_rewards(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_rewards(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xfc9b4ca277dcfd8000830aee13f8785b15516ce55a432c0d68f1bbdc0f599a49')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1706775971000)
     gas_str = '0.000818835884130552'
     amount_str = '7.989863001451442888'

--- a/rotkehlchen/tests/unit/decoders/test_odos_v1.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v1.py
@@ -18,13 +18,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x605572243c30Af7493707C9c8E8aA2Ee25537e9A']])
-def test_swap_token_to_token_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xce86cc4bb232af0ede2342b012270b1db4c61082ce2e32d8d274166cc9839143')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, approval_amount, swap_amount, received_amount, odos_fees_eth, gas_fees = TimestampMS(1691645135000), '115792089237316195423570985008687907853269984665640564035457.584007913129639935', '4000', '2.15484532751231104', '0.000151599541198592', '0.00403543'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -95,11 +91,10 @@ def test_swap_token_to_token_ethereum(database, ethereum_inquirer, ethereum_acco
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xcC91A1Fa81d7c4b10C4ECe01AbEb3EeE55e5373c']])
-def test_swap_token_to_eth_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x98805f922be9de669ddbb7c398db3c1bfb692530ad32fa72b40ac5aba49b895e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, approval_amount, swap_amount, received_amount, odos_fees_eth, gas_fees = TimestampMS(1693606715000), '115792089237316195423570985008687907853269984665640564039457.580725740003253015', '0.00328217312638692', '0.003282173126386919', '0.000000000000000001', '0.0000798467'  # noqa: E501
@@ -172,13 +167,9 @@ def test_swap_token_to_eth_arbitrum(database, arbitrum_one_inquirer, arbitrum_on
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x61c7953578576F56E369482cBbE545733798a3b7']])
-def test_swap_eth_to_token_optimism(database, optimism_inquirer, optimism_accounts):
+def test_swap_eth_to_token_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x82e41cedb2265288f4475d8c7137bcaa031e5969ecbfa21551a797f5a7a71e8f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1691607223000), '1.347', '2494.738788', '0.000108989578875775'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -224,11 +215,10 @@ def test_swap_eth_to_token_optimism(database, optimism_inquirer, optimism_accoun
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x0638df8ce244060e2ce2eEC04484334a99608Fa6']])
-def test_swap_matic_to_token_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_swap_matic_to_token_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3802c36346914887b09d65d6ace796ba2549a8947aed9087475b78cef3b089e8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, swap_amount, received_amount, odos_fees_eth, gas_fees = TimestampMS(1700674099000), '5', '420.01909972952905', '66.153912047014979328', '0.022903685'  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_odos_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v2.py
@@ -23,13 +23,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd1AcFE3854229682ff38fc6bbdFa81211020DaB8']])
-def test_swap_token_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0efcdf00cf582b5befb367e4527bcde302c3bb078aa7683c51b3a14df5ae2e1e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721202275000), '6421.31', '7037.875022', '0.00129060601'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -75,13 +71,9 @@ def test_swap_token_to_token(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x3097eCF8195aBc13dA5a56a16D686Fc3166EB056']])
-def test_swap_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf2e7b37c24428631dad93b436019aa1602dbc4315f06a231a87b75b33f2f3491')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721210603000), '0.252163033513435945', '0.252169099350692012', '0.00211742541059688'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -127,13 +119,9 @@ def test_swap_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd68f1ee4e3f7c54295F296B9a579664767784a2c']])
-def test_swap_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3bd3fa946e7da66914bd0c90deccea9ed41fd19e6f7b34e23e7a971eaffa48d8')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, gas_fees = TimestampMS(1721215703000), '0.48', '0.000956250976660625'
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -179,13 +167,9 @@ def test_swap_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xB3dB8a7fB7f35CD64A46d5F06992DF99F815e67d']])
-def test_swap_multi_to_single(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xedc73ef9cec8f60630a509d87038e8826f6ca334443ffc025e03d212ffa9e267')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount_barron, swap_amount_sapo, received_amount, odos_fees, gas_fees = TimestampMS(1721212283000), '21952.133805449', '25347.248642364588152989', '0.008056869560090457', '0.000000805767532763', '0.001959751810319688'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -281,13 +265,9 @@ def test_swap_multi_to_single(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x62975846Ad2401b4dD9d65D7aE5BD40B4239CB23']])
-def test_swap_single_to_multi(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa331b8a62ccf8a62960a6a4edda43f3b835c0a76b5c6365691936077787a5507')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, received_amount_sfrax, received_amount_rgusd, odos_fees_sfrax, odos_fees_rgusd, gas_fees = TimestampMS(1721103275000), '0.01', '16.393269664059458706', '17.599136295574420014', '0.001639490915497496', '0.001760089638521295', '0.00234938705101066'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -372,13 +352,9 @@ def test_swap_single_to_multi(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd0392C8cE1b658f1f3D5dFcbacA159F90625E87F']])
-def test_swap_multi_to_multi(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2ae9298c00c76fc63df4112a7924a5deb908f095cb9d41d284e890aee31ca114')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount_sweth, swap_amount_usdc, received_amount_eth, received_amount_cbeth, odos_fees_eth, odos_fees_cbeth, gas_fees = TimestampMS(1720651511000), '0.300942750197910709', '5.085873', '0.21177820231350276', '0.101348638838421792', '0.000021179938225173', '0.000010135877471590', '0.00194866414'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -488,11 +464,10 @@ def test_swap_multi_to_multi(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x437AD8a22CeeD33cBC4e661f8ef33D57a390d287']])
-def test_swap_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_swap_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xab0ca6d2749425e0e45a60dc66daa5059276bf2b97db5939949e24564dff9826')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721303364000), '5', '3.797619', '0.000006397028928'  # noqa: E501
@@ -552,13 +527,9 @@ def test_swap_on_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_acco
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0x19B43787fbC106d427Be3ca3307d4Fb0A73D83Dc']])
-def test_swap_on_base(database, base_inquirer, base_accounts):
+def test_swap_on_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2029ab1ad9985a21c8a064be8384b531d55864f37f16a1716a00da8577891aab')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp, approval_amount, swap_amount, received_amount, gas_fees = TimestampMS(1721303613000), '9007199254724259.054195778508578652', '10.586121519928495085', '0.003163240870272189', '0.00000767513097358'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -616,13 +587,9 @@ def test_swap_on_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x1a8C829cA8F9525AB2bc812460BE4Ba8f32B586E']])
-def test_swap_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc7c9b85ba66e6d262a5bf23afd75a49ffb6c079979587d5bbc1dddd647afc906')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, approval_amount, swap_amount_usdc, swap_amount_usdce, received_amount, odos_fees, gas_fees = TimestampMS(1721310953000), '115792089237316195423570985008687907853269984665640564039457584007913129.447868', '1.199279', '0.192067', '0.000401886614321588', '0.000000040192680701', '0.000015691756359161'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,
@@ -706,11 +673,10 @@ def test_swap_on_optimism(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xB14cF335808931BDED4B232c6d01C65e5E73237F']])
-def test_swap_on_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x82bd45bcf1faf80f4b2e0d12b3e45c5801d1065a7e6a7daf68cd35a3a33c5fc7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp, approval_amount, swap_amount, received_amount, gas_fees = TimestampMS(1721305107000), '0.0000001', '0.0000019', '0.217325398483406396', '0.006751666697583186'  # noqa: E501
@@ -770,13 +736,9 @@ def test_swap_on_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('scroll_accounts', [['0x0a32d140700edb28165C88D1000A910c247dFDCA']])
-def test_swap_on_scroll(database, scroll_inquirer, scroll_accounts):
+def test_swap_on_scroll(scroll_inquirer, scroll_accounts):
     tx_hash = deserialize_evm_tx_hash('0x442e968d8a5c6adb81bf087041ed3dd19dc2f20725044c7f9c435bf6234d9992')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721305362000), '0.042810448486080933', '0.049288894534015152', '0.000033784756880726'  # noqa: E501
     expected_events = [EvmEvent(
         tx_hash=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_omni.py
+++ b/rotkehlchen/tests/unit/decoders/test_omni.py
@@ -20,14 +20,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9211043D7012457a51caB901e5b184dA2Ef8b245']])
-def test_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc626898273896eb771e9725137849dd104e388aad49687068a7681b5c54893fe')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str = TimestampMS(1713555527000), '0.000567969103578996'
     expected_events = [
         EvmEvent(
@@ -76,14 +72,10 @@ def test_claim(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x361D6a0A6ce25c833081DAa7C31c416D4295eC5A']])
-def test_stake(database, ethereum_inquirer, ethereum_accounts):
+def test_stake(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x66f47dc448d7371eeccaa500af1aea76a1620de56c621187be83b1cc19bf861c')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, omni_str = TimestampMS(1713604307000), '0.00061736344563685', '5.06213676'
     expected_events = [
         EvmEvent(
@@ -130,14 +122,10 @@ def test_stake(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x77782FcAFAF67576b7423ae5173CDe6D83695796']])
-def test_claim_and_stake(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_and_stake(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x630c32c20d75c51ffe7b1db1cb3d82d357a8db4da10c1c5b212e01f8e92f6310')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, omni_str = TimestampMS(1713602555000), '0.000645708531342875', '15.3275649'
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_omnibridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_omnibridge.py
@@ -21,13 +21,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xcA74F404E0C7bfA35B13B511097df966D5a65597']])
-def test_omnibridge_ethereum_token_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_omnibridge_ethereum_token_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x34b2058dd53b09c49fb415c402427f142d4da2789dff01655cc7254b949ec32d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, bridge_amount = ethereum_accounts[0], TimestampMS(1718409971000), '0.00097359584767956', '32.614964635297737403'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -61,13 +57,9 @@ def test_omnibridge_ethereum_token_deposit(database, ethereum_inquirer, ethereum
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x683fC308f72491B33D200b4EB10Fa9780904173d']])
-def test_omnibridge_ethereum_eth_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_omnibridge_ethereum_eth_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa19b48afa68a21ed7076559f7f6234c25d11645ea757f0d66f960056dc263a67')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, bridge_amount = ethereum_accounts[0], TimestampMS(1723812767000), '0.000927846227501566', '0.4'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -101,13 +93,9 @@ def test_omnibridge_ethereum_eth_deposit(database, ethereum_inquirer, ethereum_a
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xD2e5D774BE8dF6A2e5f091812e10149BbB12702f']])
-def test_omnibridge_gnosis_token_deposit(database, gnosis_inquirer, gnosis_accounts):
+def test_omnibridge_gnosis_token_deposit(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x36dfd776bcc430609ea47ea74893095f27e62e691d8622569cc43ea70cec3dd4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, bridge_amount = gnosis_accounts[0], TimestampMS(1723743095000), '0.000318556', '8416.007021'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -141,13 +129,9 @@ def test_omnibridge_gnosis_token_deposit(database, gnosis_inquirer, gnosis_accou
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9164dDF23c029E30b2eB0EbacbB4dEa3C0E1ac43']])
-def test_omnibridge_ethereum_token_withdrawal(database, ethereum_inquirer, ethereum_accounts):
+def test_omnibridge_ethereum_token_withdrawal(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa56d72db76b6c7cfd3db1d2d51902b6f611f5124157ae50a6fd2f5dac7bbfa54')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, bridge_amount = ethereum_accounts[0], TimestampMS(1723719059000), '0.000740577652951968', '8420.660675'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -181,13 +165,9 @@ def test_omnibridge_ethereum_token_withdrawal(database, ethereum_inquirer, ether
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x8D1D236F45a7DEcB769D88963b0F699cDBE5D833']])
-def test_omnibridge_ethereum_eth_withdrawal(database, ethereum_inquirer, ethereum_accounts):
+def test_omnibridge_ethereum_eth_withdrawal(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0d5b64cb8b79e4a728b22caf7ac51a0a595278fd6b2265775a4429a204e4e5e3')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, bridge_amount = ethereum_accounts[0], TimestampMS(1723786739000), '0.000333774965537772', '24.42848'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -221,13 +201,9 @@ def test_omnibridge_ethereum_eth_withdrawal(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xcc2c6D82e00E14f81FFc8e4F6A26c4522adA5a34']])
-def test_omnibridge_gnosis_token_withdrawal(database, gnosis_inquirer, gnosis_accounts):
+def test_omnibridge_gnosis_token_withdrawal(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6d4006bc0927588758911407d0f01124056453ab8828897a1c4a125a5f574520')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address, timestamp, bridge_amount = gnosis_accounts[0], TimestampMS(1598480695000), '300'
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_optimism.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism.py
@@ -21,16 +21,12 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [[ADDY]])
-def test_optimism_airdrop_1_claim(database, optimism_inquirer):
+def test_optimism_airdrop_1_claim(optimism_inquirer):
     """Data taken from
     https://optimistic.etherscan.io/tx/0xda810d7e1757c6ce7387b437c26472f802eec47404e60d4f1eaa9f23bf8d8b73
     """
     tx_hash = deserialize_evm_tx_hash('0xda810d7e1757c6ce7387b437c26472f802eec47404e60d4f1eaa9f23bf8d8b73')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1673337921000)
     expected_events = [
         EvmEvent(
@@ -65,13 +61,9 @@ def test_optimism_airdrop_1_claim(database, optimism_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x168FEB2E7de2aC0c37a239261D3F9e1b396F22a2']])
-def test_optimism_airdrop_4_claim(database, optimism_accounts, optimism_inquirer):
+def test_optimism_airdrop_4_claim(optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xb5b478b321a81ae03565dd72bd625fcb203a97f017670b28e306a893414ae83b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, claim_amount = TimestampMS(1712777987000), '0.000007620095114963', '6000'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -106,16 +98,12 @@ def test_optimism_airdrop_4_claim(database, optimism_accounts, optimism_inquirer
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [[ADDY]])
-def test_optimism_delegate_change(database, optimism_inquirer):
+def test_optimism_delegate_change(optimism_inquirer):
     """Data taken from
     https://optimistic.etherscan.io/tx/0xe0b31814f787385ab9f680c2ecf7e20e6dd2f880d979a44487768add26faa594
     """
     tx_hash = deserialize_evm_tx_hash('0xe0b31814f787385ab9f680c2ecf7e20e6dd2f880d979a44487768add26faa594')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1673338011000)
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_optimism_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism_bridge.py
@@ -20,16 +20,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
-def test_deposit_erc20(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_erc20(ethereum_inquirer, ethereum_accounts):
     """Data is taken from
     https://etherscan.io/tx/0x0297cc824348e477007dfea9b8a1e6a1ff9ddce3c4b35f170b4429bee5a8a00b
     """
     evmhash = deserialize_evm_tx_hash('0x0297cc824348e477007dfea9b8a1e6a1ff9ddce3c4b35f170b4429bee5a8a00b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -63,16 +59,12 @@ def test_deposit_erc20(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x18C22c88146B24a2c96E65c82666d976A4ba5a94']])
-def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_eth(ethereum_inquirer, ethereum_accounts):
     """Data is taken from
     https://etherscan.io/tx/0x4ccfa0fa8bf0a75030357c1ea0aa9040df4167785523e557beb640c00e039fb6
     """
     evmhash = deserialize_evm_tx_hash('0x4ccfa0fa8bf0a75030357c1ea0aa9040df4167785523e557beb640c00e039fb6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -106,14 +98,10 @@ def test_deposit_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
-def test_receive_erc20_on_optimism_legacy(database, optimism_inquirer, optimism_accounts):
+def test_receive_erc20_on_optimism_legacy(optimism_inquirer, optimism_accounts):
     """Legacy bridge deposit to optimism. Where l1fee exists in receipt data"""
     evmhash = deserialize_evm_tx_hash('0x1d47c8026bfc63ed0af553bd240430978cb43efba00864d597a747c90464074f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -135,14 +123,10 @@ def test_receive_erc20_on_optimism_legacy(database, optimism_inquirer, optimism_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_receive_erc20_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_receive_erc20_on_optimism(optimism_inquirer, optimism_accounts):
     """Newer bridge deposit to optimism. Where l1fee is 0 and missing from receipt data"""
     evmhash = deserialize_evm_tx_hash('0x0c0515e562917f86c8895765058df1d3df5aaf98aff00813c6f7d22c62a9b7d4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -164,16 +148,12 @@ def test_receive_erc20_on_optimism(database, optimism_inquirer, optimism_account
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xfc399B17D1Ddf01a518DcaeE557ef776bf288f63']])
-def test_receive_eth_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_receive_eth_on_optimism(optimism_inquirer, optimism_accounts):
     """Data is taken from
     https://optimistic.etherscan.io/tx/0x6a93d5aaa075c9c044d2591370cd5b9e83259370ddd618267c4757715da000c2
     """
     evmhash = deserialize_evm_tx_hash('0x6a93d5aaa075c9c044d2591370cd5b9e83259370ddd618267c4757715da000c2')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -195,16 +175,12 @@ def test_receive_eth_on_optimism(database, optimism_inquirer, optimism_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x261FD12AF4c4bAbb30F44c1B0FE20a718A39b04C']])
-def test_withdraw_erc20(database, optimism_inquirer, optimism_accounts):
+def test_withdraw_erc20(optimism_inquirer, optimism_accounts):
     """Data is taken from
     https://optimistic.etherscan.io/tx/0x5798c5d91658e6a3722f8507ca25ac9b21d7df555d364f5cd1f5578c92329412
     """
     evmhash = deserialize_evm_tx_hash('0x5798c5d91658e6a3722f8507ca25ac9b21d7df555d364f5cd1f5578c92329412')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -238,16 +214,12 @@ def test_withdraw_erc20(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xE232E72983E329757F02292322296f5B96dAfC8F']])
-def test_withdraw_eth(database, optimism_inquirer, optimism_accounts):
+def test_withdraw_eth(optimism_inquirer, optimism_accounts):
     """Data is taken from
     https://optimistic.etherscan.io/tx/0xe2111cddcd42c8214770c7a3270490c31663cd8b4b20b3fc27018ca3ce7a3979
     """
     evmhash = deserialize_evm_tx_hash('0xe2111cddcd42c8214770c7a3270490c31663cd8b4b20b3fc27018ca3ce7a3979')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -281,16 +253,12 @@ def test_withdraw_eth(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x261FD12AF4c4bAbb30F44c1B0FE20a718A39b04C']])
-def test_claim_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_erc20_on_ethereum(ethereum_inquirer, ethereum_accounts):
     """Data is taken from
     https://etherscan.io/tx/0xa577a47e439cc95d3f2b90f7c10a305c0c648c8f8b8a055872e622f341ab969e
     """
     evmhash = deserialize_evm_tx_hash('0xa577a47e439cc95d3f2b90f7c10a305c0c648c8f8b8a055872e622f341ab969e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -324,16 +292,12 @@ def test_claim_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xE232E72983E329757F02292322296f5B96dAfC8F']])
-def test_claim_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_eth_on_ethereum(ethereum_inquirer, ethereum_accounts):
     """Data is taken from
     https://etherscan.io/tx/0x785df1d7f2cb08ba956792393a2d947f1c18b39bd924e238811e4a14da10b0c4
     """
     evmhash = deserialize_evm_tx_hash('0x785df1d7f2cb08ba956792393a2d947f1c18b39bd924e238811e4a14da10b0c4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
@@ -367,16 +331,12 @@ def test_claim_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xC02ad7b9a9121fc849196E844DC869D2250DF3A6']])
-def test_prove_withdrawal(database, ethereum_inquirer, ethereum_accounts):
+def test_prove_withdrawal(ethereum_inquirer, ethereum_accounts):
     """Test that withdrawal proving of the 2-step withdrawal is recognized properly
     https://blog.oplabs.co/two-step-withdrawals/
     """
     evmhash = deserialize_evm_tx_hash('0xc68e09838d421ea4cdde39a30917579943a29d74e3d93266b52ee8ebdc841f78')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1694198291000)
     user_address = ethereum_accounts[0]
     gas_str = '0.015525942536120381'
@@ -412,13 +372,9 @@ def test_prove_withdrawal(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x74eEFF1A4D24C9Cd48FF9D8Dabd9Db0120b9Caf6']])
-def test_deposit_dai_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_dai_on_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xad659c207e54b3fdb2124e38b8cfa673851c49feb97115f45ba396f80a4fd35b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address, timestamp, gas_amount, deposit_amount = ethereum_accounts[0], TimestampMS(1723807967000), '0.0006873796276356', '97.27'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -452,13 +408,9 @@ def test_deposit_dai_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_deposit_dai_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_deposit_dai_on_optimism(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xd566bc86bdc88cf811fee5bbf5f233cb8add71642fdf547866f4054c4362a922')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address, timestamp, gas_amount, deposit_amount = optimism_accounts[0], TimestampMS(1670442294000), '0.000073960153367596', '106317.949168317256453804'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -492,13 +444,9 @@ def test_deposit_dai_on_optimism(database, optimism_inquirer, optimism_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_withdraw_dai_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_withdraw_dai_on_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x3e958996b7c4b2466ca9521d4c688ff4817c28d66bb3f52ec1174c6d0f1c44db')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address, timestamp, gas_amount, receive_amount = ethereum_accounts[0], TimestampMS(1671053711000), '0.0097257501', '106317.949168317256453804'  # noqa: E501
     assert events == [
         EvmEvent(
@@ -532,13 +480,9 @@ def test_withdraw_dai_on_ethereum(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x301605C95acbED7A1fD9C2c0DeEe964e2AFBd0C3']])
-def test_withdraw_dai_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_withdraw_dai_on_optimism(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0x785d75b9a5c93b2ad47b662f8f98f9c63d31cd629497bcbd846c57a70f76366e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address, timestamp, deposit_amount = optimism_accounts[0], TimestampMS(1724102399000), '309.321'  # noqa: E501
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
@@ -14,13 +14,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_vote_cast(database, optimism_inquirer, optimism_accounts):
+def test_vote_cast(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xeb9fb7b5047a30c4bb7e68343c6657ba4b0f0bcaf3d64972dcc01ccc3c10608b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -54,16 +50,12 @@ def test_vote_cast(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_vote_cast_with_params(database, optimism_inquirer, optimism_accounts):
+def test_vote_cast_with_params(optimism_inquirer, optimism_accounts):
     """Data is taken from
     https://optimistic.etherscan.io/tx/0x7f54f0d15d1790ca2dd3c4870d9421f09a52f5bbe7f09472f864dc248f90f412
     """
     evmhash = deserialize_evm_tx_hash('0x7f54f0d15d1790ca2dd3c4870d9421f09a52f5bbe7f09472f864dc248f90f412')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
@@ -97,13 +89,9 @@ def test_vote_cast_with_params(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_vote_cast_with_reason(database, optimism_inquirer, optimism_accounts):
+def test_vote_cast_with_reason(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xced69de2a81814554b9f69a19240737f0728f94bd67d94c73f960d24f99343bd')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     timestamp = TimestampMS(1706051703000)
     gas_amount = '0.000022621225472652'

--- a/rotkehlchen/tests/unit/decoders/test_paladin.py
+++ b/rotkehlchen/tests/unit/decoders/test_paladin.py
@@ -18,15 +18,11 @@ from rotkehlchen.utils.misc import timestamp_to_date
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xA2BF60058C0657C45FDd1741220b4A7F0DA91CA3']])
-def test_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x8a2bf33211bb1903ee3db7ca5a7bef10b168fdd68701cd3c9dc17c7b0c60a3f7')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas, amount, period = TimestampMS(1672197467000), '0.00120340458490378', '1079.056809836717269824', 1671062400  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_paraswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap.py
@@ -49,13 +49,9 @@ A_POLYGON_POS_DAI = Asset('eip155:137/erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf8fa0bB0798489445577fA7387dcB2125C361c28']])
-def test_simple_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_simple_swap_no_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xeab04bca5abb6a794fd83e3c336b128824a2d3a72abf565d82a6ecd39d5929ef')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704814775000)
     swap_amount, received_amount, approval_amount, gas_fees = '3860.977240111926214656', '3997.851328', '115792089237316195423570985008687907853269984665640564034996.606767801203425279', '0.003865522700588692'  # noqa: E501
@@ -116,13 +112,9 @@ def test_simple_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x711ee578860F6f621401A6148b09F69c1F8508B2']])
-def test_simple_swap_eth_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_simple_swap_eth_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xeeea20b39f157fe59fa4904fd4b62f8971188b53d05c6831e0ed67ee157e40c2')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704806231000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '3.020129914302378395', '3.019113864780728103', '0.00680806307180382', '0.028681581715416916'  # noqa: E501
@@ -183,13 +175,9 @@ def test_simple_swap_eth_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xd3669637F3C520d73eE922EA62D2C33F547F9Cd6']])
-def test_simple_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_simple_swap_token_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf4d28d1c46dde983fac73db8e651514fe7299edaf40870766462362b1b1a1d83')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704797495000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '138.2851', '1190.359719', '0.0034595', '11.308417'  # noqa: E501
@@ -263,13 +251,9 @@ def test_simple_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xf84C3222D213e53a053A97E426738Cb12c50CBA5']])
-def test_simple_buy(database, ethereum_inquirer, ethereum_accounts):
+def test_simple_buy(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x695739b3eab8dc7e6ef7f9b362983cfd4d9b81592b0840bd0ca69b0b2e8e51f9')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704888587000)
     swap_amount, received_amount, gas_fees = '223.031074350165285613', '200.000000000000000001', '0.00727228725913224'  # noqa: E501
@@ -317,13 +301,9 @@ def test_simple_buy(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x33e543cB6Be7b33fF95FAF61eA8106b384E74912']])
-def test_multi_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_multi_swap_no_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6f7313845874cb26cda5d63adcbf9899edf257f2e196a7ace641bdbb179947e7')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704815411000)
     swap_amount, received_amount, gas_fees = '400', '30.498415074803766847', '0.007613212553923857'
@@ -371,13 +351,9 @@ def test_multi_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xBc067f00652Ba0B3278a3d373431769F2805Bc27']])
-def test_multi_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_multi_swap_token_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0c55b3df325d145b82fbe4e135e88eeae9820b035842b2ec5e17ccb1357375c6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704883367000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '24996', '48398.029944956021622964', '0.010829082710902124', '91.956256895416441083'  # noqa: E501
@@ -438,13 +414,9 @@ def test_multi_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4e9B2f2B72F6A5B3735cD18357F0F0EF950D1Ba7']])
-def test_mega_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_mega_swap_no_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5c36bcfa67d3306a3fe21203b7279e589d26c9925d055b3174ac259b262345f3')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704802211000)
     swap_amount, received_amount, gas_fees = '219410.681102', '4.68800235', '0.019375015240876558'
@@ -505,13 +477,9 @@ def test_mega_swap_no_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x752921eAead738CFd1aEB8571a58480dB51e42C1']])
-def test_mega_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
+def test_mega_swap_token_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9c529e46976ce23d1caf3dc1c062ee3c9ec9c327014f5447761409788e842294')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704881183000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '42226.901446319896728285', '40567.774843', '0.028635611789064984', '0.858994'  # noqa: E501
@@ -572,13 +540,9 @@ def test_mega_swap_token_fee(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xe952e50D1F82bBfb5054311Ca689807e343a1ab8']])
-def test_swap_on_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_on_uniswap_v2_fork(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6fa4a6a9c0d9c5aad831cc1ff149fb7683c0573db93571bc43acb5b4848314ae')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704889739000)
     swap_amount, received_amount, gas_fees = '0.35', '835.81811', '0.00296189763180853'
@@ -626,13 +590,9 @@ def test_swap_on_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4AE269b8e9116f8E44797D7424E8351286FCDfab']])
-def test_swap_on_uniswap_v2_fork_with_permit(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_on_uniswap_v2_fork_with_permit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xaab04d564e1f065b350e6aa6fda9d0ff51082e8810520e691866fdade91ba9c4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704889595000)
     swap_amount, received_amount, approval_amount, gas_fees = '150', '150.152117', '115792089237316195423570985008687907853269984665640564039457584007913129.639935', '0.004565275677196416'  # noqa: E501
@@ -693,13 +653,9 @@ def test_swap_on_uniswap_v2_fork_with_permit(database, ethereum_inquirer, ethere
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA80F8ac7Fe79558854E26A49867D11f8cF9cC36B']])
-def test_buy_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts):
+def test_buy_uniswap_v2_fork(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x15df127374a04772df72b94685f60f71200da679e4bc2c334a12889fe2ab046c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1705575743000)
     swap_amount, received_amount, gas_fees = '0.396919294295211225', '40', '0.004393070468277507'
@@ -747,13 +703,9 @@ def test_buy_uniswap_v2_fork(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xB855c4eBb5b6eB3F2033aecC4E543e27BC39465D']])
-def test_direct_uniswap_v3_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_direct_uniswap_v3_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2b6e830d4b32c22b3c4c2a26dbdb9a17c3cc2962fc35d5b4cd5d56c58cbec68a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1704888899000)
     swap_amount, received_amount, gas_fees = '2010000', '3.265498018938813939', '0.005934293486927232'  # noqa: E501
@@ -801,13 +753,9 @@ def test_direct_uniswap_v3_swap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xE93EB339C3d826F8A4d14Cc14CA008375915000F']])
-def test_direct_curve_v1_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_direct_curve_v1_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5a601f524592627eaf3562e4cb1340880260a1bf627a984392308cdf79a828dc')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1705577795000)
     swap_amount, received_amount, gas_fees = '1175.108', '1343.06000017590196878', '0.008673416651691594'  # noqa: E501
@@ -868,13 +816,9 @@ def test_direct_curve_v1_swap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x6133de401FB609aACB767D8b379157731a09b66b']])
-def test_direct_curve_v2_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_direct_curve_v2_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2ea92952050e9f5cbf9b46619355a3b34822286443e10a6f5405573330def118')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1705502243000)
     swap_amount, received_amount, gas_fees = '5.48189', '184.099593744496046878', '0.01392159540206184'  # noqa: E501
@@ -922,13 +866,9 @@ def test_direct_curve_v2_swap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x23a49A9930f5b562c6B1096C3e6b5BEc133E8B2E']])
-def test_direct_balancer_v2_given_swap(database, ethereum_inquirer, ethereum_accounts):
+def test_direct_balancer_v2_given_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x606413e4074e79e68ee0f79eee96c94cf091e7c061a551d2dd2a27044fb007e7')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1705575743000)
     swap_amount, received_amount, gas_fees = '17438.484493735105063894', '0.253269184972671572', '0.006247513881593877'  # noqa: E501
@@ -1002,11 +942,10 @@ def test_direct_balancer_v2_given_swap(database, ethereum_inquirer, ethereum_acc
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xFee285cf79719FC3552c5F7c540554f09DAdAD21']])
-def test_simple_buy_fee_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_simple_buy_fee_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x92a422b746cc1ce14b795e5fc2239cdf3146482a5bc3c5278dccb1c3ccccdc17')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address = arbitrum_one_accounts[0]
@@ -1082,11 +1021,10 @@ def test_simple_buy_fee_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_o
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0x66CF237A0D3505E80eF083E0F8D4Cad09Fd0BFe4']])
-def test_simple_swap_no_fee_base(database, base_inquirer, base_accounts):
+def test_simple_swap_no_fee_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf93a7211656753e841899b40edf3a9ccfded6b40b6d7b3538a4215362f9bd34f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address = base_accounts[0]
@@ -1136,11 +1074,10 @@ def test_simple_swap_no_fee_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xDa2181fB19f2Fe365BeF6Ccb84209d6FDb0d1828']])
-def test_direct_curve_v1_swap_optimism(database, optimism_inquirer, optimism_accounts):
+def test_direct_curve_v1_swap_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x83ac5abc6819fca458f614e4fdbca6fe324bbea8b7ce5fb072bf99407cd8c031')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address = optimism_accounts[0]
@@ -1216,11 +1153,10 @@ def test_direct_curve_v1_swap_optimism(database, optimism_inquirer, optimism_acc
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xe03679B59AC0026036ba4518bc0d5e5F800Bd9c1']])
-def test_direct_uniswap_v3_swap_polygon(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_direct_uniswap_v3_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4f72cff63802c8eed51662e3d1e20bc7e86ac06cdc1aa490c26cfeee075b6018')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     user_address = polygon_pos_accounts[0]
@@ -1283,13 +1219,9 @@ def test_direct_uniswap_v3_swap_polygon(database, polygon_pos_inquirer, polygon_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x60A543647a1ecAccAADFc2DF27a2D1D74e60A39f']])
-def test_paraswap_fork_with_factory(database, ethereum_inquirer, ethereum_accounts):
+def test_paraswap_fork_with_factory(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x90d9e615e808d5d9b62f6f072c783e9a9f8417c46fcc6665a4aadd927dc74fce')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
 
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1646086826000)

--- a/rotkehlchen/tests/unit/decoders/test_pickle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pickle.py
@@ -22,14 +22,10 @@ PICKLE_JAR = string_to_evm_address('0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69')
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0f1a748cDF53Bbad378CE2C4429463d01CcE0C3f']])
-def test_pickle_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_pickle_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xba9a52a144d4e79580a557160e9f8269d3e5373ce44bce00ebd609754034b7bd')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, deposit_str, withdraw_str, approve_str = TimestampMS(1646619202000), '0.00355751579933013', '907.258590539447889901', '560.885632516582380401', '115792089237316195423570985008687907853269984665640564027654.491316674464992473'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -88,14 +84,10 @@ def test_pickle_deposit(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xC7Dc4Cd171812a441A30472219d390f4F15f6070']])
-def test_pickle_withdraw(database, ethereum_inquirer, ethereum_accounts):
+def test_pickle_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x91bc102e1cbb0e4542a10a7a13370b5e591d8d284989bdb0ca4ece4e54e61bab')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, deposit_str, withdraw_str = TimestampMS(1646873135000), '0.00389232626065528', '245.522202162316534411', '403.097099656688209687'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -142,14 +134,10 @@ def test_pickle_withdraw(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd7aC4581eF4E2BB6cC3734Da183B981bfd0Ee2A2']])
-def test_claim_cornichon(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_cornichon(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x23a52632e47eeaf9588972cc3f65a2101745952880be17828d810da3735f333f')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, amount_str = TimestampMS(1606695800000), '0.002380306', '125.214613076726835921'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_polygon.py
+++ b/rotkehlchen/tests/unit/decoders/test_polygon.py
@@ -17,14 +17,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x692C673814eDB9Fe6DB2a6F4227F40524240Cbec']])
-def test_matic_to_pol_migration(database, ethereum_inquirer, ethereum_accounts):
+def test_matic_to_pol_migration(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6c30b202e7223ea93b9d1c898d7012b699d14bec5434e8839fc290858718f6a2')  # noqa: E501
     timestamp = TimestampMS(1698285215000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '10000.28'
     gas_str = '0.001792178291324676'
     expected_events = [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_safe.py
+++ b/rotkehlchen/tests/unit/decoders/test_safe.py
@@ -21,17 +21,13 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
         '0x7ac712ec4C58dEd138CC4e63e0fd59F697cC6963',
     ],
 ])
-def test_added_owner(database, ethereum_inquirer, ethereum_accounts):
+def test_added_owner(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x2702bb7cf56d012b9bc85d66428a361d560172a5e519384e7c507db22d07090f')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
     multisig_address = ethereum_accounts[1]
     new_owner = '0xa0DD8E6c5440a424cD19f5Ec30F8fa485E814247'
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1611089364000)
     gas_amount_str = '0.004625442'
     expected_events = [
@@ -72,17 +68,13 @@ def test_added_owner(database, ethereum_inquirer, ethereum_accounts):
         '0x7ac712ec4C58dEd138CC4e63e0fd59F697cC6963',
     ],
 ])
-def test_removed_owner(database, ethereum_inquirer, ethereum_accounts):
+def test_removed_owner(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x868a3c64eb7e68a0c0fde4ec94f7825f1400ebba9aeefc284771b0136cbd72dd')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
     multisig_address = ethereum_accounts[1]
     removed_owner = '0x8a7dbC2824AcaC4d272289a33b255C3F1f3cdf32'
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1623789005000)
     gas_amount_str = '0.00130834'
     expected_events = [
@@ -123,16 +115,12 @@ def test_removed_owner(database, ethereum_inquirer, ethereum_accounts):
         '0x7ac712ec4C58dEd138CC4e63e0fd59F697cC6963',
     ],
 ])
-def test_changed_threshold(database, ethereum_inquirer, ethereum_accounts):
+def test_changed_threshold(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x8332c637f98362dea0885f744f121d09ac5c548603f833b9d0bd9513fa637c52')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
     multisig_address = ethereum_accounts[1]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1614713692000)
     gas_amount_str = '0.005093127'
     expected_events = [
@@ -168,18 +156,14 @@ def test_changed_threshold(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_execution_success(database, ethereum_inquirer, ethereum_accounts):
+def test_execution_success(ethereum_inquirer, ethereum_accounts):
     """
-    Test that a succesful safe transaction execution shows something if the executor is tracked
+    Test that a successful safe transaction execution shows something if the executor is tracked
     """
     tx_hex = deserialize_evm_tx_hash('0x7bfaa362453a9320243d7f604b7ffff10c31964a62e779a8cd280987b203875f')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     multisig_address = '0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52'
     timestamp = TimestampMS(1656087756000)
     gas_amount_str = '0.006953999441541852'
@@ -216,18 +200,14 @@ def test_execution_success(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x0Cec743b8CE4Ef8802cAc0e5df18a180ed8402A7']])
-def test_execution_failure(database, ethereum_inquirer, ethereum_accounts):
+def test_execution_failure(ethereum_inquirer, ethereum_accounts):
     """
     Test that a failed safe transaction execution shows something if the executor is tracked
     """
     tx_hex = deserialize_evm_tx_hash('0xf4b387bac0e6fa05b811098fb747297bdb9ce06152aa9e841750a85ed4d4bece')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     multisig_address = '0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52'
     timestamp = TimestampMS(1599570321000)
     gas_amount_str = '0.020435096'
@@ -264,16 +244,12 @@ def test_execution_failure(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x96399Ddb62d833029fbEf774d1FE044AF33E98Ef']])
-def test_safe_creation(database, ethereum_inquirer, ethereum_accounts):
+def test_safe_creation(ethereum_inquirer, ethereum_accounts):
     """Test that creation of new safes is tracked"""
     tx_hex = deserialize_evm_tx_hash('0xa9e3c581f39403a0a2eb5a3e604be715c0a4ee8aa4bcc9bddece5c268b47e233')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1691846051000)
     gas_amount_str = '0.004928138478008416'
     expected_events = [
@@ -309,14 +285,13 @@ def test_safe_creation(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])  # yabir.eth  # noqa: E501
-def test_safe_spam(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_safe_spam(polygon_pos_inquirer, polygon_pos_accounts):
     """Test that a safe transaction if from an unrelated account, does not appear in events"""
     tx_hex = deserialize_evm_tx_hash('0xefb07f4d166d6887eada96e61fd6821bfdf889d5435d75ab44d4ca0fa7627396')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = polygon_pos_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     timestamp = TimestampMS(1651102781000)
@@ -345,14 +320,10 @@ def test_safe_spam(database, polygon_pos_inquirer, polygon_pos_accounts):
     '0x4a24fe31b4D7215e7643f738058130054f9b3F3A',
     '0xF2961617C402404A4BB0Cd3d83992b5B4C8090eE',
 ]])
-def test_safe_vesting_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_safe_vesting_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc831d94b43be533e83562da9bc10b38b4bab6ce6046c3a9baf76c5359634625a')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1717404395000), '0.00123180896602807', '20549.221611721611721612'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -404,14 +375,10 @@ def test_safe_vesting_claim(database, ethereum_inquirer, ethereum_accounts):
     '0x663aD41156a9B2Da7Ead2edC6494E102c9b36184',
     '0xA76C44d0adD77F9403715D8B6F47AD4e6515EC8c',
 ]])
-def test_safe_lock(database, ethereum_inquirer, ethereum_accounts):
+def test_safe_lock(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xad3d976ae02cf82f109cc2d2f3e8f2f10df6a00a4825e3f04cf0e1b7e68a06b8')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1719926867000), '0.00072087801264352', '5115.763372'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -487,14 +454,10 @@ def test_safe_lock(database, ethereum_inquirer, ethereum_accounts):
     '0xdfDA7181EB27A69d897E82cF96C5BcbdC3c059B0',
     '0x51C40354119dd14C02d8ab24ed72C12D29f8cdA4',
 ]])
-def test_safe_unlock(database, ethereum_inquirer, ethereum_accounts):
+def test_safe_unlock(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x51d4c06ff00be729fe5bc79215253e45e65ce4c8531cd249633c6e76754c89d0')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1721101211000), '0.0003433', '1026.126150242296748346'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -545,14 +508,10 @@ def test_safe_unlock(database, ethereum_inquirer, ethereum_accounts):
     '0xf901C093edC3AB68c796eD29253E8EAf3349663f',
     '0xd90c2DC41d97c62585841A8b6E0d500A5217B9Ab',
 ]])
-def test_safe_withdraw_unlocked(database, ethereum_inquirer, ethereum_accounts):
+def test_safe_withdraw_unlocked(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x9520c7e117225afc930d1092bf35c17e6726c6564ed4e757eeb6a3c29d10304b')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1721130791000), '0.00095328952396285', '2404.451820314008697626'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
@@ -28,13 +28,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfa8666aE51F5b136596248d9411b03AC9040fff0']])
-def test_deposit_eth_from_ethereum_to_scroll(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_eth_from_ethereum_to_scroll(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x1d924e2f2f63cf5a2d78ceaa6289658cf4743e968d23f78064d55c7428f78b60')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1711626707000)
     gas, amount, bridging_fee = '0.006936488814808056', '0.1179', '0.0002604'
@@ -83,13 +79,9 @@ def test_deposit_eth_from_ethereum_to_scroll(database, ethereum_inquirer, ethere
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xfa8666aE51F5b136596248d9411b03AC9040fff0']])
-def test_receive_eth_on_scroll(database, scroll_inquirer, scroll_accounts):
+def test_receive_eth_on_scroll(scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0xd47e37dc8acb08b86bd90214d1df15549305e6d5fe126b97ff3b66a1b814b801')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     user_address = scroll_accounts[0]
     timestamp = TimestampMS(1711627620000)
     amount = '0.1179'
@@ -113,13 +105,9 @@ def test_receive_eth_on_scroll(database, scroll_inquirer, scroll_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xEa72f0d67045b2cffbFB18E56744799f9F860CB7']])
-def test_withdraw_eth_from_scroll_to_ethereum(database, scroll_inquirer, scroll_accounts):
+def test_withdraw_eth_from_scroll_to_ethereum(scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x87c44e16cf62a8aa8e56b9677e6c400041b6731a5c24f9b8ca2deb6e00202a42')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     user_address = scroll_accounts[0]
     timestamp = TimestampMS(1708178454000)
     gas, amount = '0.00021234172322581', '0.6'
@@ -155,13 +143,9 @@ def test_withdraw_eth_from_scroll_to_ethereum(database, scroll_inquirer, scroll_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xEa72f0d67045b2cffbFB18E56744799f9F860CB7']])
-def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_receive_eth_on_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xed4d0ddc99b88caa07d5d15faf376abade6cc06eaf6a28dce47eac66695503c4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1708187711000)
     gas, amount = '0.003718494016624992', '0.6'
@@ -197,13 +181,9 @@ def test_receive_eth_on_ethereum(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xD297a2E732537f9fFb2Da53816FC84c7A50a11C2']])
-def test_deposit_erc20_from_ethereum_to_scroll(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_erc20_from_ethereum_to_scroll(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xd80e6894bce182c2976bb9fa64e162f1757a087057b00638b43fe0c5154cf1a6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1711698851000)
     gas, fee, amount = '0.005582179923194343', '0.000122880', '100'
@@ -252,13 +232,9 @@ def test_deposit_erc20_from_ethereum_to_scroll(database, ethereum_inquirer, ethe
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xD297a2E732537f9fFb2Da53816FC84c7A50a11C2']])
-def test_receive_erc20_on_scroll(database, scroll_inquirer, scroll_accounts):
+def test_receive_erc20_on_scroll(scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x630cd85723676d993f4afdd9f182cd2468444748eb7b1c6c0c8cc1db0d925c15')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     user_address = scroll_accounts[0]
     timestamp = TimestampMS(1711699803000)
     amount = '100'
@@ -282,14 +258,10 @@ def test_receive_erc20_on_scroll(database, scroll_inquirer, scroll_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x182A0c65bCB008adAaE404e30A813c9797BD717c']])
-def test_withdraw_erc20_from_scroll_to_ethereum(database, scroll_inquirer, scroll_accounts, caplog):  # noqa: E501
+def test_withdraw_erc20_from_scroll_to_ethereum(scroll_inquirer, scroll_accounts, caplog):
     """Test that USDT withdrawals from scroll to L1 work fine"""
     evmhash = deserialize_evm_tx_hash('0x0ff9e74db99dc2224fac1ab4e20cc8dba1cd1b0d089d657f0f005488b37cc20c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     user_address = scroll_accounts[0]
     timestamp = TimestampMS(1708535681000)
     gas, amount = '0.000430578838556533', '1000.001993'
@@ -328,16 +300,12 @@ def test_withdraw_erc20_from_scroll_to_ethereum(database, scroll_inquirer, scrol
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xa6145DFB72ADBd7D018c30f611bde7D943EE2E17']])
-def test_withdraw_usdc_from_scroll_to_ethereum(database, scroll_inquirer, scroll_accounts):
+def test_withdraw_usdc_from_scroll_to_ethereum(scroll_inquirer, scroll_accounts):
     """
     Test that USDC withdrawals from scroll to L1 work fine. This is just to test that
     our code is not token/gateway specific"""
     evmhash = deserialize_evm_tx_hash('0xc21fbdc6b7a2051eb10a53a255ed55c11f776a053d4dbd72954120ebe0120307')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
 
     user_address = scroll_accounts[0]
     timestamp = TimestampMS(1708534727000)
@@ -374,13 +342,9 @@ def test_withdraw_usdc_from_scroll_to_ethereum(database, scroll_inquirer, scroll
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x59ceD3eeB1cb01AfE92ADbC994D1CE78310E668E']])
-def test_receive_erc20_on_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_receive_erc20_on_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0xbe6e98db62ee719922c7d01b0b623e16c8ee162a2bf9143603f11eba3e3dd474')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1708223951000)
     gas, amount = '0.002531473518821568', '1647'
@@ -416,13 +380,9 @@ def test_receive_erc20_on_ethereum(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd32dEe97C7D7Fdfb826CC3bB210dD009D2750ae2']])
-def test_deposit_send_message_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_send_message_ethereum(ethereum_inquirer, ethereum_accounts):
     evmhash = deserialize_evm_tx_hash('0x7ae1e3ef6e4d87e2e44446a683b9ca624241a24d294b60ddec39af1309aeb37a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1708771043000)
     gas, fee, amount = '0.00353129959117221', '0.0000811440', '0.034'
@@ -471,13 +431,9 @@ def test_deposit_send_message_ethereum(database, ethereum_inquirer, ethereum_acc
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('scroll_accounts', [['0xd32dEe97C7D7Fdfb826CC3bB210dD009D2750ae2']])
-def test_receive_deposit_message_scroll(database, scroll_inquirer, scroll_accounts):
+def test_receive_deposit_message_scroll(scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x2844533993f614da06a4a81ee692f10562b4b2d077265a33605ca9415d0dcacb')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     user_address = scroll_accounts[0]
     timestamp = TimestampMS(1708772190000)
     amount = '0.034'

--- a/rotkehlchen/tests/unit/decoders/test_shapeshift.py
+++ b/rotkehlchen/tests/unit/decoders/test_shapeshift.py
@@ -14,14 +14,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3800966F67ccBA1976F69D006374204fba56d240']])
-def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x6635d1e12fed1a95019a53e6f6495c586891bf7b41bccfc5838f9b1703a9c20c')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1634470709000)
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_shutter.py
+++ b/rotkehlchen/tests/unit/decoders/test_shutter.py
@@ -17,14 +17,10 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xCc60Eb2f64E7AD9b6924939B7985970D29A0108c']])
-def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3f20929de51baefdc688997a05bde1e32120cb7d4e0fda5da3963b1a620d0a8b')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1706703155000)
     gas_amount_str, claimed_amount = '0.006946508605618104', '1086.95652173913'
     expected_events = [
@@ -61,14 +57,10 @@ def test_airdrop_claim(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x36bE40f9bd613dFf47294E7e10D4cae072E06A2D']])
-def test_shu_delegation(database, ethereum_inquirer, ethereum_accounts):
+def test_shu_delegation(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x46a476b09c85d2278f1ac889e943d7f47d029d0985719cc2a73d589a73cb2473')  # noqa: E501
     tx_hash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1705596215000)
     gas_amount_str = '0.00549203889835413'
     expected_events = [

--- a/rotkehlchen/tests/unit/decoders/test_socket.py
+++ b/rotkehlchen/tests/unit/decoders/test_socket.py
@@ -14,13 +14,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_optimism_to_arb_bridge(database, optimism_inquirer, optimism_accounts):
+def test_optimism_to_arb_bridge(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xe8c9cffe2a2bbccf81cf8dd34f9b89c01b00ae3f0ff74eab089de96f4624165c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     user_address = optimism_accounts[0]
     bridged_amount, gas_amount = '360.791433', '0.000035854553456552'
     timestamp = TimestampMS(1705844449000)
@@ -56,11 +52,10 @@ def test_optimism_to_arb_bridge(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-def test_bridge_eth(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_bridge_eth(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xb1e29bebca0300ff02ee478dfa6c0c2197169761e1c0dcc87418c53a6530d3a5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     user_address = arbitrum_one_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_stakedao.py
+++ b/rotkehlchen/tests/unit/decoders/test_stakedao.py
@@ -20,15 +20,11 @@ from rotkehlchen.utils.misc import timestamp_to_date
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6eEC7Dd840e3c1aBbaC157bB3C14e2aCBa72bC1e']])
-def test_claim_one(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_one(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3f747b34f1d0a6c59c62b5d6c3aba8f2bd278546cd53daa131327242c7c5b02e')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1684662791000)
     amount_str = '215.403304465915246838'
     period = 1684368000
@@ -67,15 +63,11 @@ def test_claim_one(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x54dEa0D442c3254419382f0b5Fc5D245eb241569']])
-def test_old_claim(database, ethereum_inquirer, ethereum_accounts):
+def test_old_claim(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc76710a3bd4428ae8f462f75b31fcf56bbf40c4cfe2746f62259437526735073')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas_str, amount_str, period = TimestampMS(1673676767000), '0.002265930693617121', '1.029361212967421451', 1673481600  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -112,15 +104,11 @@ def test_old_claim(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x3c28C42B24B7909c8292920929f083F60C4997A6']])
-def test_claim_multiple(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_multiple(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xc866db3fcbef6359919c444de324b6f059f299ed155f5bff00abd81537c88627')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1678952351000)
     period = 1678924800
     amount1_str = '43.57001129039620188'

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -28,13 +28,9 @@ ADDY_3 = string_to_evm_address('0x3D6a724247c4B133C3b279558e90EdD0c5d25751')
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_1]])
-def test_sushiswap_single_swap(database, ethereum_inquirer):
+def test_sushiswap_single_swap(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbfe3c8a13c325a32736beb34ea170053cdbbd1740a9c3ceca52060906b7f87bd')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas, swap_amount, received_amount, approved_amount = TimestampMS(1622840771000), '0.001815413', '19.157411925828275084', '18.47349725628421943', '115792089237316195423570985008687907853269984665640564039438.426595987301364851'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -95,14 +91,10 @@ def test_sushiswap_single_swap(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_2]])
-def test_sushiswap_v2_remove_liquidity(database, ethereum_inquirer):
+def test_sushiswap_v2_remove_liquidity(ethereum_inquirer):
     """This checks that removing liquidity to Sushiswap V2 pool is decoded properly"""
     tx_hash = deserialize_evm_tx_hash('0x4720a52fc768591cb3997da3a2eab76c54b69176f3c3f8d9a817c2d60dd449ac')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, spent_amount, removed_eth, removed_usdt, pool_address = TimestampMS(1672888271000), '0.006668386', '0.0000243611620791', '1.122198589808876532', '1408.739932', string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553')  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -165,14 +157,10 @@ def test_sushiswap_v2_remove_liquidity(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_3]])
-def test_sushiswap_v2_add_liquidity(database, ethereum_inquirer):
+def test_sushiswap_v2_add_liquidity(ethereum_inquirer):
     """This checks that adding liquidity to Sushiswap V2 pool is decoded properly"""
     tx_hash = deserialize_evm_tx_hash('0x2ce6f92f4020fdc4ed69a173b10c1dd2811184fac34d56188270950db1152f3a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp, gas_amount, received_amount, deposited_eth, deposited_usdt, pool_address = TimestampMS(1672893947000), '0.0030789891485573', '0.000000017297304741', '0.000797012710918264', '0.999992', string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553')  # noqa: E501
     lp_token_identifier = evm_address_to_identifier(
         address=pool_address,

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -28,13 +28,9 @@ ADDY_USER_3_ARB = string_to_evm_address('0xBe79986821637afD1406BF9278DA55cf9085c
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
-def test_thegraph_delegate(database, ethereum_inquirer):
+def test_thegraph_delegate(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x6ed3377db652151fb8e4794dd994a921a2d029ad317bd3f2a2916af239490fec')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1690731467000)
     delegate_amount, delegate_tax, gas_fees = '998.98', '5.02', '0.002150596408306665'
     approval_amount = '115792089237316195423570985008687907853269984665640563952473.318503163402575923'  # noqa: E501
@@ -100,13 +96,9 @@ def test_thegraph_delegate(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_ROTKI]])
-def test_thegraph_contract_deposit_gas(database, ethereum_inquirer):
+def test_thegraph_contract_deposit_gas(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xf254ac1bbfbf07ca21042edd3ff78dad7c3158c8218598b5359b6e415e0977b7')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1706311139000)
     gas, deposit_amount = '0.000626151499903872', '0.001135647343563552'
     indexer = string_to_evm_address('0x7D91717579885BfCFec3Cb4B4C4fe71c1EedD4dE')
@@ -144,13 +136,9 @@ def test_thegraph_contract_deposit_gas(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_ROTKI]])
-def test_thegraph_contract_transfer_approval(database, ethereum_inquirer):
+def test_thegraph_contract_transfer_approval(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbb8280cc9ca9de1d33e573a4381d88525a214fc45f84415129face03125ba22f')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1706311067000)
     gas = '0.001243940743655704'
     expected_events = [
@@ -186,13 +174,9 @@ def test_thegraph_contract_transfer_approval(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_ROTKI]])
-def test_thegraph_contract_delegation_transferred_to_l2_vested(database, ethereum_inquirer):
+def test_thegraph_contract_delegation_transferred_to_l2_vested(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x48321bb00e5c5b67f080991864606dbc493051d20712735a579d7ae31eca3d78')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1706316575000)
     gas, delegation_amount = '0.0034549683606123', '199846.719749385820105919'
     indexer = string_to_evm_address('0x5A8904be09625965d9AEc4BFfD30D853438a053e')
@@ -236,13 +220,9 @@ def test_thegraph_contract_delegation_transferred_to_l2_vested(database, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER_2, ADDY_ROTKI]])
-def test_thegraph_contract_delegation_transferred_to_l2(database, ethereum_inquirer):
+def test_thegraph_contract_delegation_transferred_to_l2(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xed80711e4cb9c428790f0d9b51f79473bf5253d5d03c04d958d411e7fa34a92e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1706317031000)
     eth_amount, gas, delegation_amount = '0.000255709530674816', '0.002540860890653745', '39243.651715794449516669'  # noqa: E501
     indexer = string_to_evm_address('0xb06071394531B63b0bac78f27e12dc2BEaA913E4')
@@ -296,13 +276,9 @@ def test_thegraph_contract_delegation_transferred_to_l2(database, ethereum_inqui
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
-def test_thegraph_undelegate(database, ethereum_inquirer):
+def test_thegraph_undelegate(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x5ca5244868d9c0d8c30a1cad0feaf137bd28acd9c3f669a09a3a199fd75ad25a')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1691771855000)
     gas_fee, undelegate_amount, lock_time = '0.00307607001551556', '1003.70342593701668535', '983'
     indexer_address = string_to_evm_address('0x6125eA331851367716beE301ECDe7F38A7E429e7')
@@ -339,13 +315,9 @@ def test_thegraph_undelegate(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
-def test_thegraph_delegated_withdrawn(database, ethereum_inquirer):
+def test_thegraph_delegated_withdrawn(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x49307751de5ba4cf98fccbdd1ab8387fd60a7ce120800212c216bf0a6a04acfa')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1694577371000)
     gas_fees, withdrawn_amount = '0.000651667321615926', '1003.70342593701668535'
     indexer_address = string_to_evm_address('0x6125eA331851367716beE301ECDe7F38A7E429e7')
@@ -382,11 +354,10 @@ def test_thegraph_delegated_withdrawn(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_1_ARB]])
-def test_thegraph_delegate_arbitrum_one(database, arbitrum_one_inquirer):
+def test_thegraph_delegate_arbitrum_one(arbitrum_one_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x3c846f305330969fb0ddb87c5ae411b4e9692f451a7ff3237b6f71020030c7d1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1713366299000)
@@ -453,11 +424,10 @@ def test_thegraph_delegate_arbitrum_one(database, arbitrum_one_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_2_ARB]])
-def test_thegraph_undelegate_arbitrum_one(database, arbitrum_one_inquirer):
+def test_thegraph_undelegate_arbitrum_one(arbitrum_one_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xc66ea685db10809b1765e8381175ada7b021b5a40f57572e220a8b94235c1f72')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1700727276000)
@@ -511,11 +481,10 @@ def test_thegraph_undelegate_arbitrum_one(database, arbitrum_one_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_3_ARB]])
-def test_thegraph_delegated_withdrawn_arbitrum_one(database, arbitrum_one_inquirer):
+def test_thegraph_delegated_withdrawn_arbitrum_one(arbitrum_one_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xd6847bc02b65891118caaa8a2882cf5db6e0938c909db112e4fa6930929d8c39')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1713445792000)

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -39,13 +39,9 @@ ADDY_4 = string_to_evm_address('0x43e141534d718D72552De1B606a5FCBc72256cD7')
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_1]])
-def test_uniswap_v2_swap(database, ethereum_inquirer):
+def test_uniswap_v2_swap(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x67cf6c4ce5078f9750a14afd2f5070c327caf8c5180bdee2be59644ac59974e1')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -92,14 +88,10 @@ def test_uniswap_v2_swap(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_1]])
-def test_uniswap_v2_swap_eth_returned(database, ethereum_inquirer):
+def test_uniswap_v2_swap_eth_returned(ethereum_inquirer):
     """Test a transaction where eth is swapped and some of it is returned due to change in price"""
     tx_hash = deserialize_evm_tx_hash('0x20ecc226c438a8803a6195d8031ae7dd97a27351e6b7429621b36194121b9b76')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1634652419000)
     expected_events = [
         EvmEvent(
@@ -160,15 +152,11 @@ def test_uniswap_v2_swap_eth_returned(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xa931b486F661540c6D709aE6DfC8BcEF347ea437']])
-def test_uniswap_v2_swap_with_approval(database, ethereum_inquirer, ethereum_accounts):
+def test_uniswap_v2_swap_with_approval(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xcbe558177f62ccdb77f59b6be11e60b0a3fed1d224d5ce28d2bb6dff59447d3b')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     assert events == [
         EvmEvent(
             tx_hash=evmhash,
@@ -226,14 +214,10 @@ def test_uniswap_v2_swap_with_approval(database, ethereum_inquirer, ethereum_acc
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_2]])
-def test_uniswap_v2_add_liquidity(database, ethereum_inquirer):
+def test_uniswap_v2_add_liquidity(ethereum_inquirer):
     """This checks that adding liquidity to a Uniswap V2 pool is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x1bab8a89a6a3f8cb127cfaf7cd58809201a4e230d0a05f9e067674749605959e')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     lp_token_identifier = evm_address_to_identifier(
         address='0xAE461cA67B15dc8dc81CE7615e0320dA1A9aB8D5',
         chain_id=ChainID.ETHEREUM,
@@ -303,14 +287,10 @@ def test_uniswap_v2_add_liquidity(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_3]])
-def test_uniswap_v2_remove_liquidity(database, ethereum_inquirer):
+def test_uniswap_v2_remove_liquidity(ethereum_inquirer):
     """This checks that removing liquidity from a Uniswap V2 pool is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x0936a16e1d3655e832c60bed52040fd5ac0d99d03865d11225b3183dba318f43')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -578,16 +558,12 @@ def test_uniswap_v2_swap_events_order(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xbcce162c23480a4d44b88F57D5D2D9997402010e']])
-def test_remove_liquidity_with_weth(database, ethereum_inquirer, ethereum_accounts):
+def test_remove_liquidity_with_weth(ethereum_inquirer, ethereum_accounts):
     """Test that removing liquidity as weth gets correctly decoded"""
     tx_hex = deserialize_evm_tx_hash('0x00007120e5281e9bdf9a57739e3ecaf736013e4a1a31ecfe44f719c229cc2cbd')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -650,15 +626,11 @@ def test_remove_liquidity_with_weth(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x3163Bb273E8D9960Ce003fD542bF26b4C529f515']])
-def test_claim_airdrop(database, ethereum_inquirer, ethereum_accounts):
+def test_claim_airdrop(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x0e50e7374e0ffbe0aea82dbe94a04ab0da3981f3bfb1a66927eb250c7aff29e3')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp = TimestampMS(1600446008000)
     gas_amount, claimed_amount = '0.027890731101011885', '408.638074'
     expected_events = [

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -39,13 +39,9 @@ ADDY_5 = string_to_evm_address('0xa931b486F661540c6D709aE6DfC8BcEF347ea437')
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
-def test_uniswap_v3_swap(database, ethereum_inquirer):
+def test_uniswap_v3_swap(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x1c50c336329a7ee41f722ce5d848ebd066b72bf44a1eaafcaa92e8c0282049d2')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -92,15 +88,11 @@ def test_uniswap_v3_swap(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_2]])
-def test_uniswap_v3_swap_received_token2(database, ethereum_inquirer):
+def test_uniswap_v3_swap_received_token2(ethereum_inquirer):
     """This test checks that the logic is correct when the asset leaving the pool is the token2 of
     the pool."""
     tx_hash = deserialize_evm_tx_hash('0x116b3a9c0b2a4857605e336438c8e4c91897a9ef2af23178f9dbceba85264bd9')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -147,14 +139,10 @@ def test_uniswap_v3_swap_received_token2(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_3]])
-def test_uniswap_v3_swap_by_aggregator(database, ethereum_inquirer):
+def test_uniswap_v3_swap_by_aggregator(ethereum_inquirer):
     """This checks that swap(s) initiated by an aggregator is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x14e73a3bbced025ae22245eae0045972c1664fc01038b2ba6b1153590f536948')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -214,15 +202,11 @@ def test_uniswap_v3_swap_by_aggregator(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd6f2F8a2D6BD2f06234a95e61b55f41676CbE50d']])
-def test_swap_eth_to_tokens(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_eth_to_tokens(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xaf8755f0ab8a0cfa8901fe2a9250a8727cca54825210061aab90f34b7a3ed9ba')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     assert events == [
         EvmEvent(
             tx_hash=evmhash,
@@ -268,15 +252,11 @@ def test_swap_eth_to_tokens(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x4bBa290826C253BD854121346c370a9886d1bC26']])
-def test_swap_eth_to_tokens_refund(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_eth_to_tokens_refund(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x265c15c2b77090afb164f4c723b158f10d94853a705eda67410a340fc0113ece')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     assert events == [
         EvmEvent(
             tx_hash=evmhash,
@@ -322,15 +302,11 @@ def test_swap_eth_to_tokens_refund(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd6f2F8a2D6BD2f06234a95e61b55f41676CbE50d']])
-def test_swap_tokens_to_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_tokens_to_eth(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x1b6c3fe84ed4f8f273a54c3e3f6ba80f843522c6a19220a05089104fc54b09ba')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     assert events == [
         EvmEvent(
             tx_hash=evmhash,
@@ -376,15 +352,11 @@ def test_swap_tokens_to_eth(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xCDeBA740656640fCA1A7b573e925f8C3b92f76b6']])
-def test_swap_tokens_to_tokens_single_receipt(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_tokens_to_tokens_single_receipt(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0x3ae92fa63a9cf672906036beb18ece09592a8a471bd7f15e4385ca5011615e51')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -431,15 +403,11 @@ def test_swap_tokens_to_tokens_single_receipt(database, ethereum_inquirer, ether
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x73264d8bE9EDDfCD25E4d54BF1b69828c9631A1C']])
-def test_swap_tokens_to_tokens_multiple_receipts(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_tokens_to_tokens_multiple_receipts(ethereum_inquirer, ethereum_accounts):
     tx_hex = deserialize_evm_tx_hash('0xa4e0dbf77bf7a9721e1ba4ecf44ed6ea8dcb1c16e9e784b6fefa30749f64e7c0')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -486,7 +454,7 @@ def test_swap_tokens_to_tokens_multiple_receipts(database, ethereum_inquirer, et
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_4]])
-def test_uniswap_v3_remove_liquidity(database, ethereum_inquirer):
+def test_uniswap_v3_remove_liquidity(ethereum_inquirer):
     """
     Check that removing liquidity from Uniswap V3 LP is decoded properly.
 
@@ -494,11 +462,7 @@ def test_uniswap_v3_remove_liquidity(database, ethereum_inquirer):
     https://etherscan.io/tx/0x76c312fe1c8604de5175c37dcbbb99cc8699336f3e4840e9e29e3383970f6c6d
     """
     tx_hash = deserialize_evm_tx_hash('0x76c312fe1c8604de5175c37dcbbb99cc8699336f3e4840e9e29e3383970f6c6d ')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 3
     expected_events = [
         EvmEvent(
@@ -546,14 +510,10 @@ def test_uniswap_v3_remove_liquidity(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_5]])
-def test_uniswap_v3_add_liquidity(database, ethereum_inquirer):
+def test_uniswap_v3_add_liquidity(ethereum_inquirer):
     """Check that adding liquidity to a Uniswap V3 LP is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x6bf3588f669a784adf5def3c0db149b0cdbcca775e472bb35f00acedee263c4c')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     expected_events = [
         EvmEvent(
             tx_hash=tx_hash,
@@ -614,14 +574,10 @@ def test_uniswap_v3_add_liquidity(database, ethereum_inquirer):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xf615a55e686499511557b3F75Ea9166DD455bFd5']])
-def test_uniswap_v3_swap_by_universal_router(database, ethereum_inquirer, ethereum_accounts):
+def test_uniswap_v3_swap_by_universal_router(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd2fe13a9727b2ff3f9458154afb8e59216864b57e0aacffeedc3d3d4cff1c43d')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1698949487000)
     assert events == [EvmEvent(
         sequence_index=0,
@@ -666,14 +622,10 @@ def test_uniswap_v3_swap_by_universal_router(database, ethereum_inquirer, ethere
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xb26655EBEe9DFA2f8D20523FE7CaE45CBe0122A2']])
-def test_uniswap_v3_weth_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_uniswap_v3_weth_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xdb9a489fa0404facc9ee514ce9e08a8dffdd5bbc051ed1fbc8d165cc4dc408f3 ')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1705025555000)
     rai_amount, weth_amount = '5409.802671424102374943', '5.964487282596591371'
     nft_id = '645638'
@@ -739,11 +691,10 @@ def test_uniswap_v3_weth_deposit(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xEEb775c27a0d476B145d2e3B4dCd10A0A5Bd064F']])
-def test_swap_on_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_swap_on_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x8fe6f4f80e34eebc8e61ad638d57fde3ec4a975817ee08ab209562d00a6aa217')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710224315000), '0.21', '416.708088668961143612', '0.0001952302'  # noqa: E501
@@ -793,13 +744,9 @@ def test_swap_on_arbitrum(database, arbitrum_one_inquirer, arbitrum_one_accounts
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0x3A4E1e525FaE9001037936164fC440df6E71f412']])
-def test_swap_on_base(database, base_inquirer, base_accounts):
+def test_swap_on_base(base_inquirer, base_accounts):
     evmhash = deserialize_evm_tx_hash('0x2125ff35709009b9782f8351db3cb5a44a0bf088c3f38de08d92eb3906394635')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=evmhash)
     timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710230035000), '0.005', '10083924.460996717903453391', '0.000189731906791024'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -847,13 +794,9 @@ def test_swap_on_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x8BAf1bBae7C3Cc1F9c5Bf20b3d13BBfe674B01B7']])
-def test_swap_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0xfbaacab45a9d788c993f08a65652e7a363a82ee2343152ffa41d07c5456d1fe7')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710230523000), '23.093637251974648887', '23.084554', '0.000335793972468462'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -901,11 +844,10 @@ def test_swap_on_optimism(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9d38bC769b4E88da3f4c31a06b626ef88a21065C']])
-def test_swap_on_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash('0x2004f7b593d4ddf9372d78adb4b89852fa70eafa42418793b142a881b4171974')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710231022000), '0.017521626565388156', '0.00097703', '0.025131590391178764'  # noqa: E501
@@ -955,13 +897,9 @@ def test_swap_on_polygon_pos(database, polygon_pos_inquirer, polygon_pos_account
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x9A539f692cDE873D6B882fc326c8d62D4cEA8048']])
-def test_add_liquidity_on_optimism(database, optimism_inquirer, optimism_accounts):
+def test_add_liquidity_on_optimism(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0x96bd0e37e1734b5e73f9abdf30b39c4e4a6879667c2d01a7be2d95a85cc0b0cc')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     timestamp, approval, op_deposit, usdc_deposit, gas_fees = TimestampMS(1713269405000), '0.000129292741769402', '10975.908530657738737186', '32.212735', '0.000027353637451875'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_velodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_velodrome.py
@@ -52,7 +52,6 @@ def test_add_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -139,7 +138,6 @@ def test_add_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -223,7 +221,6 @@ def test_remove_liquidity_v2(optimism_transaction_decoder, optimism_accounts, lo
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -309,7 +306,6 @@ def test_remove_liquidity_v1(optimism_transaction_decoder, optimism_accounts, lo
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -396,7 +392,6 @@ def test_swap_eth_to_token_v2(optimism_accounts, optimism_transaction_decoder, l
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -454,7 +449,6 @@ def test_swap_eth_to_token_v1(optimism_accounts, optimism_transaction_decoder, l
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -512,7 +506,6 @@ def test_swap_token_to_eth_v2(optimism_accounts, optimism_transaction_decoder, l
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -582,7 +575,6 @@ def test_swap_token_to_eth_v1(optimism_accounts, optimism_transaction_decoder, l
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -640,7 +632,6 @@ def test_swap_tokens_v2(optimism_accounts, optimism_transaction_decoder, load_gl
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -710,7 +701,6 @@ def test_swap_tokens_v1(optimism_accounts, optimism_transaction_decoder, load_gl
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -775,7 +765,6 @@ def test_stake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_deco
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -834,7 +823,6 @@ def test_unstake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_de
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )
@@ -880,7 +868,6 @@ def test_get_reward_from_gauge_v2(optimism_accounts, optimism_transaction_decode
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=evmhash,
         load_global_caches=load_global_caches,
     )

--- a/rotkehlchen/tests/unit/decoders/test_votium.py
+++ b/rotkehlchen/tests/unit/decoders/test_votium.py
@@ -15,16 +15,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x362C51b56D3c8f79aecf367ff301d1aFd42EDCEA']])
-def test_votium_claim_1(database, ethereum_inquirer, ethereum_accounts):
+def test_votium_claim_1(ethereum_inquirer, ethereum_accounts):
     """Test for votium contract 1 (MultiMerkleStash)"""
     tx_hex = deserialize_evm_tx_hash('0x75b81b2edd454a7b564cc55a6b676e2441e155401bde99a38d867028081d2c30')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas, amount = TimestampMS(1646375440000), '0.005264399856069432', '12.369108326706528256'  # noqa: E501
     expected_events = [
         EvmEvent(
@@ -60,16 +56,12 @@ def test_votium_claim_1(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x96CC80292fa3A7045611EB84aE09DF8bd15936d2']])
-def test_votium_claim_2(database, ethereum_inquirer, ethereum_accounts):
+def test_votium_claim_2(ethereum_inquirer, ethereum_accounts):
     """Test for votium contract 2 (veCRV Merkle Stash)"""
     tx_hex = deserialize_evm_tx_hash('0x27b48aa8f0f02e8e35f182925e2efb2a299a1410641d96de4de98666d28b36c7')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     timestamp, gas, amount = TimestampMS(1678972523000), '0.001771703400663612', '0.130390330817010288'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_weth.py
+++ b/rotkehlchen/tests/unit/decoders/test_weth.py
@@ -38,7 +38,7 @@ WETH_ARB_ADDRESS = string_to_evm_address('0x82aF49447D8a07e3bd95BD0d56f35241523f
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4B078a6A7026C32D2D6Aff763E2F37336cf552Dd']])
-def test_weth_deposit(database, ethereum_inquirer):
+def test_weth_deposit(ethereum_inquirer):
     """
     Data for deposit is taken from
     https://etherscan.io/tx/0x5bb623b365def9650816dcbaf1babde8fd0ebed737db36d3a033d7cf63792daf
@@ -46,11 +46,7 @@ def test_weth_deposit(database, ethereum_inquirer):
     tx_hex = '0x5bb623b365def9650816dcbaf1babde8fd0ebed737db36d3a033d7cf63792daf'
     timestamp = TimestampMS(1666256147000)
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     assert len(events) == 3
     expected_events = [
         EvmEvent(
@@ -107,7 +103,7 @@ def test_weth_deposit(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4b2975AfF4DeF34D3Cd4f4759b45faF738D790D3']])
-def test_weth_withdrawal(database, ethereum_inquirer):
+def test_weth_withdrawal(ethereum_inquirer):
     """
     Data for withdrawal is taken from
     https://etherscan.io/tx/0x1f3aa6f7d33bfaaaf9cdd92b16fecdf911341601c02ad89b4ec0b80c66c28a07
@@ -115,11 +111,7 @@ def test_weth_withdrawal(database, ethereum_inquirer):
     tx_hex = '0x1f3aa6f7d33bfaaaf9cdd92b16fecdf911341601c02ad89b4ec0b80c66c28a07'
     evmhash = deserialize_evm_tx_hash(tx_hex)
     timestamp = TimestampMS(1666256147000)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     assert len(events) == 3
     expected_events = [
         EvmEvent(
@@ -178,11 +170,7 @@ def test_weth_interaction_with_protocols_deposit(database, ethereum_inquirer):
     tx_hex = '0xab0dec3785632c567365c48ea1fd1178f0998773136a555912625d2668ef53e9'
     timestamp = TimestampMS(1666595591000)
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     assert len(events) == 4
     expected_events = [
         EvmEvent(
@@ -252,7 +240,7 @@ def test_weth_interaction_with_protocols_deposit(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xDea6866A866C60d68fFDFc6178C12fCFdb9d0D47']])
-def test_weth_interaction_with_protocols_withdrawal(database, ethereum_inquirer):
+def test_weth_interaction_with_protocols_withdrawal(ethereum_inquirer):
     """
     Data for deposit is taken from
     https://etherscan.io/tx/0x4a811e8cfa58cb5bd57d92d62e1f01c8578859705243fe69c6bd9e59f3dcd167
@@ -260,11 +248,7 @@ def test_weth_interaction_with_protocols_withdrawal(database, ethereum_inquirer)
     tx_hex = '0x4a811e8cfa58cb5bd57d92d62e1f01c8578859705243fe69c6bd9e59f3dcd167'
     timesatmp = TimestampMS(1666284551000)
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     assert len(events) == 3
     expected_events = [
         EvmEvent(
@@ -314,7 +298,7 @@ def test_weth_interaction_with_protocols_withdrawal(database, ethereum_inquirer)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF5f5C8924db9aa5E70Bdf7842473Ee8C7F1F4c9d']])
-def test_weth_interaction_errors(database, ethereum_inquirer):
+def test_weth_interaction_errors(ethereum_inquirer):
     """
     Check that if no out event occurs, an in event should not be created for deposit event
     https://etherscan.io/tx/0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d
@@ -322,11 +306,7 @@ def test_weth_interaction_errors(database, ethereum_inquirer):
     tx_hex = '0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d'
     timestamp = TimestampMS(1666800983000)
     evmhash = deserialize_evm_tx_hash(tx_hex)
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     assert len(events) == 3
     expected_events = [
         EvmEvent(
@@ -372,14 +352,10 @@ def test_weth_interaction_errors(database, ethereum_inquirer):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_wxdai_unwrap(database, gnosis_inquirer, gnosis_accounts):
+def test_wxdai_unwrap(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xa6af9ea737de26c87a36367fd896a8fe471049f4c18ac909901336aaccbf2369')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1707739650000)
     gas_amount, unwrapped_amount = '0.0000886822502438', '555.374747825771664891'
     wxdai_address = A_WXDAI.resolve_to_evm_token().evm_address
@@ -430,14 +406,10 @@ def test_wxdai_unwrap(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0xd6f585378F3232E440B165AD56658bFcA76D1B32']])
-def test_wxdai_wrap(database, gnosis_inquirer, gnosis_accounts):
+def test_wxdai_wrap(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x8cf8362f36e5a76912bc05ef804c0ea4b4f2de54700afe9ced99aa486f3dd0e8')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1707744465000)
     gas_amount, wrapped_amount = '0.0000586761', '103'
     wxdai_address = A_WXDAI.resolve_to_evm_token().evm_address
@@ -488,11 +460,10 @@ def test_wxdai_wrap(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xBE6660FBE96B61B72Bf35FFaB40eB2CA886A7f85']])
-def test_weth_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_weth_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0xc19c7e1e0af7819b1922a287d034540e8f8dba4e065317d6483d48ac27e727e9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     timestamp = TimestampMS(1712238368000)
@@ -543,11 +514,10 @@ def test_weth_withdraw_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_on
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x7aBAee8F04EFd689961115f7A28bAA2E73Be6703']])
-def test_weth_deposit_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_weth_deposit_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     evmhash = deserialize_evm_tx_hash('0x57cc837c6f3d84c8fa3db8a7405f7244f11d32152159edf5ba79f5a7c34919b8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     timestamp = TimestampMS(1712328694000)
@@ -598,13 +568,9 @@ def test_weth_deposit_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x81aa5101D4c376cd6DC031EA62D7b64A9BAE10a0']])
-def test_weth_withdraw_optimism(database, optimism_inquirer, optimism_accounts):
+def test_weth_withdraw_optimism(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0x4a6b47e1f622a8ad059bd0723c53f2c71f12e7b105d2ef2ff4dff07ac1f185c0')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1712240095000)
     amount, gas_fees = '0.000518962654328944', '0.000001897927938075'
     expected_events = [
@@ -653,13 +619,9 @@ def test_weth_withdraw_optimism(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0xD6f30247e6a8B8656a8B02Ea37247f5eb939c626']])
-def test_weth_deposit_optimism(database, optimism_inquirer, optimism_accounts):
+def test_weth_deposit_optimism(optimism_inquirer, optimism_accounts):
     evmhash = deserialize_evm_tx_hash('0x42074e2228be1716f84888f1993fa62443f591945b21dfbf159a64ae467990c4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1712241853000)
     amount, gas_fees = '0.0345', '0.000002820767318933'
     expected_events = [
@@ -708,13 +670,9 @@ def test_weth_deposit_optimism(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0x6247666Ea4C80083035214780978E9EBa4AA6Cf4']])
-def test_weth_withdraw_scroll(database, scroll_inquirer, scroll_accounts):
+def test_weth_withdraw_scroll(scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x88f49633073a7667f93eb888ec2151c26f449cc10afca565a15f8df68ee20f82')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1712239879000)
     amount, gas_fees = '0.00211824', '0.000194659253936861'
     expected_events = [
@@ -763,13 +721,9 @@ def test_weth_withdraw_scroll(database, scroll_inquirer, scroll_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('scroll_accounts', [['0xdFd21F8aA81c5787160F9a4B39357F5FE1c743DC']])
-def test_weth_deposit_scroll(database, scroll_inquirer, scroll_accounts):
+def test_weth_deposit_scroll(scroll_inquirer, scroll_accounts):
     evmhash = deserialize_evm_tx_hash('0x1fa6d87801891fcea66a9be2d4fce1c52569c5ce30579fbe7de37eb05bd247f8')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=scroll_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1712239897000)
     amount, gas_fees = '0.135', '0.000199290832110225'
     expected_events = [
@@ -818,13 +772,9 @@ def test_weth_deposit_scroll(database, scroll_inquirer, scroll_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0x44f29ebE386c409376C66ad268F9Ae595c8C3e76']])
-def test_weth_withdraw_base(database, base_inquirer, base_accounts):
+def test_weth_withdraw_base(base_inquirer, base_accounts):
     evmhash = deserialize_evm_tx_hash('0x8d54608c2f684d880ad40a16cf9b82525c51520798ae8875d543d3338327ddad')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1712239837000)
     amount, gas_fees = '0.00022448658511341', '0.000000533995613184'
     expected_events = [
@@ -873,13 +823,9 @@ def test_weth_withdraw_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xf396e7dbb20489D47F2daBfDA013163223B892a0']])
-def test_weth_deposit_base(database, base_inquirer, base_accounts):
+def test_weth_deposit_base(base_inquirer, base_accounts):
     evmhash = deserialize_evm_tx_hash('0x0d418e4a858ca5faf00c36b685561ca0fdac52ebd10364bf2cb6d7b5969e84e5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=evmhash)
     timestamp = TimestampMS(1712239899000)
     amount, gas_fees = '1.2', '0.000000775794575663'
     expected_events = [
@@ -928,11 +874,10 @@ def test_weth_deposit_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x33C0Aae5b2b6Eae2a6286B3a6621B55DcC02dC9e']])
-def test_wmatic_deposit_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_wmatic_deposit_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash('0xba581391d417a6dcc31031f1cf7cba6e63b701a8680828445ffdde73777843e1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     timestamp = TimestampMS(1712851902000)
@@ -983,11 +928,10 @@ def test_wmatic_deposit_polygon_pos(database, polygon_pos_inquirer, polygon_pos_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xdAA9E3CA7500d7Ba3855dF9d8BCCde229C13919e']])
-def test_wmatic_withdraw_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_wmatic_withdraw_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
     evmhash = deserialize_evm_tx_hash('0xe90ed71875ff44ea45ea960d006ec4c0ccb86506cba494471aba4ba9dc86123f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=evmhash,
     )
     timestamp = TimestampMS(1712851796000)

--- a/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
@@ -17,13 +17,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x4c1a316De360E08817eB88dD31A0E7305005fB65']])
-def test_bridge_dai_from_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_bridge_dai_from_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe17f61edb9fe278720679ecfd5498f75082e38bf4779e5e6403a551f5084ee23')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1697470703000)
     amount = FVal('19.997099097418611102')
@@ -59,14 +55,10 @@ def test_bridge_dai_from_ethereum(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfF025244b556F0CD4617FBfE67F7986D7292A3E4']])
-def test_bridge_dai_from_ethereum_nolog(database, ethereum_inquirer, ethereum_accounts):
+def test_bridge_dai_from_ethereum_nolog(ethereum_inquirer, ethereum_accounts):
     """Test the case where a simple transfer to the bridge is recognized as a bridging event"""
     tx_hash = deserialize_evm_tx_hash('0x196e7d687e1e2ce280dbe7f52b6ffe5a61d3a851b38740a37d1d00caffce7562')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1705093391000)
     gas, amount = '0.00115669008897503', '193.961036565990280733'
@@ -102,14 +94,10 @@ def test_bridge_dai_from_ethereum_nolog(database, ethereum_inquirer, ethereum_ac
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x07AD02e0C1FA0b09fC945ff197E18e9C256838c6']])
-def test_withdraw_dai_to_ethereum(database, ethereum_inquirer, ethereum_accounts):
+def test_withdraw_dai_to_ethereum(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xb151a9294e7cdf9b62d5716eff3d69cc96c6fa3f1279b1d36c16896bd9cb3b32')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1697473655000)
     amount = FVal(900)
     assert events == [
@@ -144,14 +132,10 @@ def test_withdraw_dai_to_ethereum(database, ethereum_inquirer, ethereum_accounts
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x07AD02e0C1FA0b09fC945ff197E18e9C256838c6']])
-def test_withdraw_dai_from_gnosis(database, gnosis_inquirer, gnosis_accounts):
+def test_withdraw_dai_from_gnosis(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x1a7014cbc1e6af2558c3a3cafd7fe87d8d67d27242b5abe8af0d4bf51a5230f6')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1697473395000)
     amount = FVal(900)
     assert events == [
@@ -186,14 +170,10 @@ def test_withdraw_dai_from_gnosis(database, gnosis_inquirer, gnosis_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x7DA9A33d15413F499299687cC9d81DE84684E28E']])
-def test_deposit_dai_to_gnosis(database, gnosis_inquirer, gnosis_accounts):
+def test_deposit_dai_to_gnosis(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x5892a695860f6087a2d93140f05e6365142ff77fd7128e39dbc03128d5797ac4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=gnosis_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     assert events == [EvmEvent(
         sequence_index=24,
         timestamp=TimestampMS(1609959945000),

--- a/rotkehlchen/tests/unit/decoders/test_yearn.py
+++ b/rotkehlchen/tests/unit/decoders/test_yearn.py
@@ -478,7 +478,7 @@ def test_withdraw_yearn_v1(database, ethereum_inquirer, eth_transactions):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfDb7EEc5eBF4c4aC7734748474123aC25C6eDCc8']])
-def test_deposit_yearn_full_amount(database, ethereum_inquirer, ethereum_accounts):
+def test_deposit_yearn_full_amount(ethereum_inquirer, ethereum_accounts):
     """
     In the case of deposits and withdrawals for yearn there are two different signatures for
     the functions used. If no amount is provided all the available amount is deposited/withdrawn.
@@ -486,11 +486,7 @@ def test_deposit_yearn_full_amount(database, ethereum_inquirer, ethereum_account
     tx_hex = deserialize_evm_tx_hash('0x02486ccc1fe49b3c7df60c51efad78ddca5af025834e30ba1a736ff352b33592')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     assert events == [
         EvmEvent(
             tx_hash=evmhash,

--- a/rotkehlchen/tests/unit/decoders/test_ygov.py
+++ b/rotkehlchen/tests/unit/decoders/test_ygov.py
@@ -14,13 +14,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xB04a6DB13942b6d4416AbeC5A8327866375c17a4']])
-def test_ygov_stake(database, ethereum_inquirer, ethereum_accounts):
+def test_ygov_stake(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1c596eb9189d124418d5bd060cb702acf20be8f7b18220fbec9b94a99b95c1d3')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1594992345000)
     addy_user = ethereum_accounts[0]
     gas_amount, deposited_amount = '0.005269935', '1736.929114514645653598'
@@ -58,13 +54,9 @@ def test_ygov_stake(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA7499Aa6464c078EeB940da2fc95C6aCd010c3Cc']])
-def test_ygov_get_reward(database, ethereum_inquirer, ethereum_accounts):
+def test_ygov_get_reward(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9063899641457daf68518b7017a4df30a79a0630224528aee0f2c483db76fc58')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1623310131000)
     addy_user = ethereum_accounts[0]
     gas_amount, reward_amount = '0.0010707', '0.224594237566776997'
@@ -102,13 +94,9 @@ def test_ygov_get_reward(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3AA33a58BFD82EA119E36b8886BC7E36E6F7Aa29']])
-def test_ygov_exit(database, ethereum_inquirer, ethereum_accounts):
+def test_ygov_exit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x42787b2b175d7f09401c3fd68c92f78982de2deef2214196261a31258c68006b')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1633109458000)
     addy_user = ethereum_accounts[0]
     gas_amount, reward_amount, withdrawn_amount = '0.012938107', '2.281399151169433806', '665811.174187646507558478'  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_zerox.py
+++ b/rotkehlchen/tests/unit/decoders/test_zerox.py
@@ -44,13 +44,9 @@ A_BULL: Final = Asset('eip155:137/erc20:0x9f95e17b2668AFE01F8fbD157068b0a4405Cc0
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xaE84961b9FA7412fEAEf209fD8f50C4F8Ef4D8fD']])
-def test_sell_to_uniswap(database, ethereum_inquirer, ethereum_accounts):
+def test_sell_to_uniswap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb9827174e182a1b8df3507d13c5cedccdc974c4edd5d66f59355f7e9758b9006')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709225123000)
     swap_amount, received_amount, gas_fees = '12.425145745058641', '646.553802069266414457', '0.018008266883477871'  # noqa: E501
     expected_events = [EvmEvent(
@@ -97,13 +93,9 @@ def test_sell_to_uniswap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc2aAd9386835C90deC9d669e35c128461E6102CA']])
-def test_sell_eth_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereum_accounts):
+def test_sell_eth_for_token_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5b7719016f7d7d3d8ed9d4d86afd0e0079551d0a7795f70f01764ce5eaa44478')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709222447000)
     swap_amount, received_amount, gas_fees = '0.2882978462709', '85192.182824334037015387', '0.007717607607009392'  # noqa: E501
     expected_events = [EvmEvent(
@@ -150,13 +142,9 @@ def test_sell_eth_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereum_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xed288d0261421C7cf36a56f23297cD5F4635A089']])
-def test_sell_token_for_eth_to_uniswap_v3(database, ethereum_inquirer, ethereum_accounts):
+def test_sell_token_for_eth_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x68416e19252c678cdf67ae9b7adff742d78f95cea3c3f0582d3dc930340e5bdf')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709225147000)
     swap_amount, received_amount, gas_fees = '150000', '1.446309922122136822', '0.013066559749685724'  # noqa: E501
     expected_events = [EvmEvent(
@@ -203,13 +191,9 @@ def test_sell_token_for_eth_to_uniswap_v3(database, ethereum_inquirer, ethereum_
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xCCD54C835d7199ceEE2AedA4722C69eeeA6E606D']])
-def test_sell_token_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereum_accounts):
+def test_sell_token_for_token_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6efe8a18de9ca3183bdb319be445f1b0b9041c0e8208fa04a58ee276b54574dd')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709054219000)
     swap_amount, received_amount, gas_fees = '26035459.499107021225491254', '6627.784156933620641174', '0.011785737692958302'  # noqa: E501
     expected_events = [EvmEvent(
@@ -256,13 +240,9 @@ def test_sell_token_for_token_to_uniswap_v3(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xddb143606305559e6b69843c1f53f2689D2aB605']])
-def test_multiplex_batch_sell_eth_for_token(database, ethereum_inquirer, ethereum_accounts):
+def test_multiplex_batch_sell_eth_for_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa151bc4f1c69591598386eaa65761cefd706cbfe0a1a340d8856dbfe2c3bd8c5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709282363000)
     swap_amount, received_amount, gas_fees = '1.160624381328078', '155577.466855002838240404', '0.0083327194970355'  # noqa: E501
     expected_events = [EvmEvent(
@@ -309,13 +289,9 @@ def test_multiplex_batch_sell_eth_for_token(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xdf0093104D66509B35411815d7b29c40C16c9578']])
-def test_multiplex_batch_sell_token_for_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_multiplex_batch_sell_token_for_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf9b40a3bbbd92fe72099cff45564e099782fc9b0b4bd40c2d87484b43735b3b1')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709306375000)
     swap_amount, received_amount, gas_fees = '13438.664993496960137988', '2.669421884825430502', '0.01627396521423088'  # noqa: E501
     expected_events = [EvmEvent(
@@ -362,13 +338,9 @@ def test_multiplex_batch_sell_token_for_eth(database, ethereum_inquirer, ethereu
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xF6a17316821eD254EC0DFa270c6F9f0D3317f706']])
-def test_multiplex_batch_sell_token_for_token(database, ethereum_inquirer, ethereum_accounts):
+def test_multiplex_batch_sell_token_for_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0f422be6e6904700181c3effb0600a8ed7e1616e70e6587d383b29290d6a7c1d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709300411000)
     swap_amount, received_amount, gas_fees = '125.156732374288853661', '43405.98545005', '0.018050672959219548'  # noqa: E501
     expected_events = [EvmEvent(
@@ -415,13 +387,9 @@ def test_multiplex_batch_sell_token_for_token(database, ethereum_inquirer, ether
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA5a81a7Bf4A737dAbCd8a4C5fc2A36598c1943bF']])
-def test_multiplex_multihop_sell_token_for_token(database, ethereum_inquirer, ethereum_accounts):
+def test_multiplex_multihop_sell_token_for_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xceccb105d312df00105eca2560b8da4cd0e791bb0f0da4cebeb17ca46abf2ce4')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709652443000)
     swap_amount, received_amount, gas_fees = '64666', '143469.489576604990799103', '0.03327224673453317'  # noqa: E501
     expected_events = [EvmEvent(
@@ -468,14 +436,10 @@ def test_multiplex_multihop_sell_token_for_token(database, ethereum_inquirer, et
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x773E123A1F1d5495a8Eaf4556a9f4e8aFDd9989C']])
-def test_0x415565b0_eth_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_0x415565b0_eth_to_token(ethereum_inquirer, ethereum_accounts):
     """Test ETH to Token swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x56dd5341b27b744e3ef3a2f356a6db48cb811397495a4cb9e8924c8232ef9abc')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709302619000)
     swap_amount, received_amount, gas_fees = '2.9077036701035723', '688264582.664559041869620658', '0.016733414171811015'  # noqa: E501
     expected_events = [EvmEvent(
@@ -522,14 +486,10 @@ def test_0x415565b0_eth_to_token(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x61Ead4d3e373332c2099e2DC63F916Dbe99f4B0c']])
-def test_0x415565b0_token_to_eth(database, ethereum_inquirer, ethereum_accounts):
+def test_0x415565b0_token_to_eth(ethereum_inquirer, ethereum_accounts):
     """Test Token to ETH swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xc4bab35f7499def296e9ccb08eebd8933ad8c37ff2701f2750027600f9050c55')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709302223000)
     swap_amount, received_amount, gas_fees = '5000', '1.450387601635590055', '0.01419246270466794'
     expected_events = [EvmEvent(
@@ -576,14 +536,10 @@ def test_0x415565b0_token_to_eth(database, ethereum_inquirer, ethereum_accounts)
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x85A28E964FCF12E0a6db44B3432794B08aD2426d']])
-def test_0x415565b0_token_to_token(database, ethereum_inquirer, ethereum_accounts):
+def test_0x415565b0_token_to_token(ethereum_inquirer, ethereum_accounts):
     """Test Token to Token swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x29bd536ecd4cacec3495b02f6375ab7465be64fff015916484746cd18da7a37d')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709301911000)
     swap_amount, received_amount, gas_fees = '1496', '1480.467089', '0.014804818364279386'
     expected_events = [EvmEvent(
@@ -630,14 +586,10 @@ def test_0x415565b0_token_to_token(database, ethereum_inquirer, ethereum_account
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xE4BeF064c912BC95C404850019909efe8D357716']])
-def test_execute_meta_transaction_v2(database, ethereum_inquirer, ethereum_accounts):
+def test_execute_meta_transaction_v2(ethereum_inquirer, ethereum_accounts):
     """Test meta transaction swaps done via the 0x protocol router contract."""
     tx_hash = deserialize_evm_tx_hash('0xb77f8e36a86517928f890296a263cafafa48ef01c6cc424a838b59b4401bf314')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709638007000)
     swap_amount, received_amount, meta_tx_fees = '1405.596892', '4910.533168813496285354', '58.171192'  # noqa: E501
     expected_events = [EvmEvent(
@@ -685,14 +637,10 @@ def test_execute_meta_transaction_v2(database, ethereum_inquirer, ethereum_accou
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3951970BA92CBFff00496e8C5Ebd675cEB614773']])
-def test_execute_meta_transaction_v2_multiplex(database, ethereum_inquirer, ethereum_accounts):
+def test_execute_meta_transaction_v2_multiplex(ethereum_inquirer, ethereum_accounts):
     """Test meta transaction multiplex swaps done via the 0x protocol router contract."""
     tx_hash = deserialize_evm_tx_hash('0x48f48d62b9829152c5963716acaed198320595859093cfc8a117742287f5a5eb')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709641247000)
     swap_amount, received_amount, meta_tx_fees = '49934.597014', '352963.071479518181477885', '65.402986'  # noqa: E501
     expected_events = [EvmEvent(
@@ -740,14 +688,10 @@ def test_execute_meta_transaction_v2_multiplex(database, ethereum_inquirer, ethe
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x2dcd7947973cb5CBf20e3dBF0663F566D1De9CdA']])
-def test_execute_meta_transaction_v2_flash(database, ethereum_inquirer, ethereum_accounts):
+def test_execute_meta_transaction_v2_flash(ethereum_inquirer, ethereum_accounts):
     """Test meta transaction swaps done via the 0x protocol using its flash contract."""
     tx_hash = deserialize_evm_tx_hash('0xf0be288974b275768725e7322c66d4086bd9b70bac4427af394966d333c0c807')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709633675000)
     swap_amount, received_amount, meta_tx_fees = '10659.465069', '25162.301091908076364354', '60.028487'  # noqa: E501
     expected_events = [EvmEvent(
@@ -795,11 +739,10 @@ def test_execute_meta_transaction_v2_flash(database, ethereum_inquirer, ethereum
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x701D5a3344C98765b36014A8a71941f499A2Bc75']])
-def test_swap_on_polygon_pos(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8e7c52d519d1ca0d1dfd8c8c21a2d2c34574e2bdada0ae7faafd49c1ddb8e8a6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1709653684000)
@@ -848,11 +791,10 @@ def test_swap_on_polygon_pos(database, polygon_pos_inquirer, polygon_pos_account
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xf06cc31757760CC9B8235C868ED90789f9c1E883']])
-def test_swap_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_accounts):
+def test_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x355c18ab70fb5d17098b6bc8fd527ce00f0b25c8220d6fe29522a1fb64b711bc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1709664647000)
@@ -902,13 +844,9 @@ def test_swap_arbitrum_one(database, arbitrum_one_inquirer, arbitrum_one_account
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('optimism_accounts', [['0x4Ea754349AcE5303c82f0d1D491041e042f2ad22']])
-def test_swap_optimism(database, optimism_inquirer, optimism_accounts):
+def test_swap_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6b2b2d8c0cf2e27bb9e6c8309fd9887a066f9b72139acfe13d7ca5c29ae6c0ff')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=optimism_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1707868177000)
     swap_amount, received_amount, meta_tx_fees = '1.181244', '1.180785', '0.818756'
     expected_events = [EvmEvent(
@@ -956,13 +894,9 @@ def test_swap_optimism(database, optimism_inquirer, optimism_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('base_accounts', [['0xF68D2BfCecd7895BBa05a7451Dd09A1749026454']])
-def test_swap_base(database, base_inquirer, base_accounts):
+def test_swap_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4a5eb8fac7ef1d6637ff1d54e67791e4a5a49effb141f30e5af90f5aba5d48a5')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=base_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709665909000)
     swap_amount, received_amount, meta_tx_fees = '688.271588', '1726.46678822133419734', '4.288419'
     expected_events = [EvmEvent(
@@ -1010,13 +944,9 @@ def test_swap_base(database, base_inquirer, base_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA26B29a299c65D0F63A8568BA5663028347f5571']])
-def test_swap_on_pancakeswap(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_on_pancakeswap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xcfb3b1587bb4d24a06d0f543493098ab285ae3763a489911da5bbea99bcb3499')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709701415000)
     swap_amount, received_amount, gas_fees = '10.414111669423209', '36912.012249', '0.017837784148433769'  # noqa: E501
     expected_events = [EvmEvent(
@@ -1063,13 +993,9 @@ def test_swap_on_pancakeswap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x74882149e6a43b8E69cAC6Aef92D753e96054B78']])
-def test_swap_on_curve(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_on_curve(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x12d794e7ced93da02978aa9b46b59f27ceab49724fdb1b0c39963792af68fdf0')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1709683307000)
     swap_amount, received_amount, gas_fees = '458480.413', '459177.562744', '0.03000569702410494'
     expected_events = [EvmEvent(
@@ -1116,13 +1042,9 @@ def test_swap_on_curve(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xfD1F67fDbA4F0C1952861345237463b39228F1C6']])
-def test_swap_on_sushiswap(database, ethereum_inquirer, ethereum_accounts):
+def test_swap_on_sushiswap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x802f7d1c4b2f1b7ef48e5c3af92a3a166a91624b89e736f85b90df3dd7ce9d73')  # noqa: E501
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     timestamp = TimestampMS(1708569407000)
     swap_amount, received_amount, gas_fees = '50', '68.557872437267381014', '0.007767959110971294'
     expected_events = [EvmEvent(
@@ -1169,11 +1091,10 @@ def test_swap_on_sushiswap(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xb3Dd5Cdb7F73acD1177c96409412e0b326E9C457']])
-def test_swap_on_quickswap(database, polygon_pos_inquirer, polygon_pos_accounts):
+def test_swap_on_quickswap(polygon_pos_inquirer, polygon_pos_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7b1bef89b8890e060787924a279e040ce8d50aedd35337747af6d56024ce269e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        database=database,
         tx_hash=tx_hash,
     )
     timestamp = TimestampMS(1709675020000)

--- a/rotkehlchen/tests/unit/decoders/test_zksync.py
+++ b/rotkehlchen/tests/unit/decoders/test_zksync.py
@@ -13,7 +13,7 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7277F7849966426d345D8F6B9AFD1d3d89183083']])
-def test_zksync_lite_legacy_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_zksync_lite_legacy_deposit(ethereum_inquirer, ethereum_accounts):
     """
     Test a transaction with the OnChainDeposit event which is missing
     from the newest implementation of the proxy address
@@ -22,11 +22,7 @@ def test_zksync_lite_legacy_deposit(database, ethereum_inquirer, ethereum_accoun
     evmhash = deserialize_evm_tx_hash(tx_hex)
     timestamp = TimestampMS(1607624823000)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas_str = '0.003633546'
     dai_str = '9.4361'
     expected_events = [
@@ -62,17 +58,13 @@ def test_zksync_lite_legacy_deposit(database, ethereum_inquirer, ethereum_accoun
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x7277F7849966426d345D8F6B9AFD1d3d89183083']])
-def test_zksync_lite_deposit(database, ethereum_inquirer, ethereum_accounts):
+def test_zksync_lite_deposit(ethereum_inquirer, ethereum_accounts):
     """Test a transaction with the Deposit event"""
     tx_hex = deserialize_evm_tx_hash('0x041514c879ae6f4f36c44000270ce482798502be230865911d1013978f4bcb87')  # noqa: E501
     evmhash = deserialize_evm_tx_hash(tx_hex)
     timestamp = TimestampMS(1639578202000)
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=tx_hex,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     gas_str = '0.007252433740671543'
     dai_str = '18.4614'
     expected_events = [
@@ -108,15 +100,11 @@ def test_zksync_lite_deposit(database, ethereum_inquirer, ethereum_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
-def test_zksync_lite_withdrawal(database, ethereum_inquirer, ethereum_accounts):
+def test_zksync_lite_withdrawal(ethereum_inquirer, ethereum_accounts):
     """Test a transaction with the Withdrawal event"""
     evmhash = deserialize_evm_tx_hash('0x234407968b9a688be3fb37cf7ff8ef3b4168d6cd85ec45b8344bb2a88832f982')  # noqa: E501
     user_address = ethereum_accounts[0]
-    events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=ethereum_inquirer,
-        database=database,
-        tx_hash=evmhash,
-    )
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=evmhash)
     timestamp, eth_str, dai_str, pan_str, usdc_str, usdt_str = TimestampMS(1604326368000), '1.4437093', '1691.92749999', '1586.6', '57.25', '15.2'  # noqa: E501
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/test_evm_balances.py
+++ b/rotkehlchen/tests/unit/test_evm_balances.py
@@ -40,7 +40,6 @@ def test_optimism_balances(
     tx_hex = deserialize_evm_tx_hash('0xed7e13e4941bba33edbbd70c4f48c734629fd67fe4eac43ce1bed3ef8f3da7df')  # transaction that interacts with the gauge address  # noqa: E501
     get_decoded_events_of_transaction(  # decode events that interact with the gauge address. This is needed because the query_balances which is used later only queries balances for addresses interacted wth gauges. This also populates the global db with the event assets  # noqa: E501
         evm_inquirer=optimism_inquirer,
-        database=user_database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -64,13 +64,11 @@ def test_delete_transactions_by_chain(
     """
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=deserialize_evm_tx_hash('0xac02ba9db26eee16f72a4b155fd07517ead140a539b1c41b67ba5a52b85d9dcb'),
         relevant_address=gnosis_accounts[0],
     )
     get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=deserialize_evm_tx_hash('0xafce539bd7fb898c5f03fdccf4c34e2c5c9ca321d612142953a7baf2849caafd'),
         relevant_address=gnosis_accounts[0],
     )

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -311,7 +311,6 @@ def test_token_detection_after_decoding(
     with patch.object(database, 'save_tokens_for_address') as save_tokens_mock:
         get_decoded_events_of_transaction(
             evm_inquirer=ethereum_inquirer,
-            database=database,
             tx_hash=deserialize_evm_tx_hash('0x21713730e79832ad0a88c9695745a95cd6e475fe69232f2aa8993ca98e6db92f'),
         )
         assert save_tokens_mock.call_count == 1

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -76,7 +76,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.inquirer import Inquirer
 
 
@@ -94,7 +93,6 @@ def test_curve_balances(
     tx_hex = deserialize_evm_tx_hash('0x09b67a0846ce2f6bea50221cfb5ac67f5b2f55b89300e45f58bf2f69dc589d43')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -124,7 +122,6 @@ def test_convex_gauges_balances(
     tx_hex = deserialize_evm_tx_hash('0x0d8863fb26d57ca11dc11c694dbf6a13ef03920e39d0482081aa88b0b20ba61b')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     convex_balances_inquirer = ConvexBalances(
@@ -154,13 +151,11 @@ def test_convex_staking_balances(
     tx_hex = deserialize_evm_tx_hash('0x0d8863fb26d57ca11dc11c694dbf6a13ef03920e39d0482081aa88b0b20ba61b')  # noqa: E501
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     tx_hex = deserialize_evm_tx_hash('0x679746961f731819e351f866b33bc2267dfb341e9d0b30ebccd012834ae3ffde')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     convex_balances_inquirer = ConvexBalances(
@@ -195,7 +190,6 @@ def test_convex_staking_balances_without_gauges(
     tx_hex = deserialize_evm_tx_hash('0x38bd199803e7cb065c809ce07957afc0647a41da4c0610d1209a843d9b045cd6')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     convex_balances_inquirer = ConvexBalances(
@@ -226,7 +220,6 @@ def test_velodrome_v2_staking_balances(
     tx_hex = deserialize_evm_tx_hash('0xed7e13e4941bba33edbbd70c4f48c734629fd67fe4eac43ce1bed3ef8f3da7df')  # transaction that interacts with the gauge address  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(  # decode events that interact with the gauge address  # noqa: E501
         evm_inquirer=optimism_inquirer,
-        database=optimism_transaction_decoder.database,
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )
@@ -261,7 +254,6 @@ def test_thegraph_balances(
     amount = '6626.873960369737'
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     thegraph_balances_inquirer = ThegraphBalances(
@@ -296,7 +288,6 @@ def test_thegraph_balances_arbitrum_one(
     tx_hex = deserialize_evm_tx_hash('0x3c846f305330969fb0ddb87c5ae411b4e9692f451a7ff3237b6f71020030c7d1')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=arbitrum_one_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     thegraph_balances_inquirer = ThegraphBalancesArbitrumOne(
@@ -319,7 +310,6 @@ def test_thegraph_balances_arbitrum_one(
 def test_thegraph_balances_vested_arbitrum_one(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_transaction_decoder: 'ArbitrumOneTransactionDecoder',
-        database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
         arbitrum_one_manager_connect_at_start,
@@ -338,7 +328,6 @@ def test_thegraph_balances_vested_arbitrum_one(
     ):
         get_decoded_events_of_transaction(
             evm_inquirer=ethereum_inquirer,
-            database=database,
             tx_hash=deserialize_evm_tx_hash(
                 tx_hash,
             ),
@@ -387,7 +376,6 @@ def test_octant_balances(
     tx_hex = deserialize_evm_tx_hash('0x29944efad254413b5eccdd5f13f14642ab830dbf51d5f2cfc59cf4957f33671a')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     octant_balances_inquirer = OctantBalances(
@@ -412,7 +400,6 @@ def test_eigenlayer_balances(
     tx_hex = deserialize_evm_tx_hash('0x89981857ab9f31369f954ae332ffd910e1f3c8efe531efde5f26666316855591')  # noqa: E501
     events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     assert len(events) == 2
@@ -440,7 +427,6 @@ def test_eigenpod_balances(
     tx_hex = deserialize_evm_tx_hash('0xb6fa282227916f9b16df953f79a5859ba80b8bc3b9c6adc01f262070d3c9e3d5')  # noqa: E501
     events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     assert len(events) == 2
@@ -487,7 +473,6 @@ def test_gmx_balances(
         tx_hex = deserialize_evm_tx_hash(tx_hash)
         _, tx_decoder = get_decoded_events_of_transaction(
             evm_inquirer=arbitrum_one_inquirer,
-            database=arbitrum_one_transaction_decoder.database,
             tx_hash=tx_hex,
         )
 
@@ -557,7 +542,6 @@ def test_gmx_balances_staking(
     )
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=arbitrum_one_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0x25160bf17e5a77935c7661933c045739dba44606859a20f00f187ef291e56a8f'),
     )
     balances_inquirer = GmxBalances(
@@ -587,7 +571,6 @@ def test_aave_balances_staking(
     amount = FVal('0.134274348203440352')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0xfaf96358784483a96a61db6aa4ecf4ac87294b841671ca208de6b5d8f83edf17'),
     )
     balances_inquirer = AaveBalances(
@@ -758,7 +741,6 @@ def test_blur_balances(
     amount = FVal('6350.3577325406')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     blur_balances_inquirer = BlurBalances(
@@ -787,7 +769,6 @@ def test_hop_balances_staking(
     lp_amount, reward_amount = FVal('0.005676129314105837'), FVal('0.06248913329652552')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=arbitrum_one_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0x6329984b82cb85903fee9fef61fb77cdf848ff6344056156da2e66676ad91473'),
     )
     balances_inquirer = HopBalances(
@@ -819,7 +800,6 @@ def test_hop_balances_staking_2(
     lp_amount, reward_amount = FVal('0.005676129314105837'), FVal('0.008945843949587174')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=arbitrum_one_transaction_decoder.database,
         tx_hash=deserialize_evm_tx_hash('0xe0c1f6f152422784a4e4346d84af7d32fda95eab17da257f3fdc5121f4a6fbc8'),
     )
     balances_inquirer = HopBalances(
@@ -851,7 +831,6 @@ def test_gearbox_balances(
     amount = FVal('260.869836197270890866')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     protocol_balances_inquirer = GearboxBalances(
@@ -880,7 +859,6 @@ def test_gearbox_balances_arb(
     amount = FVal('139896.73226582730792446')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        database=arbitrum_one_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     protocol_balances_inquirer = GearboxBalancesArbitrumOne(
@@ -909,7 +887,6 @@ def test_safe_locked(
     amount = FVal('11515.763372')
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=ethereum_transaction_decoder.database,
         tx_hash=tx_hex,
     )
     protocol_balances_inquirer = SafeBalances(

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -624,7 +624,6 @@ def test_maybe_augmented_detect_new_spam_tokens(
     tx_hex = deserialize_evm_tx_hash('0x6c10aaafec60e012316f54e2ac691b0a64d8744c21382fd3eb5013b4d1935bab')  # noqa: E501
     get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     token = EvmToken(evm_address_to_identifier(
@@ -639,7 +638,6 @@ def test_maybe_augmented_detect_new_spam_tokens(
     tx_hex = deserialize_evm_tx_hash('0x5d7e7646e3749fcd575ea76e35763fa8eeb6dfb83c4c242a4448ee1495f695ba')  # noqa: E501
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     globaldb.delete_asset_by_identifier(A_YFI.identifier)
@@ -685,7 +683,6 @@ def test_tasks_dont_schedule_if_no_eth_address(task_manager: TaskManager) -> Non
 @pytest.mark.parametrize('max_tasks_num', [5])
 def test_augmented_detection_pendle_transactions(
         task_manager: TaskManager,
-        database: 'DBHandler',
         globaldb: GlobalDBHandler,
         ethereum_inquirer: 'EthereumInquirer',
 ) -> None:
@@ -696,7 +693,6 @@ def test_augmented_detection_pendle_transactions(
     tx_hex = deserialize_evm_tx_hash('0x9d4ff6ae12790aa747f2f886529092476df6b63e745684b80b8f32c61b90be67')  # noqa: E501
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        database=database,
         tx_hash=tx_hex,
     )
     token = EvmToken(evm_address_to_identifier(
@@ -1005,7 +1001,6 @@ def test_maybe_create_calendar_reminder(
     ens_events = [
         next(x for x in get_decoded_events_of_transaction(  # decode ENS registration/renewal event and get the event with the metadata  # noqa: E501
             evm_inquirer=ethereum_inquirer,
-            database=database,
             tx_hash=ens_tx_hash,
         )[0] if x.extra_data is not None) for ens_tx_hash in ens_tx_hashes
     ]

--- a/rotkehlchen/tests/unit/uniswap/test_calculate_events_balances.py
+++ b/rotkehlchen/tests/unit/uniswap/test_calculate_events_balances.py
@@ -43,17 +43,12 @@ def test_single_pool_without_balances(rotkehlchen_api_server: 'APIServer', ether
     to calculate the based on their info.
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    database = rotki.data.db
     ethereum_inquirer = rotki.chains_aggregator.ethereum.node_inquirer
     uniswap = rotki.chains_aggregator.get_module('uniswap')
     tx_hex_1 = deserialize_evm_tx_hash('0xa9ce328d0e2d2fa8932890bfd4bc61411abd34a4aaa48fc8b853c873a55ea824')  # noqa: E501
     tx_hex_2 = deserialize_evm_tx_hash('0x27ddad4f187e965a3ee37257b75d297ff79b2663fd0a2d8d15f7efaccf1238fa')  # noqa: E501
     for tx_hex in (tx_hex_1, tx_hex_2):
-        get_decoded_events_of_transaction(
-            evm_inquirer=ethereum_inquirer,
-            database=database,
-            tx_hash=tx_hex,
-        )
+        get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     assert uniswap is not None
     with patch(
         'rotkehlchen.chain.ethereum.modules.uniswap.uniswap.Uniswap.get_balances',
@@ -81,7 +76,6 @@ def test_multiple_pools_without_balances(rotkehlchen_api_server: 'APIServer', et
     required to calculate the based on their info.
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    database = rotki.data.db
     ethereum_inquirer = rotki.chains_aggregator.ethereum.node_inquirer
     uniswap = rotki.chains_aggregator.get_module('uniswap')
     tx_hex_1 = deserialize_evm_tx_hash('0xa9ce328d0e2d2fa8932890bfd4bc61411abd34a4aaa48fc8b853c873a55ea824')  # noqa: E501
@@ -89,11 +83,7 @@ def test_multiple_pools_without_balances(rotkehlchen_api_server: 'APIServer', et
     tx_hex_3 = deserialize_evm_tx_hash('0x1e7fd116b316af49f6c52b3ca44f3c5d24c2a6f80a5b5e674b5f94155bd2cec4')  # noqa: E501
     tx_hex_4 = deserialize_evm_tx_hash('0x140bdba831f9494cf0ead6d57009e1eae45ed629a78ee74ccbf49018afae0ffa')  # noqa: E501
     for tx_hex in (tx_hex_1, tx_hex_2, tx_hex_3, tx_hex_4):
-        get_decoded_events_of_transaction(
-            evm_inquirer=ethereum_inquirer,
-            database=database,
-            tx_hash=tx_hex,
-        )
+        get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     uniswap = rotki.chains_aggregator.get_module('uniswap')
     assert uniswap is not None
     with patch(
@@ -121,16 +111,11 @@ def test_single_pool_with_balances(rotkehlchen_api_server: 'APIServer', ethereum
     Test LP current balances are factorized in the pool events balance
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    database = rotki.data.db
     ethereum_inquirer = rotki.chains_aggregator.ethereum.node_inquirer
     tx_hex_1 = deserialize_evm_tx_hash('0xa9ce328d0e2d2fa8932890bfd4bc61411abd34a4aaa48fc8b853c873a55ea824')  # noqa: E501
     tx_hex_2 = deserialize_evm_tx_hash('0x27ddad4f187e965a3ee37257b75d297ff79b2663fd0a2d8d15f7efaccf1238fa')  # noqa: E501
     for tx_hex in (tx_hex_1, tx_hex_2):
-        get_decoded_events_of_transaction(
-            evm_inquirer=ethereum_inquirer,
-            database=database,
-            tx_hash=tx_hex,
-        )
+        get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hex)
     uniswap = rotki.chains_aggregator.get_module('uniswap')
     assert uniswap is not None
     with patch(


### PR DESCRIPTION
Removes the argument database from the function used in tests to decode transactions. It is not needed since it is also provided in the inquirer.

As a followup we should provide a fixture to decode transactions since we repeat a lot of work

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
