### PR TITLE
Fix query of exit ts of eth validators

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Fix an error querying the exit timestamp for the ethereum validators.
+
 * :release:`1.35.0 <2024-10-02>`
 * :feature:`8428` Rotki will now properly decode cowswap fees and order types after 2024-03-19 by querying the cowswap API for offchain data.
 * :feature:`7817` Users will be able to add CEX mapping for unknown assets from exchange notifications.

--- a/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
@@ -197,7 +197,8 @@ class BeaconInquirer:
           deserialized due to unexpected format
         """
         # Beaconcha.in only keys
-        index_key = 'validatorindex'
+        beacon_chain_index_key = 'validatorindex'
+        index_key = beacon_chain_index_key
         valuegetter = operator.getitem
         withdrawal_credentials_key = 'withdrawalcredentials'
         activation_epoch_key = 'activationepoch'
@@ -246,7 +247,7 @@ class BeaconInquirer:
                 if queried_beaconchain and (exit_epoch := entry.get('exitepoch', 0)) != 0:
                     exited_ts = epoch_to_timestamp(exit_epoch)
                 else:  # query this index from beaconchain to see if exited
-                    indices_mapping_to_query_beaconchain[entry[index_key]] = idx
+                    indices_mapping_to_query_beaconchain[deserialize_int(entry[index_key])] = idx
 
             details.append(ValidatorDetails(
                 validator_index=deserialize_int(entry[index_key]),
@@ -261,7 +262,7 @@ class BeaconInquirer:
             node_results = self.beaconchain.get_validator_data(list(indices_mapping_to_query_beaconchain))  # noqa: E501
             for entry in node_results:
                 if (exit_epoch := entry.get('exitepoch', 0)) != 0:
-                    details[indices_mapping_to_query_beaconchain[entry[index_key]]].exited_timestamp = epoch_to_timestamp(exit_epoch)  # noqa: E501
+                    details[indices_mapping_to_query_beaconchain[entry[beacon_chain_index_key]]].exited_timestamp = epoch_to_timestamp(exit_epoch)  # noqa: E501
 
         return details
 


### PR DESCRIPTION
If the user had its own beacon node and we couldn't obtain the exit timestamp we make a query to beaconchain but at the moment of processing the results we were using the wrong key for the validator index because it was being set previously for the beacon node.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
