### PR TITLE
Restore websotcket message at the start of new version upgrade

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -74,7 +74,8 @@ DB Upgrade status
 =========================
 
 The messages sent by rotki when a user is logging in and a db upgrade is happening. The format is the following.
-
+A message having ``total_steps`` and ``current_step`` being ``0`` is sent at the start for the frontend to
+switch to the progress screen from the login screen.
 
 ::
 
@@ -101,6 +102,8 @@ Data migration status
 =========================
 
 The messages sent by rotki when a user is logging in and a db upgrade is happening. The format is the following.
+A message having ``total_steps`` and ``current_step`` being ``0`` is sent at the start for the frontend to
+switch to the progress screen from the login screen.
 
 
 ::

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -73,8 +73,8 @@ def assert_progress_message(msg, step_num, description, migration_version, migra
     assert msg['data']['target_version'] == LAST_DATA_MIGRATION
     migration = msg['data']['current_migration']
     assert migration['version'] == migration_version
-    assert migration['total_steps'] == migration_steps
-    assert migration['current_step'] == step_num + 1
+    assert migration['total_steps'] == (migration_steps if step_num != 0 else 0)
+    assert migration['current_step'] == step_num
     if description is not None:
         assert description in migration['description']
     else:
@@ -89,7 +89,7 @@ def assert_add_addresses_migration_ws_messages(
 ) -> None:
     """Asserts that all steps of a data migration that adds addresses are correctly applied
     by checking the websocket messages"""
-    num_messages = migration_steps
+    num_messages = migration_steps + 1  # +1 for the message for added address
     websocket_connection.wait_until_messages_num(num=num_messages, timeout=10)
     assert websocket_connection.messages_num() == num_messages
 
@@ -100,23 +100,25 @@ def assert_add_addresses_migration_ws_messages(
             assert sorted(msg['data'], key=operator.itemgetter('chain', 'address')) == sorted(
                 chain_to_added_address, key=operator.itemgetter('chain', 'address'),
             )  # checks that the addresses have been added
+        elif i == 0:  # new migration round message
+            assert_progress_message(msg, i, None, migration_version, migration_steps)
 
         if migration_version == 10:
-            if i == 0:
+            if i == 1:
                 assert_progress_message(msg, i, 'Fetching new spam assets info', migration_version, migration_steps)  # noqa: E501
-            elif i == 1:
+            elif i == 2:
                 assert_progress_message(msg, i, 'Ensuring polygon node consistency', migration_version, migration_steps)  # noqa: E501
-            if 2 <= i <= 5:
+            if 3 <= i <= 6:
                 assert_progress_message(msg, i, 'EVM chain activity', migration_version, migration_steps)  # noqa: E501
-            elif i == 6:
+            elif i == 7:
                 assert_progress_message(msg, i, 'Potentially write migrated addresses to the DB', migration_version, migration_steps)  # noqa: E501
 
         elif migration_version in {11, 12}:
-            if i == 0:
+            if i == 1:
                 assert_progress_message(msg, i, 'Fetching new spam assets and rpc data info', migration_version, migration_steps)  # noqa: E501
-            elif i in {1, 2}:
+            elif i in {2, 3}:
                 assert_progress_message(msg, i, 'EVM chain activity', migration_version, migration_steps)  # noqa: E501
-            elif i == 3:
+            elif i == 4:
                 assert_progress_message(msg, i, 'Potentially write migrated addresses to the DB', migration_version, migration_steps)  # noqa: E501
 
 

--- a/rotkehlchen/utils/interfaces.py
+++ b/rotkehlchen/utils/interfaces.py
@@ -72,6 +72,8 @@ class ProgressUpdater(ABC):
         self.current_version = version
         self.current_round_total_steps = 0
         self.current_round_current_step = 0
+        # required signal for the frontend to switch to the progress screen from the login screen
+        self._notify_frontend()
 
     def set_total_steps(self, steps: int) -> None:
         """


### PR DESCRIPTION
Reverts https://github.com/rotki/rotki/pull/8644 and documents why it was needed.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
