### PR TITLE
Eth2 cache and premium check

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -215,7 +215,7 @@ from rotkehlchen.icons import (
 )
 from rotkehlchen.inquirer import CurrentPriceOracle, Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import PremiumCredentials
+from rotkehlchen.premium.premium import PremiumCredentials, has_premium_check
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.serialization.serialize import process_result, process_result_list
 from rotkehlchen.tasks.utils import query_missing_prices_of_base_entries
@@ -1616,7 +1616,7 @@ class RestAPI:
         error_or_empty, events = self.rotkehlchen.history_querying_manager.get_history(
             start_ts=from_timestamp,
             end_ts=to_timestamp,
-            has_premium=self.rotkehlchen.premium is not None,
+            has_premium=has_premium_check(self.rotkehlchen.premium),
         )
         if error_or_empty != '':
             return wrap_in_fail_result(error_or_empty, status_code=HTTPStatus.CONFLICT)
@@ -3761,7 +3761,7 @@ class RestAPI:
         dbevents = DBHistoryEvents(self.rotkehlchen.data.db)
         has_premium = False
         entries_limit = FREE_HISTORY_EVENTS_LIMIT
-        if self.rotkehlchen.premium is not None:
+        if has_premium_check(self.rotkehlchen.premium):
             has_premium = True
             entries_limit = - 1
 
