### PR TITLE
fix: do truncate address better

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventType.vue
+++ b/frontend/app/src/components/history/events/HistoryEventType.vue
@@ -50,7 +50,7 @@ const evmOrEthDepositEvent = computed(() => get(isEvmEventRef(event)) || get(isE
           icon
           :item="onlineEvent.location"
           size="16px"
-          class="mr-1"
+          class="mr-2"
         />
         <HashLink
           :show-icon="!onlineEvent"

--- a/frontend/app/src/utils/truncate.ts
+++ b/frontend/app/src/utils/truncate.ts
@@ -26,7 +26,7 @@ export function truncateAddress(address: string, truncLength = 4): string {
 
   const length = address.length;
 
-  if (length <= truncLength * 2 + startPadding)
+  if (length <= truncLength * 2 + startPadding + 3)
     return address;
 
   return `${address.slice(0, truncLength + startPadding)}...${address.slice(length - truncLength, length)}`;


### PR DESCRIPTION
Increase the limit (3 chars), because the `...` takes up 3 spaces, so instead of showing the `...`, just show the original string.

Before: 
<img width="279" alt="image" src="https://github.com/user-attachments/assets/6c4d2ac6-a83c-4d2d-acfa-53c6f6a1f959" />

After:
<img width="283" alt="image" src="https://github.com/user-attachments/assets/1e944574-18a5-4ff9-9249-48b072ca12c2" />
