### PR TITLE
Removed old query ranges for gnosis

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migrations_19.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_19.py
@@ -2,8 +2,10 @@ import logging
 import shutil
 from typing import TYPE_CHECKING
 
+from rotkehlchen.chain.gnosis.constants import BRIDGE_QUERIED_ADDRESS_PREFIX
 from rotkehlchen.constants import APPDIR_NAME
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.types import SupportedBlockchain
 from rotkehlchen.utils.progress import perform_userdb_migration_steps, progress_step
 
 if TYPE_CHECKING:
@@ -27,5 +29,28 @@ def data_migration_19(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
         if bad_folder.exists():
             log.info(f'Deleting folder {bad_folder} created by mistake')
             shutil.rmtree(bad_folder)
+
+    @progress_step(description='Cleaning unused gnosis bridge logs.')
+    def _delete_old_gnosis_bridge_ranges(rotki: 'Rotkehlchen') -> None:
+        """Delete query ranges for accounts that were deleted"""
+        db = rotki.data.db
+        with db.conn.read_ctx() as cursor:
+            addresses = db.get_single_blockchain_addresses(
+                cursor=cursor,
+                blockchain=SupportedBlockchain.GNOSIS,
+            )
+            db_query_ranges: list[str] = [row[0] for row in cursor.execute(
+                'SELECT name FROM used_query_ranges WHERE name LIKE ?',
+                (f'{BRIDGE_QUERIED_ADDRESS_PREFIX}%',),
+            )]
+
+        expected_ranges = {f'{BRIDGE_QUERIED_ADDRESS_PREFIX}{address}' for address in addresses}
+        with db.conn.write_ctx() as write_cursor:
+            for entry_name in db_query_ranges:
+                if entry_name not in expected_ranges:
+                    write_cursor.execute(
+                        'DELETE FROM used_query_ranges where name=?',
+                        (entry_name,),
+                    )
 
     perform_userdb_migration_steps(rotki, progress_handler, should_vacuum=True)

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -30,6 +30,7 @@ from rotkehlchen.chain.bitcoin.xpub import (
     deserialize_derivation_path_for_db,
 )
 from rotkehlchen.chain.evm.types import NodeName, WeightedNode
+from rotkehlchen.chain.gnosis.constants import BRIDGE_QUERIED_ADDRESS_PREFIX
 from rotkehlchen.chain.substrate.types import SubstrateAddress
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_ETH, A_ETH2, A_USD
@@ -2175,6 +2176,11 @@ class DBHandler:
 
         dbtx = DBEvmTx(self)
         dbtx.delete_transactions(write_cursor=write_cursor, address=address, chain=blockchain)
+        if blockchain == SupportedBlockchain.GNOSIS:
+            write_cursor.execute(
+                'DELETE FROM used_query_ranges WHERE name=?',
+                (f'{BRIDGE_QUERIED_ADDRESS_PREFIX}{address}',),
+            )
 
     def delete_data_for_evmlike_address(
             self,


### PR DESCRIPTION
It was possible to delete a gnosis account without clearing the query ranges for bridge logs. This triggered an issue with the sql statement trying to find the range to query.

THis PR:
- Remove the ranges for accounts not tracked
- Ensures that the query for logs only uses information for the selected addresses
- Clears the entry in the queried ranges when deleting a gnosis address

