### PR TITLE
Fix Defillama price queries for zksync era

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` ZKSync Era tokens will now have prices queried properly by defillama.
+
 * :release:`1.34.3 <2024-08-20>`
 * :feature:`-` Generic events can now be created or imported with location being bitcoin, bitcoin cash, polkadot and kusama.
 * :bug:`-` Importing events with generic import will no longer create a fee event if the fee is zero. Before it was not creating one only if fee was omitted.

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -108,6 +108,8 @@ class Defillama(HistoricalPriceOracleInterface, PenalizablePriceOracleMixin):
                 chain_name = 'bsc'
             elif asset.chain_id == ChainID.AVALANCHE:
                 chain_name = 'avax'
+            elif asset.chain_id == ChainID.ZKSYNC_ERA:
+                chain_name = 'era'
             else:
                 chain_name = str(asset.chain_id)
 


### PR DESCRIPTION
Incorrect:
https://coins.llama.fi/prices/current/zksync_era:0x5A7d6b2F92C77FAD6CCaBd7EE0624E64907Eaf3E

Correct:
https://coins.llama.fi/prices/current/era:0x5A7d6b2F92C77FAD6CCaBd7EE0624E64907Eaf3E
