### PR TITLE
fix(docker): Increase Node.js memory limit to prevent build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM --platform=$BUILDPLATFORM node:20-buster AS frontend-build-stage
 ARG BUILDARCH
 ENV COREPACK_ENABLE_STRICT=0
 ENV CYPRESS_INSTALL_BINARY=0
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 WORKDIR /app
 COPY frontend/ .
 RUN if [ "$BUILDARCH" != "amd64" ]; then apt-get update && apt-get install -y build-essential python3 --no-install-recommends; fi


### PR DESCRIPTION
Fixes #9100

## Checklist

- [ ] The PR modified the frontend build process in Docker, but no user guide changes are needed as this is an internal build improvement.

## Description

This PR increases the Node.js memory limit during Docker build to prevent frontend build failures caused by memory allocation errors during TypeScript type checking.

### Problem
During Docker build, the frontend build process fails with memory allocation errors:
```
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL rotki@1.36.1 build
Exit status 1
ELIFECYCLE Command failed with exit code 1
```

### Solution
Added `NODE_OPTIONS="--max-old-space-size=4096"` environment variable to Dockerfile to increase the Node.js heap memory limit to 4GB.

### Testing
- Docker build completes successfully
- Frontend works as expected in the Docker container
