### PR TITLE
fix: make pinned section persistent for better UX

### DIFF
--- a/frontend/app/src/components/PinnedSidebar.vue
+++ b/frontend/app/src/components/PinnedSidebar.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-const display = defineModel<boolean>({ required: true });
-
 const ReportActionableCard = defineAsyncComponent(() => import('@/components/profitloss/ReportActionableCard.vue'));
 
-const { pinned } = storeToRefs(useAreaVisibilityStore());
+const { pinned, showPinned } = storeToRefs(useAreaVisibilityStore());
+
+const { isLgAndDown } = useBreakpoint();
 
 const component: ComputedRef = computed(() => {
   const pinnedValue = get(pinned);
@@ -16,10 +16,11 @@ const component: ComputedRef = computed(() => {
 
 <template>
   <RuiNavigationDrawer
-    v-model="display"
-    width="560px"
-    temporary
+    v-model="showPinned"
+    :temporary="isLgAndDown"
+    width="500px"
     position="right"
+    class="border-l border-rui-grey-300 dark:border-rui-grey-800 z-[6]"
   >
     <div>
       <Component

--- a/frontend/app/src/components/app/AppCore.vue
+++ b/frontend/app/src/components/app/AppCore.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const visibilityStore = useAreaVisibilityStore();
-const { showDrawer, isMini } = storeToRefs(visibilityStore);
+const { showDrawer, isMini, showPinned } = storeToRefs(visibilityStore);
 const { overall } = storeToRefs(useStatisticsStore());
 const { logged } = storeToRefs(useSessionAuthStore());
 const toggleDrawer = visibilityStore.toggleDrawer;
@@ -54,6 +54,7 @@ onMounted(() => {
       :class="{
         small: isMini,
         expanded,
+        pinned: showPinned,
       }"
     >
       <main>
@@ -111,7 +112,7 @@ onMounted(() => {
 <style scoped lang="scss">
 .app {
   &-main {
-    @apply pt-6 pb-16 w-full;
+    @apply pt-6 pb-16 w-full transition-all;
     min-height: calc(100vh - 64px);
 
     &.small {
@@ -120,6 +121,10 @@ onMounted(() => {
 
     &.expanded {
       @apply pl-[300px];
+    }
+
+    &.pinned {
+      @apply xl:pr-[485px];
     }
   }
 }

--- a/frontend/app/src/components/history/events/HistoryEventsTableActions.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsTableActions.vue
@@ -73,7 +73,7 @@ function redecodePageTransactions(): void {
       color="primary"
       :disabled="processing"
       :class="{
-        '!divide-rui-grey-200': processing,
+        '!divide-rui-grey-200 dark:!divide-rui-grey-800': processing,
       }"
     >
       <RuiButton

--- a/frontend/app/src/components/profitloss/ReportActionableCard.vue
+++ b/frontend/app/src/components/profitloss/ReportActionableCard.vue
@@ -26,7 +26,7 @@ const ReportMissingPrices = defineAsyncComponent(() => import('@/components/prof
 
 const { t } = useI18n();
 const { report, isPinned } = toRefs(props);
-const { pinned } = storeToRefs(useAreaVisibilityStore());
+const { pinned, showPinned } = storeToRefs(useAreaVisibilityStore());
 
 function setDialog(dialog: boolean) {
   emit('set-dialog', dialog);
@@ -192,6 +192,10 @@ function close() {
     setPinned(null);
   else setDialog(false);
 }
+
+function closePinnedSidebar() {
+  set(showPinned, false);
+}
 </script>
 
 <template>
@@ -211,6 +215,19 @@ function close() {
         <RuiIcon
           class="text-white"
           name="close-line"
+        />
+      </RuiButton>
+      <RuiButton
+        v-else
+        variant="text"
+        size="sm"
+        icon
+        @click="closePinnedSidebar()"
+      >
+        <RuiIcon
+          class="text-white"
+          name="arrow-right-s-line"
+          size="20"
         />
       </RuiButton>
 

--- a/frontend/app/src/components/profitloss/ReportMissingPrices.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingPrices.vue
@@ -239,7 +239,7 @@ async function refreshHistoricalPrice(item: EditableMissingPrice) {
 .table {
   &--pinned {
     max-height: 100%;
-    height: calc(100vh - 250px);
+    height: calc(100vh - 245px);
   }
 }
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4114,7 +4114,7 @@
           "missing_acquisitions": "Missing Acquisitions",
           "missing_amount": "Missing Amount",
           "quick_action": "Quick Action",
-          "total_missing": "Total Amount Missing"
+          "total_missing": "Amount Missing"
         },
         "hint": "Some asset acquisitions are missing. You will need to figure out where you bought them and either import or manually create the relevant acquisition events",
         "title": "Missing Acquisitions ({total})",

--- a/frontend/app/src/main.scss
+++ b/frontend/app/src/main.scss
@@ -28,7 +28,7 @@ body {
 }
 
 aside {
-  @apply top-[3.5rem] md:top-[4rem] max-h-[calc(100vh-3.5rem)] md:max-h-[calc(100vh-4rem)] #{!important};
+  @apply max-w-[100vw] top-[3.5rem] md:top-[4rem] max-h-[calc(100vh-3.5rem)] md:max-h-[calc(100vh-4rem)] #{!important};
 }
 
 .table-inside-dialog {


### PR DESCRIPTION
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/0e944060-79a2-4188-bbf4-d1cd0a168c86">

Make the pinned section persistent, so user can see history events and the pinned section simultaneously