### PR TITLE
Change logic for connecting nodes

### DIFF
--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -91,7 +91,6 @@ from rotkehlchen.types import (
     CHAIN_IDS_WITH_BALANCE_PROTOCOLS,
     CHAINS_WITH_CHAIN_MANAGER,
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
-    EVM_CHAINS_WITH_TRANSACTIONS_TYPE,
     SUPPORTED_CHAIN_IDS,
     SUPPORTED_EVM_CHAINS_TYPE,
     SUPPORTED_EVM_EVMLIKE_CHAINS,
@@ -315,12 +314,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         }
         self.chain_modify_append: dict[SupportedBlockchain, Callable[[SupportedBlockchain, BlockchainAddress], None]] = {  # noqa: E501
             SupportedBlockchain.ETHEREUM: self._append_eth_account_modification,  # type:ignore
-            SupportedBlockchain.OPTIMISM: self._append_evm_account_modification,  # type:ignore
-            SupportedBlockchain.POLYGON_POS: self._append_evm_account_modification,  # type:ignore
-            SupportedBlockchain.ARBITRUM_ONE: self._append_evm_account_modification,  # type:ignore
-            SupportedBlockchain.BASE: self._append_evm_account_modification,  # type:ignore
-            SupportedBlockchain.GNOSIS: self._append_evm_account_modification,  # type:ignore
-            SupportedBlockchain.SCROLL: self._append_evm_account_modification,  # type:ignore
         }
         self.chain_modify_remove: dict[SupportedBlockchain, Callable[[SupportedBlockchain, BlockchainAddress], None]] = {  # noqa: E501
             SupportedBlockchain.ETHEREUM: self._remove_eth_account_modification,  # type:ignore
@@ -803,16 +796,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                 seconds=SUBSTRATE_NODE_CONNECTION_TIMEOUT,
             )
 
-    def _append_evm_account_modification(
-            self,
-            blockchain: EVM_CHAINS_WITH_TRANSACTIONS_TYPE,
-            address: ChecksumEvmAddress,  # pylint: disable=unused-argument
-    ) -> None:
-        """Extra code to run when a non-eth but evm account addition happens"""
-        # If this is the first account added, connect to all relevant nodes
-        chain_manager = self.get_chain_manager(blockchain)
-        chain_manager.node_inquirer.maybe_connect_to_nodes(when_tracked_accounts=False)
-
     def _append_eth_account_modification(
             self,
             blockchain: Literal[SupportedBlockchain.ETHEREUM],  # pylint: disable=unused-argument
@@ -820,7 +803,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     ) -> None:
         """Extra code to run when eth account addition happens"""
         # If this is the first account added, connect to all relevant nodes
-        self.ethereum.node_inquirer.maybe_connect_to_nodes(when_tracked_accounts=False)
         for _, module in self.iterate_modules():
             module.on_account_addition(address)
 

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -43,7 +43,6 @@ from rotkehlchen.externalapis.opensea import Opensea
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.tests.utils.blockchain import maybe_modify_rpc_nodes
 from rotkehlchen.tests.utils.decoders import patch_decoder_reload_data
