### PR TITLE
Serious fixes at the log event querying mechanism

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 
 * :bug:`8668` Changes the tag filter logic from OR to AND in the account view.
+* :bug:`-` Graph delegation log queries will now query a smaller amount of events.
 * :bug:`-` Fix an error querying the exit timestamp for the ethereum validators.
 * :bug:`8669` Fixes double conversion for displayed price in manual balances when not using USD as the selected currency.
 

--- a/rotkehlchen/chain/evm/decoding/thegraph/constants.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/constants.py
@@ -11,34 +11,34 @@ THEGRAPH_CPT_DETAILS: Final = CounterpartyDetails(
 
 GRAPH_DELEGATION_TRANSFER_ABI: Final = [
     {
-        'anonymous': 'false',
+        'anonymous': False,
         'inputs': [
             {
-                'indexed': 'true',
+                'indexed': True,
                 'internalType': 'address',
                 'name': 'delegator',
                 'type': 'address',
             },
             {
-                'indexed': 'true',
+                'indexed': True,
                 'internalType': 'address',
                 'name': 'l2Delegator',
                 'type': 'address',
             },
             {
-                'indexed': 'true',
+                'indexed': True,
                 'internalType': 'address',
                 'name': 'indexer',
                 'type': 'address',
             },
             {
-                'indexed': 'false',
+                'indexed': False,
                 'internalType': 'address',
                 'name': 'l2Indexer',
                 'type': 'address',
             },
             {
-                'indexed': 'false',
+                'indexed': False,
                 'internalType': 'uint256',
                 'name': 'transferredDelegationTokens',
                 'type': 'uint256',


### PR DESCRIPTION

#### [Graph delegations log queries will now query proper amount of events](https://github.com/rotki/rotki/commit/6d614a6000d4004d2e6082e171c4b844d8a0824f) 

The problem was that the log query could not be formulated
properly. Since the hardcoded ABI was using strings instead of booleans.


---- 
plus wrote an extensive test