### PR TITLE
Optionally add originating_event_id to MissingAcquisitions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5896,6 +5896,7 @@ Get missing acquisitions and prices
                 "missing_amount": "0.1"
               },
               {
+	        "originating_event_id": 424242,
                 "asset": "eip155:1/erc20:0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
                 "time": 1439048640,
                 "found_amount": "0",
@@ -5908,6 +5909,7 @@ Get missing acquisitions and prices
                 "missing_amount": "0.0035000000"
               },
               {
+	        "originating_event_id": 424242,
                 "asset": "eip155:1/erc20:0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
                 "time": 1439994442,
                 "found_amount": "0",

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -140,7 +140,7 @@ class Accountant:
         with self.db.conn.read_ctx() as cursor:
             db_settings = self.db.get_settings(cursor)
             self.ignored_asset_ids = self.db.get_ignored_asset_ids(cursor)
-            # Create a new pnl report in the DB to be used to save each event generated
+            # Create a new pnl report in the DB to be used to save each generated event
             dbpnl = DBAccountingReports(self.db)
             first_ts = Timestamp(0) if len(events) == 0 else events[0].get_timestamp()
             report_id = dbpnl.add_report(

--- a/rotkehlchen/accounting/cost_basis/prefork.py
+++ b/rotkehlchen/accounting/cost_basis/prefork.py
@@ -69,6 +69,7 @@ def handle_prefork_asset_acquisitions(
 
 
 def handle_prefork_asset_spends(
+        originating_event_id: int | None,
         cost_basis: 'CostBasisCalculator',
         asset: Asset,
         amount: FVal,
@@ -84,11 +85,31 @@ def handle_prefork_asset_spends(
     # the preforked asset acquisition data is what's missing so user would getLogger
     # two messages. So as an example one for missing ETH data and one for ETC data
     if asset == A_ETH and timestamp < ETH_DAO_FORK_TS:
-        cost_basis.reduce_asset_amount(asset=A_ETC, amount=amount, timestamp=timestamp)
+        cost_basis.reduce_asset_amount(
+            originating_event_id=originating_event_id,
+            asset=A_ETC,
+            amount=amount,
+            timestamp=timestamp,
+        )
 
     if asset == A_BTC and timestamp < BTC_BCH_FORK_TS:
-        cost_basis.reduce_asset_amount(asset=A_BCH, amount=amount, timestamp=timestamp)
-        cost_basis.reduce_asset_amount(asset=A_BSV, amount=amount, timestamp=timestamp)
+        cost_basis.reduce_asset_amount(
+            originating_event_id=originating_event_id,
+            asset=A_BCH,
+            amount=amount,
+            timestamp=timestamp,
+        )
+        cost_basis.reduce_asset_amount(
+            originating_event_id=originating_event_id,
+            asset=A_BSV,
+            amount=amount,
+            timestamp=timestamp,
+        )
 
     if asset == A_BCH and timestamp < BCH_BSV_FORK_TS:
-        cost_basis.reduce_asset_amount(asset=A_BSV, amount=amount, timestamp=timestamp)
+        cost_basis.reduce_asset_amount(
+            originating_event_id=originating_event_id,
+            asset=A_BSV,
+            amount=amount,
+            timestamp=timestamp,
+        )

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -170,6 +170,7 @@ class EventsAccountant:
         group_id = out_event.event_identifier + str(out_event.sequence_index) + str(in_event.sequence_index)  # noqa: E501
         extra_data = general_extra_data | {'group_id': group_id}
         _, trade_taxable_amount = self.pot.add_out_event(
+            originating_event_id=out_event.identifier,
             event_type=AccountingEventType.TRANSACTION_EVENT,
             notes=out_event.notes or '',
             location=out_event.location,
@@ -215,6 +216,7 @@ class EventsAccountant:
             events_to_add_queue.extend([
                 (self.pot.add_in_event, add_in_event_kwargs),
                 (self.pot.add_out_event, {
+                    'originating_event_id': fee_event.identifier,
                     'event_type': AccountingEventType.FEE,
                     'notes': fee_event.notes,
                     'location': fee_event.location,

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -224,8 +224,11 @@ class AccountingPot(CustomizableDateMixin):
             count_entire_amount_spend: bool = True,
             count_cost_basis_pnl: bool = True,
             extra_data: dict[str, Any] | None = None,
+            originating_event_id: int | None = None,
     ) -> tuple[FVal, FVal]:
         """Add an asset spend event for the pot and count it in PnL if needed
+
+        Since we still have history events mixed with other type of events this can be None.
 
         If a custom price for the asset should be used it can be passed here via
         given_price. Price is always in profit currency during accounting.
@@ -239,6 +242,9 @@ class AccountingPot(CustomizableDateMixin):
         If count_cost_basis_pnl is True then we also count any profit/loss the asset
         may have had compared to when it was acquired.
 
+        originating_event_id is the identifier of the history event that originated it.
+        Can be missing since at the moment not all events are history events.
+
         Returns (free, taxable) amounts.
         """
         if amount == ZERO:  # do nothing for zero spends
@@ -248,6 +254,7 @@ class AccountingPot(CustomizableDateMixin):
             taxable = False  # for buys with fiat do not count it as taxable
 
         handle_prefork_asset_spends(
+            originating_event_id=originating_event_id,
             cost_basis=self.cost_basis,
             asset=asset,
             amount=amount,
@@ -268,6 +275,7 @@ class AccountingPot(CustomizableDateMixin):
         spend_cost = None
         if count_cost_basis_pnl:
             spend_cost = self.cost_basis.spend_asset(
+                originating_event_id=originating_event_id,
                 location=location,
                 timestamp=timestamp,
                 asset=asset,

--- a/rotkehlchen/accounting/types.py
+++ b/rotkehlchen/accounting/types.py
@@ -108,18 +108,36 @@ class NamedJson(NamedTuple):
 
 
 class MissingAcquisition(NamedTuple):
+    """Data for a missing acquisition
+
+    originating_event_id is the identifier of the history event that originated it.
+    Can be missing since at the moment not all events are history events.
+
+    asset is the asset whose acquisition we can't find
+
+    time is the time of the originating event
+
+    found_amount is the amount needed by the originating event that we have found
+
+    missing_amount is the amount needed by the originating event that we have not found
+    """
+    originating_event_id: int | None
     asset: Asset
     time: Timestamp
     found_amount: FVal
     missing_amount: FVal
 
     def serialize(self) -> dict[str, str | int]:
-        return {
+        data = {
             'asset': self.asset.identifier,
             'time': self.time,
             'found_amount': str(self.found_amount),
             'missing_amount': str(self.missing_amount),
         }
+        if self.originating_event_id:
+            data['originating_event_id'] = self.originating_event_id
+
+        return data  # type: ignore
 
 
 class MissingPrice(NamedTuple):

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/accountant.py
@@ -50,6 +50,7 @@ class Aavev2Accountant(ModuleAccountantInterface):
             loss = -1 * self.assets_borrowed[key]
             resolved_asset = event.asset.resolve_to_asset_with_symbol()
             pot.add_out_event(
+                originating_event_id=event.identifier,
                 event_type=AccountingEventType.TRANSACTION_EVENT,
                 notes=f'Lost {loss} {resolved_asset.symbol} as debt during payback to Aave v2 loan for {event.location_label}',  # noqa: E501
                 location=event.location,

--- a/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
@@ -46,6 +46,7 @@ class MakerdaoAccountant(ModuleAccountantInterface):
         if self.vault_balances[cdp_id] < ZERO:
             loss = -1 * self.vault_balances[cdp_id]
             pot.add_out_event(
+                originating_event_id=event.identifier,
                 event_type=AccountingEventType.TRANSACTION_EVENT,
                 notes=f'Lost {loss} DAI as debt during payback to CDP {cdp_id}',
                 location=event.location,

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -191,6 +191,7 @@ class AssetMovement(AccountingEventMixin):
             return 1
 
         accounting.add_out_event(
+            originating_event_id=None,  # not a history event, but an asset movement
             event_type=AccountingEventType.ASSET_MOVEMENT,
             notes=f'{self.location} {self.category!s}',
             location=self.location,
@@ -392,6 +393,7 @@ class Trade(AccountingEventMixin):
             return 1
 
         _, trade_taxable_amount = accounting.add_out_event(
+            originating_event_id=None,  # not a history event, but a Trade
             event_type=AccountingEventType.TRADE,
             notes=notes + ' Amount out',
             location=self.location,
@@ -434,6 +436,7 @@ class Trade(AccountingEventMixin):
                 fee_taxable_amount_ratio = trade_taxable_amount / amount_out
 
             accounting.add_out_event(
+                originating_event_id=None,  # not a history event, but a Trade
                 event_type=AccountingEventType.FEE,
                 notes=notes + 'Fee',
                 location=self.location,
@@ -607,6 +610,7 @@ class MarginPosition(AccountingEventMixin):
         )
         if self.fee != ZERO:  # Fee is not included in the asset price here since it is not a swap/trade event.  # noqa: E501
             accounting.add_out_event(
+                originating_event_id=None,  # not a history event, but a Trade
                 event_type=AccountingEventType.FEE,
                 notes='Margin position. Fee',
                 location=self.location,


### PR DESCRIPTION
This commit adds the identifier of the history event at which we have encountered a missing acquisition as originating_event_id.

It's optional and may be missing, since not all events are history events at the moment.

Part of https://github.com/rotki/rotki/issues/8690
