### PR TITLE
Fix incorrect order in curve deposit & stake

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :bug:`-` rotki will correctly decode all the Aura rewards claim events.
 * :bug:`-` rotki will now properly detect supported protocol balances in Polygon PoS, Gnosis, and Scroll.
 * :bug:`9163` Cryptocompare price queries will be handled correctly again. Fixes "the 'FVal' object is not subscriptable".
+* :bug:`-` Fix a rare incorrect order when depositing and staking in curve gauges.
 * :bug:`-` When querying the price of BSQ rotki will define it as the price of 100 satoshi.
 
 * :release:`1.37.0 <2024-12-24>`


### PR DESCRIPTION
It was possible that if multiple deposit events happened they weren't correctly ordered and other events could appear in between such approvals.

In the test case the order was:

```
- deposit
- deposit
- approval
- receive wrapped
```

and after this fix it is:

```
- approval
- deposit
- deposit
- receive wrapped
```

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
