### PR TITLE
Convert monerium v1 events to v2

### DIFF
--- a/rotkehlchen/chain/gnosis/decoding/decoder.py
+++ b/rotkehlchen/chain/gnosis/decoding/decoder.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Final
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
+from rotkehlchen.chain.gnosis.modules.monerium.constants import V1_TO_V2_MONERIUM_MAPPINGS
 from rotkehlchen.chain.gnosis.tokens import GNOSIS_MONERIUM_LEGACY_ADDRESSES
 from rotkehlchen.constants.assets import A_XDAI
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -41,6 +42,7 @@ class GnosisTransactionDecoder(EVMTransactionDecoder):
                 address_is_exchange_fn=self._address_is_exchange,
             ),
             addresses_exceptions=dict.fromkeys(GNOSIS_MONERIUM_LEGACY_ADDRESSES, MONERIUM_V2_CONTRACTS_BLOCK),  # noqa: E501
+            exceptions_mappings=V1_TO_V2_MONERIUM_MAPPINGS,
         )
 
     # -- methods that need to be implemented by child classes --

--- a/rotkehlchen/chain/gnosis/modules/monerium/constants.py
+++ b/rotkehlchen/chain/gnosis/modules/monerium/constants.py
@@ -1,5 +1,6 @@
 from typing import Final
 
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 GNOSIS_MONERIUM_LEGACY_ADDRESSES: Final = {
@@ -13,4 +14,11 @@ GNOSIS_MONERIUM_ADDRESSES: Final = GNOSIS_MONERIUM_LEGACY_ADDRESSES | {
     string_to_evm_address('0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053'),  # GBPe
     string_to_evm_address('0x50D1A74F4b6dcaCddD97fd442C0e22a4c97F2b7f'),  # USDe
     string_to_evm_address('0x614Bd419D3735C9eb51542C06e5Acc09a9953f61'),  # ISKe
+}
+
+V1_TO_V2_MONERIUM_MAPPINGS: Final = {
+    'eip155:100/erc20:0xcB444e90D8198415266c6a2724b7900fb12FC56E': Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),  # noqa: E501
+    'eip155:100/erc20:0x5Cb9073902F2035222B9749F8fB0c9BFe5527108': Asset('eip155:100/erc20:0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053'),  # noqa: E501
+    'eip155:100/erc20:0x20E694659536C6B46e4B8BE8f6303fFCD8d1dF69': Asset('eip155:100/erc20:0x50D1A74F4b6dcaCddD97fd442C0e22a4c97F2b7f'),  # noqa: E501
+    'eip155:100/erc20:0xD8F84BF2E036A3c8E4c0e25ed2aAe0370F3CCca8': Asset('eip155:100/erc20:0x614Bd419D3735C9eb51542C06e5Acc09a9953f61'),  # noqa: E501
 }

--- a/rotkehlchen/chain/polygon_pos/decoding/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/decoding/decoder.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Final
 
 from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
+from rotkehlchen.chain.polygon_pos.modules.monerium.constants import V1_TO_V2_MONERIUM_MAPPINGS
 from rotkehlchen.chain.polygon_pos.tokens import POLYGON_MONERIUM_LEGACY_ADDRESSES
 from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -41,6 +42,7 @@ class PolygonPOSTransactionDecoder(EVMTransactionDecoder):
                 address_is_exchange_fn=self._address_is_exchange,
             ),
             addresses_exceptions=dict.fromkeys(POLYGON_MONERIUM_LEGACY_ADDRESSES, MONERIUM_V2_CONTRACTS_BLOCK),  # noqa: E501
+            exceptions_mappings=V1_TO_V2_MONERIUM_MAPPINGS,
         )
 
     # -- methods that need to be implemented by child classes --

