### PR TITLE
style: update styling of auto-update notification

### DIFF
--- a/frontend/app/src/components/status/update/AppUpdatePopup.vue
+++ b/frontend/app/src/components/status/update/AppUpdatePopup.vue
@@ -63,33 +63,35 @@ onMounted(async () => {
     v-if="isPackaged"
     :model-value="showUpdatePopup"
     :timeout="-1"
-    class="top-[3.5rem] text-rui-text"
+    class="top-[3.5rem] text-rui-text !bg-transparent"
     width="380px"
   >
-    <div class="p-2">
+    <RuiCard rounded="md">
       <div
         v-if="!restarting"
         class="flex items-center gap-4"
       >
-        <RuiIcon
-          v-if="error"
-          size="40"
-          color="error"
-          name="error-warning-line"
-        />
-        <RuiIcon
-          v-else-if="!downloadReady && !downloading"
-          size="40"
-          color="primary"
-          name="arrow-up-circle-line"
-        />
-        <RuiIcon
-          v-else
-          size="40"
-          color="primary"
-          name="arrow-down-circle-line"
-        />
-        <div class="text-body-1">
+        <div class="w-10 h-10">
+          <RuiIcon
+            v-if="error"
+            size="40"
+            color="error"
+            name="error-warning-line"
+          />
+          <RuiIcon
+            v-else-if="!downloadReady && !downloading"
+            size="40"
+            color="primary"
+            name="arrow-up-circle-line"
+          />
+          <RuiIcon
+            v-else
+            size="40"
+            color="primary"
+            name="arrow-down-circle-line"
+          />
+        </div>
+        <div class="text-body-2">
           <span
             v-if="error"
             class="text-rui-error"
@@ -175,6 +177,6 @@ onMounted(async () => {
           </RuiButton>
         </div>
       </div>
-    </div>
+    </RuiCard>
   </RuiNotification>
 </template>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4876,7 +4876,7 @@
     "install_failed": {
       "message": "An error occurred while installing the application update: {message}"
     },
-    "messages": "A new version of rotki is available. See {releaseNotes}.",
+    "messages": "A new version of rotki is available. See the {releaseNotes}.",
     "release_notes": "release notes",
     "restart": "rotki will restart in a moment to apply the update."
   },


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

## Notes 
To test, set to always true, 
https://github.com/rotki/rotki/blob/9a7b56b241203e897212e40140f30def4dd2f5bc/frontend/app/src/store/session/index.ts#L185

and then go through the vue-dev-tools and play with the downloadReady, downloading properties to see the different states

## Changes
Adds an RuiCard for the notification because the previous style didn't look that good and also makes sure that the icons don't shrink based on the text.

![image](https://github.com/user-attachments/assets/e3aa9ffd-9ee8-4079-bb16-27b849b76874)
![image](https://github.com/user-attachments/assets/5c48653a-dc7b-4b87-9a11-d84c7c5af94b)
![image](https://github.com/user-attachments/assets/3bd32ca2-2314-4300-9abb-2e6678bb5d1e)

