### PR TITLE
Colibri: user db

### DIFF
--- a/colibri/Cargo.lock
+++ b/colibri/Cargo.lock
@@ -80,6 +80,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-sqlite"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a86b242350ea4ff78866f8253182dd49dddb1decd4e596b918098ed250fd2"
+dependencies = [
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-util",
+ "rusqlite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +254,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "colibri"
 version = "0.1.0"
 dependencies = [
+ "async-sqlite",
  "axum",
  "clap",
  "dirs",
@@ -276,6 +289,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deranged"
@@ -417,6 +445,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,9 +474,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]

--- a/colibri/Cargo.toml
+++ b/colibri/Cargo.toml
@@ -22,4 +22,5 @@ dirs = "6.0.0"
 # for CLI args parsing
 clap = { version = "4.5.26", features = ["string"] }
 # for globalDB and other sqlite operations
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled", "sqlcipher"] }
+async-sqlite = {version = "0.4.0" }

--- a/colibri/src/api.rs
+++ b/colibri/src/api.rs
@@ -1,42 +1,17 @@
-use axum::{extract::Json, extract::State, response::IntoResponse};
-use serde::Deserialize;
+pub mod database;
+pub mod icons;
+mod utils;
+
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use crate::coingecko;
-use crate::icons;
+use crate::database::DBHandler;
 
 #[derive(Clone)]
 pub struct AppState {
     pub data_dir: PathBuf,
     pub coingecko: Arc<coingecko::Coingecko>,
-}
-
-#[derive(Deserialize)]
-pub struct AssetIconRequest {
-    asset_id: String,
-    match_header: Option<String>,
-}
-
-/// The handler for the get icon endpoint
-///
-/// Gets the given icon from the user's system if it's already
-/// downloaded or asks for it from the icon sources. Returns it
-/// if found and a 404 if not
-pub async fn get_icon(
-    State(state): State<AppState>,
-    Json(payload): Json<AssetIconRequest>,
-) -> impl IntoResponse {
-    match icons::get_or_query_icon(
-        state.coingecko,
-        state.data_dir,
-        &payload.asset_id,
-        payload.match_header,
-    )
-    .await
-    {
-        (status, Some(headers), Some(bytes)) => (status, headers, bytes).into_response(),
-        (status, Some(headers), None) => (status, headers).into_response(),
-        (status, _, _) => status.into_response(),
-    }
+    pub userdb: Arc<RwLock<DBHandler>>,
 }

--- a/colibri/src/api/database.rs
+++ b/colibri/src/api/database.rs
@@ -1,0 +1,64 @@
+use axum::{extract::Json, extract::State, http::StatusCode, response::IntoResponse};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::api::utils::ApiResponse;
+use crate::api::AppState;
+
+#[derive(Deserialize)]
+pub struct UnlockDatabase {
+    username: String,
+    password: String,
+}
+
+pub async fn unlock_user(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<UnlockDatabase>,
+) -> impl IntoResponse {
+    let mut db = state.userdb.write().await;
+    if db.client.is_some() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::<String> {
+                result: None,
+                message: "DB already unlocked".to_string(),
+            }),
+        ).into_response()
+    }
+
+    let db_path = state
+        .data_dir
+        .join("users")
+        .join(payload.username)
+        .join("rotkehlchen.db");
+
+    match db.unlock(db_path, payload.password).await {
+        Ok(_) => (StatusCode::OK, "Ok").into_response(),
+        Err(err) => (StatusCode::BAD_REQUEST, err.to_string()).into_response(),
+    }
+}
+
+pub async fn get_ignored_assets(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let db = state.userdb.read().await;
+    match db.get_ignored_assets(false).await {
+        Ok(set) => {
+            let ignored_assets: Vec<String> = set.into_iter().collect();
+            (
+                StatusCode::OK,
+                Json(ApiResponse {
+                    result: Some(ignored_assets),
+                    message: "".to_string(),
+                }),
+            ).into_response()
+        }
+        Err(err) => {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse::<String> {
+                    result: None,
+                    message: format!("Failed to query ignored assets due to {}", err),
+                }),
+            ).into_response()
+        }
+    }
+}

