### PR TITLE
Add support for batch current price queries

### DIFF
--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -678,9 +678,9 @@ class Coingecko(
     ) -> str | None:
         vs_currency = to_asset.identifier.lower()
         if vs_currency not in COINGECKO_SIMPLE_VS_CURRENCIES:
-            from_str = from_asset.identifier if from_asset is not None else 'multiple assets'
             log.warning(
-                f'Tried to query coingecko {location} from {from_str} '
+                f'Tried to query coingecko {location} from '
+                f"{from_asset.identifier if from_asset is not None else 'multiple assets'} "
                 f'to {to_asset.identifier}. But to_asset is not supported',
             )
             return None
@@ -692,15 +692,15 @@ class Coingecko(
             from_asset: AssetWithOracles,
             to_asset: AssetWithOracles,
     ) -> Price:
-        """Wrapper for query_multiple_current_price when only querying a single price.
+        """Wrapper for query_multiple_current_prices when only querying a single price.
         Returns the asset price or ZERO_PRICE if no price is found.
         """
-        return self.query_multiple_current_price(
+        return self.query_multiple_current_prices(
             from_assets=[from_asset],
             to_asset=to_asset,
         ).get(from_asset, ZERO_PRICE)
 
-    def query_multiple_current_price(
+    def query_multiple_current_prices(
             self,
             from_assets: list[AssetWithOracles],
             to_asset: AssetWithOracles,

--- a/rotkehlchen/globaldb/manual_price_oracles.py
+++ b/rotkehlchen/globaldb/manual_price_oracles.py
@@ -57,11 +57,10 @@ class ManualCurrentOracle(CurrentPriceOracleInterface, DBSetterMixin):
             # ManualCurrentOracle does a special handling of RecursionError using
             # `coming_from_latest_price` to detect recursions on the manual prices and break
             # it to continue to the next oracle.
-            current_to_asset_price, _ = Inquirer._find_price(
-                from_asset=current_to_asset,
+            current_to_asset_price, _ = Inquirer._find_prices(
+                from_assets=[current_to_asset],
                 to_asset=to_asset,
-                coming_from_latest_price=True,
-            )
+            ).get(current_to_asset, (ZERO_PRICE, None))
 
             return Price(current_price * current_to_asset_price)
         finally:

--- a/rotkehlchen/globaldb/manual_price_oracles.py
+++ b/rotkehlchen/globaldb/manual_price_oracles.py
@@ -52,16 +52,10 @@ class ManualCurrentOracle(CurrentPriceOracleInterface, DBSetterMixin):
                 return ZERO_PRICE
 
             current_to_asset, current_price = manual_current_result
-
-            # we call _find_price to avoid catching the recursion error at `find_price_and_oracle`.
-            # ManualCurrentOracle does a special handling of RecursionError using
-            # `coming_from_latest_price` to detect recursions on the manual prices and break
-            # it to continue to the next oracle.
-            current_to_asset_price, _ = Inquirer._find_prices(
-                from_assets=[current_to_asset],
+            current_to_asset_price = Inquirer.find_price(
+                from_asset=current_to_asset,
                 to_asset=to_asset,
-            ).get(current_to_asset, (ZERO_PRICE, None))
-
+            )
             return Price(current_price * current_to_asset_price)
         finally:
             # Ensure we remove the pair after processing, even if an error occurs

--- a/rotkehlchen/interfaces.py
+++ b/rotkehlchen/interfaces.py
@@ -6,6 +6,7 @@ from json import JSONDecodeError
 from typing import Any, Final
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
+from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.globaldb.cache import (
     globaldb_get_unique_cache_last_queried_ts_by_key,
     globaldb_get_unique_cache_value,
@@ -54,6 +55,29 @@ class CurrentPriceOracleInterface(abc.ABC):
         Returns:
             Current price between from_asset and to_asset using this oracle's data
         """
+
+    def query_multiple_current_price(
+            self,
+            from_assets: list[AssetWithOracles],
+            to_asset: AssetWithOracles,
+    ) -> dict[AssetWithOracles, Price]:
+        """Query current price between all from_assets to to_asset.
+
+        Returns a dict mapping assets to prices found. Assets for which a price was not found
+        are not included in the dict.
+        """
+        # TODO: Implement this function for all oracles and make this an abstract method.
+        # For oracles that don't have this implemented yet,
+        # simply call query_current_price for each from_asset.
+        prices: dict[AssetWithOracles, Price] = {}
+        for from_asset in from_assets:
+            if (price := self.query_current_price(
+                    from_asset=from_asset,
+                    to_asset=to_asset,
+            )) != ZERO_PRICE:
+                prices[from_asset] = price
+
+        return prices
 
 
 class HistoricalPriceOracleInterface(CurrentPriceOracleInterface, abc.ABC):

--- a/rotkehlchen/interfaces.py
+++ b/rotkehlchen/interfaces.py
@@ -56,7 +56,7 @@ class CurrentPriceOracleInterface(abc.ABC):
             Current price between from_asset and to_asset using this oracle's data
         """
 
-    def query_multiple_current_price(
+    def query_multiple_current_prices(
             self,
             from_assets: list[AssetWithOracles],
             to_asset: AssetWithOracles,

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -96,8 +96,8 @@ def test_coingecko_with_api_key(database):
 
 
 @pytest.mark.vcr
-def test_coingecko_query_multiple_current_price(session_coingecko: 'Coingecko'):
-    assert session_coingecko.query_multiple_current_price(
+def test_coingecko_query_multiple_current_prices(session_coingecko: 'Coingecko'):
+    assert session_coingecko.query_multiple_current_prices(
         from_assets=[
             A_BTC.resolve_to_asset_with_oracles(),
             A_DAI.resolve_to_asset_with_oracles(),

--- a/rotkehlchen/tests/external_apis/test_coingecko.py
+++ b/rotkehlchen/tests/external_apis/test_coingecko.py
@@ -2,7 +2,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_YFI
+from rotkehlchen.constants.assets import A_BNB, A_BTC, A_DAI, A_ETH, A_EUR, A_YFI
 from rotkehlchen.errors.asset import UnsupportedAsset
 from rotkehlchen.externalapis.coingecko import Coingecko, CoingeckoAssetData
 from rotkehlchen.fval import FVal
@@ -93,3 +93,15 @@ def test_coingecko_with_api_key(database):
 
     )
     assert result == FVal('3295.1477375227337')
+
+
+@pytest.mark.vcr
+def test_coingecko_query_multiple_current_price(session_coingecko: 'Coingecko'):
+    assert session_coingecko.query_multiple_current_price(
+        from_assets=[
+            A_BTC.resolve_to_asset_with_oracles(),
+            A_DAI.resolve_to_asset_with_oracles(),
+            A_BNB.resolve_to_asset_with_oracles(),
+        ],
+        to_asset=A_ETH.resolve_to_asset_with_oracles(),
+    ) == {A_BTC: FVal(31.906046), A_DAI: FVal(0.0003068), A_BNB: FVal(0.21387074)}


### PR DESCRIPTION
Related #8978

Implements support for batch current price queries in the inquirer, and coingecko (other oracles are simply queried sequentially for now, and will need modified in later PRs).

The bulk of the changes are in the inquirer's price querying logic. In order to avoid repeated code, single asset price queries and batch queries are handled by the same functions with a single asset query simply using a list with one element.

Also I had to rework the price mocking stuff in `rotkehlchen/tests/fixtures/accounting.py`, as its now the batch querying functions that call each other within the inquirer logic.