### PR TITLE
fix: notes format when asset is multi-word

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventNote.vue
+++ b/frontend/app/src/components/history/events/HistoryEventNote.vue
@@ -82,6 +82,7 @@ function isLinkType(t: any): t is keyof ExplorerUrls {
       <AmountDisplay
         v-else-if="note.type === NoteType.AMOUNT && note.amount"
         :key="`${index}-amount`"
+        no-truncate
         :asset="note.asset"
         :value="note.amount"
       />

--- a/frontend/app/src/composables/history/events/notes.ts
+++ b/frontend/app/src/composables/history/events/notes.ts
@@ -119,10 +119,22 @@ export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
     if (get(scrambleData) && counterpartyVal === 'monerium')
       notesVal = findAndScrambleIBAN(notesVal);
 
-    // label each word from notes whether it is an address or not
     const words = notesVal.split(/[\s,]+/);
+    const assetWords = asset ? asset.split(/\s+/) : [];
+    const processedWords: string[] = [];
 
-    words.forEach((wordItem, index) => {
+    for (let i = 0; i < words.length; i++) {
+      if (i + assetWords.length <= words.length
+        && words.slice(i, i + assetWords.length).join(' ') === asset) {
+        processedWords.push(asset);
+        i += assetWords.length - 1;
+      }
+      else {
+        processedWords.push(words[i]);
+      }
+    }
+
+    processedWords.forEach((wordItem, index) => {
       if (skip) {
         skip = false;
         return;
@@ -193,8 +205,8 @@ export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
         && !isNaN(Number.parseFloat(word))
         && bigNumberify(word).eq(amountVal)
         && amountVal.gt(0)
-        && index < words.length - 1
-        && words[index + 1] === asset;
+        && index < processedWords.length - 1
+        && processedWords[index + 1] === asset;
 
       if (isAmount) {
         formats.push({

--- a/frontend/app/tests/unit/specs/composables/history/notes.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/notes.spec.ts
@@ -57,6 +57,26 @@ describe('composables::history/notes', () => {
     expect(formatted).toMatchObject(expected);
   });
 
+  it('with amount and asset (multi-word)', () => {
+    const notes = 'Receive 100 Spectral Token';
+
+    const formatted = get(formatNotes({ notes, amount: bigNumberify(100), assetId: 'Spectral Token' }));
+
+    const expected: NoteFormat[] = [
+      {
+        type: NoteType.WORD,
+        word: 'Receive',
+      },
+      {
+        type: NoteType.AMOUNT,
+        amount: bigNumberify(100),
+        asset: 'Spectral Token',
+      },
+    ];
+
+    expect(formatted).toMatchObject(expected);
+  });
+
   it('with ETH address', () => {
     const address = '0xCb2286d9471cc185281c4f763d34A962ED212962';
     const notes = `Address ${address}`;


### PR DESCRIPTION
Fix issue where if the asset symbol is multi-word, then the amount in the notes won't be formatted, because we compare the asset, word 1 by 1, so it wouldn't match