### PR TITLE
Cleanup thegraph transactions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 * :feature:`-` Gnosis pay referral rewards will now be properly seen as referrals and not generic receive.
 * :bug:`8668` Changes the tag filter logic from OR to AND in the account view.
-* :bug:`-` Graph delegation log queries will now query a smaller amount of events.
+* :bug:`-` Graph delegation log queries will now query a smaller amount of events. For users who had moved graph staking to Arbitrum and ended up having over 180k transactions in their DB, this should now be fixed and the DB size should be normal again.
 * :bug:`-` Fix an error querying the exit timestamp for the ethereum validators.
 * :bug:`8669` Fixes double conversion for displayed price in manual balances when not using USD as the selected currency.
 

--- a/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/vaults.py
@@ -24,7 +24,12 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, EVMTxHash, Timestamp
-from rotkehlchen.utils.misc import address_to_bytes32, hexstr_to_int, shift_num_right_by, ts_now
+from rotkehlchen.utils.misc import (
+    address_to_bytes32_hexstr,
+    hexstr_to_int,
+    shift_num_right_by,
+    ts_now,
+)
 
 from .cache import collateral_type_to_join_contract, collateral_type_to_underlying_asset
 from .constants import MAKERDAO_REQUERY_PERIOD, WAD
@@ -276,7 +281,7 @@ class MakerdaoVaults(HasDSProxy):
         argument_filters = {
             'sig': '0x76088703',  # frob
             'arg1': '0x' + vault.ilk.hex(),  # ilk
-            'arg2': address_to_bytes32(urn),  # urn
+            'arg2': address_to_bytes32_hexstr(urn),  # urn
             # arg3 can be urn for the 1st deposit, and proxy/owner for the next ones
             # so don't filter for it
         }
@@ -303,7 +308,7 @@ class MakerdaoVaults(HasDSProxy):
             # Vault the usr in the first deposit will be the old address. To
             # detect the first deposit in these cases we need to check for
             # arg1 being the urn so we skip: 'usr': proxy,
