### PR TITLE
Fix history event export/download api endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5328,7 +5328,7 @@ Exporting History Events
    .. note::
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
-   Doing a PUT on this endpoint with the given filter parameters will download a csv with all history events matching the filter. All arguments are optional. If no filter is used all the events will be downloaded.
+   Doing a PUT on this endpoint with the given filter parameters will export a csv with all history events matching the filters that can be downloaded later via the /history/events/export/download endpoint. All arguments are optional. If no filter is used all the events will be downloaded.
 
    .. _filter-request-args-label:
 
@@ -5371,13 +5371,54 @@ Exporting History Events
    .. sourcecode:: http
 
       HTTP/1.1 200 OK
-      Content-Type: text/csv
+      Content-Type: application/json
 
-   :statuscode 200: Events successfully downloaded
+      {
+          "result": true,
+          "message": ""
+      }
+
+   :statuscode 200: Events successfully exported
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 409: No user is logged in or failure at event download.
    :statuscode 500: Internal rotki error
    :statuscode 502: Couldn't fetch prices for all the events due to being rate limited.
+
+Downloading Exported History Events
+============================================
+
+.. http:post:: /api/(version)/history/events/export/download
+
+   Doing a POST on this endpoint will download the CSV exported in a previous call to the export endpoint and specified here with file_path.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      POST /api/1/history/events/export/download HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {
+          "file_path": "/tmp/tmprg88k0co/history_events.csv"
+      }
+
+   .. _history_download_schema_section:
+
+   :reqjson string file_path: The CSV file to be downloaded.
+
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: text/csv
+
+   :statuscode 200: CSV successfully downloaded
+   :statuscode 400: Provided JSON is in some way malformed
+   :statuscode 409: No user is logged in or failure.
+   :statuscode 500: Internal rotki error
 
 Querying online events
 ============================================

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4792,7 +4792,7 @@ class RestAPI:
             filter_query: HistoryBaseEntryFilterQuery,
             directory_path: Path | None,
     ) -> dict[str, Any] | Response:
