### PR TITLE
Reload decoder data on demand during event decoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :release:`1.35.0 <2024-10-01>`
+* :release:`1.35.0 <2024-10-02>`
 * :feature:`8428` Rotki will now properly decode cowswap fees and order types after 2024-03-19 by querying the cowswap API for offchain data.
 * :feature:`7817` Users will be able to add CEX mapping for unknown assets from exchange notifications.
 * :feature:`8528` Rotki will now limit the number of validators queried for balances for non-premium users.

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -76,11 +76,13 @@ class DecodingOutput:
     and is used in post-decoding rules like in the case of balancer
     - refresh_balances may be set to True if the user's on-chain balances in some protocols has
     changed (for example if the user has deposited / withdrawn funds from a curve gauge).
-    """
+    - reload_decoders can be None in which case nothing happens. Or a set of decoders names for which to reload data. The decoder's name is the class name without the Decoder suffic. For example Eigenlayer for EigenlayerDecoder
+    """  # noqa: E501
     event: Optional['EvmEvent'] = None
     action_items: list[ActionItem] = field(default_factory=list)
     matched_counterparty: str | None = None
     refresh_balances: bool = False
+    reload_decoders: set[str] | None = None
 
 
 class TransferEnrichmentOutput(NamedTuple):

--- a/rotkehlchen/tests/unit/decoders/test_aave_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v2.py
@@ -290,7 +290,7 @@ def test_aave_v2_enable_collateral(database, ethereum_inquirer, eth_transactions
         ethereum_inquirer=ethereum_inquirer,
         transactions=eth_transactions,
     )
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -376,7 +376,7 @@ def test_aave_v2_disable_collateral(database, ethereum_inquirer, eth_transaction
         ethereum_inquirer=ethereum_inquirer,
         transactions=eth_transactions,
     )
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -482,7 +482,7 @@ def test_aave_v2_deposit(database, ethereum_inquirer, eth_transactions):
     with dbevmtx.db.user_write() as cursor, patch_decoder_reload_data():
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -731,7 +731,7 @@ def test_aave_v2_repay(database, ethereum_inquirer, eth_transactions):
         ethereum_inquirer=ethereum_inquirer,
         transactions=eth_transactions,
     )
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -240,7 +240,7 @@ def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     timestamp = TimestampMS(1655675488000)
     expected_events = [
         EvmEvent(
@@ -469,7 +469,7 @@ def test_cvx_stake(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -611,7 +611,7 @@ def test_cvx_get_reward(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -702,7 +702,7 @@ def test_cvx_withdraw(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -785,7 +785,7 @@ def test_claimzap_abracadabras(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,
@@ -877,7 +877,7 @@ def test_claimzap_cvx_locker(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -127,7 +127,7 @@ def test_curve_deposit(database, ethereum_transaction_decoder):
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -268,7 +268,7 @@ def test_curve_deposit_eth(database, ethereum_transaction_decoder):
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -423,7 +423,7 @@ def test_curve_remove_liquidity(
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -542,7 +542,7 @@ def test_curve_remove_liquidity_with_internal(database, ethereum_transaction_dec
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         dbevmtx.add_evm_internal_transactions(cursor, [internal_tx], relevant_address=location_label)  # noqa: E501
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -705,7 +705,7 @@ def test_curve_remove_imbalanced(database, ethereum_transaction_decoder):
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )

--- a/rotkehlchen/tests/unit/decoders/test_enriched.py
+++ b/rotkehlchen/tests/unit/decoders/test_enriched.py
@@ -82,7 +82,7 @@ def test_1inch_claim(database, ethereum_inquirer, eth_transactions):
     with dbevmtx.db.user_write() as cursor, patch_decoder_reload_data():
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     assert len(events) == 2
     timestamp = TimestampMS(1646375440000)
     expected_events = [
@@ -181,7 +181,7 @@ def test_gitcoin_claim(database, ethereum_inquirer, eth_transactions):
     with dbevmtx.db.user_write() as cursor, patch_decoder_reload_data():
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     assert len(events) == 2
     expected_events = [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -246,7 +246,7 @@ def test_no_logs_and_zero_eth(
     dbevmtx = DBEvmTx(database)
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -328,7 +328,7 @@ def test_simple_erc20_transfer(
     tx_decoder = ethereum_transaction_decoder if chain is ChainID.ETHEREUM else optimism_transaction_decoder  # noqa: E501
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = tx_decoder._decode_transaction(
+    events, _, _ = tx_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -412,7 +412,7 @@ def test_eth_transfer(
     tx_decoder = ethereum_transaction_decoder if chain is ChainID.ETHEREUM else optimism_transaction_decoder  # noqa: E501
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = tx_decoder._decode_transaction(
+    events, _, _ = tx_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -496,7 +496,7 @@ def test_eth_spend(
     tx_decoder = ethereum_transaction_decoder if chain is ChainID.ETHEREUM else optimism_transaction_decoder  # noqa: E501
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = tx_decoder._decode_transaction(
+    events, _, _ = tx_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -572,7 +572,7 @@ def test_eth_deposit(
     dbevmtx = DBEvmTx(database)
     with database.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )

--- a/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
@@ -94,7 +94,7 @@ def test_makerdao_sai_new_cdp(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -247,7 +247,7 @@ def test_makerdao_sai_borrow_sai(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -382,7 +382,7 @@ def test_makerdao_sai_close_cdp(ethereum_transaction_decoder):
     with dbevmtx.db.user_write() as cursor, patch_decoder_reload_data():
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -553,7 +553,7 @@ def test_makerdao_sai_repay_sai(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -664,7 +664,7 @@ def test_makerdao_sai_deposit_weth(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -768,7 +768,7 @@ def test_makerdao_sai_deposit_peth(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -907,7 +907,7 @@ def test_makerdao_sai_liquidation(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -1019,7 +1019,7 @@ def test_makerdao_sai_collateral_removal(ethereum_transaction_decoder):
     with dbevmtx.db.user_write() as cursor, patch_decoder_reload_data():
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -1119,7 +1119,7 @@ def test_makerdao_sai_underlying_collateral_removal(ethereum_transaction_decoder
     with dbevmtx.db.user_write() as cursor, patch_decoder_reload_data():
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         ethereum_transaction_decoder.reload_data(cursor)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -1395,7 +1395,7 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -1658,7 +1658,7 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -1903,7 +1903,7 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
     dbevmtx = DBEvmTx(ethereum_transaction_decoder.database)
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )
@@ -2141,7 +2141,7 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
     with dbevmtx.db.user_write() as cursor:
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         dbevmtx.add_evm_internal_transactions(cursor, [internal_tx], relevant_address=ADDY_10)
-    events, _ = ethereum_transaction_decoder._decode_transaction(
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
         transaction=transaction,
         tx_receipt=receipt,
     )

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -498,7 +498,7 @@ def test_uniswap_v2_swap_events_order(
         dbevmtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
 
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     expected_events = [
         EvmEvent(
             tx_hash=evmhash,

--- a/rotkehlchen/tests/unit/decoders/test_yearn.py
+++ b/rotkehlchen/tests/unit/decoders/test_yearn.py
@@ -97,7 +97,7 @@ def test_deposit_yearn_v2(database, ethereum_inquirer, eth_transactions):
     with database.user_write() as cursor, patch_decoder_reload_data():
         dbethtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
 
     assert len(events) == 3
     expected_events = [
@@ -207,7 +207,7 @@ def test_withdraw_yearn_v2(database, ethereum_inquirer, eth_transactions):
     with database.user_write() as cursor, patch_decoder_reload_data():
         dbethtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
 
     assert len(events) == 3
     expected_events = [
@@ -317,7 +317,7 @@ def test_deposit_yearn_v1(database, ethereum_inquirer, eth_transactions):
     with database.user_write() as cursor, patch_decoder_reload_data():
         dbethtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
 
     assert len(events) == 3
     expected_events = [
@@ -427,7 +427,7 @@ def test_withdraw_yearn_v1(database, ethereum_inquirer, eth_transactions):
     with database.user_write() as cursor, patch_decoder_reload_data():
         dbethtx.add_evm_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
-    events, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
+    events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
 
     assert len(events) == 3
     expected_events = [

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -137,7 +137,7 @@ def test_tx_decode(ethereum_transaction_decoder, database):
             for tx in transactions:
                 receipt = dbevmtx.get_receipt(cursor, tx.tx_hash, ChainID.ETHEREUM)
                 assert receipt is not None, 'all receipts should be queried in the test DB'
-                events, _ = decoder._get_or_decode_transaction_events(tx, receipt, ignore_cache=False)  # noqa: E501
+                events, _, _ = decoder._get_or_decode_transaction_events(tx, receipt, ignore_cache=False)  # noqa: E501
                 if tx.tx_hash == approve_tx_hash:
                     assert len(events) == 2
                     assert_events_equal(events[0], EvmEvent(
@@ -175,7 +175,7 @@ def test_tx_decode(ethereum_transaction_decoder, database):
             for tx in transactions:
                 receipt = dbevmtx.get_receipt(cursor, tx.tx_hash, ChainID.ETHEREUM)
                 assert receipt is not None, 'all receipts should be queried in the test DB'
-                events, _ = decoder._get_or_decode_transaction_events(tx, receipt, ignore_cache=False)  # noqa: E501
+                events, _, _ = decoder._get_or_decode_transaction_events(tx, receipt, ignore_cache=False)  # noqa: E501
         assert decode_mock.call_count == len(transactions)
 
     dbevents = DBHistoryEvents(database)

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -420,11 +420,13 @@ def get_decoded_events_of_transaction(
         transactions: EvmTransactions | None = None,
         relevant_address: ChecksumAddress | None = None,
         load_global_caches: list[str] | None = None,
+        evm_decoder: 'EVMTransactionDecoder|None' = None,
 ) -> tuple[list['EvmEvent'], 'EVMTransactionDecoder']:
     """A convenience function to ask get transaction, receipt and decoded event for a tx_hash
 
     It also accepts `transactions` in case the caller whants to apply some mocks (like call_count)
-    on that object.
+    on that object. Same thing for evm_decoder if the callers want to use it before
+    for any reason.
 
     If relevant_address is provided then the added transactions are added linked to
     the provided address.
@@ -444,7 +446,11 @@ def get_decoded_events_of_transaction(
     if mappings_result is not None:
         if transactions is None:
             transactions = mappings_result[0](evm_inquirer, evm_inquirer.database)
-        decoder: EVMTransactionDecoder = mappings_result[1](evm_inquirer.database, evm_inquirer, transactions)  # noqa: E501
+        if evm_decoder is None:
+            decoder: EVMTransactionDecoder = mappings_result[1](evm_inquirer.database, evm_inquirer, transactions)  # noqa: E501
+        else:
+            decoder = evm_decoder
+
     else:
         raise AssertionError('Unsupported chainID at tests')
 


### PR DESCRIPTION
If a new event adds information that any other decoder needs to use then this system will allow it to happen.

Probably need to use it in more places other than just the eigenlayer eigenpod deployments

