### PR TITLE
fix: set the initial undecoded tx status relative to undecoded transactions

### DIFF
--- a/frontend/app/src/composables/history/events/tx/decoding.ts
+++ b/frontend/app/src/composables/history/events/tx/decoding.ts
@@ -45,10 +45,13 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
         Object.fromEntries(
           Object.entries(breakdown).map(([chain, entry]) => [
             chain,
+            // The ws message assumes that total is the number of undecoded txs,
+            // For this reason we initialize the status similarly and ignore the total,
+            // which in this case is the total of all transactions.
             {
               chain,
-              total: entry.total,
-              processed: entry.total - entry.undecoded,
+              total: entry.undecoded,
+              processed: 0,
             },
           ]),
         ),


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
