### PR TITLE
Ensure that requests doesn't block

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ web3==6.20.1
 content-hash==2.0.0
 rotki-pysqlcipher3==2024.1.2
 requests==2.32.3
+grequests==0.7.0
 urllib3==2.2.3
 coincurve==20.0.0
 base58check==1.0.2

--- a/rotkehlchen/__main__.py
+++ b/rotkehlchen/__main__.py
@@ -1,8 +1,14 @@
-from gevent import monkey  # isort:skip
+from gevent import monkey
+
 monkey.patch_all()  # isort:skip
+
 import logging
 import sys
 import traceback
+
+# import grequests to ensure that it doesn't get imported after requests
+import grequests  # noqa: F401
+import requests  # noqa: F401
 
 from rotkehlchen.errors.misc import DBSchemaError, SystemPermissionError
 from rotkehlchen.logging import RotkehlchenLogsAdapter

--- a/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Literal, overload
 
+import grequests
 import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
@@ -44,7 +45,7 @@ class BeaconNode:
         May raise:
         - RemoteError if we can't connect to the given rpc endpoint
         """
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.set_rpc_endpoint(rpc_endpoint)
 
     def set_rpc_endpoint(self, rpc_endpoint: str) -> None:

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -8,6 +8,7 @@ from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
+import grequests
 import requests
 from ens import ENS
 from eth_abi.exceptions import DecodingError
@@ -372,6 +373,7 @@ class EvmNodeInquirer(ABC, LockableQueryMixIn):
         provider = HTTPProvider(
             endpoint_uri=node.endpoint,
             request_kwargs={'timeout': self.rpc_timeout},
+            session=grequests.Session(),
         )
         ens = ENS(provider) if self.chain_id == ChainID.ETHEREUM else None
         web3 = Web3(provider, ens=ens)

--- a/rotkehlchen/externalapis/beaconchain/service.py
+++ b/rotkehlchen/externalapis/beaconchain/service.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import urlencode
 
 import gevent
+import grequests
 import requests
 from gevent.lock import Semaphore
 
@@ -52,7 +53,7 @@ class BeaconChain(ExternalServiceWithApiKey):
     def __init__(self, database: 'DBHandler', msg_aggregator: MessagesAggregator) -> None:
         super().__init__(database=database, service_name=ExternalService.BEACONCHAIN)
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.warning_given = False
         set_user_agent(self.session)
         self.url = f'{BEACONCHAIN_ROOT_URL}/api/v1/'

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -4,6 +4,7 @@ from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import gevent
+import grequests
 import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
@@ -51,7 +52,7 @@ class Blockscout(ExternalServiceWithApiKey):
             service_name={v: k for k, v in BLOCKSCOUT_TO_CHAINID.items()}[self.chain_id],
         )
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = grequests.Session()
         set_user_agent(self.session)
         match blockchain:
             case SupportedBlockchain.ETHEREUM:

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -3,6 +3,7 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
+import grequests
 import requests
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -526,7 +527,7 @@ class Coingecko(
         ExternalServiceWithApiKeyOptionalDB.__init__(self, database=database, service_name=ExternalService.COINGECKO)  # noqa: E501
         HistoricalPriceOracleWithCoinListInterface.__init__(self, oracle_name='coingecko')
         PenalizablePriceOracleMixin.__init__(self)
-        self.session = requests.session()
+        self.session = grequests.Session()
         set_user_agent(self.session)
         self.last_rate_limit = 0
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias
 
+import grequests
 import requests
 
 from rotkehlchen.db.settings import CachedSettings
@@ -38,7 +39,7 @@ class CowswapAPI:
 
     def __init__(self, database: 'DBHandler', chain: SUPPORTED_COWSWAP_BLOCKCHAIN) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.api_url = f'https://api.cow.fi/{CHAIN_MAPPING[chain]}/api/v1'
 
     def _query(self, endpoint: str) -> dict[str, Any]:

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -4,6 +4,7 @@ from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import gevent
+import grequests
 import requests
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -203,7 +204,7 @@ class Cryptocompare(
             service_name=ExternalService.CRYPTOCOMPARE,
         )
         PenalizablePriceOracleMixin.__init__(self)
-        self.session = requests.session()
+        self.session = grequests.Session()
         set_user_agent(self.session)
         self.last_histohour_query_ts = 0
         self.last_rate_limit = 0

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -3,6 +3,7 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
+import grequests
 import requests
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -50,7 +51,7 @@ class Defillama(
         )
         HistoricalPriceOracleInterface.__init__(self, oracle_name='defillama')
         PenalizablePriceOracleMixin.__init__(self)
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
         self.last_rate_limit = 0
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -9,6 +9,7 @@ from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Final, Literal, overload
 
 import gevent
+import grequests
 import requests
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
@@ -118,7 +119,7 @@ class Etherscan(ExternalServiceWithApiKey, ABC):
             SupportedBlockchain.SCROLL,
         ) else 'api-'
         self.base_url = base_url
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.warning_given = False
         set_user_agent(self.session)
         self.timestamp_to_block_cache: LRUCacheWithRemove[Timestamp, int] = LRUCacheWithRemove(maxsize=32)  # noqa: E501

--- a/rotkehlchen/externalapis/gnosispay.py
+++ b/rotkehlchen/externalapis/gnosispay.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal
 
+import grequests
 import requests
 
 from rotkehlchen.assets.asset import AssetWithSymbol
@@ -78,7 +79,7 @@ class GnosisPay:
 
     def __init__(self, database: 'DBHandler', session_token: str) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.session_token = session_token
         set_user_agent(self.session)
 

--- a/rotkehlchen/externalapis/monerium.py
+++ b/rotkehlchen/externalapis/monerium.py
@@ -2,6 +2,7 @@ import logging
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal
 
+import grequests
 import requests
 
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
@@ -32,7 +33,7 @@ class Monerium:
 
     def __init__(self, database: 'DBHandler', user: str, password: str) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.user = user
         self.password = password
         set_user_agent(self.session)

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -5,6 +5,7 @@ from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
 
 import gevent
+import grequests
 import requests
 from eth_utils import to_checksum_address
 
@@ -139,7 +140,7 @@ class Opensea(ExternalServiceWithApiKey):
     ) -> None:
         super().__init__(database=database, service_name=ExternalService.OPENSEA)
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = grequests.Session()
         self.session.headers.update({
             'Content-Type': 'application/json',
         })


### PR DESCRIPTION
As per https://docs.python-requests.org/en/latest/user/advanced/#blocking-or-non-blocking it seems that requests always blocks and gevent doesn't patch it. This PR adds grequests that is made by the requests team to work with gevent.

With this changes I managed to not have any 30000ms error while adding a new address and I was able to work at all the time with the app.
