### PR TITLE
Fix globaldb caches

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -65,7 +65,6 @@ from rotkehlchen.chain.ethereum.airdrops import check_airdrops, fetch_airdrops_m
 from rotkehlchen.chain.ethereum.defi.protocols import DEFI_PROTOCOLS
 from rotkehlchen.chain.ethereum.modules.convex.convex_cache import (
     query_convex_data,
-    save_convex_data_to_cache,
 )
 from rotkehlchen.chain.ethereum.modules.eth2.constants import FREE_VALIDATORS_LIMIT
 from rotkehlchen.chain.ethereum.modules.eth2.structures import PerformanceStatusFilter
@@ -80,16 +79,13 @@ from rotkehlchen.chain.ethereum.utils import try_download_ens_avatar
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
 from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     query_curve_data,
-    save_curve_data_to_cache,
 )
 from rotkehlchen.chain.evm.decoding.gearbox.gearbox_cache import (
     query_gearbox_data,
-    save_gearbox_data_to_cache,
 )
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.decoding.velodrome.velodrome_cache import (
     query_velodrome_like_data,
-    save_velodrome_data_to_cache,
 )
 from rotkehlchen.chain.evm.names import find_ens_mappings, search_for_addresses_names
 from rotkehlchen.chain.evm.types import EvmlikeAccount, WeightedNode
@@ -4641,8 +4637,8 @@ class RestAPI:
         arbitrum_inquirer = self.rotkehlchen.chains_aggregator.arbitrum_one.node_inquirer
         gnosis_inquirer = self.rotkehlchen.chains_aggregator.gnosis.node_inquirer
         polygon_inquirer = self.rotkehlchen.chains_aggregator.polygon_pos.node_inquirer
-        for (cache, cache_type, query_method, save_method, chain_id, inquirer) in [
-            ('curve pools', CacheType.CURVE_LP_TOKENS, query_curve_data, save_curve_data_to_cache, chain_id, node_inquirer)  # noqa: E501
+        for (cache, cache_type, query_method, chain_id, inquirer) in [
+            ('curve pools', CacheType.CURVE_LP_TOKENS, query_curve_data, chain_id, node_inquirer)
             for chain_id, node_inquirer in (
                 (ChainID.ETHEREUM, eth_node_inquirer),
                 (ChainID.OPTIMISM, optimism_inquirer),
@@ -4652,15 +4648,14 @@ class RestAPI:
                 (ChainID.POLYGON_POS, polygon_inquirer),
             )
         ] + [
-            ('convex pools', CacheType.CONVEX_POOL_ADDRESS, query_convex_data, save_convex_data_to_cache, None, eth_node_inquirer),  # noqa: E501
-            ('velodrome pools', CacheType.VELODROME_POOL_ADDRESS, query_velodrome_like_data, save_velodrome_data_to_cache, None, optimism_inquirer),  # noqa: E501
-            ('aerodrome pools', CacheType.AERODROME_POOL_ADDRESS, query_velodrome_like_data, save_velodrome_data_to_cache, None, base_inquirer),  # noqa: E501
-            ('gearbox pools', CacheType.GEARBOX_POOL_ADDRESS, query_gearbox_data, save_gearbox_data_to_cache, ChainID.ETHEREUM, eth_node_inquirer),  # noqa: E501
+            ('convex pools', CacheType.CONVEX_POOL_ADDRESS, query_convex_data, None, eth_node_inquirer),  # noqa: E501
+            ('velodrome pools', CacheType.VELODROME_POOL_ADDRESS, query_velodrome_like_data, None, optimism_inquirer),  # noqa: E501
+            ('aerodrome pools', CacheType.AERODROME_POOL_ADDRESS, query_velodrome_like_data, None, base_inquirer),  # noqa: E501
+            ('gearbox pools', CacheType.GEARBOX_POOL_ADDRESS, query_gearbox_data, ChainID.ETHEREUM, eth_node_inquirer),  # noqa: E501
         ]:
             if inquirer.ensure_cache_data_is_updated(
                 cache_type=cache_type,
                 query_method=query_method,
-                save_method=save_method,
                 chain_id=chain_id,
                 cache_key_parts=[] if chain_id is None else (str(chain_id.serialize_for_db()),),
                 force_refresh=True,

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -20,7 +20,6 @@ from rotkehlchen.chain.ethereum.modules.convex.constants import (
 from rotkehlchen.chain.ethereum.modules.convex.convex_cache import (
     query_convex_data,
     read_convex_data_from_cache,
-    save_convex_data_to_cache,
 )
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -72,7 +71,6 @@ class ConvexDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
             evm_inquirer=ethereum_inquirer,
             cache_type_to_check_for_freshness=CacheType.CONVEX_POOL_ADDRESS,
             query_data_method=query_convex_data,
-            save_data_to_cache_method=save_convex_data_to_cache,
             read_data_from_cache_method=read_convex_data_from_cache,
         )
         self.cvx = A_CVX.resolve_to_evm_token()

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -26,7 +26,6 @@ from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     get_lp_and_gauge_token_addresses,
     query_curve_data,
     read_curve_pools_and_gauges,
-    save_curve_data_to_cache,
 )
 from rotkehlchen.chain.evm.decoding.interfaces import (
     DecoderInterface,
@@ -87,9 +86,8 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
         ReloadablePoolsAndGaugesDecoderMixin.__init__(
             self,
             evm_inquirer=evm_inquirer,
-            cache_type_to_check_for_freshness=CacheType.CURVE_POOL_ADDRESS,
+            cache_type_to_check_for_freshness=CacheType.CURVE_LP_TOKENS,
             query_data_method=query_curve_data,
-            save_data_to_cache_method=save_curve_data_to_cache,
             read_data_from_cache_method=read_curve_pools_and_gauges,
             chain_id=evm_inquirer.chain_id,
         )

--- a/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
@@ -12,7 +12,6 @@ from rotkehlchen.chain.evm.decoding.gearbox.gearbox_cache import (
     GearboxPoolData,
     query_gearbox_data,
     read_gearbox_data_from_cache,
-    save_gearbox_data_to_cache,
 )
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface, ReloadableCacheDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -66,7 +65,6 @@ class GearboxCommonDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
             evm_inquirer=evm_inquirer,
             cache_type_to_check_for_freshness=CacheType.GEARBOX_POOL_ADDRESS,
             query_data_method=query_gearbox_data,
-            save_data_to_cache_method=save_gearbox_data_to_cache,
             read_data_from_cache_method=read_gearbox_data_from_cache,
             chain_id=self.evm_inquirer.chain_id,
         )

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -26,7 +26,6 @@ from rotkehlchen.chain.evm.decoding.velodrome.constants import (
 )
 from rotkehlchen.chain.evm.decoding.velodrome.velodrome_cache import (
     query_velodrome_like_data,
-    save_velodrome_data_to_cache,
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct
@@ -70,7 +69,6 @@ class VelodromeLikeDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixi
             evm_inquirer=evm_inquirer,
             cache_type_to_check_for_freshness=pool_cache_type,
             query_data_method=query_velodrome_like_data,
-            save_data_to_cache_method=save_velodrome_data_to_cache,
             read_data_from_cache_method=read_fn,
         )
         self.counterparty = counterparty

--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     query_curve_data,
-    save_curve_data_to_cache,
 )
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.fval import FVal
@@ -70,7 +69,6 @@ class CurveManagerMixin:
         if node_inquirer.ensure_cache_data_is_updated(
             cache_type=CacheType.CURVE_LP_TOKENS,
             query_method=query_curve_data,
-            save_method=save_curve_data_to_cache,
             chain_id=node_inquirer.chain_id,
             cache_key_parts=(str(node_inquirer.chain_id.serialize_for_db()),),
         ) is False:

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -18,7 +18,6 @@ from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     CurvePoolData,
     _query_curve_data_from_api,
     query_curve_data,