-            'arg1': address_to_bytes32(urn),
+            'arg1': address_to_bytes32_hexstr(urn),
         }
         try:
             events = self.ethereum.get_logs(
@@ -409,7 +414,7 @@ class MakerdaoVaults(HasDSProxy):
         # Get the dai generation events
         argument_filters = {
             'sig': '0xbb35783b',  # move
-            'arg1': address_to_bytes32(urn),
+            'arg1': address_to_bytes32_hexstr(urn),
             # For CDPs that were created by migrating from SAI the first DAI generation
             # during vault creation will have the old owner as arg2. So we can't
             # filter for it here. Still seems like the urn as arg1 is sufficient
@@ -445,7 +450,7 @@ class MakerdaoVaults(HasDSProxy):
         argument_filters = {
             'sig': '0x3b4da69f',  # join
             'usr': proxy,
-            'arg1': address_to_bytes32(urn),
+            'arg1': address_to_bytes32_hexstr(urn),
         }
         events = self.makerdao_dai_join.get_logs_since_deployment(
             node_inquirer=self.ethereum,

--- a/rotkehlchen/data_migrations/constants.py
+++ b/rotkehlchen/data_migrations/constants.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-LAST_DATA_MIGRATION: Final = 17
+LAST_DATA_MIGRATION: Final = 18

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -14,6 +14,7 @@ from rotkehlchen.data_migrations.migrations.migrations_14 import data_migration_
 from rotkehlchen.data_migrations.migrations.migrations_15 import data_migration_15
 from rotkehlchen.data_migrations.migrations.migrations_16 import data_migration_16
 from rotkehlchen.data_migrations.migrations.migrations_17 import data_migration_17
+from rotkehlchen.data_migrations.migrations.migrations_18 import data_migration_18
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 from .constants import LAST_DATA_MIGRATION
@@ -43,6 +44,7 @@ MIGRATION_LIST = [  # remember to bump LAST_DATA_MIGRATION if editing this
     MigrationRecord(version=15, function=data_migration_15),
     MigrationRecord(version=16, function=data_migration_16),
     MigrationRecord(version=17, function=data_migration_17),
+    MigrationRecord(version=18, function=data_migration_18),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migrations_18.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_18.py
@@ -1,0 +1,128 @@
+import logging
+from typing import TYPE_CHECKING
+
+from rotkehlchen.chain.evm.decoding.thegraph.constants import CPT_THEGRAPH
+from rotkehlchen.db.filtering import EvmEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.types import Location
+from rotkehlchen.utils.misc import address_to_bytes32
+
+if TYPE_CHECKING:
+    from rotkehlchen.data_migrations.progress import MigrationProgressHandler
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+@enter_exit_debug_log()
+def cleanup_extra_thegraph_txs(rotki: 'Rotkehlchen') -> None:
+    dbevents = DBHistoryEvents(rotki.data.db)
+    with rotki.data.db.conn.read_ctx() as cursor:
+        tracked_addresses = rotki.data.db.get_evm_accounts(cursor)
+
+    if len(tracked_addresses) == 0:
+        return
+
+    db_filter = EvmEventFilterQuery.make(
+        counterparties=[CPT_THEGRAPH],
+        location=Location.ETHEREUM,
+        event_types=[HistoryEventType.INFORMATIONAL],
+        event_subtypes=[HistoryEventSubType.APPROVE],
+        location_labels=tracked_addresses,  # type: ignore  # sequence[address] == list[str]
+        order_by_rules=[('timestamp', True)],  # order by timestamp in ascending order
+    )
+    with rotki.data.db.conn.read_ctx() as cursor:
+        events = dbevents.get_history_events(
+            cursor=cursor,
+            filter_query=db_filter,
+            has_premium=True,
+        )
+    approved_delegators = {x.address for x in events if x.address is not None}
+    all_addresses = approved_delegators | set(tracked_addresses)
+
+    tracked_placeholders = ','.join('?' * len(tracked_addresses))
+    delegators_placeholders = ','.join('?' * len(approved_delegators))
+    all_placeholders = ','.join('?' * (len(approved_delegators) + len(tracked_addresses)))
+    # Find all possible logs we need to keep for our related addresses and mark the transactions
+    querystr = f"""SELECT DISTINCT et.tx_hash FROM evm_transactions et
+JOIN evmtx_receipts er ON et.identifier = er.tx_id
+JOIN evmtx_receipt_logs erl ON er.tx_id = erl.tx_id
+JOIN evmtx_receipt_log_topics erlt0 ON erl.identifier = erlt0.log
+JOIN evmtx_receipt_log_topics erlt2 ON erl.identifier = erlt2.log
+WHERE erl.address = '0xF55041E37E12cD407ad00CE2910B8269B01263b9'
+  AND
+    (erlt0.topic_index = 0  /* DelegationTransferredToL2 */
+  AND erlt0.topic = X'231E5CFEFF7759A468241D939AB04A60D603B17E359057ABBB8F52AFC3E4986B'
+AND ((
+     erlt2.topic_index = 2
+     AND erlt2.topic IN ({tracked_placeholders}))"""
+    query_bindings = [address_to_bytes32(x) for x in tracked_addresses]
+
+    if len(approved_delegators) != 0:
+        querystr += f' OR (erlt2.topic_index = 1 AND erlt2.topic IN({delegators_placeholders}))'
+        query_bindings += [address_to_bytes32(x) for x in approved_delegators]
+
+    querystr += f"""
+    ))OR
+    ((erlt0.topic_index = 0  /* StakeDelegationWithdrawn */
+    AND erlt0.topic = X'1B2E7737E043C5CF1B587CEB4DAEB7AE00148B9BDA8F79F1093EEAD08F141952') AND (erlt2.topic_index = 2 AND erlt2.topic IN ({all_placeholders})))
+    """  # noqa: E501
+    query_bindings += [address_to_bytes32(x) for x in all_addresses]
+
+    querystr += f"""
+    OR
+    ((erlt0.topic_index = 0  /* StakeDelegated */
+    AND erlt0.topic = X'CD0366DCE5247D874FFC60A762AA7ABBB82C1695BBB171609C1B8861E279EB73') AND (erlt2.topic_index = 2 AND erlt2.topic IN ({all_placeholders})))
+    """  # noqa: E501
+    query_bindings += [address_to_bytes32(x) for x in all_addresses]
+
+    querystr += f"""
+    OR
+    ((erlt0.topic_index = 0  /* StakeDelegatedLocked */
+    AND erlt0.topic = X'0430183F84D9C4502386D499DA806543DEE1D9DE83C08B01E39A6D2116C43B25') AND (erlt2.topic_index = 2 AND erlt2.topic IN ({all_placeholders})))
+    """  # noqa: E501
+    query_bindings += [address_to_bytes32(x) for x in all_addresses]
+
+    to_keep_hashes = []
+    with rotki.data.db.conn.read_ctx() as cursor:
+        cursor.execute(querystr, query_bindings)
+        to_keep_hashes = [x[0] for x in cursor]
+
+    # Finally delete the unneeded transactions
+    query_bindings = []
+    querystr = """DELETE FROM evm_transactions
+    WHERE identifier IN (
+    SELECT DISTINCT et.identifier
+    FROM evm_transactions et
+    JOIN evmtx_receipts er ON et.identifier = er.tx_id
+    JOIN evmtx_receipt_logs erl ON er.tx_id = erl.tx_id
+    WHERE erl.address = '0xF55041E37E12cD407ad00CE2910B8269B01263b9'
+) AND tx_hash NOT IN (SELECT tx_hash from evm_events_info)"""
+    if len(to_keep_hashes) != 0:
+        # we have also performed a thorough logs query above in case some were not decoded.
+        # As if the transactions were not decoded yet then the
+        # tx_hash NOT IN (SELECT tx_hash from evm_events_info) won't help avoid
+        # deleting important transactions
+        to_keep_placeholders = ','.join('?' * len(to_keep_hashes))
+        querystr += f' AND tx_hash NOT IN ({to_keep_placeholders})'
+        query_bindings += to_keep_hashes
+
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        write_cursor.execute(querystr, query_bindings)
+
+    rotki.data.db.conn.execute('VACUUM;')  # also since this cleans up a lot of space vacuum
+
+
+def data_migration_18(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:  # pylint: disable=unused-argument
+    """
+    Introduced at v1.35.1
+
+    Fix the issue of extra transactions saved in the DB from the graph queries
+    for delegation to arbitrum
+    """
+    progress_handler.set_total_steps(1)
+    cleanup_extra_thegraph_txs(rotki)
+    progress_handler.new_step()

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -122,6 +122,7 @@ from rotkehlchen.types import (
     EVM_CHAINS_WITH_TRANSACTIONS,
     SPAM_PROTOCOL,
     SUPPORTED_BITCOIN_CHAINS,
+    SUPPORTED_EVM_CHAINS,
     SUPPORTED_EVM_CHAINS_TYPE,
     SUPPORTED_EVM_EVMLIKE_CHAINS,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
@@ -1336,6 +1337,15 @@ class DBHandler:
             '(account, chain_id, key, value) VALUES (?, ?, ?, ?)',
             insert_rows,
         )
+
+    def get_evm_accounts(self, cursor: 'DBCursor') -> list[ChecksumEvmAddress]:
+        """Returns a list of unique EVM accounts from all EVM chains."""
+        placeholders = ','.join('?' * len(SUPPORTED_EVM_CHAINS))
+        cursor.execute(
+            f'SELECT DISTINCT account FROM blockchain_accounts WHERE blockchain IN ({placeholders});',  # noqa: E501
+            [chain.value for chain in SUPPORTED_EVM_CHAINS],
+        )
+        return [entry[0] for entry in cursor]
 
     def get_blockchain_accounts(self, cursor: 'DBCursor') -> BlockchainAccounts:
         """Returns a Blockchain accounts instance containing all blockchain account addresses"""

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -6,6 +6,7 @@ import operator
 import re
 import sys
 import time
+from binascii import unhexlify
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from itertools import zip_longest
@@ -296,8 +297,12 @@ def hex_or_bytes_to_address(value: bytes | str) -> ChecksumEvmAddress:
         ) from e
 
 
-def address_to_bytes32(address: ChecksumEvmAddress) -> str:
+def address_to_bytes32_hexstr(address: ChecksumEvmAddress) -> str:
     return '0x' + 24 * '0' + address.lower()[2:]
+
+
+def address_to_bytes32(address: ChecksumEvmAddress) -> bytes:
+    return unhexlify(24 * '0' + address.lower()[2:])
 
 
 T = TypeVar('T')


### PR DESCRIPTION
### [Add get_evm_accounts to bugfixes too](https://github.com/rotki/rotki/commit/0ab45683376b47871de4f7ed55d8da18d44d248e) 

This was added by nicholas in develop

### [Delete all un-needed thegraph evm transactions](https://github.com/rotki/rotki/commit/16c25a6570250f215e5689c9020982b6bc6e01ef) 

This is fixing the extra amount of transactions that were added in the
DB for people who used the graph protocol and moved their staking to
arbitrum.

It was caused by a too open log query bug that was fixed in commit
https://github.com/rotki/rotki/commit/61c2772261de1cc4ca1dda7388699c92ffef88b4 and with this commit we are fixing
the DB of those that were affected.