### PR TITLE
Fix an always true elif in node_inquirer logs query handling

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -141,7 +141,7 @@ def _query_web3_get_logs(
 
                 block_range = initial_block_range = 9999  # ensure that block range doesn't get reset to a range bigger than what is allowed for this node  # noqa: E501
                 continue
-            elif 'eth_getLogs is limited to a 1000 blocks range':  # seen in https://1rpc.io/gnosis  # noqa: E501
+            elif msg == 'eth_getLogs is limited to a 1000 blocks range':  # seen in https://1rpc.io/gnosis  # noqa: E501
                 if (until_block - start_block) // 1_000 > MAX_NODE_LOG_QUERY_CALLS:
                     log.debug(f'Querying logs with a range of 1000 from {web3} will take too much time. Stopping here')  # noqa: E501
                     raise


### PR DESCRIPTION
The bug was introduced here: https://github.com/rotki/rotki/commit/1a3d7536ab94d7d470cdd816d1cd861b99042771

