### PR TITLE
fix: allow deletion on simple rpc node manager

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Fix issue when user tries to delete Kusama, Polkadot, or Beaconchain RPC URL.
 * :bug:`-` rotki should now warn you again when gnosis pay authentication token expires.
 
 * :release:`1.37.1 <2025-01-10>`

--- a/frontend/app/src/components/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/components/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -36,8 +36,8 @@ function edit(item: string) {
   set(inputUrl, item);
 }
 
-async function save() {
-  if (!(await get(form)?.validate()))
+async function save(force: boolean = false) {
+  if (!(await get(form)?.validate()) && !force)
     return;
 
   const value = get(inputUrl);
@@ -63,7 +63,7 @@ const { show } = useConfirmStore();
 
 async function deleteNode() {
   set(inputUrl, '');
-  await save();
+  await save(true);
 }
 
 function showDeleteConfirmation() {


### PR DESCRIPTION
fix: allow deletion on simple rpc node manager (kusama, polkadot, beaconchain)