### PR TITLE
Fix yearn v2 deposit/withdrawal in special cases

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,13 +2,14 @@
 Changelog
 =========
 
+* :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.
 * :bug:`-` Deleting an ethereum address will now remove the withdrawals cache for that address so re-adding it will now properly detect ethereum staking withdrawals again.
 * :bug:`-` Fix double count of cowswap fees.
 * :bug:`-` Allow the rotki app to be minimized using the shortcut for each platform.
 * :bug:`-` Fix issue when user tries to delete Kusama, Polkadot, or Beaconchain RPC URL.
 * :bug:`-` rotki should now warn you again when gnosis pay authentication token expires.
 * :bug:`-` rotki will now properly decode aave v2 to v3 migrations for polygon and mainnet
-* :bug:`-` rotki will now properly decode some  aave v3 wrapped eth transactions that were not decoded properly in the past.
+* :bug:`-` rotki will now properly decode some aave v3 wrapped eth transactions that were not decoded properly in the past.
 
 * :release:`1.37.1 <2025-01-10>`
 * :bug:`-` OKX balances will now include assets in the funding account.


### PR DESCRIPTION
The part of the decoder for yearn v2 that was based only on transfer was too open. It was matching on all transfer of the vault and its underlying token and as such the logic was breaking for more complicated transactions.
