### PR TITLE
Fix extrainternaltx cache

### DIFF
--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -85,11 +85,13 @@ class OdosCommonDecoderBase(DecoderInterface):
         if self.native_currency.identifier in output_tokens:
             try:  # download (if not there) and find all native token transfers from/to the router
                 internal_native_ins = self.evm_txns.get_and_ensure_internal_txns_of_parent_in_db(
+                    chain_id=self.base.evm_inquirer.chain_id,
                     tx_hash=context.transaction.tx_hash,
                     to_address=self.router_address,
                     user_address=sender,
                 )
                 internal_native_outs = self.evm_txns.get_and_ensure_internal_txns_of_parent_in_db(
+                    chain_id=self.base.evm_inquirer.chain_id,
                     tx_hash=context.transaction.tx_hash,
                     from_address=self.router_address,
                     to_address=sender,

--- a/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
@@ -128,6 +128,7 @@ class ParaswapCommonDecoder(DecoderInterface, ABC):
             try:
                 internal_fee_txs = self.evm_txns.get_and_ensure_internal_txns_of_parent_in_db(
                     tx_hash=context.transaction.tx_hash,
+                    chain_id=self.base.evm_inquirer.chain_id,
                     from_address=self.router_address,
                     to_address=self.fee_receiver_address,
                     user_address=sender,

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Final, TypedDict, Unpack, overload
+from typing import Any, Final, TypedDict, Unpack, overload
 
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.db.constants import EXTRAINTERNALTXPREFIX
@@ -47,8 +47,9 @@ class AddressArgType(TypedDict):
 
 class ExtraTxArgType(TypedDict):
     """Type of kwargs, used to get the value of `DBCacheDynamic.EXTRA_INTERNAL_TX`"""
-    tx_hash: str  # using str instead of EVMTxHash because DB schema is in TEXT
+    chain_id: int
     receiver: ChecksumEvmAddress
+    tx_hash: str  # using str instead of EVMTxHash because DB schema is in TEXT
 
 
 def _deserialize_int_from_str(value: str) -> int | None:
@@ -68,7 +69,7 @@ class DBCacheDynamic(Enum):
     LAST_BLOCK_ID: Final = '{location}_{location_name}_{account_id}_last_block_id', _deserialize_int_from_str  # noqa: E501
     WITHDRAWALS_TS: Final = 'ethwithdrawalsts_{address}', _deserialize_timestamp_from_str
     WITHDRAWALS_IDX: Final = 'ethwithdrawalsidx_{address}', _deserialize_int_from_str
-    EXTRA_INTERNAL_TX: Final = f'{EXTRAINTERNALTXPREFIX}_{{tx_hash}}_{{receiver}}', string_to_evm_address  # noqa: E501
+    EXTRA_INTERNAL_TX: Final = f'{EXTRAINTERNALTXPREFIX}_{{chain_id}}_{{receiver}}_{{tx_hash}}', string_to_evm_address  # noqa: E501
 
     @overload
     def get_db_key(self, **kwargs: Unpack[LabeledLocationArgsType]) -> str:
@@ -86,7 +87,7 @@ class DBCacheDynamic(Enum):
     def get_db_key(self, **kwargs: Unpack[ExtraTxArgType]) -> str:
         ...
 
-    def get_db_key(self, **kwargs: str) -> str:
+    def get_db_key(self, **kwargs: Any) -> str:
         """Get the key that is used in the DB schema for the given kwargs.
 
         May Raise KeyError if incompatible kwargs are passed. Pass the kwargs according to the

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -756,7 +756,7 @@ class DBHandler:
             self,
             cursor: 'DBCursor',
             name: DBCacheDynamic,
-            **kwargs: str,
+            **kwargs: Any,
     ) -> int | Timestamp | str | ChecksumEvmAddress | None:
         """Returns the cache value from the `key_value_cache` table of the DB
         according to the given `name` and `kwargs`. Defaults to `None` if not found."""
@@ -852,7 +852,7 @@ class DBHandler:
             write_cursor: 'DBCursor',
             name: DBCacheDynamic,
             value: int | Timestamp | ChecksumEvmAddress,
-            **kwargs: str,
+            **kwargs: Any,
     ) -> None:
         """Save the name-value pair of the cache with variable name to the `key_value_cache` table."""  # noqa: E501
         write_cursor.execute(
@@ -2102,7 +2102,7 @@ class DBHandler:
         )
 
         write_cursor.execute(
-            f"DELETE FROM key_value_cache WHERE name LIKE '{EXTRAINTERNALTXPREFIX}_%' AND value = ?",  # noqa: E501
+            f"DELETE FROM key_value_cache WHERE name LIKE '{EXTRAINTERNALTXPREFIX}_{blockchain.to_chain_id().value}%' AND value = ?",  # noqa: E501
             (address,),
         )
 

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -526,7 +526,7 @@ class DBEvmTx:
         # Delete any key_value_cache entries
         write_cursor.executemany(
             'DELETE FROM key_value_cache WHERE name LIKE ?',
-            [(f'{EXTRAINTERNALTXPREFIX}_{tx_hash.hex()}%',) for tx_hash in tx_hashes],
+            [(f'{EXTRAINTERNALTXPREFIX}_{chain_id.value}_%_{tx_hash.hex()}',) for tx_hash in tx_hashes],  # noqa: E501
         )
 
     def get_queried_range(

--- a/rotkehlchen/db/upgrades/v46_v47.py
+++ b/rotkehlchen/db/upgrades/v46_v47.py
@@ -26,4 +26,8 @@ def upgrade_v46_to_v47(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             INSERT OR IGNORE INTO location(location, seq) VALUES ('v', 54);
             """)
 
+    @progress_step(description='Remove extrainternaltx cache.')
+    def _clean_cache(write_cursor: 'DBCursor') -> None:
+        write_cursor.execute("DELETE FROM key_value_cache WHERE name LIKE 'extrainternaltx_%'")
+
     perform_userdb_upgrade_steps(db=db, progress_handler=progress_handler, should_vacuum=True)

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -993,12 +993,14 @@ def test_query_transactions_check_decoded_events(
             write_cursor=write_cursor,
             name=DBCacheDynamic.EXTRA_INTERNAL_TX,
             value=random_user_address,
+            chain_id=1,
             tx_hash='0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f',
             receiver=random_receiver_in_cache,
         )
         assert rotki.data.db.get_dynamic_cache(  # ensure it's properly set
             cursor=write_cursor,
             name=DBCacheDynamic.EXTRA_INTERNAL_TX,
+            chain_id=1,
             tx_hash='0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f',
             receiver=random_receiver_in_cache,
         ) == random_user_address
@@ -1033,6 +1035,7 @@ def test_query_transactions_check_decoded_events(
         assert rotki.data.db.get_dynamic_cache(
             cursor=cursor,
             name=DBCacheDynamic.EXTRA_INTERNAL_TX,
+            chain_id=1,
             tx_hash='0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f',
             receiver=random_receiver_in_cache,
         ) is None

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -370,7 +370,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         random_tx_hash_in_cache = make_evm_tx_hash().hex()  # pylint: disable=no-member
 
         cache_data = (
-            (DBCacheDynamic.EXTRA_INTERNAL_TX, {'tx_hash': random_tx_hash_in_cache, 'receiver': existing_address}, existing_address),  # noqa: E501
+            (DBCacheDynamic.EXTRA_INTERNAL_TX, {'chain_id': 1, 'tx_hash': random_tx_hash_in_cache, 'receiver': existing_address}, existing_address),  # noqa: E501
             (DBCacheDynamic.WITHDRAWALS_TS, {'address': existing_address}, Timestamp(1737327943)),
             (DBCacheDynamic.WITHDRAWALS_IDX, {'address': existing_address}, 4242),
         )


### PR DESCRIPTION
- Clean up the extrainternaltx cache in the user DB upgrade.
- Include chain ID in it for the future so that we don't delete the cache for all chains every time we end up deleting a single chain address

