### PR TITLE
Remove hex_or_bytes_to_int

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ARB
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
@@ -45,7 +45,7 @@ class AirdropsDecoder(ArbitrumDecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.topics[1])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        raw_amount = int.from_bytes(context.tx_log.data[0:32])
         amount = asset_normalized_value(amount=raw_amount, asset=self.arb_token)
 
         for event in context.decoded_events:

--- a/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
@@ -27,7 +27,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, from_wei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
@@ -142,7 +142,7 @@ class ArbitrumOneBridgeDecoder(ArbitrumDecoderInterface):
         (Sending assets from arbitrum one)
         """
         from_token = self.base.get_or_create_evm_token(from_token_address)
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        raw_amount = int.from_bytes(context.tx_log.data[64:96])
         amount = asset_normalized_value(raw_amount, to_asset)
         to_label = f'address {to_address}'
         if to_address == from_address:
@@ -181,7 +181,7 @@ class ArbitrumOneBridgeDecoder(ArbitrumDecoderInterface):
         if not self.base.any_tracked([from_address, to_address]):
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[128:160])
+        raw_amount = int.from_bytes(context.tx_log.data[128:160])
         amount = from_wei(FVal(raw_amount))
         for event in context.decoded_events:
             if (
@@ -256,7 +256,7 @@ class ArbitrumOneBridgeDecoder(ArbitrumDecoderInterface):
         if context.tx_log.topics[0] != ERC20_DEPOSIT_FINALIZED:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        raw_amount = int.from_bytes(context.tx_log.data[:32])
         l1_token_address = bytes_to_address(context.tx_log.topics[1])
         from_address = bytes_to_address(context.tx_log.topics[2])
         to_address = bytes_to_address(context.tx_log.topics[3])

--- a/rotkehlchen/chain/arbitrum_one/modules/gmx/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gmx/decoder.py
@@ -30,7 +30,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
@@ -75,11 +75,11 @@ class GmxDecoder(ArbitrumDecoderInterface):
         token_out = self.base.get_or_create_evm_asset(bytes_to_address(context.tx_log.data[32:64]))
         token_in = self.base.get_or_create_evm_asset(bytes_to_address(context.tx_log.data[64:96]))
         amount_out = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data[96:128]),
+            amount=int.from_bytes(context.tx_log.data[96:128]),
             asset=token_out,
         )
         amount_in = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data[128:160]),
+            amount=int.from_bytes(context.tx_log.data[128:160]),
             asset=token_in,
         )
 
@@ -211,7 +211,7 @@ class GmxDecoder(ArbitrumDecoderInterface):
 
         account = bytes_to_address(context.tx_log.data[0:32])
         token_addrs = bytes_to_address(context.tx_log.data[32:64])
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        amount_raw = int.from_bytes(context.tx_log.data[64:96])
 
         staked_token = self.base.get_or_create_evm_asset(address=token_addrs)
         amount = asset_normalized_value(amount=amount_raw, asset=staked_token)

--- a/rotkehlchen/chain/ethereum/modules/aave/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     REDEEM_AAVE,
@@ -53,7 +53,7 @@ class AaveDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token_amount=int.from_bytes(context.tx_log.data[:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         return method(from_address=from_address, to_address=to_address, amount=amount, context=context)  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 DEPOSIT = b'\xc1,W\xb1\xc7:,:.\xa4a>\x94v\xab\xb3\xd8\xd1F\x85z\xabs)\xe2BC\xfbYq\x0c\x82'
 REDEEM_UNDERLYING = b'\x9cN\xd5\x99\xcd\x85U\xb9\xc1\xe8\xcdvC$\r}q\xebv\xb7\x92\x94\x8cI\xfc\xb4\xd4\x11\xf7\xb6\xb3\xc6'  # noqa: E501
@@ -38,7 +38,7 @@ class Aavev1Decoder(DecoderInterface):
         reserve_address = bytes_to_address(context.tx_log.topics[1])
         reserve_asset = self.base.get_or_create_evm_asset(reserve_address)
         user_address = bytes_to_address(context.tx_log.topics[2])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        raw_amount = int.from_bytes(context.tx_log.data[0:32])
         amount = asset_normalized_value(raw_amount, reserve_asset)
         atoken = asset_to_atoken(asset=reserve_asset, version=1)
         if atoken is None:
@@ -74,7 +74,7 @@ class Aavev1Decoder(DecoderInterface):
         reserve_address = bytes_to_address(context.tx_log.topics[1])
         reserve_asset = self.base.get_or_create_evm_asset(reserve_address)
         user_address = bytes_to_address(context.tx_log.topics[2])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        raw_amount = int.from_bytes(context.tx_log.data[0:32])
         amount = asset_normalized_value(raw_amount, reserve_asset)
         atoken = asset_to_atoken(asset=reserve_asset, version=1)
         if atoken is None:
@@ -117,7 +117,7 @@ class Aavev1Decoder(DecoderInterface):
         for event in context.decoded_events:
             asset = event.asset.resolve_to_evm_token()
             if event.event_type == HistoryEventType.SPEND and asset_normalized_value(
-                amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),  # debt amount
+                amount=int.from_bytes(context.tx_log.data[32:64]),  # debt amount
                 asset=asset,
             ) == event.balance.amount:
                 # we are transfering the debt token

--- a/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
@@ -34,7 +34,7 @@ from rotkehlchen.constants.assets import (
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     CPT_BADGER,
@@ -112,7 +112,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
         if context.tx_log.topics[0] != FOX_CLAIMED:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        raw_amount = int.from_bytes(context.tx_log.data[64:96])
         amount = token_normalized_value_decimals(
             token_amount=raw_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # fox 18 decimals
@@ -135,7 +135,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
         if context.tx_log.topics[0] != BADGER_HUNT_EVENT:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        raw_amount = int.from_bytes(context.tx_log.data[32:64])
         amount = token_normalized_value_decimals(
             token_amount=raw_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # badger 18 decimals
@@ -163,7 +163,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.data[0:32])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        raw_amount = int.from_bytes(context.tx_log.data[32:64])
 
         if airdrop == CPT_CONVEX:
             amount = token_normalized_value_decimals(
@@ -211,7 +211,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
 
         user_address = bytes_to_address(context.tx_log.topics[1])
         delegate_address = bytes_to_address(context.tx_log.topics[2])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        raw_amount = int.from_bytes(context.tx_log.data[0:32])
         amount = token_normalized_value_decimals(
             token_amount=raw_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # elfi 18 decimals
@@ -226,7 +226,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             if other_log.topics[0] != ERC20_OR_ERC721_TRANSFER:
                 continue
 
-            transfer_raw = hex_or_bytes_to_int(other_log.data[0:32])
+            transfer_raw = int.from_bytes(other_log.data[0:32])
             if (
                 other_log.address == ELFI_ADDRESS and
                 transfer_raw == raw_amount
@@ -253,7 +253,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
         if context.tx_log.topics[0] != ENS_CLAIM:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        raw_amount = int.from_bytes(context.tx_log.data[:32])
         amount = token_normalized_value_decimals(
             token_amount=raw_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # ens 18 decimals

--- a/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, from_wei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -66,17 +66,17 @@ class ArbitrumOneBridgeDecoder(DecoderInterface):
             #
             # It has 2 int as 32-bytes packed first, which are the offsets for the other two
             # and then has two more 32-bytes which are the address and the msg.value
-            value_offset = hex_or_bytes_to_int(context.tx_log.data[:32])
-            address_offset = hex_or_bytes_to_int(context.tx_log.data[32:64])
+            value_offset = int.from_bytes(context.tx_log.data[:32])
+            address_offset = int.from_bytes(context.tx_log.data[32:64])
             user_address = bytes_to_address(context.tx_log.data[address_offset:address_offset + 32])  # noqa: E501
-            raw_amount = hex_or_bytes_to_int(context.tx_log.data[address_offset + value_offset:address_offset + value_offset + 32])  # noqa: E501
+            raw_amount = int.from_bytes(context.tx_log.data[address_offset + value_offset:address_offset + value_offset + 32])  # noqa: E501
 
             amount = from_wei(FVal(raw_amount))
             expected_event_type = HistoryEventType.SPEND
             new_event_type = HistoryEventType.DEPOSIT
             from_chain, to_chain = ChainID.ETHEREUM, ChainID.ARBITRUM_ONE
         else:  # ETH_WITHDRAWAL_FINALIZED
-            raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+            raw_amount = int.from_bytes(context.tx_log.data[:32])
             user_address = bytes_to_address(context.tx_log.topics[2])
             amount = from_wei(FVal(raw_amount))
             expected_event_type = HistoryEventType.RECEIVE
@@ -118,7 +118,7 @@ class ArbitrumOneBridgeDecoder(DecoderInterface):
 
         ethereum_token_address = bytes_to_address(tx_log.data[:32])
         asset = self.base.get_or_create_evm_token(ethereum_token_address)
-        raw_amount = hex_or_bytes_to_int(tx_log.data[32:])
+        raw_amount = int.from_bytes(tx_log.data[32:])
         amount = asset_normalized_value(raw_amount, asset)
 
         expected_event_type, new_event_type, from_chain, to_chain, _ = bridge_prepare_data(

--- a/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v1/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -57,7 +57,7 @@ class Balancerv1Decoder(DecoderInterface):
         events_information = []
         for target_log in target_logs:
             token_address = bytes_to_address(target_log.topics[2])
-            amount = hex_or_bytes_to_int(target_log.data[0:32])
+            amount = int.from_bytes(target_log.data[0:32])
             if target_log.topics[0] == JOIN_V1:
                 balancer_event_type = BalancerV1EventTypes.JOIN
                 ds_address = bytes_to_address(target_log.topics[1])

--- a/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/balancer/v2/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.constants.assets import A_ETH, A_WETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -64,8 +64,8 @@ class Balancerv2Decoder(DecoderInterface):
         # The transfer event appears after the swap event, so we need to propagate information
         from_token_address = bytes_to_address(context.tx_log.topics[2])
         to_token_address = bytes_to_address(context.tx_log.topics[3])
-        amount_in = hex_or_bytes_to_int(context.tx_log.data[0:32])
-        amount_out = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        amount_in = int.from_bytes(context.tx_log.data[0:32])
+        amount_out = int.from_bytes(context.tx_log.data[32:64])
 
         # Create action item to propagate the information about the swap to the transfer enrichers
         to_token = self.base.get_or_create_evm_token(to_token_address)

--- a/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -126,7 +126,7 @@ class BaseBridgeDecoder(DecoderInterface):
             from_address = bytes_to_address(context.tx_log.data[0:32])
             to_address = bytes_to_address(context.tx_log.topics[3])
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        raw_amount = int.from_bytes(context.tx_log.data[32:64])
         asset = EvmToken(strethaddress_to_identifier(bytes_to_address(context.tx_log.topics[1])))
         amount = asset_normalized_value(amount=raw_amount, asset=asset)
 

--- a/rotkehlchen/chain/ethereum/modules/blur/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/blur/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     BLUR_AIRDROP_2_CLAIM,
@@ -51,7 +51,7 @@ class BlurDecoder(DecoderInterface):
         if not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[1])):
             return DEFAULT_DECODING_OUTPUT
 
-        stake_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        stake_amount = int.from_bytes(context.tx_log.data[:32])
         stake_amount_norm = token_normalized_value_decimals(
             token_amount=stake_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,
@@ -89,7 +89,7 @@ class BlurDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token_amount=int.from_bytes(context.tx_log.data[:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         for event in context.decoded_events:
@@ -116,7 +116,7 @@ class BlurDecoder(DecoderInterface):
         if self.base.is_tracked(user := bytes_to_address(context.tx_log.topics[1])) is False:
             return DEFAULT_DECODING_OUTPUT
 
-        claim_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        claim_amount = int.from_bytes(context.tx_log.data[:32])
         claim_amount_norm = token_normalized_value_decimals(
             token_amount=claim_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -25,7 +25,7 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .utils import get_compound_underlying_token
 
@@ -76,8 +76,8 @@ class Compoundv2Decoder(DecoderInterface):
         if not self.base.is_tracked(minter):
             return DEFAULT_DECODING_OUTPUT
 
-        mint_amount_raw = hex_or_bytes_to_int(tx_log.data[32:64])
-        minted_amount_raw = hex_or_bytes_to_int(tx_log.data[64:96])
+        mint_amount_raw = int.from_bytes(tx_log.data[32:64])
+        minted_amount_raw = int.from_bytes(tx_log.data[64:96])
         underlying_asset = get_compound_underlying_token(compound_token)
         if underlying_asset is None:
             return DEFAULT_DECODING_OUTPUT
@@ -128,8 +128,8 @@ class Compoundv2Decoder(DecoderInterface):
         if not self.base.is_tracked(redeemer):
             return DEFAULT_DECODING_OUTPUT
 
-        redeem_amount_raw = hex_or_bytes_to_int(tx_log.data[32:64])
-        redeem_tokens_raw = hex_or_bytes_to_int(tx_log.data[64:96])
+        redeem_amount_raw = int.from_bytes(tx_log.data[32:64])
+        redeem_tokens_raw = int.from_bytes(tx_log.data[64:96])
         underlying_asset = get_compound_underlying_token(compound_token)
         if underlying_asset is None:
             return DEFAULT_DECODING_OUTPUT
@@ -174,11 +174,11 @@ class Compoundv2Decoder(DecoderInterface):
                 return DEFAULT_DECODING_OUTPUT
 
         if tx_log.topics[0] == BORROW_COMPOUND:
-            amount_raw = hex_or_bytes_to_int(tx_log.data[32:64])
+            amount_raw = int.from_bytes(tx_log.data[32:64])
             payer = None
         else:
             # is a repayment
-            amount_raw = hex_or_bytes_to_int(tx_log.data[64:96])
+            amount_raw = int.from_bytes(tx_log.data[64:96])
             payer = bytes_to_address(tx_log.data[0:32])
 
         amount = asset_normalized_value(amount_raw, underlying_asset)
@@ -226,9 +226,9 @@ class Compoundv2Decoder(DecoderInterface):
         """Decode a liquidation event happening over a tracked account"""
         borrower = bytes_to_address(tx_log.data[32:64])
         liquidator_address = bytes_to_address(tx_log.data[0:32])
-        repay_amount_raw = hex_or_bytes_to_int(tx_log.data[64:96])
+        repay_amount_raw = int.from_bytes(tx_log.data[64:96])
         collateral_ctoken_address = bytes_to_address(tx_log.data[96:128])
-        seize_amount_raw = hex_or_bytes_to_int(tx_log.data[128:160])
+        seize_amount_raw = int.from_bytes(tx_log.data[128:160])
 
         collateral_ctoken = get_or_create_evm_token(
             userdb=self.base.database,

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -40,7 +40,7 @@ from rotkehlchen.history.events.structures.base import HistoryEventSubType, Hist
 from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import CURVE_POOL_PROTOCOL, CacheType, ChecksumEvmAddress, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -109,7 +109,7 @@ class ConvexDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
         - deposits/withdrawals
         - claim rewards
         """
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        amount_raw = int.from_bytes(context.tx_log.data[0:32])
         interacted_address = bytes_to_address(context.tx_log.topics[1])
         found_event_modifying_balances = False
         # in the case of withdrawing CVX from an expired lock the withdrawn event
