### PR TITLE
Save last timestamp for periodic tasks

### DIFF
--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -151,6 +151,11 @@ def autodetect_spam_assets_in_db(user_db: DBHandler) -> None:
             log.debug(f'Detected spam token {identifier} at chain {deserialized_chain_id}')
 
     if len(detected_spam_assets) == 0:
+        with user_db.conn.write_ctx() as write_cursor:
+            write_cursor.execute(  # remember last time spam detection ran
+                'INSERT OR REPLACE INTO key_value_cache (name, value) VALUES (?, ?)',
+                (DBCacheStatic.LAST_SPAM_ASSETS_DETECT_KEY.value, str(ts_now())),
+            )
         return
 
     # update the user list of ignored assets

--- a/rotkehlchen/tasks/calendar.py
+++ b/rotkehlchen/tasks/calendar.py
@@ -71,10 +71,12 @@ def notify_reminders(
 
 def delete_past_calendar_entries(database: DBHandler) -> None:
     """delete old calendar entries that the user has allowed to delete"""
+    now = ts_now()
     with database.conn.write_ctx() as write_cursor:
-        write_cursor.execute(
-            'DELETE FROM calendar WHERE timestamp < ? AND auto_delete=1',
-            (ts_now(),),
+        write_cursor.execute('DELETE FROM calendar WHERE timestamp < ? AND auto_delete=1', (now,))
+        write_cursor.execute(  # remember last time this task ran
+            'INSERT OR REPLACE INTO key_value_cache (name, value) VALUES (?, ?)',
+            (DBCacheStatic.LAST_DELETE_PAST_CALENDAR_EVENTS.value, str(now)),
         )
 
 

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -876,6 +876,12 @@ def test_calendar_entries_get_deleted(
             'SELECT description FROM calendar',
         ).fetchall() == [('renew hania.eth',)]
 
+    assert should_run_periodic_task(
+        database=database,
+        key_name=DBCacheStatic.LAST_DELETE_PAST_CALENDAR_EVENTS,
+        refresh_period=DAY_IN_SECONDS,
+    ) is False
+
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('max_tasks_num', [5])


### PR DESCRIPTION
Save last timestamp of execution for calendar and spam assets task

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
