### PR TITLE
fix: refactor message dialog to avoid state flickering

### DIFF
--- a/frontend/app/src/components/app/AppMessages.vue
+++ b/frontend/app/src/components/app/AppMessages.vue
@@ -20,9 +20,8 @@ const { globalPayload } = useAddressBookForm();
     root
   />
   <MessageDialog
-    :title="message.title"
-    :message="message.description"
-    :success="message.success"
+    v-if="message"
+    :message="message"
     @dismiss="dismissMessage()"
   />
   <ConfirmDialog

--- a/frontend/app/src/components/dialogs/MessageDialog.vue
+++ b/frontend/app/src/components/dialogs/MessageDialog.vue
@@ -1,34 +1,25 @@
 <script setup lang="ts">
 import type { RuiIcons } from '@rotki/ui-library';
+import type { Message } from '@rotki/common';
 
-const props = withDefaults(defineProps<{
-  title: string;
-  message: string;
-  success?: boolean;
-}>(), {
-  success: false,
-});
+const props = defineProps<{
+  message: Message;
+}>();
 
 const emit = defineEmits<{
   dismiss: [];
 }>();
 
-const { message, success } = toRefs(props);
+const { message } = toRefs(props);
 
 const { t } = useI18n();
 
-const visible = ref<boolean>(false);
-
-const icon = computed<RuiIcons>(() => (get(success) ? 'checkbox-circle-line' : 'error-warning-line'));
-
-watch(message, (message) => {
-  set(visible, message.length > 0);
-});
+const icon = computed<RuiIcons>(() => (get(props.message.success) ? 'checkbox-circle-line' : 'error-warning-line'));
 </script>
 
 <template>
   <RuiDialog
-    :model-value="visible"
+    :model-value="true"
     max-width="500"
     persistent
     z-index="10000"
@@ -39,10 +30,10 @@ watch(message, (message) => {
     <RuiCard>
       <template #header>
         <h5
-          :class="success ? 'text-rui-success' : 'text-rui-error'"
+          :class="message.success ? 'text-rui-success' : 'text-rui-error'"
           class="text-h5"
         >
-          {{ title }}
+          {{ message.title }}
         </h5>
       </template>
 
@@ -51,7 +42,7 @@ watch(message, (message) => {
           <RuiIcon
             size="40"
             :name="icon"
-            :class="success ? 'text-rui-success' : 'text-rui-error'"
+            :class="message.success ? 'text-rui-success' : 'text-rui-error'"
           />
         </div>
         <div
@@ -66,7 +57,7 @@ watch(message, (message) => {
         <div class="grow" />
         <RuiButton
           data-cy="message-dialog__ok"
-          :color="success ? 'success' : 'error'"
+          :color="message.success ? 'success' : 'error'"
           @click="emit('dismiss')"
         >
           {{ t('common.actions.ok') }}

--- a/frontend/app/src/store/message.ts
+++ b/frontend/app/src/store/message.ts
@@ -1,20 +1,16 @@
 import type { Message, SemiPartial } from '@rotki/common';
 
-function emptyMessage(): Message {
-  return {
-    title: '',
-    description: '',
-    success: false,
-  };
-}
-
 export const useMessageStore = defineStore('message', () => {
-  const message = ref(emptyMessage());
-  const showMessage = computed(() => get(message).title.length > 0);
+  const message = ref<Message>();
+  const showMessage = computed(() => isDefined(message));
 
   const { t } = useI18n();
 
-  const setMessage = (msg: SemiPartial<Message, 'description'> = emptyMessage()): void => {
+  const setMessage = (msg?: SemiPartial<Message, 'description'>): void => {
+    if (!msg) {
+      set(message, undefined);
+      return;
+    }
     set(message, {
       ...{
         title: msg.success ? t('message.success.title') : t('message.error.title'),

--- a/frontend/app/tests/unit/specs/store/session/queried-addresses.spec.ts
+++ b/frontend/app/tests/unit/specs/store/session/queried-addresses.spec.ts
@@ -32,7 +32,7 @@ describe('session:queried addresses store', () => {
     await store.fetchQueriedAddresses();
     expect(api.queriedAddresses).toHaveBeenCalledTimes(1);
     expect(store.queriedAddresses).toMatchObject({});
-    expect(messageStore.message.description).toBeTruthy();
+    expect(messageStore.message?.description).toBeTruthy();
   });
 
   it('addQueriedAddress', async () => {
@@ -62,7 +62,7 @@ describe('session:queried addresses store', () => {
     await store.addQueriedAddress(payload);
     expect(api.addQueriedAddress).toHaveBeenCalledWith(payload);
     expect(store.queriedAddresses).toMatchObject({});
-    expect(messageStore.message.description).toBeTruthy();
+    expect(messageStore.message?.description).toBeTruthy();
   });
 
   it('deletedQueriedAddress', async () => {
@@ -100,6 +100,6 @@ describe('session:queried addresses store', () => {
     await store.deleteQueriedAddress(payload);
     expect(api.deleteQueriedAddress).toHaveBeenCalledWith(payload);
     expect(store.queriedAddresses).toMatchObject(originalState);
-    expect(messageStore.message.description).toBeTruthy();
+    expect(messageStore.message?.description).toBeTruthy();
   });
 });


### PR DESCRIPTION
With the previous approach, you would see a small flicker when it reset to success from error state.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
