### PR TITLE
Extend backend linting to more files + address all findings

### DIFF
--- a/.github/scripts/notifier.py
+++ b/.github/scripts/notifier.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
 from http import HTTPStatus
 
 import requests
@@ -48,9 +49,9 @@ def main() -> None:
         'content': msg,
     }
 
-    response = requests.post(url=url, data=data)
+    response = requests.post(url=url, data=data, timeout=30)
     if response.status_code != HTTPStatus.OK:
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
-COMMON_LINT_PATHS = rotkehlchen/ rotkehlchen_mock/ package.py
+COMMON_LINT_PATHS = rotkehlchen/ rotkehlchen_mock/ package.py docs/conf.py packaging/docker/entrypoint.py
 TOOLS_LINT_PATH = tools/
 ALL_LINT_PATHS = $(COMMON_LINT_PATHS) $(TOOLS_LINT_PATH)
 
 lint:
-	ruff check $(ALL_LINT_PATHS)
+	ruff check .
 	double-indent --dry-run $(ALL_LINT_PATHS)
 	mypy $(COMMON_LINT_PATHS) --install-types --non-interactive
 	pylint --rcfile .pylint.rc $(ALL_LINT_PATHS)
 
 
 format:
-	ruff check $(ALL_LINT_PATHS) --fix
+	ruff check . --fix
 	double-indent $(ALL_LINT_PATHS)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -49,8 +48,8 @@ extensions = [
 
 
 # 'releases' (changelog) settings
-releases_issue_uri = "https://github.com/rotki/rotki/issues/%s"
-releases_release_uri = "https://github.com/rotki/rotki/releases/tag/v%s"
+releases_issue_uri = 'https://github.com/rotki/rotki/issues/%s'
+releases_release_uri = 'https://github.com/rotki/rotki/releases/tag/v%s'
 # Enables 0.x.y releases to not be grouped into feature and bugfix releases
 # see: http://releases.readthedocs.io/en/latest/concepts.html#unstable-prehistory-mode
 # This needs to be kept enabled even once 1.0 has been reached!
@@ -160,7 +159,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (master_doc, 'rotki', 'rotki Documentation',
-     [author], 1)
+     [author], 1),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'rotki'
-copyright = '2018-2020, Eleftherios Karapetsas. 2020-2022, Rotki Solutions GmbH'
+project_copyright = '2018-2020, Eleftherios Karapetsas. 2020-2022, Rotki Solutions GmbH'
 author = 'The rotki team'
 
 # The short X.Y version
@@ -126,7 +126,7 @@ htmlhelp_basename = 'rotkidoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'rotki'
-project_copyright = '2018-2020, Eleftherios Karapetsas. 2020-2022, Rotki Solutions GmbH'
+project_copyright = '2018-2020, Eleftherios Karapetsas. 2020-2024, Rotki Solutions GmbH'
 author = 'The rotki team'
 
 # The short X.Y version

--- a/packaging/docker/entrypoint.py
+++ b/packaging/docker/entrypoint.py
@@ -3,12 +3,12 @@ import json
 import logging
 import os
 import shutil
-from signal import signal, SIGINT, SIGTERM, SIGQUIT
 import subprocess
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from signal import SIGINT, SIGQUIT, SIGTERM, signal
+from typing import Any
 
 logger = logging.getLogger('monitor')
 logging.basicConfig(level=logging.DEBUG)
@@ -24,7 +24,7 @@ def cleanup_tmp() -> None:
     logger.info('Preparing to cleanup tmp directory')
     tmp_dir = Path('/tmp/').glob('*')
     cache_cutoff = datetime.today() - timedelta(hours=6)
-    cutoff_epoch = int(cache_cutoff.strftime("%s"))
+    cutoff_epoch = int(cache_cutoff.strftime('%s'))
     to_delete = filter(lambda x: can_delete(x, cutoff_epoch), tmp_dir)
 
     deleted = 0
@@ -51,7 +51,7 @@ def cleanup_tmp() -> None:
     logger.info(f'Deleted {deleted} files or directories, skipped {skipped} from /tmp')
 
 
