### PR TITLE
Pin eth-typing and fix types after release 5.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ greenlet==3.1.1
 gevent-websocket==0.10.1  # like the below is abandoned
 wsaccel==0.6.6  # recommended for acceleration of gevent-websocket. But abandoned.
 web3==7.3.0
+eth-typing==5.0.1
 content-hash==2.0.0
 rotki-pysqlcipher3==2024.1.2
 requests==2.32.3

--- a/rotkehlchen/chain/evm/decoding/thegraph/constants.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/constants.py
@@ -13,31 +13,31 @@ THEGRAPH_CPT_DETAILS: Final = CounterpartyDetails(
 )
 
 GRAPH_DELEGATION_TRANSFER_ABI: Final[Sequence[ABIEvent]] = [
-    {  # all type ignores are due to inability of typing to see ABIComponentIndexed
+    {
         'anonymous': False,
         'inputs': [
             {
-                'indexed': True,  # type: ignore
+                'indexed': True,
                 'name': 'delegator',
                 'type': 'address',
             },
             {
-                'indexed': True,  # type: ignore
+                'indexed': True,
                 'name': 'l2Delegator',
                 'type': 'address',
             },
             {
-                'indexed': True,  # type: ignore
+                'indexed': True,
                 'name': 'indexer',
                 'type': 'address',
             },
             {
-                'indexed': False,  # type: ignore
+                'indexed': False,
                 'name': 'l2Indexer',
                 'type': 'address',
             },
             {
-                'indexed': False,  # type: ignore
+                'indexed': False,
                 'name': 'transferredDelegationTokens',
                 'type': 'uint256',
             },

--- a/rotkehlchen/chain/gnosis/transactions.py
+++ b/rotkehlchen/chain/gnosis/transactions.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from .node_inquirer import GnosisInquirer
 
-ADDED_RECEIVER_ABI: Final[ABI] = [{'anonymous': False, 'inputs': [{'indexed': False, 'name': 'amount', 'type': 'uint256'}, {'indexed': True, 'name': 'receiver', 'type': 'address'}, {'indexed': True, 'name': 'bridge', 'type': 'address'}], 'name': 'AddedReceiver', 'type': 'event'}]  # type: ignore  # noqa: E501  # the ABIComponentIndexed problem
+ADDED_RECEIVER_ABI: Final[ABI] = [{'anonymous': False, 'inputs': [{'indexed': False, 'name': 'amount', 'type': 'uint256'}, {'indexed': True, 'name': 'receiver', 'type': 'address'}, {'indexed': True, 'name': 'bridge', 'type': 'address'}], 'name': 'AddedReceiver', 'type': 'event'}]  # noqa: E501
 DEPLOYED_BLOCK: Final = 9053325
 DEPLOYED_TS: Final = 1539027985
 


### PR DESCRIPTION
Related to https://github.com/ethereum/eth-typing/issues/91

Taken out of https://github.com/rotki/rotki/pull/8740 to test develop only and why api tests time out