### PR TITLE
Fix minor grammar typo in __add__ and __sub__ methods Update pnl.py

### DIFF
--- a/rotkehlchen/accounting/pnl.py
+++ b/rotkehlchen/accounting/pnl.py
@@ -34,7 +34,7 @@ class PNL:
         if isinstance(x, FVal | int):
             return PNL(taxable=self.taxable + x, free=self.free + x)
 
-        raise TypeError(f'Cant add type {type(x)} to PNL')
+        raise TypeError(f"Can't add type {type(x)} to PNL")
 
     __radd__ = __add__
 
@@ -44,7 +44,7 @@ class PNL:
         if isinstance(x, FVal | int):
             return PNL(taxable=self.taxable - x, free=self.free - x)
 
-        raise TypeError(f'Cant sub type {type(x)} from PNL')
+        raise TypeError(f"Can't sub type {type(x)} from PNL")
 
     __rsub__ = __sub__
 


### PR DESCRIPTION
This update addresses a minor grammar issue in the `__add__` and `__sub__` methods. The word "Cant" has been corrected to "Can't" (with an apostrophe) to reflect proper grammar.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
