### PR TITLE
Spam assets fixes

### DIFF
--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
@@ -15,6 +17,7 @@ from rotkehlchen.chain.scroll.constants import SCROLL_ETHERSCAN_NODE
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_PAX, A_USDT
 from rotkehlchen.constants.prices import ZERO_PRICE
+from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.data_migrations.constants import LAST_DATA_MIGRATION
 from rotkehlchen.data_migrations.manager import (
     MIGRATION_LIST,
@@ -25,7 +28,9 @@ from rotkehlchen.db.constants import UpdateType
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
+from rotkehlchen.globaldb.cache import globaldb_delete_general_cache_values
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.globaldb.utils import set_token_spam_protocol
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.icons import IconManager
@@ -34,7 +39,9 @@ from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.tests.utils.exchanges import check_saved_events_for_exchange
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.types import (
+    SPAM_PROTOCOL,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
+    CacheType,
     ChainID,
     ChecksumEvmAddress,
     EvmTokenKind,
@@ -80,6 +87,30 @@ def assert_progress_message(msg, step_num, description, migration_version, migra
         assert description in migration['description']
     else:
         assert migration['description'] is None
+
+
+def _populate_spam_tokens(data_handler: DataHandler):
+    tokens = [
+        EvmToken('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),  # new eure
+        EvmToken('eip155:100/erc20:0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053'),  # new GBPe
+        EvmToken('eip155:100/erc20:0xcB444e90D8198415266c6a2724b7900fb12FC56E'),  # legacy eure
+    ]
+    with GlobalDBHandler().conn.write_ctx() as write_cursor:
+        for token in tokens:
+            set_token_spam_protocol(write_cursor=write_cursor, token=token, is_spam=True)
+
+            # remove the asset from the whitelist if it was there
+            globaldb_delete_general_cache_values(
+                write_cursor=write_cursor,
+                key_parts=(CacheType.SPAM_ASSET_FALSE_POSITIVE,),
+                values=(token.identifier,),
+            )
+            AssetResolver.clean_memory_cache(token.identifier)
+
+    # add to ignored assets if it wasn't there
+    data_handler.add_ignored_assets(assets=tokens)
+
+    return tokens
 
 
 def assert_add_addresses_migration_ws_messages(
@@ -675,6 +706,9 @@ def test_migration_18(rotkehlchen_api_server: 'APIServer') -> None:
             tx_hash=tx_hash,
         )
 
+    # mark a few assets as spam
+    tokens = _populate_spam_tokens(rotki.data)
+
     # add all the transactions that are irrelevant to us, emulating the problem
     # that all transactions of 0xF55041E37E12cD407ad00CE2910B8269B01263b9 were saved
     # in the DB
@@ -695,7 +729,10 @@ def test_migration_18(rotkehlchen_api_server: 'APIServer') -> None:
 
     with rotki.data.db.conn.read_ctx() as cursor:
         assert {x[0] for x in cursor.execute('SELECT tx_hash FROM evm_transactions').fetchall()} == set(kept_txs + bad_txs)  # make sure they are all written in the DB  # noqa: E501
-
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM multisettings WHERE name="ignored_asset" AND value IN (?, ?, ?)',
+            [token.identifier for token in tokens],
+        ).fetchone()[0] == 3
     with patch(
         'rotkehlchen.data_migrations.manager.MIGRATION_LIST',
         new=[MIGRATION_LIST[11]],
@@ -704,6 +741,13 @@ def test_migration_18(rotkehlchen_api_server: 'APIServer') -> None:
 
     with rotki.data.db.conn.read_ctx() as cursor:
         result_kept_txs = {x[0] for x in cursor.execute('SELECT tx_hash FROM evm_transactions').fetchall()}  # noqa: E501
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM multisettings WHERE name="ignored_asset" AND value IN (?, ?, ?)',
+            [token.identifier for token in tokens],
+        ).fetchone()[0] == 0
+
+    for token in tokens:
+        assert EvmToken(token.identifier).protocol != SPAM_PROTOCOL
 
     assert result_kept_txs == set(kept_txs)  # after the migration see all irrelevant transactions are deleted  # noqa: E501
 

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -629,10 +629,10 @@ def test_maybe_augmented_detect_new_spam_tokens(
     Test the augmented spam detection schedule and behaviour. We use a token that is not detected
     in the fast checks that we do and that is airdropped in a multisend transaction.
     """
-    tx_hex = deserialize_evm_tx_hash('0x6c10aaafec60e012316f54e2ac691b0a64d8744c21382fd3eb5013b4d1935bab')  # noqa: E501
+    spam_tx_hex = deserialize_evm_tx_hash('0x6c10aaafec60e012316f54e2ac691b0a64d8744c21382fd3eb5013b4d1935bab')  # noqa: E501
     get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hex,
+        tx_hash=spam_tx_hex,
     )
     token = EvmToken(evm_address_to_identifier(
         address='0x456FEb37ca5F087f7B59F5F684437cf1dd6e968f',


### PR DESCRIPTION
- Improve the query used to loop the events (this saves defillama queries)
- consider having coingecko/cc identifiers
- count the transfer events in sql and increase the threshold
- avoid having the monerium assets flagged as spam