### PR TITLE
Use new balance scanner contract

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,8 @@ Changelog
 * :bug:`-` Fix the issue where some asset values show zero in the edit snapshot form.
 * :bug:`-` Fix the issue where the pagination for the account table resets to the first page when the user expands the account.
 * :bug:`8892` rotki will now correctly fetch Starknet token prices before May 2024 from Cryptocompare, when the ticker changed from STARK to STRK.
-* :bug:`-` The airdrops directory should no longer appear under the user directory in certain cirsumstances
+* :bug:`-` The airdrops directory should no longer appear under the user directory in certain circumstances.
+* :bug:`-` Fix an issue that caused the token detection to fail under some circumstances involving broken tokens.
 
 * :release:`1.36.0 <2024-11-06>`
 * :bug:`-` The exported file that overrides the file with the same name should have the latest modified time.

--- a/rotkehlchen/chain/arbitrum_one/node_inquirer.py
+++ b/rotkehlchen/chain/arbitrum_one/node_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -52,7 +53,7 @@ class ArbitrumOneInquirer(EvmNodeInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xcA11bde05977b3631167028862bE2a173976CA11')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.ARBITRUM_ONE,

--- a/rotkehlchen/chain/arbitrum_one/node_inquirer.py
+++ b/rotkehlchen/chain/arbitrum_one/node_inquirer.py
@@ -52,7 +52,7 @@ class ArbitrumOneInquirer(EvmNodeInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xcA11bde05977b3631167028862bE2a173976CA11')),
-            contract_scan=contracts.contract(string_to_evm_address('0x532E03C3167726cCfE0C777758b58b31054d3402')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.ARBITRUM_ONE,

--- a/rotkehlchen/chain/base/node_inquirer.py
+++ b/rotkehlchen/chain/base/node_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.l2_with_l1_fees.node_inquirer import L2WithL1FeesInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -52,7 +53,7 @@ class BaseInquirer(L2WithL1FeesInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xeDF6D2a16e8081F777eB623EeB4411466556aF3d')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.BASE,

--- a/rotkehlchen/chain/base/node_inquirer.py
+++ b/rotkehlchen/chain/base/node_inquirer.py
@@ -52,7 +52,7 @@ class BaseInquirer(L2WithL1FeesInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xeDF6D2a16e8081F777eB623EeB4411466556aF3d')),
-            contract_scan=contracts.contract(string_to_evm_address('0x2d26d6b698f6494efdB908A2A4f11ae5Fee86099')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.BASE,

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -199,7 +199,7 @@ class ProtocolWithGauges(ProtocolWithBalance):
         )
         result = self.evm_inquirer.contract_scan.call(
             node_inquirer=self.evm_inquirer,
-            method_name='tokensBalance',
+            method_name='tokens_balance',
             arguments=[address, staking_addresses],
             call_order=call_order,
         )

--- a/rotkehlchen/chain/ethereum/node_inquirer.py
+++ b/rotkehlchen/chain/ethereum/node_inquirer.py
@@ -18,6 +18,7 @@ from rotkehlchen.chain.ethereum.constants import (
     ETHEREUM_ETHERSCAN_NODE,
     PRUNED_NODE_CHECK_TX_HASH,
 )
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import (
     WEB3_LOGQUERY_BLOCK_RANGE,
@@ -76,7 +77,7 @@ class EthereumInquirer(DSProxyInquirerWithCacheData):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             dsproxy_registry=contracts.contract(string_to_evm_address('0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4')),
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(

--- a/rotkehlchen/chain/ethereum/node_inquirer.py
+++ b/rotkehlchen/chain/ethereum/node_inquirer.py
@@ -76,7 +76,7 @@ class EthereumInquirer(DSProxyInquirerWithCacheData):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696')),
-            contract_scan=contracts.contract(string_to_evm_address('0x86F25b64e1Fe4C5162cDEeD5245575D32eC549db')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             dsproxy_registry=contracts.contract(string_to_evm_address('0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4')),
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(

--- a/rotkehlchen/chain/evm/base_contracts.py
+++ b/rotkehlchen/chain/evm/base_contracts.py
@@ -1,0 +1,11 @@
+import json
+from typing import Final
+
+from rotkehlchen.chain.evm.contracts import EvmContract
+from rotkehlchen.chain.evm.types import string_to_evm_address
+
+BALANCE_SCANNER: Final = EvmContract(  # defined here only until we merge bugfixes to develop  # noqa: E501
+    address=string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92'),
+    abi=json.loads('[{"inputs":[{"name":"addresses","type":"address[]"}],"name":"ether_balances","outputs":[{"name":"","type":"uint256[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"name":"owner","type":"address"},{"name":"tokens","type":"address[]"}],"name":"tokens_balance","outputs":[{"name":"","type":"uint256[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"name":"owners","type":"address[]"},{"name":"token","type":"address"}],"name":"token_balances","outputs":[{"name":"","type":"uint256[]"}],"stateMutability":"view","type":"function"}]'),
+    deployed_block=0,
+)

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -329,7 +329,7 @@ class EvmNodeInquirer(ABC, LockableQueryMixIn):
         )
         result = self.contract_scan.call(
             node_inquirer=self,
-            method_name='etherBalances',
+            method_name='ether_balances',
             arguments=[accounts],
             call_order=call_order if call_order is not None else self.default_call_order(),
         )

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -64,7 +64,7 @@ DetectedTokensType = dict[
 # tokens the benchmark will probably have to run again.
 
 
-OTHER_MAX_TOKEN_CHUNK_LENGTH = 590
+OTHER_MAX_TOKEN_CHUNK_LENGTH = 460
 
 # maximum 32-bytes arguments in one call to a contract (either tokensBalance or multicall)
 ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT = 110
@@ -153,7 +153,7 @@ class EvmTokens(ABC):
         )
         result = self.evm_inquirer.contract_scan.call(
             node_inquirer=self.evm_inquirer,
-            method_name='tokensBalance',
+            method_name='tokens_balance',
             arguments=[address, [x.address for x in tokens]],
             call_order=call_order,
         )
@@ -199,7 +199,7 @@ class EvmTokens(ABC):
                 (
                     self.evm_inquirer.contract_scan.address,
                     self.evm_inquirer.contract_scan.encode(
-                        method_name='tokensBalance',
+                        method_name='tokens_balance',
                         arguments=[address, tokens_addrs],
                     ),
                 ),
@@ -212,7 +212,7 @@ class EvmTokens(ABC):
         for (address, tokens), result in zip(chunk, results, strict=True):
             decoded_result = self.evm_inquirer.contract_scan.decode(
                 result=result,
-                method_name='tokensBalance',
+                method_name='tokens_balance',
                 arguments=[address, [token.evm_address for token in tokens]],
             )[0]
             for token, token_balance in zip(tokens, decoded_result, strict=True):

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -37,31 +37,33 @@ DetectedTokensType = dict[
     tuple[list[EvmToken] | None, Timestamp | None],
 ]
 
-# 08/08/2020
-# Etherscan has by far the fastest responding server if you use a (free) API key
+# 27/11/2024
+# Etherscan has by far the fastest responding server if you use an API key
 # The chunk length for Etherscan is limited though to 120 addresses due to the URI length.
-# For all other nodes (mycrypto, avado cloud, blockscout) we have run some benchmarks
-# with them being queried randomly with different chunk lenghts. They are all for an account with:
-# - 29 ethereum addresses
-# - rotki knows of 1010 different ethereum tokens as of this writing
-# Type        |  Chunk Length | Elapsed Seconds | Avg. secs per call
-# Open Nodes  |     300       |      105        |      2.379
-# Open Nodes  |     400       |      112        |      2.735
-# Open Nodes  |     450       |       90        |      2.287
-# Open Nodes  |     520       |       89        |      2.275
-# Open Nodes  |     575       |       75        |      1.982
-# Open Nodes  |     585       |       77        |      2.034
-# Open Nodes  |     590       |       74        |      1.931
-# Open Nodes  |     590       |       79        |      2.086
-# Open Nodes  |     600       |       80        |      2.068
-# Open Nodes  |     600       |       86        |      2.275
+# For all other nodes (ankr, cloudflare, flashbots) we have run some benchmarks
+# with them being queried randomly with different chunk lenghts.
+# - They are for a single account
+# - rotki knows of 5264 different ethereum tokens as of this writing
+# - The code used is available in https://github.com/rotki/rotki/pull/8951
+# chunk size, time, node, seed, comments
 #
-# Etherscan   |     120       |       112       |      2.218
-# Etherscan   |     120       |       99        |      1.957
-# Etherscan   |     120       |       102       |      2.026
+# 375, 5.452023983001709,  flashbots
+# 375, 5.356801986694336,  flashbots , 42
+# 375, 8.883646965026855,  cloudflare
+# 375, 10.064039945602417, cloudflare
+# 375, 6.45735502243042,   cloudflare
+# 375, 5.277329921722412,  cloudflare, 80
+# 375, 4.732897043228149,  ankr      , 90
+# 500, 4.8045032024383545, ankr + flashbots, 90,  ankr and cloudlare had a single call out of gas
+# 480, 5.05453896522522, ankr, 90, ankr had a single call out of gas. Cloudflare okey
+# 460, 3.771683931350708, ankr + cloudflare, 90, only 1 request to ankr failed
+# 460, 4.571718215942383, ankr + cloudflare, 90, only 1 request to ankr failed
+# 460, 6.436861991882324, flashbots, 42
+# 460, 3.726022243499756, flahbots + ankr, 80
+# 460, 7.433700084686279, cloudflare + ankr, 460
 #
-# With this we have settled on a 590 chunk length. When we surpass 1180 ethereum
-# tokens the benchmark will probably have to run again.
+# With this we have settled on a 460 chunk length since it was the highest round number that
+# didn't hit any issue executing the query in the open nodes.
 
 
 OTHER_MAX_TOKEN_CHUNK_LENGTH = 460

--- a/rotkehlchen/chain/gnosis/node_inquirer.py
+++ b/rotkehlchen/chain/gnosis/node_inquirer.py
@@ -52,7 +52,7 @@ class GnosisInquirer(EvmNodeInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xcA11bde05977b3631167028862bE2a173976CA11')),
-            contract_scan=contracts.contract(string_to_evm_address('0x571C62a1c863aEAD01c1d34D8cB3Ee2c6f938800')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             native_token=A_XDAI.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.GNOSIS,

--- a/rotkehlchen/chain/gnosis/node_inquirer.py
+++ b/rotkehlchen/chain/gnosis/node_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -52,7 +53,7 @@ class GnosisInquirer(EvmNodeInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xcA11bde05977b3631167028862bE2a173976CA11')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             native_token=A_XDAI.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.GNOSIS,

--- a/rotkehlchen/chain/optimism/node_inquirer.py
+++ b/rotkehlchen/chain/optimism/node_inquirer.py
@@ -54,7 +54,7 @@ class OptimismInquirer(DSProxyL2WithL1FeesInquirerWithCacheData):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0x2DC0E2aa608532Da689e89e237dF582B783E552C')),
-            contract_scan=contracts.contract(string_to_evm_address('0x1e21bc42FaF802A0F115dC998e2F0d522aDb1F68')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             dsproxy_registry=contracts.contract(string_to_evm_address('0x283Cc5C26e53D66ed2Ea252D986F094B37E6e895')),
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(

--- a/rotkehlchen/chain/optimism/node_inquirer.py
+++ b/rotkehlchen/chain/optimism/node_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.l2_with_l1_fees.node_inquirer import (
     DSProxyL2WithL1FeesInquirerWithCacheData,
@@ -54,7 +55,7 @@ class OptimismInquirer(DSProxyL2WithL1FeesInquirerWithCacheData):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0x2DC0E2aa608532Da689e89e237dF582B783E552C')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             dsproxy_registry=contracts.contract(string_to_evm_address('0x283Cc5C26e53D66ed2Ea252D986F094B37E6e895')),
             native_token=A_ETH.resolve_to_crypto_asset(),
             blockscout=Blockscout(

--- a/rotkehlchen/chain/polygon_pos/node_inquirer.py
+++ b/rotkehlchen/chain/polygon_pos/node_inquirer.py
@@ -52,7 +52,7 @@ class PolygonPOSInquirer(EvmNodeInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0x275617327c958bD06b5D6b871E7f491D76113dd8')),
-            contract_scan=contracts.contract(string_to_evm_address('0x2aB513B211C801673758D1C32815605B5289ad29')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             native_token=A_POLYGON_POS_MATIC.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.POLYGON_POS,

--- a/rotkehlchen/chain/polygon_pos/node_inquirer.py
+++ b/rotkehlchen/chain/polygon_pos/node_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -52,7 +53,7 @@ class PolygonPOSInquirer(EvmNodeInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0x275617327c958bD06b5D6b871E7f491D76113dd8')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             native_token=A_POLYGON_POS_MATIC.resolve_to_crypto_asset(),
             blockscout=Blockscout(
                 blockchain=SupportedBlockchain.POLYGON_POS,

--- a/rotkehlchen/chain/scroll/node_inquirer.py
+++ b/rotkehlchen/chain/scroll/node_inquirer.py
@@ -51,7 +51,7 @@ class ScrollInquirer(L2WithL1FeesInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xcA11bde05977b3631167028862bE2a173976CA11')),
-            contract_scan=contracts.contract(string_to_evm_address('0xc97EE9490F4e3A3136A513DB38E3C7b47e69303B')),
+            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
             native_token=A_ETH.resolve_to_crypto_asset(),
         )
         self.etherscan = cast(ScrollEtherscan, self.etherscan)

--- a/rotkehlchen/chain/scroll/node_inquirer.py
+++ b/rotkehlchen/chain/scroll/node_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 from rotkehlchen.chain.constants import DEFAULT_EVM_RPC_TIMEOUT
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.l2_with_l1_fees.node_inquirer import L2WithL1FeesInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -51,7 +52,7 @@ class ScrollInquirer(L2WithL1FeesInquirer):
             contracts=contracts,
             rpc_timeout=rpc_timeout,
             contract_multicall=contracts.contract(string_to_evm_address('0xcA11bde05977b3631167028862bE2a173976CA11')),
-            contract_scan=contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92')),
+            contract_scan=BALANCE_SCANNER,
             native_token=A_ETH.resolve_to_crypto_asset(),
         )
         self.etherscan = cast(ScrollEtherscan, self.etherscan)

--- a/rotkehlchen/tests/api/blockchain/test_optimism.py
+++ b/rotkehlchen/tests/api/blockchain/test_optimism.py
@@ -66,8 +66,7 @@ def test_add_optimism_blockchain_account(rotkehlchen_api_server: 'APIServer') ->
     now = ts_now()
     # now check that detecting tokens works
     optimism_tokens = (
-        Asset('eip155:10/erc20:0x4F604735c1cF31399C6E711D5962b2B3E0225AD3'),
-        Asset('eip155:10/erc20:0x94b008aA00579c1307B0EF2c499aD98a8ce58e58'),
+        Asset('eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),
     )
     # patch get_evm_tokens return value to just a few tokens
     # to prevent issues when the asset database changes

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -20,7 +20,7 @@ from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V3
 from rotkehlchen.chain.evm.tokens import TokenBalancesType
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
-from rotkehlchen.constants.assets import A_DAI, A_USDC, A_USDT, A_WBTC, A_WETH
+from rotkehlchen.constants.assets import A_DAI, A_USDC, A_WETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
@@ -102,34 +102,13 @@ def test_query_aave_balances(rotkehlchen_api_server: APIServer) -> None:
             'lending': {
                 A_DAI.identifier: {
                     'balance': Balance(
-                        amount=FVal('25319.644933920807083535'),
-                        usd_value=FVal('37979.4674008812106253025'),
+                        amount=FVal('21528.498187325929022298'),
+                        usd_value=FVal('32292.7472809888935334470'),
                     ).serialize(),
-                    'apy': '0.15%',
+                    'apy': '0.00%',
                 },
             },
             'borrowing': {},
-        },
-        AAVE_BALANCESV2_TEST_ACC: {
-            'lending': {
-                A_WBTC.identifier: {
-                    'balance': Balance(
-                        amount=FVal('0.43022092'),
-                        usd_value=FVal('0.645331380'),
-                    ).serialize(),
-                    'apy': '0.11%',
-                },
-            },
-            'borrowing': {
-                A_USDT.identifier: {
-                    'balance': Balance(
-                        amount=FVal('20582.495008'),
-                        usd_value=FVal('30873.7425120'),
-                    ).serialize(),
-                    'stable_apr': '39.20%',
-                    'variable_apr': '33.20%',
-                },
-            },
         },
         AAVE_BALANCESV3_TEST_ACC: {
             'lending': {
@@ -138,7 +117,7 @@ def test_query_aave_balances(rotkehlchen_api_server: APIServer) -> None:
                         amount=FVal('123'),
                         usd_value=FVal('12.3'),
                     ).serialize(),
-                    'apy': '1.60%',
+                    'apy': '2.02%',
                 },
             },
             'borrowing': {
@@ -147,8 +126,8 @@ def test_query_aave_balances(rotkehlchen_api_server: APIServer) -> None:
                         amount=FVal('456'),
                         usd_value=FVal('4560'),
                     ).serialize(),
-                    'stable_apr': '9.51%',
-                    'variable_apr': '8.01%',
+                    'stable_apr': '0.00%',
+                    'variable_apr': '10.21%',
                 },
             },
         },

--- a/rotkehlchen/tests/api/test_compound.py
+++ b/rotkehlchen/tests/api/test_compound.py
@@ -153,49 +153,49 @@ def test_query_compound_v3_balances(
         ethereum_accounts[0]: {
             'lending': {
                 c_usdc_v3.identifier: {
-                    'apy': '6.42%',
+                    'apy': '9.90%',
                     'balance': get_balance('333349.851793'),
                 },
             }, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('2.356445'),
+                    'balance': get_balance('12.012345'),
                 },
             },
         }, ethereum_accounts[1]: {
             'lending': {
                 c_usdc_v3.identifier: {
-                    'apy': '6.42%',
+                    'apy': '9.90%',
                     'balance': get_balance('0.32795'),
                 },
             }, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('0'),
+                    'balance': get_balance('0.000016'),
                 },
             },
         }, ethereum_accounts[2]: {
             'borrowing': {
                 c_usdc_v3.identifier: {
-                    'apy': '8.63%',
-                    'balance': get_balance('166903.418564'),
+                    'apy': '11.57%',
+                    'balance': get_balance('20834.273226'),
                 },
             }, 'lending': {}, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('0.22238'),
+                    'balance': get_balance('0.19064'),
                 },
             },
         }, ethereum_accounts[3]: {
             'borrowing': {
                 c_usdc_v3.identifier: {
-                    'apy': '8.63%',
-                    'balance': get_balance('257.564495'),
+                    'apy': '11.57%',
+                    'balance': get_balance('0'),
                 },
             }, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('0.000038'),
+                    'balance': get_balance('0.000941'),
                 },
             },
         },

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -261,12 +261,12 @@ def test_native_token_balance(
         balances = blockchain.balances.polygon_pos[address].assets
         assert balances == {
             pol: Balance(
-                amount=FVal('8.206486866125895549'),
-                usd_value=FVal('12.3097302991888433235'),
+                amount=FVal('8.204435619126641457'),
+                usd_value=FVal('12.3066534286899621855'),
             ),
             usdc: Balance(
-                amount=FVal('10.045085'),
-                usd_value=FVal('15.0676275'),
+                amount=FVal('0.33078'),
+                usd_value=FVal('0.496170'),
             ),
             weth: Balance(
                 amount=FVal('0.007712106620416874'),

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -26,7 +26,7 @@ from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithBalance
 from rotkehlchen.chain.ethereum.modules.aave.balances import AaveBalances
 from rotkehlchen.chain.ethereum.modules.blur.balances import BlurBalances
 from rotkehlchen.chain.ethereum.modules.blur.constants import BLUR_IDENTIFIER
-from rotkehlchen.chain.ethereum.modules.convex.balances import ConvexBalances
+from rotkehlchen.chain.ethereum.modules.convex.balances import CPT_CONVEX, ConvexBalances
 from rotkehlchen.chain.ethereum.modules.curve.balances import CurveBalances
 from rotkehlchen.chain.ethereum.modules.eigenlayer.balances import EigenlayerBalances
 from rotkehlchen.chain.ethereum.modules.gearbox.balances import GearboxBalances
@@ -101,7 +101,6 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize('ethereum_accounts', [['0xb24cE065a3A9bbCCED4B74b6F4435b852286396d']])
 def test_curve_balances(
         ethereum_inquirer: 'EthereumInquirer',
-        ethereum_transaction_decoder: 'EthereumTransactionDecoder',
         ethereum_accounts: list[ChecksumEvmAddress],
         load_global_caches: list[str],
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
@@ -126,14 +125,14 @@ def test_curve_balances(
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('ethereum_accounts', [['0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF']])
+@pytest.mark.parametrize('load_global_caches', [[CPT_CONVEX]])
+@pytest.mark.parametrize('ethereum_accounts', [['0x53913A03a065f685097f8E8f40284D58016bB0F9']])
 def test_convex_gauges_balances(
         ethereum_inquirer: 'EthereumInquirer',
-        ethereum_transaction_decoder: 'EthereumTransactionDecoder',
         ethereum_accounts: list[ChecksumEvmAddress],
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
 ) -> None:
-    tx_hex = deserialize_evm_tx_hash('0x0d8863fb26d57ca11dc11c694dbf6a13ef03920e39d0482081aa88b0b20ba61b')  # noqa: E501
+    tx_hex = deserialize_evm_tx_hash('0xf9d35b99cd67a506d216dbfeaaeb89adcfb3b8d104f2d863c97278eacee1bc41')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         tx_hash=tx_hex,
@@ -144,28 +143,28 @@ def test_convex_gauges_balances(
     )
     convex_balances = convex_balances_inquirer.query_balances()
     user_balance = convex_balances[ethereum_accounts[0]]
-    asset = EvmToken('eip155:1/erc20:0x06325440D014e39736583c165C2963BA99fAf14E')
+    asset = EvmToken('eip155:1/erc20:0xF9835375f6b268743Ea0a54d742Aa156947f8C06')
     assert user_balance.assets[asset] == Balance(
-        amount=FVal('2.096616951181033047'),
-        usd_value=FVal('3.1449254267715495705'),
+        amount=FVal('34.011048723934089999'),
+        usd_value=FVal('51.0165730859011349985'),
     )
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('ethereum_accounts', [['0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF']])
+@pytest.mark.parametrize('load_global_caches', [[CPT_CONVEX]])
+@pytest.mark.parametrize('ethereum_accounts', [['0x36928dCA92EA4eDA2292d0090e60532eB6A32475']])
 def test_convex_staking_balances(
         ethereum_inquirer: 'EthereumInquirer',
-        ethereum_transaction_decoder: 'EthereumTransactionDecoder',
         ethereum_accounts: list[ChecksumEvmAddress],
         inquirer: 'Inquirer',  # pylint: disable=unused-argument
 ) -> None:
-    """Check Convex balance query for CSV locked and staked"""
-    tx_hex = deserialize_evm_tx_hash('0x0d8863fb26d57ca11dc11c694dbf6a13ef03920e39d0482081aa88b0b20ba61b')  # noqa: E501
-    get_decoded_events_of_transaction(
+    """Check Convex balance query for CVX locked and staked"""
+    tx_hex = deserialize_evm_tx_hash('0x9a1cdbbe383d7677cf45b54106af0cf7e07f65eb1809f9bd3ecea8bb905600d3')  # noqa: E501
+    _, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         tx_hash=tx_hex,
     )
-    tx_hex = deserialize_evm_tx_hash('0x679746961f731819e351f866b33bc2267dfb341e9d0b30ebccd012834ae3ffde')  # noqa: E501
+    tx_hex = deserialize_evm_tx_hash('0x49f4dabfee05cc78e2b19a574373ad5afb1de52e03d7b355fe8611be7137e411')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         tx_hash=tx_hex,
@@ -178,13 +177,13 @@ def test_convex_staking_balances(
     user_balance = convex_balances[ethereum_accounts[0]]
     # the amount here is the sum of the locked ~44 and the staked tokens ~333
     assert user_balance.assets[A_CVX.resolve_to_evm_token()] == Balance(
-        amount=FVal('378.311754894794233025'),
-        usd_value=FVal('567.4676323421913495375'),
+        amount=FVal('18229.934390350508148387'),
+        usd_value=FVal('27344.9015855257622225805'),
     )
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('ethereum_accounts', [['0x0c3ce74FCB2B93F9244544919572818Dc2AC0641']])
+@pytest.mark.parametrize('ethereum_accounts', [['0x36928dCA92EA4eDA2292d0090e60532eB6A32475']])
 def test_convex_staking_balances_without_gauges(
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_transaction_decoder: 'EthereumTransactionDecoder',
@@ -197,7 +196,7 @@ def test_convex_staking_balances_without_gauges(
     balances returned from the gauges and those balances before this test were
     not a defaultdict and could lead to a failure.
     """
-    tx_hex = deserialize_evm_tx_hash('0x38bd199803e7cb065c809ce07957afc0647a41da4c0610d1209a843d9b045cd6')  # noqa: E501
+    tx_hex = deserialize_evm_tx_hash('0x49f4dabfee05cc78e2b19a574373ad5afb1de52e03d7b355fe8611be7137e411')  # noqa: E501
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
         tx_hash=tx_hex,
@@ -209,8 +208,8 @@ def test_convex_staking_balances_without_gauges(
     convex_balances = convex_balances_inquirer.query_balances()
     user_balance = convex_balances[ethereum_accounts[0]]
     assert user_balance.assets[A_CVX.resolve_to_evm_token()] == Balance(
-        amount=FVal('44.126532249621479557'),
-        usd_value=FVal('66.1897983744322193355'),
+        amount=FVal('18229.934390350508148387'),
+        usd_value=FVal('27344.9015855257622225805'),
     )
 
 
@@ -717,10 +716,10 @@ def test_compound_v3_token_balances_liabilities(
         return Balance(
             amount=FVal(amount), usd_value=FVal(amount) * CURRENT_PRICE_MOCK,
         )
-    assert blockchain.balances.eth[ethereum_accounts[0]].liabilities[A_USDC] == get_balance('166903.779933')  # noqa: E501
+    assert blockchain.balances.eth[ethereum_accounts[0]].liabilities[A_USDC] == get_balance('20833.286308')  # noqa: E501
     assert blockchain.balances.eth[ethereum_accounts[1]].assets[c_usdc_v3] == get_balance('0.32795')  # noqa: E501
-    assert blockchain.balances.eth[ethereum_accounts[2]].liabilities[A_USDC] == get_balance('257.565053')  # noqa: E501
-    assert blockchain.balances.eth[ethereum_accounts[3]].liabilities[A_USDC] == get_balance('589398.492789')  # noqa: E501
+    assert blockchain.balances.eth[ethereum_accounts[2]].liabilities[A_USDC] == get_balance('0')
+    assert blockchain.balances.eth[ethereum_accounts[3]].liabilities[A_USDC] == get_balance('134508.993003')  # noqa: E501
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -215,7 +215,7 @@ def mock_etherscan_query(
         extra_flags: list[str] | None,
         original_requests_get,
 ):
-    eth_scan = ethereum.contracts.contract(string_to_evm_address('0x86F25b64e1Fe4C5162cDEeD5245575D32eC549db'))  # noqa: E501
+    eth_scan = ethereum.contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92'))  # noqa: E501
     eth_multicall = ethereum.contracts.contract(string_to_evm_address('0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'))  # noqa: E501
     original_queries = [] if original_queries is None else original_queries
     extra_flags = [] if extra_flags is None else extra_flags
@@ -341,12 +341,12 @@ def mock_etherscan_query(
                 multicall_purpose = 'compound_balances'
             elif '5f3b5dfeb7b28cdbd7faba78963ee202a494e2a2' in url:
                 multicall_purpose = 'vecrv'
-            elif '86f25b64e1fe4c5162cdeed5245575d32ec549db' in url:
+            elif '54ecf3f6f61f63fdfe7c27ee8a86e54899600c92' in url:
                 multicall_purpose = 'multibalance_query'
             else:
                 raise AssertionError('Unknown multicall in mocked tests')
 
-            if '86f25b64e1fe4c5162cdeed5245575d32ec549db' in url:
+            if '54ecf3f6f61f63fdfe7c27ee8a86e54899600c92' in url:
                 # can appear mixed with above so multibalance can trump the rest since actionable
                 multicall_purpose = 'multibalance_query'
 
@@ -369,7 +369,7 @@ def mock_etherscan_query(
                     # not really the given args, but we just want the fn abi
                     args = [next(iter(eth_map.keys())), list(eth_map.keys())]
                     scan_fn_abi = ethscan_contract._find_matching_fn_abi(
-                        'tokensBalance',
+                        'tokens_balance',
                         *args,
                     )
                     scan_input_types = get_abi_input_types(scan_fn_abi)
@@ -415,13 +415,13 @@ def mock_etherscan_query(
             web3 = Web3()
             contract = eth_scan
             ethscan_contract = web3.eth.contract(address=contract.address, abi=contract.abi)
-            if 'data=0xdbdbb51b' in url:  # Eth balance query
+            if 'data=0xee1806d2' in url:  # Eth balance query
                 data = url.split('data=')[1]
                 if '&apikey' in data:
                     data = data.split('&apikey')[0]
 
                 fn_abi = ethscan_contract._find_matching_fn_abi(
-                    'etherBalances',
+                    'ether_balances',
                     *[list(eth_map.keys())],
                 )
                 input_types = get_abi_input_types(fn_abi)
@@ -433,14 +433,14 @@ def mock_etherscan_query(
                     args.append(int(eth_map[account_address]['ETH']))
                 result = '0x' + web3.codec.encode(output_types, [args]).hex()
                 response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
-            elif 'data=0x06187b4f' in url:  # Multi token multiaddress balance query
+            elif 'data=0x665bb79e' in url:  # Multi token multiaddress balance query
                 data = url.split('data=')[1]
                 if '&apikey' in data:
                     data = data.split('&apikey')[0]
                 # not really the given args, but we just want the fn abi
                 args = [list(eth_map.keys()), list(eth_map.keys())]
                 fn_abi = ethscan_contract._find_matching_fn_abi(
-                    fn_identifier='tokensBalances',
+                    fn_identifier='tokens_balances',
                     args=args,
                 )
                 input_types = get_abi_input_types(fn_abi)
@@ -468,14 +468,14 @@ def mock_etherscan_query(
                 result = '0x' + web3.codec.encode(output_types, [args]).hex()
                 response = f'{{"jsonrpc":"2.0","id":1,"result":"{result}"}}'
 
-            elif 'data=0xe5da1b68' in url:  # Multi token balance query
+            elif 'data=0xb0d861b8' in url:  # Multi token balance query
                 data = url.split('data=')[1]
                 if '&apikey' in data:
                     data = data.split('&apikey')[0]
                 # not really the given args, but we just want the fn abi
                 args = ['str', list(eth_map.keys())]
                 fn_abi = ethscan_contract._find_matching_fn_abi(
-                    'tokensBalance',
+                    'tokens_balance',
                     *args,
                 )
                 input_types = get_abi_input_types(fn_abi)

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -9,6 +9,7 @@ from web3 import Web3
 
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.ethereum.defi.zerionsdk import ZERION_ADAPTER_ADDRESS
+from rotkehlchen.chain.evm.base_contracts import BALANCE_SCANNER
 from rotkehlchen.chain.evm.types import NodeName, Web3Node, string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_BTC, A_ETH
@@ -215,7 +216,7 @@ def mock_etherscan_query(
         extra_flags: list[str] | None,
         original_requests_get,
 ):
-    eth_scan = ethereum.contracts.contract(string_to_evm_address('0x54eCF3f6f61F63fdFE7c27Ee8A86e54899600C92'))  # noqa: E501
+    eth_scan = BALANCE_SCANNER
     eth_multicall = ethereum.contracts.contract(string_to_evm_address('0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'))  # noqa: E501
     original_queries = [] if original_queries is None else original_queries
     extra_flags = [] if extra_flags is None else extra_flags

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
-NODE_CONNECTION_TIMEOUT = 10
+NODE_CONNECTION_TIMEOUT = 3
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
-NODE_CONNECTION_TIMEOUT = 3
+NODE_CONNECTION_TIMEOUT = 10
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)


### PR DESCRIPTION
This commit introduces a new balance scanner contracts. It is writting in vyper and is important because in case of a revert calling the balanceof for a contract it returns 0 instead of failing the transaction.

This change solves an issue where a bad token could make rotki not query balances properly.

Regarding the chunk size I've checked different sizes

```
chunk size, time, node, seed, comments

375, 5.452023983001709,  flashbots
375, 5.356801986694336,  flashbots , 42
375, 8.883646965026855,  cloudflare
375, 10.064039945602417, cloudflare
375, 6.45735502243042,   cloudflare
375, 5.277329921722412,  cloudflare, 80
375, 4.732897043228149,  ankr      , 90
500, 4.8045032024383545, ankr + flashbots, 90,  ankr and cloudlare had a single call out of gas
480, 5.05453896522522, ankr, 90, ankr had a single call out of gas. Cloudflare okey
460, 3.771683931350708, ankr + cloudflare, 90, only 1 request to ankr failed
460, 4.571718215942383, ankr + cloudflare, 90, only 1 request to ankr failed
460, 6.436861991882324, flashbots, 42
460, 3.726022243499756, flahbots + ankr, 80
460, 7.433700084686279, cloudflare + ankr, 460
```

and the optimal was 460. I'm under the impression that a token consumes a little bit more of gas and makes the transaction fail.

The checks were made with this test

```python
import pytest
from rotkehlchen.chain.ethereum.manager import EthereumManager
from rotkehlchen.types import ChecksumEvmAddress
from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
from rotkehlchen.types import SupportedBlockchain
import time
import random

@pytest.mark.parametrize('ethereum_accounts', [[
    '0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF',
]])
@pytest.mark.parametrize('ethereum_manager_connect_at_start', ['DEFAULT'])
def test_token_detection(
    ethereum_manager: EthereumManager,
    ethereum_accounts: list[ChecksumEvmAddress],
):
    random.seed(120)
    # nodes = ethereum_manager.node_inquirer.database.get_rpc_nodes(blockchain=SupportedBlockchain.ETHEREUM)
    # ethereum_manager.node_inquirer.connect_to_multiple_nodes(nodes)
    # wait_until_all_nodes_connected(
    #     connect_at_start=nodes,
    #     evm_inquirer=ethereum_manager.node_inquirer,
    # )
    start = time.time()
    tokens = ethereum_manager.tokens._query_new_tokens(
        addresses=ethereum_accounts,
    )
    # print(tokens)
    print(time.time() - start)
```
