### PR TITLE
fix: downgrade electron to v33

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -90,7 +90,7 @@
     "dmg-license": "1.0.11",
     "dotenv": "16.4.7",
     "dotenv-cli": "8.0.0",
-    "electron": "34.0.0",
+    "electron": "33.3.2",
     "electron-builder": "25.1.8",
     "electron-store": "8.2.0",
     "flush-promises": "1.0.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       electron:
-        specifier: 34.0.0
-        version: 34.0.0
+        specifier: 33.3.2
+        version: 33.3.2
       electron-builder:
         specifier: 25.1.8
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
@@ -3814,8 +3814,8 @@ packages:
     resolution: {integrity: sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==}
     engines: {node: '>=8.0.0'}
 
-  electron@34.0.0:
-    resolution: {integrity: sha512-fpaPb0lifoUJ6UJa4Lk8/0B2Ku/xDZWdc1Gkj67jbygTCrvSon0qquju6Ltx1Kz23GRqqlIHXiy9EvrjpY7/Wg==}
+  electron@33.3.2:
+    resolution: {integrity: sha512-2pWr0frM9UrZGX1d7eoFdMROw10h2vXIWJmXdjwlKnSWWUm18GCrEOUeDUr+IMgz5EjO7JM7FQDHDMApeMgHyg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -11759,7 +11759,7 @@ snapshots:
       jsonfile: 4.0.0
       mkdirp: 0.5.6
 
-  electron@34.0.0:
+  electron@33.3.2:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 20.17.14


### PR DESCRIPTION
Need to wait until https://issues.chromium.org/issues/391393420 is resolved

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
