### PR TITLE
Add aave lido tokens

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Bitmex balances will now be queried correctly.
+* :feature:`-` Lido and EtherFI reserve tokens will now be automatically queried.
 
 * :release:`1.37.0 <2024-12-24>`
 * :feature:`7144` Users will be able to import multiple addresses into the address book via CSV.

--- a/rotkehlchen/chain/arbitrum_one/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/aave/v3/decoder.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.aave.v3.constants import POOL_ADDRESS
+from rotkehlchen.chain.evm.decoding.aave.v3.constants import EVM_POOLS
 from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3CommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
@@ -22,7 +22,7 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=POOL_ADDRESS,
+            pool_addresses=EVM_POOLS,
             native_gateways=(string_to_evm_address('0xecD4bd3121F9FD604ffaC631bF6d41ec12f1fafb'),),
             treasury=string_to_evm_address('0x053D55f9B5AF8694c503EB288a1B7E552f590710'),
             incentives=string_to_evm_address('0x929EC64c34a17401F460460D4B9390518E5B473e'),

--- a/rotkehlchen/chain/base/modules/aave/v3/constants.py
+++ b/rotkehlchen/chain/base/modules/aave/v3/constants.py
@@ -2,4 +2,4 @@ from typing import Final
 
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
-AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x2d8A3C5677189723C4cB8873CfC9C8976FDF38Ac')
+AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0xd82a47fdebB5bf5329b09441C3DaB4b5df2153Ad')