-        """Export or Download history events data to a CSV file."""
+        """Export history events data to a CSV file."""
         dbevents = DBHistoryEvents(self.rotkehlchen.data.db)
         with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
             history_events, _, _ = dbevents.get_history_events_and_limit_info(
@@ -4842,35 +4842,22 @@ class RestAPI:
             # maintain insertion order without storing extra info
             headers.update(dict.fromkeys(serialized_event))
 
-        if directory_path is None:  # on download
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:  # needed on windows, see https://tinyurl.com/tmp-win-err  # noqa: E501
-                file_path = Path(temp_dir) / FILENAME_HISTORY_EVENTS_CSV
-                try:
-                    dict_to_csv_file(
-                        path=file_path,
-                        dictionary_list=serialized_history_events,
-                        csv_delimiter=settings.csv_export_delimiter,
-                        headers=headers.keys(),
-                    )
-                    register_post_download_cleanup(file_path)
-                    return send_file(
-                        path_or_file=file_path,
-                        mimetype='text/csv',
-                        as_attachment=True,
-                        download_name=FILENAME_HISTORY_EVENTS_CSV,
-                    )
-                except (CSVWriteError, PermissionError) as e:
-                    return wrap_in_fail_result(
-                        message=str(e),
-                        status_code=HTTPStatus.CONFLICT,
-                    )
-                except FileNotFoundError:
-                    return wrap_in_fail_result(
-                        message='No file was found',
-                        status_code=HTTPStatus.NOT_FOUND,
-                    )
+        try:
+            if directory_path is None:  # file will be downloaded later via download_history_events_csv endpoint  # noqa: E501
+                file_path = Path(tempfile.mkdtemp()) / FILENAME_HISTORY_EVENTS_CSV
+                dict_to_csv_file(
+                    path=file_path,
+                    dictionary_list=serialized_history_events,
+                    csv_delimiter=settings.csv_export_delimiter,
+                    headers=headers.keys(),
+                )
+                return {
+                    'result': {'file_path': str(file_path)},
+                    'message': '',
+                    'status_code': HTTPStatus.OK,
+                }
 
-        try:  # from here and below we do a direct export to filesystem
+            # else do a direct export to filesystem
             directory_path.mkdir(parents=True, exist_ok=True)
             file_path = directory_path / FILENAME_HISTORY_EVENTS_CSV
             dict_to_csv_file(
@@ -4883,6 +4870,16 @@ class RestAPI:
             return wrap_in_fail_result(message=str(e), status_code=HTTPStatus.CONFLICT)
 
         return OK_RESULT
+
+    def download_history_events_csv(self, file_path: str) -> Response:
+        """Download history events data CSV file."""
+        register_post_download_cleanup(Path(file_path))
+        return send_file(
+            path_or_file=file_path,
+            mimetype='text/csv',
+            as_attachment=True,
+            download_name=FILENAME_HISTORY_EVENTS_CSV,
+        )
 
     def _invalidate_cache_for_accounting_rule(
             self,

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -91,6 +91,7 @@ from rotkehlchen.api.v1.resources import (
     ExchangeRatesResource,
     ExchangesDataResource,
     ExchangesResource,
+    ExportHistoryDownloadResource,
     ExportHistoryEventResource,
     ExternalServicesResource,
     FalsePositiveSpamTokenResource,
@@ -226,6 +227,7 @@ URLS_V1: URLS = [
     ('/history/events/products', EvmProductsResource),
     ('/history/events/details', EventDetailsResource),
     ('/history/events/export', ExportHistoryEventResource),
+    ('/history/events/export/download', ExportHistoryDownloadResource),
     ('/history/actionable_items', HistoryActionableItemsResource),
     ('/reports', AccountingReportsResource),
     (

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -96,6 +96,7 @@ from rotkehlchen.api.v1.schemas import (
     ExchangesResourceAddSchema,
     ExchangesResourceEditSchema,
     ExchangesResourceRemoveSchema,
+    ExportHistoryDownloadSchema,
     ExportHistoryEventSchema,
     ExternalServicesResourceAddSchema,
     ExternalServicesResourceDeleteSchema,
@@ -3153,6 +3154,16 @@ class ExportHistoryEventResource(BaseMethodView):
     @use_kwargs(put_schema, location='json_and_query')
     def put(self, async_query: bool, filter_query: 'HistoryBaseEntryFilterQuery') -> Response | dict[str, Any]:  # noqa: E501
         return self.rest_api.export_history_events(filter_query=filter_query, directory_path=None, async_query=async_query)  # noqa: E501
+
+
+class ExportHistoryDownloadResource(BaseMethodView):
+
+    post_schema = ExportHistoryDownloadSchema()
+
+    @require_loggedin_user()
+    @use_kwargs(post_schema, location='json')
+    def post(self, file_path: str) -> Response:
+        return self.rest_api.download_history_events_csv(file_path=file_path)
 
 
 class AccountingRulesResource(BaseMethodView):

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3434,6 +3434,11 @@ class ExportHistoryEventSchema(HistoryEventSchema, AsyncQueryArgumentSchema):
         return extra_fields
 
 
+class ExportHistoryDownloadSchema(Schema):
+    """Schema for downloading history events CSVs."""
+    file_path = fields.String(required=True)
+
+
 class AccountingRuleIdSchema(Schema):
     event_type = SerializableEnumField(enum_class=HistoryEventType, required=True)
     event_subtype = SerializableEnumField(enum_class=HistoryEventSubType, required=True)


### PR DESCRIPTION
Changes the history events CSV download into a two step process with an asynchronous request first to export the events and then a separate request to download the generated CSV file.

Related to the problem with history events CSV downloads when running in docker reported in [discord](https://discord.com/channels/657906918408585217/745172610240872508/1308910435935719425).

Backend changes only.