### PR TITLE
Add ability to vacuum at migrations. Enable for migration 18.

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migrations_18.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_18.py
@@ -226,4 +226,5 @@ def data_migration_18(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
         with GlobalDBHandler().conn.write_ctx() as write_cursor:
             write_cursor.execute('DELETE FROM unique_cache WHERE key=?', ('YEARN_VAULTS',))
 
-    perform_userdb_migration_steps(rotki, progress_handler)
+    # perform steps and Vacuum since we potentially delete lots of un-needed data
+    perform_userdb_migration_steps(rotki, progress_handler, should_vacuum=True)


### PR DESCRIPTION
Reason is that this migration gets rid of a lot of un-needed data for users in some special cases and vacuuming is the only way to reclaim that DB space.

