### PR TITLE
update assets before schema-breaking DB upgrades

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -183,6 +183,7 @@ from rotkehlchen.externalapis.github import Github
 from rotkehlchen.externalapis.gnosispay import GNOSIS_PAY_TX_TIMESTAMP_RANGE, init_gnosis_pay
 from rotkehlchen.externalapis.monerium import init_monerium
 from rotkehlchen.fval import FVal
+from rotkehlchen.globaldb.asset_updates.manager import ASSETS_VERSION_KEY
 from rotkehlchen.globaldb.assets_management import export_assets_from_file, import_assets_from_file
 from rotkehlchen.globaldb.cache import (
     globaldb_delete_general_cache_values,
@@ -190,7 +191,6 @@ from rotkehlchen.globaldb.cache import (
     globaldb_set_general_cache_values,
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.globaldb.updates import ASSETS_VERSION_KEY
 from rotkehlchen.globaldb.utils import set_token_spam_protocol
 from rotkehlchen.history.events.structures.base import (
     HistoryBaseEntryType,

--- a/rotkehlchen/globaldb/asset_updates/parsers.py
+++ b/rotkehlchen/globaldb/asset_updates/parsers.py
@@ -1,0 +1,348 @@
+import abc
+import logging
+import re
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from rotkehlchen.assets.types import AssetData, AssetType
+from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
+from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind, Timestamp
+
+from .types import VersionRange
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rotkehlchen.db.drivers.gevent import DBConnection
+
+T = TypeVar('T')
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class BaseAssetParser(abc.ABC, Generic[T]):
+    """Base assets parser with common parsing functionality.
+
+    This was introduced to handle asset updates that need to be applied
+    before global db schema version changes. By having dedicated parser classes for different
+    data types (assets, collections, mappings), we can ensure compatible updates
+    are applied before the schema transitions to a new version.
+    """
+    def __init__(self) -> None:
+        self._double_quotes_re = re.compile(r'\"(.*?)\"')
+        self._string_re = re.compile(r'.*([\'"])(.*?)\1.*')
+        self._version_parsers: list[tuple[VersionRange, Callable]] = []
+
+    def parse(self, insert_text: str, version: int, connection: 'DBConnection') -> T:
+        for version_range, parser in self._version_parsers:
+            if version_range.contains(version):
+                return parser(insert_text=insert_text, connection=connection)
+
+        assert False, f'No parser found for version {version}. One needs to be implemented and configured'  # noqa: E501, PT015, B011
+
+    def _parse_value(self, value: str) -> str | int | None:
+        match = self._string_re.match(value)
+        if match is not None:
+            return match.group(2)
+
+        value = value.strip()
+        if value == 'NULL':
+            return None
+
+        try:
+            return int(value)
+        except ValueError:
+            return value
+
+    def _parse_str(self, value: str, name: str, insert_text: str) -> str:
+        result = self._parse_value(value)
+        if not isinstance(result, str):
+            raise DeserializationError(
+                f'Got invalid {name} {value} from {insert_text}',
+            )
+        return result
+
+    def _parse_optional_str(self, value: str, name: str, insert_text: str) -> str | None:
+        result = self._parse_value(value)
+        if result is not None and not isinstance(result, str):
+            raise DeserializationError(
+                f'Got invalid {name} {value} from {insert_text}',
+            )
+        return result
+
+    def _parse_optional_int(self, value: str, name: str, insert_text: str) -> int | None:
+        result = self._parse_value(value)
+        if result is not None and not isinstance(result, int):
+            raise DeserializationError(
+                f'Got invalid {name} {value} from {insert_text}',
+            )
+        return result
+
+    def standardize_quotes(self, text: str) -> str:
+        """Convert double quotes to single quotes for consistency.
+
+        We enforce single quotes for all SQL values. If any old updates
+        come with double quotes, we convert them here.
+        """
+        def replace_double_quotes(match_result: re.Match[str]) -> str:
+            content = match_result.group(1).replace("'", "''")
+            return f"'{content}'"
+
+        return self._double_quotes_re.sub(replace_double_quotes, text)
+
+
+class AssetParser(BaseAssetParser[AssetData]):
+    """Parser for assets introduced in global db v3 (assets v15+)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._assets_re = re.compile(r'.*INSERT +INTO +assets\( *identifier *, *name *, *type *\) *VALUES\(([^,]*?),([^,]*?),([^,]*?)\).*?')  # noqa: E501
+        self._common_details_re = re.compile(r'.*INSERT +INTO +common_asset_details\( *identifier *, *symbol *, *coingecko *, *cryptocompare *, *forked *, *started *, *swapped_for *\) *VALUES\((.*?),(.*?),(.*?),(.*?),(.*?),([^,]*?),([^,]*?)\).*')  # noqa: E501
+        self._evm_tokens_re = re.compile(r'.*INSERT +INTO +evm_tokens\( *identifier *, *token_kind *, *chain *, *address *, *decimals *, *protocol *\) *VALUES\(([^,]*?),([^,]*?),([^,]*?),([^,]*?),([^,]*?),([^,]*?)\).*')  # noqa: E501
+        self._version_parsers = [
+            (VersionRange(15, None), self._parse),
+        ]
+
+    def _parse(self, connection: 'DBConnection', insert_text: str) -> AssetData:
+        asset_data = self._parse_asset_data(insert_text)
+        address = decimals = protocol = chain_id = token_kind = None
+        if asset_data.asset_type == AssetType.EVM_TOKEN:
+            address, decimals, protocol, chain_id, token_kind = self._parse_evm_token_data(insert_text)  # noqa: E501
+
+        return AssetData(
+            identifier=asset_data.identifier,
+            name=asset_data.name,
+            symbol=asset_data.symbol,
+            asset_type=asset_data.asset_type,
+            started=asset_data.started,
+            forked=asset_data.forked,
+            swapped_for=asset_data.swapped_for,
+            address=address,
+            chain_id=chain_id,
+            token_kind=token_kind,
+            decimals=decimals,
+            cryptocompare=asset_data.cryptocompare,
+            coingecko=asset_data.coingecko,
+            protocol=protocol,
+        )
+
+    def _parse_asset_data(self, insert_text: str) -> AssetData:
+        """Parse basic asset data for format"""
+        assets_match = self._assets_re.match(insert_text)
+        if assets_match is None:
+            raise DeserializationError(
+                f'At asset DB update could not parse asset data out of {insert_text}',
+            )
+        if len(assets_match.groups()) != 3:
+            raise DeserializationError(
+                f'At asset DB update could not parse asset data out of {insert_text}',
+            )
+
+        raw_type = self._parse_str(assets_match.group(3), 'asset type', insert_text)
+        asset_type = AssetType.deserialize_from_db(raw_type)
+        common_details_match = self._common_details_re.match(insert_text)
+        if common_details_match is None:
+            raise DeserializationError(
+                f'At asset DB update could not parse common asset '
+                f'details data out of {insert_text}',
+            )
+
+        raw_started = self._parse_optional_int(common_details_match.group(6), 'started', insert_text)  # noqa: E501
+        started = Timestamp(raw_started) if raw_started else None
+        return AssetData(
+            identifier=self._parse_str(common_details_match.group(1), 'identifier', insert_text),
+            asset_type=asset_type,
+            name=self._parse_str(assets_match.group(2), 'name', insert_text),
+            symbol=self._parse_str(common_details_match.group(2), 'symbol', insert_text),
+            started=started,
+            swapped_for=self._parse_optional_str(
+                common_details_match.group(7),
+                'swapped_for',
+                insert_text,
+            ),
+            coingecko=self._parse_optional_str(
+                common_details_match.group(3),
+                'coingecko',
+                insert_text,
+            ),
+            cryptocompare=self._parse_optional_str(
+                common_details_match.group(4),
+                'cryptocompare',
+                insert_text,
+            ),
+            forked=self._parse_optional_str(
+                common_details_match.group(5),
+                'forked',
+                insert_text,
+            ),
+            chain_id=None,
+            address=None,
+            token_kind=None,
+            decimals=None,
+            protocol=None,
+        )
+
+    def _parse_evm_token_data(
+            self,
+            insert_text: str,
+    ) -> tuple[ChecksumEvmAddress, int | None, str | None, ChainID | None, EvmTokenKind | None]:
+        """Read information related to evm assets from the insert line.
+        May raise:
+            - DeserializationError: if the regex didn't work or we failed to deserialize any value
+        """
+        match = self._evm_tokens_re.match(insert_text)
+        if match is None:
+            raise DeserializationError(
+                f'At asset DB update could not parse evm token data out '
+                f'of {insert_text}',
+            )
+
+        if len(match.groups()) != 6:
+            raise DeserializationError(
+                f'At asset DB update could not parse evm token data out of {insert_text}',
+            )
+
+        chain_value = self._parse_optional_int(
+            value=match.group(3),
+            name='chain',
+            insert_text=insert_text,
+        )
+        chain_id = ChainID.deserialize(chain_value) if chain_value is not None else None
+        token_kind_value = self._parse_optional_str(
+            value=match.group(2),
+            name='token_kind',
+            insert_text=insert_text,
+        )
+        token_kind = (
+            EvmTokenKind.deserialize_from_db(token_kind_value)
+            if token_kind_value is not None
+            else None
+        )
+        return (
+            deserialize_evm_address(self._parse_str(match.group(4), 'address', insert_text)),
+            self._parse_optional_int(match.group(5), 'decimals', insert_text),
+            self._parse_optional_str(match.group(6), 'protocol', insert_text),
+            chain_id,
+            token_kind,
+        )
+
+
+class AssetCollectionParser(BaseAssetParser[tuple[int, str, str] | tuple[int, str, str, str]]):
+    """Parser for asset collections introduced in global db v4 (assets v16+).
+
+    Uses new format after global db v10 which adds main_asset field.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._latest_collection_re = re.compile(r'.*INSERT +INTO +asset_collections\( *id *, *name *, *symbol, *main_asset *\) *VALUES +\(([^,]*?),([^,]*?),([^,]*?),([^,]*?)\).*?')  # noqa: E501
+        self._legacy_collection_re = re.compile(r'.*INSERT +INTO +asset_collections\( *id *, *name *, *symbol *\) *VALUES +\(([^,]*?),([^,]*?),([^,]*?)\).*?')  # noqa: E501
+        self._version_parsers = [
+            (VersionRange(16, 31), self._parse_legacy_format),
+            (VersionRange(32, None), self._parse_latest_format),
+        ]
+
+    def _parse_latest_format(self, connection: 'DBConnection', insert_text: str) -> tuple[int, str, str, str]:  # noqa: E501
+        collection_match = self._latest_collection_re.match(insert_text)
+        if collection_match is None:
+            log.error(f'Failed to match asset collection {insert_text}')
+            raise DeserializationError(
+                f'At asset DB update could not parse asset collection data out of {insert_text}',
+            )
+
+        groups = collection_match.groups()
+        if len(groups) != 4:
+            log.error(f'Asset collection {insert_text} does not have the expected elements')
+            raise DeserializationError(
+                f'At asset DB update could not parse asset collection data out of {insert_text}',
+            )
+
+        collection_id = self._parse_value(collection_match.group(1))
+        if not isinstance(collection_id, int):
+            raise DeserializationError(
+                f'At asset DB update invalid collection ID {collection_id} from {insert_text}',
+            )
+
+        name = self._parse_str(collection_match.group(2), 'name', insert_text)
+        symbol = self._parse_str(collection_match.group(3), 'symbol', insert_text)
+        main_asset = self._parse_str(collection_match.group(4), 'main_asset', insert_text)
+        return collection_id, name, symbol, main_asset
+
+    def _parse_legacy_format(self, connection: 'DBConnection', insert_text: str) -> tuple[int, str, str]:  # noqa: E501
+        collection_match = self._legacy_collection_re.match(insert_text)
+        if collection_match is None:
+            log.error(f'Failed to match asset collection {insert_text}')
+            raise DeserializationError(
+                f'At asset DB update could not parse asset collection data out of {insert_text}',
+            )
+
+        groups = collection_match.groups()
+        if len(groups) != 3:
+            log.error(f'Asset collection {insert_text} does not have the expected elements')
+            raise DeserializationError(
+                f'At asset DB update could not parse asset collection data out of {insert_text}',
+            )
+
+        collection_id = self._parse_value(collection_match.group(1))
+        if not isinstance(collection_id, int):
+            raise DeserializationError(
+                f'At asset DB update invalid collection ID {collection_id} from {insert_text}',
+            )
+
+        name = self._parse_str(collection_match.group(2), 'name', insert_text)
+        symbol = self._parse_str(collection_match.group(3), 'symbol', insert_text)
+        return collection_id, name, symbol
+
+
+class MultiAssetMappingsParser(BaseAssetParser[tuple[int, str]]):
+    """Parser for assets introduced in global db v4 (assets v16+)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._mappings_re = re.compile(r'.*INSERT +INTO +multiasset_mappings\( *collection_id *, *asset *\) *VALUES +\(([^,]*?), *([\'"])([^,]+?)\2\).*?')  # noqa: E501
+        self._version_parsers = [
+            (VersionRange(16, None), self._parse),
+        ]
+
+    def _parse(self, connection: 'DBConnection', insert_text: str) -> tuple[int, str]:
+        mapping_match = self._mappings_re.match(insert_text)
+        if mapping_match is None:
+            log.error(f'Failed to match asset collection mapping {insert_text}')
+            raise DeserializationError(
+                f'At asset DB update could not parse asset collection data out of {insert_text}',
+            )
+
+        groups = mapping_match.groups()
+        if len(groups) != 3:
+            log.error(f'Failed to find all elements in asset collection mapping {insert_text}')
+            raise DeserializationError(
+                f'At asset DB update could not parse asset collection data out of {insert_text}',
+            )
+
+        collection_id = self._parse_value(mapping_match.group(1))
+        if not isinstance(collection_id, int):
+            raise DeserializationError(
+                f'At asset DB update invalid collection ID {collection_id} from {insert_text}',
+            )
+
+        asset_identifier = mapping_match.group(3)
+        # check that the asset exists and so does the collection
+        with connection.read_ctx() as cursor:
+            cursor.execute('SELECT COUNT(*) FROM assets where identifier=?', (asset_identifier,))
+            if cursor.fetchone()[0] == 0:
+                raise UnknownAsset(asset_identifier)
+
+            cursor.execute(
+                'SELECT COUNT(*) FROM asset_collections WHERE id=?',
+                (collection_id,),
+            )
+            if cursor.fetchone()[0] != 1:
+                raise DeserializationError(
+                    f'Tried to add asset to collection with id {collection_id} but it does not exist',  # noqa: E501
+                )
+
+        return collection_id, asset_identifier

--- a/rotkehlchen/globaldb/asset_updates/types.py
+++ b/rotkehlchen/globaldb/asset_updates/types.py
@@ -1,0 +1,21 @@
+from enum import Enum, auto
+from typing import NamedTuple
+
+
+class UpdateFileType(Enum):
+    ASSETS = auto()
+    ASSET_COLLECTIONS = auto()
+    ASSET_COLLECTIONS_MAPPINGS = auto()
+
+
+class VersionRange(NamedTuple):
+    """Represents a version range with inclusive bounds"""
+    start: int
+    end: int | None = None  # None means no upper bound
+
+    def contains(self, version: int) -> bool:
+        """Check if a version is within this range"""
+        if self.end is None:
+            return version >= self.start
+
+        return self.start <= version <= self.end

--- a/rotkehlchen/globaldb/upgrades/manager.py
+++ b/rotkehlchen/globaldb/upgrades/manager.py
@@ -5,26 +5,39 @@ import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from rotkehlchen.globaldb.asset_updates.manager import AssetsUpdater
+from rotkehlchen.globaldb.migrations.manager import (
+    LAST_DATA_MIGRATION,
+    maybe_apply_globaldb_migrations,
+)
+from rotkehlchen.globaldb.schema import DB_SCRIPT_CREATE_TABLES
 from rotkehlchen.globaldb.upgrades.v6_v7 import migrate_to_v7
 from rotkehlchen.globaldb.upgrades.v7_v8 import migrate_to_v8
 from rotkehlchen.globaldb.upgrades.v8_v9 import migrate_to_v9
+from rotkehlchen.globaldb.utils import (
+    GLOBAL_DB_SCHEMA_BREAKING_CHANGES,
+    GLOBAL_DB_VERSION,
+    MIN_SUPPORTED_GLOBAL_DB_VERSION,
+    globaldb_get_setting_value,
+)
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import ts_now
 from rotkehlchen.utils.upgrades import DBUpgradeProgressHandler, UpgradeRecord
 
-from ..utils import GLOBAL_DB_VERSION, MIN_SUPPORTED_GLOBAL_DB_VERSION, globaldb_get_setting_value
 from .v2_v3 import migrate_to_v3
 from .v3_v4 import migrate_to_v4
 from .v4_v5 import migrate_to_v5
 from .v5_v6 import migrate_to_v6
 from .v9_v10 import migrate_to_v10
 
-logger = logging.getLogger(__name__)
-log = RotkehlchenLogsAdapter(logger)
-
 if TYPE_CHECKING:
     from rotkehlchen.db.drivers.gevent import DBConnection
+    from rotkehlchen.globaldb.handler import GlobalDBHandler
     from rotkehlchen.user_messages import MessagesAggregator
+
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 UPGRADES_LIST = [
@@ -68,15 +81,17 @@ def maybe_upgrade_globaldb(
         global_dir: Path,
         db_filename: str,
         msg_aggregator: 'MessagesAggregator',
+        globaldb: 'GlobalDBHandler | None' = None,
 ) -> bool:
     """Maybe upgrade the global DB.
 
     Returns True if this is a fresh DB. In that
     case the caller should make sure to input the latest version
-    and also the latest migration in the settings.
+    and also the latest migration in the settings. In all other cases returns False.
 
-    In all other cases returns False"""
-
+    The globaldb parameter is needed to handle schema-breaking changes that require
+    updating assets data before the DB schema is modified.
+    """
     try:
         with connection.read_ctx() as cursor:
             db_version = globaldb_get_setting_value(cursor, 'version', GLOBAL_DB_VERSION)
@@ -102,6 +117,12 @@ def maybe_upgrade_globaldb(
         target_version=GLOBAL_DB_VERSION,
     )
     for upgrade in UPGRADES_LIST:
+        if globaldb is not None and upgrade.from_version in GLOBAL_DB_SCHEMA_BREAKING_CHANGES:
+            AssetsUpdater(
+                globaldb=globaldb,
+                msg_aggregator=msg_aggregator,
+            ).apply_pending_compatible_updates()
+
         _perform_single_upgrade(
             upgrade=upgrade,
             connection=connection,
@@ -171,3 +192,44 @@ def _perform_single_upgrade(
             'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
             ('version', str(to_version)),
         )
+
+
+def configure_globaldb(
+        global_dir: Path,
+        db_filename: str,
+        connection: 'DBConnection',
+        msg_aggregator: 'MessagesAggregator',
+        globaldb: 'GlobalDBHandler | None' = None,
+) -> None:
+    """Configure the global database and handle schema upgrades.
+
+    - global_dir: Directory containing the global database
+    - db_filename: Name of the database file (typically global.db)
+    - connection: The database connection object
+    - msg_aggregator: Message aggregator for logging
+    - globaldb: Optional handler instance - determines whether asset updates are attempted
+
+    May raise:
+        - DBSchemaError if the database schema is invalid.
+    """
+    is_fresh_db = maybe_upgrade_globaldb(
+        globaldb=globaldb,
+        connection=connection,
+        global_dir=global_dir,
+        db_filename=db_filename,
+        msg_aggregator=msg_aggregator,
+    )
+
+    # its not a fresh database and foreign keys are not turned on by default.
+    connection.executescript('PRAGMA foreign_keys=on;')
+    connection.execute('PRAGMA journal_mode=WAL;')
+    if is_fresh_db is True:
+        connection.executescript(DB_SCRIPT_CREATE_TABLES)
+        with connection.write_ctx() as cursor:
+            cursor.executemany(
+                'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
+                [('version', str(GLOBAL_DB_VERSION)), ('last_data_migration', str(LAST_DATA_MIGRATION))],  # noqa: E501
+            )
+    else:
+        maybe_apply_globaldb_migrations(connection)
+    connection.schema_sanity_check()

--- a/rotkehlchen/globaldb/utils.py
+++ b/rotkehlchen/globaldb/utils.py
@@ -1,6 +1,12 @@
+import os
+import shutil
+import sqlite3
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.resolver import AssetResolver
+from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType
+from rotkehlchen.errors.misc import DBUpgradeError
 from rotkehlchen.types import SPAM_PROTOCOL
 
 if TYPE_CHECKING:
@@ -14,7 +20,9 @@ if TYPE_CHECKING:
 GLOBAL_DB_VERSION = 10
 ASSETS_FILE_IMPORT_ACCEPTED_GLOBALDB_VERSIONS = (3, GLOBAL_DB_VERSION)
 MIN_SUPPORTED_GLOBAL_DB_VERSION = 2
-
+GLOBAL_DB_SCHEMA_BREAKING_CHANGES = {
+    9,  # v9 to v10 breaks asset collections schema
+}
 # Some functions that split the logic out of some GlobalDB query functions that are
 # complicated enough to be abstracted and are used in multiple places. The main reason
 # this exists is a bad design in the GlobalDBHandler() that can create circular imports.
@@ -51,3 +59,64 @@ def set_token_spam_protocol(
     )
     object.__setattr__(token, 'protocol', None)
     AssetResolver.clean_memory_cache(identifier=token.identifier)
+
+
+def initialize_globaldb(
+        global_dir: Path,
+        db_filename: str,
+        sql_vm_instructions_cb: int,
+) -> tuple[DBConnection, bool]:
+    """
+    Checks the database whether there are any not finished upgrades and automatically uses a
+    backup if there are any. If no backup found, throws an error.
+
+    - global_dir: The directory in which to find the global.db to initialize
+    - db_filename: The filename of the DB. Almost always: global.db.
+    - sql_vm_instructions_cb is a connection setting. Check DBConnection for details.
+
+    Returns the DB connection and true if a DB backup was used and False otherwise
+    May raise:
+        - DBUpgradeError
+    """
+    connection = DBConnection(
+        path=global_dir / db_filename,
+        connection_type=DBConnectionType.GLOBAL,
+        sql_vm_instructions_cb=sql_vm_instructions_cb,
+    )
+    try:
+        with connection.read_ctx() as cursor:
+            ongoing_upgrade_from_version = globaldb_get_setting_value(
+                cursor=cursor,
+                name='ongoing_upgrade_from_version',
+                default_value=-1,
+            )
+    except sqlite3.OperationalError:  # pylint: disable=no-member
+        ongoing_upgrade_from_version = -1  # Fresh DB
+
+    if ongoing_upgrade_from_version == -1:
+        return connection, False  # We are all good
+
+    # Otherwise replace the db with a backup and relogin
+    connection.close()
+    backup_postfix = f'global_db_v{ongoing_upgrade_from_version}.backup'
+    found_backups = list(filter(
+        lambda x: x[-len(backup_postfix):] == backup_postfix,
+        os.listdir(global_dir),
+    ))
+    if len(found_backups) == 0:
+        raise DBUpgradeError(
+            'Your global database is in a half-upgraded state and there was no backup '
+            'found. Please open an issue on our github or contact us in our discord server.',
+        )
+
+    backup_to_use = max(found_backups)  # Use latest backup
+    shutil.copyfile(
+        global_dir / backup_to_use,
+        global_dir / db_filename,
+    )
+    connection = DBConnection(
+        path=global_dir / db_filename,
+        connection_type=DBConnectionType.GLOBAL,
+        sql_vm_instructions_cb=sql_vm_instructions_cb,
+    )
+    return connection, True

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -16,7 +16,7 @@ from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.structures.balance import Balance, BalanceType
 from rotkehlchen.api.websockets.notifier import RotkiNotifier
 from rotkehlchen.api.websockets.typedefs import WSMessageType
-from rotkehlchen.assets.asset import Asset, AssetResolver, AssetWithOracles, Nft
+from rotkehlchen.assets.asset import Asset, AssetWithOracles, Nft
 from rotkehlchen.balances.manual import (
     account_for_manually_tracked_asset_balances,
     get_manually_tracked_balances,
@@ -50,7 +50,6 @@ from rotkehlchen.chain.substrate.utils import (
 from rotkehlchen.chain.zksync_lite.manager import ZksyncLiteManager
 from rotkehlchen.config import default_data_directory
 from rotkehlchen.constants import ONE, ZERO
-from rotkehlchen.constants.assets import CONSTANT_ASSETS
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.data_import.manager import CSVDataImporter
 from rotkehlchen.data_migrations.manager import DataMigrationManager
@@ -75,9 +74,9 @@ from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 from rotkehlchen.externalapis.defillama import Defillama
 from rotkehlchen.fval import FVal
+from rotkehlchen.globaldb.asset_updates.manager import AssetsUpdater
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.globaldb.manual_price_oracles import ManualCurrentOracle
-from rotkehlchen.globaldb.updates import AssetsUpdater
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.history.manager import HistoryQueryingManager
 from rotkehlchen.history.price import PriceHistorian
@@ -168,10 +167,10 @@ class Rotkehlchen:
         # Initialize the GlobalDBHandler singleton. Has to be initialized BEFORE asset resolver
         globaldb = GlobalDBHandler(
             data_dir=self.data_dir,
+            perform_assets_updates=True,
             sql_vm_instructions_cb=self.args.sqlite_instructions,
             msg_aggregator=self.msg_aggregator,
         )
-        AssetResolver(globaldb=globaldb, constant_assets=CONSTANT_ASSETS)
         if globaldb.used_backup is True:
             self.msg_aggregator.add_warning(
                 'Your global database was left in an half-upgraded state. '
@@ -510,7 +509,10 @@ class Rotkehlchen:
         )
 
         self.migration_manager.maybe_migrate_data()
-        self.assets_updater = AssetsUpdater(self.msg_aggregator)
+        self.assets_updater = AssetsUpdater(
+            msg_aggregator=self.msg_aggregator,
+            globaldb=GlobalDBHandler(),
+        )
         self.greenlet_manager.spawn_and_track(
             after_seconds=None,
             task_name='Check data updates',

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -85,6 +85,7 @@ def create_globaldb(
         data_directory,
         sql_vm_instructions_cb,
         messages_aggregator,
+        perform_assets_updates=False,
 ) -> GlobalDBHandler:
     # Since this is a singleton and we want it initialized everytime the fixture
     # is called make sure its instance is always starting from scratch
@@ -94,6 +95,7 @@ def create_globaldb(
         data_dir=data_directory,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
         msg_aggregator=messages_aggregator,
+        perform_assets_updates=perform_assets_updates,
     )
 
 
@@ -128,7 +130,7 @@ def _initialize_fixture_globaldb(
         )
         if run_globaldb_migrations is False:
             stack.enter_context(
-                patch('rotkehlchen.globaldb.handler.maybe_apply_globaldb_migrations', side_effect=lambda *args: None),  # noqa: E501
+                patch('rotkehlchen.globaldb.upgrades.manager.maybe_apply_globaldb_migrations', side_effect=lambda *args: None),  # noqa: E501
             )
         if reload_user_assets is False:
             stack.enter_context(


### PR DESCRIPTION
currently, when the global db schema is upgraded, we may miss asset updates that were compatible with the old schema but incompatible with the new one. this pr ensures we apply pending asset updates before upgrading the db schema.

key changes:
- pass globaldbhandler to db upgrade functions for asset updates.
- add `assets_updater.apply_pending_compatible_updates()`
- refactor parsing logic into dedicated parser classes.