### PR TITLE
Tweak external services api response

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -459,8 +459,12 @@ Getting or modifying external services API credentials
       {
          "result":{
             "etherscan":{
-               "eth": {"api_key":"key1"},
-               "arbitrum_one": {"api_key":"key3"}
+               "ethereum": {"api_key":"key1"},
+               "arbitrum_one": {"api_key":"key3"},
+               "optimism": null, "polygon_pos" null, "gnosis": null, "scroll": null
+            },
+            "blockscout": {
+                "ethereum": null, "optimism": null, "polygon_pos": null, "arbitrum_one": null, "base": null, "gnosis": null
             },
             "cryptocompare": {"api_key":"boooookey"},
             "opensea": {"api_key":"goooookey"},
@@ -469,7 +473,7 @@ Getting or modifying external services API credentials
          "message":""
       }
 
-   :resjson object result: The result object contains as many entries as the external services. Each entry's key is the name and the value is another object of the form ``{"api_key": "foo"}``. For etherscan services all are grouped under the ``etherscan`` key. If there are no etherscan services this key won't be present. The ``monerium`` service has a different structure than the rest. Has ``username`` and ``password`` keys. The  ``gnosis_pay`` service at the moment is hacky. Need to provide the auth js session token in place of the api key.
+   :resjson object result: The result object contains as many entries as the external services. Each entry's key is the name and the value is another object of the form ``{"api_key": "foo"}``. For etherscan services all are grouped under the ``etherscan`` key. Same for blockscout. They both contain all possible api keys that etherscan and blockscout can have. For keys that the user does not have in etherscan and blockscout it returns null. The ``monerium`` service has a different structure than the rest. Has ``username`` and ``password`` keys. The  ``gnosis_pay`` service at the moment is hacky. Need to provide the auth js session token in place of the api key.
    :statuscode 200: Querying of external service credentials was successful
    :statuscode 401: There is no logged in user
    :statuscode 500: Internal rotki error

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -220,6 +220,8 @@ from rotkehlchen.serialization.serialize import process_result, process_result_l
 from rotkehlchen.tasks.utils import query_missing_prices_of_base_entries
 from rotkehlchen.types import (
     AVAILABLE_MODULES_MAP,
+    BLOCKSCOUT_TO_CHAINID,
+    ETHERSCAN_TO_CHAINID,
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
     EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
     EVM_EVMLIKE_LOCATIONS,
@@ -606,12 +608,15 @@ class RestAPI:
     def _return_external_services_response(self) -> Response:
         credentials_list = self.rotkehlchen.data.db.get_all_external_service_credentials()
         response_dict: dict[str, Any] = {}
+        response_dict['blockscout'] = {chain_id.to_name(): None for _, chain_id in BLOCKSCOUT_TO_CHAINID.items()}  # noqa: E501
+        response_dict['etherscan'] = {chain_id.to_name(): None for _, chain_id in ETHERSCAN_TO_CHAINID.items()}  # noqa: E501
         for credential in credentials_list:
             name, key_info = credential.serialize_for_api()
             if (chain := credential.service.get_chain_for_etherscan()) is not None:
-                if 'etherscan' not in response_dict:
-                    response_dict['etherscan'] = {}
                 response_dict['etherscan'][chain.to_name()] = key_info
+            elif (chain := credential.service.get_chain_for_blockscout()) is not None:
+                response_dict['blockscout'][chain.to_name()] = key_info
+
             else:
                 response_dict[name] = key_info
 

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -18,10 +18,10 @@ from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_fval, deserialize_timestamp
 from rotkehlchen.types import (
+    BLOCKSCOUT_TO_CHAINID,
     SUPPORTED_EVM_CHAINS_TYPE,
     ChainID,
     ChecksumEvmAddress,
-    ExternalService,
     SupportedBlockchain,
     Timestamp,
 )
@@ -46,9 +46,10 @@ class Blockscout(ExternalServiceWithApiKey):
             msg_aggregator: MessagesAggregator,
     ) -> None:
         self.chain_id = blockchain.to_chain_id()
+        chainid_to_blockscout = {v: k for k, v in BLOCKSCOUT_TO_CHAINID.items()}
         super().__init__(
             database=database,
-            service_name=ExternalService.chain_to_blockscout(self.chain_id),
+            service_name=chainid_to_blockscout[self.chain_id],
         )
         self.db: DBHandler  # specifying DB is not optional
         self.msg_aggregator = msg_aggregator

--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -9,6 +9,11 @@ from rotkehlchen.tests.utils.api import (
     assert_proper_sync_response_with_result,
 )
 
+EMPTY_RESULT = {
+    'etherscan': {'ethereum': None, 'optimism': None, 'polygon_pos': None, 'arbitrum_one': None, 'base': None, 'gnosis': None, 'scroll': None},  # noqa: E501
+'blockscout': {'ethereum': None, 'optimism': None, 'polygon_pos': None, 'arbitrum_one': None, 'base': None, 'gnosis': None},  # noqa: E501
+}
+
 
 @pytest.mark.parametrize('include_etherscan_key', [False])
 @pytest.mark.parametrize('include_cryptocompare_key', [False])
@@ -20,11 +25,12 @@ def test_add_get_external_service(rotkehlchen_api_server):
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result == {}
+    assert result == EMPTY_RESULT
 
     # Now add some data and see that the response shows they are added
     expected_result = {
-        'etherscan': {'ethereum': {'api_key': 'key1'}, 'arbitrum_one': {'api_key': 'key3'}},
+        'etherscan': {'ethereum': {'api_key': 'key1'}, 'arbitrum_one': {'api_key': 'key3'}, 'optimism': None, 'polygon_pos': None, 'base': None, 'gnosis': None, 'scroll': None},  # noqa: E501
+        'blockscout': {'ethereum': None, 'optimism': None, 'polygon_pos': None, 'arbitrum_one': None, 'base': None, 'gnosis': None},  # noqa: E501
         'cryptocompare': {'api_key': 'key2'},
         'monerium': {'username': 'Ben', 'password': 'supersafepassword'},
     }
@@ -72,7 +78,8 @@ def test_delete_external_service(rotkehlchen_api_server):
     """Tests that delete external service credentials works"""
     # Add some data and see that the response shows they are added
     expected_result = {
-        'etherscan': {'ethereum': {'api_key': 'key1'}},
+        'etherscan': {'ethereum': {'api_key': 'key1'}, 'optimism': None, 'polygon_pos': None, 'arbitrum_one': None, 'base': None, 'gnosis': None, 'scroll': None},  # noqa: E501
+        'blockscout': {'ethereum': None, 'optimism': None, 'polygon_pos': None, 'arbitrum_one': None, 'base': None, 'gnosis': None},  # noqa: E501
         'cryptocompare': {'api_key': 'key2'},
     }
     data = {'services': [
@@ -88,7 +95,7 @@ def test_delete_external_service(rotkehlchen_api_server):
 
     # Now try to delete an entry and see the response shows it's deleted
     data = {'services': ['etherscan']}
-    del expected_result['etherscan']
+    expected_result['etherscan']['ethereum'] = None
     response = requests.delete(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
         json=data,
@@ -111,14 +118,14 @@ def test_delete_external_service(rotkehlchen_api_server):
         json=data,
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result == {}
+    assert result == EMPTY_RESULT
 
     # Query again and see that the modified services are returned
     response = requests.get(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result == {}
+    assert result == EMPTY_RESULT
 
 
 def test_add_external_services_errors(rotkehlchen_api_server):

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -152,39 +152,11 @@ class ExternalService(SerializableEnumNameMixin):
 
     def get_chain_for_etherscan(self) -> Optional['ChainID']:
         """If the service is an etherscan service return its chain"""
-        if self == ExternalService.ETHERSCAN:
-            return ChainID.ETHEREUM
-        elif self == ExternalService.OPTIMISM_ETHERSCAN:
-            return ChainID.OPTIMISM
-        elif self == ExternalService.POLYGON_POS_ETHERSCAN:
-            return ChainID.POLYGON_POS
-        elif self == ExternalService.ARBITRUM_ONE_ETHERSCAN:
-            return ChainID.ARBITRUM_ONE
-        elif self == ExternalService.BASE_ETHERSCAN:
-            return ChainID.BASE
-        elif self == ExternalService.GNOSIS_ETHERSCAN:
-            return ChainID.GNOSIS
-        elif self == ExternalService.SCROLL_ETHERSCAN:
-            return ChainID.SCROLL
+        return ETHERSCAN_TO_CHAINID.get(self)
 
-        return None
-
-    @classmethod
-    def chain_to_blockscout(cls, chain_id: 'ChainID') -> 'ExternalService':
-        if chain_id == ChainID.ETHEREUM:
-            return ExternalService.BLOCKSCOUT
-        elif chain_id == ChainID.ARBITRUM_ONE:
-            return ExternalService.ARBITRUM_ONE_BLOCKSCOUT
-        elif chain_id == ChainID.BASE:
-            return ExternalService.BASE_BLOCKSCOUT
-        elif chain_id == ChainID.OPTIMISM:
-            return ExternalService.OPTIMISM_BLOCKSCOUT
-        elif chain_id == ChainID.GNOSIS:
-            return ExternalService.GNOSIS_BLOCKSCOUT
-        elif chain_id == ChainID.POLYGON_POS:
-            return ExternalService.POLYGON_POS_BLOCKSCOUT
-
-        raise NotImplementedError(f'Blockscout service not implemented for {chain_id}')
+    def get_chain_for_blockscout(self) -> Optional['ChainID']:
+        """If the service is a blockscout service return its chain"""
+        return BLOCKSCOUT_TO_CHAINID.get(self)
 
     def premium_only(self) -> bool:
         return self in {ExternalService.GNOSIS_PAY, ExternalService.MONERIUM}
@@ -370,6 +342,26 @@ SUPPORTED_CHAIN_IDS = Literal[
     ChainID.GNOSIS,
     ChainID.SCROLL,
 ]
+
+
+BLOCKSCOUT_TO_CHAINID = {
+    ExternalService.BLOCKSCOUT: ChainID.ETHEREUM,
+    ExternalService.OPTIMISM_BLOCKSCOUT: ChainID.OPTIMISM,
+    ExternalService.POLYGON_POS_BLOCKSCOUT: ChainID.POLYGON_POS,
+    ExternalService.ARBITRUM_ONE_BLOCKSCOUT: ChainID.ARBITRUM_ONE,
+    ExternalService.BASE_BLOCKSCOUT: ChainID.BASE,
+    ExternalService.GNOSIS_BLOCKSCOUT: ChainID.GNOSIS,
+}
+
+ETHERSCAN_TO_CHAINID = {
+    ExternalService.ETHERSCAN: ChainID.ETHEREUM,
+    ExternalService.OPTIMISM_ETHERSCAN: ChainID.OPTIMISM,
+    ExternalService.POLYGON_POS_ETHERSCAN: ChainID.POLYGON_POS,
+    ExternalService.ARBITRUM_ONE_ETHERSCAN: ChainID.ARBITRUM_ONE,
+    ExternalService.BASE_ETHERSCAN: ChainID.BASE,
+    ExternalService.GNOSIS_ETHERSCAN: ChainID.GNOSIS,
+    ExternalService.SCROLL_ETHERSCAN: ChainID.SCROLL,
+}
 
 
 class EvmlikeChain(StrEnum):


### PR DESCRIPTION
It will now always return all possible blockscout and etherscan api key values with null value if not existing, so that the frontend can use them to show what blockscout/etherscan keys exist

