### PR TITLE
Gemini reward handling & events

### DIFF
--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -241,6 +241,15 @@ TRANSFERS_RESPONSE = """[
       "amount": "1.00",
       "txHash": "7bffd85893ee8e72e31061a84d25c45f2c4537c2f765a1e79feb06a7294445c3",
       "destination": "0xd24400ae8BfEBb18cA49Be86258a3C749cf46853"
+   },
+   {
+      "type":"Reward",
+      "status":"Complete",
+      "timestampms":1535452530431,
+      "eid":341170014,
+      "currency":"ETH",
+      "amount":"0.000161",
+      "method":"CreditCard"
    }
 ]"""
 
@@ -337,6 +346,17 @@ def test_gemini_query_deposits_withdrawals(sandbox_gemini):
         fee_asset=A_USD,
         fee=ZERO,
         link='341167014',
+    ), AssetMovement(
+        location=Location.GEMINI,
+        category=AssetMovementCategory.DEPOSIT,
+        address=None,
+        transaction_id=None,
+        timestamp=Timestamp(1535452530),
+        asset=A_ETH,
+        amount=FVal('0.000161'),
+        fee_asset=A_ETH,
+        fee=ZERO,
+        link='341170014',
     )]
     # The deposits should be returned with the oldest first (so given list is reversed)
     assert movements == expected_movements[::-1]


### PR DESCRIPTION
Closes #9006 

## Checklist

- [x] The PR modified gemini asset movement deserialization and added a related asset movement in the gemini tests


## Specification

Taking inspiration from the coinbase implementation, this PR adds a `GEMINI_EVENTS_PREFIX` and sets it as `GMNI_`. Please let me know if you have some preference related to that.

Also taking (half) inspiration from the coinbase implementation, this PR accesses the DB in the same way the coinbase implementation does, but instead of having all of the default methods point to `_query_transactions`, I just handle history events and writing to the db within `query_online_deposits_withdrawals`, and then return the asset movements to let that be handled as it is currently. Let me know if you'd like me to take it all the way and implement `_query_transactions` like the coinbase implementation.

Also, this is my first PR for Rotki, so let me know if I did anything else wrong. Hopefully I read the docs correctly and don't end up wasting your time.