### PR TITLE
fix: add missing key-attr on import page and history events

### DIFF
--- a/frontend/app/src/components/helper/BlockchainAccountSelector.vue
+++ b/frontend/app/src/components/helper/BlockchainAccountSelector.vue
@@ -201,6 +201,7 @@ function getAccount(account: AccountWithAddressData): Account {
       :model-value="internalValue"
       :options="displayedAccounts"
       :filter="filter"
+      key-attr="key"
       auto-select-first
       :loading="loading"
       :disabled="loading"

--- a/frontend/app/src/components/import/GroupedImport.vue
+++ b/frontend/app/src/components/import/GroupedImport.vue
@@ -142,7 +142,7 @@ const [DefineDisplay, ReuseDisplay] = createReusableTemplate<{
         return-object
         variant="outlined"
         key-attr="key"
-        >
+      >
         <template #selection="{ item }">
           <ReuseDisplay v-bind="item" />
         </template>

--- a/frontend/app/src/components/import/GroupedImport.vue
+++ b/frontend/app/src/components/import/GroupedImport.vue
@@ -141,7 +141,8 @@ const [DefineDisplay, ReuseDisplay] = createReusableTemplate<{
         hide-details
         return-object
         variant="outlined"
-      >
+        key-attr="key"
+        >
         <template #selection="{ item }">
           <ReuseDisplay v-bind="item" />
         </template>


### PR DESCRIPTION
This PR fixes issue #8497 by adding the missing key attribute on import page and history events filter by account.