@@ -164,7 +164,7 @@ class ConvexDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
                     # it during balances queries
                     for log_event in context.all_logs:
                         if log_event.topics[0] == STAKED:
-                            deposit_amount_raw = hex_or_bytes_to_int(context.tx_log.data[0:32])
+                            deposit_amount_raw = int.from_bytes(context.tx_log.data[0:32])
                             staking_address = bytes_to_address(log_event.topics[1])
                             if deposit_amount_raw == amount_raw and staking_address == event.location_label:  # noqa: E501
                                 event.extra_data = {'gauge_address': log_event.address}
@@ -218,9 +218,9 @@ class ConvexDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
         """
         withdrawals_log_entries = filter(lambda x: x.topics[0] == CVX_LOCK_WITHDRAWN, all_logs)
         amounts_withdrawn = [
-            asset_normalized_value(hex_or_bytes_to_int(tx_log.data[0:32]), self.cvx)
+            asset_normalized_value(int.from_bytes(tx_log.data[0:32]), self.cvx)
             for tx_log in withdrawals_log_entries
-            if bool(hex_or_bytes_to_int(tx_log.data[32:64])) is False  # false means not relocked
+            if bool(int.from_bytes(tx_log.data[32:64])) is False  # false means not relocked
         ]
 
         for event in decoded_events:

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int, timestamp_to_date
+from rotkehlchen.utils.misc import bytes_to_address, timestamp_to_date
 
 from .constants import (
     AAVE_POOLS,
@@ -104,7 +104,7 @@ class CurveDecoder(CurveCommonDecoder):
 
         user_note = '' if user_address == context.transaction.from_address else f' from {user_address}'  # noqa: E501
         gauge_address = bytes_to_address(context.tx_log.data[64:96])
-        vote_weight = hex_or_bytes_to_int(context.tx_log.data[96:128])
+        vote_weight = int.from_bytes(context.tx_log.data[96:128])
         if vote_weight == 0:
             verb = 'Reset vote'
             weight_note = ''
@@ -133,7 +133,7 @@ class CurveDecoder(CurveCommonDecoder):
         if not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[1])):
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        raw_amount = int.from_bytes(context.tx_log.data[:32])
         suffix = ''
         if user_address != context.transaction.from_address:
             suffix = f' for {user_address}'
@@ -162,7 +162,7 @@ class CurveDecoder(CurveCommonDecoder):
         if not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[1])):
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        raw_amount = int.from_bytes(context.tx_log.data[:32])
         return method(
             context=context,
             amount=token_normalized_value_decimals(token_amount=raw_amount, token_decimals=DEFAULT_TOKEN_DECIMALS),  # noqa: E501
@@ -170,7 +170,7 @@ class CurveDecoder(CurveCommonDecoder):
         )
 
     def _decode_voting_escrow_deposit(self, context: DecoderContext, amount: FVal, suffix: str) -> DecodingOutput:  # noqa: E501
-        locktime = Timestamp(hex_or_bytes_to_int(context.tx_log.topics[2]))
+        locktime = Timestamp(int.from_bytes(context.tx_log.topics[2]))
         for event in context.decoded_events:
             if event.event_type == HistoryEventType.SPEND and event.event_subtype == HistoryEventSubType.NONE and event.asset == A_CRV and event.balance.amount == amount:  # noqa: E501
                 event.event_type = HistoryEventType.DEPOSIT

--- a/rotkehlchen/chain/ethereum/modules/defisaver/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/defisaver/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_DEFISAVER, DEACTIVATE_SUB, SUB_STORAGE, SUBSCRIBE
 
@@ -24,7 +24,7 @@ log = RotkehlchenLogsAdapter(logger)
 class DefisaverDecoder(DecoderInterface):
 
     def _decode_subscribe(self, context: DecoderContext) -> DecodingOutput:
-        sub_id = hex_or_bytes_to_int(context.tx_log.topics[1])
+        sub_id = int.from_bytes(context.tx_log.topics[1])
         proxy = bytes_to_address(context.tx_log.topics[2])
         event = self.base.make_event_from_transaction(
             transaction=context.transaction,
@@ -41,7 +41,7 @@ class DefisaverDecoder(DecoderInterface):
         return DecodingOutput(event=event)
 
     def _decode_deactivate_sub(self, context: DecoderContext) -> DecodingOutput:
-        sub_id = hex_or_bytes_to_int(context.tx_log.topics[1])
+        sub_id = int.from_bytes(context.tx_log.topics[1])
         event = self.base.make_event_from_transaction(
             transaction=context.transaction,
             tx_log=context.tx_log,

--- a/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
@@ -20,7 +20,7 @@ from rotkehlchen.history.events.structures.eth2 import EthDepositEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, Eth2PubKey
-from rotkehlchen.utils.misc import from_gwei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import from_gwei
 
 from .constants import CPT_ETH2, UNKNOWN_VALIDATOR_INDEX
 
@@ -37,7 +37,7 @@ class Eth2Decoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         public_key = Eth2PubKey(encode_hex(context.tx_log.data[192:240]))
-        amount = from_gwei(hex_or_bytes_to_int(context.tx_log.data[352:360], byteorder='little'))
+        amount = from_gwei(int.from_bytes(context.tx_log.data[352:360], byteorder='little'))
 
         validator_index = UNKNOWN_VALIDATOR_INDEX
         extra_data = None

--- a/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.constants.resolver import ethaddress_to_identifier
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CLAIMED, CPT_FLUENCE, DEV_REWARD_DISTRIBUTOR, FLUENCE_IDENTIFIER
 
@@ -49,7 +49,7 @@ class FluenceDecoder(DecoderInterface):
             context: DecoderContext,
             user_address: ChecksumEvmAddress,
     ) -> DecodingOutput:
-        amount = token_normalized_value_decimals(hex_or_bytes_to_int(context.tx_log.data[32:64]), 18)  # noqa: E501
+        amount = token_normalized_value_decimals(int.from_bytes(context.tx_log.data[32:64]), 18)
 
         for event in context.decoded_events:
             if event.event_type == HistoryEventType.RECEIVE and event.balance.amount == amount and event.location_label == user_address and event.asset.identifier == ethaddress_to_identifier(DEV_REWARD_DISTRIBUTOR):  # noqa: E501
@@ -68,7 +68,7 @@ class FluenceDecoder(DecoderInterface):
             context: DecoderContext,
             user_address: ChecksumEvmAddress,
     ) -> DecodingOutput:
-        amount = token_normalized_value_decimals(hex_or_bytes_to_int(context.tx_log.data[0:32]), 18)  # noqa: E501
+        amount = token_normalized_value_decimals(int.from_bytes(context.tx_log.data[0:32]), 18)
         # need to also create the FLT-DROP burn event
         out_event = self.base.make_event_from_transaction(
             transaction=context.transaction,

--- a/rotkehlchen/chain/ethereum/modules/golem/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/golem/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants.assets import A_GLM
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_GOLEM, GNT_MIGRATION_ADDRESS
 
@@ -38,7 +38,7 @@ class GolemDecoder(DecoderInterface):
         if not self.base.is_tracked(from_address):
             return DEFAULT_DECODING_OUTPUT
 
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        amount_raw = int.from_bytes(context.tx_log.data[64:96])
         amount = token_normalized_value_decimals(amount_raw, 18)
 
         # Create the GNT out event, since no transfer event is emitted

--- a/rotkehlchen/chain/ethereum/modules/hop/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hop/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import BRIDGES, HOP_GOVERNOR
 
@@ -58,7 +58,7 @@ class HopDecoder(HopCommonDecoder, GovernableDecoderInterface):
         if (bridge := self.bridges.get(context.tx_log.address)) is None:
             return DEFAULT_DECODING_OUTPUT
 
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        amount_raw = int.from_bytes(context.tx_log.data[:32])
         amount = self._get_bridge_asset_amount(amount_raw=amount_raw, identifier=bridge.identifier)
 
         for event in context.decoded_events:
@@ -71,7 +71,7 @@ class HopDecoder(HopCommonDecoder, GovernableDecoderInterface):
                     asset=event.asset,
                     recipient=recipient,
                     sender=string_to_evm_address(event.location_label) if event.location_label else None,  # noqa: E501
-                    chain_id=hex_or_bytes_to_int(context.tx_log.topics[1]),
+                    chain_id=int.from_bytes(context.tx_log.topics[1]),
                 )
                 break
 

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_KYBER_LEGACY
 
@@ -68,8 +68,8 @@ class KyberDecoder(KyberCommonDecoder):
             return DEFAULT_DECODING_OUTPUT
 
         sender, source_asset, destination_asset = self._legacy_contracts_basic_info(context.tx_log)
-        spent_amount_raw = hex_or_bytes_to_int(context.tx_log.data[64:96])
-        return_amount_raw = hex_or_bytes_to_int(context.tx_log.data[96:128])
+        spent_amount_raw = int.from_bytes(context.tx_log.data[64:96])
+        return_amount_raw = int.from_bytes(context.tx_log.data[96:128])
         spent_amount = asset_normalized_value(amount=spent_amount_raw, asset=source_asset)
         return_amount = asset_normalized_value(amount=return_amount_raw, asset=destination_asset)
         self._maybe_update_events(
@@ -89,8 +89,8 @@ class KyberDecoder(KyberCommonDecoder):
             return DEFAULT_DECODING_OUTPUT
 
         sender, source_asset, destination_asset = self._legacy_contracts_basic_info(context.tx_log)
-        spent_amount_raw = hex_or_bytes_to_int(context.tx_log.data[96:128])
-        return_amount_raw = hex_or_bytes_to_int(context.tx_log.data[128:160])
+        spent_amount_raw = int.from_bytes(context.tx_log.data[96:128])
+        return_amount_raw = int.from_bytes(context.tx_log.data[128:160])
         spent_amount = asset_normalized_value(amount=spent_amount_raw, asset=source_asset)
         return_amount = asset_normalized_value(amount=return_amount_raw, asset=destination_asset)
         self._maybe_update_events(

--- a/rotkehlchen/chain/ethereum/modules/lido/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lido/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.constants.assets import A_ETH, A_STETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, from_wei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 from .constants import CPT_LIDO, LIDO_STETH_SUBMITTED, STETH_MAX_ROUND_ERROR_WEI
 
@@ -44,7 +44,7 @@ class LidoDecoder(DecoderInterface):
 
     def _decode_lido_staking_in_steth(self, context: DecoderContext, sender: ChecksumEvmAddress) -> DecodingOutput:  # noqa: E501
         """Decode the submit of eth to lido contract for obtaining steth in return"""
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        amount_raw = int.from_bytes(context.tx_log.data[:32])
         collateral_amount = token_normalized_value_decimals(
             token_amount=amount_raw,
             token_decimals=18,

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.history.events.structures.evm_event import LIQUITY_STAKING_DETA
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     ACTIVE_POOL,
@@ -126,12 +126,12 @@ class LiquityDecoder(DecoderInterface):
         collected_eth, collected_lqty = ZERO, ZERO
         if context.tx_log.topics[0] == STABILITY_POOL_GAIN_WITHDRAW:
             collected_eth = asset_normalized_value(
-                amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+                amount=int.from_bytes(context.tx_log.data[0:32]),
                 asset=self.eth,
             )
         elif context.tx_log.topics[0] in {STABILITY_POOL_LQTY_PAID_TO_DEPOSITOR, STABILITY_POOL_LQTY_PAID_TO_FRONTEND}:  # noqa: E501
             collected_lqty = asset_normalized_value(
-                amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+                amount=int.from_bytes(context.tx_log.data[0:32]),
                 asset=self.lqty,
             )
             if collected_lqty == ZERO:
@@ -200,7 +200,7 @@ class LiquityDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         if (fee_amount := asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            amount=int.from_bytes(context.tx_log.data[0:32]),
             asset=self.lusd,
         )) == ZERO:  # for many operations it emits a zero event log
             return DEFAULT_DECODING_OUTPUT
@@ -234,7 +234,7 @@ class LiquityDecoder(DecoderInterface):
         if context.tx_log.topics[0] == STAKING_LQTY_CHANGE:
             user = self.base.get_address_or_proxy_owner(bytes_to_address(context.tx_log.topics[1]))
             lqty_amount = asset_normalized_value(
-                amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+                amount=int.from_bytes(context.tx_log.data[0:32]),
                 asset=self.lqty,
             )
 

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -25,7 +25,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_PETH, A_SAI, A_WETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -86,7 +86,7 @@ class MakerdaosaiDecoder(DecoderInterface):
         An example of such transaction is:
         https://etherscan.io/tx/0x4e569aa1f23dc771f1c9ad05ab7cdb0af2607358b166a8137b702f81b88e37b9
         """
