### PR TITLE
Fix re-querying of zksync lite transactions

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -389,6 +389,6 @@ If an unknown asset is encountered on an exchange we emit a message with the fol
 
 
 - ``location``: Exchange where the asset was found.
-- ``name``: Differentiates between multiple instances of the same location.
+- ``name``: Differentiates between multiple instances of the same exchange.
 - ``identifier``: Asset identifier of the unknown asset.
 - ``details``: Details about what type of event was being processed when the unknown asset was encountered.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2766,21 +2766,19 @@ class RestAPI:
     @async_api_call()
     def refresh_evmlike_transactions(
             self,
-            from_timestamp: Timestamp,
-            to_timestamp: Timestamp,
+            from_timestamp: Timestamp,  # pylint: disable=unused-argument
+            to_timestamp: Timestamp,  # pylint: disable=unused-argument
             accounts: list[EvmlikeAccount] | None,
             chain: EvmlikeChain | None,  # pylint: disable=unused-argument
     ) -> dict[str, Any]:
-        """Refresh evmlike chain transactions. The chain is unused arg since only for zksynclite"""
+        """Refresh evmlike chain transactions.
+        The chain and timestamps are unused args since this is currently only for zksynclite,
+        and zksynclite's API doesn't support queries by timestamp."""
         message, status_code = '', HTTPStatus.OK
         # lazy mode. At the moment this can only be ZKSYnc lite
         addresses = [x.address for x in accounts] if accounts else self.rotkehlchen.chains_aggregator.accounts.zksync_lite  # noqa: E501
         for address in addresses:
-            self.rotkehlchen.chains_aggregator.zksync_lite.fetch_transactions(
-                address=address,
-                start_ts=from_timestamp,
-                end_ts=to_timestamp,
-            )
+            self.rotkehlchen.chains_aggregator.zksync_lite.fetch_transactions(address)
 
         return {'result': True, 'message': message, 'status_code': status_code}
 

--- a/rotkehlchen/chain/zksync_lite/constants.py
+++ b/rotkehlchen/chain/zksync_lite/constants.py
@@ -1,5 +1,4 @@
 from typing import Final
 
 ZKSYNCLITE_MAX_LIMIT: Final = 100
-ZKSYNCLITE_TX_SAVEPREFIX: Final = 'zksynclitetxs_'
 ZKL_IDENTIFIER: Final = 'zkl{tx_hash}'

--- a/rotkehlchen/chain/zksync_lite/manager.py
+++ b/rotkehlchen/chain/zksync_lite/manager.py
@@ -19,7 +19,6 @@ from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.history_events import DBHistoryEvents
-from rotkehlchen.db.ranges import DBQueryRanges
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import NotERC20Conformant, RemoteError
@@ -37,7 +36,6 @@ from rotkehlchen.types import (
     EVMTxHash,
     Fee,
     Location,
-    Timestamp,
     deserialize_evm_tx_hash,
 )
 from rotkehlchen.utils.misc import iso8601ts_to_timestamp, set_user_agent, ts_sec_to_ms
@@ -48,7 +46,7 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
 
-from .constants import ZKL_IDENTIFIER, ZKSYNCLITE_MAX_LIMIT, ZKSYNCLITE_TX_SAVEPREFIX
+from .constants import ZKL_IDENTIFIER, ZKSYNCLITE_MAX_LIMIT
 from .structures import ZKSyncLiteSwapData, ZKSyncLiteTransaction, ZKSyncLiteTXType
 
 logger = logging.getLogger(__name__)
@@ -165,26 +163,29 @@ class ZksyncLiteManager:
 
         return result
 
