### PR TITLE
Update bitmex

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 * :bug:`9163` Cryptocompare price queries will be handled correctly again. Fixes "the 'FVal' object is not subscriptable".
 * :bug:`-` Fix a rare incorrect order when depositing and staking in curve gauges.
 * :bug:`-` When querying the price of BSQ rotki will define it as the price of 100 satoshi.
+* :bug:`-` Bitmex balances will now be queried correctly.
 
 * :release:`1.37.0 <2024-12-24>`
 * :feature:`7144` Users will be able to import multiple addresses into the address book via CSV.

--- a/rotkehlchen/chain/ethereum/utils.py
+++ b/rotkehlchen/chain/ethereum/utils.py
@@ -48,6 +48,10 @@ def token_normalized_value_decimals(token_amount: int, token_decimals: int | Non
     return token_amount / (FVal(10) ** FVal(token_decimals))
 
 
+def normalized_fval_value_decimals(amount: FVal, decimals: int) -> FVal:
+    return amount / (FVal(10) ** FVal(decimals))
+
+
 def token_raw_value_decimals(token_amount: FVal, token_decimals: int | None) -> int:
     if token_decimals is None:  # if somehow no info on decimals ends up here assume 18
         token_decimals = 18

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -749,6 +749,7 @@ def create_test_bitmex(
         msg_aggregator=msg_aggregator,
     )
     bitmex.first_connection_made = True
+    bitmex.asset_to_decimals = {'XBt': 8, 'USDt': 6}
     return bitmex
 
 

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -415,7 +415,7 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
             )
         return MockResponse(200, payload)
 
-    def mock_bitmex_api_queries(url, data):  # pylint: disable=unused-argument
+    def mock_bitmex_api_queries(url):
         if remote_errors:
             payload = invalid_payload
         elif 'user/walletHistory' in url:


### PR DESCRIPTION
This PR:

- brings the fixes of bitmex to bugfixes
- changes the base url from `bitmex.com` to `www.bitmex.com`. I tested it myself and without the `www.` it fails.
- handles errors in the api response
- fixes wrong value decoded in the asset movements. We were applying decimals only to bitcoin and other assets got huge values
- eth uses the special symbol `gwei` so mapped it