### PR TITLE
Compoundv3 supplied collateral should now be detected

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`8982` Fix the issue where Cmd / Alt + Arrow Left / Arrow Right forces navigation, as it should interact with user selection in text input.
+* :bug:`-` Some of the Compound v3 supplied collateral that was not detected by rotki will now be properly seen as balance.
 * :bug:`8983` The asset amount will be shown if only one asset is detected in an account.
 * :feature:`8991` Add direct navigation to asset details when clicking on small asset icons in the blockchain balances table.
 

--- a/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
@@ -188,7 +188,9 @@ class Compoundv3CommonDecoder(DecoderInterface):
             )
             return DEFAULT_DECODING_OUTPUT
 
-        action_items = []  # also create an action item for the receive of the cTokens
+        # create an action item for the receive of the cTokens. It's possible that
+        # there is no cToken received if you just supply collateral to the COMET contract
+        action_items = []
         if paired_event is not None and action_from_event_type is not None:
             action_items.append(ActionItem(
                 action='transform',

--- a/rotkehlchen/tests/api/test_compound.py
+++ b/rotkehlchen/tests/api/test_compound.py
@@ -92,7 +92,6 @@ def test_query_compound_balances(
     '0x478768685e023B8AF2815369b353b786713fDEa4',
     '0x3eab2E72fA768C3cB8ab071929AC3C8aed6CbFA6',
     '0x1107F797c1af4982b038Eb91260b3f9A90eecee9',
-    '0x577e1290fE9561A9654b7b42B1C10c7Ea90c8a07',
 ]])
 @pytest.mark.parametrize('have_decoders', [[True]])
 @pytest.mark.parametrize('ethereum_modules', [['compound']])
@@ -153,19 +152,19 @@ def test_query_compound_v3_balances(
         ethereum_accounts[0]: {
             'lending': {
                 c_usdc_v3.identifier: {
-                    'apy': '9.90%',
+                    'apy': '18.62%',
                     'balance': get_balance('333349.851793'),
                 },
             }, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('12.012345'),
+                    'balance': get_balance('12.317773'),
                 },
             },
         }, ethereum_accounts[1]: {
             'lending': {
                 c_usdc_v3.identifier: {
-                    'apy': '9.90%',
+                    'apy': '18.62%',
                     'balance': get_balance('0.32795'),
                 },
             }, 'rewards': {
@@ -177,25 +176,13 @@ def test_query_compound_v3_balances(
         }, ethereum_accounts[2]: {
             'borrowing': {
                 c_usdc_v3.identifier: {
-                    'apy': '11.57%',
-                    'balance': get_balance('20834.273226'),
+                    'apy': '21.26%',
+                    'balance': get_balance('22378.61881'),
                 },
             }, 'lending': {}, 'rewards': {
                 A_COMP.identifier: {
                     'apy': None,
-                    'balance': get_balance('0.19064'),
-                },
-            },
-        }, ethereum_accounts[3]: {
-            'borrowing': {
-                c_usdc_v3.identifier: {
-                    'apy': '11.57%',
-                    'balance': get_balance('0'),
-                },
-            }, 'rewards': {
-                A_COMP.identifier: {
-                    'apy': None,
-                    'balance': get_balance('0.000941'),
+                    'balance': get_balance('0.212129'),
                 },
             },
         },


### PR DESCRIPTION
It seems that for compound there is the various COMET contracts
which are the proxies to which the user supplies collateral. We
have those marked with compound-v3 protocol in the global DB.
The underlying token of the cometContract is what is primarily borrowed
from it. For example for:
https://basescan.org/address/0xb125e6687d4313864e53df431d5425969c15eb2f#readProxyContract
it's USDC.
If you supply USDC to it you can get the balance of your supplied collateral by
balanceOf on that contract. If you borrow USDC you can get it from borrowBalanceOf
on that contract.
But you can also supply other types of collateral to this contract. And to see those
the user needs to call `userCollateral` on that contract with user address and
collateral address as arguments.


source: https://www.rareskills.io/post/compound-v3-contracts-tutorial