### PR TITLE
Limit requests for slow nodes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 * :bug:`8892` rotki will now correctly fetch Starknet token prices before May 2024 from Cryptocompare, when the ticker changed from STARK to STRK.
 * :bug:`-` The airdrops directory should no longer appear under the user directory in certain circumstances.
 * :bug:`-` Fix an issue that caused the token detection to fail under some circumstances involving broken tokens.
+* :bug:`-` rotki won't try to query logs from slow nodes.
 
 * :release:`1.36.0 <2024-11-06>`
 * :bug:`-` The exported file that overrides the file with the same name should have the latest modified time.

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -85,6 +85,7 @@ def _connect_task_prefix(chain_name: str) -> str:
 
 
 WEB3_LOGQUERY_BLOCK_RANGE = 250000
+MAX_NODE_LOG_QUERY_CALLS = 500  # max queries for a node that can query logs from up to 1000/10_000 blocks  # noqa: E501
 
 
 def _query_web3_get_logs(
@@ -134,9 +135,17 @@ def _query_web3_get_logs(
 
             # errors from: https://infura.io/docs/ethereum/json-rpc/eth-getLogs
             if msg == 'query returned more than 10000 results':
+                if (until_block - start_block) // 10_000 > MAX_NODE_LOG_QUERY_CALLS:
+                    log.debug(f'Querying logs with a range of 10_000 from {web3} will take too much time. Stopping here')  # noqa: E501
+                    raise
+
                 block_range = initial_block_range = 9999  # ensure that block range doesn't get reset to a range bigger than what is allowed for this node  # noqa: E501
                 continue
             elif 'eth_getLogs is limited to a 1000 blocks range':  # seen in https://1rpc.io/gnosis  # noqa: E501
+                if (until_block - start_block) // 1_000 > MAX_NODE_LOG_QUERY_CALLS:
+                    log.debug(f'Querying logs with a range of 1000 from {web3} will take too much time. Stopping here')  # noqa: E501
+                    raise
+
                 block_range = initial_block_range = 999
                 continue
             elif msg == 'query timeout exceeded':

--- a/rotkehlchen/tests/integration/test_gnosischain.py
+++ b/rotkehlchen/tests/integration/test_gnosischain.py
@@ -15,20 +15,21 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-@pytest.mark.freeze_time('2023-10-25 22:50:45 GMT')
+@pytest.mark.freeze_time('2024-11-28 10:44:55 GMT')
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('gnosis_accounts', [['0x0D0B3A4fB611D11b044444Ed2154cDcd7830d506', '0xdFba7a5EeE7b2Aed0E463e983CB96873DbDD25F0']])  # noqa: E501
+@pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65', '0x2449fE0bEA58e027f374e90b296e72Dfd7bCcBaE']])  # noqa: E501
 def test_gnosischain_specific_chain_data(
         database: 'DBHandler',
         gnosis_transactions: 'GnosisTransactions',
         gnosis_accounts: list[ChecksumEvmAddress],
 ) -> None:
     now = ts_now()
+    start_ts = Timestamp(1711618437)
     expected_hashes = [
-        deserialize_evm_tx_hash('0xd7f2c2370d56b36ef4415d79f6f762d3c56dc28b6ca901a4caab8780b6f9d658'),
-        deserialize_evm_tx_hash('0x0f31899a9c457fbc37b16fef4f9a19281989e5109fb69dc75b88b277b24adf0e'),
-        deserialize_evm_tx_hash('0x3461f584d26a356fabe3f24c5dce60a5395f10924f346a4d44e22031a6d8173c'),
-        deserialize_evm_tx_hash('0xc4d486ef5927973cb90aa9d18d5e8f5b768f31284d5d09d770b953f6f9b286a7'),
+        deserialize_evm_tx_hash('0x53ea77773da6ea732a8037a6104439d00dd480c080ff72eb43659ceb3c84a49f'),
+        deserialize_evm_tx_hash('0x580ff7e66b3d248e827ac4b9ac584a7548ef2b06bb5ac465f9a6fd8b3c16c20e'),
+        deserialize_evm_tx_hash('0xd120b4923082c30710a06df21324c91b1886a0f6451336a98a2d9e6c5dcf42c0'),
+        deserialize_evm_tx_hash('0xde1157f4e48bd6d053af43e9193c278959bd636207d0b38fe90e5201bc0e9664'),
     ]
 
     def check_db() -> None:
@@ -50,7 +51,7 @@ def test_gnosischain_specific_chain_data(
             for address in gnosis_accounts:
                 # check used query ranges are set
                 from_ts, to_ts = database.get_used_query_range(cursor, f'{BRIDGE_QUERIED_ADDRESS_PREFIX}{address}')  # type: ignore # noqa: E501
-                assert from_ts == Timestamp(0)
+                assert from_ts == start_ts
                 assert to_ts == now
 
     get_logs_patch = patch.object(
@@ -62,7 +63,7 @@ def test_gnosischain_specific_chain_data(
     with get_logs_patch as fn:
         gnosis_transactions.get_chain_specific_multiaddress_data(
             addresses=gnosis_accounts,
-            from_ts=Timestamp(0),
+            from_ts=Timestamp(1711618437),
             to_ts=now,
         )
         first_call_count = fn.call_count
@@ -71,7 +72,7 @@ def test_gnosischain_specific_chain_data(
         # call it again and make sure nothing happens and DB is unchanged
         gnosis_transactions.get_chain_specific_multiaddress_data(
             addresses=gnosis_accounts,
-            from_ts=Timestamp(0),
+            from_ts=Timestamp(1711618437),
             to_ts=now,
         )
         assert fn.call_count == first_call_count, 'no log queries should happen'


### PR DESCRIPTION
This PR does:

- Limit the query of logs for slow nodes
- Saves progress querying gnosis chain logs
- Makes gnosis chain to query logs only using local and etherscan nodes
