### PR TITLE
Coinbase events are now pulled properly after initial sync

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`8916` Coinbase events (trades, deposits/withdrawals, earn etc.) will now be properly pulled after the initial sync. 
 * :bug:`-` Fix the issue where some asset values show zero in the edit snapshot form.
 * :bug:`-` Fix the issue where the pagination for the account table resets to the first page when the user expands the account.
 * :bug:`8892` rotki will now correctly fetch Starknet token prices before May 2024 from Cryptocompare, when the ticker changed from STARK to STRK.

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -619,8 +619,10 @@ class Coinbase(ExchangeInterface):
         options = {}
         if last_tx_id is not None:
             options['starting_after'] = last_tx_id
+            options['order'] = 'asc'
         transactions = self._api_query(f'accounts/{account_id}/transactions', options=options)
         if len(transactions) == 0:
+            log.debug('Coinbase API query returned no transactions')
             return trades, asset_movements, history_events
 
         trade_pairs = defaultdict(list)  # Maps every trade id to their two transactions
@@ -666,7 +668,7 @@ class Coinbase(ExchangeInterface):
         with self.db.user_write() as write_cursor:  # Remember last transaction id for account
             write_cursor.execute(
                 'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES(?, ?) ',
-                (account_last_id_name, transactions[-1]['id']),
+                (account_last_id_name, transactions[-1]['id']),  # -1 takes last transaction due to ascending order  # noqa: E501
             )
 
         return trades, asset_movements, history_events


### PR DESCRIPTION
At some point this must have stopped working due to their API changing the default results order in the response order. Our code was made to work with ascending order and they must have changed the default to descending.

Now we explicitly specify the order.

Fix #8916

