### PR TITLE
fix:csv import error severity

### DIFF
--- a/frontend/app/src/composables/message-handling.ts
+++ b/frontend/app/src/composables/message-handling.ts
@@ -253,11 +253,20 @@ export function useMessageHandling(): UseMessageHandling {
           messageBody = `${messageBody}\n${t('notification_messages.csv_import_result.rows', { rows: groupConsecutiveNumbers(error.rows) }, error.rows.length)}`;
       });
     }
+    let severity: Severity;
+    if (importedEntries === 0) {
+      severity = Severity.ERROR;
+    } else if (importedEntries < totalEntries) {
+      severity = Severity.WARNING;
+    } else {
+      severity = Severity.INFO;
+    }
+
     return {
       title,
       message: messageBody,
       display: true,
-      severity: importedEntries < totalEntries ? Severity.WARNING : Severity.INFO,
+      severity,
       priority: Priority.HIGH,
     };
   };

--- a/frontend/app/src/composables/message-handling.ts
+++ b/frontend/app/src/composables/message-handling.ts
@@ -254,14 +254,12 @@ export function useMessageHandling(): UseMessageHandling {
       });
     }
     let severity: Severity;
-    if (importedEntries === 0) {
+    if (importedEntries === 0)
       severity = Severity.ERROR;
-    } else if (importedEntries < totalEntries) {
+    else if (importedEntries < totalEntries)
       severity = Severity.WARNING;
-    } else {
+    else
       severity = Severity.INFO;
-    }
-
     return {
       title,
       message: messageBody,


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

When CSV imports fail completely (0 successful entries), the notification now displays as an error (red) instead of a warning (orange). 