### PR TITLE
add historical balance query endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13866,3 +13866,88 @@ Managing calendar reminders
   :statuscode 200: Data queried correctly.
   :statuscode 401: No user is currently logged in.
   :statuscode 500: Internal rotki error.
+
+Historical Balance Queries
+==============================
+
+  .. http:post:: /api/(version)/balances/historical
+
+    Gets historical balance data at a specific timestamp, calculated from processing of historical events.
+    If asset is provided, returns balance for that specific asset. Otherwise returns balances for all assets.
+
+    .. note::
+      This endpoint can also be queried asynchronously by using ``"async_query": true``.
+
+    **Example Request (All Assets):**
+
+      .. http:example:: curl wget httpie python-requests
+
+        PUT /api/(version)/balances/historical HTTP/1.1
+        Host: localhost:5042
+        Content-Type: application/json;charset=UTF-8
+
+        { "timestamp": 1672531200 }
+
+    **Example Request (Single Asset):**
+
+      .. http:example:: curl wget httpie python-requests
+
+      PUT /api/(version)/balances/historical HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {
+        "timestamp": 1672531200,
+        "asset": "BTC"
+      }
+
+      :reqjsonarr integer timestamp: The timestamp to query the balance for
+      :reqjsonarr string asset: (Optional) The asset identifier to query balance for. If not provided, returns balances for all assets.
+
+    **Example Response (All Assets):**
+
+      .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+          "message": "",
+          "result": {
+            "BTC": {
+              "amount": "2.0",
+              "price": "20000"
+            },
+            "ETH": {
+              "amount": "10.0",
+              "price": "1500"
+            }
+          },
+          "status_code": 200
+        }
+
+    **Example Response (Single Asset):**
+
+      .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "message": "",
+        "result": {
+          "amount": "2.0",
+          "price": "20000"
+        },
+        "status_code": 200
+      }
+
+      :resjson object result: Either a mapping of all assets to their balance info, or single asset balance info if asset was provided
+      :resjson string amount: The amount of the asset held at the timestamp
+      :resjson string price: The price of the asset at the timestamp in the user's profit currency
+      :statuscode 200: Historical balances returned
+      :statuscode 400: Malformed query
+      :statuscode 404: No historical data found for the timestamp
+      :statuscode 403: User does not have premium access
+      :statuscode 409: User is not logged in
+      :statuscode 500: Internal Rotki error

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -145,6 +145,7 @@ from rotkehlchen.api.v1.resources import (
     StatsWrapResource,
     SupportedChainsResource,
     TagsResource,
+    TimestampHistoricalBalanceResource,
     TradesResource,
     TypesMappingsResource,
     UserAssetsResource,
@@ -333,6 +334,7 @@ URLS_V1: URLS = [
     ('/defi/metadata', DefiMetadataResource),
     ('/calendar', CalendarResource),
     ('/calendar/reminders', CalendarRemindersResource),
+    ('/balances/historical', TimestampHistoricalBalanceResource),
 ]
 
 logger = logging.getLogger(__name__)

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -103,6 +103,7 @@ from rotkehlchen.api.v1.schemas import (
     ExternalServicesResourceDeleteSchema,
     FileListSchema,
     HistoricalAssetsPriceSchema,
+    HistoricalPerAssetBalanceSchema,
     HistoryEventSchema,
     HistoryEventsDeletionSchema,
     HistoryExportingSchema,
@@ -3377,4 +3378,29 @@ class StatsWrapResource(BaseMethodView):
         return self.rest_api.query_wrap_stats(
             from_ts=from_timestamp,
             to_ts=to_timestamp,
+        )
+
+
+class TimestampHistoricalBalanceResource(BaseMethodView):
+
+    post_schema = HistoricalPerAssetBalanceSchema()
+
+    @require_premium_user(active_check=False)
+    @use_kwargs(post_schema, location='json')
+    def post(
+            self,
+            async_query: bool,
+            timestamp: Timestamp,
+            asset: Asset | None = None,
+    ) -> Response:
+        if asset is None:
+            return self.rest_api.get_historical_balance(
+                timestamp=timestamp,
+                async_query=async_query,
+            )
+
+        return self.rest_api.get_historical_asset_balance(
+            asset=asset,
+            timestamp=timestamp,
+            async_query=async_query,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3851,3 +3851,7 @@ class UpdateCalendarReminderSchema(NewCalendarReminderSchema, IntegerIdentifierS
     @post_load
     def make_calendar_entry(self, data: dict[str, Any], **_kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: E501
         return {'reminder': self._process_reminder(data)}
+
+
+class HistoricalPerAssetBalanceSchema(SnapshotTimestampQuerySchema, AsyncQueryArgumentSchema):
+    asset = AssetField(expected_type=Asset, load_default=None)

--- a/rotkehlchen/balances/historical.py
+++ b/rotkehlchen/balances/historical.py
@@ -1,0 +1,114 @@
+from collections import defaultdict
+from typing import TYPE_CHECKING, TypedDict
+
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants.prices import ZERO_PRICE
+from rotkehlchen.db.filtering import HistoryEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.errors.misc import NotFoundError, RemoteError
+from rotkehlchen.errors.price import NoPriceForGivenTimestamp
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.types import EventDirection
+from rotkehlchen.history.price import PriceHistorian
+from rotkehlchen.types import Timestamp
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+
+
+class HistoricalBalance(TypedDict):
+    amount: FVal
+    price: FVal
+
+
+class HistoricalBalancesManager:
+    """Processes historical events and calculates balances"""
+
+    def __init__(self, db: 'DBHandler') -> None:
+        self.db = db
+
+    def get_balances(self, timestamp: Timestamp) -> dict[Asset, HistoricalBalance]:
+        """Get historical balances for all assets at a given timestamp
+
+        May raise:
+        - NotFoundError if balance for the given timestamp does not exist.
+        """
+        events, main_currency = self._get_events_and_currency(timestamp)
+        if len(events) == 0:
+            raise NotFoundError('No historical data found until the given timestamp.')
+
+        amounts = self._calculate_balance_from_events(events)
+        result: dict[Asset, HistoricalBalance] = {}
+        for asset, amount in amounts.items():
+            try:
+                price = PriceHistorian().query_historical_price(
+                    from_asset=asset,
+                    to_asset=main_currency,
+                    timestamp=timestamp,
+                )
+            except (RemoteError, NoPriceForGivenTimestamp):
+                price = ZERO_PRICE
+
+            result[asset] = {'amount': amount, 'price': price}
+
+        return result
+
+    def get_asset_balance(self, asset: Asset, timestamp: Timestamp) -> HistoricalBalance:
+        """Get historical balance for a single asset at a given timestamp
+
+        May raise:
+        - NotFoundError if balance for the asset at the given timestamp does not exist.
+        """
+        events, main_currency = self._get_events_and_currency(timestamp, (asset,))
+        if len(events) == 0:
+            raise NotFoundError(f'No historical data found for {asset} until the given timestamp.')
+
+        amounts = self._calculate_balance_from_events(events)
+        try:
+            price = PriceHistorian().query_historical_price(
+                from_asset=asset,
+                to_asset=main_currency,
+                timestamp=timestamp,
+            )
+        except (RemoteError, NoPriceForGivenTimestamp):
+            price = ZERO_PRICE
+
+        return {'amount': amounts[asset], 'price': price}
+
+    def _get_events_and_currency(
+            self,
+            timestamp: Timestamp,
+            assets: tuple[Asset, ...] | None = None,
+    ) -> tuple[list, Asset]:
+        """Helper method to get historical events and main currency from DB"""
+        db_history_events = DBHistoryEvents(database=self.db)
+        with self.db.conn.read_ctx() as cursor:
+            events = db_history_events.get_history_events(
+                cursor=cursor,
+                filter_query=HistoryEventFilterQuery.make(
+                    to_ts=timestamp,
+                    assets=assets,
+                ),
+                has_premium=True,
+            )
+            main_currency = self.db.get_setting(cursor=cursor, name='main_currency')
+
+        return events, main_currency
+
+    @staticmethod
+    def _calculate_balance_from_events(events: list) -> dict[Asset, FVal]:
+        """Calculate balances from a list of historical events"""
+        amounts: dict[Asset, FVal] = defaultdict(FVal)
+        for event in events:
+            if (
+                (direction := event.maybe_get_direction()) is None or
+                direction == EventDirection.NEUTRAL
+            ):
+                continue
+
+            if direction == EventDirection.IN:
+                amounts[event.asset] += event.balance.amount
+            else:  # EventDirection.OUT
+                amounts[event.asset] -= event.balance.amount
+
+        return amounts

--- a/rotkehlchen/errors/misc.py
+++ b/rotkehlchen/errors/misc.py
@@ -26,6 +26,10 @@ class AlreadyExists(Exception):
     pass
 
 
+class NotFoundError(Exception):
+    pass
+
+
 class RemoteError(Exception):
     """Thrown when a remote API can't be reached or throws unexpected error"""
 

--- a/rotkehlchen/tests/api/test_historical_balances.py
+++ b/rotkehlchen/tests/api/test_historical_balances.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+import requests
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.constants import DAY_IN_SECONDS
+from rotkehlchen.constants.assets import A_BTC, A_ETH
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.base import HistoryEvent
+from rotkehlchen.history.events.structures.types import (
+    HistoryEventSubType,
+    HistoryEventType,
+)
+from rotkehlchen.tests.utils.api import (
+    api_url_for,
+    assert_error_response,
+    assert_ok_async_response,
+    assert_proper_sync_response_with_result,
+    wait_for_async_task,
+)
+from rotkehlchen.types import Location, Timestamp
+from rotkehlchen.utils.misc import ts_sec_to_ms
+
+if TYPE_CHECKING:
+    from rotkehlchen.api.server import APIServer
+
+START_TS = Timestamp(1672531200)
+
+
+@pytest.fixture(name='setup_historical_data')
+def fixture_setup_historical_data(rotkehlchen_api_server: 'APIServer') -> None:
+    db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
+    events = [
+        HistoryEvent(  # Day 1: Initial receive
+            event_identifier='btc_receive_1',
+            sequence_index=0,
+            timestamp=ts_sec_to_ms(START_TS),
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            location=Location.BLOCKCHAIN,
+            asset=A_BTC,
+            balance=Balance(amount=FVal('2')),
+            notes='Receive BTC',
+        ),
+        HistoryEvent(  # another receive
+            event_identifier='eth_receive_1',
+            sequence_index=1,
+            timestamp=ts_sec_to_ms(Timestamp(START_TS + 3000)),
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            location=Location.BLOCKCHAIN,
+            asset=A_ETH,
+            balance=Balance(amount=FVal('10')),
+            notes='Receive ETH',
+        ),
+        HistoryEvent(  # Day 3: Partial spend
+            event_identifier='btc_spend_1',
+            sequence_index=2,
+            timestamp=ts_sec_to_ms(Timestamp(START_TS + DAY_IN_SECONDS * 2)),
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.NONE,
+            location=Location.BLOCKCHAIN,
+            asset=A_BTC,
+            balance=Balance(amount=FVal('0.5')),
+            notes='BTC partial spend',
+        ),
+    ]
+    with db.user_write() as write_cursor:
+        DBHistoryEvents(database=db).add_history_events(
+            write_cursor=write_cursor,
+            history=events,
+        )
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('should_mock_price_queries', [False])
+def test_get_historical_balance(
+        rotkehlchen_api_server: 'APIServer',
+        setup_historical_data: None,
+) -> None:
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'timestamphistoricalbalanceresource',
+        ),
+        json={'timestamp': START_TS + DAY_IN_SECONDS * 2},
+    )
+
+    result = assert_proper_sync_response_with_result(response)
+    assert result['BTC']['amount'] == '1.5'
+    assert result['BTC']['price'] == '15806.226022787'
+    assert result['ETH']['amount'] == '10'
+    assert result['ETH']['price'] == '1151.10913718085'
+
+    # try retrieving the balance of a day without event and
+    # see that the balance of the previous day is used.
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'timestamphistoricalbalanceresource',
+        ),
+        json={
+            'timestamp': START_TS + DAY_IN_SECONDS,  # Day 2
+            'async_query': True,
+        },
+    )
+    task_id = assert_ok_async_response(response)
+    outcome = wait_for_async_task(
+        rotkehlchen_api_server,
+        task_id,
+    )
+    # Balances(amount) should be same as day 1
+    assert outcome['result']['BTC']['amount'] == '2'
+    assert outcome['result']['ETH']['amount'] == '10'
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('should_mock_price_queries', [False])
+def test_get_historical_asset_balance(
+        rotkehlchen_api_server: 'APIServer',
+        setup_historical_data: None,
+) -> None:
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'timestamphistoricalbalanceresource',
+        ),
+        json={
+            'asset': 'BTC',
+            'timestamp': START_TS + DAY_IN_SECONDS * 2,  # Day 3
+        },
+    )
+
+    result = assert_proper_sync_response_with_result(response)
+    # Should show post-withdrawal balance
+    assert result['amount'] == '1.5'  # 2 - 0.5
+    assert result['price'] == '15806.226022787'
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('should_mock_price_queries', [False])
+def test_get_historical_balance_before_first_event(
+        rotkehlchen_api_server: 'APIServer',
+        setup_historical_data: None,
+) -> None:
+    """Test getting historical balances before any events"""
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'timestamphistoricalbalanceresource',
+        ),
+        json={'timestamp': START_TS - DAY_IN_SECONDS},  # Day before first event
+    )
+    assert_error_response(
+        response=response,
+        contained_in_msg='No historical data found until the given timestamp.',
+        status_code=HTTPStatus.NOT_FOUND,
+    )
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('should_mock_price_queries', [False])
+def test_get_historical_balance_unknown_asset(rotkehlchen_api_server: 'APIServer') -> None:
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'timestamphistoricalbalanceresource',
+        ),
+        json={
+            'asset': 'UNKNOWN',
+            'timestamp': START_TS,
+        },
+    )
+
+    assert_error_response(
+        response=response,
+        contained_in_msg='Unknown asset UNKNOWN',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+
+
+def test_get_historical_asset_balance_without_premium(rotkehlchen_api_server: 'APIServer') -> None:
+    response = requests.post(
+        api_url_for(
+            rotkehlchen_api_server,
+            'timestamphistoricalbalanceresource',
+        ),
+        json={
+            'asset': 'BTC',
+            'timestamp': START_TS,
+        },
+    )
+    assert_error_response(
+        response=response,
+        contained_in_msg='does not have a premium subscription',
+        status_code=HTTPStatus.FORBIDDEN,
+    )


### PR DESCRIPTION
## Overview
Adds new API endpoints to query historical asset balances at specific timestamps. 

## Endpoints
- `GET /balances/historical/{timestamp}`: Returns balances for all assets at timestamp
- `POST /balances/historical`: Returns balance for a specific asset at timestamp