### PR TITLE
Fix issue merging assets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.
 * :bug:`-` Deleting an ethereum address will now remove the withdrawals cache for that address so re-adding it will now properly detect ethereum staking withdrawals again.
 * :bug:`-` Fix double count of cowswap fees.
+* :bug:`-` Fix an error when merging two assets if they both appear at the same snapshot.
 * :bug:`-` Allow the rotki app to be minimized using the shortcut for each platform.
 * :bug:`-` Fix issue when user tries to delete Kusama, Polkadot, or Beaconchain RPC URL.
 * :bug:`-` rotki should now warn you again when gnosis pay authentication token expires.


### PR DESCRIPTION
When two assets were selected to be merged we weren't merging their timed balances. This triggers a constraint error (in addition to a bug) since we need to sum both the entries for both assets if they are in the same timestamp and share the same category.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
