### PR TITLE
Save calls for free coingecko history api call more than 1 year ago

### DIFF
--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -8,7 +8,7 @@ import requests
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.constants.resolver import evm_address_to_identifier, strethaddress_to_identifier
-from rotkehlchen.constants.timing import DAY_IN_SECONDS
+from rotkehlchen.constants.timing import DAY_IN_SECONDS, YEAR_IN_SECONDS
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import RemoteError
@@ -744,6 +744,11 @@ class Coingecko(
             timestamp: Timestamp,
             seconds: int | None = None,
     ) -> bool:
+        """Apart from penalization, for coingecko if there is no paid API key then it won't
+        allow you to query further than a year in history. So let's save ourselves network calls"""
+        if self.api_key is None and ts_now() - timestamp > YEAR_IN_SECONDS:
+            return False
+
         return not self.is_penalized()
 
     def rate_limited_in_last(

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -467,6 +467,7 @@ def test_history_debug_import(rotkehlchen_api_server: 'APIServer') -> None:
     )
 
 
+@pytest.mark.freeze_time('2023-05-11 15:06:00 GMT')  # set to make sure coingecko queries history ( < 1 year from events)  # noqa: E501
 @pytest.mark.parametrize('have_decoders', [True])
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('should_mock_price_queries', [False])


### PR DESCRIPTION
Because this is what happens. They stop it :(

![2025-01-06_18-43](https://github.com/user-attachments/assets/e80a1b8f-f2fe-4f06-8454-61a65156a3c3)
