### PR TITLE
fix: update checker plugin to specify tsconfig path

### DIFF
--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -47,6 +47,8 @@ if (envPath)
 if (!hmrEnabled)
   console.info('HMR is disabled');
 
+const enableChecker = !(process.env.CI || process.env.VITE_TEST || process.env.VITEST);
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -69,9 +71,13 @@ export default defineConfig({
       importMode: 'async',
     }),
     vue(),
-    checker({
-      vueTsc: !(process.env.CI || process.env.VITE_TEST || process.env.VITEST),
-    }),
+    checker(enableChecker
+      ? {
+          vueTsc: {
+            tsconfigPath: 'tsconfig.app.json',
+          },
+        }
+      : {}),
     AutoImport({
       packagePresets: ['@rotki/common'],
       include: [


### PR DESCRIPTION
It seems that the current version is not compatible with the `references` approach.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
