### PR TITLE
fix: check for ping before starting colibri

### DIFF
--- a/packaging/docker/entrypoint.py
+++ b/packaging/docker/entrypoint.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.DEBUG)
 DEFAULT_LOG_LEVEL = 'critical'
 
 
-def check_core_api_availability(retries: int = 5, wait_seconds: int = 10) -> bool:
+def check_core_api_availability(retries: int = 30, wait_seconds: int = 10) -> bool:
     """
     Checks the availability of the core backend API by sending a ping request.
     The check must be successful before starting colibri since colibri needs


### PR DESCRIPTION
This is to avoid an error in colibri if the global db is not yet initialized.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
