### PR TITLE
Fix oracles that required a database connection

### DIFF
--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -1354,3 +1354,18 @@ class Inquirer:
         raise RemoteError(
             f'Could not find a current {base.identifier} price for {quote.identifier}',
         )
+
+    @staticmethod
+    def clear() -> None:
+        """
+        ensure that we don't have oracles that depend on the logged
+        in user. Calling `set_oracles_order` if we want to use the Inquirer
+        again is required.
+        """
+        inquirer = Inquirer()
+        inquirer._uniswapv2 = None
+        inquirer._uniswapv3 = None
+        del inquirer._oracle_instances
+        del inquirer._oracles
+        del inquirer._oracle_instances_not_onchain
+        del inquirer._oracles_not_onchain

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -539,6 +539,8 @@ class Rotkehlchen:
         # Make sure no messages leak to other user sessions
         self.msg_aggregator.consume_errors()
         self.msg_aggregator.consume_warnings()
+        PriceHistorian._PriceHistorian__instance = None  # type: ignore  #  has no attribute "_PriceHistorian__instance" but is the name used by python
+        Inquirer.clear()
 
         # We have locks in the chain aggregator that gets removed in this
         # function and in the db connections. The user db gets replaced but the globaldb


### PR DESCRIPTION
The oracles weren't removing the singleton and from season to season a reference to the ethereum_manager was kept but it had an old database connection closed after logout. This PR ensures that we clear the singletons during logout