### PR TITLE
fix: to timestamp filter for calendar endpoint

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3733,6 +3733,7 @@ class QueryCalendarSchema(
         load_default=None,
     )
     identifiers = fields.List(fields.Integer, load_default=None)
+    to_timestamp = TimestampField(load_default=None)
 
     def __init__(self, chain_aggregator: 'ChainsAggregator') -> None:
         super().__init__()


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