-        cdp_id = hex_or_bytes_to_int(context.tx_log.topics[2])
+        cdp_id = int.from_bytes(context.tx_log.topics[2])
         for event in context.decoded_events:
             if (
                 event.event_type == HistoryEventType.RECEIVE and
@@ -99,7 +99,7 @@ class MakerdaosaiDecoder(DecoderInterface):
                         log.topics[0] == PETH_BURN_EVENT_TOPIC and
                         log.address == POOLED_ETHER_ADDRESS and
                         # checks that the amount to be withdrawn matches the amount of PETH burnt
-                        hex_or_bytes_to_int(context.tx_log.topics[3]) == hex_or_bytes_to_int(log.data[:32])  # noqa: E501
+                        int.from_bytes(context.tx_log.topics[3]) == int.from_bytes(log.data[:32])
                     ):
                         event.event_type = HistoryEventType.WITHDRAWAL
                         event.event_subtype = HistoryEventSubType.REMOVE_ASSET
@@ -129,7 +129,7 @@ class MakerdaosaiDecoder(DecoderInterface):
                 break
 
         cdp_creator = bytes_to_address(context.tx_log.topics[1])
-        cdp_id = hex_or_bytes_to_int(context.tx_log.data[:32])
+        cdp_id = int.from_bytes(context.tx_log.data[:32])
         event = self.base.make_event_from_transaction(
             transaction=context.transaction,
             tx_log=context.tx_log,
@@ -154,7 +154,7 @@ class MakerdaosaiDecoder(DecoderInterface):
         https://etherscan.io/tx/0xc851e18df6dec02ac2efff000298001e839dde3d6e99d25d1d98ecb0d390c9a6
         """
         cdp_creator = bytes_to_address(context.tx_log.topics[1])
-        cdp_id = hex_or_bytes_to_int(context.tx_log.data[128:])
+        cdp_id = int.from_bytes(context.tx_log.data[128:])
 
         for event in context.decoded_events:
             if (
@@ -189,9 +189,9 @@ class MakerdaosaiDecoder(DecoderInterface):
         An example of such transaction is:
         https://etherscan.io/tx/0x4aed2d2fe5712a5b65cb6866c51ae672a53e39fa25f343e4c6ebaa8eae21de80
         """
-        cdp_id = hex_or_bytes_to_int(context.tx_log.topics[2])
+        cdp_id = int.from_bytes(context.tx_log.topics[2])
         withdrawer = bytes_to_address(context.tx_log.topics[1])
-        amount_withdrawn_raw = hex_or_bytes_to_int(context.tx_log.topics[3])
+        amount_withdrawn_raw = int.from_bytes(context.tx_log.topics[3])
         amount_withdrawn = asset_normalized_value(amount=amount_withdrawn_raw, asset=self.sai)
 
         for decoded_event in context.decoded_events:
@@ -244,9 +244,9 @@ class MakerdaosaiDecoder(DecoderInterface):
         An example of such transaction is:
         https://etherscan.io/tx/0xe964cb12f4bbfa1ba4b6db8464eb3f2d4234ceafb0b5ec5f4a2188b0264bab27
         """
-        cdp_id = hex_or_bytes_to_int(context.tx_log.topics[2])
+        cdp_id = int.from_bytes(context.tx_log.topics[2])
         depositor = bytes_to_address(context.tx_log.topics[1])
-        amount_paid_raw = hex_or_bytes_to_int(context.tx_log.topics[3])
+        amount_paid_raw = int.from_bytes(context.tx_log.topics[3])
         amount_paid = asset_normalized_value(amount=amount_paid_raw, asset=self.sai)
 
         for event in context.decoded_events:
@@ -296,7 +296,7 @@ class MakerdaosaiDecoder(DecoderInterface):
         https://etherscan.io/tx/0x65d53653c584cde22e559cec4667a7278f75966360590b725d87055fb17552ba
         """
         liquidator = bytes_to_address(context.tx_log.topics[1])
-        cdp_id = hex_or_bytes_to_int(context.tx_log.topics[2])
+        cdp_id = int.from_bytes(context.tx_log.topics[2])
 
         for event in context.decoded_events:
             if (
@@ -316,7 +316,7 @@ class MakerdaosaiDecoder(DecoderInterface):
                 bytes_to_address(log.topics[1]) == MAKERDAO_SAITUB_CONTRACT and
                 bytes_to_address(log.topics[2]) == MAKERDAO_SAITAP_CONTRACT
             ):
-                amount_raw = hex_or_bytes_to_int(log.data[:32])
+                amount_raw = int.from_bytes(log.data[:32])
                 amount = asset_normalized_value(amount=amount_raw, asset=self.weth)
 
                 event = self.base.make_event_from_transaction(
@@ -369,7 +369,7 @@ class MakerdaosaiDecoder(DecoderInterface):
                         log.topics[0] == PETH_MINT_EVENT_TOPIC and
                         log.address == POOLED_ETHER_ADDRESS and
                         # checks that the amount to be deposited matches the amount of PETH minted
-                        hex_or_bytes_to_int(log.data[:32]) == hex_or_bytes_to_int(context.tx_log.topics[2])  # noqa: E501
+                        int.from_bytes(log.data[:32]) == int.from_bytes(context.tx_log.topics[2])
                     ):
                         event.event_type = HistoryEventType.DEPOSIT
                         event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
@@ -433,7 +433,7 @@ class MakerdaosaiDecoder(DecoderInterface):
         """
         if context.tx_log.topics[0] == PETH_MINT_EVENT_TOPIC:
             owner = bytes_to_address(context.tx_log.topics[1])
-            amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+            amount_raw = int.from_bytes(context.tx_log.data[:32])
             amount = asset_normalized_value(amount=amount_raw, asset=self.peth)
 
             event = self.base.make_event_from_transaction(
@@ -465,8 +465,8 @@ class MakerdaosaiDecoder(DecoderInterface):
         if tx_log.topics[0] != SAI_CDP_MIGRATION_TOPIC:
             return DEFAULT_DECODING_OUTPUT
 
-        old_cdp_id = hex_or_bytes_to_int(tx_log.topics[1])
-        new_cdp_id = hex_or_bytes_to_int(tx_log.topics[2])
+        old_cdp_id = int.from_bytes(tx_log.topics[1])
+        new_cdp_id = int.from_bytes(tx_log.topics[2])
         owner = bytes_to_address(tx_log.data[:32])
 
         event = self.base.make_event_from_transaction(

--- a/rotkehlchen/chain/ethereum/modules/octant/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants.assets import A_ETH, A_GLM
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_OCTANT, LOCKED, OCTANT_DEPOSITS, OCTANT_REWARDS, UNLOCKED, WITHDRAWN
 
@@ -61,7 +61,7 @@ class OctantDecoder(DecoderInterface):
         else:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        raw_amount = int.from_bytes(context.tx_log.data[32:64])
         address = bytes_to_address(context.tx_log.data[96:128])
         if self.base.is_tracked(address) is False:
             return DEFAULT_DECODING_OUTPUT
@@ -94,8 +94,8 @@ class OctantDecoder(DecoderInterface):
         if not self.base.is_tracked(user):
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
-        epoch = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        raw_amount = int.from_bytes(context.tx_log.data[32:64])
+        epoch = int.from_bytes(context.tx_log.data[64:96])
         amount = token_normalized_value_decimals(raw_amount, 18)  # always ETH
         for event in context.decoded_events:
             if (

--- a/rotkehlchen/chain/ethereum/modules/omni/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/omni/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_OMNI, OMNI_AIDROP_CONTRACT, OMNI_STAKING_CONTRACT, OMNI_TOKEN_ID
 
@@ -101,7 +101,7 @@ class OmniDecoder(CliqueAirdropDecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         staked_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=18,  # omni has 18 decimals
         )
         transfer_found = False

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from ..constants import CPT_ONEINCH_V1
 
@@ -35,9 +35,9 @@ class Oneinchv1Decoder(DecoderInterface):
         from_asset = self.base.get_or_create_evm_asset(from_token_address)
         to_asset = self.base.get_or_create_evm_asset(to_token_address)
 
-        from_raw = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        from_raw = int.from_bytes(context.tx_log.data[64:96])
         from_amount = asset_normalized_value(from_raw, from_asset)
-        to_raw = hex_or_bytes_to_int(context.tx_log.data[96:128])
+        to_raw = int.from_bytes(context.tx_log.data[96:128])
         to_amount = asset_normalized_value(to_raw, to_asset)
 
         out_event = in_event = None
@@ -78,8 +78,8 @@ class Oneinchv1Decoder(DecoderInterface):
         """We use the Swapped event to get the fee kept by 1inch"""
         to_token_address = bytes_to_address(context.tx_log.topics[2])
         to_asset = self.base.get_or_create_evm_asset(to_token_address)
-        to_raw = hex_or_bytes_to_int(context.tx_log.data[32:64])
-        fee_raw = hex_or_bytes_to_int(context.tx_log.data[96:128])
+        to_raw = int.from_bytes(context.tx_log.data[32:64])
+        fee_raw = int.from_bytes(context.tx_log.data[96:128])
         if fee_raw == 0:
             return DEFAULT_DECODING_OUTPUT  # no need to do anything for zero fee taken
 

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from rotkehlchen.chain.evm.decoding.oneinch.decoder import OneinchCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -38,8 +38,8 @@ class Oneinchv2Decoder(OneinchCommonDecoder):
             receiver=bytes_to_address(context.tx_log.data[0:32]),
             source_token_address=bytes_to_address(context.tx_log.topics[2]),
             destination_token_address=bytes_to_address(context.tx_log.topics[3]),
-            spent_amount_raw=hex_or_bytes_to_int(context.tx_log.data[64:96]),
-            return_amount_raw=hex_or_bytes_to_int(context.tx_log.data[96:128]),
+            spent_amount_raw=int.from_bytes(context.tx_log.data[64:96]),
+            return_amount_raw=int.from_bytes(context.tx_log.data[96:128]),
         )
 
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/ethereum/modules/optimism_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/optimism_bridge/decoder.py
@@ -18,10 +18,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind
-from rotkehlchen.utils.misc import (
-    bytes_to_address,
-    hex_or_bytes_to_int,
-)
+from rotkehlchen.utils.misc import bytes_to_address
 
 BRIDGE_ADDRESSES: Final = (
     string_to_evm_address('0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1'),  # Normal Bridge
@@ -54,7 +51,7 @@ class OptimismBridgeDecoder(DecoderInterface):
         # Read information from event's topics & data
         if context.tx_log.topics[0] in {ETH_DEPOSIT_INITIATED, ETH_WITHDRAWAL_FINALIZED}:
             asset = A_ETH.resolve_to_crypto_asset()
-            raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+            raw_amount = int.from_bytes(context.tx_log.data[:32])
             amount = asset_normalized_value(raw_amount, asset)
             from_address = bytes_to_address(context.tx_log.topics[1])
             to_address = bytes_to_address(context.tx_log.topics[2])
@@ -65,7 +62,7 @@ class OptimismBridgeDecoder(DecoderInterface):
                 chain_id=ChainID.ETHEREUM,
                 token_type=EvmTokenKind.ERC20,
             ))
-            raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+            raw_amount = int.from_bytes(context.tx_log.data[32:64])
             amount = asset_normalized_value(raw_amount, asset)
             from_address = bytes_to_address(context.tx_log.topics[3])
             to_address = bytes_to_address(context.tx_log.data[:32])

--- a/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, Timestamp
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int, timestamp_to_date
+from rotkehlchen.utils.misc import bytes_to_address, timestamp_to_date
 
 from .constants import CLAIMED, CPT_PALADIN, PALADIN_MERKLE_DISTRIBUTOR_V2
 
@@ -31,9 +31,9 @@ class PaladinDecoder(DecoderInterface):
         if not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[3])):
             return DEFAULT_DECODING_OUTPUT
 
-        amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        amount = int.from_bytes(context.tx_log.data[32:64])
         reward_token_address = bytes_to_address(context.tx_log.data[64:96])
-        period = Timestamp(hex_or_bytes_to_int(context.tx_log.topics[2]))
+        period = Timestamp(int.from_bytes(context.tx_log.topics[2]))
         claimed_token = get_or_create_evm_token(
             userdb=self.base.database,
             evm_address=reward_token_address,

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import PICKLE_JAR_PROTOCOL, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CORN_TOKEN_ID, CORNICHON_CLAIM, CPT_PICKLE
 
@@ -76,7 +76,7 @@ class PickleFinanceDecoder(MerkleClaimDecoderInterface):
         ):
             if EvmToken(ethaddress_to_identifier(context.tx_log.address)) != context.event.asset:
                 return FAILED_ENRICHMENT_OUTPUT
-            amount_raw = hex_or_bytes_to_int(context.tx_log.data)
+            amount_raw = int.from_bytes(context.tx_log.data)
             amount = asset_normalized_value(
                 amount=amount_raw,
                 asset=context.event.asset.resolve_to_crypto_asset(),
@@ -92,7 +92,7 @@ class PickleFinanceDecoder(MerkleClaimDecoderInterface):
             context.event.event_subtype == HistoryEventSubType.NONE and
             context.tx_log.address in self.pickle_contracts
         ):
-            amount_raw = hex_or_bytes_to_int(context.tx_log.data)
+            amount_raw = int.from_bytes(context.tx_log.data)
             amount = asset_normalized_value(
                 amount=amount_raw,
                 asset=context.event.asset.resolve_to_crypto_asset(),
@@ -113,7 +113,7 @@ class PickleFinanceDecoder(MerkleClaimDecoderInterface):
         ):
             if context.event.asset != EvmToken(ethaddress_to_identifier(context.tx_log.address)):
                 return FAILED_ENRICHMENT_OUTPUT
-            amount_raw = hex_or_bytes_to_int(context.tx_log.data)
+            amount_raw = int.from_bytes(context.tx_log.data)
             amount = asset_normalized_value(
                 amount=amount_raw,
                 asset=context.event.asset.resolve_to_crypto_asset(),
@@ -134,7 +134,7 @@ class PickleFinanceDecoder(MerkleClaimDecoderInterface):
         ):
             if context.event.asset != EvmToken(ethaddress_to_identifier(context.tx_log.address)):
                 return FAILED_ENRICHMENT_OUTPUT
-            amount_raw = hex_or_bytes_to_int(context.tx_log.data)
+            amount_raw = int.from_bytes(context.tx_log.data)
             amount = asset_normalized_value(
                 amount=amount_raw,
                 asset=context.event.asset.resolve_to_crypto_asset(),

--- a/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.constants.assets import A_ETH_MATIC
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import POLYGON_MIGRATION_ADDRESS
 
@@ -44,7 +44,7 @@ class PolygonDecoder(DecoderInterface):
         if not self.base.is_tracked(account):
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        raw_amount = int.from_bytes(context.tx_log.data[:32])
         amount = token_normalized_value_decimals(raw_amount, 18)
 
         action_items = [ActionItem(

--- a/rotkehlchen/chain/ethereum/modules/safe/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     CLAIMED_VESTING,
@@ -83,7 +83,7 @@ class SafeDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         for event in context.decoded_events:
@@ -111,7 +111,7 @@ class SafeDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         event = self.base.make_event_from_transaction(
@@ -133,7 +133,7 @@ class SafeDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         action_item = ActionItem(

--- a/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
@@ -26,7 +26,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, from_wei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -103,7 +103,7 @@ class ScrollBridgeDecoder(DecoderInterface):
 
         sender = bytes_to_address(context.tx_log.topics[1])
         target = bytes_to_address(context.tx_log.topics[2])
-        value = hex_or_bytes_to_int(context.tx_log.data[:32])
+        value = int.from_bytes(context.tx_log.data[:32])
         amount = from_wei(FVal(value))
 
         if not self.base.any_tracked([sender, target]):
@@ -131,7 +131,7 @@ class ScrollBridgeDecoder(DecoderInterface):
 
         ethereum_token_address = bytes_to_address(tx_log.topics[1])
         asset = self.base.get_or_create_evm_token(ethereum_token_address)
-        raw_amount = hex_or_bytes_to_int(tx_log.data[32:64])
+        raw_amount = int.from_bytes(tx_log.data[32:64])
         amount = asset_normalized_value(raw_amount, asset)
         expected_event_type, new_event_type, from_chain, to_chain, _ = bridge_prepare_data(
             tx_log=tx_log,

--- a/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_SHUTTER, REDEEMED_VESTING, SHUTTER_AIDROP_CONTRACT
 
@@ -68,7 +68,7 @@ class ShutterDecoder(DecoderInterface):
                 bytes_to_address(tx_log.topics[1]) == SHUTTER_AIDROP_CONTRACT and
                 bytes_to_address(tx_log.topics[2]) == vesting_contract_address
             ):
-                amount = token_normalized_value(token_amount=hex_or_bytes_to_int(tx_log.data), token=self.shu)  # noqa: E501
+                amount = token_normalized_value(token_amount=int.from_bytes(tx_log.data), token=self.shu)  # noqa: E501
                 break
         else:
             log.error(f'Could not find the SHU transfer in {context.transaction.tx_hash.hex()}')

--- a/rotkehlchen/chain/ethereum/modules/sky/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sky/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     CPT_SKY,
@@ -45,7 +45,7 @@ class SkyDecoder(DecoderInterface):
         if context.tx_log.topics[0] != DAI_TO_USDS:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        raw_amount = int.from_bytes(context.tx_log.data[0:32])
         amount = token_normalized_value_decimals(
             token_amount=raw_amount,
             token_decimals=DEFAULT_TOKEN_DECIMALS,
@@ -78,11 +78,11 @@ class SkyDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         mkr_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         sky_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            token_amount=int.from_bytes(context.tx_log.data[32:64]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         user = bytes_to_address(context.tx_log.topics[2])
@@ -126,13 +126,13 @@ class SkyDecoder(DecoderInterface):
 
         received_address = bytes_to_address(context.tx_log.topics[2])
         if (assets_amount := token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )) == ZERO:
             return DEFAULT_DECODING_OUTPUT
 
         shares_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            token_amount=int.from_bytes(context.tx_log.data[32:64]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
 

--- a/rotkehlchen/chain/ethereum/modules/stakedao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/stakedao/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, Timestamp
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int, timestamp_to_date
+from rotkehlchen.utils.misc import bytes_to_address, timestamp_to_date
 
 from .constants import (
     CLAIMED_WITH_BOUNTY,
@@ -65,8 +65,8 @@ class StakedaoDecoder(DecoderInterface):
         # we are not checking user address in the logs as user is not always
         # the recipient according to the contract
         reward_token_address = bytes_to_address(context.tx_log.data[0:32])
-        amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
-        period = Timestamp(hex_or_bytes_to_int(context.tx_log.data[96:128]))
+        amount = int.from_bytes(context.tx_log.data[32:64])
+        period = Timestamp(int.from_bytes(context.tx_log.data[96:128]))
         return self._decode_claim(context=context, reward_token_address=reward_token_address, amount=amount, period=period)  # noqa: E501
 
     def _decode_claim_with_bribe(self, context: DecoderContext) -> DecodingOutput:
@@ -76,8 +76,8 @@ class StakedaoDecoder(DecoderInterface):
         # we are not checking user address in the logs as user is not always
         # the recipient according to the contract
         reward_token_address = bytes_to_address(context.tx_log.topics[2])
-        amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
-        period = Timestamp(hex_or_bytes_to_int(context.tx_log.data[32:64]))
+        amount = int.from_bytes(context.tx_log.data[0:32])
+        period = Timestamp(int.from_bytes(context.tx_log.data[32:64]))
         return self._decode_claim(context=context, reward_token_address=reward_token_address, amount=amount, period=period)  # noqa: E501
 
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
@@ -20,7 +20,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     APPROVE_PROTOCOL,
@@ -65,7 +65,7 @@ class ThegraphDecoder(ThegraphCommonDecoder):
         indexer = bytes_to_address(context.tx_log.topics[3])
         indexer_l2 = bytes_to_address(context.tx_log.data[:32])
         transferred_delegation_tokens = token_normalized_value(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[32:]),
+            token_amount=int.from_bytes(context.tx_log.data[32:]),
             token=self.token,
         )
         event = self.base.make_event_from_transaction(
@@ -112,7 +112,7 @@ class ThegraphDecoder(ThegraphCommonDecoder):
             return DEFAULT_DECODING_OUTPUT
 
         indexer = bytes_to_address(context.tx_log.topics[1])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data)
+        raw_amount = int.from_bytes(context.tx_log.data)
         amount = token_normalized_value_decimals(raw_amount, DEFAULT_TOKEN_DECIMALS)
         for event in context.decoded_events:
             if (

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/common.py
@@ -42,7 +42,7 @@ from rotkehlchen.types import (
     EvmTransaction,
     EVMTxHash,
 )
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -101,8 +101,8 @@ def decode_uniswap_v2_like_swap(
 
     # amount_in is the amount that enters the pool and amount_out the one
     # that leaves the pool
-    amount_in_0, amount_in_1 = hex_or_bytes_to_int(tx_log.data[0:32]), hex_or_bytes_to_int(tx_log.data[32:64])  # noqa: E501
-    amount_out_0, amount_out_1 = hex_or_bytes_to_int(tx_log.data[64:96]), hex_or_bytes_to_int(tx_log.data[96:128])  # noqa: E501
+    amount_in_0, amount_in_1 = int.from_bytes(tx_log.data[0:32]), int.from_bytes(tx_log.data[32:64])  # noqa: E501
+    amount_out_0, amount_out_1 = int.from_bytes(tx_log.data[64:96]), int.from_bytes(tx_log.data[96:128])  # noqa: E501
     amount_in, amount_out = amount_in_0, amount_out_0
     if amount_in == ZERO:
         amount_in = amount_in_1
@@ -202,8 +202,8 @@ def decode_uniswap_like_deposit_and_withdrawals(
     """  # noqa: E501
     resolved_eth = A_ETH.resolve_to_crypto_asset()
     target_pool_address = tx_log.address
-    amount0_raw = hex_or_bytes_to_int(tx_log.data[:32])
-    amount1_raw = hex_or_bytes_to_int(tx_log.data[32:64])
+    amount0_raw = int.from_bytes(tx_log.data[:32])
+    amount1_raw = int.from_bytes(tx_log.data[32:64])
 
     token0: EvmToken | None = None
     token1: EvmToken | None = None
@@ -221,7 +221,7 @@ def decode_uniswap_like_deposit_and_withdrawals(
     # First, get the tokens deposited into the pool. The reason for this approach is
     # to circumvent scenarios where the mint/burn event comes before the needed transfer events.
     for other_log in all_logs:
-        if other_log.topics[0] == ERC20_OR_ERC721_TRANSFER and hex_or_bytes_to_int(other_log.data[:32]) == amount0_raw:  # noqa: E501
+        if other_log.topics[0] == ERC20_OR_ERC721_TRANSFER and int.from_bytes(other_log.data[:32]) == amount0_raw:  # noqa: E501
             token0 = get_or_create_evm_token(
                 userdb=database,
                 evm_address=other_log.address,
@@ -233,7 +233,7 @@ def decode_uniswap_like_deposit_and_withdrawals(
             # we make a distinction between token and asset since for eth uniswap moves around
             # WETH but we could receive ETH
             asset_0 = resolved_eth if token0 == A_WETH else token0
-        elif other_log.topics[0] == ERC20_OR_ERC721_TRANSFER and hex_or_bytes_to_int(other_log.data[:32]) == amount1_raw:  # noqa: E501
+        elif other_log.topics[0] == ERC20_OR_ERC721_TRANSFER and int.from_bytes(other_log.data[:32]) == amount1_raw:  # noqa: E501
             token1 = get_or_create_evm_token(
                 userdb=database,
                 evm_address=other_log.address,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -21,7 +21,6 @@ from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.types import EvmTransaction
-from rotkehlchen.utils.misc import hex_or_bytes_to_int
 
 if TYPE_CHECKING:
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -49,8 +48,8 @@ class Uniswapv2Decoder(DecoderInterface):
         """
         # amount_in is the amount that enters the pool and amount_out the one
         # that leaves the pool
-        amount_in_token_0, amount_in_token_1 = hex_or_bytes_to_int(tx_log.data[0:32]), hex_or_bytes_to_int(tx_log.data[32:64])  # noqa: E501
-        amount_out_token_0, amount_out_token_1 = hex_or_bytes_to_int(tx_log.data[64:96]), hex_or_bytes_to_int(tx_log.data[96:128])  # noqa: E501
+        amount_in_token_0, amount_in_token_1 = int.from_bytes(tx_log.data[0:32]), int.from_bytes(tx_log.data[32:64])  # noqa: E501
+        amount_out_token_0, amount_out_token_1 = int.from_bytes(tx_log.data[64:96]), int.from_bytes(tx_log.data[96:128])  # noqa: E501
         amount_in, amount_out = amount_in_token_0, amount_out_token_0
         if amount_in == ZERO:
             amount_in = amount_in_token_1

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CLAIMED, CPT_VOTIUM, VOTIUM_CONTRACTS
 
@@ -31,7 +31,7 @@ class VotiumDecoder(DecoderInterface):
         claimed_token_address = bytes_to_address(context.tx_log.topics[1])
         claimed_token = self.base.get_or_create_evm_token(claimed_token_address)
         receiver = bytes_to_address(context.tx_log.topics[2])
-        claimed_amount_raw = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        claimed_amount_raw = int.from_bytes(context.tx_log.data[32:64])
         amount = asset_normalized_value(amount=claimed_amount_raw, asset=claimed_token)
 
         for event in context.decoded_events:

--- a/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
@@ -15,7 +15,6 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.constants.assets import A_CRVP_DAIUSDCTTUSD, A_YFI
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.utils.misc import hex_or_bytes_to_int
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -45,7 +44,7 @@ class YearnygovDecoder(DecoderInterface):
     def _decode_withdrawal(self, context: 'DecoderContext') -> None:
         """Handle withdraw from the governance contract"""
         withdrawn_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=18,
         )
 
@@ -65,7 +64,7 @@ class YearnygovDecoder(DecoderInterface):
     def _decode_reward_token(self, context: 'DecoderContext') -> None:
         """Handle rewards claim"""
         withdrawn_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=18,
         )
 
@@ -84,7 +83,7 @@ class YearnygovDecoder(DecoderInterface):
     def _decode_stake(self, context: 'DecoderContext') -> None:
         """Decode depositing the crv pool token in the gov contract"""
         staked_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=18,
         )
 

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_ZKSYNC, ZKSYNC_BRIDGE
 
@@ -29,7 +29,7 @@ class ZksyncDecoder(DecoderInterface):
         elif context.tx_log.topics[0] == DEPOSIT:
             for tx_log in context.all_logs:  # iterate
                 if tx_log.topics[0] == NEW_PRIORITY_REQUEST:
-                    op_type = hex_or_bytes_to_int(tx_log.data[64:96])
+                    op_type = int.from_bytes(tx_log.data[64:96])
                     if op_type != 1:
                         continue  # 1 is deposit and this is what we are searching for
                     user_address = bytes_to_address(tx_log.data[0:32])
@@ -48,7 +48,7 @@ class ZksyncDecoder(DecoderInterface):
         https://github.com/rotki/rotki/pull/3985/files
         to get the ids of tokens and then match them to what is deposited.
         """
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data)
+        amount_raw = int.from_bytes(context.tx_log.data)
 
         for event in context.decoded_events:
             if event.event_type == HistoryEventType.SPEND and event.location_label == user_address:

--- a/rotkehlchen/chain/evm/decoding/aave/common.py
+++ b/rotkehlchen/chain/evm/decoding/aave/common.py
@@ -31,10 +31,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, EvmTransaction
-from rotkehlchen.utils.misc import (
-    bytes_to_address,
-    hex_or_bytes_to_int,
-)
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -141,7 +138,7 @@ class Commonv2v3Decoder(DecoderInterface):
             return None, None
 
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(tx_log.data[32:64]),
+            amount=int.from_bytes(tx_log.data[32:64]),
             asset=token,
         )
         deposit_event, receive_event = None, None
@@ -197,7 +194,7 @@ class Commonv2v3Decoder(DecoderInterface):
         ):
             return None, None
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(tx_log.data),
+            amount=int.from_bytes(tx_log.data),
             asset=token,
         )
         symbol = self.evm_inquirer.native_token.symbol if is_wnative_user else token.symbol
@@ -252,13 +249,13 @@ class Commonv2v3Decoder(DecoderInterface):
             return None, None
 
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(tx_log.data[32:64]),
+            amount=int.from_bytes(tx_log.data[32:64]),
             asset=token,
         )