-def load_config_from_file() -> Optional[Dict[str, Any]]:
+def load_config_from_file() -> dict[str, Any] | None:
     config_file = Path('/config/rotki_config.json')
     if not config_file.exists():
         logger.info('no config file provided')
@@ -66,7 +66,7 @@ def load_config_from_file() -> Optional[Dict[str, Any]]:
             return None
 
 
-def load_config_from_env() -> Dict[str, Any]:
+def load_config_from_env() -> dict[str, Any]:
     loglevel = os.environ.get('LOGLEVEL')
     logfromothermodules = os.environ.get('LOGFROMOTHERMODDULES')
     max_size_in_mb_all_logs = os.environ.get('MAX_SIZE_IN_MB_ALL_LOGS')
@@ -82,7 +82,7 @@ def load_config_from_env() -> Dict[str, Any]:
     }
 
 
-def load_config() -> List[str]:
+def load_config() -> list[str]:
     env_config = load_config_from_env()
     file_config = load_config_from_file()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,14 @@ known-third-party = ["packaging"]  # packaging is otherwise detected as first-pa
     "S603",  # Script called by us. No variable input
     "S607",  # Script called by us. Partial executable path is fine.
 ]
+"docs/conf.py" = [
+    "ERA001",  # Lots of comments with text combined with commented-out example code
+    "INP001",  # no need for __init__ here
+]
+"packaging/docker/entrypoint.py" = [
+    "S",  # fixme
+]
+
 
 [tool.vulture]
 

--- a/pytestgeventwrapper.py
+++ b/pytestgeventwrapper.py
@@ -1,6 +1,7 @@
-from gevent import monkey, queue  # isort:skip # noqa
-monkey.patch_all()  # isort:skip # noqa
+from gevent import monkey, queue  # isort:skip
+monkey.patch_all()  # isort:skip
 from urllib3.connectionpool import ConnectionPool
+
 # Try to see if we will see no more deadlocks with this
 # https://github.com/gevent/gevent/issues/1957#issuecomment-1902072588
 ConnectionPool.QueueCls = queue.LifoQueue

--- a/stubs/Crypto/Random/__init__.pyi
+++ b/stubs/Crypto/Random/__init__.pyi
@@ -1,12 +1,10 @@
 # Stub created after looking at Crypto/Random/__init__.py
 from typing import Any
 
-
-class _UrandomRNG(object):
+class _UrandomRNG:
 
     def read(self, n: int) -> bytes:
         ...
-
 
 def new(*args: Any, **kwargs: Any) -> _UrandomRNG:
     ...


### PR DESCRIPTION
Split out from https://github.com/rotki/rotki/pull/8473

This treats all Python files as first class citizens by including them when linting.  

Notes: 
* This is done due to a potential switch to pre-commit proposed in https://github.com/rotki/rotki/pull/8473 ... pre-commit hooks by default apply to all files of a specified type in a repo ... it is possible to exclude files/folders, but applying to all files *now* allows to later use the hooks without converting the current includes to excludes.
* It also allows running just `ruff check .` without thinking about files/folders
* `mypy .` or `pylint .`  is not possible: they can recursively scan the repo, but cause issues due either not ignoring node_modules/ or venv folders as specified in .gitignore (only ruff does respect that) or ignoring folder unexpectedly if there is no `__init__.py` file.
* The list of folders to lint for mypy/pylint will go away when those tools run as pre-commit hook as pre-commit will use `git ls-files` to find all files, so folders in .gitignore will be correctly excluded.

<details>
  <summary>Fixed findings</summary>
  
.github/scripts/notifier.py:51:16: S113 Probable use of `requests` call without timeout
   |
49 |     }
50 | 
51 |     response = requests.post(url=url, data=data)
   |                ^^^^^^^^^^^^^ S113
52 |     if response.status_code != HTTPStatus.OK:
53 |         exit(1)
   |

.github/scripts/notifier.py:53:9: PLR1722 Use `sys.exit()` instead of `exit`
   |
51 |     response = requests.post(url=url, data=data)
52 |     if response.status_code != HTTPStatus.OK:
53 |         exit(1)
   |         ^^^^ PLR1722
   |
   = help: Replace `exit` with `sys.exit()`

