### PR TITLE
fix: refactor conditional check for improved readability rules.py

### DIFF
--- a/rotkehlchen/accounting/rules.py
+++ b/rotkehlchen/accounting/rules.py
@@ -57,7 +57,7 @@ class AccountingRulesManager:
         else:
             callback = None
 
-        if isinstance(event, EvmEvent) is False or rule is not None:
+        if not isinstance(event, EvmEvent) or rule is not None:
             return rule, callback
 
         event_id_no_cpt = event.get_type_identifier(include_counterparty=False)


### PR DESCRIPTION
# Description

In the following line:

```python
if isinstance(event, EvmEvent) is False or rule is not None:
```

The conditional check can be simplified to:

```python
if not isinstance(event, EvmEvent) or rule is not None:
```

This change improves readability and aligns with Python’s preferred idiomatic style. By removing the unnecessary `is False` comparison, the code becomes more concise and easier to understand. It also reduces cognitive load for other developers reading or maintaining the code, making it a small but valuable improvement.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
