### PR TITLE
Bump ruff to 0.8.1, apply TC006

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -2,7 +2,7 @@ mypy==1.13.0
 mypy-extensions==1.0.0
 pylint==3.3.1
 astroid==3.3.4  # engine of pylint, upgrade them together
-ruff==0.8.0
+ruff==0.8.1
 double-indent-rotki==0.1.7  # our fork of double indent
 
 # type packages used by mypy

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -102,11 +102,11 @@ class EventsAccountant:
                     f'event for {event} is not there',
                 )
                 return 1
-            in_event = cast(HistoryBaseEntry, next(events_iterator))  # guaranteed by the if check
 
+            in_event = cast('HistoryBaseEntry', next(events_iterator))  # guaranteed by the if check  # noqa: E501
             next_event = events_iterator.peek(None)
             if next_event and isinstance(next_event, HistoryBaseEntry) and next_event.event_identifier == event.event_identifier and next_event.event_subtype == HistoryEventSubType.FEE:  # noqa: E501
-                fee_event = cast(HistoryBaseEntry, next(events_iterator))  # guaranteed by if check
+                fee_event = cast('HistoryBaseEntry', next(events_iterator))  # guaranteed by if check  # noqa: E501
 
             return self._process_swap(
                 timestamp=timestamp,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -90,7 +90,6 @@ from rotkehlchen.chain.evm.decoding.velodrome.velodrome_cache import (
 from rotkehlchen.chain.evm.names import find_ens_mappings, search_for_addresses_names
 from rotkehlchen.chain.evm.types import EvmlikeAccount, WeightedNode
 from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import CPT_GNOSIS_PAY
-from rotkehlchen.chain.gnosis.modules.gnosis_pay.decoder import GnosisPayDecoder
 from rotkehlchen.chain.zksync_lite.constants import ZKL_IDENTIFIER
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_USD
@@ -272,6 +271,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.bitcoin.xpub import XpubData
     from rotkehlchen.chain.evm.accounting.structures import BaseEventSettings
     from rotkehlchen.chain.evm.manager import EvmManager
+    from rotkehlchen.chain.gnosis.modules.gnosis_pay.decoder import GnosisPayDecoder
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
     from rotkehlchen.exchanges.kraken import KrakenAccountType
@@ -645,7 +645,7 @@ class RestAPI:
         if (
                 updates_gnosispay and
                 (gnosispay_decoder := cast(
-                    GnosisPayDecoder,
+                    'GnosisPayDecoder',
                     self.rotkehlchen.chains_aggregator.get_evm_manager(ChainID.GNOSIS).transactions_decoder.decoders.get('GnosisPay'),
                 )) is not None
         ):

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2866,7 +2866,7 @@ class AddressWithOptionalBlockchainSchema(Schema):
     ) -> OptionalChainAddress:
         if (
             data['blockchain'] is not None and
-            cast(SupportedBlockchain, data['blockchain']).get_chain_type() == ChainType.EVM
+            cast('SupportedBlockchain', data['blockchain']).get_chain_type() == ChainType.EVM
         ):
             try:
                 address = to_checksum_address(data['address'])
@@ -2897,7 +2897,7 @@ class AddressWithOptionalBlockchainSchema(Schema):
         if data['blockchain'] is None:
             return
 
-        blockchain = cast(SupportedBlockchain, data['blockchain'])
+        blockchain = cast('SupportedBlockchain', data['blockchain'])
         if ((
             blockchain == SupportedBlockchain.BITCOIN and
             is_valid_btc_address(data['address']) is False

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -24,7 +24,6 @@ from rotkehlchen.chain.arbitrum_one.modules.thegraph.balances import (
     ThegraphBalances as ThegraphBalancesArbitrumOne,
 )
 from rotkehlchen.chain.arbitrum_one.modules.umami.balances import UmamiBalances
-from rotkehlchen.chain.avalanche.manager import AvalancheManager
 from rotkehlchen.chain.base.modules.aerodrome.balances import AerodromeBalances
 from rotkehlchen.chain.base.modules.extrafi.balances import (
     ExtrafiBalances as ExtrafiBalancesBase,
@@ -119,6 +118,7 @@ from .balances import BlockchainBalances, BlockchainBalancesUpdate
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.manager import ArbitrumOneManager
+    from rotkehlchen.chain.avalanche.manager import AvalancheManager
     from rotkehlchen.chain.base.manager import BaseManager
     from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithBalance
     from rotkehlchen.chain.ethereum.manager import EthereumManager
@@ -1491,7 +1491,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             chain_manager: EvmManager = self.get_chain_manager(chain)
             try:
                 if chain == SupportedBlockchain.AVALANCHE:
-                    avax_manager = cast(AvalancheManager, chain_manager)
+                    avax_manager = cast('AvalancheManager', chain_manager)
                     try:
                         # just check balance and nonce in avalanche
                         has_activity = (

--- a/rotkehlchen/chain/arbitrum_one/node_inquirer.py
+++ b/rotkehlchen/chain/arbitrum_one/node_inquirer.py
@@ -61,7 +61,7 @@ class ArbitrumOneInquirer(EvmNodeInquirer):
                 msg_aggregator=database.msg_aggregator,
             ),
         )
-        self.etherscan = cast(ArbitrumOneEtherscan, self.etherscan)
+        self.etherscan = cast('ArbitrumOneEtherscan', self.etherscan)
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/chain/base/node_inquirer.py
+++ b/rotkehlchen/chain/base/node_inquirer.py
@@ -61,7 +61,7 @@ class BaseInquirer(L2WithL1FeesInquirer):
                 msg_aggregator=database.msg_aggregator,
             ),
         )
-        self.etherscan = cast(BaseEtherscan, self.etherscan)
+        self.etherscan = cast('BaseEtherscan', self.etherscan)
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/chain/bitcoin/hdkey.py
+++ b/rotkehlchen/chain/bitcoin/hdkey.py
@@ -280,8 +280,8 @@ class HDKey:
         """
         xpub = bytearray()
 
-        xpub.extend(b58decode(cast(str, self.xpub))[0:4])  # prefix
-        xpub.extend([cast(int, self.depth) + 1])               # depth
+        xpub.extend(b58decode(cast('str', self.xpub))[0:4])  # prefix
+        xpub.extend([cast('int', self.depth) + 1])               # depth
         xpub.extend(self.fingerprint)                          # fingerprint
         xpub.extend(index.to_bytes(4, byteorder='big'))        # index
         xpub.extend(chain_code)                                # chain_code

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -452,7 +452,7 @@ def process_airdrop_with_api_data(
             continue
 
         try:
-            amount = deserialize_int(cast(int, token_num))
+            amount = deserialize_int(cast('int', token_num))
         except DeserializationError as e:
             log.error(f'Failed to read amount from {protocol_name} API: {e}. Skipping')
             continue

--- a/rotkehlchen/chain/ethereum/modules/aave/aave.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/aave.py
@@ -295,7 +295,7 @@ class Aave(EthereumModule):
                 earned_atoken_balances[event.asset] += Balance(amount=amount_diff, usd_value=amount_diff * usd_price)  # noqa: E501
 
         for borrowed_asset, amount in historical_borrow_balances.items():
-            borrow_balance = balances.borrowing.get(cast(CryptoAsset, borrowed_asset), None)
+            borrow_balance = balances.borrowing.get(cast('CryptoAsset', borrowed_asset), None)
             this_amount = abs(amount)  # the amount is always <= 0 as it represents a debt position that can get repaid but we need it positive for the calculations  # noqa: E501
             if borrow_balance is not None:
                 this_amount += borrow_balance.balance.amount

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -62,7 +62,7 @@ class GetPositionsResult (TypedDict):
 
 
 def default_balance_with_proxy_factory() -> LiquityBalanceWithProxy:
-    return cast(LiquityBalanceWithProxy, {'proxies': None, 'balances': None})
+    return cast('LiquityBalanceWithProxy', {'proxies': None, 'balances': None})
 
 
 class Liquity(HasDSProxy):

--- a/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
@@ -10,13 +10,13 @@ from rotkehlchen.constants.assets import A_DAI
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import get_event_type_identifier
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.types import ChecksumEvmAddress
 
 from .constants import CPT_DSR, CPT_VAULT
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.pot import AccountingPot
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
+    from rotkehlchen.types import ChecksumEvmAddress
 
 
 class MakerdaoAccountant(ModuleAccountantInterface):
@@ -65,7 +65,7 @@ class MakerdaoAccountant(ModuleAccountantInterface):
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],  # pylint: disable=unused-argument
     ) -> int:
-        address = cast(ChecksumEvmAddress, event.location_label)  # should always exist
+        address = cast('ChecksumEvmAddress', event.location_label)  # should always exist
         self.dsr_balances[address] += event.balance.amount
         return 1
 
@@ -75,7 +75,7 @@ class MakerdaoAccountant(ModuleAccountantInterface):
             event: 'EvmEvent',
             other_events: Iterator['EvmEvent'],  # pylint: disable=unused-argument
     ) -> int:
-        address = cast(ChecksumEvmAddress, event.location_label)  # should always exist
+        address = cast('ChecksumEvmAddress', event.location_label)  # should always exist
         self.dsr_balances[address] -= event.balance.amount
         if self.dsr_balances[address] < ZERO:
             profit = -1 * self.dsr_balances[address]

--- a/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
@@ -90,7 +90,7 @@ class CowswapCommonDecoder(DecoderInterface, abc.ABC):
         self.native_asset_flow_address = NATIVE_ASSET_FLOW_ADDRESS
         self.cowswap_api = CowswapAPI(
             database=self.evm_inquirer.database,
-            chain=cast(SUPPORTED_COWSWAP_BLOCKCHAIN, self.evm_inquirer.blockchain),
+            chain=cast('SUPPORTED_COWSWAP_BLOCKCHAIN', self.evm_inquirer.blockchain),
         )
 
     def _decode_native_asset_orders(self, context: DecoderContext) -> DecodingOutput:

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/transactions.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/transactions.py
@@ -3,13 +3,13 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from rotkehlchen.chain.evm.l2_with_l1_fees.node_inquirer import L2WithL1FeesInquirer
-from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
 from rotkehlchen.chain.evm.transactions import EvmTransactions
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
     from rotkehlchen.chain.evm.structures import EvmTxReceipt
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
@@ -61,7 +61,7 @@ class L2WithL1FeesTransactions(EvmTransactions, ABC):
             return tx_data, tx_receipt  # all good, l1_fee is in the database
 
         transaction, _ = self.evm_inquirer.get_transaction_by_hash(tx_hash=tx_hash)
-        transaction = cast(L2WithL1FeesTransaction, transaction)
+        transaction = cast('L2WithL1FeesTransaction', transaction)
         tx_id = cursor.execute(
             'SELECT identifier FROM evm_transactions WHERE tx_hash = ?',
             (tx_hash,),

--- a/rotkehlchen/chain/evm/names.py
+++ b/rotkehlchen/chain/evm/names.py
@@ -150,7 +150,7 @@ def _blockchain_address_to_name(
     if chain_address.blockchain is None:
         return None
 
-    chain_address = cast(ChainAddress, chain_address)
+    chain_address = cast('ChainAddress', chain_address)
     return DBAddressbook(db).get_addressbook_entry_name(AddressbookType.PRIVATE, chain_address)
 
 

--- a/rotkehlchen/chain/gnosis/node_inquirer.py
+++ b/rotkehlchen/chain/gnosis/node_inquirer.py
@@ -61,7 +61,7 @@ class GnosisInquirer(EvmNodeInquirer):
                 msg_aggregator=database.msg_aggregator,
             ),
         )
-        self.etherscan = cast(GnosisEtherscan, self.etherscan)
+        self.etherscan = cast('GnosisEtherscan', self.etherscan)
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/chain/optimism/node_inquirer.py
+++ b/rotkehlchen/chain/optimism/node_inquirer.py
@@ -64,7 +64,7 @@ class OptimismInquirer(DSProxyL2WithL1FeesInquirerWithCacheData):
                 msg_aggregator=database.msg_aggregator,
             ),
         )
-        self.etherscan = cast(OptimismEtherscan, self.etherscan)
+        self.etherscan = cast('OptimismEtherscan', self.etherscan)
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/chain/polygon_pos/node_inquirer.py
+++ b/rotkehlchen/chain/polygon_pos/node_inquirer.py
@@ -61,7 +61,7 @@ class PolygonPOSInquirer(EvmNodeInquirer):
                 msg_aggregator=database.msg_aggregator,
             ),
         )
-        self.etherscan = cast(PolygonPOSEtherscan, self.etherscan)
+        self.etherscan = cast('PolygonPOSEtherscan', self.etherscan)
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/chain/scroll/node_inquirer.py
+++ b/rotkehlchen/chain/scroll/node_inquirer.py
@@ -55,7 +55,7 @@ class ScrollInquirer(L2WithL1FeesInquirer):
             contract_scan=BALANCE_SCANNER,
             native_token=A_ETH.resolve_to_crypto_asset(),
         )
-        self.etherscan = cast(ScrollEtherscan, self.etherscan)
+        self.etherscan = cast('ScrollEtherscan', self.etherscan)
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -505,7 +505,7 @@ class SubstrateManager:
         node_attributes_map = self.available_node_attributes_map.copy()
         own_node_attributes = node_attributes_map.pop(own_node, None)
         available_nodes_call_order = sorted(
-            cast(Iterable, node_attributes_map.items()),
+            cast('Iterable', node_attributes_map.items()),
             key=lambda item: -item[1].weight_block,
         )
         if own_node_attributes is not None:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1614,7 +1614,7 @@ class DBHandler:
 
         for key2, val2 in data['location'].items():
             # Here we know val2 is just a Dict since the key to data is 'location'
-            val2 = cast(dict, val2)
+            val2 = cast('dict', val2)
             location = Location.deserialize(key2).serialize_for_db()
             locations.append(LocationData(
                 time=timestamp, location=location, usd_value=str(val2['usd_value']),

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -322,7 +322,7 @@ class Bitfinex(ExchangeInterface):
                 raw_results=response_list,
                 processed_result_ids=processed_result_ids,
             )
-            results.extend(cast(Iterable, results_))
+            results.extend(cast('Iterable', results_))
             # NB: Copying the set before updating it prevents losing the call args values
             processed_result_ids = processed_result_ids.copy()
             # type ignore is due to always having a trade link for bitfinex trades

--- a/rotkehlchen/externalapis/beaconchain/service.py
+++ b/rotkehlchen/externalapis/beaconchain/service.py
@@ -386,7 +386,7 @@ class BeaconChain(ExternalServiceWithApiKey):
         if exit_ts is not None and last_known_timestamp > exit_ts:
             return []  # nothing new to add
 
-        data = cast(list[dict[str, Any]], self._query(
+        data = cast('list[dict[str, Any]]', self._query(
             module='validator',
             endpoint='stats',
             encoded_args=str(validator_index),

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -314,19 +314,19 @@ class GlobalDBHandler:
                 if asset.asset_type == AssetType.CUSTOM_ASSET:
                     write_cursor.execute(
                         'INSERT INTO custom_assets(identifier, type, notes) VALUES(?, ?, ?)',
-                        cast(CustomAsset, asset).serialize_for_db(),
+                        cast('CustomAsset', asset).serialize_for_db(),
                     )
                     return
 
                 # since the asset is not a custom asset it can only be an asset with oracles
-                asset = cast(AssetWithOracles, asset)
+                asset = cast('AssetWithOracles', asset)
                 forked, started, swapped_for = None, None, None
                 if asset.is_crypto():
                     if asset.is_evm_token():
-                        asset = cast(EvmToken, asset)
+                        asset = cast('EvmToken', asset)
                         GlobalDBHandler.add_evm_token_data(write_cursor, asset)
                     else:
-                        asset = cast(CryptoAsset, asset)
+                        asset = cast('CryptoAsset', asset)
 
                     forked = asset.forked.identifier if asset.forked else None
                     started = asset.started
@@ -1152,7 +1152,7 @@ class GlobalDBHandler:
         details_update_query = 'UPDATE common_asset_details SET symbol=?, coingecko=?, cryptocompare=?'  # noqa: E501
         details_update_bindings: tuple = (asset.symbol, asset.coingecko, asset.cryptocompare)
         if asset.is_crypto():
-            asset = cast(CryptoAsset, asset)
+            asset = cast('CryptoAsset', asset)
             details_update_query += ', forked=?, started=?, swapped_for=?'
             details_update_bindings += (
                 asset.forked.identifier if asset.forked else None,
@@ -1934,9 +1934,9 @@ class GlobalDBHandler:
             self.add_asset(asset)
         elif asset.asset_type == AssetType.EVM_TOKEN:
             # in this case the asset exists and needs to be updated
-            self.edit_evm_token(cast(EvmToken, asset))
+            self.edit_evm_token(cast('EvmToken', asset))
         else:
-            self.edit_user_asset(cast(CryptoAsset, asset))
+            self.edit_user_asset(cast('CryptoAsset', asset))
 
         return asset
 

--- a/rotkehlchen/history/events/structures/eth2.py
+++ b/rotkehlchen/history/events/structures/eth2.py
@@ -163,7 +163,7 @@ class EthWithdrawalEvent(EthStakingEvent):
 
     @classmethod
     def deserialize_from_db(cls: type['EthWithdrawalEvent'], entry: tuple) -> 'EthWithdrawalEvent':
-        entry = cast(ETH_STAKING_EVENT_DB_TUPLE_READ, entry)
+        entry = cast('ETH_STAKING_EVENT_DB_TUPLE_READ', entry)
         amount = deserialize_fval(entry[5], 'amount', 'eth withdrawal event')
         usd_value = deserialize_fval(entry[6], 'usd_value', 'eth withdrawal event')
         return cls(
@@ -290,7 +290,7 @@ class EthBlockEvent(EthStakingEvent):
 
     @classmethod
     def deserialize_from_db(cls: type['EthBlockEvent'], entry: tuple) -> 'EthBlockEvent':
-        entry = cast(ETH_STAKING_EVENT_DB_TUPLE_READ, entry)
+        entry = cast('ETH_STAKING_EVENT_DB_TUPLE_READ', entry)
         amount = deserialize_fval(entry[5], 'amount', 'eth block event')
         usd_value = deserialize_fval(entry[6], 'usd_value', 'eth block event')
         return cls(
@@ -431,7 +431,7 @@ class EthDepositEvent(EvmEvent, EthStakingEvent):  # noqa: PLW1641  # hash in su
 
     @classmethod
     def deserialize_from_db(cls: type['EthDepositEvent'], entry: tuple) -> 'EthDepositEvent':
-        entry = cast(EVM_DEPOSIT_EVENT_DB_TUPLE_READ, entry)
+        entry = cast('EVM_DEPOSIT_EVENT_DB_TUPLE_READ', entry)
         amount = deserialize_fval(entry[5], 'amount', 'eth deposit event')
         usd_value = deserialize_fval(entry[6], 'usd_value', 'eth deposit event')
         return cls(

--- a/rotkehlchen/history/events/structures/evm_event.py
+++ b/rotkehlchen/history/events/structures/evm_event.py
@@ -189,7 +189,7 @@ class EvmEvent(HistoryBaseEntry):  # hash in superclass
 
     @classmethod
     def deserialize_from_db(cls: type['EvmEvent'], entry: tuple) -> 'EvmEvent':
-        entry = cast(EVM_EVENT_DB_TUPLE_READ, entry)
+        entry = cast('EVM_EVENT_DB_TUPLE_READ', entry)
         extra_data = None
         if entry[16] is not None:
             try:

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -955,7 +955,7 @@ class Inquirer:
         - RemoteError
         """
         assert lp_token.chain_id in CURVE_CHAIN_IDS, f'{lp_token} is not on a curve supported chain'  # noqa: E501
-        chain_id = cast(CURVE_CHAIN_ID_TYPE, lp_token.chain_id)
+        chain_id = cast('CURVE_CHAIN_ID_TYPE', lp_token.chain_id)
         evm_manager = self.get_evm_manager(chain_id=chain_id)
         evm_manager.assure_curve_cache_is_queried_and_decoder_updated(
             node_inquirer=evm_manager.node_inquirer,

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -258,7 +258,7 @@ class Premium:
         device_id = machineid.hashed_id(self.username)
 
         for device in device_data['devices']:
-            device = cast(dict[str, str], device)
+            device = cast('dict[str, str]', device)
             if (remote_id := device.get('device_identifier')) == device_id:
                 break
             if remote_id is None:

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -915,9 +915,9 @@ class Rotkehlchen:
         )
         with contextlib.ExitStack() as stack:
             if blockchain in EVM_CHAINS_WITH_TRANSACTIONS:
-                blockchain = cast(EVM_CHAINS_WITH_TRANSACTIONS_TYPE, blockchain)  # by default mypy doesn't narrow the type  # noqa: E501
+                blockchain = cast('EVM_CHAINS_WITH_TRANSACTIONS_TYPE', blockchain)  # by default mypy doesn't narrow the type  # noqa: E501
                 evm_manager = self.chains_aggregator.get_chain_manager(blockchain)
-                evm_addresses: list[ChecksumEvmAddress] = cast(list[ChecksumEvmAddress], accounts)
+                evm_addresses: list[ChecksumEvmAddress] = cast('list[ChecksumEvmAddress]', accounts)  # noqa: E501
                 self.maybe_kill_running_tx_query_tasks(blockchain, evm_addresses)
                 stack.enter_context(evm_manager.transactions.wait_until_no_query_for(evm_addresses))
                 stack.enter_context(evm_manager.transactions.missing_receipts_lock)
@@ -1005,7 +1005,7 @@ class Rotkehlchen:
             else:
                 location_str = str(exchange.location)
                 if location_str not in balances:  # need to widen type at assignment here
-                    balances[location_str] = cast(dict[Asset, Balance], exchange_balances)
+                    balances[location_str] = cast('dict[Asset, Balance]', exchange_balances)
                 else:  # multiple exchange of same type. Combine balances
                     balances[location_str] = combine_dicts(
                         balances[location_str],

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -1023,7 +1023,7 @@ def test_kraken_staking(rotkehlchen_api_server_with_exchanges, start_with_valid_
 def test_kraken_informational_fees(rotkehlchen_api_server_with_exchanges: 'APIServer'):
     """Test that we correctly ignore fees in events that we currently ignore as margin trades"""
     rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen
-    kraken = cast(MockKraken, try_get_first_exchange(rotki.exchange_manager, Location.KRAKEN))
+    kraken = cast('MockKraken', try_get_first_exchange(rotki.exchange_manager, Location.KRAKEN))
     input_ledger = """
     {
         "ledger":{

--- a/rotkehlchen/tests/fixtures/google.py
+++ b/rotkehlchen/tests/fixtures/google.py
@@ -11,6 +11,7 @@ from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+from rotkehlchen.db.utils import str_to_bool
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ class GoogleService:
         self.drive_service = _login('drive', 'v3', DRIVE_SCOPES, credentials_path)
         self.sheets_service = _login('sheets', 'v4', SHEETS_SCOPES, credentials_path)
         self.user_email = os.environ.get('GOOGLE_EMAIL', None)
-        self.send_email = os.environ.get('SEND_GOOGLE_SHARE_EMAIL', False)
+        self.send_email = str_to_bool(os.environ.get('SEND_GOOGLE_SHARE_EMAIL', 'False'))
         if isinstance(self.send_email, str):
             self.send_email = self.send_email.lower() == 'true'
 

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -12,7 +12,6 @@ from rotkehlchen.chain.ethereum.modules.curve.constants import (
     GAUGE_BRIBE_V2,
     VOTING_ESCROW,
 )
-from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE, DEPOSIT_AND_STAKE_ZAP
@@ -51,6 +50,9 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.hexbytes import hexstring_to_bytes
 from rotkehlchen.utils.misc import timestamp_to_date
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 
 
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
@@ -823,7 +825,7 @@ def test_gauge_vote(ethereum_accounts, ethereum_transaction_decoder) -> None:
     user_address = ethereum_accounts[0]
     timestamp = TimestampMS(1685562071000)
     events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=cast(EthereumInquirer, ethereum_transaction_decoder.evm_inquirer),
+        evm_inquirer=cast('EthereumInquirer', ethereum_transaction_decoder.evm_inquirer),
         tx_hash=tx_hex,
     )
     expected_events = [
@@ -872,7 +874,7 @@ def test_gauge_deposit(
     evmhash = deserialize_evm_tx_hash(tx_hex)
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
-        evm_inquirer=cast(EthereumInquirer, ethereum_transaction_decoder.evm_inquirer),
+        evm_inquirer=cast('EthereumInquirer', ethereum_transaction_decoder.evm_inquirer),
         tx_hash=tx_hex,
         load_global_caches=load_global_caches,
     )

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -31,7 +31,6 @@ from rotkehlchen.chain.evm.decoding.gearbox.gearbox_cache import (
     query_gearbox_data,
     read_gearbox_data_from_cache,
 )
-from rotkehlchen.chain.evm.decoding.interfaces import ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.velodrome.constants import CPT_VELODROME
 from rotkehlchen.chain.evm.decoding.velodrome.velodrome_cache import (
     query_velodrome_like_data,
@@ -54,6 +53,7 @@ from rotkehlchen.types import (
 )
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.evm.decoding.interfaces import ReloadableDecoderMixin
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
 
 
@@ -473,7 +473,7 @@ def test_reload_cache_timestamps(blockchain: ChainsAggregator, freezer):
     ) is True
 
     curve = cast(
-        ReloadableDecoderMixin,
+        'ReloadableDecoderMixin',
         blockchain.ethereum.transactions_decoder.decoders['Curve'],
     )
     with patch(

--- a/rotkehlchen/tests/unit/test_cost_basis.py
+++ b/rotkehlchen/tests/unit/test_cost_basis.py
@@ -8,7 +8,6 @@ import pytest
 
 from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.cost_basis import AssetAcquisitionEvent
-from rotkehlchen.accounting.cost_basis.base import AverageCostBasisMethod
 from rotkehlchen.accounting.export.csv import FILENAME_ALL_CSV, CSVExporter
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
@@ -40,6 +39,7 @@ from rotkehlchen.types import (
 )
 
 if TYPE_CHECKING:
+    from rotkehlchen.accounting.cost_basis.base import AverageCostBasisMethod
     from rotkehlchen.db.dbhandler import DBHandler
 
 
@@ -889,7 +889,7 @@ def test_accounting_average_cost_basis(accountant: Accountant):
     pot = accountant.pots[0]
     events = pot.processed_events
     cost_basis = pot.cost_basis
-    manager = cast(AverageCostBasisMethod, cost_basis.get_events(A_ETH).acquisitions_manager)
+    manager = cast('AverageCostBasisMethod', cost_basis.get_events(A_ETH).acquisitions_manager)
 
     # Step 1. Add an acquisition
     add_in_event(pot, amount=FVal(2), price=Price(FVal(10)))  # Buy 2 ETH for $10  total acb: $20

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -978,7 +978,7 @@ def test_deadlock_logout(
         globaldb: GlobalDBHandler,  # pylint: disable=unused-argument
 ):
     """Test that we don't leave locks acquired by a greenlet that has been killed during logout"""
-    task_manager = cast(TaskManager, rotkehlchen_instance.task_manager)
+    task_manager = cast('TaskManager', rotkehlchen_instance.task_manager)
     task_manager.max_tasks_num = 10
     task_runs = 0
 
@@ -1027,7 +1027,7 @@ def test_snapshots_dont_happen_always(rotkehlchen_api_server: 'APIServer') -> No
     creating a snapshot for each run of the background task.
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    task_manager = cast(TaskManager, rotki.task_manager)
+    task_manager = cast('TaskManager', rotki.task_manager)
 
     task_manager.potential_tasks = [task_manager._maybe_update_snapshot_balances]
     task_manager.should_schedule = True

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -30,12 +30,12 @@ from rotkehlchen.tests.utils.constants import (
     TX_HASH_STR3,
 )
 from rotkehlchen.tests.utils.exchanges import POLONIEX_MOCK_DEPOSIT_WITHDRAWALS_RESPONSE
-from rotkehlchen.tests.utils.kraken import MockKraken
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import AssetMovementCategory, Fee, Location, Timestamp
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
+    from rotkehlchen.tests.utils.kraken import MockKraken
 
 TEST_END_TS = 1559427707
 
@@ -947,7 +947,7 @@ def prepare_rotki_for_history_processing_test(
     Makes sure blockchain accounts are loaded, kraken does not generate random trades
     and that all mocks are ready.
     """
-    kraken = cast(MockKraken, rotki.exchange_manager.connected_exchanges.get(Location.KRAKEN)[0])  # type: ignore
+    kraken = cast('MockKraken', rotki.exchange_manager.connected_exchanges.get(Location.KRAKEN)[0])  # type: ignore
     kraken.random_trade_data = False
     kraken.random_ledgers_data = False
     kraken.remote_errors = remote_errors

--- a/rotkehlchen/utils/hexbytes.py
+++ b/rotkehlchen/utils/hexbytes.py
@@ -48,7 +48,7 @@ class HexBytes(bytes):
             val: Web3HexBytes | (bytearray | (bytes | str)),
     ) -> 'HexBytes':
         bytesval = to_bytes(val)
-        return cast(HexBytes, super().__new__(cls, bytesval))  # type: ignore  # https://github.com/python/typeshed/issues/2630
+        return cast('HexBytes', super().__new__(cls, bytesval))  # type: ignore  # https://github.com/python/typeshed/issues/2630
 
     def hex(self) -> str:  # type: ignore
         """


### PR DESCRIPTION
Almost all changes stem from applying TC006, https://docs.astral.sh/ruff/rules/runtime-cast-value/ which essentially makes sure that cast, since it does nothing in runtime takes a string literal and we get rid of symbol lookups in runtime and sometimes can get rid of the entire variable if only used in typing.
