### PR TITLE
Fixes issue with curve cache

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :feature:`8492` Eigenlayer PEPE upgrade changes will now be properly understood by rotki. That means AVS rewards claiming, ability to restake beacon chain staked ETH and new batched withdrawals directly to the eigenpod. For more read here: https://docs.eigenlayer.xyz/eigenlayer/restaking-guides/restaking-developer-guide#pepe-release
 * :bug:`-` The Manage Assets / Assets page will now show the correct assets on every page.
 * :feature:`7536` Added the ability to customize the CSV delimiter in the frontend settings. Users can now choose their preferred delimiter for CSV exports.
+* :feature:`8013` Added support in Optimism and Base for Extra Finance.
 * :feature:`2217` Users will now be able to use Uniswap V2 and V3 as historical price oracles.
 * :bug:`-` Fixed the “Show More Events” button to properly render additional events when there are more than 6, allowing it to load more as expected.
 * :bug:`-` Improve the filtering UI when there are no suggestions for a filter.
@@ -30,6 +31,7 @@ Changelog
 * :bug:`-` rotki will now decode the swaps done on velodrome v2 in the right order.
 * :bug:`-` ZKSync Era tokens will now have prices queried properly by defillama.
 * :bug:`-` rotki will now query TheGraph delegations only for the addresses that interacted with the protocol.
+* :bug:`-` Fixes a bug that was causing rotki to always query curve for new pools.
 * :bug:`8452` Fix Monerium integration after the v2 contracts upgrade.
 
 * :release:`1.34.3 <2024-08-20>`

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -127,11 +128,12 @@ def generate_address_via_create2(
     return to_checksum_address(contract_address)
 
 
-def should_update_protocol_cache(cache_key: CacheType, *args: str) -> bool:
+def should_update_protocol_cache(cache_key: CacheType, args: Sequence[str] | None = None) -> bool:
     """
     Checks if the last time the cache_key was queried is far enough to trigger
     the process of querying it again.
     """
+    args = args if args is not None else []
     with GlobalDBHandler().conn.read_ctx() as cursor:
         if cache_key in UNIQUE_CACHE_KEYS:
             last_update_ts = globaldb_get_unique_cache_last_queried_ts_by_key(

--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -72,7 +72,7 @@ class CurveManagerMixin:
             query_method=query_curve_data,
             save_method=save_curve_data_to_cache,
             chain_id=node_inquirer.chain_id,
-            cache_key_parts=(str(node_inquirer.chain_id.serialize_for_db())),
+            cache_key_parts=(str(node_inquirer.chain_id.serialize_for_db()),),
         ) is False:
             return
 

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -1452,7 +1452,7 @@ class EvmNodeInquirer(ABC, LockableQueryMixIn):
         if cache_key_parts is None:
             cache_key_parts = []
         if (
-            should_update_protocol_cache(cache_type, *cache_key_parts) is False and
+            should_update_protocol_cache(cache_type, cache_key_parts) is False and
             force_refresh is False
         ):
             return False

--- a/rotkehlchen/globaldb/cache.py
+++ b/rotkehlchen/globaldb/cache.py
@@ -196,15 +196,15 @@ def globaldb_get_general_cache_last_queried_ts_by_key(
     Get the last_queried_ts of the oldest stored element by key_parts. If there is no such
     element returns Timestamp(0)
     """
-    cache_key = compute_cache_key(key_parts)
     cursor.execute(
         'SELECT last_queried_ts FROM general_cache WHERE key=? '
-        'ORDER BY last_queried_ts ASC',
-        (cache_key,),
+        'ORDER BY last_queried_ts DESC',
+        (compute_cache_key(key_parts),),
     )
-    result = cursor.fetchone()
-    if result is None:
+
+    if (result := cursor.fetchone()) is None:
         return Timestamp(0)
+
     return Timestamp(result[0])
 
 
@@ -216,15 +216,15 @@ def globaldb_get_unique_cache_last_queried_ts_by_key(
     Get the last_queried_ts of the oldest stored element by key_parts. If there is no such
     element returns Timestamp(0)
     """
-    cache_key = compute_cache_key(key_parts)
     cursor.execute(
         'SELECT last_queried_ts FROM unique_cache WHERE key=? '
-        'ORDER BY last_queried_ts ASC',
-        (cache_key,),
+        'ORDER BY last_queried_ts DESC',
+        (compute_cache_key(key_parts),),
     )
-    result = cursor.fetchone()
-    if result is None:
+
+    if (result := cursor.fetchone()) is None:
         return Timestamp(0)
+
     return Timestamp(result[0])
 
 

--- a/rotkehlchen/globaldb/upgrades/v8_v9.py
+++ b/rotkehlchen/globaldb/upgrades/v8_v9.py
@@ -22,6 +22,16 @@ def _add_uniswap_to_price_history_source_types(write_cursor: 'DBCursor') -> None
     )
 
 
+@enter_exit_debug_log()
+def _remove_bad_cache_entries(write_cursor: 'DBCursor') -> None:
+    """Removes entries from the globaldb cache for curve pools that might be keeping
+    an invalid last_queried_ts.
+    """
+    write_cursor.execute(
+        'DELETE FROM general_cache WHERE last_queried_ts=0 AND key LIKE "CURVE_LP_TOKENS%"',
+    )
+
+
 @enter_exit_debug_log(name='globaldb v8->v9 upgrade')
 def migrate_to_v9(connection: 'DBConnection') -> None:
     """This globalDB upgrade does the following:
@@ -31,3 +41,4 @@ def migrate_to_v9(connection: 'DBConnection') -> None:
     with connection.write_ctx() as write_cursor:
         _addressbook_schema_update(write_cursor)
         _add_uniswap_to_price_history_source_types(write_cursor)
+        _remove_bad_cache_entries(write_cursor)


### PR DESCRIPTION
The previous globaldb upgrade reseted the last queried ts for some curve pools but this had the side effect of setting to 0 the timestamp of a delisted curve pool. It was making that for ethereum we always queried curve for new pools.

This PR:

- Sorts in DESC order to check the last modification of the cache
- Adds a step in the globaldb upgrade to remove this 0 entry