--- a/rotkehlchen/chain/base/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/base/modules/aave/v3/decoder.py
@@ -21,7 +21,7 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=string_to_evm_address('0xA238Dd80C259a72e81d7e4664a9801593F98d1c5'),
+            pool_addresses=(string_to_evm_address('0xA238Dd80C259a72e81d7e4664a9801593F98d1c5'),),
             native_gateways=(string_to_evm_address('0x8be473dCfA93132658821E67CbEB684ec8Ea2E74'),),
             treasury=string_to_evm_address('0xBA9424d650A4F5c80a0dA641254d1AcCE2A37057'),
             incentives=string_to_evm_address('0xf9cc4F0D883F1a1eb2c253bdb46c254Ca51E1F44'),

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
@@ -23,7 +23,7 @@ class Aavev2Decoder(Aavev2CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=POOL_ADDRESS,
+            pool_addresses=(POOL_ADDRESS,),
             native_gateways=ETH_GATEWAYS,
             incentives=string_to_evm_address('0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5'),
             incentives_reward_token=string_to_evm_address('0x4da27a545c0c5B758a6BA100e3a049001de870f5'),  # stkAAVE  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/aave/v3/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v3/constants.py
@@ -2,4 +2,8 @@ from typing import Final
 
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
-AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x7B4EB56E7CD4b454BA8ff71E4518426369a138a3')
+AAVE_V3_DATA_PROVIDER_OLD: Final = string_to_evm_address('0x7B4EB56E7CD4b454BA8ff71E4518426369a138a3')  # noqa: E501
+# Those can be found in https://search.onaave.com/?q=protocol%20data%20provider
+AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x41393e5e337606dc3821075Af65AeE84D7688CBD')
+LIDO_AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x08795CFE08C7a81dCDFf482BbAAF474B240f31cD')  # noqa: E501
+ETHERFI_AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0xE7d490885A68f00d9886508DF281D67263ed5758')  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v3/decoder.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from rotkehlchen.chain.evm.decoding.aave.v3.constants import POOL_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3CommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
@@ -21,7 +22,11 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=string_to_evm_address('0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2'),
+            pool_addresses=(
+                POOL_ADDRESS,
+                string_to_evm_address('0x4e033931ad43597d96D6bcc25c280717730B58B1'),  # lido pool
+                string_to_evm_address('0x0AA97c284e98396202b6A04024F5E2c65026F3c0'),  # etherfi
+            ),
             native_gateways=(string_to_evm_address('0x893411580e590D62dDBca8a703d61Cc4A8c7b2b9'),),
             treasury=string_to_evm_address('0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c'),
             incentives=string_to_evm_address('0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb'),

--- a/rotkehlchen/chain/evm/contracts.py
+++ b/rotkehlchen/chain/evm/contracts.py
@@ -221,7 +221,7 @@ class EvmContracts(Generic[T]):
         Missing contract is a programming error and should never happen.
         """
         contract = self.contract_by_address(address=address, fallback_to_packaged_db=True)
-        assert contract, f'No contract data for {address} found'
+        assert contract, f'No contract data for {address} found at chain {self.chain_id.to_name()}'
         return contract
 
     @classmethod

--- a/rotkehlchen/chain/evm/decoding/aave/common.py
+++ b/rotkehlchen/chain/evm/decoding/aave/common.py
@@ -1,5 +1,6 @@
 import logging
 from abc import abstractmethod
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from rotkehlchen.accounting.structures.balance import Balance
@@ -22,7 +23,6 @@ from rotkehlchen.chain.evm.decoding.structures import (
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
-from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
@@ -47,7 +47,7 @@ class Commonv2v3Decoder(DecoderInterface):
             self,
             counterparty: Literal['aave-v2', 'aave-v3'],
             label: Literal['AAVE v2', 'AAVE v3'],
-            pool_address: 'ChecksumEvmAddress',
+            pool_addresses: Sequence['ChecksumEvmAddress'],
             deposit_signature: bytes,
             borrow_signature: bytes,
             repay_signature: bytes,
@@ -57,7 +57,7 @@ class Commonv2v3Decoder(DecoderInterface):
             msg_aggregator: 'MessagesAggregator',
     ):
         self.counterparty = counterparty
-        self.pool_address = pool_address
+        self.pool_addresses = pool_addresses
         self.deposit_signature = deposit_signature
         self.borrow_signature = borrow_signature
         self.repay_signature = repay_signature
@@ -487,6 +487,4 @@ class Commonv2v3Decoder(DecoderInterface):
 
     # DecoderInterface method
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
-        return {
-            string_to_evm_address(self.pool_address): (self._decode_lending_pool_events,),
-        }
+        return dict.fromkeys(self.pool_addresses, (self._decode_lending_pool_events,))

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
@@ -24,7 +25,7 @@ class Aavev2CommonDecoder(Commonv2v3Decoder):
             evm_inquirer: 'EvmNodeInquirer',
             base_tools: 'BaseDecoderTools',
             msg_aggregator: 'MessagesAggregator',
-            pool_address: 'ChecksumEvmAddress',
+            pool_addresses: Sequence['ChecksumEvmAddress'],
             native_gateways: 'tuple[ChecksumEvmAddress, ...]',
             incentives: 'ChecksumEvmAddress',
             incentives_reward_token: 'ChecksumEvmAddress',
@@ -33,7 +34,7 @@ class Aavev2CommonDecoder(Commonv2v3Decoder):
             self,
             counterparty=CPT_AAVE_V2,
             label='AAVE v2',
-            pool_address=pool_address,
+            pool_addresses=pool_addresses,
             deposit_signature=DEPOSIT,
             borrow_signature=BORROW,
             repay_signature=REPAY,

--- a/rotkehlchen/chain/evm/decoding/aave/v3/constants.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/constants.py
@@ -4,8 +4,11 @@ from typing import Final
 
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
-POOL_ADDRESS: Final = string_to_evm_address('0x794a61358D6845594F94dc1DB02A252b5b4814aD')
-AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x69FA688f1Dc47d4B5d8029D5a35FB7a548310654')
+POOL_ADDRESS: Final = string_to_evm_address('0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2')
+OLD_POOL_ADDRESS: Final = string_to_evm_address('0x794a61358D6845594F94dc1DB02A252b5b4814aD')
+EVM_POOLS: Final = (POOL_ADDRESS, OLD_POOL_ADDRESS)
+
+AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x7F23D86Ee20D869112572136221e173428DD740B')
 DEPOSIT: Final = b'+bw6\xbc\xa1\\\xd58\x1d\xcf\x80\xb0\xbf\x11\xfd\x19}\x01\xa07\xc5+\x92z\x88\x1a\x10\xfbs\xbaa'  # noqa: E501
 BORROW: Final = b'\xb3\xd0\x84\x82\x0f\xb1\xa9\xde\xcf\xfb\x17d6\xbd\x02U\x8d\x15\xfa\xc9\xb0\xdd\xfe\xd8\xc4e\xbcsY\xd7\xdc\xe0'  # noqa: E501
 REPAY: Final = b'\xa54\xc8\xdb\xe7\x1f\x87\x1f\x9f50\xe9zt`\x1f\xea\x17\xb4&\xca\xe0.\x1cZ\xeeB\xc9lx@Q'  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.accounting.structures.balance import Balance
@@ -39,7 +39,7 @@ class Aavev3CommonDecoder(Commonv2v3Decoder):
             evm_inquirer: 'EvmNodeInquirer',
             base_tools: 'BaseDecoderTools',
             msg_aggregator: 'MessagesAggregator',
-            pool_address: 'ChecksumEvmAddress',
+            pool_addresses: Sequence['ChecksumEvmAddress'],
             native_gateways: 'tuple[ChecksumEvmAddress, ...]',
             treasury: 'ChecksumEvmAddress',
             incentives: 'ChecksumEvmAddress',
@@ -48,7 +48,7 @@ class Aavev3CommonDecoder(Commonv2v3Decoder):
             self,
             counterparty=CPT_AAVE_V3,
             label='AAVE v3',
-            pool_address=pool_address,
+            pool_addresses=pool_addresses,
             deposit_signature=DEPOSIT,
             borrow_signature=BORROW,
             repay_signature=REPAY,
@@ -270,7 +270,7 @@ class Aavev3CommonDecoder(Commonv2v3Decoder):
         return dict.fromkeys(GlobalDBHandler.get_addresses_by_protocol(
             chain_id=self.evm_inquirer.chain_id,
             protocol=CPT_AAVE_V3,
-        ), CPT_AAVE_V3) | {self.pool_address: CPT_AAVE_V3}
+        ), CPT_AAVE_V3) | dict.fromkeys(self.pool_addresses, CPT_AAVE_V3)
 
     def post_decoding_rules(self) -> dict[str, list[tuple[int, Callable]]]:
         return {CPT_AAVE_V3: [(0, self._decode_interest)]}

--- a/rotkehlchen/chain/gnosis/modules/aave/v3/constants.py
+++ b/rotkehlchen/chain/gnosis/modules/aave/v3/constants.py
@@ -2,4 +2,4 @@ from typing import Final
 
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
-AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x501B4c19dd9C2e06E94dA7b6D5Ed4ddA013EC741')
+AAVE_V3_DATA_PROVIDER: Final = string_to_evm_address('0x57038C3e3Fe0a170BB72DE2fD56E98e4d1a69717')

--- a/rotkehlchen/chain/gnosis/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/aave/v3/decoder.py
@@ -21,7 +21,7 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=string_to_evm_address('0xb50201558B00496A145fE76f7424749556E326D8'),
+            pool_addresses=(string_to_evm_address('0xb50201558B00496A145fE76f7424749556E326D8'),),
             native_gateways=(string_to_evm_address('0xfE76366A986B72c3f2923e05E6ba07b7de5401e4'),),
             treasury=string_to_evm_address('0x3e652E97ff339B73421f824F5b03d75b62F1Fb51'),
             incentives=string_to_evm_address('0xaD4F91D26254B6B0C6346b390dDA2991FDE2F20d'),

--- a/rotkehlchen/chain/optimism/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/aave/v3/decoder.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.aave.v3.constants import POOL_ADDRESS
+from rotkehlchen.chain.evm.decoding.aave.v3.constants import EVM_POOLS
 from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3CommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
@@ -22,7 +22,7 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=POOL_ADDRESS,
+            pool_addresses=EVM_POOLS,
             native_gateways=(string_to_evm_address('0xe9E52021f4e11DEAD8661812A0A6c8627abA2a54'),),
             treasury=string_to_evm_address('0xB2289E329D2F85F1eD31Adbb30eA345278F21bcf'),
             incentives=string_to_evm_address('0x929EC64c34a17401F460460D4B9390518E5B473e'),

--- a/rotkehlchen/chain/polygon_pos/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/aave/v2/decoder.py
@@ -21,7 +21,7 @@ class Aavev2Decoder(Aavev2CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=string_to_evm_address('0x8dFf5E27EA6b7AC08EbFdf9eB090F32ee9a30fcf'),
+            pool_addresses=(string_to_evm_address('0x8dFf5E27EA6b7AC08EbFdf9eB090F32ee9a30fcf'),),
             native_gateways=(string_to_evm_address('0xf1e6d4347105138B51E2bacA9A22fA228309ebB1'),),
             incentives=string_to_evm_address('0x357D51124f59836DeD84c8a1730D72B749d8BC23'),
             incentives_reward_token=string_to_evm_address('0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270'),  # wrapped Matic  # noqa: E501

--- a/rotkehlchen/chain/polygon_pos/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/aave/v3/decoder.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.aave.v3.constants import POOL_ADDRESS
+from rotkehlchen.chain.evm.decoding.aave.v3.constants import EVM_POOLS
 from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3CommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
@@ -22,7 +22,7 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=POOL_ADDRESS,
+            pool_addresses=EVM_POOLS,
             native_gateways=(string_to_evm_address('0xC1E320966c485ebF2A0A2A6d3c0Dc860A156eB1B'),),
             treasury=string_to_evm_address('0xe8599F3cc5D38a9aD6F3684cd5CEa72f10Dbc383'),
             incentives=string_to_evm_address('0x929EC64c34a17401F460460D4B9390518E5B473e'),

--- a/rotkehlchen/chain/scroll/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/aave/v3/decoder.py
@@ -21,7 +21,7 @@ class Aavev3Decoder(Aavev3CommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            pool_address=string_to_evm_address('0x11fCfe756c05AD438e312a7fd934381537D3cFfe'),
+            pool_addresses=(string_to_evm_address('0x11fCfe756c05AD438e312a7fd934381537D3cFfe'),),
             native_gateways=(string_to_evm_address('0xFF75A4B698E3Ec95E608ac0f22A03B8368E05F5D'),),
             treasury=string_to_evm_address('0x90eB541e1a431D8a30ED85A77675D1F001128cb5'),
             incentives=string_to_evm_address('0xa3f3100C4f1D0624DB9DB97b40C13885Ce297799'),

--- a/rotkehlchen/tests/api/test_aave.py
+++ b/rotkehlchen/tests/api/test_aave.py
@@ -117,7 +117,7 @@ def test_query_aave_balances(rotkehlchen_api_server: APIServer) -> None:
                         amount=FVal('123'),
                         usd_value=FVal('12.3'),
                     ).serialize(),
-                    'apy': '2.02%',
+                    'apy': '1.83%',
                 },
             },
             'borrowing': {
@@ -127,7 +127,7 @@ def test_query_aave_balances(rotkehlchen_api_server: APIServer) -> None:
                         usd_value=FVal('4560'),
                     ).serialize(),
                     'stable_apr': '0.00%',
-                    'variable_apr': '10.21%',
+                    'variable_apr': '13.67%',
                 },
             },
         },


### PR DESCRIPTION
This PR:

- Tracks lido and etherFI aave reserve tokens
- Improves performance of task for querying aave tokens

The performance has been improved mostly by reducing the number of remote calls but also by reducing the number of function calls.

The worst case that we had before is when we had to add new reserve tokens. This would mean that for each token we will make a multicall to retrieve name, symbol and decimals in one query. We had `num_aave_providers * num_reservers * num_debt_tokens` queries. In the case of ethereum it meant to do around 100 rpc calls.

What I've done is to check what tokens need to have their details queried and then do bigger multicalls since I query name, symbol and decimals of all of them in 3 multicalls (instead of num_debt_tokens). This allowed me to avoid recreating classes from web3.py like the contract class that happened every time we had to query details and encode/decode serveral times the same information.

Now for the ethereum data we do ~30 rpc calls, ~1/3 of what we were doing before. Also the cassette file went from 15K lines to 5K lines.