-        rate_mode = hex_or_bytes_to_int(tx_log.data[64:96])
+        rate_mode = int.from_bytes(tx_log.data[64:96])
         # Aave uses ray math https://docs.aave.com/developers/v/1.0/developing-on-aave/important-considerations#ray-math  # noqa: E501
         # To get the rate we have to divide the value by 1e27. And then multiply by 100 to get the percentage.  # noqa: E501
-        rate = hex_or_bytes_to_int(tx_log.data[96:128]) / FVal(RAY) * 100
+        rate = int.from_bytes(tx_log.data[96:128]) / FVal(RAY) * 100
         notes = f'Borrow {amount} {token.symbol} from {self.label} with {"stable" if rate_mode == 1 else "variable"} APY {rate.num:.2f}%'  # noqa: E501
         if on_behalf_of != user:
             notes += f' on behalf of {on_behalf_of}'
@@ -361,7 +358,7 @@ class Commonv2v3Decoder(DecoderInterface):
                 mint = (
                     bytes_to_address(tx_log.topics[2]),  # onBehalfOf
                     asset_normalized_value(  # amount minted
-                        amount=hex_or_bytes_to_int(tx_log.data[0:32]),
+                        amount=int.from_bytes(tx_log.data[0:32]),
                         asset=token,
                     ),
                     token,
@@ -453,7 +450,7 @@ class Commonv2v3Decoder(DecoderInterface):
 
         reward_token = self.base.get_or_create_evm_token(address=reward_token_address)
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(amount_raw),
+            amount=int.from_bytes(amount_raw),
             asset=reward_token,
         )
 

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.aave.common import Commonv2v3Decoder
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT, DecodingOutput
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from ..constants import CPT_AAVE_V2
 from .constants import BORROW, DEPOSIT, REPAY
