### PR TITLE
refactor: remove v-data-table leftovers from pagination

### DIFF
--- a/frontend/app/auto-imports.d.ts
+++ b/frontend/app/auto-imports.d.ts
@@ -93,6 +93,8 @@ declare global {
   const aggregateTotal: typeof import('./src/utils/calculation')['aggregateTotal']
   const aggregateTotals: typeof import('./src/utils/blockchain/accounts/index')['aggregateTotals']
   const appendAssetBalance: typeof import('./src/utils/balances')['appendAssetBalance']
+  const applyPaginationDefaults: typeof import('./src/composables/use-pagination-filter/utils')['applyPaginationDefaults']
+  const applySortingDefaults: typeof import('./src/composables/use-pagination-filter/utils')['applySortingDefaults']
   const arrayify: typeof import('./src/utils/array')['arrayify']
   const assert: typeof import('@rotki/common')['assert']
   const assetSum: typeof import('./src/utils/calculation')['assetSum']
@@ -184,6 +186,7 @@ declare global {
   const getAddressFromEvmIdentifier: typeof import('@rotki/common')['getAddressFromEvmIdentifier']
   const getAddressesFromWallet: typeof import('./src/utils/metamask')['getAddressesFromWallet']
   const getAllBrowserWalletProviders: typeof import('./src/utils/metamask')['getAllBrowserWalletProviders']
+  const getApiSortingParams: typeof import('./src/composables/use-pagination-filter/utils')['getApiSortingParams']
   const getBackendUrl: typeof import('./src/utils/account-management')['getBackendUrl']
   const getBalances: typeof import('./src/utils/defi/xswap')['getBalances']
   const getChain: typeof import('./src/utils/blockchain/accounts/utils')['getChain']
@@ -314,6 +317,9 @@ declare global {
   const onUpdated: typeof import('vue')['onUpdated']
   const onWatcherCleanup: typeof import('vue')['onWatcherCleanup']
   const onlyIfTruthy: typeof import('@rotki/common')['onlyIfTruthy']
+  const paginationQueryParsers: typeof import('@/composables/use-pagination-filter/utils')['paginationQueryParsers']
+  const parseQueryHistory: typeof import('./src/composables/use-pagination-filter/utils')['parseQueryHistory']
+  const parseQueryPagination: typeof import('./src/composables/use-pagination-filter/utils')['parseQueryPagination']
   const pausableWatch: typeof import('@vueuse/core')['pausableWatch']
   const pluralize: typeof import('@rotki/common')['pluralize']
   const pluralizeLastWord: typeof import('@rotki/common')['pluralizeLastWord']
@@ -517,6 +523,7 @@ declare global {
   const useClipboardItems: typeof import('@vueuse/core')['useClipboardItems']
   const useCloned: typeof import('@vueuse/core')['useCloned']
   const useColorMode: typeof import('@vueuse/core')['useColorMode']
+  const useCommonTableProps: typeof import('./src/composables/use-common-table-props/index')['useCommonTableProps']
   const useCompoundApi: typeof import('./src/composables/api/defi/compound')['useCompoundApi']
   const useCompoundStore: typeof import('./src/store/defi/compound/index')['useCompoundStore']
   const useComputedRef: typeof import('./src/composables/utils/useComputedRef/index')['useComputedRef']
@@ -563,7 +570,6 @@ declare global {
   const useElementHover: typeof import('@vueuse/core')['useElementHover']
   const useElementSize: typeof import('@vueuse/core')['useElementSize']
   const useElementVisibility: typeof import('@vueuse/core')['useElementVisibility']
-  const useEmptyFilter: typeof import('./src/composables/filters/index')['useEmptyFilter']
   const useEmptyOrSome: typeof import('./src/composables/utils/useEmptyOrSome/index')['useEmptyOrSome']
   const useEth2Api: typeof import('./src/composables/api/staking/eth2')['useEth2Api']
   const useEth2DailyStats: typeof import('./src/composables/staking/eth2/daily-stats')['useEth2DailyStats']
@@ -692,7 +698,7 @@ declare global {
   const useOffsetPagination: typeof import('@vueuse/core')['useOffsetPagination']
   const useOnline: typeof import('@vueuse/core')['useOnline']
   const usePageLeave: typeof import('@vueuse/core')['usePageLeave']
-  const usePaginationFilters: typeof import('./src/composables/filter-paginate')['usePaginationFilters']
+  const usePaginationFilters: typeof import('./src/composables/use-pagination-filter/index')['usePaginationFilters']
   const useParallax: typeof import('@vueuse/core')['useParallax']
   const useParentElement: typeof import('@vueuse/core')['useParentElement']
   const usePerformanceObserver: typeof import('@vueuse/core')['usePerformanceObserver']
@@ -968,6 +974,8 @@ declare module 'vue' {
     readonly aggregateTotal: UnwrapRef<typeof import('./src/utils/calculation')['aggregateTotal']>
     readonly aggregateTotals: UnwrapRef<typeof import('./src/utils/blockchain/accounts/index')['aggregateTotals']>
     readonly appendAssetBalance: UnwrapRef<typeof import('./src/utils/balances')['appendAssetBalance']>
+    readonly applyPaginationDefaults: UnwrapRef<typeof import('./src/composables/use-pagination-filter/utils')['applyPaginationDefaults']>
+    readonly applySortingDefaults: UnwrapRef<typeof import('./src/composables/use-pagination-filter/utils')['applySortingDefaults']>
     readonly arrayify: UnwrapRef<typeof import('./src/utils/array')['arrayify']>
     readonly assert: UnwrapRef<typeof import('@rotki/common')['assert']>
     readonly assetSum: UnwrapRef<typeof import('./src/utils/calculation')['assetSum']>
@@ -1030,7 +1038,6 @@ declare module 'vue' {
     readonly debouncedWatch: UnwrapRef<typeof import('@vueuse/core')['debouncedWatch']>
     readonly decodeHtmlEntities: UnwrapRef<typeof import('@rotki/common')['decodeHtmlEntities']>
     readonly defaultCollectionState: UnwrapRef<typeof import('./src/utils/collection')['defaultCollectionState']>
-    readonly defaultOptions: UnwrapRef<typeof import('./src/utils/collection')['defaultOptions']>
     readonly defineAsyncComponent: UnwrapRef<typeof import('vue')['defineAsyncComponent']>
     readonly defineComponent: UnwrapRef<typeof import('vue')['defineComponent']>
     readonly defineStore: UnwrapRef<typeof import('pinia')['defineStore']>
@@ -1059,6 +1066,7 @@ declare module 'vue' {
     readonly getAddressFromEvmIdentifier: UnwrapRef<typeof import('@rotki/common')['getAddressFromEvmIdentifier']>
     readonly getAddressesFromWallet: UnwrapRef<typeof import('./src/utils/metamask')['getAddressesFromWallet']>
     readonly getAllBrowserWalletProviders: UnwrapRef<typeof import('./src/utils/metamask')['getAllBrowserWalletProviders']>
+    readonly getApiSortingParams: UnwrapRef<typeof import('./src/composables/use-pagination-filter/utils')['getApiSortingParams']>
     readonly getBackendUrl: UnwrapRef<typeof import('./src/utils/account-management')['getBackendUrl']>
     readonly getBalances: UnwrapRef<typeof import('./src/utils/defi/xswap')['getBalances']>
     readonly getChain: UnwrapRef<typeof import('./src/utils/blockchain/accounts/utils')['getChain']>
@@ -1189,6 +1197,8 @@ declare module 'vue' {
     readonly onUpdated: UnwrapRef<typeof import('vue')['onUpdated']>
     readonly onWatcherCleanup: UnwrapRef<typeof import('vue')['onWatcherCleanup']>
     readonly onlyIfTruthy: UnwrapRef<typeof import('@rotki/common')['onlyIfTruthy']>
+    readonly parseQueryHistory: UnwrapRef<typeof import('./src/composables/use-pagination-filter/utils')['parseQueryHistory']>
+    readonly parseQueryPagination: UnwrapRef<typeof import('./src/composables/use-pagination-filter/utils')['parseQueryPagination']>
     readonly pausableWatch: UnwrapRef<typeof import('@vueuse/core')['pausableWatch']>
     readonly pluralize: UnwrapRef<typeof import('@rotki/common')['pluralize']>
     readonly pluralizeLastWord: UnwrapRef<typeof import('@rotki/common')['pluralizeLastWord']>
@@ -1392,6 +1402,7 @@ declare module 'vue' {
     readonly useClipboardItems: UnwrapRef<typeof import('@vueuse/core')['useClipboardItems']>
     readonly useCloned: UnwrapRef<typeof import('@vueuse/core')['useCloned']>
     readonly useColorMode: UnwrapRef<typeof import('@vueuse/core')['useColorMode']>
+    readonly useCommonTableProps: UnwrapRef<typeof import('./src/composables/use-common-table-props/index')['useCommonTableProps']>
     readonly useCompoundApi: UnwrapRef<typeof import('./src/composables/api/defi/compound')['useCompoundApi']>
     readonly useCompoundStore: UnwrapRef<typeof import('./src/store/defi/compound/index')['useCompoundStore']>
     readonly useComputedRef: UnwrapRef<typeof import('./src/composables/utils/useComputedRef/index')['useComputedRef']>
@@ -1438,7 +1449,6 @@ declare module 'vue' {
     readonly useElementHover: UnwrapRef<typeof import('@vueuse/core')['useElementHover']>
     readonly useElementSize: UnwrapRef<typeof import('@vueuse/core')['useElementSize']>
     readonly useElementVisibility: UnwrapRef<typeof import('@vueuse/core')['useElementVisibility']>
-    readonly useEmptyFilter: UnwrapRef<typeof import('./src/composables/filters/index')['useEmptyFilter']>
     readonly useEmptyOrSome: UnwrapRef<typeof import('./src/composables/utils/useEmptyOrSome/index')['useEmptyOrSome']>
     readonly useEth2Api: UnwrapRef<typeof import('./src/composables/api/staking/eth2')['useEth2Api']>
     readonly useEth2DailyStats: UnwrapRef<typeof import('./src/composables/staking/eth2/daily-stats')['useEth2DailyStats']>
@@ -1567,7 +1577,7 @@ declare module 'vue' {
     readonly useOffsetPagination: UnwrapRef<typeof import('@vueuse/core')['useOffsetPagination']>
     readonly useOnline: UnwrapRef<typeof import('@vueuse/core')['useOnline']>
     readonly usePageLeave: UnwrapRef<typeof import('@vueuse/core')['usePageLeave']>
-    readonly usePaginationFilters: UnwrapRef<typeof import('./src/composables/filter-paginate')['usePaginationFilters']>
+    readonly usePaginationFilters: UnwrapRef<typeof import('./src/composables/use-pagination-filter/index')['usePaginationFilters']>
     readonly useParallax: UnwrapRef<typeof import('@vueuse/core')['useParallax']>
     readonly useParentElement: UnwrapRef<typeof import('@vueuse/core')['useParentElement']>
     readonly usePerformanceObserver: UnwrapRef<typeof import('@vueuse/core')['usePerformanceObserver']>

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -5,7 +5,6 @@ import AccountBalancesTable from '@/components/accounts/AccountBalancesTable.vue
 import AccountGroupDetailsTable from '@/components/accounts/AccountGroupDetailsTable.vue';
 import DetectTokenChainsSelection from '@/components/accounts/balances/DetectTokenChainsSelection.vue';
 import type { AccountManageState } from '@/composables/accounts/blockchain/use-account-manage';
-import type { Collection } from '@/types/collection';
 import type {
   BlockchainAccountGroupWithBalance,
   BlockchainAccountRequestPayload,
@@ -48,8 +47,6 @@ const {
 } = usePaginationFilters<
   BlockchainAccountGroupWithBalance,
   BlockchainAccountRequestPayload,
-  BlockchainAccountGroupWithBalance,
-  Collection<BlockchainAccountGroupWithBalance>,
   Filters,
   Matcher
 >(fetchAccountsPage, {
@@ -81,11 +78,12 @@ const {
 
     set(query, q ? fromUriEncoded(q) : {});
   },
-  customPageParams: computed(() => ({
+  requestParams: computed(() => ({
     excluded: get(chainExclusionFilter),
   })),
   defaultSortBy: {
-    key: 'usdValue',
+    column: 'usdValue',
+    direction: 'desc',
   },
 });
 

--- a/frontend/app/src/components/accounts/AccountBalancesTable.vue
+++ b/frontend/app/src/components/accounts/AccountBalancesTable.vue
@@ -2,7 +2,7 @@
 import { isEmpty, some } from 'lodash-es';
 import { TaskType } from '@/types/task-type';
 import { Section } from '@/types/status';
-import type { TableRowKey } from '@/composables/filter-paginate';
+import type { TableRowKey } from '@/composables/use-pagination-filter/types';
 import type { AccountManageState } from '@/composables/accounts/blockchain/use-account-manage';
 import type { Collection } from '@/types/collection';
 import type { DataTableColumn, DataTableSortData, TablePaginationData } from '@rotki/ui-library';

--- a/frontend/app/src/components/accounts/AccountGroupDetailsTable.vue
+++ b/frontend/app/src/components/accounts/AccountGroupDetailsTable.vue
@@ -37,13 +37,14 @@ const {
     const { expanded: expandedIds } = RouterExpandedIdsSchema.parse(query);
     set(expanded, expandedIds);
   },
-  customPageParams: computed(() => ({
+  requestParams: computed(() => ({
     groupId: props.groupId,
     chain: props.chains,
     tags: props.tags,
   })),
   defaultSortBy: {
-    key: 'usdValue',
+    column: 'usdValue',
+    direction: 'desc',
   },
   query,
 });

--- a/frontend/app/src/components/accounts/EthStakingValidators.vue
+++ b/frontend/app/src/components/accounts/EthStakingValidators.vue
@@ -5,7 +5,6 @@ import { Section } from '@/types/status';
 import PercentageDisplay from '@/components/display/PercentageDisplay.vue';
 import HashLink from '@/components/helper/HashLink.vue';
 import { SavedFilterLocation } from '@/types/filtering';
-import type { Collection } from '@/types/collection';
 import type { Filters, Matcher } from '@/composables/filters/eth-validator';
 import type { StakingValidatorManage } from '@/composables/accounts/blockchain/use-account-manage';
 import type { ContextColorsType, DataTableColumn } from '@rotki/ui-library';
@@ -36,15 +35,14 @@ const {
 } = usePaginationFilters<
   EthereumValidator,
   EthereumValidatorRequestPayload,
-  EthereumValidator,
-  Collection<EthereumValidator>,
   Filters,
   Matcher
 >(fetchValidators, {
   history: 'router',
   filterSchema: () => useEthValidatorAccountFilter(t),
   defaultSortBy: {
-    key: 'index',
+    column: 'index',
+    direction: 'desc',
   },
 });
 

--- a/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
+++ b/frontend/app/src/components/accounts/balances/NonFungibleBalances.vue
@@ -90,10 +90,10 @@ const {
     set(ignoredAssetsHandling, query.ignoredAssetsHandling || 'exclude');
   },
   extraParams,
-  defaultSortBy: {
-    key: ['usdPrice'],
-    ascending: [false],
-  },
+  defaultSortBy: [{
+    column: 'usdPrice',
+    direction: 'desc',
+  }],
 });
 
 const { setPostSubmitFunc, setOpenDialog } = useLatestPriceForm();

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -4,7 +4,6 @@ import { isEqual } from 'lodash-es';
 import { Section } from '@/types/status';
 import type { Filters, Matcher } from '@/composables/filters/manual-balances';
 import type { ManualBalance, ManualBalanceRequestPayload, ManualBalanceWithPrice } from '@/types/manual-balances';
-import type { Collection } from '@/types/collection';
 import type { DataTableColumn } from '@rotki/ui-library';
 
 const props = defineProps<{
@@ -47,8 +46,6 @@ const {
 } = usePaginationFilters<
   ManualBalanceWithPrice,
   ManualBalanceRequestPayload,
-  ManualBalanceWithPrice,
-  Collection<ManualBalanceWithPrice>,
   Filters,
   Matcher
 >(
@@ -59,9 +56,12 @@ const {
     extraParams: computed(() => ({
       tags: get(tags),
     })),
-    defaultSortBy: {
-      key: ['usdValue'],
-    },
+    defaultSortBy: [
+      {
+        column: 'usdValue',
+        direction: 'desc',
+      },
+    ],
     onUpdateFilters(query) {
       const schema = ManualBalancesFilterSchema.parse(query);
       if (schema.tags)

--- a/frontend/app/src/components/address-book-manager/AddressBookManagement.vue
+++ b/frontend/app/src/components/address-book-manager/AddressBookManagement.vue
@@ -5,7 +5,6 @@ import type {
   AddressBookPayload,
   AddressBookRequestPayload,
 } from '@/types/eth-names';
-import type { Collection } from '@/types/collection';
 import type { Filters, Matcher } from '@/composables/filters/address-book';
 
 const selectedChain = ref<string>();
@@ -29,11 +28,17 @@ const formPayload = ref<Partial<AddressBookPayload>>(emptyForm());
 
 const { getAddressBook } = useAddressesNamesStore();
 
-const { filters, matchers, state, isLoading, fetchData, sort, pagination } = usePaginationFilters<
+const {
+  filters,
+  matchers,
+  state,
+  isLoading,
+  fetchData,
+  sort,
+  pagination,
+} = usePaginationFilters<
   AddressBookEntry,
   AddressBookRequestPayload,
-  AddressBookEntry,
-  Collection<AddressBookEntry>,
   Filters,
   Matcher
 >(filter => getAddressBook(get(location), filter), {
@@ -42,10 +47,10 @@ const { filters, matchers, state, isLoading, fetchData, sort, pagination } = use
   extraParams: computed(() => ({
     blockchain: get(selectedChain),
   })),
-  defaultSortBy: {
-    key: ['name'],
-    ascending: [true],
-  },
+  defaultSortBy: [{
+    column: 'name',
+    direction: 'asc',
+  }],
 });
 
 function openForm(item: AddressBookEntry | null = null) {

--- a/frontend/app/src/components/asset-manager/cex-mapping/ManageCexMappingContent.vue
+++ b/frontend/app/src/components/asset-manager/cex-mapping/ManageCexMappingContent.vue
@@ -10,8 +10,9 @@ const { fetchAllCexMapping, deleteCexMapping } = useAssetCexMappingApi();
 
 const selectedLocation = ref<string>('');
 const selectedSymbol = ref<string>('');
-
 const editMode = ref<boolean>(false);
+
+const { editableItem } = useCommonTableProps<CexMapping>();
 
 const extraParams = computed(() => {
   const location = get(selectedLocation);
@@ -27,7 +28,6 @@ const extraParams = computed(() => {
 const {
   state,
   isLoading: loading,
-  editableItem,
   fetchData,
   pagination,
 } = usePaginationFilters<

--- a/frontend/app/src/components/asset-manager/custom/CustomAssetContent.vue
+++ b/frontend/app/src/components/asset-manager/custom/CustomAssetContent.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Nullable } from '@rotki/common';
-import type { Collection } from '@/types/collection';
 import type { Filters, Matcher } from '@/composables/filters/custom-assets';
 import type { CustomAsset, CustomAssetRequestPayload } from '@/types/asset';
 
@@ -21,12 +20,11 @@ const types = ref<string[]>([]);
 const router = useRouter();
 const route = useRoute();
 
-const { deleteCustomAsset, queryAllCustomAssets, getCustomAssetTypes } = useAssetManagementApi();
 const { setMessage } = useMessageStore();
-
 const { show } = useConfirmStore();
-
+const { deleteCustomAsset, queryAllCustomAssets, getCustomAssetTypes } = useAssetManagementApi();
 const { setOpenDialog, setPostSubmitFunc } = useCustomAssetForm();
+const { expanded, editableItem } = useCommonTableProps<CustomAsset>();
 
 async function deleteAsset(assetId: string) {
   try {
@@ -47,27 +45,23 @@ async function deleteAsset(assetId: string) {
 const {
   state,
   filters,
-  expanded,
   matchers,
   fetchData,
   isLoading: loading,
-  editableItem,
   pagination,
   sort,
 } = usePaginationFilters<
   CustomAsset,
   CustomAssetRequestPayload,
-  CustomAsset,
-  Collection<CustomAsset>,
   Filters,
   Matcher
 >(queryAllCustomAssets, {
   history: get(mainPage) ? 'router' : false,
   filterSchema: () => useCustomAssetFilter(types),
-  defaultSortBy: {
-    key: ['name'],
-    ascending: [false],
-  },
+  defaultSortBy: [{
+    column: 'name',
+    direction: 'desc',
+  }],
 });
 
 const dialogTitle = computed<string>(() =>

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetContent.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { isEqual, keyBy } from 'lodash-es';
 import type { Nullable, SupportedAsset } from '@rotki/common';
-import type { Collection } from '@/types/collection';
 import type { AssetRequestPayload, IgnoredAssetsHandlingType } from '@/types/asset';
 import type { Filters, Matcher } from '@/composables/filters/assets';
 
@@ -27,6 +26,8 @@ const ignoredFilter = ref<{
   onlyShowWhitelisted: false,
   ignoredAssetsHandling: 'exclude',
 });
+
+const { expanded, selected, editableItem } = useCommonTableProps<SupportedAsset>();
 
 const extraParams = computed(() => {
   const { ignoredAssetsHandling, onlyShowOwned, onlyShowWhitelisted } = get(ignoredFilter);
@@ -55,11 +56,8 @@ async function confirmDelete(toDeleteAsset: SupportedAsset) {
 const {
   filters,
   matchers,
-  expanded,
-  selected,
   state: assets,
   isLoading: loading,
-  editableItem,
   fetchData,
   setPage,
   sort,
@@ -67,8 +65,6 @@ const {
 } = usePaginationFilters<
   SupportedAsset,
   AssetRequestPayload,
-  SupportedAsset,
-  Collection<SupportedAsset>,
   Filters,
   Matcher
 >(queryAllAssets, {
@@ -83,8 +79,8 @@ const {
   },
   extraParams,
   defaultSortBy: {
-    key: 'symbol',
-    ascending: [true],
+    column: 'symbol',
+    direction: 'asc',
   },
 });
 

--- a/frontend/app/src/components/calendar/CalendarView.vue
+++ b/frontend/app/src/components/calendar/CalendarView.vue
@@ -28,12 +28,12 @@ const extraParams = computed(() => {
 });
 
 const { getAccountByAddress } = useBlockchainStore();
+const { editableItem } = useCommonTableProps<CalendarEvent>();
 
 const {
   state: events,
   isLoading,
   fetchData,
-  editableItem,
 } = usePaginationFilters<
   CalendarEvent,
   CalendarEventRequestPayload
@@ -52,11 +52,10 @@ const {
     }
   },
   defaultSortBy: {
-    key: ['timestamp'],
-    ascending: [true],
+    direction: 'asc',
   },
   extraParams,
-  customPageParams: computed<Partial<CalendarEventRequestPayload>>(() => {
+  requestParams: computed<Partial<CalendarEventRequestPayload>>(() => {
     const params: Writeable<Partial<CalendarEventRequestPayload>> = {};
     const accountsVal = get(accounts);
 

--- a/frontend/app/src/components/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/components/dashboard/NftBalanceTable.vue
@@ -35,10 +35,10 @@ const {
   NonFungibleBalancesRequestPayload
 >(fetchNonFungibleBalances, {
   extraParams,
-  defaultSortBy: {
-    key: ['usdPrice'],
-    ascending: [false],
-  },
+  defaultSortBy: [{
+    column: 'usdPrice',
+    direction: 'desc',
+  }],
 });
 
 const { isLoading: isSectionLoading } = useStatusStore();

--- a/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
+++ b/frontend/app/src/components/history/deposits-withdrawals/DepositsWithdrawalsContent.vue
@@ -2,8 +2,7 @@
 import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
-import type { AssetMovement, AssetMovementEntry, AssetMovementRequestPayload } from '@/types/history/asset-movements';
-import type { Collection } from '@/types/collection';
+import type { AssetMovementEntry, AssetMovementRequestPayload } from '@/types/history/asset-movements';
 import type { Filters, Matcher } from '@/composables/filters/asset-movement';
 import type { Writeable } from '@rotki/common';
 import type { DataTableColumn } from '@rotki/ui-library';
@@ -85,10 +84,9 @@ const extraParams = computed(() => ({
 }));
 
 const { fetchAssetMovements, refreshAssetMovements } = useAssetMovements();
+const { selected, expanded } = useCommonTableProps<AssetMovementEntry>();
 
 const {
-  selected,
-  expanded,
   isLoading,
   state: assetMovements,
   filters,
@@ -98,10 +96,8 @@ const {
   pagination,
   fetchData,
 } = usePaginationFilters<
-  AssetMovement,
-  AssetMovementRequestPayload,
   AssetMovementEntry,
-  Collection<AssetMovementEntry>,
+  AssetMovementRequestPayload,
   Filters,
   Matcher
 >(fetchAssetMovements, {
@@ -111,7 +107,7 @@ const {
   onUpdateFilters(query) {
     set(showIgnoredAssets, query.excludeIgnoredAssets === 'false');
   },
-  customPageParams: computed<Partial<AssetMovementRequestPayload>>(() => {
+  requestParams: computed<Partial<AssetMovementRequestPayload>>(() => {
     const params: Writeable<Partial<AssetMovementRequestPayload>> = {};
     const location = get(locationOverview);
 

--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -13,7 +13,6 @@ import type {
   ShowEventHistoryForm,
 } from '@/types/history/events';
 import type { AddressData, BlockchainAccount } from '@/types/blockchain/accounts';
-import type { Collection } from '@/types/collection';
 import type { AccountingRuleEntry } from '@/types/settings/accounting';
 import type { Filters, Matcher } from '@/composables/filters/events';
 
@@ -125,6 +124,8 @@ const includes = computed<{ evmEvents: boolean; onlineEvents: boolean }>(() => {
   };
 });
 
+const { editableItem } = useCommonTableProps<HistoryEventEntry>();
+
 const {
   isLoading: groupLoading,
   userAction,
@@ -135,14 +136,11 @@ const {
   updateFilter,
   fetchData,
   pageParams,
-  editableItem,
   pagination,
   sort,
 } = usePaginationFilters<
-  HistoryEvent,
-  HistoryEventRequestPayload,
   HistoryEventEntry,
-  Collection<HistoryEventEntry>,
+  HistoryEventRequestPayload,
   Filters,
   Matcher
 >(fetchHistoryEvents, {
@@ -178,7 +176,7 @@ const {
     }
     return undefined;
   }),
-  customPageParams: computed<Partial<HistoryEventRequestPayload>>(() => {
+  requestParams: computed<Partial<HistoryEventRequestPayload>>(() => {
     const params: Writeable<Partial<HistoryEventRequestPayload>> = {
       counterparties: get(protocols),
       eventTypes: get(eventTypes),

--- a/frontend/app/src/components/history/trades/ClosedTrades.vue
+++ b/frontend/app/src/components/history/trades/ClosedTrades.vue
@@ -4,8 +4,7 @@ import { Section } from '@/types/status';
 import { IgnoreActionType } from '@/types/history/ignored';
 import { SavedFilterLocation } from '@/types/filtering';
 import type { Writeable } from '@rotki/common';
-import type { Trade, TradeEntry, TradeRequestPayload } from '@/types/history/trade';
-import type { Collection } from '@/types/collection';
+import type { TradeEntry, TradeRequestPayload } from '@/types/history/trade';
 import type { Filters, Matcher } from '@/composables/filters/trades';
 import type { DataTableColumn } from '@rotki/ui-library';
 
@@ -109,15 +108,10 @@ const extraParams = computed(() => ({
 
 const assetInfoRetrievalStore = useAssetInfoRetrieval();
 const { assetSymbol } = assetInfoRetrievalStore;
-
 const { deleteExternalTrade, fetchTrades, refreshTrades } = useTrades();
+const { selected, editableItem, itemsToDelete: tradesToDelete, confirmationMessage, expanded } = useCommonTableProps<TradeEntry>();
 
 const {
-  selected,
-  editableItem,
-  itemsToDelete: tradesToDelete,
-  confirmationMessage,
-  expanded,
   isLoading,
   state: trades,
   filters,
@@ -127,10 +121,8 @@ const {
   sort,
   fetchData,
 } = usePaginationFilters<
-  Trade,
-  TradeRequestPayload,
   TradeEntry,
-  Collection<TradeEntry>,
+  TradeRequestPayload,
   Filters,
   Matcher
 >(fetchTrades, {
@@ -141,7 +133,7 @@ const {
     set(hideIgnoredTrades, query.includeIgnoredTrades === 'false');
     set(showIgnoredAssets, query.excludeIgnoredAssets === 'false');
   },
-  customPageParams: computed<Partial<TradeRequestPayload>>(() => {
+  requestParams: computed<Partial<TradeRequestPayload>>(() => {
     const params: Writeable<Partial<TradeRequestPayload>> = {};
     const location = get(locationOverview);
 

--- a/frontend/app/src/components/notes/UserNotesList.vue
+++ b/frontend/app/src/components/notes/UserNotesList.vue
@@ -39,10 +39,13 @@ const {
   fetchData,
   pagination,
 } = usePaginationFilters<UserNote, UserNotesRequestPayload>(fetchUserNotes, {
-  defaultSortBy: {
-    key: ['isPinned', 'lastUpdateTimestamp'],
-    ascending: [false, false],
-  },
+  defaultSortBy: [{
+    column: 'isPinned',
+    direction: 'desc',
+  }, {
+    column: 'lastUpdateTimestamp',
+    direction: 'desc',
+  }],
   extraParams,
 });
 

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleSetting.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { TaskType } from '@/types/task-type';
 import type { DataTableColumn } from '@rotki/ui-library';
-import type { Collection } from '@/types/collection';
 import type { Filters, Matcher } from '@/composables/filters/accounting-rule';
 import type { AccountingRuleEntry, AccountingRuleRequestPayload } from '@/types/settings/accounting';
 
@@ -10,6 +9,7 @@ const router = useRouter();
 const route = useRoute();
 
 const { getAccountingRule, getAccountingRules, getAccountingRulesConflicts, exportJSON } = useAccountingSettings();
+const { editableItem } = useCommonTableProps<AccountingRuleEntry>();
 
 const {
   state,
@@ -20,12 +20,9 @@ const {
   pagination,
   matchers,
   updateFilter,
-  editableItem,
 } = usePaginationFilters<
   AccountingRuleEntry,
   AccountingRuleRequestPayload,
-  AccountingRuleEntry,
-  Collection<AccountingRuleEntry>,
   Filters,
   Matcher
 >(getAccountingRules, {

--- a/frontend/app/src/composables/filters/accounting-rule.ts
+++ b/frontend/app/src/composables/filters/accounting-rule.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/types/filtering';
 
 enum AccountingRuleFilterKeys {

--- a/frontend/app/src/composables/filters/address-book.ts
+++ b/frontend/app/src/composables/filters/address-book.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { MatchedKeyword, SearchMatcher } from '@/types/filtering';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum AddressBookFilterKeys {
   NAME = 'name',

--- a/frontend/app/src/composables/filters/asset-movement.ts
+++ b/frontend/app/src/composables/filters/asset-movement.ts
@@ -9,7 +9,7 @@ import {
   dateValidator,
 } from '@/types/filtering';
 import { MovementCategory } from '@/types/history/asset-movements';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum AssetMovementFilterKeys {
   LOCATION = 'location',

--- a/frontend/app/src/composables/filters/assets.ts
+++ b/frontend/app/src/composables/filters/assets.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { MatchedKeyword, SearchMatcher } from '@/types/filtering';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum AssetFilterKeys {
   SYMBOL = 'symbol',

--- a/frontend/app/src/composables/filters/blockchain-account.ts
+++ b/frontend/app/src/composables/filters/blockchain-account.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { CommaSeparatedStringSchema, RouterExpandedIdsSchema } from '@/types/route';
 import type { MaybeRef } from '@vueuse/core';
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/types/filtering';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum BlockchainAccountFilterKeys {
   ADDRESS = 'address',

--- a/frontend/app/src/composables/filters/custom-assets.ts
+++ b/frontend/app/src/composables/filters/custom-assets.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { MaybeRef } from '@vueuse/core';
 import type { MatchedKeyword, SearchMatcher } from '@/types/filtering';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum CustomAssetFilterKeys {
   NAME = 'name',

--- a/frontend/app/src/composables/filters/eth-validator.ts
+++ b/frontend/app/src/composables/filters/eth-validator.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/types/filtering';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum EthValidatorAccountFilterKeys {
   INDEX = 'validator_index',

--- a/frontend/app/src/composables/filters/events.ts
+++ b/frontend/app/src/composables/filters/events.ts
@@ -11,7 +11,7 @@ import {
   dateValidator,
 } from '@/types/filtering';
 import type { MaybeRef } from '@vueuse/core';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum HistoryEventFilterKeys {
   START = 'start',

--- a/frontend/app/src/composables/filters/index.ts
+++ b/frontend/app/src/composables/filters/index.ts
@@ -1,8 +1,0 @@
-import type { FilterSchema } from '@/composables/filter-paginate';
-
-export function useEmptyFilter<F extends NonNullable<unknown> | void, M>(): FilterSchema<F | undefined, M> {
-  return {
-    filters: ref(),
-    matchers: computed<M[]>(() => []),
-  };
-}

--- a/frontend/app/src/composables/filters/kraken-staking.ts
+++ b/frontend/app/src/composables/filters/kraken-staking.ts
@@ -1,5 +1,5 @@
 import { type MatchedKeyword, type SearchMatcher, assetSuggestions } from '@/types/filtering';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum KrakenStakingKeys {
   TYPE = 'type',

--- a/frontend/app/src/composables/filters/manual-balances.ts
+++ b/frontend/app/src/composables/filters/manual-balances.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { type MatchedKeyword, type SearchMatcher, assetDeserializer, assetSuggestions } from '@/types/filtering';
 import { CommaSeparatedStringSchema } from '@/types/route';
 import type { MaybeRef } from '@vueuse/core';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum ManualBalanceFilterKeys {
   LOCATION = 'location',

--- a/frontend/app/src/composables/filters/saved.ts
+++ b/frontend/app/src/composables/filters/saved.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from '@vueuse/core';
 import type { BaseSuggestion, SavedFilterLocation, Suggestion } from '@/types/filtering';
 import type { ActionStatus } from '@/types/action';
+import type { ComputedRef } from 'vue';
 
 const LIMIT_PER_LOCATION = 10;
 

--- a/frontend/app/src/composables/filters/trades.ts
+++ b/frontend/app/src/composables/filters/trades.ts
@@ -9,7 +9,7 @@ import {
   dateValidator,
 } from '@/types/filtering';
 import { TradeType } from '@/types/history/trade';
-import type { FilterSchema } from '@/composables/filter-paginate';
+import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 
 enum TradeFilterKeys {
   BASE = 'base',

--- a/frontend/app/src/composables/use-common-table-props/index.ts
+++ b/frontend/app/src/composables/use-common-table-props/index.ts
@@ -1,0 +1,28 @@
+import type { Ref } from 'vue';
+
+interface UseCommonTablePropsReturn< V extends NonNullable<unknown>> {
+  selected: Ref<V[]>;
+  openDialog: Ref<boolean>;
+  editableItem: Ref<V | undefined>;
+  itemsToDelete: Ref<V[]>;
+  confirmationMessage: Ref<string>;
+  expanded: Ref<V[]>;
+}
+
+export function useCommonTableProps<V extends NonNullable<unknown>>(): UseCommonTablePropsReturn<V> {
+  const selected = ref<V[]>([]) as Ref<V[]>;
+  const openDialog = ref<boolean>(false);
+  const editableItem = ref<V>();
+  const itemsToDelete = ref<V[]>([]) as Ref<V[]>;
+  const confirmationMessage = ref<string>('');
+  const expanded = ref<V[]>([]) as Ref<V[]>;
+
+  return {
+    selected,
+    openDialog,
+    editableItem,
+    itemsToDelete,
+    confirmationMessage,
+    expanded,
+  };
+}

--- a/frontend/app/src/composables/use-pagination-filter/types.ts
+++ b/frontend/app/src/composables/use-pagination-filter/types.ts
@@ -1,0 +1,15 @@
+import type { DataTableSortColumn } from '@rotki/ui-library';
+import type { ComputedRef, Ref } from 'vue';
+import type { ZodSchema } from 'zod';
+
+export type TableRowKey<T> = keyof T extends string ? keyof T : never;
+
+export type SingleColumnSorting<T extends NonNullable<unknown>> = Required<DataTableSortColumn<T>>;
+
+export type Sorting<T extends NonNullable<unknown>> = SingleColumnSorting<T> | SingleColumnSorting<T>[];
+
+export interface FilterSchema<F, M> {
+  filters: Ref<F>;
+  matchers: ComputedRef<M[]>;
+  RouteFilterSchema?: ZodSchema;
+}

--- a/frontend/app/src/composables/use-pagination-filter/utils.ts
+++ b/frontend/app/src/composables/use-pagination-filter/utils.ts
@@ -1,0 +1,111 @@
+import { HistoryPaginationSchema, HistorySortOrderSchema, type LocationQuery } from '@/types/route';
+import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { SingleColumnSorting, Sorting, TableRowKey } from '@/composables/use-pagination-filter/types';
+
+function getSorting<T extends NonNullable<unknown>>(
+  sorting: { column?: string; direction?: 'asc' | 'desc' },
+): SingleColumnSorting<T> {
+  const {
+    column = 'timestamp',
+    direction = 'desc',
+  } = sorting;
+  return {
+    column: column as TableRowKey<T>,
+    direction,
+  };
+}
+
+export function parseQueryHistory<T extends NonNullable<unknown>>(query: LocationQuery, defaults: Sorting<T>): Sorting<T> {
+  const singleSort = !Array.isArray(defaults);
+  const sorting = HistorySortOrderSchema.parse(query);
+
+  const sort = sorting.sort;
+  const order = sorting.sortOrder;
+  if (!sort && !order) {
+    return defaults;
+  }
+
+  if (singleSort) {
+    return getSorting({
+      column: sort?.[0],
+      direction: order?.[0],
+    });
+  }
+  else {
+    const length = sort?.length || order?.length || 0;
+    const sorting: SingleColumnSorting<T>[] = [];
+
+    for (let i = 0; i < length; i++) {
+      sorting.push(getSorting({
+        column: sort?.[i],
+        direction: order?.[i],
+      }));
+    }
+
+    return sorting;
+  }
+}
+
+export function parseQueryPagination(query: LocationQuery, pagination: TablePaginationData): TablePaginationData {
+  const { page, limit } = HistoryPaginationSchema.parse(query);
+
+  return {
+    ...pagination,
+    ...(page ? { page } : {}),
+    ...(limit ? { limit } : {}),
+  } satisfies TablePaginationData;
+}
+
+export function applySortingDefaults<T extends NonNullable<unknown>>(sorting: DataTableSortData<T>): Sorting<T> {
+  const defaultColumn = 'timestamp' as TableRowKey<T>;
+  const defaultDirection = 'desc';
+  if (!sorting) {
+    return {
+      column: defaultColumn,
+      direction: defaultDirection,
+    };
+  }
+  else if (Array.isArray(sorting)) {
+    return sorting.map(item => ({
+      column: item.column ?? defaultColumn,
+      direction: item.direction,
+    }));
+  }
+  else {
+    return {
+      column: sorting.column ?? defaultColumn,
+      direction: sorting.direction,
+    };
+  }
+}
+
+export function applyPaginationDefaults(limit: number): TablePaginationData {
+  return {
+    page: 1,
+    limit,
+    total: -1,
+  };
+}
+
+export function getApiSortingParams<T extends NonNullable<unknown>>(sorting: Sorting<T>): { orderByAttributes: string[]; ascending: boolean[] } {
+  if (Array.isArray(sorting)) {
+    if (sorting.length === 0) {
+      return {
+        orderByAttributes: ['timestamp'],
+        ascending: [false],
+      };
+    }
+    else {
+      return {
+        orderByAttributes: sorting.map(item => transformCase(item.column)),
+        ascending: sorting.map(item => item.direction === 'asc'),
+      };
+    }
+  }
+  else {
+    return {
+      orderByAttributes: [transformCase(sorting.column)],
+      ascending: [sorting.direction === 'asc'],
+    };
+  }
+}

--- a/frontend/app/src/types/pagination.ts
+++ b/frontend/app/src/types/pagination.ts
@@ -1,7 +1,0 @@
-export interface TablePagination<T> {
-  page: number;
-  itemsPerPage: number;
-  sortBy: (keyof T)[];
-  sortDesc: boolean[];
-  singleSort: boolean;
-}

--- a/frontend/app/src/types/route.ts
+++ b/frontend/app/src/types/route.ts
@@ -14,33 +14,33 @@ export const RouterExpandedIdsSchema = z.object({
   expanded: CommaSeparatedStringSchema,
 });
 
-export const RouterPaginationOptionsSchema = z.object({
-  itemsPerPage: z
-    .string()
-    .transform(val => parseInt(val))
-    .optional(),
-  page: z
-    .string()
-    .transform(val => parseInt(val))
-    .optional(),
-  sortBy: z
-    .array(z.string())
+const SortOrderSchema = z.enum(['asc', 'desc']);
+
+export const HistorySortOrderSchema = z.object({
+  sort: z.array(z.string())
     .or(z.string())
     .transform(arrayify)
     .optional(),
-  sortDesc: z
-    .array(z.string())
-    .or(z.string())
-    .transform((val) => {
-      const arr = arrayify(val);
-      return arr.map(entry => entry === 'true');
-    })
+  sortOrder: z.array(SortOrderSchema)
+    .or(SortOrderSchema)
+    .transform(arrayify)
     .optional(),
 });
 
+export const HistoryPaginationSchema = z.object({
+  limit: z.coerce
+    .number()
+    .min(1)
+    .optional(),
+  page: z.coerce
+    .number()
+    .min(1)
+    .optional()
+    .default(1),
+});
+
 export const RouterAccountsSchema = z.object({
-  accounts: z
-    .array(z.string())
+  accounts: z.array(z.string())
     .or(z.string())
     .transform((val) => {
       const arr = arrayify(val);

--- a/frontend/app/src/utils/collection.ts
+++ b/frontend/app/src/utils/collection.ts
@@ -1,6 +1,6 @@
 import type { BigNumber } from '@rotki/common';
 import type { Collection, CollectionResponse } from '@/types/collection';
-import type { TablePagination } from '@/types/pagination';
+import type { ComputedRef, Ref } from 'vue';
 
 type Entries = 'entries' | 'entriesFound' | 'entriesLimit' | 'entriesTotal';
 
@@ -86,20 +86,5 @@ export function setupEntryLimit(
   return {
     itemLength,
     showUpgradeRow,
-  };
-}
-
-export function defaultOptions<T extends NonNullable<unknown>>(defaultSortBy?: {
-  key?: keyof T | (keyof T)[];
-  ascending?: boolean[];
-}): TablePagination<T> {
-  const { itemsPerPage } = useFrontendSettingsStore();
-  const sortByKey = defaultSortBy?.key;
-  return {
-    page: 1,
-    itemsPerPage,
-    sortBy: arrayify(sortByKey || 'timestamp' as keyof T),
-    sortDesc: defaultSortBy?.ascending ? defaultSortBy?.ascending.map(bool => !bool) : [true],
-    singleSort: sortByKey ? !Array.isArray(sortByKey) : false,
   };
 }

--- a/frontend/app/tests/e2e/pages/history-page/trade-history-page.ts
+++ b/frontend/app/tests/e2e/pages/history-page/trade-history-page.ts
@@ -142,4 +142,8 @@ export class TradeHistoryPage {
       range,
     );
   }
+
+  sortByColumn(number: number) {
+    cy.get('[data-cy=closed-trades] thead th').eq(number).click();
+  }
 }

--- a/frontend/app/tests/e2e/pages/rotki-app.ts
+++ b/frontend/app/tests/e2e/pages/rotki-app.ts
@@ -157,19 +157,21 @@ export class RotkiApp {
   shouldHaveQueryParam(key: string, value: string) {
     cy.location().should((loc) => {
       const query = new URLSearchParams(loc.href);
-      expect(query.get(key)).to.equal(value);
+      expect(query.get(key), `query key ${key}`).to.equal(value);
     });
   }
 
   /**
-   * to get array query param values from route
-   * @param {string} key
-   * @param {string[]} values
+   * Asserts that the current URL does not have the specified query parameter.
+   *
+   * @param {string} key - The query parameter key to check.
+   * @return {void}
    */
-  shouldHaveQueryParams(key: string, values: string[]) {
+  shouldNotHaveQueryParam(key: string): void {
     cy.location().should((loc) => {
       const query = new URLSearchParams(loc.href);
-      expect(query.getAll(key)).to.deep.equal(values);
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(query.get(key), `query key ${key}`).to.be.null;
     });
   }
 

--- a/frontend/app/tests/e2e/specs/history/trade-history.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/trade-history.spec.ts
@@ -86,19 +86,20 @@ describe('trade history', () => {
     tradeHistoryPage.visibleEntries(10);
     tradeHistoryPage.totalEntries(24);
     tradeHistoryPage.shouldBeOnPage('1 - 10');
+    app.shouldNotHaveQueryParam('page');
 
     // go to page 2
     tradeHistoryPage.nextPage();
     tradeHistoryPage.shouldBeOnPage('11 - 20');
     app.shouldHaveQueryParam('page', '2');
-    app.shouldHaveQueryParams('sortBy', ['timestamp']);
+    app.shouldNotHaveQueryParam('sort');
 
     // apply filter location
     tradeHistoryPage.filterTrades('location: equities');
     tradeHistoryPage.visibleEntries(10);
     tradeHistoryPage.totalEntries(12);
     tradeHistoryPage.shouldBeOnPage('1 - 10');
-    app.shouldHaveQueryParam('page', '1');
+    app.shouldNotHaveQueryParam('page');
 
     // go to page 2
     tradeHistoryPage.nextPage();
@@ -110,7 +111,7 @@ describe('trade history', () => {
     cy.go(-1);
     tradeHistoryPage.shouldBeOnPage('1 - 10');
     tradeHistoryPage.visibleEntries(10);
-    app.shouldHaveQueryParam('page', '1');
+    app.shouldNotHaveQueryParam('page');
 
     // history back, should remove filter
     cy.go(-1);
@@ -120,7 +121,11 @@ describe('trade history', () => {
     // history forward, should reapply location filter
     cy.go(1);
     tradeHistoryPage.totalEntries(12);
-    app.shouldHaveQueryParam('page', '1');
+    app.shouldNotHaveQueryParam('page');
+
+    tradeHistoryPage.sortByColumn(4);
+    app.shouldHaveQueryParam('sort', 'amount');
+    app.shouldHaveQueryParam('sortOrder', 'asc');
 
     app.logout();
   });

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
@@ -70,34 +70,31 @@ describe('composables::history/filter-paginate', () => {
         sort,
         state,
         fetchData,
-        applyRouteFilter,
         isLoading,
       } = usePaginationFilters<NonFungibleBalance>(fetchNonFungibleBalances, {
         history: get(mainPage) ? 'router' : false,
         locationOverview,
         onUpdateFilters,
         extraParams,
-        defaultSortBy: {
-          key: ['name'],
-          ascending: [true],
-        },
+        defaultSortBy: [{
+          column: 'name',
+          direction: 'asc',
+        }],
       });
 
-      expect(get(userAction)).toBe(true);
+      expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
       expect(get(filters)).to.toStrictEqual(undefined);
       expect(get(sort)).toHaveLength(1);
-      expect(get(sort)).toMatchObject([
-        {
-          column: 'name',
-          direction: 'asc',
-        },
-      ]);
+      expect(get(sort)).toMatchObject([{
+        column: 'name',
+        direction: 'asc',
+      }]);
       expect(get(state).data).toHaveLength(0);
       expect(get(state).total).toEqual(0);
 
       set(userAction, true);
-      applyRouteFilter();
+      await nextTick();
       fetchData().catch(() => {});
       expect(get(isLoading)).toBe(true);
       await flushPromises();
@@ -115,10 +112,12 @@ describe('composables::history/filter-paginate', () => {
         locationOverview,
         onUpdateFilters,
         extraParams,
-        defaultSortBy: {
-          key: ['name'],
-          ascending: [true],
-        },
+        defaultSortBy: [
+          {
+            column: 'name',
+            direction: 'asc',
+          },
+        ],
       });
 
       expect(get(isLoading)).toBe(false);
@@ -132,21 +131,27 @@ describe('composables::history/filter-paginate', () => {
 
     it('modify filters and fetch data correctly', async () => {
       const pushSpy = vi.spyOn(router, 'push');
-      const query = { sortDesc: ['false'] };
+      const query = { sortOrder: ['asc'] };
 
       const {
         isLoading,
         state,
+        sort,
       } = usePaginationFilters<NonFungibleBalance>(fetchNonFungibleBalances, {
         history: get(mainPage) ? 'router' : false,
         locationOverview,
         onUpdateFilters,
         extraParams,
-        defaultSortBy: {
-          key: ['name'],
-          ascending: [false],
-        },
+        defaultSortBy: [{
+          column: 'name',
+          direction: 'desc',
+        }],
       });
+
+      expect(get(sort)).toStrictEqual([{
+        column: 'name',
+        direction: 'desc',
+      }]);
 
       await router.push({
         query,
@@ -166,6 +171,10 @@ describe('composables::history/filter-paginate', () => {
       expect(get(state).data).toHaveLength(9);
       expect(get(state).found).toEqual(29);
       expect(get(state).total).toEqual(30);
+      expect(get(sort)).toStrictEqual([{
+        column: 'timestamp',
+        direction: 'asc',
+      }]);
     });
   });
 });

--- a/frontend/app/tests/unit/specs/composables/assets/filter-paginate-assets.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/assets/filter-paginate-assets.spec.ts
@@ -54,36 +54,33 @@ describe('composables::assets/filter-paginate', () => {
     });
 
     it('initialize composable correctly', async () => {
-      const { userAction, filters, sort, state, fetchData, applyRouteFilter, isLoading } = usePaginationFilters<
+      const { userAction, filters, sort, state, fetchData, isLoading } = usePaginationFilters<
         SupportedAsset,
         AssetRequestPayload,
-        SupportedAsset,
-        Collection<SupportedAsset>,
         Filters,
         Matcher
       >(fetchAssets, {
         history: get(mainPage) ? 'router' : false,
         filterSchema: useAssetFilter,
         locationOverview,
-        defaultSortBy: {
-          key: 'symbol',
-          ascending: [true],
-        },
+        defaultSortBy: [{
+          column: 'symbol',
+          direction: 'asc',
+        }],
       });
 
-      expect(get(userAction)).toBe(true);
+      expect(get(userAction)).toBe(false);
       expect(get(isLoading)).toBe(false);
-      expect(get(filters)).to.toStrictEqual({});
-      expect(Array.isArray(get(sort))).toBe(false);
-      expect(get(sort)).toMatchObject({
+      expect(get(filters)).toStrictEqual({});
+      expect(get(sort)).toStrictEqual([{
         column: 'symbol',
         direction: 'asc',
-      });
+      }]);
       expect(get(state).data).toHaveLength(0);
       expect(get(state).total).toEqual(0);
 
       set(userAction, true);
-      applyRouteFilter();
+      await nextTick();
       fetchData().catch(() => {});
       expect(get(isLoading)).toBe(true);
       await flushPromises();
@@ -96,8 +93,6 @@ describe('composables::assets/filter-paginate', () => {
       const { isLoading, state, filters, matchers } = usePaginationFilters<
         SupportedAsset,
         AssetRequestPayload,
-        SupportedAsset,
-        Collection<SupportedAsset>,
         Filters,
         Matcher
       >(fetchAssets, {
@@ -117,20 +112,27 @@ describe('composables::assets/filter-paginate', () => {
 
     it('modify filters and fetch data correctly', async () => {
       const pushSpy = vi.spyOn(router, 'push');
-      const query = { sortBy: ['category'], sortDesc: ['true'] };
+      const query = { sort: ['category'], sortOrder: ['desc'] };
 
-      const { isLoading, state } = usePaginationFilters<
+      const { isLoading, state, sort } = usePaginationFilters<
         SupportedAsset,
         AssetRequestPayload,
-        SupportedAsset,
-        Collection<SupportedAsset>,
         Filters,
         Matcher
       >(fetchAssets, {
         history: get(mainPage) ? 'router' : false,
         filterSchema: useAssetFilter,
         locationOverview,
+        defaultSortBy: [{
+          column: 'symbol',
+          direction: 'asc',
+        }],
       });
+
+      expect(get(sort)).toStrictEqual([{
+        column: 'symbol',
+        direction: 'asc',
+      }]);
 
       await router.push({
         query,
@@ -151,6 +153,11 @@ describe('composables::assets/filter-paginate', () => {
       expect(get(state).found).toEqual(210);
       expect(get(state).limit).toEqual(-1);
       expect(get(state).total).toEqual(210);
+
+      expect(get(sort)).toStrictEqual([{
+        column: 'category',
+        direction: 'desc',
+      }]);
     });
   });
 });


### PR DESCRIPTION
Also splits state unrelated to history to a new composable

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
