### PR TITLE
Address connection errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`9163` Cryptocompare will handle correctly price queries again.
+* :bug:`9163` Cryptocompare price queries will be handled correctly again. Fixes "the 'FVal' object is not subscriptable".
 * :bug:`-` When querying the price of BSQ rotki will define it as the price of 100 satoshi.
 
 * :release:`1.37.0 <2024-12-24>`

--- a/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
@@ -22,6 +22,7 @@ from rotkehlchen.serialization.deserialize import (
 )
 from rotkehlchen.types import ChecksumEvmAddress, Eth2PubKey, Timestamp
 from rotkehlchen.utils.misc import from_gwei
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 from .constants import BEACONCHAIN_MAX_EPOCH, DEFAULT_VALIDATOR_CHUNK_SIZE, FREE_VALIDATORS_LIMIT
@@ -44,7 +45,7 @@ class BeaconNode:
         May raise:
         - RemoteError if we can't connect to the given rpc endpoint
         """
-        self.session = requests.session()
+        self.session = create_session()
         self.set_rpc_endpoint(rpc_endpoint)
 
     def set_rpc_endpoint(self, rpc_endpoint: str) -> None:

--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -129,6 +129,7 @@ from rotkehlchen.serialization.deserialize import deserialize_int_from_str
 from rotkehlchen.types import ChecksumEvmAddress, ExternalService
 from rotkehlchen.utils.interfaces import EthereumModule
 from rotkehlchen.utils.mixins.lockable import LockableQueryMixIn, protect_with_lock
+from rotkehlchen.utils.network import create_session
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -162,7 +163,7 @@ class Loopring(ExternalServiceWithApiKey, EthereumModule, LockableQueryMixIn):
         LockableQueryMixIn.__init__(self)
         api_key = self._get_api_key()
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = create_session()
         if api_key:
             self.session.headers.update({'X-API-KEY': api_key})
         self.base_url = 'https://api3.loopring.io/api/v3/'

--- a/rotkehlchen/chain/zksync_lite/manager.py
+++ b/rotkehlchen/chain/zksync_lite/manager.py
@@ -39,6 +39,7 @@ from rotkehlchen.types import (
     deserialize_evm_tx_hash,
 )
 from rotkehlchen.utils.misc import iso8601ts_to_timestamp, set_user_agent, ts_sec_to_ms
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ class ZksyncLiteManager:
             database: 'DBHandler',
     ) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = create_session()
         set_user_agent(self.session)
         self.id_to_token: dict[int, CryptoAsset] = {}
         self.symbol_to_token: dict[str, CryptoAsset] = {}

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -3,8 +3,6 @@ from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
-import requests
-
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import AssetWithOracles
@@ -27,6 +25,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import set_user_agent, ts_now
 from rotkehlchen.utils.mixins.cacheable import CacheableMixIn
 from rotkehlchen.utils.mixins.lockable import LockableQueryMixIn, protect_with_lock
+from rotkehlchen.utils.network import create_session
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -89,7 +88,7 @@ class ExchangeInterface(CacheableMixIn, LockableQueryMixIn):
         self.secret = secret
         self.msg_aggregator = msg_aggregator
         self.first_connection_made = False
-        self.session = requests.session()
+        self.session = create_session()
         set_user_agent(self.session)
         log.info(f'Initialized {location!s} exchange {name}')
 

--- a/rotkehlchen/externalapis/beaconchain/service.py
+++ b/rotkehlchen/externalapis/beaconchain/service.py
@@ -35,6 +35,7 @@ from rotkehlchen.utils.misc import (
     ts_now,
     ts_sec_to_ms,
 )
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -52,7 +53,7 @@ class BeaconChain(ExternalServiceWithApiKey):
     def __init__(self, database: 'DBHandler', msg_aggregator: MessagesAggregator) -> None:
         super().__init__(database=database, service_name=ExternalService.BEACONCHAIN)
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = create_session()
         self.warning_given = False
         set_user_agent(self.session)
         self.url = f'{BEACONCHAIN_ROOT_URL}/api/v1/'

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -27,6 +27,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import from_wei, iso8601ts_to_timestamp, set_user_agent, ts_sec_to_ms
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ class Blockscout(ExternalServiceWithApiKey):
             service_name={v: k for k, v in BLOCKSCOUT_TO_CHAINID.items()}[self.chain_id],
         )
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = create_session()
         set_user_agent(self.session)
         match blockchain:
             case SupportedBlockchain.ETHEREUM:

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -22,6 +22,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, EvmTokenKind, ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import create_timestamp, set_user_agent, timestamp_to_date, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
+from rotkehlchen.utils.network import create_session
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -526,7 +527,7 @@ class Coingecko(
         ExternalServiceWithApiKeyOptionalDB.__init__(self, database=database, service_name=ExternalService.COINGECKO)  # noqa: E501
         HistoricalPriceOracleWithCoinListInterface.__init__(self, oracle_name='coingecko')
         PenalizablePriceOracleMixin.__init__(self)
-        self.session = requests.session()
+        self.session = create_session()
         set_user_agent(self.session)
         self.last_rate_limit = 0
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -10,6 +10,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import SupportedBlockchain, Timestamp
 from rotkehlchen.utils.misc import iso8601ts_to_timestamp
+from rotkehlchen.utils.network import create_session
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -38,7 +39,7 @@ class CowswapAPI:
 
     def __init__(self, database: 'DBHandler', chain: SUPPORTED_COWSWAP_BLOCKCHAIN) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = create_session()
         self.api_url = f'https://api.cow.fi/{CHAIN_MAPPING[chain]}/api/v1'
 
     def _query(self, endpoint: str) -> dict[str, Any]:

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -53,6 +53,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import pairwise, set_user_agent, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -206,7 +207,7 @@ class Cryptocompare(
             service_name=ExternalService.CRYPTOCOMPARE,
         )
         PenalizablePriceOracleMixin.__init__(self)
-        self.session = requests.session()
+        self.session = create_session()
         set_user_agent(self.session)
         self.last_histohour_query_ts = 0
         self.last_rate_limit = 0

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -27,6 +27,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import create_timestamp, timestamp_to_date, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
+from rotkehlchen.utils.network import create_session
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -50,7 +51,7 @@ class Defillama(
         )
         HistoricalPriceOracleInterface.__init__(self, oracle_name='defillama')
         PenalizablePriceOracleMixin.__init__(self)
-        self.session = requests.session()
+        self.session = create_session()
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
         self.last_rate_limit = 0
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -43,6 +43,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.data_structures import LRUCacheWithRemove
 from rotkehlchen.utils.misc import hexstr_to_int, set_user_agent
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -118,7 +119,7 @@ class Etherscan(ExternalServiceWithApiKey, ABC):
             SupportedBlockchain.SCROLL,
         ) else 'api-'
         self.base_url = base_url
-        self.session = requests.session()
+        self.session = create_session()
         self.warning_given = False
         set_user_agent(self.session)
         self.timestamp_to_block_cache: LRUCacheWithRemove[Timestamp, int] = LRUCacheWithRemove(maxsize=32)  # noqa: E501

--- a/rotkehlchen/externalapis/gnosispay.py
+++ b/rotkehlchen/externalapis/gnosispay.py
@@ -24,6 +24,7 @@ from rotkehlchen.utils.misc import (
     timestamp_to_iso8601,
     ts_now,
 )
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_list
 
 if TYPE_CHECKING:
@@ -83,7 +84,7 @@ class GnosisPay:
 
     def __init__(self, database: 'DBHandler', session_token: str) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = create_session()
         self.session_token = session_token
         set_user_agent(self.session)
 

--- a/rotkehlchen/externalapis/monerium.py
+++ b/rotkehlchen/externalapis/monerium.py
@@ -14,6 +14,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import EVMTxHash, Location, deserialize_evm_tx_hash
 from rotkehlchen.utils.misc import set_user_agent, ts_now
+from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_list
 
 if TYPE_CHECKING:
@@ -32,7 +33,7 @@ class Monerium:
 
     def __init__(self, database: 'DBHandler', user: str, password: str) -> None:
         self.database = database
-        self.session = requests.session()
+        self.session = create_session()
         self.user = user
         self.password = password
         set_user_agent(self.session)

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -32,6 +32,7 @@ from rotkehlchen.serialization.deserialize import (
 )
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTokenKind, ExternalService
 from rotkehlchen.user_messages import MessagesAggregator
+from rotkehlchen.utils.network import create_session
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -139,7 +140,7 @@ class Opensea(ExternalServiceWithApiKey):
     ) -> None:
         super().__init__(database=database, service_name=ExternalService.OPENSEA)
         self.msg_aggregator = msg_aggregator
-        self.session = requests.session()
+        self.session = create_session()
         self.session.headers.update({
             'Content-Type': 'application/json',
         })

--- a/rotkehlchen/utils/network.py
+++ b/rotkehlchen/utils/network.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, overload
 
 import gevent
 import requests
+from requests.adapters import HTTPAdapter
 
 from rotkehlchen.constants import GLOBAL_REQUESTS_TIMEOUT
 from rotkehlchen.db.settings import CachedSettings
@@ -14,6 +15,22 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+
+def create_session() -> requests.Session:
+    """Create a requests session with the configuration to retry a maximum
+    of 3 times on connection errors or DNS resolution errors.
+
+    From the requests docs about max_retries:
+    The maximum number of retries each connection should attempt. Note, this applies only
+    to failed DNS lookups, socket connections and connection timeouts, never to requests
+    where data has made it to the server.
+    """
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=5)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
 
 
 def request_get(


### PR DESCRIPTION
When the app is left running for a long time and I come back to it I see connectionError: connection clossed by remote server. This happens to me mostly with kraken.

After some investigation the cause seems to be the keep alive property of the connection. The session will use the connection that has expired and get this error from the server.

It is not a behaviour from requests but internal to urllib. The solution seems to be to use the httpAdapter class and enforce a retry, by default it doesn't happen. From the rquests docs:

https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter

```
max_retries – The maximum number of retries each connection should attempt.
Note, this applies only to failed DNS lookups, socket connections and
connection timeouts, never to requests where data has made it to the server.
By default, Requests does not retry failed connections.
```

