### PR TITLE
fix: remove "Blockchain balances per asset" title attribute

### DIFF
--- a/frontend/app/src/locales/cn.json
+++ b/frontend/app/src/locales/cn.json
@@ -1272,9 +1272,6 @@
       "edit_subtitle": "修改账户信息",
       "edit_title": "编辑区块链账户"
     },
-    "per_asset": {
-      "title": "每项资产的区块链余额"
-    },
     "title": "每项资产的区块链余额"
   },
   "borrowing": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1517,9 +1517,6 @@
       "edit_subtitle": "Modify account details",
       "edit_title": "Edit blockchain account"
     },
-    "per_asset": {
-      "title": "Blockchain Balances per Asset"
-    },
     "title": "Blockchain Balances per asset",
     "unify_accounts_table": "Unify accounts table"
   },

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -1244,9 +1244,6 @@
       "edit_subtitle": "Modify account details",
       "edit_title": "Edit blockchain account"
     },
-    "per_asset": {
-      "title": "Blockchain Balances per Asset"
-    },
     "title": "Blockchain Balances per asset"
   },
   "borrowing": {

--- a/frontend/app/src/locales/fr.json
+++ b/frontend/app/src/locales/fr.json
@@ -1424,9 +1424,6 @@
       "edit_subtitle": "Modifier les détails du compte",
       "edit_title": "Modifier le compte blockchain"
     },
-    "per_asset": {
-      "title": "Solde blockchain par actif"
-    },
     "title": "Solde blockchain par actif"
   },
   "borrowing": {

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -1252,9 +1252,6 @@
       "edit_subtitle": "Modify account details",
       "edit_title": "Edit blockchain account"
     },
-    "per_asset": {
-      "title": "Blockchain Balances per Asset"
-    },
     "title": "Blockchain Balances per asset"
   },
   "borrowing": {

--- a/frontend/app/src/pages/balances/blockchain/[[tab]].vue
+++ b/frontend/app/src/pages/balances/blockchain/[[tab]].vue
@@ -147,7 +147,6 @@ watchImmediate(route, (route) => {
         <AssetBalances
           data-cy="blockchain-asset-balances"
           :loading="isBlockchainLoading"
-          :title="t('blockchain_balances.per_asset.title')"
           :balances="blockchainAssets"
           :search="search"
           sticky-header


### PR DESCRIPTION
Remove a "Blockchain Balances per Asset" tooltip which was appearing on mouse-over anywhere inside the "Blockchain Balances per asset" section.

Partial fix for #8992.

## Side note

This seems like an improvement to me, but no one on the core team has had a chance to comment on #8992 yet, so I appreciate it may be contentious.

Nevertheless, this is my first PR contribution in a long time, so even if it's not the best approach, it still serves as good practice for getting familiar with hacking on Rotki again :)

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.