### PR TITLE
Switch to pre-commit for (backend) linting

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -183,8 +183,7 @@ jobs:
 
   lint-backend:
     name: 'Backend lint'
-    needs: ['check-changes']
-    if: ${{ github.event_name != 'push' && needs.check-changes.outputs.backend_tasks }}
+    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -206,8 +205,14 @@ jobs:
           uv pip install --system -r requirements_lint.txt
           uv pip install --system -e .
           git rev-parse HEAD
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pre-commit
+            .mypy_cache
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml', 'requirements_lint.txt') }}
       - name: Lint
-        run: make lint
+        run: make pre-commit
 
   test-backend:
     if: ${{ github.event_name != 'push' && needs.check-changes.outputs.backend_tasks }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+# Apply to all files without committing:
+#   pre-commit run --all-files
+# Update this file:
+#   pre-commit autoupdate
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.4
+    hooks:
+      # lint & attempt to correct failures (e.g. pyupgrade)
+      - id: ruff
+        args: [--fix, --show-fixes]
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy --install-types --non-interactive
+        types: [python]
+        exclude: ^tools/
+        language: system
+        require_serial: true
+  - repo: https://github.com/LefterisJP/double-indent
+    # there is no version tag (yet) to use instead
+    rev: 8cecc0e3d92ad8ceb24a6e29ca75ed0c430e427a
+    hooks:
+      - id: double-indent
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, '2', --offset, '2', --sequence, '4', --implicit_start]
+        exclude: ^(.github|frontend)/
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.2
+    hooks:
+      - id: check-github-workflows
+      - id: check-readthedocs
+  - repo: https://github.com/pylint-dev/pylint
+    rev: v3.2.7
+    hooks:
+      - id: pylint
+        args: [--rcfile=.pylint.rc]
+        additional_dependencies: [astroid==3.2.4]
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: '3.11'
 
 sphinx:
   configuration: docs/conf.py

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,9 @@
-COMMON_LINT_PATHS = rotkehlchen/ rotkehlchen_mock/ package.py docs/conf.py packaging/docker/entrypoint.py
-TOOLS_LINT_PATH = tools/
-ALL_LINT_PATHS = $(COMMON_LINT_PATHS) $(TOOLS_LINT_PATH)
-
-lint:
-	ruff check $(ALL_LINT_PATHS)
-	double-indent --dry-run $(ALL_LINT_PATHS)
-	mypy $(COMMON_LINT_PATHS) --install-types --non-interactive
-	pylint --rcfile .pylint.rc $(ALL_LINT_PATHS)
+pre-commit:
+	pre-commit run --verbose --color=always --all-files --show-diff-on-failure
 
 
-format:
-	ruff check $(ALL_LINT_PATHS) --fix
-	double-indent $(ALL_LINT_PATHS)
+pre-commit-fast:
+	SKIP=pylint pre-commit run --verbose --color=always --all-files --show-diff-on-failure
 
 
 clean:
@@ -55,3 +47,5 @@ create-cassette:
 # https://stackoverflow.com/a/6273809/110395
 %:
 	@:
+
+.PHONY: all $(MAKECMDGOALS)

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,9 +1,9 @@
+pre-commit==3.8.0
+
 mypy==1.11.2
 mypy-extensions==1.0.0
-pylint==3.2.7
+pylint==3.2.7   # required for the pylint plugins unit tests
 astroid==3.2.4  # engine of pylint, upgrade them together
-ruff==0.6.4
-double-indent-rotki==0.1.7  # our fork of double indent
 
 # type packages used by mypy
 # pinned here so that we can have reproducible mypy runs

--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -199,9 +199,6 @@ class TimestampField(fields.Field):
 
 class TimestampMSField(fields.Field):
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
     def _deserialize(
             self,
             value: str,


### PR DESCRIPTION
This is maybe opinionated and controversial, but I still give it a try :)

Update: Crossed out what was done by other split out PRs to get the diff smaller here

Idea of this PR is to improve the overall backend lint experience by:
* ~~Disabling all pylint checks that are already implemented in ruff (ruff runs in <1 seconds, pylint still needs XX seconds)~~
* ~~Replacing `isort` with according ruff `I` rule (much faster)~~
* ~~Removing flake8 + plugins (flake8-commas, flake8-bugbear, flake8-comprehensions, flake8-debugger, flake8-executable, pep8-naming) as they all got implemented in ruff ([see](https://docs.astral.sh/ruff/rules/) and ruff is orders of magnitude faster)~~
* ~~Removing flake8-mutable as it appears un-maintained, see https://github.com/ebeweber/flake8-mutable (this allows to completely let go off flake8)~~
* ~~Removing flake8-tuple as it appears un-maintained, https://github.com/ar4s/flake8_tuple (this allows to completely let go off flake8)~~
* Introducing **pre-commit** as framework to combine various linters/formatters:
  * Lots of projects  + even pylint use pre-commit nowadays, see https://github.com/pylint-dev/pylint/blob/main/.pre-commit-config.yaml
  * Hooks are repos, that are each cloned + installed + cached in their own isolated folder/venv (except `mypy`)
  * pre-commit detects files via `git ls-files` (also in hidden folders or folder without `__init__.py`) and filters them for each hook by specified types.
  * pre-commit executes each hook and does the overall exit code handling: it runs all hooks, measures their execution time and the overall exit code tells if changes have been done and if there are findings to be handled.
  * Converted the existing linters (ruff, mypy, pylint, double-indent) to hooks and added some more
* Squashing the `lint` + `format` Make target into one `pre-commit` target, where the exit code tells if everything is fine or things got changed / need attention
* Adding a `pre-commit-fast` Make target (runs all hooks except pylint in <5secs!) ... that can be also potentially triggered via fswatch/inotify by any file change while working on the repo with any IDE.
* Enabling the backend lint github workflow job to always run as it lints/formats files beyond the backend only... though didn't rename it into anything else as it still mostly applies to the backend + some additional fundamental (not frontend) files.

Note:
* Many more hooks could be added via additional PRs (don't want to make this PR any bigger), like hooks for `shellcheck`, `hadolint`, `codespell`, `pretty-format-toml` and applying `yamlfmt` to more files.... update: and add frontend lint hooks like `eslint`.
* ~~The majority of changes in the Python files in this PR come from: enabling `I` in ruff + excluding less folders.~~

This PR is crafted into 3 commits:
* first one containing all the manual changes mentioned above
* second one is entirely automatically created by applying the added pre-commit config
* third one are the remaining manual changes ~~that come from no applying all the linting to more files compared to before~~

Final motivator for this: Run linters <5sec (nice constant feedback loop during development) + extensible lint setup (=pre-commit).

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
