### PR TITLE
Separate SPAM from DECODED as transaction attributes

### DIFF
--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -497,7 +497,7 @@ def query_curve_data(
         cache_type: Literal[CacheType.CURVE_LP_TOKENS],
         msg_aggregator: 'MessagesAggregator',
 ) -> list[CurvePoolData] | None:
-    """Query curve lp tokens, curve pools and curve gauges and saves them in the database.
+    """Query curve lp tokens, curve pools and curve gauges and save them in the database.
     First tries to find data via curve api and if fails to do so, queries the chain (metaregistry).
 
     Returns list of pools if either api or chain query was successful, otherwise None.
@@ -532,7 +532,7 @@ def query_curve_data(
             return None
 
     if len(pools_data) == 0:
-        # if no new pools update the last_queried_ts of db entries
+        # if no new pools, update the last_queried_ts of db entries
         with GlobalDBHandler().conn.write_ctx() as write_cursor:
             globaldb_update_cache_last_ts(
                 write_cursor=write_cursor,

--- a/rotkehlchen/data_migrations/migrations/migrations_15.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_15.py
@@ -5,7 +5,6 @@ from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -55,7 +54,7 @@ def data_migration_15(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
             write_cursor.execute('DELETE FROM history_events WHERE identifier=?', (identifier,))
             write_cursor.execute(
                 'DELETE from evm_tx_mappings WHERE tx_id=? AND value=?',
-                (identifier, HISTORY_MAPPING_STATE_DECODED),
+                (identifier, 0),  # decoded value
             )
 
     for _, tx_hash, location in event_data:  # redecode them

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -7,11 +7,14 @@ KRAKEN_ACCOUNT_TYPE_KEY = 'kraken_account_type'
 BINANCE_MARKETS_KEY = 'binance_selected_trade_pairs'
 USER_CREDENTIAL_MAPPING_KEYS = (KRAKEN_ACCOUNT_TYPE_KEY, BINANCE_MARKETS_KEY)
 
+
+# -- EVM transactions attributes values -- used in evm_tx_mappings
+EVMTX_DECODED = 0
+EVMTX_SPAM = 1
+
 # -- history_events_mappings values --
 HISTORY_MAPPING_KEY_STATE = 'state'
-HISTORY_MAPPING_STATE_DECODED = 0
 HISTORY_MAPPING_STATE_CUSTOMIZED = 1
-HISTORY_MAPPING_STATE_SPAM = 2
 
 
 EVM_ACCOUNTS_DETAILS_LAST_QUERIED_TS = 'last_queried_timestamp'

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -14,9 +14,9 @@ from rotkehlchen.chain.optimism.constants import OPTIMISM_GENESIS
 from rotkehlchen.chain.polygon_pos.constants import POLYGON_POS_GENESIS
 from rotkehlchen.chain.scroll.constants import SCROLL_GENESIS
 from rotkehlchen.db.constants import (
+    EVMTX_DECODED,
+    EVMTX_SPAM,
     EXTRAINTERNALTXPREFIX,
-    HISTORY_MAPPING_STATE_DECODED,
-    HISTORY_MAPPING_STATE_SPAM,
 )
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery, TransactionsNotDecodedFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -536,7 +536,7 @@ class DBEvmTx:
         # Delete all remaining evm_tx_mappings so decoding can happen again
         write_cursor.executemany(
             'DELETE FROM evm_tx_mappings WHERE tx_id=? AND value IN (?, ?)',
-            [(x, HISTORY_MAPPING_STATE_DECODED, HISTORY_MAPPING_STATE_SPAM) for x in tx_ids],
+            [(x, EVMTX_DECODED, EVMTX_SPAM) for x in tx_ids],
         )
         # Delete any key_value_cache entries
         write_cursor.executemany(

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -15,10 +15,10 @@ from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.db.constants import (
     ETH_STAKING_EVENT_FIELDS,
     EVM_EVENT_FIELDS,
+    EVMTX_DECODED,
     HISTORY_BASE_ENTRY_FIELDS,
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
@@ -204,7 +204,7 @@ class DBTransactionsPendingDecodingFilter(DBFilter):
 
     def prepare(self) -> tuple[list[str], list[Any]]:
         query_filters = ['(B.tx_id IS NULL OR B.tx_id NOT IN (SELECT tx_id FROM evm_tx_mappings WHERE value=?))']  # noqa: E501
-        bindings: list[int] = [HISTORY_MAPPING_STATE_DECODED]
+        bindings: list[int] = [EVMTX_DECODED]
         if self.chain_id is not None:
             bindings.append(self.chain_id.serialize_for_db())
             query_filters.append('C.chain_id=?')

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -14,11 +14,11 @@ from rotkehlchen.db.constants import (
     ETH_STAKING_FIELD_LENGTH,
     EVM_EVENT_FIELDS,
     EVM_FIELD_LENGTH,
+    EVMTX_DECODED,
     HISTORY_BASE_ENTRY_FIELDS,
     HISTORY_BASE_ENTRY_LENGTH,
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.filtering import (
     ALL_EVENTS_DATA_JOIN,
@@ -246,7 +246,7 @@ class DBHistoryEvents:
         if location != Location.ZKSYNC_LITE and len(transaction_hashes) != 0:
             write_cursor.executemany(
                 'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) AND value=?',  # noqa: E501
-                [(x[0], location.to_chain_id(), HISTORY_MAPPING_STATE_DECODED) for x in transaction_hashes],  # noqa: E501
+                [(x[0], location.to_chain_id(), EVMTX_DECODED) for x in transaction_hashes],
             )
 
     def delete_events_by_tx_hash(

--- a/rotkehlchen/db/upgrades/v35_v36.py
+++ b/rotkehlchen/db/upgrades/v35_v36.py
@@ -7,7 +7,6 @@ from rotkehlchen.constants import ONE
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.settings import DEFAULT_ACTIVE_MODULES
 from rotkehlchen.db.utils import table_exists, update_table_schema
@@ -578,7 +577,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
     write_cursor.executemany(querystr, bindings)
     write_cursor.executemany(
         'DELETE from evm_tx_mappings WHERE tx_hash=? AND chain_id=? AND value=?',
-        [(tx_hash, ChainID.ETHEREUM.serialize_for_db(), HISTORY_MAPPING_STATE_DECODED) for tx_hash in tx_hashes],  # noqa: E501
+        [(tx_hash, ChainID.ETHEREUM.serialize_for_db(), 0) for tx_hash in tx_hashes],  # 0 -> decoded tx state # noqa: E501
     )
 
 

--- a/rotkehlchen/db/upgrades/v36_v37.py
+++ b/rotkehlchen/db/upgrades/v36_v37.py
@@ -8,7 +8,6 @@ from rotkehlchen.constants.assets import A_ETH2
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.fval import FVal
@@ -47,7 +46,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
     write_cursor.executemany(querystr, bindings)
     write_cursor.executemany(
         'DELETE from evm_tx_mappings WHERE tx_hash=? AND value=?',
-        [(tx_hash, HISTORY_MAPPING_STATE_DECODED) for tx_hash in tx_hashes],
+        [(tx_hash, 0) for tx_hash in tx_hashes],  # 0 -> decoded state
     )
 
 

--- a/rotkehlchen/db/upgrades/v37_v38.py
+++ b/rotkehlchen/db/upgrades/v37_v38.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import enter_exit_debug_log
@@ -108,7 +107,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
     write_cursor.execute(querystr, bindings)
     write_cursor.execute(
         'DELETE from evm_tx_mappings WHERE tx_hash IN (SELECT tx_hash FROM evm_transactions) AND value=?',  # noqa: E501
-        (HISTORY_MAPPING_STATE_DECODED,),
+        (0,),  # decoded tx state
     )
 
 

--- a/rotkehlchen/db/upgrades/v38_v39.py
+++ b/rotkehlchen/db/upgrades/v38_v39.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
@@ -306,7 +305,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
     write_cursor.execute(querystr, bindings)
     write_cursor.execute(
         'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions) AND value=?',  # noqa: E501
-        (HISTORY_MAPPING_STATE_DECODED,),
+        (0,),  # decoded tx state
     )
 
 

--- a/rotkehlchen/db/upgrades/v39_v40.py
+++ b/rotkehlchen/db/upgrades/v39_v40.py
@@ -9,7 +9,6 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
     NO_ACCOUNTING_COUNTERPARTY,
 )
 from rotkehlchen.db.utils import update_table_schema
@@ -353,7 +352,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
     write_cursor.execute(querystr, bindings)
     write_cursor.execute(
         'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions) AND value=?',  # noqa: E501
-        (HISTORY_MAPPING_STATE_DECODED,),
+        (0,),  # decoded state
     )
 
 

--- a/rotkehlchen/db/upgrades/v40_v41.py
+++ b/rotkehlchen/db/upgrades/v40_v41.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
@@ -201,7 +200,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(
             'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions) AND value=?',  # noqa: E501
-            (HISTORY_MAPPING_STATE_DECODED,),
+            (0,),  # 0 -> decoded tx state
         )
 
 

--- a/rotkehlchen/db/upgrades/v41_v42.py
+++ b/rotkehlchen/db/upgrades/v41_v42.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.types import ChainID, Location
@@ -184,7 +183,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(
             'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions) AND value=?',  # noqa: E501
-            (HISTORY_MAPPING_STATE_DECODED,),
+            (0,),  # decoded tx state
         )
 
 

--- a/rotkehlchen/db/upgrades/v42_v43.py
+++ b/rotkehlchen/db/upgrades/v42_v43.py
@@ -6,7 +6,6 @@ from rotkehlchen.constants.misc import AIRDROPSDIR_NAME, APPDIR_NAME
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.types import Location
@@ -86,7 +85,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(
             'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions) AND value=?',  # noqa: E501
-            (HISTORY_MAPPING_STATE_DECODED,),
+            (0,),  # decoded state
         )
 
 

--- a/rotkehlchen/db/upgrades/v43_v44.py
+++ b/rotkehlchen/db/upgrades/v43_v44.py
@@ -8,7 +8,6 @@ from eth_utils import to_checksum_address
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
     HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_DECODED,
 )
 from rotkehlchen.db.upgrades.utils import fix_address_book_duplications
 from rotkehlchen.history.types import HistoricalPriceOracle
@@ -206,7 +205,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(
             'DELETE from evm_tx_mappings WHERE tx_id IN (SELECT identifier FROM evm_transactions) AND value=?',  # noqa: E501
-            (HISTORY_MAPPING_STATE_DECODED,),
+            (0,),  # decoded tx state
         )
 
 

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -325,6 +325,7 @@ class Etherscan(ExternalServiceWithApiKey, ABC):
                                 gevent.sleep(backoff)
                                 backoff *= 2
                                 continue
+
                             elif result.startswith('Max daily'):
                                 raise RemoteError('Etherscan max daily rate limit reached.')
 

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -15,7 +15,7 @@ from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.scroll.constants import SCROLL_GENESIS
 from rotkehlchen.chain.structures import TimestampOrBlockRange
-from rotkehlchen.db.constants import HISTORY_MAPPING_STATE_DECODED
+from rotkehlchen.db.constants import EVMTX_DECODED
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
@@ -486,7 +486,7 @@ class Etherscan(ExternalServiceWithApiKey, ABC):
                             write_cursor.execute(
                                 'DELETE from evm_tx_mappings WHERE tx_id=(SELECT identifier FROM '
                                 'evm_transactions WHERE tx_hash=? AND chain_id=?) AND value=?',
-                                (GENESIS_HASH, self.chain.to_chain_id().serialize_for_db(), HISTORY_MAPPING_STATE_DECODED),  # noqa: E501
+                                (GENESIS_HASH, self.chain.to_chain_id().serialize_for_db(), EVMTX_DECODED),  # noqa: E501
                             )
                 except DeserializationError as e:
                     self.msg_aggregator.add_warning(f'{e!s}. Skipping transaction')

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
 from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_SAI
-from rotkehlchen.db.constants import HISTORY_MAPPING_STATE_DECODED, HISTORY_MAPPING_STATE_SPAM
+from rotkehlchen.db.constants import EVMTX_DECODED, EVMTX_SPAM
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmEventFilterQuery, EvmTransactionsFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -233,7 +233,7 @@ def test_query_and_decode_transactions_works_with_different_chains(
     with database.user_write() as write_cursor:
         write_cursor.execute(
             'INSERT INTO evm_tx_mappings(tx_id, value) VALUES(?, ?)',
-            (3, HISTORY_MAPPING_STATE_SPAM),
+            (3, EVMTX_SPAM),
         )
     hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None)
     assert len(hashes) == 2
@@ -242,7 +242,7 @@ def test_query_and_decode_transactions_works_with_different_chains(
     with database.user_write() as write_cursor:
         write_cursor.execute(
             'INSERT INTO evm_tx_mappings(tx_id, value) VALUES(?, ?)',
-            (3, HISTORY_MAPPING_STATE_DECODED),
+            (3, EVMTX_DECODED),
         )
     hashes = dbevmtx.get_transaction_hashes_not_decoded(chain_id=ChainID.ETHEREUM, limit=None)
     assert len(hashes) == 1


### PR DESCRIPTION
Also need to (in another commit) figure out the usages of those flags and at least rename them to avoid confusion.

They look like they are the same enum while one applies to history events and another to transactions