### PR TITLE
Fix an edge case at logout

### DIFF
--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -957,7 +957,8 @@ class TaskManager:
             return
 
         with self.schedule_lock:
-            self._schedule()
+            if self.should_schedule:  # adding this check here to protect against going to schedule during logout/shutdown once task manager has been cleared and DB has been deleted  # noqa: E501
+                self._schedule()
 
     def clear(self) -> None:
         """Ensure that no task is kept referenced. Used when removing the task manager"""
@@ -965,3 +966,4 @@ class TaskManager:
             gevent.killall(task_list)
 
         self.running_greenlets.clear()
+        self.should_schedule = False


### PR DESCRIPTION
During shutdown/logout there can be an edge condition when the scheduling is waiting on the schedule lock. The schedule lock is acquired by the logout process and the cleaning up/shutdown.

Then it's released once logout has been completed and scheduling proceeds to try and schedule a tasks while db has no active connection.

Example traceback

```
[10/09/2024 11:30:54 CEST] INFO rotkehlchen.rotkehlchen Greenlet-5: User successfully logged out user=rotki_gmbh
[10/09/2024 11:30:54 CEST] DEBUG rotkehlchen.api.rest Greenlet-5: Waiting for greenlets
[10/09/2024 11:30:54 CEST] DEBUG rotkehlchen.tasks.manager Greenlet-6: At task scheduling. Current greenlets: 0 Max greenlets: 2. Will schedule.
[10/09/2024 11:30:54 CEST] ERROR rotkehlchen.api.rest Greenlet with id 133937608510720: Main greenlet dies with exception: 'NoneType' object has no attribute 'read_ctx'.
Exception Name: <class 'AttributeError'>
Exception Info: 'NoneType' object has no attribute 'read_ctx'
Traceback:
   File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/rotkehlchen.py", line 619, in main_loop
    self.task_manager.schedule()
    ^^^^^^^^^^^^^^^^^
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/tasks/manager.py", line 960, in schedule
    self._schedule()
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/tasks/manager.py", line 940, in _schedule
    new_greenlets = scheduling_fn()
    ^^^^^^^^^^^^^^^^^
  File "/home/lefteris/w/rotkehlchen/rotkehlchen/tasks/manager.py", line 560, in _maybe_query_produced_blocks
    with self.database.conn.read_ctx() as cursor:
    ^^^^^^^^^^^^^^^^^

[10/09/2024 11:30:54 CEST] DEBUG rotkehlchen.api.rest Greenlet-5: Waited for greenlets. Killing all other greenlets
[10/09/2024 11:30:54 CEST] DEBUG rotkehlchen.api.rest Greenlet-5:
Shutdown completed
```