docs/conf.py:1:1: UP009 [*] UTF-8 encoding declaration is unnecessary
  |
1 | # -*- coding: utf-8 -*-
  | ^^^^^^^^^^^^^^^^^^^^^^^ UP009
2 | #
3 | # Configuration file for the Sphinx documentation builder.
  |
  = help: Remove unnecessary coding comment

docs/conf.py:1:1: INP001 File `docs/conf.py` is part of an implicit namespace package. Add an `__init__.py`.
docs/conf.py:15:1: ERA001 Found commented-out code
   |
13 | # documentation root, use os.path.abspath to make it absolute, like shown here.
14 | #
15 | # import os
   | ^^^^^^^^^^^ ERA001
16 | # import sys
17 | # sys.path.insert(0, os.path.abspath('.'))
   |
   = help: Remove commented-out code

docs/conf.py:16:1: ERA001 Found commented-out code
   |
14 | #
15 | # import os
16 | # import sys
   | ^^^^^^^^^^^^ ERA001
17 | # sys.path.insert(0, os.path.abspath('.'))
   |
   = help: Remove commented-out code

docs/conf.py:17:1: ERA001 Found commented-out code
   |
15 | # import os
16 | # import sys
17 | # sys.path.insert(0, os.path.abspath('.'))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
   |
   = help: Remove commented-out code

docs/conf.py:23:1: A001 Variable `copyright` is shadowing a Python builtin
   |
22 | project = 'rotki'
23 | copyright = '2018-2020, Eleftherios Karapetsas. 2020-2022, Rotki Solutions GmbH'
   | ^^^^^^^^^ A001
24 | author = 'The rotki team'
   |

docs/conf.py:36:1: ERA001 Found commented-out code
   |
34 | # If your documentation needs a minimal Sphinx version, state it here.
35 | #
36 | # needs_sphinx = '1.0'
   | ^^^^^^^^^^^^^^^^^^^^^^ ERA001
37 | 
38 | # Add any Sphinx extension module names here, as strings. They can be
   |
   = help: Remove commented-out code

docs/conf.py:52:22: Q000 [*] Double quotes found but single quotes preferred
   |
51 | # 'releases' (changelog) settings
52 | releases_issue_uri = "https://github.com/rotki/rotki/issues/%s"
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Q000
53 | releases_release_uri = "https://github.com/rotki/rotki/releases/tag/v%s"
54 | # Enables 0.x.y releases to not be grouped into feature and bugfix releases
   |
   = help: Replace double quotes with single quotes

docs/conf.py:53:24: Q000 [*] Double quotes found but single quotes preferred
   |
51 | # 'releases' (changelog) settings
52 | releases_issue_uri = "https://github.com/rotki/rotki/issues/%s"
53 | releases_release_uri = "https://github.com/rotki/rotki/releases/tag/v%s"
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Q000
54 | # Enables 0.x.y releases to not be grouped into feature and bugfix releases
55 | # see: http://releases.readthedocs.io/en/latest/concepts.html#unstable-prehistory-mode
   |
   = help: Replace double quotes with single quotes

docs/conf.py:65:1: ERA001 Found commented-out code
   |
63 | # You can specify multiple suffix as a list of string:
64 | #
65 | # source_suffix = ['.rst', '.md']
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
66 | source_suffix = '.rst'
   |
   = help: Remove commented-out code

docs/conf.py:113:1: ERA001 Found commented-out code
    |
111 | # 'searchbox.html']``.
112 | #
113 | # html_sidebars = {}
    | ^^^^^^^^^^^^^^^^^^^^ ERA001
114 | 
115 | # The name of an image file (relative to this directory) to place at the top
    |
    = help: Remove commented-out code

docs/conf.py:133:5: ERA001 Found commented-out code
    |
131 |     # The paper size ('letterpaper' or 'a4paper').
132 |     #
133 |     # 'papersize': 'letterpaper',
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
134 | 
135 |     # The font size ('10pt', '11pt' or '12pt').
    |
    = help: Remove commented-out code