@@ -60,7 +60,7 @@ class Aavev2CommonDecoder(Commonv2v3Decoder):
 
             asset = event.asset.resolve_to_evm_token()
             if asset_normalized_value(
-                amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),  # liquidated amount
+                amount=int.from_bytes(context.tx_log.data[32:64]),  # liquidated amount
                 asset=asset,
             ) == event.balance.amount and asset.protocol == CPT_AAVE_V2:
                 # we are transfering the aTOKEN
@@ -70,7 +70,7 @@ class Aavev2CommonDecoder(Commonv2v3Decoder):
                 event.counterparty = CPT_AAVE_V2
                 event.address = context.tx_log.address
             elif asset_normalized_value(
-                amount=hex_or_bytes_to_int(context.tx_log.data[:32]),  # debt amount
+                amount=int.from_bytes(context.tx_log.data[:32]),  # debt amount
                 asset=asset,
             ) == event.balance.amount:
                 # we are transfering the debt token

--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from ..constants import CPT_AAVE_V3, MINT
 from .constants import BORROW, BURN, DEPOSIT, REPAY, REWARDS_CLAIMED
@@ -71,7 +71,7 @@ class Aavev3CommonDecoder(Commonv2v3Decoder):
 
         amounts = [  # payback amount and liquidation amount
             asset_normalized_value(
-                amount=hex_or_bytes_to_int(log.data[:32]),
+                amount=int.from_bytes(log.data[:32]),
                 asset=EvmToken(evm_address_to_identifier(
                     address=log.address,
                     token_type=EvmTokenKind.ERC20,
@@ -193,7 +193,7 @@ class Aavev3CommonDecoder(Commonv2v3Decoder):
                     bytes_to_address(_log.topics[2]) == token_event.location_label
                 ) and (
                     balance_increase := asset_normalized_value(
-                        amount=hex_or_bytes_to_int(_log.data[32:64]),
+                        amount=int.from_bytes(_log.data[32:64]),
                         asset=token,
                     )
                 ) > 0
@@ -203,7 +203,7 @@ class Aavev3CommonDecoder(Commonv2v3Decoder):
                     # when we get some interest less than the total token to be returned, the net
                     # burned token is slightly less. So save its corrected amount and assign it later  # noqa: E501
                     corrected_amount = asset_normalized_value(
-                        amount=hex_or_bytes_to_int(_log.data[:32]),
+                        amount=int.from_bytes(_log.data[:32]),
                         asset=token,
                     )
                     earned_token_address = token.evm_address

--- a/rotkehlchen/chain/evm/decoding/base.py
+++ b/rotkehlchen/chain/evm/decoding/base.py
@@ -27,7 +27,7 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_norma
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import EvmTokenKind, EvmTransaction, EVMTxHash, Location
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int, ts_sec_to_ms
+from rotkehlchen.utils.misc import bytes_to_address, ts_sec_to_ms
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -169,7 +169,7 @@ class BaseDecoderTools:
         extra_data = None
         event_type, event_subtype, location_label, address, counterparty, verb = direction_result
         counterparty_or_address = counterparty or address
-        amount_raw_or_token_id = hex_or_bytes_to_int(tx_log.data)
+        amount_raw_or_token_id = int.from_bytes(tx_log.data)
         if token.token_kind == EvmTokenKind.ERC20:
             amount = token_normalized_value(token_amount=amount_raw_or_token_id, token=token)
             if event_type in OUTGOING_EVENT_TYPES:
@@ -179,9 +179,9 @@ class BaseDecoderTools:
         elif token.token_kind == EvmTokenKind.ERC721:
             try:
                 if self.is_non_conformant_erc721(token.evm_address):  # id is in the data
-                    token_id = hex_or_bytes_to_int(tx_log.data[0:32])
+                    token_id = int.from_bytes(tx_log.data[0:32])
                 else:
-                    token_id = hex_or_bytes_to_int(tx_log.topics[3])
+                    token_id = int.from_bytes(tx_log.topics[3])
             except IndexError as e:
                 log.debug(
                     f'At decoding of token {token.evm_address} as ERC721 got '

--- a/rotkehlchen/chain/evm/decoding/cctp/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cctp/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -55,9 +55,9 @@ class CctpCommonDecoder(DecoderInterface):
         if not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[3])):
             return DEFAULT_DECODING_OUTPUT
 
-        to_chain = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        to_chain = int.from_bytes(context.tx_log.data[64:96])
         deposit_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=USDC_DECIMALS,
         )
         for event in context.decoded_events:
@@ -88,7 +88,7 @@ class CctpCommonDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         deposit_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=USDC_DECIMALS,
         )
         for event in context.decoded_events:
