### PR TITLE
Handle yearn api query errors better

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 * :bug:`-` Graph delegation log queries will now query a smaller amount of events. For users who had moved graph staking to Arbitrum and ended up having over 180k transactions in their DB, this should now be fixed and the DB size should be normal again.
 * :bug:`-` Fix an error querying the exit timestamp for the ethereum validators.
 * :bug:`8669` Fixes double conversion for displayed price in manual balances when not using USD as the selected currency.
+* :bug:`-` Better handling of failure to fetch data from yearn API.
 
 * :release:`1.35.0 <2024-10-02>`
 * :feature:`8428` Rotki will now properly decode cowswap fees and order types after 2024-03-19 by querying the cowswap API for offchain data.


### PR DESCRIPTION
The function that queried and merged data from yearn API was pretty bad. The bug was that it just continued with the response as an unbound variable if the api query failed.

But also error handling and reporting was bad.
Added error logging everywhere and also refactored to exit early for better readability