docs/conf.py:137:5: ERA001 Found commented-out code
    |
135 |     # The font size ('10pt', '11pt' or '12pt').
136 |     #
137 |     # 'pointsize': '10pt',
    |     ^^^^^^^^^^^^^^^^^^^^^^ ERA001
138 | 
139 |     # Additional stuff for the LaTeX preamble.
    |
    = help: Remove commented-out code

docs/conf.py:141:5: ERA001 Found commented-out code
    |
139 |     # Additional stuff for the LaTeX preamble.
140 |     #
141 |     # 'preamble': '',
    |     ^^^^^^^^^^^^^^^^^ ERA001
142 | 
143 |     # Latex figure (float) alignment
    |
    = help: Remove commented-out code

docs/conf.py:145:5: ERA001 Found commented-out code
    |
143 |     # Latex figure (float) alignment
144 |     #
145 |     # 'figure_align': 'htbp',
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
146 | }
    |
    = help: Remove commented-out code

docs/conf.py:163:18: COM812 [*] Trailing comma missing
    |
161 | man_pages = [
162 |     (master_doc, 'rotki', 'rotki Documentation',
163 |      [author], 1)
    |                   COM812
164 | ]
    |
    = help: Add trailing comma

docs/conf.py:187:1: ERA001 Found commented-out code
    |
185 | # or the project homepage.
186 | #
187 | # epub_identifier = ''
    | ^^^^^^^^^^^^^^^^^^^^^^ ERA001
188 | 
189 | # A unique identification for the text.
    |
    = help: Remove commented-out code

docs/conf.py:191:1: ERA001 Found commented-out code
    |
189 | # A unique identification for the text.
190 | #
191 | # epub_uid = ''
    | ^^^^^^^^^^^^^^^ ERA001
192 | 
193 | # A list of files that should not be packed into the epub file.
    |
    = help: Remove commented-out code

packaging/docker/entrypoint.py:2:1: I001 [*] Import block is un-sorted or un-formatted
   |
 1 |   #!/usr/bin/python3
 2 | / import json
 3 | | import logging
 4 | | import os
 5 | | import shutil
 6 | | from signal import signal, SIGINT, SIGTERM, SIGQUIT
 7 | | import subprocess
 8 | | import time
 9 | | from datetime import datetime, timedelta
10 | | from pathlib import Path
11 | | from typing import Any, Dict, List, Optional
12 | | 
13 | | logger = logging.getLogger('monitor')
   | |_^ I001
14 |   logging.basicConfig(level=logging.DEBUG)
   |
   = help: Organize imports

packaging/docker/entrypoint.py:7:8: S404 `subprocess` module is possibly insecure
  |
5 | import shutil
6 | from signal import signal, SIGINT, SIGTERM, SIGQUIT
7 | import subprocess
  |        ^^^^^^^^^^ S404
8 | import time
9 | from datetime import datetime, timedelta
  |

packaging/docker/entrypoint.py:11:1: UP035 `typing.Dict` is deprecated, use `dict` instead
   |
 9 | from datetime import datetime, timedelta
10 | from pathlib import Path
11 | from typing import Any, Dict, List, Optional
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
12 | 
13 | logger = logging.getLogger('monitor')
   |

packaging/docker/entrypoint.py:11:1: UP035 `typing.List` is deprecated, use `list` instead
   |
 9 | from datetime import datetime, timedelta
10 | from pathlib import Path
11 | from typing import Any, Dict, List, Optional
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
12 | 
13 | logger = logging.getLogger('monitor')
   |

packaging/docker/entrypoint.py:25:20: S108 Probable insecure usage of temporary file or directory: "/tmp/"
   |
23 | def cleanup_tmp() -> None:
24 |     logger.info('Preparing to cleanup tmp directory')
25 |     tmp_dir = Path('/tmp/').glob('*')
   |                    ^^^^^^^ S108
26 |     cache_cutoff = datetime.today() - timedelta(hours=6)
27 |     cutoff_epoch = int(cache_cutoff.strftime("%s"))
   |

