### PR TITLE
fix: allow electron app to be minimized on macos

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Allow the rotki app to be minimized using the shortcut for each platform.
 * :bug:`-` Fix issue when user tries to delete Kusama, Polkadot, or Beaconchain RPC URL.
 * :bug:`-` rotki should now warn you again when gnosis pay authentication token expires.
 

--- a/frontend/app/electron/main/menu.ts
+++ b/frontend/app/electron/main/menu.ts
@@ -122,7 +122,12 @@ const fileMenu = {
   submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
 };
 
-const developmentViewMenu = [{ role: 'reload' }, { role: 'forceReload' }, { role: 'toggleDevTools' }, separator];
+const developmentViewMenu = [
+  { role: 'reload' },
+  { role: 'forceReload' },
+  { role: 'toggleDevTools' },
+  separator,
+];
 
 const minimize = {
   id: 'MINIMIZE_TO_TRAY',
@@ -149,6 +154,7 @@ const viewMenu = {
   label: '&View',
   submenu: [
     ...(isDevelopment ? developmentViewMenu : [{ role: 'toggleDevTools', visible: false }]),
+    { role: 'minimize' },
     { role: 'resetZoom' },
     { role: 'zoomIn' },
     { role: 'zoomOut' },
@@ -160,12 +166,18 @@ const viewMenu = {
   ],
 };
 const defaultMenuTemplate: any[] = [
-  // On a mac we want to show a "rotki" menu item in the app bar
+  // On Mac, we want to show a "rotki" menu item in the app bar.
   ...(isMac
     ? [
         {
           label: app.name,
-          submenu: [{ role: 'hide' }, { role: 'hideOthers' }, { role: 'unhide' }, separator, { role: 'quit' }],
+          submenu: [
+            { role: 'hide' },
+            { role: 'hideOthers' },
+            { role: 'unhide' },
+            separator,
+            { role: 'quit' },
+          ],
         },
       ]
     : []),


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
