### PR TITLE
Disable scheduled workflows + cassette merges in repo forks

### DIFF
--- a/.github/workflows/rotki_cassette_merge.yml
+++ b/.github/workflows/rotki_cassette_merge.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   merge:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'rotki/rotki' }}
     environment: cassette-merge
     steps:
       - uses: rotki/action-cassette-deck@v2

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build-linux:
     name: Build linux binary
+    if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     env:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -76,6 +77,7 @@ jobs:
 
   build-macos:
     name: 'Build macOS binary ${{ matrix.os.arch }}'
+    if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:
@@ -180,6 +182,7 @@ jobs:
 
   build-windows:
     name: Build windows binary
+    if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     env:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -245,6 +248,7 @@ jobs:
 
   build-docker:
     name: Build docker images
+    if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     environment: docker
     steps:
@@ -302,7 +306,7 @@ jobs:
 
   notify:
     name: 'Success check'
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
     needs: [ 'build-linux', 'build-windows', 'build-macos', 'build-docker' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   linux:
     uses: ./.github/workflows/task_backend_tests.yml
+    if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     with:
       os: ubuntu-20.04
       test_environment: nightly
@@ -17,7 +18,7 @@ jobs:
 
   macos:
     uses: ./.github/workflows/task_backend_tests.yml
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
     needs: ['linux']
     with:
       os: macos-latest
@@ -26,7 +27,7 @@ jobs:
 
   windows:
     uses: ./.github/workflows/task_backend_tests.yml
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
     with:
       os: windows-latest
       test_environment: nightly
@@ -34,21 +35,21 @@ jobs:
 
   e2e:
     uses: ./.github/workflows/task_e2e_tests.yml
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
     needs: [ 'macos' ]
     secrets: inherit
 
   unittest-frontend:
     uses: ./.github/workflows/task_fe_unit_tests.yml
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
 
   verify-link:
     uses: ./.github/workflows/task_fe_external_links_verification.yml
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
 
   notify:
     name: 'Success check'
-    if: ${{ always() }}
+    if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
     needs: [ 'linux', 'macos', 'windows' ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This disables scheduled workflows and cassette merges in repository forks:
* to save resources in forks (the workflows make not that much sense there)
* to reduce the github notification noise of failed workflows as those workflows anyways fail as forks by default are missing credentials to notify / push artifacts

Notes:
* The workflows can still be triggered by pushing commits to the `build` and `tests` branch in forks.
* the `always()` calls has to remain otherwise jobs would not run despite `github.repository == 'rotki/rotki'` evaluating to true (tested that).

This allows new OSS developers:
* to clone the repo without burning personal action resources via not working scheduled flows or the need to manually disable those
* to create/merge/close PRs **within** the fork to work against the ci workflow without triggering the cassette flow (before opening already tested PRs against the real parent repo)

Thanks!

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
