### PR TITLE
Prevent balancer cache protocol misconfiguration

### DIFF
--- a/rotkehlchen/chain/evm/decoding/balancer/balancer_cache.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/balancer_cache.py
@@ -100,9 +100,6 @@ def query_balancer_data(
                         address=get_or_create_evm_token(
                             userdb=inquirer.database,
                             chain_id=inquirer.chain_id,
-                            protocol=protocol,
-                            name=token['name'].strip(),
-                            symbol=token['symbol'].strip(),
                             evm_address=deserialize_evm_address(token['address']),
                             encounter=token_encounter_info,
                         ).evm_address,


### PR DESCRIPTION
The logic was setting the protocol of the underlying token to balancer by mistake. Also it could edit the name and symbol. This won't happen anymore.