-    save_curve_data_to_cache,
 )
 from rotkehlchen.chain.evm.types import NodeName, string_to_evm_address
 from rotkehlchen.chain.polygon_pos.constants import POLYGON_POS_POL_HARDFORK
@@ -474,7 +473,6 @@ def test_find_curve_lp_token_price(inquirer: 'Inquirer', blockchain: 'ChainsAggr
             manager.node_inquirer.ensure_cache_data_is_updated(
                 cache_type=CacheType.CURVE_LP_TOKENS,
                 query_method=query_curve_data,
-                save_method=save_curve_data_to_cache,
                 chain_id=manager.node_inquirer.chain_id,
                 cache_key_parts=(str(manager.node_inquirer.chain_id.serialize_for_db()),),
             )

--- a/rotkehlchen/tests/unit/test_zerionsdk.py
+++ b/rotkehlchen/tests/unit/test_zerionsdk.py
@@ -1,4 +1,5 @@
 import warnings as test_warnings
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -37,7 +38,11 @@ def test_query_all_protocol_balances_for_account(
     )
     inquirer.inject_evm_managers(((ChainID.ETHEREUM, ethereum_manager),))
     zerion = ZerionSDK(ethereum_manager.node_inquirer, function_scope_messages_aggregator, database)  # noqa: E501
-    balances = zerion.all_balances_for_account('0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662')
+    with patch(
+        'rotkehlchen.chain.evm.decoding.curve.curve_cache._query_curve_data_from_api',
+        new=MagicMock(return_value=[]),
+    ):
+        balances = zerion.all_balances_for_account('0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662')
 
     if len(balances) == 0:
         test_warnings.warn(UserWarning('Test account for DeFi balances has no balances'))


### PR DESCRIPTION
- Curve was using the wrong key to check for freshness of the cache
- Now query method of decoders also save to database and update last queried ts. This reduces
complexity in the flow and bugs
- Fixes a bug where if no new pool was detected in the protocols with cache the last_queried_ts
wasn't being updated. Related to the previous point
