### PR TITLE
Adjust logic for NFTs balances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Changelog
 * :feature:`8101` Failed transactions will now be displayed as failed and not just show "burned gas" event only.
 * :feature:`-` Transactions claiming SAFE tokens from vesting will now be properly decoded.
 * :feature:`-` Transactions locking, unlocking and withdrawing SAFE tokens will now be properly decoded. Also any locked SAFE tokens will be automatically detected and their balance counted.
+* :bug:`8535` Users won't see their total net worth duplicated when tracking NFTs as tokens.  
 * :bug:`-` rotki will now decode the events of all the velodrome pools which were getting skipped before.
 * :bug:`8477` rotki will now properly decode very old Arbitrum bridge withdrawals.
 * :bug:`-` rotki will now decode the swaps done on velodrome v2 in the right order.

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -4,6 +4,8 @@ from dataclasses import InitVar, dataclass, field
 from functools import total_ordering
 from typing import Any, NamedTuple, Optional, Union
 
+from eth_utils import to_checksum_address
+
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V3
 from rotkehlchen.chain.evm.decoding.aave.v3.constants import DEBT_TOKEN_SYMBOL_REGEX
@@ -584,7 +586,7 @@ class Nft(EvmToken):
         identifier_parts = self.identifier[len(NFT_DIRECTIVE):].split('_')
         if len(identifier_parts) == 0 or len(identifier_parts[0]) == 0:
             raise UnknownAsset(self.identifier)
-        address = identifier_parts[0]
+        address = to_checksum_address(identifier_parts[0])
         object.__setattr__(self, 'asset_type', AssetType.EVM_TOKEN)
         object.__setattr__(self, 'name', f'nft with id {self.identifier}')
         object.__setattr__(self, 'symbol', self.identifier[len(NFT_DIRECTIVE):])


### PR DESCRIPTION
If a user added a NFT token to the list of assets it was getting queried as any other token and getting double counted by also the NFT module.

WHat I did in this PR is:

- Ignore a token from the balance query if it is also in the nfts tables. The idea is to allow people tracking NFTs in chains where we don't support Opensea
- In the snapshots ignore NFTs if they are already in the list of balances

Closes #8535
