### PR TITLE
Gnosis pay payments and api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -469,7 +469,7 @@ Getting or modifying external services API credentials
          "message":""
       }
 
-   :resjson object result: The result object contains as many entries as the external services. Each entry's key is the name and the value is another object of the form ``{"api_key": "foo"}``. For etherscan services all are grouped under the ``etherscan`` key. If there are no etherscan services this key won't be present. The ``monerium`` service has a different structure than the rest. Has ``username`` and ``password`` keys.
+   :resjson object result: The result object contains as many entries as the external services. Each entry's key is the name and the value is another object of the form ``{"api_key": "foo"}``. For etherscan services all are grouped under the ``etherscan`` key. If there are no etherscan services this key won't be present. The ``monerium`` service has a different structure than the rest. Has ``username`` and ``password`` keys. The  ``gnosis_pay`` service at the moment is hacky. Need to provide the auth js session token in place of the api key.
    :statuscode 200: Querying of external service credentials was successful
    :statuscode 401: There is no logged in user
    :statuscode 500: Internal rotki error

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/constants.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/constants.py
@@ -4,6 +4,9 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 GNOSIS_PAY_CASHBACK_ADDRESS: Final = string_to_evm_address('0xCdF50be9061086e2eCfE6e4a1BF9164d43568EEC')  # noqa: E501
+GNOSIS_PAY_SPENDER_ADDRESS: Final = string_to_evm_address('0xcFF260bfbc199dC82717494299b1AcADe25F549b')  # noqa: E501
+
+SPEND: Final = b'\xca\x8f\xbb\x9b\xda\x99\x84\x8fDyq\xea\xe6*\xd0\xad+\xc7\xca\xf9\xaf\xcc\r\x8eN\x8f\xfc\xf7\xe0k\xc2\x8f'  # noqa: E501
 
 CPT_GNOSIS_PAY: Final = 'gnosis pay'
 GNOSIS_PAY_CPT_DETAILS: Final = CounterpartyDetails(

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
@@ -11,9 +12,12 @@ from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import (
     CPT_GNOSIS_PAY,
     GNOSIS_PAY_CASHBACK_ADDRESS,
     GNOSIS_PAY_CPT_DETAILS,
+    GNOSIS_PAY_SPENDER_ADDRESS,
+    SPEND,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
+from rotkehlchen.utils.misc import hex_or_bytes_to_address, hex_or_bytes_to_int
 
 
 class GnosisPayDecoder(DecoderInterface):
@@ -31,8 +35,39 @@ class GnosisPayDecoder(DecoderInterface):
 
         return DEFAULT_DECODING_OUTPUT
 
+    def decode_spend(self, context: DecoderContext) -> DecodingOutput:
+        if context.tx_log.topics[0] != SPEND:
+            return DEFAULT_DECODING_OUTPUT
+
+        token = self.base.get_or_create_evm_token(
+            address=hex_or_bytes_to_address(context.tx_log.data[0:32]),
+        )
+        # Account is the roles module, which is the 2nd module in the array
+        # when doing getModulesPaginated("0x0000000000000000000000000000000000000001")
+        # with pageSize 100
+        # hex_or_bytes_to_address(context.tx_log.data[32:64])  # noqa: ERA001
+        # should we use it?
+        raw_amount = hex_or_bytes_to_int(context.tx_log.data[96:128])
+        amount = token_normalized_value(raw_amount, token)
+
+        for event in context.decoded_events:
+            if (
+                    event.event_type == HistoryEventType.SPEND and
+                    event.event_subtype == HistoryEventSubType.NONE and
+                    event.asset == token and
+                    event.balance.amount == amount
+            ):
+                event.counterparty = CPT_GNOSIS_PAY
+                event.event_subtype = HistoryEventSubType.PAYMENT
+                event.notes = f'Spend {event.balance.amount} {token.symbol} via Gnosis Pay'
+
+        return DEFAULT_DECODING_OUTPUT
+
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
-        return {GNOSIS_PAY_CASHBACK_ADDRESS: (self.decode_cashback_events,)}
+        return {
+            GNOSIS_PAY_CASHBACK_ADDRESS: (self.decode_cashback_events,),
+            GNOSIS_PAY_SPENDER_ADDRESS: (self.decode_spend,),
+        }
 
     @staticmethod
     def counterparties() -> tuple[CounterpartyDetails, ...]:

--- a/rotkehlchen/externalapis/gnosispay.py
+++ b/rotkehlchen/externalapis/gnosispay.py
@@ -1,0 +1,172 @@
+import logging
+from json import JSONDecodeError
+from typing import TYPE_CHECKING, Any, Literal
+
+import requests
+
+from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import CPT_GNOSIS_PAY
+from rotkehlchen.db.filtering import EvmEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.settings import CachedSettings
+from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.types import EVMTxHash, Location, Timestamp, deserialize_evm_tx_hash
+from rotkehlchen.utils.misc import set_user_agent, timestamp_to_iso8601
+from rotkehlchen.utils.serialization import jsonloads_list
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class GnosisPay:
+    """This is the gnosis pay API interface
+
+    https://api.gnosispay.com/api-docs/
+
+    For now they have no api keys but you can get the __Secure-authjs.session-token
+    cookie from your local storage once logged in and put it to rotki. Then all data
+    is queriable.
+    """
+
+    def __init__(self, database: 'DBHandler', session_token: str) -> None:
+        self.database = database
+        self.session = requests.session()
+        self.session_token = session_token
+        set_user_agent(self.session)
+
+    def _query(
+            self,
+            endpoint: Literal['transactions'],
+            params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query a gnosis pay API endpoint with the hacky session token authentication"""
+        querystr = 'https://app.gnosispay.com/api/v1/' + endpoint
+        log.debug(f'Querying Gnosis PAy API  {querystr}')
+        timeout = CachedSettings().get_timeout_tuple()
+        try:
+            response = self.session.get(
+                url=querystr,
+                params=params,
+                timeout=timeout,
+                cookies={'__Secure-authjs.session-token': self.session_token},
+            )
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Querying {querystr} failed due to {e!s}') from e
+
+        if response.status_code != 200:
+            raise RemoteError(
+                f'Gnosis Pay API request {response.url} failed '
+                f'with HTTP status code {response.status_code} and text '
+                f'{response.text}',
+            )
+
+        try:
+            json_ret = jsonloads_list(response.text)
+        except JSONDecodeError as e:
+            raise RemoteError(
+                f'Gnosis Pay API returned invalid JSON response: {response.text}',
+            ) from e
+
+        return json_ret
+
+    def get_and_process_transactions(
+            self,
+            after_ts: Timestamp,
+            tx_hash: EVMTxHash | None = None,
+    ) -> None:
+        """Query for gnosis pay transactions and merchant data after a given timestamp.
+
+        Then search for our events and if there is a matching event overlay the
+        merchant data on top.
+
+                DMed by gnosis pay devs
+                export enum PaymentStatus {
+                  Approved = "Approved",
+                  IncorrectPin = "IncorrectPin",
+                  InsufficientFunds = "InsufficientFunds",
+                  InvalidAmount = "InvalidAmount",
+                  PinEntryTriesExceeded = "PinEntryTriesExceeded",
+                  IncorrectSecurityCode = "IncorrectSecurityCode",
+                  Reversal = "Reversal",
+                  PartialReversal = "PartialReversal",
+                  Other = "Other",
+                }
+
+        mcc is the merchant code category and details can be seen here:
+        https://usa.visa.com/content/dam/VCOM/download/merchants/visa-merchant-data-standards-manual.pdf
+        """
+        data = self._query(
+            endpoint='transactions',
+            params={'after': timestamp_to_iso8601(after_ts)},
+        )
+        dbevents = DBHistoryEvents(self.database)
+        for entry in data:
+            try:
+                if entry['status'] != 'Approved':
+                    continue  # only check approved
+
+                entry_tx_hash = deserialize_evm_tx_hash(entry['transactions'][0]['hash'])  # take 1st transaction for now  # noqa: E501
+                if tx_hash and tx_hash != entry_tx_hash:
+                    continue
+
+                # now get the corresponding event
+                with self.database.conn.read_ctx() as cursor:
+                    events = dbevents.get_history_events(
+                        cursor=cursor,
+                        filter_query=EvmEventFilterQuery.make(
+                            tx_hashes=[entry_tx_hash],
+                            counterparties=[CPT_GNOSIS_PAY],
+                            location=Location.GNOSIS,
+                        ),
+                        has_premium=True,
+                    )
+
+                if len(events) != 1:
+                    log.error(f'Could not find gnosis pay event corresponding to {entry_tx_hash.hex()} in the DB. Skipping.')  # pylint: disable=no-member # noqa: E501
+                    continue
+
+                verb, preposition = 'Pay', 'to'
+                if int(entry['mcc']) == 6011:  # ATM cash withdrawal
+                    verb, preposition = 'Withdraw', 'from'
+
+                tx_currency_symbol = entry['transactionCurrency']['symbol']
+                billing_currency_symbol = entry['billingCurrency']['symbol']
+                tx_currency_amount = FVal(entry['transactionAmount']) / FVal(10 ** entry['transactionCurrency']['decimals'])  # noqa: E501
+                merchant_name = entry['merchant']['name'].rstrip()
+                notes = f'{verb} {tx_currency_amount} {tx_currency_symbol}'
+                if tx_currency_symbol != billing_currency_symbol:
+                    billing_currency_amount = FVal(entry['billingAmount']) / FVal(10 ** entry['billingCurrency']['decimals'])  # noqa: E501
+                    notes += f' ({billing_currency_amount} {billing_currency_symbol})'
+
+                notes += f' {preposition} {merchant_name}'
+                city = entry['merchant']['city'].rstrip()
+                if not (city.startswith('+') or city.isdigit()):  # for some reason sometiems there is phone numbers in merchant data instead of a city name  # noqa: E501
+                    notes += f' in {city}'
+
+                notes += f' :country:{entry["merchant"]["country"]["alpha2"]}:'
+                querystr = 'UPDATE history_events SET notes=? WHERE identifier=?'
+                bindings = (notes, events[0].identifier)
+                log.debug(f'Updating notes for gnosis pay event with tx_hash={entry_tx_hash.hex()}')  # pylint: disable=no-member # noqa: E501
+                with self.database.user_write() as write_cursor:
+                    write_cursor.execute(querystr, bindings)
+
+            except KeyError as e:
+                log.error(f'Could not find key {e!s} in Gnosis pay transaction response: {entry}')
+                continue
+
+
+def init_gnosis_pay(database: 'DBHandler') -> GnosisPay | None:
+    """Create a gnosis pay instance using the provided database"""
+    with database.conn.read_ctx() as cursor:
+        result = cursor.execute(
+            'SELECT api_key FROM external_service_credentials WHERE name=?',
+            ('gnosis_pay',),
+        ).fetchone()
+        if result is None:
+            return None
+
+    return GnosisPay(database=database, session_token=result[0])

--- a/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
+++ b/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
@@ -38,3 +38,32 @@ def test_gnosis_pay_cashback(gnosis_inquirer, gnosis_accounts):
             address=GNOSIS_PAY_CASHBACK_ADDRESS,
         ),
     ]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_accounts', [[
+    '0xF4a1fB1689104479De1EcADfA472A9B866D08B16',  # user's gnosis pay safe
+]])
+def test_gnosis_pay_spend(gnosis_inquirer, gnosis_accounts):
+    tx_hash = deserialize_evm_tx_hash('0xe8d666d6acf22e5a50dfea7ece1473558a854dfa04441ea9b3d0898843364ad8')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        tx_hash=tx_hash,
+    )
+    amount = '8.5'
+    assert events == [
+        EvmEvent(
+            sequence_index=29,
+            timestamp=TimestampMS(1726590745000),
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.PAYMENT,
+            asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
+            balance=Balance(amount=FVal(amount)),
+            location_label=gnosis_accounts[0],
+            notes=f'Spend {amount} EURe via Gnosis Pay',
+            tx_hash=tx_hash,
+            counterparty=CPT_GNOSIS_PAY,
+            address='0x4822521E6135CD2599199c83Ea35179229A172EE',
+        ),
+    ]

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -136,6 +136,7 @@ class ExternalService(SerializableEnumNameMixin):
     BLOCKSCOUT = auto()
     MONERIUM = auto()
     THEGRAPH = auto()
+    GNOSIS_PAY = auto()
 
     def get_chain_for_etherscan(self) -> Optional['ChainID']:
         """If the service is an etherscan service return its chain"""
@@ -155,6 +156,9 @@ class ExternalService(SerializableEnumNameMixin):
             return ChainID.SCROLL
 
         return None
+
+    def premium_only(self) -> bool:
+        return self in {ExternalService.GNOSIS_PAY, ExternalService.MONERIUM}
 
 
 class ExternalServiceApiCredentials(NamedTuple):


### PR DESCRIPTION
This adds a hacky first integration with gnosis pay API to pull
merchant data and overlay it over gnosis pay transactions.

- No tests written yet for the api data. Should mock some things.
- Not querying them periodically at all. May need to do it and not
  just on demand.


Making this PR first now so the frontend can also do their part of the integration. Frontend should:

- [ ] Add a new external service API insertion only for premium users. This should be to add the `__Secure-authjs.session-token` for Gnosis Pay API as the "key" of the Gnosis PAY api. Much like monerium should have a warning that this is experimental. No risks warning, as it's read only for sure.
- [ ] Explain how to add it in a docs entry like we do with monerium. The way do do it is to login gnosis pay and then open the console and go to cookies that the app keeps and take the value of `__Secure-authjs.session-token`
![2024-09-18_13-31](https://github.com/user-attachments/assets/78e004fa-3d33-4d0d-a759-c3643d814d0a)

- [ ] For all events that are spend/pay and counterparty `gnosis pay` have a special render rule to render the country flag which is part of the notes as: `:country:alpha2:`. For example for Germany `:country:DE:`.