### PR TITLE
feat(IconTokenDisplay): add click navigation to asset details

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 =========
 Changelog
 =========
+* :feature:`-`  Add direct navigation to asset details when clicking on small asset icons (IconTokenDisplay).
 
 * :release:`1.36.1 <2024-11-29>`
 * :bug:`-` Coinbase deposits that appeared as withdrawals should now appear as deposits again. Would need to purge and requery coinbase to fix this.

--- a/frontend/app/src/components/accounts/IconTokenDisplay.vue
+++ b/frontend/app/src/components/accounts/IconTokenDisplay.vue
@@ -15,8 +15,17 @@ const props = withDefaults(defineProps<{
 });
 
 const { assets, visible } = toRefs(props);
-
 const showMore = computed<number>(() => get(assets).length - get(visible));
+const router = useRouter();
+
+async function navigateToAsset(asset: AssetBalance) {
+  await router.push({
+    name: '/assets/[identifier]',
+    params: {
+      identifier: asset.asset,
+    },
+  });
+}
 </script>
 
 <template>
@@ -33,6 +42,7 @@ const showMore = computed<number>(() => get(assets).length - get(visible));
           <div
             data-cy="top-asset"
             class="rounded-full size-8 flex items-center justify-center border-2 border-white dark:border-rui-grey-700 -ml-2 cursor-pointer"
+            @click="navigateToAsset(asset)"
           >
             <AssetIcon
               no-tooltip


### PR DESCRIPTION
Closes #8991

### Changes
- Added click navigation to IconTokenDisplay component
- Maintains existing tooltip functionality (shows balances in top assets on hover)
- Uses consistent navigation pattern matching other asset links in the app
