### PR TITLE
Use the correct gnosis pay API url

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` rotki should now warn you again when gnosis pay authentication token expires.
+
 * :release:`1.37.1 <2025-01-10>`
 * :bug:`-` OKX balances will now include assets in the funding account.
 * :bug:`-` Bybit balances in the funding account will now be queried.

--- a/rotkehlchen/externalapis/gnosispay.py
+++ b/rotkehlchen/externalapis/gnosispay.py
@@ -98,7 +98,7 @@ class GnosisPay:
         May raise:
         - RemoteError if there is a problem querying the API
         """
-        querystr = 'https://app.gnosispay.com/api/v1/' + endpoint
+        querystr = 'https://api.gnosispay.com/api/v1/' + endpoint
         log.debug(f'Querying Gnosis Pay API {querystr} with {params=}')
         timeout = CachedSettings().get_timeout_tuple()
         try:


### PR DESCRIPTION
The proper error codes will be only returned by api.gnosispay. The fact app.gnosispay worked for so long is just luck.

