### PR TITLE
Fix cache update for maker

### DIFF
--- a/rotkehlchen/greenlets/manager.py
+++ b/rotkehlchen/greenlets/manager.py
@@ -43,7 +43,7 @@ class GreenletManager:
             method: Callable,
             **kwargs: Any,
     ) -> gevent.Greenlet:
-        log.debug('Spawning task manager task "{task_name}"')
+        log.debug(f'Spawning task manager task "{task_name}"')
         if after_seconds is None:
             greenlet = gevent.spawn(method, **kwargs)
         else:


### PR DESCRIPTION
This PR ensures that the maker task updates properly the last queried timestamp for maker unique cache

