### PR TITLE
fix: remove property that was causing manual balance price double conversion

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,9 @@
 Changelog
 =========
 
+
 * :bug:`-` Fix an error querying the exit timestamp for the ethereum validators.
+* :bug:`8669` Fixes double conversion for displayed price in manual balances when not using USD as the selected currency.
 
 * :release:`1.35.0 <2024-10-02>`
 * :feature:`8428` Rotki will now properly decode cowswap fees and order types after 2024-03-19 by querying the cowswap API for offchain data.

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -232,7 +232,6 @@ watchDebounced(
           show-currency="symbol"
           :price-asset="row.asset"
           :price-of-asset="row.usdPrice"
-          fiat-currency="USD"
           :value="row.usdPrice"
         />
       </template>


### PR DESCRIPTION
Closes #8669

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
