### PR TITLE
Fix (Coingecko): Prevent rate-limit from icons query

### DIFF
--- a/rotkehlchen/icons.py
+++ b/rotkehlchen/icons.py
@@ -1,5 +1,4 @@
 import hashlib
-import itertools
 import logging
 import shutil
 import urllib.parse
@@ -7,12 +6,10 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import gevent
 import requests
 from flask import Response, make_response
 
 from rotkehlchen.assets.asset import Asset, AssetWithNameAndType
-from rotkehlchen.assets.types import AssetType
 from rotkehlchen.constants.misc import (
     ALLASSETIMAGESDIR_NAME,
     ASSETIMAGESDIR_NAME,
@@ -237,59 +234,6 @@ class IconManager:
             coingecko_id=coingecko_id,
         )
         return None, True
-
-    def _assets_with_coingecko_id(self) -> dict[str, str]:
-        """Create a mapping of all the assets identifiers to their coingecko id if it is set"""
-        querystr = """
-        SELECT A.identifier, B.coingecko from assets as A JOIN common_asset_details as B
-        ON B.identifier = A.identifier WHERE A.type != ? AND B.coingecko IS NOT NULL AND B.coingecko != ""
-        """  # noqa: E501
-        assets_mappings: dict[str, str] = {}
-        with GlobalDBHandler().conn.read_ctx() as cursor:
-            fiat_type = AssetType.FIAT.serialize_for_db()
-            cursor.execute(querystr, [fiat_type])
-            for entry in cursor:
-                assets_mappings[entry[0]] = entry[1]
-        return assets_mappings
-
-    def query_uncached_icons_batch(self, batch_size: int) -> bool:
-        """Queries a batch of uncached icons for assets
-
-        Returns true if there is more icons left to cache after this batch.
-        """
-        coingecko_integrated_asset = self._assets_with_coingecko_id()
-        coingecko_integrated_asset_ids = set(coingecko_integrated_asset.keys())
-        cached_asset_ids = [
-            str(x.name)[:-10] for x in self.icons_dir.glob('*_small.png') if x.is_file()
-        ]
-        uncached_asset_ids = (
-            coingecko_integrated_asset_ids - set(cached_asset_ids) - self.failed_asset_ids.get_values()  # noqa: E501
-        )
-        log.info(
-            f'Periodic task to query coingecko for {batch_size} uncached asset icons. '
-            f'Uncached assets: {len(uncached_asset_ids)}. Cached assets: {len(cached_asset_ids)}',
-        )
-        assets_to_query = [(asset_id, coingecko_id) for asset_id, coingecko_id in coingecko_integrated_asset.items() if asset_id in uncached_asset_ids]  # noqa: E501
-        for asset_id, coingecko_id in itertools.islice(assets_to_query, batch_size):
-            self.query_coingecko_for_icon(asset=AssetWithNameAndType(asset_id), coingecko_id=coingecko_id)  # noqa: E501
-
-        return len(uncached_asset_ids) > batch_size
-
-    def periodically_query_icons_until_all_cached(
-            self,
-            batch_size: int,
-            sleep_time_secs: float,
-    ) -> None:
-        """Periodically query all uncached icons until we have icons cached for all
-        of the known assets that have coingecko integration"""
-        if batch_size == 0:
-            return
-
-        while True:
-            carry_on = self.query_uncached_icons_batch(batch_size=batch_size)
-            if not carry_on:
-                break
-            gevent.sleep(sleep_time_secs)
 
     def add_icon(self, asset: Asset, icon_path: Path) -> None:
         """Adds the icon in the custom icons directory for the asset

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -493,15 +493,6 @@ class Rotkehlchen:
         )
 
         self.migration_manager.maybe_migrate_data()
-        self.greenlet_manager.spawn_and_track(
-            after_seconds=5,
-            task_name='periodically_query_icons_until_all_cached',
-            exception_is_error=False,
-            method=self.icon_manager.periodically_query_icons_until_all_cached,
-            batch_size=ICONS_BATCH_SIZE,
-            sleep_time_secs=ICONS_QUERY_SLEEP,
-        )
-
         self.assets_updater = AssetsUpdater(self.msg_aggregator)
         self.greenlet_manager.spawn_and_track(
             after_seconds=None,

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -65,12 +65,6 @@ def test_coingecko_historical_price(session_coingecko):
     assert price == Price(FVal('2065.603754353392'))
 
 
-def test_assets_with_icons(icon_manager):
-    """Checks that _assets_with_coingecko_id returns a proper result"""
-    x = icon_manager._assets_with_coingecko_id()
-    assert len(x) > 1000
-
-
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_asset_icons_for_collections(icon_manager: IconManager) -> None:
     """

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -1137,6 +1137,7 @@ def test_snapshots_dont_happen_always(rotkehlchen_api_server: 'APIServer') -> No
             'rotkehlchen.db.dbhandler.DBHandler.get_last_balance_save_time',
             return_value=Timestamp(0),
         ):
+            gevent.sleep(1)  # wait for 1 second to save the next timestamp
             task_manager.schedule()
             gevent.joinall(rotki.greenlet_manager.greenlets)
 


### PR DESCRIPTION
## Checklist

- [x] Remove periodic queries of asset icons from Coingecko to prevent rate limiting.