### PR TITLE
Monerium fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` ZKSync Era tokens will now have prices queried properly by defillama.
+* :bug:`8452` Fix Monerium integration after the v2 contracts upgrade.
 
 * :release:`1.34.3 <2024-08-20>`
 * :feature:`-` Generic events can now be created or imported with location being bitcoin, bitcoin cash, polkadot and kusama.

--- a/rotkehlchen/chain/ethereum/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/monerium/decoder.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
-from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecoder
 
-from rotkehlchen.constants.assets import A_ETH_EURE
+from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecoder
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -21,5 +21,10 @@ class MoneriumDecoder(MoneriumCommonDecoder):
             evm_inquirer=ethereum_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            native_asset=A_ETH_EURE,
+            monerium_token_addresses={
+                string_to_evm_address('0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f'),  # EURe
+                string_to_evm_address('0x7ba92741bf2a568abc6f1d3413c58c6e0244f8fd'),  # GBPe
+                string_to_evm_address('0xbc5142e0cc5eb16b47c63b0f033d4c2480853a52'),  # USDe
+                string_to_evm_address('0xc642549743a93674cf38d6431f75d6443f88e3e2'),  # ISKe
+            },
         )

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
-from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
@@ -31,14 +31,14 @@ class MoneriumCommonDecoder(DecoderInterface):
             evm_inquirer: 'EvmNodeInquirer',
             base_tools: 'BaseDecoderTools',
             msg_aggregator: 'MessagesAggregator',
-            native_asset: Asset,
+            monerium_token_addresses: set[ChecksumEvmAddress],
     ) -> None:
         super().__init__(
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
         )
-        self.eure_token = native_asset.resolve_to_evm_token()
+        self.monerium_token_addresses = monerium_token_addresses
 
     def _decode_mint_and_burn(self, context: DecoderContext) -> DecodingOutput:
         """Decode mint and burn events for monerium"""
@@ -49,43 +49,46 @@ class MoneriumCommonDecoder(DecoderInterface):
         from_address = hex_or_bytes_to_address(value=context.tx_log.topics[1])
         to_address = hex_or_bytes_to_address(value=context.tx_log.topics[2])
 
-        amount_raw = hex_or_bytes_to_int(value=context.tx_log.data)
+        token = get_or_create_evm_token(
+            userdb=self.evm_inquirer.database,
+            evm_address=context.tx_log.address,
+            chain_id=self.evm_inquirer.chain_id,
+            evm_inquirer=self.evm_inquirer,
+        )
         amount = token_normalized_value_decimals(
-            token_amount=amount_raw,
-            token_decimals=self.eure_token.decimals,
+            token_amount=hex_or_bytes_to_int(value=context.tx_log.data),
+            token_decimals=token.decimals,
         )
 
         # Not iterating over the events because the logic for decoding erc_20 transfers
         # has not been executed before calling this decoding logic
         event = None
-        if from_address == ZERO_ADDRESS:
-            # Create a mint event
+        if from_address == ZERO_ADDRESS:  # Create a mint event
             event = self.base.make_event_from_transaction(
                 transaction=context.transaction,
                 tx_log=context.tx_log,
                 event_type=HistoryEventType.RECEIVE,
                 event_subtype=HistoryEventSubType.NONE,
-                asset=self.eure_token,
+                asset=token,
                 balance=Balance(amount=amount),
                 location_label=to_address,
-                notes=f'Mint {amount} {self.eure_token.symbol}',
+                notes=f'Mint {amount} {token.symbol_or_name()}',
                 counterparty=CPT_MONERIUM,
             )
 
         elif (
             to_address == ZERO_ADDRESS and
             context.transaction.input_data.startswith((BURN_MONERIUM_SIGNATURE, BURNFROM_MONERIUM_SIGNATURE))  # noqa: E501
-        ):
-            # Create a burn event
+        ):  # Create a burn event
             event = self.base.make_event_from_transaction(
                 transaction=context.transaction,
                 tx_log=context.tx_log,
                 event_type=HistoryEventType.SPEND,
                 event_subtype=HistoryEventSubType.NONE,
-                asset=self.eure_token,
+                asset=token,
                 balance=Balance(amount=amount),
                 location_label=from_address,
-                notes=f'Burn {amount} {self.eure_token.symbol}',
+                notes=f'Burn {amount} {token.symbol_or_name()}',
                 counterparty=CPT_MONERIUM,
             )
 
@@ -94,7 +97,7 @@ class MoneriumCommonDecoder(DecoderInterface):
     # -- DecoderInterface methods
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
-        return {self.eure_token.evm_address: (self._decode_mint_and_burn,)}
+        return dict.fromkeys(self.monerium_token_addresses, (self._decode_mint_and_burn,))
 
     @staticmethod
     def counterparties() -> tuple[CounterpartyDetails, ...]:

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -248,6 +248,7 @@ class EvmTokens(ABC):
                     cursor=cursor,
                     address=address,
                     blockchain=self.evm_inquirer.blockchain,
+                    token_exceptions=self._per_chain_token_exceptions(),
                 )
 
         return addresses_info
@@ -339,6 +340,7 @@ class EvmTokens(ABC):
                     cursor=cursor,
                     address=address,
                     blockchain=self.evm_inquirer.blockchain,
+                    token_exceptions=self._per_chain_token_exceptions(),
                 )
                 if saved_list is None:
                     continue  # Do not query if we know the address has no tokens
@@ -431,6 +433,7 @@ class EvmTokensWithDSProxy(EvmTokens, ABC):
                         cursor=cursor,
                         address=proxy_address,
                         blockchain=self.evm_inquirer.blockchain,
+                        token_exceptions=self._per_chain_token_exceptions(),
                     )
 
                     if proxy_detected_tokens is not None:

--- a/rotkehlchen/chain/gnosis/decoding/decoder.py
+++ b/rotkehlchen/chain/gnosis/decoding/decoder.py
@@ -1,8 +1,9 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
+from rotkehlchen.chain.gnosis.tokens import GNOSIS_MONERIUM_LEGACY_ADDRESSES
 from rotkehlchen.constants.assets import A_XDAI
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+MONERIUM_V2_CONTRACTS_BLOCK: Final = 35656951
 
 
 class GnosisTransactionDecoder(EVMTransactionDecoder):
@@ -37,6 +40,7 @@ class GnosisTransactionDecoder(EVMTransactionDecoder):
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,
                 address_is_exchange_fn=self._address_is_exchange,
             ),
+            addresses_exceptions=dict.fromkeys(GNOSIS_MONERIUM_LEGACY_ADDRESSES, MONERIUM_V2_CONTRACTS_BLOCK),  # noqa: E501
         )
 
     # -- methods that need to be implemented by child classes --

--- a/rotkehlchen/chain/gnosis/modules/monerium/constants.py
+++ b/rotkehlchen/chain/gnosis/modules/monerium/constants.py
@@ -1,0 +1,16 @@
+from typing import Final
+
+from rotkehlchen.chain.evm.types import string_to_evm_address
+
+GNOSIS_MONERIUM_LEGACY_ADDRESSES: Final = {
+    string_to_evm_address('0xcB444e90D8198415266c6a2724b7900fb12FC56E'),  # legacy EURe
+    string_to_evm_address('0x5Cb9073902F2035222B9749F8fB0c9BFe5527108'),  # legacy GBPe
+    string_to_evm_address('0x20E694659536C6B46e4B8BE8f6303fFCD8d1dF69'),  # legacy USDe
+    string_to_evm_address('0xD8F84BF2E036A3c8E4c0e25ed2aAe0370F3CCca8'),  # legacy ISKe
+}
+GNOSIS_MONERIUM_ADDRESSES: Final = GNOSIS_MONERIUM_LEGACY_ADDRESSES | {
+    string_to_evm_address('0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),  # EURe
+    string_to_evm_address('0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053'),  # GBPe
+    string_to_evm_address('0x50D1A74F4b6dcaCddD97fd442C0e22a4c97F2b7f'),  # USDe
+    string_to_evm_address('0x614Bd419D3735C9eb51542C06e5Acc09a9953f61'),  # ISKe
+}

--- a/rotkehlchen/chain/gnosis/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/monerium/decoder.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecoder
-from rotkehlchen.constants.assets import A_GNOSIS_EURE
+from rotkehlchen.chain.gnosis.modules.monerium.constants import GNOSIS_MONERIUM_ADDRESSES
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -20,5 +20,5 @@ class MoneriumDecoder(MoneriumCommonDecoder):
             evm_inquirer=ethereum_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            native_asset=A_GNOSIS_EURE,
+            monerium_token_addresses=GNOSIS_MONERIUM_ADDRESSES,
         )

--- a/rotkehlchen/chain/gnosis/tokens.py
+++ b/rotkehlchen/chain/gnosis/tokens.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.tokens import EvmTokens
-from rotkehlchen.types import ChecksumEvmAddress
+from rotkehlchen.chain.gnosis.modules.monerium.constants import GNOSIS_MONERIUM_LEGACY_ADDRESSES
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.types import ChecksumEvmAddress
 
     from .node_inquirer import GnosisInquirer
 
@@ -15,5 +16,5 @@ class GnosisTokens(EvmTokens):
         super().__init__(database=database, evm_inquirer=gnosis_inquirer)
 
     # -- methods that need to be implemented per chain
-    def _per_chain_token_exceptions(self) -> set[ChecksumEvmAddress]:
-        return set()
+    def _per_chain_token_exceptions(self) -> set['ChecksumEvmAddress']:
+        return GNOSIS_MONERIUM_LEGACY_ADDRESSES

--- a/rotkehlchen/chain/polygon_pos/decoding/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/decoding/decoder.py
@@ -1,8 +1,9 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
+from rotkehlchen.chain.polygon_pos.tokens import POLYGON_MONERIUM_LEGACY_ADDRESSES
 from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+MONERIUM_V2_CONTRACTS_BLOCK: Final = 60733237
 
 
 class PolygonPOSTransactionDecoder(EVMTransactionDecoder):
@@ -37,6 +40,7 @@ class PolygonPOSTransactionDecoder(EVMTransactionDecoder):
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,
                 address_is_exchange_fn=self._address_is_exchange,
             ),
+            addresses_exceptions=dict.fromkeys(POLYGON_MONERIUM_LEGACY_ADDRESSES, MONERIUM_V2_CONTRACTS_BLOCK),  # noqa: E501
         )
 
     # -- methods that need to be implemented by child classes --

--- a/rotkehlchen/chain/polygon_pos/modules/monerium/constants.py
+++ b/rotkehlchen/chain/polygon_pos/modules/monerium/constants.py
@@ -1,0 +1,17 @@
+from typing import Final
+
+from rotkehlchen.chain.evm.types import string_to_evm_address
+
+POLYGON_MONERIUM_LEGACY_ADDRESSES: Final = {
+    string_to_evm_address('0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6'),  # legacy EURe
+    string_to_evm_address('0x75792CBDb361d80ba89271a079EfeE62c29FA324'),  # legacy GBPe
+    string_to_evm_address('0x64E97c1a6535afD4a313eF46F88A64a34250B719'),  # legacy USDe
+    string_to_evm_address('0xf1bBf27A9D659D326efBfa5D284EBaeFB803983D'),  # legacy ISKe
+}
+
+POLYGON_MONERIUM_ADDRESSES: Final = POLYGON_MONERIUM_LEGACY_ADDRESSES | {
+    string_to_evm_address('0xE0aEa583266584DafBB3f9C3211d5588c73fEa8d'),  # EURe
+    string_to_evm_address('0x646BEea7a02FdAdA34c8e118949fE32350aB2206'),  # GBPe
+    string_to_evm_address('0x91e2B584908C2807EFc9F846E0C2A1fe875C5141'),  # USDe
+    string_to_evm_address('0xd053fc09e8F05A43Da4ECC40a750559C938C8131'),  # ISKe
+}

--- a/rotkehlchen/chain/polygon_pos/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/monerium/decoder.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecoder
-from rotkehlchen.constants.assets import A_POLYGON_EURE
+from rotkehlchen.chain.polygon_pos.modules.monerium.constants import POLYGON_MONERIUM_ADDRESSES
 
 
 if TYPE_CHECKING:
@@ -21,5 +21,5 @@ class MoneriumDecoder(MoneriumCommonDecoder):
             evm_inquirer=ethereum_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            native_asset=A_POLYGON_EURE,
+            monerium_token_addresses=POLYGON_MONERIUM_ADDRESSES,
         )

--- a/rotkehlchen/chain/polygon_pos/tokens.py
+++ b/rotkehlchen/chain/polygon_pos/tokens.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.tokens import EvmTokens
+from rotkehlchen.chain.polygon_pos.modules.monerium.constants import (
+    POLYGON_MONERIUM_LEGACY_ADDRESSES,
+)
 from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC
 from rotkehlchen.types import ChecksumEvmAddress
 
@@ -21,4 +24,6 @@ class PolygonPOSTokens(EvmTokens):
         Polygon MATIC ERC20 token mirrors the user's balance on the chain.
         To avoid double counting, we exclude the token from the balance query.
         """
-        return {A_POLYGON_POS_MATIC.resolve_to_evm_token().evm_address}
+        return {
+            A_POLYGON_POS_MATIC.resolve_to_evm_token().evm_address,
+        } | POLYGON_MONERIUM_LEGACY_ADDRESSES

--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -27,6 +27,10 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.gnosis.modules.aave.v3.constants import (
     AAVE_V3_DATA_PROVIDER as AAVE_V3_DATA_PROVIDER_GNO,
 )
+from rotkehlchen.chain.gnosis.modules.monerium.constants import GNOSIS_MONERIUM_LEGACY_ADDRESSES
+from rotkehlchen.chain.polygon_pos.modules.monerium.constants import (
+    POLYGON_MONERIUM_LEGACY_ADDRESSES,
+)
 from rotkehlchen.chain.scroll.modules.aave.v3.constants import (
     AAVE_V3_DATA_PROVIDER as AAVE_V3_DATA_PROVIDER_SCRL,
 )
@@ -444,10 +448,18 @@ def maybe_detect_new_tokens(database: 'DBHandler') -> None:
         database.conn.write_ctx() as write_cursor,
     ):
         for (chain, location_label), tokens in detected_tokens.items():
+            if chain == SupportedBlockchain.GNOSIS:
+                token_exceptions = GNOSIS_MONERIUM_LEGACY_ADDRESSES
+            elif chain == SupportedBlockchain.POLYGON_POS:
+                token_exceptions = POLYGON_MONERIUM_LEGACY_ADDRESSES
+            else:
+                token_exceptions = set()
+
             old_tokens, _ = database.get_tokens_for_address(
                 cursor=cursor,
                 address=(address := string_to_evm_address(location_label)),
                 blockchain=chain,
+                token_exceptions=token_exceptions,
             )
             database.save_tokens_for_address(
                 write_cursor=write_cursor,

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -440,11 +440,13 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
             cursor=write_cursor,
             address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
             blockchain=SupportedBlockchain.POLYGON_POS,
+            token_exceptions=set(),
         ) == (None, None)
         eth_tokens, _ = data.db.get_tokens_for_address(
             cursor=write_cursor,
             address='0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12',
             blockchain=SupportedBlockchain.ETHEREUM,
+            token_exceptions=set(),
         )
         assert set(eth_tokens) == {A_DAI, A_USDC}
 

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -2463,3 +2463,63 @@ def test_liquidity_withdrawal(database, gnosis_inquirer, gnosis_accounts, load_g
         ),
     ]
     assert events == expected_events
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
+@pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_monerium_eure_v2(gnosis_inquirer, gnosis_accounts, load_global_caches):
+    """Regression test for https://github.com/rotki/rotki/issues/8452
+    This test pulls a transaction after the deployment of the monerium v2 contracts
+    and checks that we ignore correctly the log events emitted by the v1 contract.
+    """
+    tx_hash = deserialize_evm_tx_hash('0x1a2f03a1d89bb9ac019e6445c6d30ab32d85ca8e45ecbdf33d026700de5f7103')  # noqa: E501
+    timestamp, pool_address, gas_fees, removed_amount, returned_amount = TimestampMS(1724679110000), string_to_evm_address('0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a'), '0.0004379778', '0.019043275513941527', '0.01'  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        database=gnosis_inquirer.database,
+        tx_hash=tx_hash,
+        load_global_caches=load_global_caches,
+    )
+    assert events == [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_XDAI,
+            balance=Balance(amount=FVal(gas_fees)),
+            location_label=gnosis_accounts[0],
+            notes=f'Burned {gas_fees} XDAI for gas',
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=1,
+            timestamp=timestamp,
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+            asset=Asset(f'eip155:100/erc20:{pool_address}'),
+            balance=Balance(amount=FVal(returned_amount)),
+            location_label=gnosis_accounts[0],
+            notes=f'Return {returned_amount} crvEUReUSD',
+            counterparty=CPT_CURVE,
+            address=string_to_evm_address('0xE3FFF29d4DC930EBb787FeCd49Ee5963DADf60b6'),
+            extra_data={'withdrawal_events_num': 2},
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=2,
+            timestamp=timestamp,
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
+            balance=Balance(amount=FVal(removed_amount)),
+            location_label=gnosis_accounts[0],
+            notes=f'Remove {removed_amount} EURe from 0x056C6C5e684CeC248635eD86033378Cc444459B0 curve pool',  # noqa: E501
+            counterparty=CPT_CURVE,
+            address=string_to_evm_address('0xE3FFF29d4DC930EBb787FeCd49Ee5963DADf60b6'),
+        ),
+    ]

--- a/rotkehlchen/tests/unit/decoders/test_monerium.py
+++ b/rotkehlchen/tests/unit/decoders/test_monerium.py
@@ -1,13 +1,19 @@
+from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.constants.assets import A_ETH_EURE, A_GNOSIS_EURE, A_POLYGON_EURE
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
-from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+from rotkehlchen.types import ChecksumEvmAddress, Location, TimestampMS, deserialize_evm_tx_hash
+
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
 
 
 @pytest.mark.vcr()
@@ -204,3 +210,30 @@ def test_burnfrom_monerium_on_gnosis(database, gnosis_inquirer, gnosis_accounts)
         ),
     ]
     assert events == expected_events
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_accounts', [['0xA6Bf663Abd2c749ed479C383457b1a647dAB72E5']])
+def test_mint_v2_eure(
+        gnosis_inquirer: 'GnosisInquirer',
+        gnosis_accounts: list['ChecksumEvmAddress'],
+):
+    evmhash = deserialize_evm_tx_hash(val='0x859af3a118c2f2503dca9aba17421cfe46bfe1b9e2585988cded6cc3da0dc0f4')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        database=gnosis_inquirer.database,
+        tx_hash=evmhash,
+    )
+    assert events == [EvmEvent(
+        tx_hash=evmhash,
+        sequence_index=1,
+        timestamp=TimestampMS(1725021845000),
+        location=Location.GNOSIS,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
+        balance=Balance(amount=FVal(50)),
+        location_label=gnosis_accounts[0],
+        notes='Mint 50 EURe',
+        counterparty=CPT_MONERIUM,
+    )]

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -403,6 +403,7 @@ def test_update_snapshot_balances(rotkehlchen_instance: 'Rotkehlchen'):
             cursor=cursor,
             address=accounts[1],
             blockchain=SupportedBlockchain.ETHEREUM,
+            token_exceptions=set(),
         )
         assert set(tokens or {}) == {A_COMP, A_LUSD, A_DAI}
 


### PR DESCRIPTION
PR closing #8452

- [x] Always use the v2 contract for balance queries. Ignore v1. Handle it as ignored asset even for balances so as to not double count balances or show more tokens owned
- [x] For history events let's say T is the timestamp of the upgrade, X the old contract and Y the new. For every event involving either X or Y contracts after T count only Y and completely ignore X events and state changes.
- [ ] For accounting do same as you would do for display problems in (2) - 
 **For this since we will redecode the events it will work? Do we need to convert somehow from one contract to the other?**
- [x] We also have to edit our minting/burning logic which searches for the mint/burn transactions and decorates them with the SEPA data. To search for mint/burn of v2 after the T time.

Tokens taken from: https://monerium.dev/docs/tokens