packaging/docker/entrypoint.py:26:20: DTZ002 `datetime.datetime.today()` used
   |
24 |     logger.info('Preparing to cleanup tmp directory')
25 |     tmp_dir = Path('/tmp/').glob('*')
26 |     cache_cutoff = datetime.today() - timedelta(hours=6)
   |                    ^^^^^^^^^^^^^^^^ DTZ002
27 |     cutoff_epoch = int(cache_cutoff.strftime("%s"))
28 |     to_delete = filter(lambda x: can_delete(x, cutoff_epoch), tmp_dir)
   |
   = help: Use `datetime.datetime.now(tz=...)` instead

packaging/docker/entrypoint.py:27:46: Q000 [*] Double quotes found but single quotes preferred
   |
25 |     tmp_dir = Path('/tmp/').glob('*')
26 |     cache_cutoff = datetime.today() - timedelta(hours=6)
27 |     cutoff_epoch = int(cache_cutoff.strftime("%s"))
   |                                              ^^^^ Q000
28 |     to_delete = filter(lambda x: can_delete(x, cutoff_epoch), tmp_dir)
   |
   = help: Replace double quotes with single quotes

packaging/docker/entrypoint.py:54:32: UP007 [*] Use `X | Y` for type annotations
   |
54 | def load_config_from_file() -> Optional[Dict[str, Any]]:
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^ UP007
55 |     config_file = Path('/config/rotki_config.json')
56 |     if not config_file.exists():
   |
   = help: Convert to `X | Y`

packaging/docker/entrypoint.py:54:41: UP006 [*] Use `dict` instead of `Dict` for type annotation
   |
54 | def load_config_from_file() -> Optional[Dict[str, Any]]:
   |                                         ^^^^ UP006
55 |     config_file = Path('/config/rotki_config.json')
56 |     if not config_file.exists():
   |
   = help: Replace with `dict`

packaging/docker/entrypoint.py:60:10: PLW1514 `open` in text mode without explicit `encoding` argument
   |
58 |         return None
59 | 
60 |     with open(config_file) as file:
   |          ^^^^ PLW1514
61 |         try:
62 |             data = json.load(file)
   |
   = help: Add explicit `encoding` argument

packaging/docker/entrypoint.py:63:13: TRY300 Consider moving this statement to an `else` block
   |
61 |         try:
62 |             data = json.load(file)
63 |             return data
   |             ^^^^^^^^^^^ TRY300
64 |         except json.JSONDecodeError as e:
65 |             logger.error(e)
   |

packaging/docker/entrypoint.py:69:31: UP006 [*] Use `dict` instead of `Dict` for type annotation
   |
69 | def load_config_from_env() -> Dict[str, Any]:
   |                               ^^^^ UP006
70 |     loglevel = os.environ.get('LOGLEVEL')
71 |     logfromothermodules = os.environ.get('LOGFROMOTHERMODDULES')
   |
   = help: Replace with `dict`

packaging/docker/entrypoint.py:85:22: UP006 [*] Use `list` instead of `List` for type annotation
   |
85 | def load_config() -> List[str]:
   |                      ^^^^ UP006
86 |     env_config = load_config_from_env()
87 |     file_config = load_config_from_file()
   |
   = help: Replace with `list`

packaging/docker/entrypoint.py:128:9: FURB113 Use `args.extend(...)` instead of repeatedly calling `args.append()`
    |
127 |       if max_logfiles_num is not None:
128 |           args.append('--max-logfiles-num')
    |  _________^
129 | |         args.append(int(max_logfiles_num))
    | |__________________________________________^ FURB113
130 |   
131 |       if max_size_in_mb_all_logs is not None:
    |
    = help: Replace with `args.extend(...)`

packaging/docker/entrypoint.py:132:9: FURB113 Use `args.extend(...)` instead of repeatedly calling `args.append()`
    |
131 |       if max_size_in_mb_all_logs is not None:
132 |           args.append('--max-size-in-mb-all-logs')
    |  _________^
133 | |         args.append(int(max_size_in_mb_all_logs))
    | |_________________________________________________^ FURB113
