### PR TITLE
Fix wrong range queried in gnosis logs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 * :bug:`-` The airdrops directory should no longer appear under the user directory in certain circumstances.
 * :bug:`-` Fix an issue that caused the token detection to fail under some circumstances involving broken tokens.
 * :bug:`-` rotki won't try to query logs from slow nodes.
+* :bug:`-` Refreshing the transactions while tracking a gnosis address will be faster after the first query.
 
 * :release:`1.36.0 <2024-11-06>`
 * :bug:`-` The exported file that overrides the file with the same name should have the latest modified time.

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -158,7 +158,7 @@ class EvmTransactions(ABC):  # noqa: B024
                 start_ts=from_ts,
                 end_ts=to_ts,
             )
-        self.get_chain_specific_multiaddress_data(accounts, from_ts, to_ts)
+        self.get_chain_specific_multiaddress_data(accounts)
 
     def _query_and_save_transactions_for_range(
             self,
@@ -838,8 +838,6 @@ class EvmTransactions(ABC):  # noqa: B024
     def get_chain_specific_multiaddress_data(
             self,
             addresses: Sequence[ChecksumEvmAddress],  # pylint: disable=unused-argument
-            from_ts: Timestamp,  # pylint: disable=unused-argument
-            to_ts: Timestamp,  # pylint: disable=unused-argument
     ) -> None:
         """Can be implemented by each chain subclass to add chain-specific data queries
         for all tracked addresses at once"""


### PR DESCRIPTION
The problems is that the range queried for logs was always of the form [deployed block, latest]

The reason is that the function is called in https://github.com/rotki/rotki/blob/87dc0db0a46e67c1497ff0ed0abbab4697352348/rotkehlchen/chain/evm/transactions.py#L161 with the data that comes from the api but the frontend never sends a start/end timestamps so the range was in fact always [0, now].

Then the logic was

```python
        with self.database.conn.read_ctx() as cursor:
            cursor.execute('SELECT MAX(start_ts), MIN(end_ts) FROM used_query_ranges WHERE name LIKE ?', (f'{BRIDGE_QUERIED_ADDRESS_PREFIX}%',))  # noqa: E501
            result = cursor.fetchone()
            if result is not None:
                max_start, min_end = result

        if max_start is not None:
            if max_start <= from_ts and min_end >= to_ts:  # type: ignore # min_end not None
                return  # no need to do anything

            # else, adjust query
            from_ts = min(max_start, from_ts)
            to_ts = max(min_end, to_ts)  # type: ignore # min_end is not None
```

but in the db the ranges are stored in the form [0, end_ts] so

```
from_ts = min(max_start, from_ts)
```

was always `min(0, 0)` and to_ts was always now.

How I noticed this was by a change in the logs in my last PR that states the ranges saved to the database and I could see that it was starting from the deployed block always.

Why didn't we see it in the tests since we have a check to ensure that the info wasn't queried again? The test was calling

```
gnosis_transactions.get_chain_specific_multiaddress_data(
            addresses=gnosis_accounts,
            from_ts=Timestamp(0),
            to_ts=now,
        )
```

and the logic evaluated

```
        if max_start is not None:
            if max_start <= from_ts and min_end >= to_ts:  # type: ignore # min_end not None
                return  #
```

where `max_start <= from_ts and min_end >= to_ts` is `0 <= 0 and now >= now` and therefore no extra call was performed.

This PR changes the logic to:

1. Ignore the from and to. It introduced a bug because is not what the developer expected and we use the query ranges.
2. Properly query the widest range for logs
3. Ensure that if new addresses are added then we query logs for them

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
