### PR TITLE
Support gnosispay referrals in the history events view

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -56,6 +56,7 @@ jobs:
             fi
           fi
 
+          echo "Current HEAD is $(git rev-parse HEAD)"
           [ `git rev-parse remotes/origin/$TARGET_BRANCH` = `git merge-base remotes/origin/$TARGET_BRANCH $SOURCE_BRANCH` ] &&
           echo "VCR setup: $SOURCE_BRANCH fully rebased on $TARGET_BRANCH" && exit ||
           echo "VCR setup: $SOURCE_BRANCH not fully rebased on $TARGET_BRANCH" && exit 1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-
+* :feature:`-` Gnosis pay referral rewards will now be properly seen as referrals and not generic receive.
 * :bug:`8668` Changes the tag filter logic from OR to AND in the account view.
 * :bug:`-` Graph delegation log queries will now query a smaller amount of events.
 * :bug:`-` Fix an error querying the exit timestamp for the ethereum validators.

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/constants.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/constants.py
@@ -6,6 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 GNOSIS_PAY_CASHBACK_ADDRESS: Final = string_to_evm_address('0xCdF50be9061086e2eCfE6e4a1BF9164d43568EEC')  # noqa: E501
 GNOSIS_PAY_SPENDER_ADDRESS: Final = string_to_evm_address('0xcFF260bfbc199dC82717494299b1AcADe25F549b')  # noqa: E501
 GNOSIS_PAY_SPENDING_COLLECTOR: Final = string_to_evm_address('0x4822521E6135CD2599199c83Ea35179229A172EE')  # noqa: E501
+GNOSIS_PAY_REFERRAL_ADDRESS: Final = string_to_evm_address('0xB2e7803Ce9AA69ca0F82256Ff1eC5C9983608E04')  # noqa: E501
 
 SPEND: Final = b'\xca\x8f\xbb\x9b\xda\x99\x84\x8fDyq\xea\xe6*\xd0\xad+\xc7\xca\xf9\xaf\xcc\r\x8eN\x8f\xfc\xf7\xe0k\xc2\x8f'  # noqa: E501
 

--- a/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
+++ b/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
@@ -6,6 +6,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import (
     CPT_GNOSIS_PAY,
     GNOSIS_PAY_CASHBACK_ADDRESS,
+    GNOSIS_PAY_REFERRAL_ADDRESS,
     GNOSIS_PAY_SPENDING_COLLECTOR,
 )
 from rotkehlchen.constants.assets import Asset
@@ -47,6 +48,35 @@ def test_gnosis_pay_cashback(gnosis_inquirer, gnosis_accounts):
             tx_hash=tx_hash,
             counterparty=CPT_GNOSIS_PAY,
             address=GNOSIS_PAY_CASHBACK_ADDRESS,
+        ),
+    ]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_accounts', [[
+    '0xc746598C9dD7FC62EF8775445F2F375aCbaCa7AE',  # user's gnosis pay safe
+]])
+def test_gnosis_pay_referral(gnosis_inquirer, gnosis_accounts):
+    tx_hash = deserialize_evm_tx_hash('0xc778b8c23b823d6cec199ece516ab68658c7caafb508104f2a0c9de4d0358529')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        tx_hash=tx_hash,
+    )
+    amount = '30.23'
+    assert events == [
+        EvmEvent(
+            sequence_index=18,
+            timestamp=TimestampMS(1727856180000),
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
+            balance=Balance(amount=FVal(amount)),
+            location_label=gnosis_accounts[0],
+            notes=f'Receive referral reward of {amount} EURe from Gnosis Pay',
+            tx_hash=tx_hash,
+            counterparty=CPT_GNOSIS_PAY,
+            address=GNOSIS_PAY_REFERRAL_ADDRESS,
         ),
     ]
 


### PR DESCRIPTION
Seems we had missed this in the decoders