--- a/rotkehlchen/chain/polygon_pos/modules/monerium/constants.py
+++ b/rotkehlchen/chain/polygon_pos/modules/monerium/constants.py
@@ -1,5 +1,6 @@
 from typing import Final
 
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 POLYGON_MONERIUM_LEGACY_ADDRESSES: Final = {
@@ -14,4 +15,11 @@ POLYGON_MONERIUM_ADDRESSES: Final = POLYGON_MONERIUM_LEGACY_ADDRESSES | {
     string_to_evm_address('0x646BEea7a02FdAdA34c8e118949fE32350aB2206'),  # GBPe
     string_to_evm_address('0x91e2B584908C2807EFc9F846E0C2A1fe875C5141'),  # USDe
     string_to_evm_address('0xd053fc09e8F05A43Da4ECC40a750559C938C8131'),  # ISKe
+}
+
+V1_TO_V2_MONERIUM_MAPPINGS: Final = {
+    'eip155:137/erc20:0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6': Asset('eip155:137/erc20:0xE0aEa583266584DafBB3f9C3211d5588c73fEa8d'),  # noqa: E501
+    'eip155:137/erc20:0x75792CBDb361d80ba89271a079EfeE62c29FA324': Asset('eip155:137/erc20:0x646BEea7a02FdAdA34c8e118949fE32350aB2206'),  # noqa: E501
+    'eip155:137/erc20:0x64E97c1a6535afD4a313eF46F88A64a34250B719': Asset('eip155:137/erc20:0x91e2B584908C2807EFc9F846E0C2A1fe875C5141'),  # noqa: E501
+    'eip155:137/erc20:0xf1bBf27A9D659D326efBfa5D284EBaeFB803983D': Asset('eip155:137/erc20:0xd053fc09e8F05A43Da4ECC40a750559C938C8131'),  # noqa: E501
 }

--- a/rotkehlchen/tests/unit/decoders/test_cowswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_cowswap.py
@@ -8,6 +8,7 @@ from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.chain.evm.decoding.cowswap.decoder import GPV2_SETTLEMENT_ADDRESS
 from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
 from rotkehlchen.constants.assets import (
     A_ARB,
     A_ETH,
@@ -23,7 +24,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
-from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+from rotkehlchen.types import ChecksumEvmAddress, Location, TimestampMS, deserialize_evm_tx_hash
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -934,3 +935,45 @@ def test_swap_token_to_token_arb(database, arbitrum_one_inquirer, arbitrum_one_a
         ),
     ]
     assert events == expected_events
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_gnosis_eure_v2(
+        gnosis_inquirer: GnosisInquirer,
+        gnosis_accounts: list[ChecksumEvmAddress],
+):
+    tx_hash = deserialize_evm_tx_hash('0xf751e1aa988888ab9edfa14ac98022c7d8241664f481fde40a418723b0fed009')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        database=gnosis_inquirer.database,
+        tx_hash=tx_hash,
+    )
+    timestamp, swap_amount, received_amount, user_address = TimestampMS(1725445370000), '0.0001', '0.254038701346779266', gnosis_accounts[0]  # noqa: E501
+    assert events == [EvmEvent(
+        sequence_index=33,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_type=HistoryEventType.TRADE,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=Asset('eip155:100/erc20:0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6'),
+        balance=Balance(FVal(swap_amount)),
+        location_label=user_address,
+        notes=f'Swap {swap_amount} wstETH in cowswap',
+        tx_hash=tx_hash,
+        counterparty=CPT_COWSWAP,
+        address=string_to_evm_address('0x9008D19f58AAbD9eD0D60971565AA8510560ab41'),
+    ), EvmEvent(
+        sequence_index=34,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_type=HistoryEventType.TRADE,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
+        balance=Balance(FVal(received_amount)),
+        location_label=user_address,
+        notes=f'Receive {received_amount} EURe as the result of a swap in cowswap',
+        tx_hash=tx_hash,
+        counterparty=CPT_COWSWAP,
+        address=string_to_evm_address('0x9008D19f58AAbD9eD0D60971565AA8510560ab41'),
+    )]

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -2510,7 +2510,7 @@ def test_monerium_eure_v2(gnosis_inquirer, gnosis_accounts, load_global_caches):
             extra_data={'withdrawal_events_num': 2},
         ), EvmEvent(
             tx_hash=tx_hash,
-            sequence_index=2,
+            sequence_index=11,
             timestamp=timestamp,
             location=Location.GNOSIS,
             event_type=HistoryEventType.WITHDRAWAL,


### PR DESCRIPTION
When processing the decoded events if there are v1 events decoded after the v2 deployment ignore the v1 events and use v2 tokens