### PR TITLE
Add `asset_symbol` to history event export csv

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` History events export will now include the symbol or name of the asset to improve readability of entries.
 * :feature:`9203` rotki will now detect Uniswap V3 balances in all supported EVM chains.
 * :feature:`-` rotki will now correctly decode gitcoin profile creation and updating across supported EVM chains. Also some more gitcoin rounds are added.
 * :feature:`8780` rotki will now correctly decode Spark transactions in all supported EVM chains.

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -58,20 +58,21 @@ def assert_csv_export_response(
         assert data['result'] is True
 
     base_headers = (
-        'direction',
+        'timestamp',
+        'event_type',
+        'event_subtype',
+        'location',
+        'location_label',
+        'asset',
+        'asset_symbol',
+        'amount',
+        'fiat_value',
+        'notes',
         'identifier',
         'entry_type',
         'event_identifier',
         'sequence_index',
-        'timestamp',
-        'location',
-        'asset',
-        'amount',
-        'fiat_value',
-        'event_type',
-        'event_subtype',
-        'location_label',
-        'notes',
+        'direction',
     )
 
     extra_headers = (


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=94712667

Tries to match the output of PnL
```
        exported_dict = {
            'type': self.event_type.serialize(),
            'notes': self.notes,
            'location': str(self.location),
            'timestamp': self.timestamp,
            'asset_identifier': self.asset.identifier,
            'free_amount': str(self.free_amount),
            'taxable_amount': str(self.taxable_amount),
            'price': str(self.price),
            'pnl_taxable': str(self.pnl.taxable),
            'pnl_free': str(self.pnl.free),
        }
  ```
  
  Here's the way it looks now -- for history events.
  ```
      base_headers = (
        'event_type',
        'event_subtype',
        'direction',
        'notes',
        'location',
        'timestamp',
        'asset',
        'asset_symbol',
        'amount',
        'fiat_value',
        'identifier',
        'entry_type',
        'event_identifier',
        'sequence_index',
        'location_label',
    )
    ```
  