### PR TITLE
chore: update @rotki/ui-library dependency to 1.2.4

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,8 @@ Changelog
 
 * :bug:`-` Fixed the “Show More Events” button to properly render additional events when there are more than 6, allowing it to load more as expected.
 * :bug:`-` Improve the filtering UI when there are no suggestions for a filter.
-* :feature:`8117` Rotki will now create calendar reminders for the end of the lock period of CRV in vote escrow
-* :feature:`8339` Users will be able to import addresses from browser wallets other than MetaMask, such as Rabby Wallet, Phantom, Rainbow, etc.
+* :feature:`8117` Rotki will now create calendar reminders for the end of the lock period of CRV in vote escrow.
+* :feature:`8339` Users will be able to import addresses from browser wallets other than MetaMask, such as Rabby Wallet, Phantom, Rainbow, etc. Currently, only MetaMask supports the addition of multiple addresses, while the others only import the active address.
 * :feature:`7349` Rotki's CSV importers will now report the number of successfully imported and total entries, and each error message will include the line number of the problematic entry.
 * :feature:`8147` Users can now import data from Blockpit into rotki.
 * :feature:`-` Rotki will now decode interest earned from aave v3 as independent events.

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@rotki/common": "workspace:*",
-    "@rotki/ui-library": "1.2.3",
+    "@rotki/ui-library": "1.2.4",
     "@types/jsdom": "21.1.7",
     "@types/lodash-es": "4.17.12",
     "@vuelidate/core": "2.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@rotki/ui-library':
-        specifier: 1.2.3
-        version: 1.2.3(@vueuse/core@11.0.3(vue@3.4.38(typescript@5.5.4)))(@vueuse/shared@11.0.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4))
+        specifier: 1.2.4
+        version: 1.2.4(@vueuse/core@11.0.3(vue@3.4.38(typescript@5.5.4)))(@vueuse/shared@11.0.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4))
       '@types/jsdom':
         specifier: 21.1.7
         version: 21.1.7
@@ -1896,8 +1896,8 @@ packages:
     peerDependencies:
       eslint: ^9.0.0
 
-  '@rotki/ui-library@1.2.3':
-    resolution: {integrity: sha512-613n7Ze/8HTbF1EiOrpL0AW34/sFkOXEknz0euNAYaT3uU760DgKgzTQ9XPnMQD/8waMHMeK31rUiAqSFDD0EA==}
+  '@rotki/ui-library@1.2.4':
+    resolution: {integrity: sha512-tXFTeUNU+stz+KkdUE9LdDsFcsjXRHeEYzkz4ReWnaYD+dX3Ibf9UGA94iPlAOucSCMjJl38mmNfFYR8l65bZw==}
     engines: {node: '>=20 <21', pnpm: '>=9 <10'}
     peerDependencies:
       '@vueuse/core': '>10.0.0'
@@ -8950,7 +8950,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@1.2.3(@vueuse/core@11.0.3(vue@3.4.38(typescript@5.5.4)))(@vueuse/shared@11.0.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4))':
+  '@rotki/ui-library@1.2.4(@vueuse/core@11.0.3(vue@3.4.38(typescript@5.5.4)))(@vueuse/shared@11.0.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4))':
     dependencies:
       '@vueuse/core': 11.0.3(vue@3.4.38(typescript@5.5.4))
       '@vueuse/shared': 11.0.3(vue@3.4.38(typescript@5.5.4))


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
