### PR TITLE
fix: turn history events download to [GET]

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5387,15 +5387,15 @@ Exporting History Events
 Downloading Exported History Events
 ============================================
 
-.. http:post:: /api/(version)/history/events/export/download
+.. http:get:: /api/(version)/history/events/export/download
 
-   Doing a POST on this endpoint will download the CSV exported in a previous call to the export endpoint and specified here with file_path.
+   Doing a GET on this endpoint will download the CSV exported in a previous call to the export endpoint and specified here with file_path.
 
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests
 
-      POST /api/1/history/events/export/download HTTP/1.1
+      GET /api/1/history/events/export/download HTTP/1.1
       Host: localhost:5042
       Content-Type: application/json;charset=UTF-8
 
@@ -9414,7 +9414,7 @@ Account operations by chain type
       This endpoint can also be queried asynchronously by using ``"async_query": true``
 
    Doing a PATCH on this endpoint with a list of accounts to edit will edit the label and tags for those accounts in all the chains of the same type where they are tracked.
- 
+
    **Example Request**:
 
    .. http:example:: curl wget httpie python-requests

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -3158,11 +3158,11 @@ class ExportHistoryEventResource(BaseMethodView):
 
 class ExportHistoryDownloadResource(BaseMethodView):
 
-    post_schema = ExportHistoryDownloadSchema()
+    get_schema = ExportHistoryDownloadSchema()
 
     @require_loggedin_user()
-    @use_kwargs(post_schema, location='json')
-    def post(self, file_path: str) -> Response:
+    @use_kwargs(get_schema, location='json_and_query')
+    def get(self, file_path: str) -> Response:
         return self.rest_api.download_history_events_csv(file_path=file_path)
 
 

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -139,7 +139,7 @@ def test_history_export_download_csv(
     file_path = outcome['result']['file_path']
 
     # download the csv exported in the last api call
-    response = requests.post(
+    response = requests.get(
         api_url_for(rotkehlchen_api_server_with_exchanges, 'exporthistorydownloadresource'),
         json={'file_path': file_path},
     )


### PR DESCRIPTION
Turn endpoint `/history/events/export/download` to use [GET] instead of [POST]
So frontend can download it directly without having to turn it into blob, so we don't need to store it in memory.
https://github.com/rotki/rotki/pull/8923#discussion_r1854203922