--- a/colibri/src/api/icons.rs
+++ b/colibri/src/api/icons.rs
@@ -1,0 +1,35 @@
+use axum::{extract::Json, extract::State, response::IntoResponse};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::api::AppState;
+use crate::icons;
+
+#[derive(Deserialize)]
+pub struct AssetIconRequest {
+    asset_id: String,
+    match_header: Option<String>,
+}
+
+/// The handler for the get icon endpoint
+///
+/// Gets the given icon from the user's system if it's already
+/// downloaded or asks for it from the icon sources. Returns it
+/// if found and a 404 if not
+pub async fn get_icon(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<AssetIconRequest>,
+) -> impl IntoResponse {
+    match icons::get_or_query_icon(
+        state.coingecko.clone(),
+        state.data_dir.clone(),
+        &payload.asset_id,
+        payload.match_header,
+    )
+    .await
+    {
+        (status, Some(headers), Some(bytes)) => (status, headers, bytes).into_response(),
+        (status, Some(headers), None) => (status, headers).into_response(),
+        (status, _, _) => status.into_response(),
+    }
+}

--- a/colibri/src/api/utils.rs
+++ b/colibri/src/api/utils.rs
@@ -1,0 +1,7 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ApiResponse<T> {
+    pub result: Option<T>,
+    pub message: String,
+}

--- a/colibri/src/database/errors.rs
+++ b/colibri/src/database/errors.rs
@@ -1,0 +1,19 @@
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub enum DBError {
+    UnlockError(String),
+    QueryError(String),
+}
+
+impl std::error::Error for DBError {}
+
+impl std::fmt::Display for DBError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DBError::UnlockError(msg) | DBError::QueryError(msg) => {
+                write!(f, "Database error {}", msg)
+            }
+        }
+    }
+}

--- a/colibri/src/database/mod.rs
+++ b/colibri/src/database/mod.rs
@@ -1,0 +1,4 @@
+mod errors;
+pub mod user_db;
+
+pub use user_db::DBHandler;

--- a/colibri/src/database/user_db.rs
+++ b/colibri/src/database/user_db.rs
@@ -1,0 +1,83 @@
+use async_sqlite::{Client, ClientBuilder};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::database::errors::DBError;
+
+#[derive(Clone)]
+pub struct DBHandler {
+    pub client: Option<Arc<Client>>,
+}
+
+
+/// The user db handler for Colibri
+/// We assume its updated and up to date
+/// from the rotki python backend
+impl DBHandler {
+    pub fn new() -> Self {
+        Self { client: None }
+    }
+
+    // unlock database by creating the connection and setting the sqlcipher key
+    pub async fn unlock(&mut self, path: PathBuf, password: String) -> Result<(), DBError> {
+        let client = match ClientBuilder::new().path(path.clone()).open().await {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(DBError::UnlockError(format!(
+                    "Failed to open database at {} due to {}",
+                    path.display(),
+                    e
+                )))
+            }
+        };
+
+        match client
+            .conn(|conn| {
+                conn.pragma_update(None, "KEY", password)?;
+                Ok(())
+            }).await
+        {
+            Ok(_) => self.client = Some(Arc::new(client)),
+            Err(e) => return Err(DBError::UnlockError(e.to_string())),
+        };
+
+        Ok(())
+    }
+
+    // Gets the ignored asset ids without converting each one of them to an asset object
+    pub async fn get_ignored_assets(&self, only_nfts: bool) -> Result<HashSet<String>, DBError> {
+        let client = match &self.client {
+            Some(client) => client,
+            None => return Err(DBError::UnlockError("No client found".to_string())),
+        };
+        match client
+            .conn(move |conn| {
+                let mut ignored_assets: HashSet<String> = HashSet::new();
+                let (query, params) = if only_nfts {
+                    (
+                    "SELECT value FROM multisettings WHERE name='ignored_asset' AND value LIKE ?",
+                    rusqlite::params!["_nft_%"]
+                )
+                } else {
+                    (
+                        "SELECT value FROM multisettings WHERE name='ignored_asset'",
+                        rusqlite::params![],
+                    )
+                };
+
+                let mut stmt = conn.prepare(query)?;
+                let mut rows = stmt.query(params.as_ref())?;
+                while let Some(row) = rows.next()? {
+                    let asset: String = row.get(0)?;
+                    ignored_assets.insert(asset);
+                }
+                Ok(ignored_assets)
+            })
+            .await
+        {
+            Ok(ignored_assets) => Ok(ignored_assets),
+            Err(e) => Err(DBError::QueryError(e.to_string())),
+        }
+    }
+}


### PR DESCRIPTION
This PR:

- Adds the user db to the api state
- Adds new endpoint that replaces `/api/1/assets/ignored/`
- Uses the multi thread runtime from tokio
- Adds an api endpoint to unlock the db

Pending:

- We need to call the unlock from python
- Probably we should add a middleware as we do in python for `@require_logged_in_user` or whatever is called
- Make the response build a macro. For the case of error I need to set a placeholder type and a macro saves time