### PR TITLE
Avoid storing in memory events discarded

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2869,7 +2869,7 @@ class RestAPI:
             }
 
         try:
-            events = chain_manager.transactions_decoder.decode_transaction_hashes(
+            events = chain_manager.transactions_decoder.decode_and_get_transaction_hashes(
                 tx_hashes=[tx_hash],
                 send_ws_notifications=True,
                 ignore_cache=True,  # always redecode from here

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -345,7 +345,7 @@ class EvmTokens(ABC):
                 if saved_list is None:
                     continue  # Do not query if we know the address has no tokens
 
-                # get NFT tokens for address and ignores them from the query to avoid duplicates
+                # get NFT tokens for address and ignore them from the query to avoid duplicates
                 cursor.execute(
                     'SELECT identifier, blockchain FROM nfts WHERE owner_address=?',
                     (address,),

--- a/rotkehlchen/tests/external_apis/test_monerium.py
+++ b/rotkehlchen/tests/external_apis/test_monerium.py
@@ -234,7 +234,7 @@ def test_query_info_on_redecode_request(rotkehlchen_api_server: APIServer):
     response_txt = '[{"id":"YYYY","profile":"PP","accountId":"PP","address":"0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da","kind":"redeem","amount":"2353.57","currency":"eur","totalFee":"0","fees":[],"counterpart":{"details":{"name":"Yabir Benchakhtir","country":"ES","lastName":"Benchakhtir","firstName":"Yabir"},"identifier":{"iban":"ESXX KKKK OOOO IIII KKKK LLLL","standard":"iban"}},"memo":"Venta inversion","supportingDocumentId":"","chain":"gnosis","network":"mainnet","txHashes":["0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354"],"meta":{"state":"processed","placedBy":"ii","placedAt":"2024-04-19T13:45:00.287212Z","processedAt":"2024-04-19T13:45:00.287212Z","approvedAt":"2024-04-19T13:45:00.287212Z","confirmedAt":"2024-04-19T13:45:00.287212Z","receivedAmount":"2353.57","sentAmount":"2353.57"}}]'  # noqa: E501
     with (
         patch('requests.Session.get', side_effect=lambda *args, **kwargs: MockResponse(200, response_txt)),  # noqa: E501
-        patch('rotkehlchen.chain.evm.decoding.decoder.EVMTransactionDecoder.decode_transaction_hashes', new=add_event),  # noqa: E501
+        patch('rotkehlchen.chain.evm.decoding.decoder.EVMTransactionDecoder.decode_and_get_transaction_hashes', new=add_event),  # noqa: E501
         patch('rotkehlchen.chain.evm.transactions.EvmTransactions.get_or_query_transaction_receipt', return_value=None),  # noqa: E501
     ):
         response = requests.put(

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -224,16 +224,6 @@ def test_query_and_decode_transactions_works_with_different_chains(
     hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None)
     assert len(hashes) == 1
 
-    # decode evm transactions using the optimism decoder and without providing any tx hash
-    optimism_transaction_decoder.decode_transaction_hashes(ignore_cache=False, tx_hashes=None)
-
-    # verify that the optimism transactions got decoded but not the
-    # ethereum one (would raise an error if tried)
-    hashes = dbl2withl1feestx.get_transaction_hashes_not_decoded(chain_id=ChainID.OPTIMISM, limit=None)  # noqa: E501
-    assert len(hashes) == 0
-    hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None)
-    assert len(hashes) == 1
-
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[

--- a/rotkehlchen/tests/unit/test_nfts.py
+++ b/rotkehlchen/tests/unit/test_nfts.py
@@ -96,7 +96,7 @@ def test_duplicate_balances(
 ):
     """Checks that we don't have duplicate balances for NFTs in balances.
 
-    If a NFT is tracked only as a token and not in the NFT table we query it
+    If an NFT is tracked only as a token and not in the NFT table we query it
     but if we track them from opensea as NFTs from the NFT module we avoid
     having duplicates.
     """

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -458,5 +458,5 @@ def get_decoded_events_of_transaction(
 
     transactions.get_or_query_transaction_receipt(tx_hash=tx_hash)
     with patch_decoder_reload_data(load_global_caches):
-        result = decoder.decode_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash])
+        result = decoder.decode_and_get_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash])
     return result, decoder


### PR DESCRIPTION
I saw that we only use the decoding function without tx_hash in tests so I removed it. Also added a conditional check to discard the generated events if we aren't going to consume them later