-    def _query_and_save_transactions_for_range(
+    def _query_and_save_transactions_from_hash(
             self,
             address: ChecksumEvmAddress,
-            start_ts: Timestamp,
-            end_ts: Timestamp,
             from_hash: str,
             direction: Literal['older', 'newer'],
     ) -> None:
-        """Save transactions in a timerange. Timerange is not really respected.
-        Just saved in the DB range."""
-        ranges = DBQueryRanges(self.database)
-        location = f'{ZKSYNCLITE_TX_SAVEPREFIX}{address}'
-        current_start_ts = start_ts
-        current_end_ts = end_ts
+        """Query and save transactions before or since the transaction specified with from_hash."""
         input_transactions: set[ZKSyncLiteTransaction] = set()
         for new_transactions in self._query_zksync_api_transactions(
                 address=address,
                 from_hash=from_hash,
                 direction=direction,
         ):
+            if (
+                from_hash != 'latest' and
+                len(new_transactions) != 0 and
+                new_transactions[0].tx_hash.hex() == from_hash
+            ):
+                # When there are already transactions in the database, and new ones are queried
+                # using from_hash, the API includes the from_hash transaction in its response,
+                # so it must be removed to avoid adding duplicate entries to the database.
+                new_transactions.pop(0)
+
             if len(new_transactions) == 0:
                 continue
 
@@ -198,15 +199,6 @@ class ZksyncLiteManager:
                 self._add_zksynctxs_db(
                     write_cursor=write_cursor,
                     transactions=unique_transactions,
-                )
-                if direction == 'older':
-                    current_start_ts = new_transactions[-1].timestamp
-                else:  # direction -> newer
-                    current_end_ts = new_transactions[-1].timestamp
-                ranges.update_used_query_range(
-                    write_cursor=write_cursor,
-                    location_string=location,
-                    queried_ranges=[(current_start_ts, current_end_ts)],
                 )
 
             input_transactions |= unique_transactions
@@ -536,66 +528,33 @@ class ZksyncLiteManager:
     def fetch_transactions(
             self,
             address: ChecksumEvmAddress,
-            start_ts: Timestamp,
-            end_ts: Timestamp,
     ) -> None:
-        """Fetch all zksync transactions for an address in the given time range and save in DB"""
-        location = f'zksynctxs_{address}'
-        min_tx_hash = max_tx_hash = 'latest'
-        min_timestamp = start_ts
-        max_timestamp = end_ts
+        """Fetch zksync transactions for an address and save in DB.
+        Get only new transactions if there are existing ones, otherwise get all transactions.
+        """
+        max_tx_hash = None
         with self.database.conn.read_ctx() as cursor:
-            queried_range = self.database.get_used_query_range(cursor, location)
-
-            cursor.execute('SELECT tx_hash, min(timestamp) from zksynclite_transactions;')
-            if (result := cursor.fetchone()) is not None and result[0] is not None:
-                min_tx_hash = '0x' + result[0].hex()
-                min_timestamp = result[1]
-
             cursor.execute('SELECT tx_hash, max(timestamp) from zksynclite_transactions;')
-            result_hash = cursor.fetchone()[0]
-
-            if result is not None and (result_hash := cursor.fetchone()) is not None and result_hash[0] is not None:  # noqa: E501
-                max_tx_hash = '0x' + result_hash[0].hex()
-                max_timestamp = result[1]
+            if (max_result := cursor.fetchone()) is not None and max_result[0] is not None:
+                max_tx_hash = '0x' + max_result[0].hex()
 
         try:
-            if queried_range is None:  # no previous query, just go backwards
-                self._query_and_save_transactions_for_range(
+            if max_tx_hash is None:  # no existing entries, query all
+                self._query_and_save_transactions_from_hash(
                     address=address,
-                    start_ts=start_ts,
-                    end_ts=end_ts,
                     from_hash='latest',
                     direction='older',
                 )
-            elif queried_range[0] != 0:  # somehow oldest range is not 0, so go to zero
-                self._query_and_save_transactions_for_range(
-                    address=address,
-                    start_ts=start_ts,
-                    end_ts=min_timestamp,
-                    from_hash=min_tx_hash,
-                    direction='older',
-                )
-                self._query_and_save_transactions_for_range(
-                    address=address,
-                    start_ts=max_timestamp,
-                    end_ts=end_ts,
-                    from_hash=max_tx_hash,
-                    direction='newer',
-                )
             else:  # get the new transactions
-                self._query_and_save_transactions_for_range(
+                self._query_and_save_transactions_from_hash(
                     address=address,
-                    start_ts=max_timestamp,
-                    end_ts=end_ts,
                     from_hash=max_tx_hash,
                     direction='newer',
                 )
         except RemoteError as e:
             log.error(
                 f'Got error "{e!s}" while querying zksync lite transactions '
-                f'from zksync api. Transactions not added to the DB. '
-                f'{address=}, {start_ts=}, {end_ts=} ',
+                f'from zksync api. Transactions not added to the DB. {address=}',
             )
 
     def get_balances(

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -31,7 +31,6 @@ from rotkehlchen.chain.bitcoin.xpub import (
 )
 from rotkehlchen.chain.evm.types import NodeName, WeightedNode
 from rotkehlchen.chain.substrate.types import SubstrateAddress
-from rotkehlchen.chain.zksync_lite.constants import ZKSYNCLITE_TX_SAVEPREFIX
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_ETH, A_ETH2, A_USD
 from rotkehlchen.constants.limits import (
@@ -2124,7 +2123,6 @@ class DBHandler:
             loopring = DBLoopring(self)
             loopring.remove_accountid_mapping(write_cursor, address)
 
-        write_cursor.execute('DELETE FROM used_query_ranges WHERE name = ?', (f'{ZKSYNCLITE_TX_SAVEPREFIX}{address}',))  # noqa: E501
         write_cursor.execute(
             'DELETE FROM evm_accounts_details WHERE account=? AND chain_id=?',
             (address, blockchain.to_chain_id().serialize_for_db()),
@@ -2151,7 +2149,6 @@ class DBHandler:
             cursor=write_cursor,
             blockchain=SupportedBlockchain.ZKSYNC_LITE,
         )
-        write_cursor.execute('DELETE FROM used_query_ranges WHERE name = ?', (f'{ZKSYNCLITE_TX_SAVEPREFIX}{address}',))  # noqa: E501
         other_addresses.remove(address)  # exclude the address in question so it's only the others
 
         # delete events by tx_hash

--- a/rotkehlchen/tests/integration/test_zksynclite.py
+++ b/rotkehlchen/tests/integration/test_zksynclite.py
@@ -29,17 +29,13 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.constants import A_PAN, CURRENT_PRICE_MOCK
 from rotkehlchen.types import Fee, Location, Timestamp, deserialize_evm_tx_hash
-from rotkehlchen.utils.misc import ts_now, ts_sec_to_ms
+from rotkehlchen.utils.misc import ts_sec_to_ms
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.freeze_time('2024-03-24 00:00:00 GMT')
 def test_fetch_transactions(zksync_lite_manager):
-    zksync_lite_manager.fetch_transactions(
-        address=string_to_evm_address('0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'),
-        start_ts=Timestamp(0),
-        end_ts=ts_now(),
-    )
+    zksync_lite_manager.fetch_transactions(string_to_evm_address('0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'))
     transactions = []
     with zksync_lite_manager.database.conn.read_ctx() as cursor:
         cursor.execute(
@@ -176,11 +172,7 @@ def test_decode_fullexit(zksync_lite_manager, inquirer):  # pylint: disable=unus
     tx_hash = deserialize_evm_tx_hash('0xd61d5f242022a43b5a11c84b350cdf8b2923221bf4a89ef091d51a1494d36007')  # noqa: E501
     address = string_to_evm_address('0xd6dfD811E06267b25472753c4e57C0B28652bFB8')
     timestamp = Timestamp(1592248320)
-    zksync_lite_manager.fetch_transactions(  # timerange is not really respected
-        address=address,
-        start_ts=Timestamp(1592248200),  # 15/06/2020 - 19:10
-        end_ts=Timestamp(1592248800),  # 15/06/2020 - 19:20
-    )
+    zksync_lite_manager.fetch_transactions(address)
     transactions = zksync_lite_manager.get_db_transactions(
         queryfilter=' WHERE tx_hash=?', bindings=(tx_hash,),
     )
@@ -228,11 +220,7 @@ def test_decode_forcedexit(zksync_lite_manager, inquirer):  # pylint: disable=un
     tx_hash = deserialize_evm_tx_hash('0xfa3d59c21b709f4ffd9b0e6c7e2dfe4579d7dd5e85325575d381ad88e50a64f1')  # noqa: E501
     address = string_to_evm_address('0x4676b83307A2A4A1556cdfC4d0c21097B584f3cF')
     timestamp = Timestamp(1712296398)
-    zksync_lite_manager.fetch_transactions(  # timerange is not really respected
-        address=address,
-        start_ts=0,
-        end_ts=ts_now(),
-    )
+    zksync_lite_manager.fetch_transactions(address)
     transactions = zksync_lite_manager.get_db_transactions(
         queryfilter=' WHERE tx_hash=?', bindings=(tx_hash,),
     )
@@ -280,11 +268,7 @@ def test_decode_swap(zksync_lite_manager, inquirer):  # pylint: disable=unused-a
     tx_hash = deserialize_evm_tx_hash('0x62819dad5d0d99dc5de633ecb95629c1073bcb80a8af15464ca4b0bc95b394b9')  # noqa: E501
     address = string_to_evm_address('0x721AF5c931BAA2415428064e5F71A251F30152B1')
     timestamp = Timestamp(1710752106)
-    zksync_lite_manager.fetch_transactions(  # timerange is not really respected
-        address=address,
-        start_ts=0,
-        end_ts=ts_now(),
-    )
+    zksync_lite_manager.fetch_transactions(address)
     transactions = zksync_lite_manager.get_db_transactions(
         queryfilter=' WHERE tx_hash=?', bindings=(tx_hash,),
     )


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11?pane=issue&itemId=79419328

Changes:
* Retrieve the latest transaction from the database correctly
* Remove use of used query range, and simply check if we were able to retrieve the latest transaction to determine whether to query all transactions or only new transactions.
* When querying new transactions, skip the first transaction if it matches the from_hash since it is already in the database

Note: A fix for the [nitpick from PR 8562](https://github.com/rotki/rotki/pull/8562#discussion_r1765271397) is included in a second commit.