134 |   
135 |       if sqlite_instructions is not None:
    |
    = help: Replace with `args.extend(...)`

packaging/docker/entrypoint.py:136:9: FURB113 Use `args.extend(...)` instead of repeatedly calling `args.append()`
    |
135 |       if sqlite_instructions is not None:
136 |           args.append('--sqlite-instructions')
    |  _________^
137 | |         args.append(int(sqlite_instructions))
    | |_____________________________________________^ FURB113
138 |       return args
    |
    = help: Replace with `args.extend(...)`

packaging/docker/entrypoint.py:144:11: S603 `subprocess` call: check for execution of untrusted input
    |
143 | # start colibri first and then start rotki
144 | colibri = subprocess.Popen(['/usr/sbin/colibri'])
    |           ^^^^^^^^^^^^^^^^ S603
145 | if colibri.returncode == 1:
146 |     logger.error('Failed to start colibri')
    |

packaging/docker/entrypoint.py:147:5: PLR1722 Use `sys.exit()` instead of `exit`
    |
145 | if colibri.returncode == 1:
146 |     logger.error('Failed to start colibri')
147 |     exit(1)
    |     ^^^^ PLR1722
148 | 
149 | base_args = [
    |
    = help: Replace `exit` with `sys.exit()`

packaging/docker/entrypoint.py:158:5: S104 Possible binding to all interfaces
    |
156 |     'http://localhost:*/*,app://.',
157 |     '--api-host',
158 |     '0.0.0.0',
    |     ^^^^^^^^^ S104
159 | ]
    |

packaging/docker/entrypoint.py:166:9: S603 `subprocess` call: check for execution of untrusted input
    |
164 | logger.info('starting rotki backend')
165 | 
166 | rotki = subprocess.Popen(cmd)
    |         ^^^^^^^^^^^^^^^^ S603
167 | 
168 | if rotki.returncode == 1:
    |

packaging/docker/entrypoint.py:170:5: PLR1722 Use `sys.exit()` instead of `exit`
    |
168 | if rotki.returncode == 1:
169 |     logger.error('Failed to start rotki')
170 |     exit(1)
    |     ^^^^ PLR1722
171 | 
172 | logger.info('starting nginx')
    |
    = help: Replace `exit` with `sys.exit()`

packaging/docker/entrypoint.py:174:9: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
    |
172 | logger.info('starting nginx')
173 | 
174 | nginx = subprocess.Popen('nginx -g "daemon off;"', shell=True)
    |         ^^^^^^^^^^^^^^^^ S602
175 | 
176 | if nginx.returncode == 1:
    |

packaging/docker/entrypoint.py:174:26: S607 Starting a process with a partial executable path
    |
172 | logger.info('starting nginx')
173 | 
174 | nginx = subprocess.Popen('nginx -g "daemon off;"', shell=True)
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ S607
175 | 
176 | if nginx.returncode == 1:
    |

packaging/docker/entrypoint.py:178:5: PLR1722 Use `sys.exit()` instead of `exit`
    |
176 | if nginx.returncode == 1:
177 |     logger.error('Failed to start nginx')
178 |     exit(1)
    |     ^^^^ PLR1722
    |
    = help: Replace `exit` with `sys.exit()`

packaging/docker/entrypoint.py:185:9: PLR1722 Use `sys.exit()` instead of `exit`
    |
183 |     if process.poll() is not None:
184 |         logger.error(f'{process_name} was not running. This means that some error occurred.')
185 |         exit(1)
    |         ^^^^ PLR1722
186 | 
187 |     process.terminate()
    |
    = help: Replace `exit` with `sys.exit()`

packaging/docker/entrypoint.py:195:5: PLR1722 Use `sys.exit()` instead of `exit`
    |
193 |     terminate_process('rotki', rotki)
194 |     terminate_process('nginx', nginx)
195 |     exit(0)
    |     ^^^^ PLR1722
    |
    = help: Replace `exit` with `sys.exit()`

packaging/docker/entrypoint.py:209:9: PLR1722 Use `sys.exit()` instead of `exit`
    |
