### PR TITLE
test: change createAccount command to an async query

### DIFF
--- a/frontend/app/tests/e2e/pages/account-balances-page/blockchain-balances-page.ts
+++ b/frontend/app/tests/e2e/pages/account-balances-page/blockchain-balances-page.ts
@@ -24,6 +24,24 @@ export class BlockchainBalancesPage {
     cy.get(`[data-category=${tab}`).should('be.visible');
   }
 
+  openAddDialog() {
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-cy="notification"]').length > 0) {
+        return '[data-cy="notification_dismiss-all"]';
+      }
+
+      return '';
+    }).then((selector) => {
+      if (selector) {
+        cy.get(selector).click();
+      }
+    });
+
+    cy.get('[data-cy="notification"]').should('not.exist');
+    cy.get('[data-cy="add-blockchain-balance"]').should('be.visible');
+    cy.get('[data-cy="add-blockchain-balance"]').click();
+  }
+
   addBalance(balance: FixtureBlockchainBalance) {
     cy.get('[data-cy=bottom-dialog]').should('be.visible');
     cy.get('[data-cy="blockchain-balance-form"]').should('be.visible');

--- a/frontend/app/tests/e2e/specs/balances/blockchain-balances.spec.ts
+++ b/frontend/app/tests/e2e/specs/balances/blockchain-balances.spec.ts
@@ -41,16 +41,14 @@ describe('blockchain balances', () => {
   });
 
   it('add an ETH account and view the account balance', () => {
-    cy.get('[data-cy="add-blockchain-balance"]').should('be.visible');
-    cy.get('[data-cy="add-blockchain-balance"]').click();
+    blockchainBalancesPage.openAddDialog();
     tagManager.addTag('[data-cy="account-tag-field"]', 'public', 'Public Accounts', 'EF703C', 'FFFFF8');
     blockchainBalancesPage.addBalance(blockchainBalances[0]);
     blockchainBalancesPage.isEntryVisible(0, blockchainBalances[0]);
   });
 
   it('add a BTC account and view the account balance', () => {
-    cy.get('[data-cy="add-blockchain-balance"]').should('be.visible');
-    cy.get('[data-cy="add-blockchain-balance"]').click();
+    blockchainBalancesPage.openAddDialog();
     blockchainBalancesPage.addBalance(blockchainBalances[1]);
     blockchainBalancesPage.openTab('bitcoin');
     blockchainBalancesPage.isEntryVisible(0, blockchainBalances[1]);


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Notes
It converts the create account call to use async_query: true, and introduces polling/increased timeout. 

This should provide a fix for the cases where all the tests fail in the before all hook due to 60seconds of timeout during account creation