### PR TITLE
fix: add an empty symbol check in notes rendering

### DIFF
--- a/frontend/app/src/composables/history/events/notes.ts
+++ b/frontend/app/src/composables/history/events/notes.ts
@@ -155,7 +155,7 @@ export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
     const processedWords: string[] = [];
 
     for (let i = 0; i < words.length; i++) {
-      if (i + assetWords.length <= words.length
+      if (asset && i + assetWords.length <= words.length
         && words.slice(i, i + assetWords.length).join(' ') === asset) {
         processedWords.push(asset);
         i += assetWords.length - 1;

--- a/frontend/app/tests/unit/specs/composables/history/notes.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/notes.spec.ts
@@ -8,6 +8,9 @@ vi.mock('@/composables/assets/retrieval', () => ({
       if (isEvmIdentifier(identifier))
         return 'USDC';
 
+      if (identifier === '0xdeadbeef')
+        return '';
+
       return identifier;
     }),
   }),
@@ -353,5 +356,11 @@ describe('composables::history/notes', () => {
     ];
 
     expect(formatted).toMatchObject(expected);
+  });
+
+  it('should properly handle an asset resolving to empty string', () => {
+    const notes = 'Sell JUNO for USD. Amount out';
+    const formatted = get(formatNotes({ notes, assetId: '0xdeadbeef' }));
+    expect(formatted).toMatchObject([{ type: 'word', word: 'Sell JUNO for USD. Amount out' }]);
   });
 });


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