-from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.evm import maybe_mock_evm_inquirer
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.tests.utils.mock import mock_proxies
@@ -94,12 +93,6 @@ def _initialize_and_yield_evm_inquirer_fixture(
         inquirer = klass(
             greenlet_manager=greenlet_manager,
             database=database,
-        )
-
-    if mock_other_web3 is False:  # no mocking means we should wait till connect is done
-        wait_until_all_nodes_connected(
-            connect_at_start=nodes_to_connect_to,
-            evm_inquirer=inquirer,
         )
 
     maybe_mock_evm_inquirer(

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -35,7 +35,6 @@ from rotkehlchen.tests.utils.database import (
     run_no_db_upgrades,
 )
 from rotkehlchen.tests.utils.decoders import patch_decoder_reload_data
-from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.evm import maybe_mock_evm_inquirer
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
 from rotkehlchen.tests.utils.history import maybe_mock_historical_price_queries
@@ -412,9 +411,6 @@ def initialize_mock_rotkehlchen_instance(
         mocked_price_queries=mocked_price_queries,
         default_mock_value=default_mock_price_value,
     )
-    if network_mocking is False:
-        for evm_inquirer, connect_at_start in evm_nodes_wait:
-            wait_until_all_nodes_connected(connect_at_start=connect_at_start, evm_inquirer=evm_inquirer)  # noqa: E501
 
     if len(rotki.chains_aggregator.accounts.ksm) != 0:
         wait_until_all_substrate_nodes_connected(  # no connection would have been attempted if there are no accounts  # noqa: E501

--- a/rotkehlchen/tests/unit/test_arbitrum_one_inquirer.py
+++ b/rotkehlchen/tests/unit/test_arbitrum_one_inquirer.py
@@ -1,21 +1,32 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from rotkehlchen.tests.utils.arbitrum_one import (
     ARBITRUM_ONE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED,
 )
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize(*ARBITRUM_ONE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_arbitrum_one_nodes_prune_and_archive_status(
-        arbitrum_one_manager_connect_at_start,
-        arbitrum_one_inquirer,
+        arbitrum_one_manager_connect_at_start: list[tuple],
+        arbitrum_one_inquirer: 'ArbitrumOneInquirer',
 ):
     """Checks that connecting to a set of Arbitrum One nodes, the capabilities of those nodes
     are known and stored. It tests the nodes one by one to avoid the randomness of the connections
     to the nodes while running with the VCR cassettes.
     """
+    arbitrum_one_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=arbitrum_one_manager_connect_at_start,
+        evm_inquirer=arbitrum_one_inquirer,
+    )
     for node_name, web3_node in arbitrum_one_inquirer.web3_mapping.items():
         if node_name.endpoint == 'https://arbitrum-one-archive.allthatnode.com':
             assert not web3_node.is_pruned

--- a/rotkehlchen/tests/unit/test_base_inquirer.py
+++ b/rotkehlchen/tests/unit/test_base_inquirer.py
@@ -1,19 +1,30 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from rotkehlchen.tests.utils.base import BASE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.base.node_inquirer import BaseInquirer
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize(*BASE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('base_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_base_nodes_prune_and_archive_status(
-        base_manager_connect_at_start,
-        base_inquirer,
+        base_manager_connect_at_start: list[tuple],
+        base_inquirer: 'BaseInquirer',
 ):
     """Checks that connecting to a set of base nodes, the capabilities of those nodes are known and
     stored. It tests the nodes one by one to avoid the randomness of the connections to the nodes
     while running with the VCR cassettes.
     """
+    base_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=base_manager_connect_at_start,
+        evm_inquirer=base_inquirer,
+    )
     for node_name, web3_node in base_inquirer.web3_mapping.items():
         if node_name.endpoint == 'https://base.blockpi.network/v1/rpc/public':
             assert not web3_node.is_pruned

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +12,7 @@ from rotkehlchen.chain.evm.decoding.kyber.constants import KYBER_AGGREGATOR_SWAP
 from rotkehlchen.chain.evm.decoding.thegraph.constants import GRAPH_DELEGATION_TRANSFER_ABI
 from rotkehlchen.chain.evm.node_inquirer import _query_web3_get_logs
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
-from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.chain.evm.types import WeightedNode, string_to_evm_address
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.errors.misc import EventNotInABI, RemoteError
 from rotkehlchen.tests.utils.checks import assert_serialized_dicts_equal
@@ -26,6 +27,9 @@ from rotkehlchen.tests.utils.ethereum import (
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.types import ChainID, EvmTransaction, SupportedBlockchain, deserialize_evm_tx_hash
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 
 
 @pytest.mark.parametrize(*ETHEREUM_TEST_PARAMETERS)
@@ -337,10 +341,11 @@ def test_get_blocknumber_by_time_etherscan(ethereum_inquirer):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize(*ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 def test_ethereum_nodes_prune_and_archive_status(
-        ethereum_inquirer,
-        ethereum_manager_connect_at_start,
+        ethereum_inquirer: 'EthereumInquirer',
+        ethereum_manager_connect_at_start: list[WeightedNode],
 ):
     """Checks that connecting to a set of ethereum nodes, the capabilities of those nodes are known and stored."""  # noqa: E501
+    ethereum_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
     wait_until_all_nodes_connected(
         connect_at_start=ethereum_manager_connect_at_start,
         evm_inquirer=ethereum_inquirer,

--- a/rotkehlchen/tests/unit/test_gnosis_inquirer.py
+++ b/rotkehlchen/tests/unit/test_gnosis_inquirer.py
@@ -1,16 +1,30 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.gnosis import GNOSIS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize(*GNOSIS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('gnosis_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
-def test_gnosis_nodes_prune_and_archive_status(gnosis_manager_connect_at_start, gnosis_inquirer):
+def test_gnosis_nodes_prune_and_archive_status(
+        gnosis_manager_connect_at_start: list[tuple],
+        gnosis_inquirer: 'GnosisInquirer',
+):
     """Checks that connecting to a set of gnosis nodes, the capabilities of those nodes are
     known and stored. It tests the nodes one by one to avoid the randomness of the connections to
     the nodes while running with the VCR cassettes.
     """
+    gnosis_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=gnosis_manager_connect_at_start,
+        evm_inquirer=gnosis_inquirer,
+    )
     for node_name, web3_node in gnosis_inquirer.web3_mapping.items():
         if node_name.endpoint == 'https://gnosis.blockpi.network/v1/rpc/public':
             assert not web3_node.is_pruned

--- a/rotkehlchen/tests/unit/test_optimism_inquirer.py
+++ b/rotkehlchen/tests/unit/test_optimism_inquirer.py
@@ -1,18 +1,29 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.optimism import OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize(*OPTIMISM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('optimism_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_optimism_nodes_prune_and_archive_status(
-        optimism_manager_connect_at_start,
-        optimism_inquirer,
+        optimism_manager_connect_at_start: list[tuple],
+        optimism_inquirer: 'OptimismInquirer',
 ):
     """Checks that connecting to a set of optimism nodes, the capabilities of those nodes are known
     and stored. It tests the nodes one by one to avoid the randomness of the connections to the
     nodes while running with the VCR cassettes."""
+    optimism_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=optimism_manager_connect_at_start,
+        evm_inquirer=optimism_inquirer,
+    )
     for node_name, web3_node in optimism_inquirer.web3_mapping.items():
         if node_name.endpoint == 'https://opt-mainnet.nodereal.io/v1/e85935b614124789b99aa92930aca9a4':
             assert not web3_node.is_pruned

--- a/rotkehlchen/tests/unit/test_polygon_pos_inquirer.py
+++ b/rotkehlchen/tests/unit/test_polygon_pos_inquirer.py
@@ -1,21 +1,32 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.polygon_pos import (
     ALCHEMY_RPC_ENDPOINT,
     POLYGON_POS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED,
 )
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize(*POLYGON_POS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_polygon_pos_nodes_prune_and_archive_status(
-        polygon_pos_manager_connect_at_start,
-        polygon_pos_inquirer,
+        polygon_pos_manager_connect_at_start: list[tuple],
+        polygon_pos_inquirer: 'PolygonPOSInquirer',
 ):
     """Checks that connecting to a set of polygon POS nodes, the capabilities of those nodes are
     known and stored. It tests the nodes one by one to avoid the randomness of the connections to
     the nodes while running with the VCR cassettes."""
+    polygon_pos_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=polygon_pos_manager_connect_at_start,
+        evm_inquirer=polygon_pos_inquirer,
+    )
     for node_name, web3_node in polygon_pos_inquirer.web3_mapping.items():
         if node_name.endpoint == 'https://polygon-bor.publicnode.com':
             assert web3_node.is_pruned

--- a/rotkehlchen/tests/unit/test_scroll_inquirer.py
+++ b/rotkehlchen/tests/unit/test_scroll_inquirer.py
@@ -1,5 +1,8 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
+from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.scroll import (
     ANKR_SCROLL_NODE,
     BLOCKPI_SCROLL_NODE,
@@ -7,18 +10,26 @@ from rotkehlchen.tests.utils.scroll import (
     SCROLL_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED,
 )
 
+if TYPE_CHECKING:
+    from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
+
 
 @pytest.mark.vcr
 @pytest.mark.parametrize(*SCROLL_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED)
 @pytest.mark.parametrize('scroll_accounts', [['0xCace5b3c29211740E595850E80478416eE77cA21']])  # to connect to nodes  # noqa: E501
 def test_scroll_nodes_prune_and_archive_status(
-        scroll_manager_connect_at_start,
-        scroll_inquirer,
+        scroll_manager_connect_at_start: list[tuple],
+        scroll_inquirer: 'ScrollInquirer',
 ):
     """Checks that connecting to a set of scroll nodes, the capabilities of those nodes are known
     and stored. It tests the nodes one by one to avoid the randomness of the connections to
     the nodes while running with the VCR cassettes.
     """
+    scroll_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=scroll_manager_connect_at_start,
+        evm_inquirer=scroll_inquirer,
+    )
     for node_name, web3_node in scroll_inquirer.web3_mapping.items():
         if node_name in {BLOCKPI_SCROLL_NODE, ANKR_SCROLL_NODE, ONE_RPC_SCROLL_NODE}:
             assert not web3_node.is_pruned

--- a/rotkehlchen/tests/unit/test_zerionsdk.py
+++ b/rotkehlchen/tests/unit/test_zerionsdk.py
@@ -1,27 +1,31 @@
 import warnings as test_warnings
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from rotkehlchen.chain.ethereum.defi.zerionsdk import KNOWN_ZERION_PROTOCOL_NAMES, ZerionSDK
-from rotkehlchen.fval import FVal
-from rotkehlchen.tests.utils.ethereum import INFURA_ETH_NODE, wait_until_all_nodes_connected
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.misc import ONE
+from rotkehlchen.tests.utils.ethereum import INFURA_ETH_NODE
 from rotkehlchen.types import ChainID
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.manager import EthereumManager
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.inquirer import Inquirer
+    from rotkehlchen.user_messages import MessagesAggregator
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
-@pytest.mark.parametrize('mocked_current_prices', [{
-    'SNX': FVal('1'),
-    'cUSDT': FVal('1'),
-    'USDT': FVal('1'),
-}])
+@pytest.mark.parametrize('mocked_current_prices', [{'SNX': ONE, 'cUSDT': ONE, 'USDT': ONE}])
 def test_query_all_protocol_balances_for_account(
-        ethereum_manager,
-        function_scope_messages_aggregator,
-        inquirer,
-        ethereum_manager_connect_at_start,
-        database,
+        ethereum_manager: 'EthereumManager',
+        function_scope_messages_aggregator: 'MessagesAggregator',
+        inquirer: 'Inquirer',
+        database: 'DBHandler',
 ):
     """Simple test that we can get balances for various defi protocols via zerion
 
@@ -32,17 +36,13 @@ def test_query_all_protocol_balances_for_account(
     certain balance in a few DeFi protocols and does not change them. This way
     we can have something stable to check again.
     """
-    wait_until_all_nodes_connected(
-        connect_at_start=ethereum_manager_connect_at_start,
-        evm_inquirer=ethereum_manager.node_inquirer,
-    )
     inquirer.inject_evm_managers(((ChainID.ETHEREUM, ethereum_manager),))
     zerion = ZerionSDK(ethereum_manager.node_inquirer, function_scope_messages_aggregator, database)  # noqa: E501
     with patch(
         'rotkehlchen.chain.evm.decoding.curve.curve_cache._query_curve_data_from_api',
         new=MagicMock(return_value=[]),
     ):
-        balances = zerion.all_balances_for_account('0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662')
+        balances = zerion.all_balances_for_account(string_to_evm_address('0xf753beFE986e8Be8EBE7598C9d2b6297D9DD6662'))  # noqa: E501
 
     if len(balances) == 0:
         test_warnings.warn(UserWarning('Test account for DeFi balances has no balances'))
@@ -57,10 +57,10 @@ def test_query_all_protocol_balances_for_account(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_protocol_names_are_known(
-        ethereum_inquirer,
-        function_scope_messages_aggregator,
-        inquirer,  # pylint: disable=unused-argument
-        database,
+        ethereum_inquirer: 'EthereumInquirer',
+        function_scope_messages_aggregator: 'MessagesAggregator',
+        inquirer: 'Inquirer',  # pylint: disable=unused-argument
+        database: 'DBHandler',
 ):
     zerion = ZerionSDK(ethereum_inquirer, function_scope_messages_aggregator, database)
     protocol_names = zerion.contract.call(


### PR DESCRIPTION
This PR changes the approach for connecting to web3 nodes. Instead of connecting all the nodes for a chain at the start now it connects to nodes on demand. If for chain OP we have nodes `A, B, C` and we call a query with `default_order`
it will create a random order `[B, A, C]`. Then it will iterate and connect to `B` first. Then in the next call the order will be `[C, A, B]` and it will call C first making the connection and having `B and C` as connected nodes for now. A will be offline at this point because it hasn't been requested yet.

This PR also delays the task for sumbmitting analytics stuff