### PR TITLE
Fix pagination for assets

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -17,8 +17,8 @@ from rotkehlchen.accounting.structures.balance import Balance, BalanceType
 from rotkehlchen.accounting.structures.types import ActionType
 from rotkehlchen.accounting.types import SchemaEventType
 from rotkehlchen.assets.asset import Asset, AssetWithNameAndType, AssetWithOracles, EvmToken
+from rotkehlchen.assets.ignored_assets_handling import IgnoredAssetsHandling
 from rotkehlchen.assets.types import AssetType
-from rotkehlchen.assets.utils import IgnoredAssetsHandling
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.arbitrum_one.constants import ARBITRUM_ONE_ETHERSCAN_NODE_NAME
 from rotkehlchen.chain.base.constants import BASE_ETHERSCAN_NODE_NAME

--- a/rotkehlchen/assets/ignored_assets_handling.py
+++ b/rotkehlchen/assets/ignored_assets_handling.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable
+from enum import auto
+from typing import Literal
+
+from rotkehlchen.utils.mixins.enums import SerializableEnumNameMixin
+
+
+class IgnoredAssetsHandling(SerializableEnumNameMixin):
+    NONE = auto()
+    EXCLUDE = auto()
+    SHOW_ONLY = auto()
+
+    def operator(self) -> Literal['IN', 'NOT IN']:
+        """Caller should make sure this is narrowed between exclude and show only"""
+        if self == IgnoredAssetsHandling.EXCLUDE:
+            return 'NOT IN'
+        return 'IN'
+
+    def get_should_skip_handler(self) -> Callable[[str, set[str]], bool]:
+        """Returns a function that can be used to check if an ignored asset should be skipped.
+        The caller of this function knowingly load the entire ignored assets in memory and use
+        this function to include/exclude the ignored assets. This is because the ignored assets are
+        stored in a different database and we avoid attaching/detaching the DB here due to:
+        #7533 and https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=69334133
+        TODO: Improve this to avoid loading the entire ignored assets in memory"""
+        if self == IgnoredAssetsHandling.EXCLUDE:
+            return lambda asset, ignored_assets: asset in ignored_assets
+        if self == IgnoredAssetsHandling.SHOW_ONLY:
+            return lambda asset, ignored_assets: asset not in ignored_assets
+        return lambda asset, ignored_assets: False

--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -1,7 +1,5 @@
 import logging
-from collections.abc import Callable
-from enum import auto
-from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, Optional
 
 import regex
 
@@ -32,7 +30,6 @@ from rotkehlchen.types import (
     SupportedBlockchain,
     Timestamp,
 )
-from rotkehlchen.utils.mixins.enums import SerializableEnumNameMixin
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
@@ -417,31 +414,6 @@ def symbol_to_evm_token(symbol: str) -> EvmToken:
         raise UnknownAsset(symbol)
 
     return maybe_asset.resolve_to_evm_token()
-
-
-class IgnoredAssetsHandling(SerializableEnumNameMixin):
-    NONE = auto()
-    EXCLUDE = auto()
-    SHOW_ONLY = auto()
-
-    def operator(self) -> Literal['IN', 'NOT IN']:
-        """Caller should make sure this is narrowed between exclude and show only"""
-        if self == IgnoredAssetsHandling.EXCLUDE:
-            return 'NOT IN'
-        return 'IN'
-
-    def get_should_skip_handler(self) -> Callable[[str, set[str]], bool]:
-        """Returns a function that can be used to check if an ignored asset should be skipped.
-        The caller of this function knowingly load the entire ignored assets in memory and use
-        this function to include/exclude the ignored assets. This is because the ignored assets are
-        stored in a different database and we avoid attaching/detaching the DB here due to:
-        #7533 and https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=69334133
-        TODO: Improve this to avoid loading the entire ignored assets in memory"""
-        if self == IgnoredAssetsHandling.EXCLUDE:
-            return lambda asset, ignored_assets: asset in ignored_assets
-        if self == IgnoredAssetsHandling.SHOW_ONLY:
-            return lambda asset, ignored_assets: asset not in ignored_assets
-        return lambda asset, ignored_assets: False
 
 
 CHAIN_TO_WRAPPED_TOKEN: Final = {

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -8,8 +8,8 @@ from typing import Any, Generic, Literal, NamedTuple, TypeVar
 from rotkehlchen.accounting.types import SchemaEventType
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.ignored_assets_handling import IgnoredAssetsHandling
 from rotkehlchen.assets.types import AssetType
-from rotkehlchen.assets.utils import IgnoredAssetsHandling
 from rotkehlchen.chain.ethereum.modules.nft.structures import NftLpHandling
 from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.db.constants import (


### PR DESCRIPTION
We weren't considering the ignored assets handling logic when returning the total number of entries found. Since information is split between the userdb and the globaldb we need in some cases to iterate manually over the assets.

Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=80755755

The changes move the enum IgnoredAssetsHandling to prevent a circular import