### PR TITLE
Bump py-substrate-interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ scalecodec==1.2.11
 py-sr25519-bindings==0.2.0
 py-ed25519-zebra-bindings==1.0.1
 py-bip39-bindings==0.1.11
-substrate-interface==1.7.10
+substrate-interface==1.7.11
 beautifulsoup4==4.12.3
 maxminddb==2.6.2
 pywin32==306; sys_platform == 'win32'


### PR DESCRIPTION
This allows the dependency solver to increase the version of eth-utils and we don't get anymore the annoying warning for missing chains

Before:

![imagen](https://github.com/user-attachments/assets/46881b2a-6ce4-4c4b-9d99-828de90dfeea)


Now:
```
(rotki) ➜  rotki git:(develop) ✗ python pytestgeventwrapper.py rotkehlchen/tests/unit/test_inquirer.py
========================================================================================================================== test session starts ===========================================================================================================================
platform darwin -- Python 3.11.9, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/yabirgb/work/rotki
configfile: pyproject.toml
plugins: cov-5.0.0, pytest_freezer-0.4.8, socket-0.7.0, deadfixtures-3.0.0, anyio-4.6.0, vcr-1.0.2, web3-6.20.1, xdist-3.6.1
collected 33 items                                                                                                                                                                                                                                                       

```