### PR TITLE
Ensure addresses are checksummed

### DIFF
--- a/rotkehlchen/chain/evm/decoding/curve_lend/utils.py
+++ b/rotkehlchen/chain/evm/decoding/curve_lend/utils.py
@@ -7,7 +7,6 @@ import requests
 from rotkehlchen.assets.asset import UnderlyingToken
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
 from rotkehlchen.chain.evm.decoding.utils import get_vault_price, update_cached_vaults
-from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.globaldb.cache import (
@@ -15,7 +14,7 @@ from rotkehlchen.globaldb.cache import (
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_int
+from rotkehlchen.serialization.deserialize import deserialize_evm_address, deserialize_int
 from rotkehlchen.types import (
     CURVE_LENDING_VAULTS_PROTOCOL,
     CacheType,
@@ -66,7 +65,7 @@ def _process_curve_lending_vault(database: 'DBHandler', vault: dict[str, Any]) -
 
     underlying_token = get_or_create_evm_token(
         userdb=database,
-        evm_address=string_to_evm_address(vault['assets']['borrowed']['address']),
+        evm_address=deserialize_evm_address(vault['assets']['borrowed']['address']),
         chain_id=vault_chain_id,
         decimals=deserialize_int(vault['assets']['borrowed']['decimals']),
         symbol=vault['assets']['borrowed']['symbol'],
@@ -74,7 +73,7 @@ def _process_curve_lending_vault(database: 'DBHandler', vault: dict[str, Any]) -
     )
     vault_token = get_or_create_evm_token(
         userdb=database,
-        evm_address=string_to_evm_address(vault['address']),
+        evm_address=deserialize_evm_address(vault['address']),
         chain_id=vault_chain_id,
         protocol=CURVE_LENDING_VAULTS_PROTOCOL,
         name=vault['name'],


### PR DESCRIPTION
The API returns some addresses checksummed and others aren't. To ensure that we don't introduce bad ids in the DB we checksumm before creating the token

