### PR TITLE
Fix serialization

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -237,6 +237,7 @@ from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
     AssetAmount,
+    BlockchainAddress,
     BTCAddress,
     CacheType,
     ChainType,
@@ -853,7 +854,7 @@ class RestAPI:
             # Filter balances before serialization
             if usd_value_threshold is not None:
                 for _, chain_balances in balances.per_account:
-                    filtered_balances = {}
+                    filtered_balances: dict[BlockchainAddress, BalanceSheet | Balance] = {}
                     for account, account_data in chain_balances.items():
                         if isinstance(account_data, BalanceSheet):
                             filtered_assets = {
@@ -867,7 +868,7 @@ class RestAPI:
                         elif isinstance(account_data, Balance):
                             # For BTC and BCH, account_data is a single Balance object
                             if account_data.usd_value > usd_value_threshold:
-                                filtered_balances[account] = BalanceSheet(assets=defaultdict(Balance, {account: account_data}))  # noqa: E501
+                                filtered_balances[account] = account_data
 
                     chain_balances.clear()
                     chain_balances.update(filtered_balances)

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from vcr import VCR
 
 
+os.environ['POLARS_ALLOW_FORKING_THREAD'] = '1'
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 


### PR DESCRIPTION
- The PR adding the threshold to balances made a change that broke the logic
for serialization that we have since we have checks for the type of chain.

In addition the test didn't catch it because the balances for bitcoin weren't set

- Acknowledge polars warning about fork (doesn't affect us afaik)

```
Using fork() can cause Polars to deadlock in the child process.
  In addition, using fork() with Python in general is a recipe for mysterious
  deadlocks and crashes.

  The most likely reason you are seeing this error is because you are using the
  multiprocessing module on Linux, which uses fork() by default. This will be
  fixed in Python 3.14. Until then, you want to use the "spawn" context instead.

  See https://docs.pola.rs/user-guide/misc/multiprocessing/ for details.
```