207 |     if rotki.poll() is not None:
208 |         logger.error('rotki has terminated exiting')
209 |         exit(1)
    |         ^^^^ PLR1722
210 | 
211 |     if nginx.poll() is not None:
    |
    = help: Replace `exit` with `sys.exit()`

packaging/docker/entrypoint.py:213:9: PLR1722 Use `sys.exit()` instead of `exit`
    |
211 |     if nginx.poll() is not None:
212 |         logger.error('nginx was not running')
213 |         exit(1)
    |         ^^^^ PLR1722
214 | 
215 |     logger.info('OK: processes still running')
    |
    = help: Replace `exit` with `sys.exit()`

pytestgeventwrapper.py:1:48: RUF100 [*] Unused blanket `noqa` directive
  |
1 | from gevent import monkey, queue  # isort:skip # noqa
  |                                                ^^^^^^ RUF100
2 | monkey.patch_all()  # isort:skip # noqa
3 | from urllib3.connectionpool import ConnectionPool
  |
  = help: Remove unused `noqa` directive

pytestgeventwrapper.py:1:48: PGH004 Use specific rule codes when using `noqa`
  |
1 | from gevent import monkey, queue  # isort:skip # noqa
  |                                                ^^^^^^ PGH004
2 | monkey.patch_all()  # isort:skip # noqa
3 | from urllib3.connectionpool import ConnectionPool
  |

pytestgeventwrapper.py:2:34: RUF100 [*] Unused blanket `noqa` directive
  |
1 | from gevent import monkey, queue  # isort:skip # noqa
2 | monkey.patch_all()  # isort:skip # noqa
  |                                  ^^^^^^ RUF100
3 | from urllib3.connectionpool import ConnectionPool
4 | # Try to see if we will see no more deadlocks with this
  |
  = help: Remove unused `noqa` directive

pytestgeventwrapper.py:2:34: PGH004 Use specific rule codes when using `noqa`
  |
1 | from gevent import monkey, queue  # isort:skip # noqa
2 | monkey.patch_all()  # isort:skip # noqa
  |                                  ^^^^^^ PGH004
3 | from urllib3.connectionpool import ConnectionPool
4 | # Try to see if we will see no more deadlocks with this
  |

pytestgeventwrapper.py:3:1: I001 [*] Import block is un-sorted or un-formatted
  |
1 |   from gevent import monkey, queue  # isort:skip # noqa
2 |   monkey.patch_all()  # isort:skip # noqa
3 | / from urllib3.connectionpool import ConnectionPool
4 | | # Try to see if we will see no more deadlocks with this
  | |_^ I001
5 |   # https://github.com/gevent/gevent/issues/1957#issuecomment-1902072588
6 |   ConnectionPool.QueueCls = queue.LifoQueue
  |
  = help: Organize imports

stubs/Crypto/Random/__init__.pyi:2:1: I001 [*] Import block is un-sorted or un-formatted
  |
1 |   # Stub created after looking at Crypto/Random/__init__.py
2 | / from typing import Any
3 | | 
4 | | 
5 | | class _UrandomRNG(object):
  | |_^ I001
6 |   
7 |       def read(self, n: int) -> bytes:
  |
  = help: Organize imports

stubs/Crypto/Random/__init__.pyi:5:1: E303 [*] Too many blank lines (2)
  |
5 | class _UrandomRNG(object):
  | ^^^^^ E303
6 | 
7 |     def read(self, n: int) -> bytes:
  |
  = help: Remove extraneous blank line(s)

stubs/Crypto/Random/__init__.pyi:5:19: UP004 [*] Class `_UrandomRNG` inherits from `object`
  |
5 | class _UrandomRNG(object):
  |                   ^^^^^^ UP004
6 | 
7 |     def read(self, n: int) -> bytes:
  |
  = help: Remove `object` inheritance

stubs/Crypto/Random/__init__.pyi:11:1: E303 [*] Too many blank lines (2)
   |
11 | def new(*args: Any, **kwargs: Any) -> _UrandomRNG:
   | ^^^ E303
12 |     ...
   |
   = help: Remove extraneous blank line(s)

Found 57 errors.
  ```
</details>

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
