### PR TITLE
ci: update intel mac runner to macos-13

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -86,7 +86,7 @@ jobs:
             arch: 'arm64'
             target: 11
             platform: macosx-11.0-arm64
-          - runner: macos-12
+          - runner: macos-13
             arch: 'x86_64'
             target: 10.9
             platform: macosx-10.9-x86_64

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -182,7 +182,7 @@ jobs:
             arch: 'arm64'
             target: 11
             platform: macosx-11.0-arm64
-          - runner: macos-12
+          - runner: macos-13
             arch: 'x86_64'
             target: 10.9
             platform: macosx-10.9-x86_64


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