@@ -120,7 +120,7 @@ class CctpCommonDecoder(DecoderInterface):
                 event.event_subtype == HistoryEventSubType.BRIDGE and
                 event.counterparty == CPT_CCTP
             ):
-                from_chain = hex_or_bytes_to_int(context.tx_log.data[:32])
+                from_chain = int.from_bytes(context.tx_log.data[:32])
                 try:
                     chain_info = f' from {CCTP_DOMAIN_MAPPING[from_chain].label()} to {self.evm_inquirer.chain_id.label()}'  # noqa: E501
                     event.notes = f'Bridge {event.balance.amount} USDC{chain_info} via CCTP'

--- a/rotkehlchen/chain/evm/decoding/clique/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clique/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DecoderContext
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 
 class CliqueAirdropDecoderInterface(DecoderInterface, ABC):
@@ -21,7 +21,7 @@ class CliqueAirdropDecoderInterface(DecoderInterface, ABC):
             return None
 
         claimed_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=18,  # both omni and eigen have 18 decimals
         )
         return claiming_address, claimed_amount

--- a/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
@@ -24,7 +24,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -102,7 +102,7 @@ class ClrfundCommonDecoder(CommonGrantsDecoderMixin):
             return DEFAULT_DECODING_OUTPUT
 
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data),
+            amount=int.from_bytes(context.tx_log.data),
             asset=asset,
         )
         for event in context.decoded_events:

--- a/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind, EvmTransaction
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     COMPOUND_V3_SUPPLY,
@@ -98,7 +98,7 @@ class Compoundv3CommonDecoder(DecoderInterface):
             token_kind=EvmTokenKind.ERC20,
             evm_inquirer=self.base.evm_inquirer,
         )
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data)
+        amount_raw = int.from_bytes(context.tx_log.data)
         amount = asset_normalized_value(amount_raw, reward_token)
 
         for event in context.decoded_events:
@@ -155,7 +155,7 @@ class Compoundv3CommonDecoder(DecoderInterface):
                 break
 
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data),
+            amount=int.from_bytes(context.tx_log.data),
             asset=underlying_token,
         )
         paired_event, action_from_event_type, action_to_event_subtype, action_to_notes = None, None, None, None  # noqa: E501
@@ -283,7 +283,7 @@ class Compoundv3CommonDecoder(DecoderInterface):
             token_type=EvmTokenKind.ERC20,
         ))
         collateral_amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data),
+            amount=int.from_bytes(context.tx_log.data),
             asset=collateral_asset,
         )
 

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -58,7 +58,7 @@ from rotkehlchen.types import (
     EVMTxHash,
     Location,
 )
-from rotkehlchen.utils.misc import bytes_to_address, from_wei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 from .base import BaseDecoderTools, BaseDecoderToolsWithDSProxy
@@ -959,11 +959,11 @@ class EVMTransactionDecoder(ABC):
         if len(tx_log.topics) == 3:
             owner_address = bytes_to_address(tx_log.topics[1])
             spender_address = bytes_to_address(tx_log.topics[2])
-            amount_raw = hex_or_bytes_to_int(tx_log.data)
+            amount_raw = int.from_bytes(tx_log.data)
         elif len(tx_log.topics) == 1 and len(tx_log.data) == 96:  # malformed erc20 approve (finance.vote)  # noqa: E501
             owner_address = bytes_to_address(tx_log.data[:32])
             spender_address = bytes_to_address(tx_log.data[32:64])
-            amount_raw = hex_or_bytes_to_int(tx_log.data[64:])
+            amount_raw = int.from_bytes(tx_log.data[64:])
         else:
             log.debug(
                 f'Got an ERC20 approve event with unknown structure '

--- a/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
@@ -24,7 +24,7 @@ from rotkehlchen.constants.assets import A_DAI, A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 if TYPE_CHECKING:
@@ -59,7 +59,7 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
             return DEFAULT_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # always DAI
         )
         event = self.base.make_event_from_transaction(
@@ -81,11 +81,11 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
             return DEFAULT_DECODING_OUTPUT
 
         collected_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # always DAI
         )
         split_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            token_amount=int.from_bytes(context.tx_log.data[32:64]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # always DAI
         )
         notes = f'Collect {collected_amount} DAI from Drips v1'
@@ -143,7 +143,7 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
 
         receiver = bytes_to_address(context.tx_log.topics[2])  # receiver does not receive in this transaction  # noqa: E501
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # always DAI
         )
         action_item = ActionItem(
@@ -167,10 +167,10 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
         receiver = bytes_to_address(context.tx_log.topics[2])  # receiver does not receive in this transaction  # noqa: E501
 
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # always DAI
         )
-        end_ts = Timestamp(hex_or_bytes_to_int(context.tx_log.data[32:64]))
+        end_ts = Timestamp(int.from_bytes(context.tx_log.data[32:64]))
         new_event = self.base.make_event_next_index(
             tx_hash=context.transaction.tx_hash,
             timestamp=context.transaction.timestamp,

--- a/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
@@ -27,7 +27,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import CacheType, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     CLAIM_GEAR_WITHDRAWAL,
@@ -115,11 +115,11 @@ class GearboxCommonDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
             return None
 
         amount = token_normalized_value(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token_amount=int.from_bytes(context.tx_log.data[:32]),
             token=token,
         )
         shares = token_normalized_value(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            token_amount=int.from_bytes(context.tx_log.data[32:64]),
             token=token,
         )
         return user_address, pool_info, amount, shares
@@ -226,7 +226,7 @@ class GearboxCommonDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
     def _decode_stake(self, context: DecoderContext) -> DecodingOutput:
         user_address = bytes_to_address(context.tx_log.topics[1])
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token_amount=int.from_bytes(context.tx_log.data[:32]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
 
@@ -251,7 +251,7 @@ class GearboxCommonDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
     def _decode_unstake(self, context: DecoderContext) -> DecodingOutput:
         user_address = bytes_to_address(context.tx_log.data[:32])
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            token_amount=int.from_bytes(context.tx_log.data[32:64]),
             token_decimals=DEFAULT_TOKEN_DECIMALS,
         )
         for event in context.decoded_events:

--- a/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import DONATION_SENT, PAYOUT_CLAIMED
 
@@ -77,7 +77,7 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
 
         asset = self.base.get_or_create_evm_asset(bytes_to_address(context.tx_log.topics[1]))  # this checks for ETH special address inside # noqa: E501
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.topics[2]),
+            amount=int.from_bytes(context.tx_log.topics[2]),
             asset=asset,
         )
 

--- a/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
@@ -16,10 +16,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.utils.misc import (
-    bytes_to_address,
-    hex_or_bytes_to_int,
-)
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -118,7 +115,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
             asset = self.evm_inquirer.native_token
         else:
             asset = self.base.get_or_create_evm_token(token_address)
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        amount_raw = int.from_bytes(context.tx_log.data[32:64])
         amount = asset_normalized_value(amount_raw, asset)
 
         if donator_tracked:  # with or without receiver tracked we take this
@@ -181,7 +178,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
 
     def _decode_project_action(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] == PROJECT_CREATED:
-            project_id = hex_or_bytes_to_int(context.tx_log.topics[1])
+            project_id = int.from_bytes(context.tx_log.topics[1])
             owner = bytes_to_address(context.tx_log.topics[2])
             event = self.base.make_event_from_transaction(
                 transaction=context.transaction,
@@ -197,7 +194,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
             )
             return DecodingOutput(event=event)
         elif context.tx_log.topics[0] == METADATA_UPDATED:
-            project_id = hex_or_bytes_to_int(context.tx_log.topics[1])
+            project_id = int.from_bytes(context.tx_log.topics[1])
             event = self.base.make_event_from_transaction(
                 transaction=context.transaction,
                 tx_log=context.tx_log,
@@ -241,7 +238,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
         if self.base.is_tracked(grantee) is False:
             return DEFAULT_DECODING_OUTPUT
 
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        raw_amount = int.from_bytes(context.tx_log.data[0:32])
         token_address = bytes_to_address(context.tx_log.topics[1])
         token = self.base.get_or_create_evm_token(token_address)
         amount = asset_normalized_value(raw_amount, token)

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -25,7 +25,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import CacheType, ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
@@ -229,7 +229,7 @@ class MerkleClaimDecoderInterface(DecoderInterface, ABC):
             return DEFAULT_DECODING_OUTPUT
 
         claimed_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.topics[3]),