@@ -4203,7 +4203,7 @@ class RestAPI:
             user_notes, entries_found = self.rotkehlchen.data.db.get_user_notes_and_limit_info(
                 filter_query=filter_query,
                 cursor=cursor,
-                has_premium=self.rotkehlchen.premium is not None,
+                has_premium=has_premium_check(self.rotkehlchen.premium),
             )
             user_notes_total = self.rotkehlchen.data.db.get_entries_count(
                 cursor=cursor,

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -342,6 +342,14 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             if hasattr(module, 'premium') is True and module.premium is not None:  # type: ignore
                 module.premium = None  # type: ignore
 
+        # Also flush the cache of anything that is touched by eth2 validators since
+        # without premium we have a limit
+        self.flush_cache('query_eth2_balances')
+        self.flush_cache('query_balances')
+        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN)
+        self.flush_cache('query_balances', blockchain=None, ignore_cache=False)
+        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=False)  # noqa: E501
+
     def process_new_modules_list(self, module_names: list[ModuleName]) -> None:
         """Processes a new list of active modules
 

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/ammswap.py
@@ -32,7 +32,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import Premium
+from rotkehlchen.premium.premium import Premium, has_premium_check
 from rotkehlchen.tasks.utils import query_missing_prices_of_base_entries
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind, Timestamp
 
@@ -206,7 +206,7 @@ class AMMSwapPlatform:
                 events = db.get_history_events(
                     cursor=cursor,
                     filter_query=dbfilter,
-                    has_premium=self.premium is not None,
+                    has_premium=has_premium_check(self.premium),
                     group_by_event_ids=False,
                 )
 

--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -23,7 +23,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import Premium
+from rotkehlchen.premium.premium import Premium, has_premium_check
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp
 from rotkehlchen.utils.interfaces import EthereumModule
 from rotkehlchen.utils.misc import ts_ms_to_sec
@@ -389,7 +389,7 @@ class Aave(EthereumModule):
             events = db.get_history_events(
                 cursor=cursor,
                 filter_query=query_filter,
-                has_premium=self.premium is not None,
+                has_premium=has_premium_check(self.premium),
                 group_by_event_ids=False,
             )
 

--- a/rotkehlchen/chain/ethereum/modules/compound/compound.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/compound.py
@@ -16,6 +16,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.price import query_usd_price_zero_if_error
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.premium.premium import has_premium_check
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp
 from rotkehlchen.utils.interfaces import EthereumModule
 from rotkehlchen.utils.misc import ts_ms_to_sec
@@ -208,7 +209,7 @@ class Compound(EthereumModule, CompoundV2, CompoundV3):
             events = db.get_history_events(
                 cursor=cursor,
                 filter_query=query_filter,
-                has_premium=self.premium is not None,
+                has_premium=has_premium_check(self.premium),
                 group_by_event_ids=False,
             )
         profit, loss, liquidation, rewards = self._process_events(

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -25,7 +25,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.eth2 import EthBlockEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import Premium
+from rotkehlchen.premium.premium import Premium, has_premium_check
 from rotkehlchen.types import ChecksumEvmAddress, Eth2PubKey, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.data_structures import LRUCacheWithRemove
@@ -124,7 +124,7 @@ class Eth2(EthereumModule):
 
         balances = self.beacon_inquirer.get_balances(
             indices_or_pubkeys=list(pubkey_to_ownership.keys()),
-            has_premium=self.premium is not None,
+            has_premium=has_premium_check(self.premium),
         )
         for pubkey, balance in balances.items():
             if (ownership_proportion := pubkey_to_ownership.get(pubkey, ONE)) != ONE:
@@ -250,7 +250,7 @@ class Eth2(EthereumModule):
         if now - to_ts <= DAY_IN_SECONDS:
             balances = self.beacon_inquirer.get_balances(
                 indices_or_pubkeys=list(to_query_indices),
-                has_premium=self.premium is not None,
+                has_premium=has_premium_check(self.premium),
             )
             for pubkey, balance in balances.items():
                 entry = pnls[pubkey_to_index[pubkey]]

--- a/rotkehlchen/history/manager.py
+++ b/rotkehlchen/history/manager.py
@@ -17,6 +17,7 @@ from rotkehlchen.exchanges.manager import SUPPORTED_EXCHANGES, ExchangeManager
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryEvent
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.premium.premium import has_premium_check
 from rotkehlchen.tasks.manager import TaskManager
 from rotkehlchen.tasks.utils import query_missing_prices_of_base_entries
 from rotkehlchen.types import EVM_CHAINS_WITH_TRANSACTIONS, Location, Timestamp
@@ -141,7 +142,7 @@ class HistoryQueryingManager:
         if only_cache is False:
             self._query_services_for_trades(filter_query=filter_query)
 
-        has_premium = self.chains_aggregator.premium is not None
+        has_premium = has_premium_check(self.chains_aggregator.premium)
         with self.db.conn.read_ctx() as cursor:
             trades, filter_total_found = self.db.get_trades_and_limit_info(
                 cursor=cursor,
@@ -226,7 +227,7 @@ class HistoryQueryingManager:
         if only_cache is False:
             self._query_services_for_asset_movements(filter_query=filter_query)
 
-        has_premium = self.chains_aggregator.premium is not None
+        has_premium = has_premium_check(self.chains_aggregator.premium)
         asset_movements, filter_total_found = self.db.get_asset_movements_and_limit_info(
             filter_query=filter_query,
             has_premium=has_premium,
@@ -281,7 +282,7 @@ class HistoryQueryingManager:
                 entries_missing_prices=entries,
                 base_entries_ignore_set=task_manager.base_entries_ignore_set,
             )
-        has_premium = self.chains_aggregator.premium is not None
+        has_premium = has_premium_check(self.chains_aggregator.premium)
         events, filter_total_found, _ = db.get_history_events_and_limit_info(
             cursor=cursor,
             filter_query=filter_query,

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -532,3 +532,8 @@ def premium_create_and_verify(credentials: PremiumCredentials, username: str) ->
         return premium
 
     raise PremiumAuthenticationError('rotki API key was rejected by server')
+
+
+def has_premium_check(premium: Premium | None) -> bool:
+    """Helper function to check if we have premium"""
+    return premium is not None and premium.is_active()

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -84,7 +84,12 @@ from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.icons import IconManager
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import Premium, PremiumCredentials, premium_create_and_verify
+from rotkehlchen.premium.premium import (
+    Premium,
+    PremiumCredentials,
+    has_premium_check,
+    premium_create_and_verify,
+)
 from rotkehlchen.premium.sync import PremiumSyncManager
 from rotkehlchen.tasks.manager import DEFAULT_MAX_TASKS_NUM, TaskManager
 from rotkehlchen.types import (
@@ -940,7 +945,7 @@ class Rotkehlchen:
         error_or_empty, events = self.history_querying_manager.get_history(
             start_ts=start_ts,
             end_ts=end_ts,
-            has_premium=self.premium is not None,
+            has_premium=has_premium_check(self.premium),
         )
         report_id = self.accountant.process_history(
             start_ts=start_ts,

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -15,7 +15,7 @@ from rotkehlchen.db.updates import RotkiDataUpdater
 from rotkehlchen.exchanges.constants import EXCHANGES_WITH_PASSPHRASE
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.inquirer import Inquirer
-from rotkehlchen.premium.premium import Premium, PremiumCredentials
+from rotkehlchen.premium.premium import Premium, PremiumCredentials, SubscriptionStatus
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.api import create_api_server
 from rotkehlchen.tests.utils.args import default_args
@@ -70,6 +70,14 @@ def fixture_rotki_premium_credentials() -> PremiumCredentials:
         given_api_key=base64.b64encode(make_random_b64bytes(128)).decode(),
         given_api_secret=base64.b64encode(make_random_b64bytes(128)).decode(),
     )
+
+
+@pytest.fixture(name='rotki_premium_object')
+def fixture_rotki_premium_object(rotki_premium_credentials, username) -> Premium:
+    """Create an active rotki premium object with valid credentials"""
+    premium = Premium(credentials=rotki_premium_credentials, username=username)
+    premium.status = SubscriptionStatus.ACTIVE
+    return premium
 
 
 @pytest.fixture(name='data_migration_version', scope='session')
@@ -247,7 +255,7 @@ def initialize_mock_rotkehlchen_instance(
         start_with_logged_in_user,
         start_with_valid_premium,
         db_password,
-        rotki_premium_credentials,
+        rotki_premium_object,
         username,
         blockchain_accounts,
         include_etherscan_key,
@@ -383,7 +391,7 @@ def initialize_mock_rotkehlchen_instance(
             evm_nodes_wait.append((evm_manager.node_inquirer, connect_at_start))
 
     if start_with_valid_premium:
-        rotki.premium = Premium(credentials=rotki_premium_credentials, username=username)
+        rotki.premium = rotki_premium_object
         rotki.premium_sync_manager.premium = rotki.premium
         rotki.chains_aggregator.premium = rotki.premium
         # Add premium to all the modules
@@ -468,7 +476,7 @@ def fixture_rotkehlchen_api_server(
         start_with_logged_in_user,
         start_with_valid_premium,
         db_password,
-        rotki_premium_credentials,
+        rotki_premium_object,
         username,
         blockchain_accounts,
         include_etherscan_key,
@@ -520,7 +528,7 @@ def fixture_rotkehlchen_api_server(
         start_with_logged_in_user=start_with_logged_in_user,
         start_with_valid_premium=start_with_valid_premium,
         db_password=db_password,
-        rotki_premium_credentials=rotki_premium_credentials,
+        rotki_premium_object=rotki_premium_object,
         username=username,
         blockchain_accounts=blockchain_accounts,
         include_etherscan_key=include_etherscan_key,
@@ -593,7 +601,7 @@ def rotkehlchen_instance(
         start_with_logged_in_user,
         start_with_valid_premium,
         db_password,
-        rotki_premium_credentials,
+        rotki_premium_object,
         username,
         blockchain_accounts,
         include_etherscan_key,
@@ -636,7 +644,7 @@ def rotkehlchen_instance(
         start_with_logged_in_user=start_with_logged_in_user,
         start_with_valid_premium=start_with_valid_premium,
         db_password=db_password,
-        rotki_premium_credentials=rotki_premium_credentials,
+        rotki_premium_object=rotki_premium_object,
         username=username,
         blockchain_accounts=blockchain_accounts,
         include_etherscan_key=include_etherscan_key,

--- a/rotkehlchen/tests/unit/test_aave.py
+++ b/rotkehlchen/tests/unit/test_aave.py
@@ -13,7 +13,6 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.tests.utils.aave import ATOKENV1_TO_ASSET
 from rotkehlchen.types import ChainID, Timestamp, deserialize_evm_tx_hash
 from rotkehlchen.utils.misc import ts_now
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.history.price import PriceHistorian
     from rotkehlchen.inquirer import Inquirer
+    from rotkehlchen.premium.premium import Premium
 
 
 def test_aave_reserve_mapping():
@@ -47,7 +47,7 @@ def test_aave_v1_events_stats(
         database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_transaction_decoder: 'EthereumTransactionDecoder',
-        rotki_premium_credentials: 'PremiumCredentials',
+        rotki_premium_object: 'Premium',
         username: str,
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
         price_historian: 'PriceHistorian',  # pylint: disable=unused-argument
@@ -75,7 +75,7 @@ def test_aave_v1_events_stats(
     aave = Aave(
         ethereum_inquirer=ethereum_inquirer,
         database=database,
-        premium=Premium(credentials=rotki_premium_credentials, username=username),
+        premium=rotki_premium_object,
         msg_aggregator=database.msg_aggregator,
     )
     stats = aave.get_stats_for_addresses(

--- a/rotkehlchen/tests/unit/test_stats.py
+++ b/rotkehlchen/tests/unit/test_stats.py
@@ -7,7 +7,6 @@ from rotkehlchen.chain.ethereum.modules.liquity.trove import Liquity
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_COMP, A_CUSDC, A_DAI, A_USDC, A_WBTC
 from rotkehlchen.fval import FVal
-from rotkehlchen.premium.premium import Premium, PremiumCredentials
 from rotkehlchen.types import ChecksumEvmAddress, Price, Timestamp, deserialize_evm_tx_hash
 from rotkehlchen.utils.misc import ts_now
 
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.history.price import PriceHistorian
     from rotkehlchen.inquirer import Inquirer
+    from rotkehlchen.premium.premium import Premium
 
 
 TEST_ACCOUNTS = [
@@ -40,7 +40,7 @@ def test_compound_events_stats(
         database: 'DBHandler',
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_transaction_decoder: 'EthereumTransactionDecoder',
-        rotki_premium_credentials: 'PremiumCredentials',
+        rotki_premium_object: 'Premium',
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
         price_historian: 'PriceHistorian',  # pylint: disable=unused-argument
         ethereum_accounts: list[ChecksumEvmAddress],
@@ -72,11 +72,10 @@ def test_compound_events_stats(
         ignore_cache=True,
         tx_hashes=tx_hashes,
     )
-
     compound = Compound(
         ethereum_inquirer=ethereum_inquirer,
         database=database,
-        premium=Premium(credentials=rotki_premium_credentials, username=username),
+        premium=rotki_premium_object,
         msg_aggregator=database.msg_aggregator,
     )
     stats = compound.get_stats_for_addresses(


### PR DESCRIPTION
### [Flush eth2/chain balances cache after removing premium credentials](https://github.com/rotki/rotki/commit/405221186b589b119b6ba2a4e874210a1167be71)




### [Introduce a has_premium_check function](https://github.com/rotki/rotki/commit/a0d6256224fd11f840d1443f25770c8debeb69f4) 

This is just to combine the premium is not None check with the active
premium check. In theory this way if a key expires and after few hours
the `Premium` object detects it in all the places where this is
checked they will switch to non premium.

While before this change even if you have a `Premium` object with
expired keys and `status = NOT_ACTIVE` it would count them as premium
being active