### PR TITLE
Limit arbiscan token queries

### DIFF
--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -16,7 +16,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import ChecksumEvmAddress, Price, SupportedBlockchain, Timestamp
+from rotkehlchen.types import ChainID, ChecksumEvmAddress, Price, SupportedBlockchain, Timestamp
 from rotkehlchen.utils.misc import combine_dicts, get_chunks
 
 if TYPE_CHECKING:
@@ -71,6 +71,7 @@ OTHER_MAX_TOKEN_CHUNK_LENGTH = 460
 
 # maximum 32-bytes arguments in one call to a contract (either tokensBalance or multicall)
 ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT = 110
+ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT = 25
 
 # this is a number of arguments that a pure tokensBalance contract occupies when is added
 # to multicall. In total, it occupies (7 + number of tokens passed) arguments.
@@ -118,7 +119,7 @@ def get_chunk_size_call_order(evm_inquirer: 'EvmNodeInquirer') -> tuple[int, lis
         chunk_size = OTHER_MAX_TOKEN_CHUNK_LENGTH
         call_order = evm_inquirer.default_call_order(skip_etherscan=True)
     else:
-        chunk_size = ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT
+        chunk_size = ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT if evm_inquirer.chain_id != ChainID.ARBITRUM_ONE else ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT  # noqa: E501
         call_order = [evm_inquirer.etherscan_node]
 
     return chunk_size, call_order


### PR DESCRIPTION
## What the issue was

So when the balances are queried we do two things.

1. Query base token balances (ETH, xdai..)
2. Query evm tokens

`1.` always uses the default call order. that is a randomized order and etherscan can be the node queried. `2.` For 2 we do something special. Since we split the tokens in chunks we have a funciton `get_chunk_size_call_order`. https://github.com/rotki/rotki/blob/da76cb8e347543bb2f539a6731c8666bc382eacb/rotkehlchen/chain/evm/tokens.py#L110 (screenshot)

We changed the way nodes are connected and if in the step `1.` we query eth balances using etherscan then there is no node connected. Then the check `connected_to_any_web3` becomes False and the token balance query is made using etherscan.

Now the second issue comes and it is that arbiscan has a lower limit in the amount of tokens that can be queried and that is not hanlded in that logic.

This chain of events is what leads to an error in the token detection

## What we do in this PR

We change the size of the chunk queried when we ask for tokens to arbiscan. This avoids errors in the token detection. It still can happen that we don't connect to any node before the token detection and we only ask arbiscan

## What we need to do

We need to change how the logic works to try other nodes if we haven't connected yet to any and avoid querying etherscan/arbiscan when possible.

We can do it with a function `connect_to_any_node(default_order)` that tries to connect to any node just before we query `get_chunk_size_call_order`. This will tell us that at least there is an available node and we can proceed with anything else other than etherscan.

Other options can be considered