+            token_amount=int.from_bytes(context.tx_log.topics[3]),
             token_decimals=token_decimals,
         )
         return self._maybe_enrich_claim_transfer(context, counterparty, token_id, notes_suffix, claiming_address, claimed_amount, airdrop_identifier)  # noqa: E501
@@ -251,7 +251,7 @@ class MerkleClaimDecoderInterface(DecoderInterface, ABC):
             return DEFAULT_DECODING_OUTPUT
 
         claimed_amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[64:96]),
+            token_amount=int.from_bytes(context.tx_log.data[64:96]),
             token_decimals=token_decimals,
         )
         return self._maybe_enrich_claim_transfer(context, counterparty, token_id, notes_suffix, claiming_address, claimed_amount, airdrop_identifier)  # noqa: E501
@@ -352,8 +352,8 @@ class GovernableDecoderInterface(DecoderInterface, ABC):
         return self._decode_vote_cast_common(
             context=context,
             voter_address=voter_address,
-            vote_choice=self._decode_raw_vote(hex_or_bytes_to_int(context.tx_log.data[64:96])),
-            proposal_id=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            vote_choice=self._decode_raw_vote(int.from_bytes(context.tx_log.data[64:96])),
+            proposal_id=int.from_bytes(context.tx_log.data[32:64]),
         )
 
     def _decode_propose(self, context: DecoderContext, abi: str) -> DecodingOutput:
@@ -562,7 +562,7 @@ class CommonGrantsDecoderMixin(DecoderInterface, ABC):
 
         asset = asset.resolve_to_crypto_asset()
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(amount_raw),
+            amount=int.from_bytes(amount_raw),
             asset=asset,
         )
         for event in context.decoded_events:

--- a/rotkehlchen/chain/evm/decoding/kyber/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/kyber/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     CPT_KYBER,
@@ -81,8 +81,8 @@ class KyberCommonDecoder(DecoderInterface):
 
         source_token_address = bytes_to_address(context.tx_log.data[32:64])
         destination_token_address = bytes_to_address(context.tx_log.data[64:96])
-        spent_amount_raw = hex_or_bytes_to_int(context.tx_log.data[128:160])
-        return_amount_raw = hex_or_bytes_to_int(context.tx_log.data[160:192])
+        spent_amount_raw = int.from_bytes(context.tx_log.data[128:160])
+        return_amount_raw = int.from_bytes(context.tx_log.data[160:192])
 
         source_asset = self.base.get_or_create_evm_asset(source_token_address)
         destination_asset = self.base.get_or_create_evm_asset(destination_token_address)

--- a/rotkehlchen/chain/evm/decoding/metamask/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/metamask/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_METAMASK_SWAPS, METAMASK_FEE_TOPIC, SWAP_SIGNATURE
 
@@ -57,7 +57,7 @@ class MetamaskCommonDecoder(DecoderInterface):
         fee_raw = fee_asset_address = fee_asset = None  # extract the fee info
         for log in context.all_logs:
             if log.topics[0] == METAMASK_FEE_TOPIC:
-                fee_raw = hex_or_bytes_to_int(log.data)
+                fee_raw = int.from_bytes(log.data)
                 fee_asset = self.evm_inquirer.native_token
                 fee_asset_address = log.address
                 break
@@ -65,7 +65,7 @@ class MetamaskCommonDecoder(DecoderInterface):
                 log.topics[0] == ERC20_OR_ERC721_TRANSFER and
                 bytes_to_address(log.topics[2]) == self.fee_receiver_address
             ):
-                fee_raw = hex_or_bytes_to_int(log.data)
+                fee_raw = int.from_bytes(log.data)
                 fee_asset_address = log.address
                 break
 

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     BURN_MONERIUM_SIGNATURE,
@@ -61,7 +61,7 @@ class MoneriumCommonDecoder(DecoderInterface):
             evm_inquirer=self.evm_inquirer,
         )
         amount = token_normalized_value_decimals(
-            token_amount=hex_or_bytes_to_int(value=context.tx_log.data),
+            token_amount=int.from_bytes(context.tx_log.data),
             token_decimals=token.decimals,
         )
 

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -22,7 +22,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTokenKind
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -77,10 +77,10 @@ class OdosCommonDecoderBase(DecoderInterface):
             # can directly initialize EvmToken here because it's in output_tokens which were get_or_created above  # noqa: E501
             asset = EvmToken(identifier)
             if bytes_to_address(tx_log.topics[2]) == self.router_address:
-                router_holding_amount[asset] += asset_normalized_value(amount=hex_or_bytes_to_int(tx_log.data), asset=asset)  # noqa: E501
+                router_holding_amount[asset] += asset_normalized_value(amount=int.from_bytes(tx_log.data), asset=asset)  # noqa: E501
 
             elif bytes_to_address(tx_log.topics[1]) == self.router_address:
-                router_holding_amount[asset] -= asset_normalized_value(amount=hex_or_bytes_to_int(tx_log.data), asset=asset)  # noqa: E501
+                router_holding_amount[asset] -= asset_normalized_value(amount=int.from_bytes(tx_log.data), asset=asset)  # noqa: E501
 
         if self.native_currency.identifier in output_tokens:
             try:  # download (if not there) and find all native token transfers from/to the router

