### PR TITLE
Fix extrafi balance query for multiple pools of same token

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Extrafi lending balances when having used multiple pools of the same asset at the same time will now be properly queried.
 * :bug:`-` Liquity v1 borrowing should now properly include the fee as part of the borrowing event and present proper order of borrowing coming before the fee payment.
 * :bug:`8807` Binance CSVs with the new trade entry format should import correctly.
 * :bug:`-` Pending AAVE to claim from staking should now appear as balance in the address that is staking.

--- a/rotkehlchen/chain/evm/decoding/extrafi/balances.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/balances.py
@@ -272,7 +272,7 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
             )
             return {}
 
-        reserve_to_balance: dict[EvmToken, FVal] = {}
+        reserve_to_balance: dict[EvmToken, FVal] = defaultdict(FVal)
         for idx, result in enumerate(raw_balances):
             try:
                 reserve_token = self._maybe_query_reserve_idx_to_underlying(
@@ -286,7 +286,7 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
                 )
                 continue
 
-            reserve_to_balance[reserve_token] = token_normalized_value(
+            reserve_to_balance[reserve_token] += token_normalized_value(
                 token_amount=result[-1],
                 token=reserve_token,
             )


### PR DESCRIPTION
If a user had interacted with multiple pools of the same token only the last pool they ever interacted with would be considered for balance query.
