### PR TITLE
test: fix user security test setup

### DIFF
--- a/frontend/app/tests/unit/specs/pages/settings/user-security-settings.spec.ts
+++ b/frontend/app/tests/unit/specs/pages/settings/user-security-settings.spec.ts
@@ -4,7 +4,7 @@ import AccountSettings from '@/pages/settings/account/index.vue';
 import { libraryDefaults } from '../../../utils/provide-defaults';
 
 vi.mock('vue-router', () => ({
-  useRoute: vi.fn(),
+  useRoute: vi.fn().mockImplementation(() => ref({})),
   useRouter: vi.fn().mockReturnValue({
     push: vi.fn(),
   }),
@@ -23,7 +23,7 @@ describe('userSecuritySettings.vue', () => {
     return mount(AccountSettings, {
       global: {
         plugins: [pinia],
-        stubs: ['card-title', 'asset-select', 'asset-update', 'confirm-dialog', 'data-table'],
+        stubs: ['card-title', 'asset-select', 'asset-update', 'confirm-dialog', 'data-table', 'RouterLink'],
         provide: libraryDefaults,
       },
     });


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

fixes a couple of warnings when running the unit tests
```
[Vue warn]: Invalid watch source:  undefined A watch source can only be a getter/effect function, a ref, a reactive object, or an array of these types. 
  at <RuiTabs vertical="" indicator-position="start" color="primary" > 
  at <SettingsPage navigation= [ { id: 'security', label: 'settings.security_settings.title' } ] > 
  at <Index ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: RouterLink
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <RuiTab value=0 active=true color="primary"  ... > 
  at <RuiTabs vertical="" indicator-position="start" color="primary" > 
  at <SettingsPage navigation= [ { id: 'security', label: 'settings.security_settings.title' } ] > 
  at <Index ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: RouterLink
```