--- a/rotkehlchen/chain/evm/decoding/odos/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/odos/v2/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -46,9 +46,9 @@ class Odosv2DecoderBase(OdosCommonDecoderBase):
             # https://github.com/odos-xyz/odos-router-v2/blob/main/contracts/OdosRouterV2.sol#L64
             decoded_data: tuple[ChecksumEvmAddress, list[int], list[ChecksumEvmAddress], list[int], list[ChecksumEvmAddress]] = (  # noqa: E501
                 bytes_to_address(context.tx_log.data[0:32]),  # sender
-                [hex_or_bytes_to_int(context.tx_log.data[32:64])],  # input amount
+                [int.from_bytes(context.tx_log.data[32:64])],  # input amount
                 [bytes_to_address(context.tx_log.data[64:96])],  # input token address
-                [hex_or_bytes_to_int(context.tx_log.data[96:128])],  # output amount
+                [int.from_bytes(context.tx_log.data[96:128])],  # output amount
                 [bytes_to_address(context.tx_log.data[128:160])],  # output token address
             )
         elif context.tx_log.topics[0] == b'}\x7f\xb05\x18%:\xe0\x19\x13Sf(\xb7\x8dm\x82\xe6>\x19\xb9C\xaa\xb5\xf4\x94\x83V\x02\x12Y\xbe':  # swapMultiCompact()  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.constants.assets import A_ETH, A_WETH
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -70,7 +70,7 @@ class OmnibridgeCommonDecoder(DecoderInterface, abc.ABC):
             evm_inquirer=self.evm_inquirer,
         )
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data[0:32]),
+            amount=int.from_bytes(context.tx_log.data[0:32]),
             asset=bridged_asset,
         )
         expected_event_type, new_event_type, from_chain, to_chain, expected_location_label = bridge_prepare_data(  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import (
     BUY_ON_UNISWAP_V2_FORK,
@@ -128,7 +128,7 @@ class ParaswapCommonDecoder(DecoderInterface):
                     fee_asset = in_asset
                 elif isinstance(out_asset, EvmToken) and out_asset.evm_address == log_event.address:  # noqa: E501
                     fee_asset = out_asset
-                fee_raw = hex_or_bytes_to_int(log_event.data)
+                fee_raw = int.from_bytes(log_event.data)
                 break
         else:  # if no fee is found yet, check if fee is paid through internal transactions in the native token  # noqa: E501
             try:

--- a/rotkehlchen/chain/evm/decoding/safe/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/safe/decoder.py
@@ -12,10 +12,7 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.utils.misc import (
-    bytes_to_address,
-    hex_or_bytes_to_int,
-)
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_SAFE_MULTISIG
 
@@ -63,7 +60,7 @@ class SafemultisigDecoder(DecoderInterface):
         return DecodingOutput(event=event)
 
     def _decode_changed_threshold(self, context: DecoderContext) -> DecodingOutput:
-        threshold = hex_or_bytes_to_int(context.tx_log.data[:32])
+        threshold = int.from_bytes(context.tx_log.data[:32])
         if not self.base.any_tracked([context.transaction.from_address, context.tx_log.address]):
             return DEFAULT_DECODING_OUTPUT
 
@@ -120,7 +117,7 @@ class SafemultisigDecoder(DecoderInterface):
             if index < num_owners:
                 owners.append(bytes_to_address(entry))
             elif index == num_owners:
-                threshold = hex_or_bytes_to_int(entry)
+                threshold = int.from_bytes(entry)
             else:
                 break
 

--- a/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import CryptoAsset
@@ -53,7 +53,7 @@ class SocketBridgeDecoder(DecoderInterface):
         if context.tx_log.topics[0] != BRIDGE_TOPIC:
             return DEFAULT_DECODING_OUTPUT
 
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[0:32])
+        amount_raw = int.from_bytes(context.tx_log.data[0:32])
         token_address = bytes_to_address(context.tx_log.data[32:64])
 
         if token_address == ETH_SPECIAL_ADDRESS:
@@ -68,7 +68,7 @@ class SocketBridgeDecoder(DecoderInterface):
         amount = asset_normalized_value(amount=amount_raw, asset=bridged_asset)
         sender = bytes_to_address(context.tx_log.data[128:160])
         receiver = bytes_to_address(context.tx_log.data[160:192])
-        to_chain_id_raw = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        to_chain_id_raw = int.from_bytes(context.tx_log.data[64:96])
 
         try:
             to_chain_id = ChainID.deserialize_from_db(to_chain_id_raw)

--- a/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
@@ -22,7 +22,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress, Timestamp
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 from .constants import CPT_THEGRAPH, THEGRAPH_CPT_DETAILS
 
@@ -98,7 +98,7 @@ class ThegraphCommonDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         indexer = bytes_to_address(context.tx_log.topics[1])
-        stake_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
+        stake_amount = int.from_bytes(context.tx_log.data[:32])
         stake_amount_norm = token_normalized_value(
             token_amount=stake_amount,
             token=self.token,
@@ -161,8 +161,8 @@ class ThegraphCommonDecoder(DecoderInterface):
             return DEFAULT_DECODING_OUTPUT
 
         indexer = bytes_to_address(context.tx_log.topics[1])
-        tokens_amount = hex_or_bytes_to_int(context.tx_log.data[:32])
-        lock_timeout_secs = hex_or_bytes_to_int(context.tx_log.data[64:128])
+        tokens_amount = int.from_bytes(context.tx_log.data[:32])
+        lock_timeout_secs = int.from_bytes(context.tx_log.data[64:128])
         tokens_amount_norm = token_normalized_value(
             token_amount=tokens_amount,
             token=self.token,
@@ -192,7 +192,7 @@ class ThegraphCommonDecoder(DecoderInterface):
 
         indexer = bytes_to_address(context.tx_log.topics[1])
         tokens_amount_norm = token_normalized_value(
-            token_amount=hex_or_bytes_to_int(context.tx_log.data[:32]),
+            token_amount=int.from_bytes(context.tx_log.data[:32]),
             token=self.token,
         )
         # create action item that will modify the relevant Transfer event that will appear later

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
@@ -43,7 +43,7 @@ from rotkehlchen.types import (
     EvmTokenKind,
     EvmTransaction,
 )
-from rotkehlchen.utils.misc import hex_or_bytes_to_int, ts_ms_to_sec
+from rotkehlchen.utils.misc import ts_ms_to_sec
 
 from ..constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3, UNISWAP_ICON
 
@@ -198,8 +198,8 @@ class Uniswapv3CommonDecoder(DecoderInterface):
         # for the token0 [0:32] and the token1 [32:64]. If that difference is negative it
         # means that the tokens are leaving the pool (the user receives them) and if it is
         # positive they get into the pool (the user sends them to the pool)
-        delta_token_0 = hex_or_bytes_to_int(tx_log.data[0:32], signed=True)
-        delta_token_1 = hex_or_bytes_to_int(tx_log.data[32:64], signed=True)
+        delta_token_0 = int.from_bytes(tx_log.data[0:32], signed=True)
+        delta_token_1 = int.from_bytes(tx_log.data[32:64], signed=True)
         if delta_token_0 > 0:
             amount_sent, amount_received = delta_token_0, -delta_token_1
         else:
@@ -388,9 +388,9 @@ class Uniswapv3CommonDecoder(DecoderInterface):
         https://etherscan.io/tx/0x76c312fe1c8604de5175c37dcbbb99cc8699336f3e4840e9e29e3383970f6c6d (withdrawal)
         """  # noqa: E501
         new_action_items = []
-        liquidity_pool_id = hex_or_bytes_to_int(context.tx_log.topics[1])
-        amount0_raw = hex_or_bytes_to_int(context.tx_log.data[32:64])
-        amount1_raw = hex_or_bytes_to_int(context.tx_log.data[64:96])
+        liquidity_pool_id = int.from_bytes(context.tx_log.topics[1])
+        amount0_raw = int.from_bytes(context.tx_log.data[32:64])
+        amount1_raw = int.from_bytes(context.tx_log.data[64:96])
 
         if event_action_type == 'addition':
             notes = 'Deposit {amount} {asset} to uniswap-v3 LP {pool_id}'
@@ -539,7 +539,7 @@ class Uniswapv3CommonDecoder(DecoderInterface):
         ):
             context.event.event_type = HistoryEventType.DEPLOY
             context.event.event_subtype = HistoryEventSubType.NFT
-            context.event.notes = f'Create {CPT_UNISWAP_V3} LP with id {hex_or_bytes_to_int(context.tx_log.topics[3])}'  # noqa: E501
+            context.event.notes = f'Create {CPT_UNISWAP_V3} LP with id {int.from_bytes(context.tx_log.topics[3])}'  # noqa: E501
             context.event.counterparty = CPT_UNISWAP_V3
             return TransferEnrichmentOutput(matched_counterparty=CPT_UNISWAP_V3)
 

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -32,7 +32,7 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import CacheType, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
@@ -225,7 +225,7 @@ class VelodromeLikeDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixi
 
         user_or_contract_address = bytes_to_address(context.tx_log.topics[1])
         gauge_address = context.tx_log.address
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data)
+        raw_amount = int.from_bytes(context.tx_log.data)
         found_event_modifying_balances = False
         for event in context.decoded_events:
             crypto_asset = event.asset.resolve_to_crypto_asset()

--- a/rotkehlchen/chain/evm/decoding/weth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/weth/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -62,7 +62,7 @@ class WethDecoderBase(DecoderInterface, ABC):
 
     def _decode_deposit_event(self, context: DecoderContext) -> DecodingOutput:
         depositor = bytes_to_address(context.tx_log.topics[1])
-        deposited_amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        deposited_amount_raw = int.from_bytes(context.tx_log.data[:32])
         deposited_amount = asset_normalized_value(
             amount=deposited_amount_raw,
             asset=self.base_asset,
@@ -101,7 +101,7 @@ class WethDecoderBase(DecoderInterface, ABC):
 
     def _decode_withdrawal_event(self, context: DecoderContext) -> DecodingOutput:
         withdrawer = bytes_to_address(context.tx_log.topics[1])
-        withdrawn_amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        withdrawn_amount_raw = int.from_bytes(context.tx_log.data[:32])
         withdrawn_amount = asset_normalized_value(
             amount=withdrawn_amount_raw,
             asset=self.base_asset,

--- a/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_p
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
@@ -70,7 +70,7 @@ class XdaiBridgeCommonDecoder(DecoderInterface, abc.ABC):
             return DEFAULT_DECODING_OUTPUT
 
         amount = asset_normalized_value(
-            amount=hex_or_bytes_to_int(context.tx_log.data[32:64]),
+            amount=int.from_bytes(context.tx_log.data[32:64]),
             asset=self.bridged_asset,
         )
         expected_event_type, new_event_type, from_chain, to_chain, expected_location_label = bridge_prepare_data(  # noqa: E501

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.externalapis.gnosispay import init_gnosis_pay
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -120,7 +120,7 @@ class GnosisPayDecoder(DecoderInterface, ReloadableDecoderMixin):
         # with pageSize 100
         # hex_or_bytes_to_address(context.tx_log.data[32:64])  # noqa: ERA001
         # should we use it?
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[96:128])
+        raw_amount = int.from_bytes(context.tx_log.data[96:128])
         amount = token_normalized_value(raw_amount, token)
 
         for event in context.decoded_events:

--- a/rotkehlchen/chain/gnosis/modules/sdai/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/sdai/decoder.py
@@ -17,7 +17,6 @@ from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.gnosis.modules.sdai.constants import GNOSIS_SDAI_ADDRESS
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
-from rotkehlchen.utils.misc import hex_or_bytes_to_int
 
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS  # all tokens in this decoder use default(18)  # noqa: E501 # isort: skip
 
@@ -25,9 +24,9 @@ from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS  # all tokens
 class SdaiDecoder(DecoderInterface):
 
     def _decode_sdai_deposit_events(self, context: DecoderContext) -> DecodingOutput:
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        amount_raw = int.from_bytes(context.tx_log.data[:32])
         amount = token_normalized_value_decimals(amount_raw, DEFAULT_TOKEN_DECIMALS)
-        shares_raw = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        shares_raw = int.from_bytes(context.tx_log.data[32:64])
         shares = token_normalized_value_decimals(shares_raw, DEFAULT_TOKEN_DECIMALS)
 
         for event in context.decoded_events:
@@ -54,9 +53,9 @@ class SdaiDecoder(DecoderInterface):
         return DEFAULT_DECODING_OUTPUT
 
     def _decode_sdai_redeem_events(self, context: DecoderContext) -> DecodingOutput:
-        amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        amount_raw = int.from_bytes(context.tx_log.data[:32])
         amount = token_normalized_value_decimals(amount_raw, DEFAULT_TOKEN_DECIMALS)
-        shares_raw = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        shares_raw = int.from_bytes(context.tx_log.data[32:64])
         shares = token_normalized_value_decimals(shares_raw, DEFAULT_TOKEN_DECIMALS)
 
         for event in context.decoded_events:

--- a/rotkehlchen/chain/optimism/modules/optimism_bridge/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/optimism_bridge/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 BRIDGE_ADDRESSES: Final = (
     string_to_evm_address('0x4200000000000000000000000000000000000010'),  # Normal Bridge
@@ -47,7 +47,7 @@ class OptimismBridgeDecoder(DecoderInterface):
         optimism_token_address = bytes_to_address(context.tx_log.topics[2])
         from_address = bytes_to_address(context.tx_log.topics[3])
         to_address = bytes_to_address(context.tx_log.data[:32])
-        raw_amount = hex_or_bytes_to_int(context.tx_log.data[32:64])
+        raw_amount = int.from_bytes(context.tx_log.data[32:64])
 
         if ethereum_token_address == ZERO_ADDRESS:
             # This means that ETH was bridged

--- a/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
@@ -22,7 +22,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
-from rotkehlchen.utils.misc import bytes_to_address, from_wei, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
@@ -120,7 +120,7 @@ class ScrollBridgeDecoder(DecoderInterface):
         ethereum_token_address = bytes_to_address(tx_log.topics[1])
         l2_token_address = bytes_to_address(tx_log.topics[2])
         asset = self.base.get_or_create_evm_token(l2_token_address)
-        raw_amount = hex_or_bytes_to_int(tx_log.data[32:64])
+        raw_amount = int.from_bytes(tx_log.data[32:64])
         amount = asset_normalized_value(raw_amount, asset)
         expected_event_type, new_event_type, from_chain, to_chain, _ = bridge_prepare_data(
             tx_log=tx_log,

--- a/rotkehlchen/chain/scroll/modules/weth/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/weth/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.decoding.weth.decoder import WethDecoder as EthBaseWethDecoder
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.utils.misc import bytes_to_address, hex_or_bytes_to_int
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
@@ -20,7 +20,7 @@ log = RotkehlchenLogsAdapter(logger)
 class WethDecoder(EthBaseWethDecoder):
     def _decode_deposit_event(self, context: 'DecoderContext') -> 'DecodingOutput':
         depositor = bytes_to_address(context.tx_log.topics[1])
-        deposited_amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        deposited_amount_raw = int.from_bytes(context.tx_log.data[:32])
         deposited_amount = asset_normalized_value(
             amount=deposited_amount_raw,
             asset=self.base_asset,
@@ -53,7 +53,7 @@ class WethDecoder(EthBaseWethDecoder):
 
     def _decode_withdrawal_event(self, context: 'DecoderContext') -> 'DecodingOutput':
         withdrawer = bytes_to_address(context.tx_log.topics[1])
-        withdrawn_amount_raw = hex_or_bytes_to_int(context.tx_log.data[:32])
+        withdrawn_amount_raw = int.from_bytes(context.tx_log.data[:32])
         withdrawn_amount = asset_normalized_value(
             amount=withdrawn_amount_raw,
             asset=self.base_asset,

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -42,7 +42,7 @@ from rotkehlchen.types import (
     deserialize_evm_tx_hash,
 )
 from rotkehlchen.utils.data_structures import LRUCacheWithRemove
-from rotkehlchen.utils.misc import hex_or_bytes_to_int, set_user_agent
+from rotkehlchen.utils.misc import hexstr_to_int, set_user_agent
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -609,8 +609,8 @@ class Etherscan(ExternalServiceWithApiKey, ABC):
         block_data = self._query(module='proxy', action='eth_getBlockByNumber', options=options)
         # We need to convert some data from hex here
         # https://github.com/PyCQA/pylint/issues/4739
-        block_data['timestamp'] = hex_or_bytes_to_int(block_data['timestamp'])
-        block_data['number'] = hex_or_bytes_to_int(block_data['number'])
+        block_data['timestamp'] = hexstr_to_int(block_data['timestamp'])
+        block_data['number'] = hexstr_to_int(block_data['number'])
 
         return block_data
 

--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -10,7 +10,7 @@ from binascii import unhexlify
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from eth_utils import is_hexstr
 from eth_utils.address import to_checksum_address
@@ -247,29 +247,8 @@ def hexstr_to_int(value: str) -> int:
     return int_value
 
 
-def hex_or_bytes_to_int(
-        value: bytes | str,
-        signed: bool = False,
-        byteorder: Literal['little', 'big'] = 'big',
-) -> int:
-    """Turns a bytes/HexBytes or a hexstring into an int
-
-    May raise:
-    - ConversionError if it can't convert a value to an int or if an unexpected
-    type is given.
-    """
-    if isinstance(value, bytes):
-        int_value = int.from_bytes(value, byteorder=byteorder, signed=signed)
-    elif isinstance(value, str):
-        int_value = hexstr_to_int(value)
-    else:
-        raise ConversionError(f'Unexpected type {type(value)} given to hex_or_bytes_to_int()')
-
-    return int_value
-
-
 def bytes_to_address(value: bytes) -> ChecksumEvmAddress:
-    """Turns 32 bytes into a checksummed EVM address
+    """Turns 32 bytes/hexbytes into a checksummed EVM address
 
     May raise:
     - DeserializationError if it can't convert a value to an int or if an unexpected


### PR DESCRIPTION
Just use int.from_bytes() directly. And use hexstr_to_int when we need to deal with a string.