### PR TITLE
Solve race condition on logout with task manager

### DIFF
--- a/rotkehlchen/greenlets/manager.py
+++ b/rotkehlchen/greenlets/manager.py
@@ -29,6 +29,7 @@ class GreenletManager:
     def clear(self) -> None:
         """Clears all tracked greenlets. To be called when logging out or shutting down"""
         gevent.killall(self.greenlets)
+        self.greenlets.clear()
 
     def clear_finished(self) -> None:
         """Remove all finished tracked greenlets from the list"""

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -520,13 +520,16 @@ class Rotkehlchen:
         log.info('Logging out user', user=user)
 
         self.deactivate_premium_status()
-        self.greenlet_manager.clear()
         del self.chains_aggregator
         self.exchange_manager.delete_all_exchanges()
 
         del self.accountant
         del self.history_querying_manager
         del self.data_importer
+
+        self.task_manager.clear()  # type: ignore  # task_manager is not None here
+        self.task_manager = None
+        self.greenlet_manager.clear()
 
         self.data.logout()
         self.cryptocompare.unset_database()
@@ -535,8 +538,6 @@ class Rotkehlchen:
         # Make sure no messages leak to other user sessions
         self.msg_aggregator.consume_errors()
         self.msg_aggregator.consume_warnings()
-        self.task_manager.clear()  # type: ignore  # task_manager is not None here
-        self.task_manager = None
 
         # We have locks in the chain aggregator that gets removed in this
         # function and in the db connections. The user db gets replaced but the globaldb

--- a/rotkehlchen/tests/fixtures/greenlets.py
+++ b/rotkehlchen/tests/fixtures/greenlets.py
@@ -8,4 +8,3 @@ def greenlet_manager(messages_aggregator):
     manager = GreenletManager(msg_aggregator=messages_aggregator)
     yield manager
     manager.clear()
-    manager.greenlets.clear()


### PR DESCRIPTION
It was possible for the task manager to get the running tasks killed but spawn one new just after closing the db connection but before stopping the task manager. This change in order prevents any new task from spawning.

How the error manifested was
```
[12/09/2024 12:11:48 CEST] ERROR rotkehlchen.greenlets.manager Greenlet with id 4473405632: Periodically query history events prices died with exception: 'NoneType' object has no attribute 'read_ctx'.
Exception Name: <class 'AttributeError'>
Exception Info: 'NoneType' object has no attribute 'read_ctx'
Traceback:
   File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "/Users/yabirgb/work/rotki/rotkehlchen/tasks/utils.py", line 69, in query_missing_prices_of_base_entries
    price = inquirer.query_historical_price(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/history/price.py", line 232, in query_historical_price
    can_query_history = oracle_instance.can_query_history(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/oracles/uniswap.py", line 368, in can_query_history
    return self.is_before_contract_creation(self.ethereum.get_blocknumber_by_time(timestamp))
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/node_inquirer.py", line 291, in get_blocknumber_by_time
    return self.etherscan.get_blocknumber_by_time(ts, closest)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/externalapis/etherscan.py", line 703, in get_blocknumber_by_time
    result = self._query(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/externalapis/etherscan.py", line 244, in _query
    api_key = self._get_api_key()
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/externalapis/interface.py", line 36, in _get_api_key
    credentials = self.db.get_external_service_credentials(self.service_name)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/db/dbhandler.py", line 895, in get_external_service_credentials
    with self.conn.read_ctx() as cursor:
```
