### PR TITLE
style: improve protocol icon styling consistency

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
+++ b/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
@@ -25,7 +25,7 @@ const imagePath = '/assets/images/protocols/';
         :open-delay="400"
       >
         <template #activator>
-          <div class="rounded-full overflow-hidden bg-white">
+          <div class="rounded-full overflow-hidden bg-white w-5 h-5 flex items-center justify-center">
             <template v-if="counterparty">
               <RuiIcon
                 v-if="counterparty.icon"
@@ -37,7 +37,7 @@ const imagePath = '/assets/images/protocols/';
                 v-else-if="counterparty.image"
                 :src="`${imagePath}${counterparty.image}`"
                 contain
-                size="20px"
+                size="16px"
               />
 
               <EnsAvatar


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/548968af-716c-483d-9765-b7bbc7ab4f7d)

after:
![image](https://github.com/user-attachments/assets/bd0a926f-8150-4398-86a4-5a019e3917eb)


- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
