### PR TITLE
Fix erc721 identifier db upgrade

### DIFF
--- a/rotkehlchen/db/upgrades/v46_v47.py
+++ b/rotkehlchen/db/upgrades/v46_v47.py
@@ -32,35 +32,84 @@ def upgrade_v46_to_v47(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
     def _clean_cache(write_cursor: 'DBCursor') -> None:
         write_cursor.execute("DELETE FROM key_value_cache WHERE name LIKE 'extrainternaltx_%'")
 
-    @progress_step(description='Updating ERC721 token identifiers.')
-    def _update_erc721_token_identifiers(write_cursor: 'DBCursor') -> None:
-        """Update erc721 token identifiers to include the token id
-        for all evm events that have the token id in extra_data.
+    @progress_step(description='Remove unneeded nft collection assets (may take some time).')
+    def _remove_nft_collection_assets(write_cursor: 'DBCursor') -> None:
+        """Remove erc721 assets that have no collectible id, and also any erc20 assets
+        with the same address that were incorrectly added.
         """
-        write_cursor = write_cursor.execute("SELECT identifier, asset, extra_data FROM history_events WHERE entry_type = 2 AND extra_data != ''")  # noqa: E501
-        assets_updates = []
-        extra_data_updates = []
-        for entry in write_cursor:
-            asset_identifier = entry[1]
-            try:
-                extra_data: dict = json.loads(entry[2])
-            except json.JSONDecodeError as e:
-                log.error(f'Failed to parse {entry[2]} as JSON due to {e}')
-                continue
+        with (globaldb_conn := GlobalDBHandler().conn).read_ctx() as global_db_cursor:
+            identifiers_to_remove = tuple(entry[0] for entry in global_db_cursor.execute(
+                'SELECT identifier FROM assets WHERE identifier IN ('
+                "SELECT identifier FROM evm_tokens WHERE token_kind = 'B' "
+                "UNION SELECT REPLACE(identifier, 'erc721', 'erc20') "
+                "FROM evm_tokens WHERE token_kind = 'B');",
+            ))
 
-            if (token_id := extra_data.get('token_id')) is not None:
-                assets_updates.append((f'{asset_identifier}/{token_id}', asset_identifier))
-                # remove the token id and name from extra_data to avoid storing redundant data,
-                extra_data.pop('token_id', '')
-                extra_data.pop('token_name', '')
-                extra_data_updates.append((json.dumps(extra_data), entry[0]))
+        if (num_to_remove := len(identifiers_to_remove)) == 0:
+            return
 
-        if len(assets_updates) > 0:
-            assets_query = 'UPDATE assets SET identifier=? WHERE identifier=?'
-            with GlobalDBHandler().conn.write_ctx() as global_db_write_cursor:
-                global_db_write_cursor.executemany(assets_query, assets_updates)
+        log.debug(f'Deleting {num_to_remove} assets...')
+        placeholders = ','.join(['?'] * len(identifiers_to_remove))
+        with globaldb_conn.write_ctx() as global_db_write_cursor:
+            log.debug('Deleting from globaldb...')
+            global_db_write_cursor.execute(f'DELETE FROM assets WHERE identifier IN ({placeholders})', identifiers_to_remove)  # noqa: E501
 
-            write_cursor.executemany(assets_query, assets_updates)
-            write_cursor.executemany('UPDATE history_events SET extra_data=? WHERE identifier=?', extra_data_updates)  # noqa: E501
+        log.debug('Deleting from user db...')
+        # Load any data associated with these identifiers that might actually be valuable and
+        # save it in a temporary table that will need to be dealt with manually.
+        # For 99% of users no data should be found here.
+        selected_data = {}
+        tables_to_delete_from = []
+        values_placeholders = ','.join(['(?)'] * len(identifiers_to_remove))
+        for table, columns in (
+            ('history_events', ('asset',)),
+            ('manually_tracked_balances', ('asset',)),
+            ('trades', ('base_asset', 'quote_asset', 'fee_currency')),
+            ('margin_positions', ('pl_currency', 'fee_currency')),
+            ('zksynclite_transactions', ('asset',)),
+            ('zksynclite_swaps', ('from_asset', 'to_asset')),
+            ('nfts', ('identifier', 'last_price_asset')),
+        ):
+            column_str = ','.join([f'{table}.{column}' for column in columns])
+            result = write_cursor.execute(
+                f'WITH asset_list(value) AS (VALUES {values_placeholders}) '
+                f'SELECT * FROM {table} '
+                f'WHERE EXISTS (SELECT 1 FROM asset_list WHERE value IN ({column_str}))',
+                identifiers_to_remove,
+            ).fetchall()
+            if len(result) > 0:
+                selected_data[table] = result
+                tables_to_delete_from.append((table, columns))
+
+        if len(selected_data) > 0:
+            log.error('Found data associated with old erc721 tokens. Saving it in the temp_erc721_data table.')  # noqa: E501
+            write_cursor.execute('CREATE TABLE temp_erc721_data (table_name TEXT, data TEXT)')
+            for table, data in selected_data.items():
+                try:
+                    write_cursor.execute(
+                        'INSERT INTO temp_erc721_data(table_name, data) VALUES(?, ?)',
+                        (table, json.dumps(data)),
+                    )
+                except (TypeError, OverflowError, UnicodeEncodeError) as e:
+                    log.error(f'Failed to serialize {data!s} as json due to {e!s}')
+
+        # Delete the old erc721 assets and any associated data.
+        # The data in timed_balances and evm_accounts_details will likely be present and
+        # has no value so it is not included in the select queries above.
+        for table, columns in tuple(tables_to_delete_from) + (
+            ('timed_balances', ('currency',)),
+            ('evm_accounts_details', ('value',)),
+            ('assets', ('identifier',)),
+        ):
+            column_str = ','.join([f'{table}.{column}' for column in columns])
+            write_cursor.execute(
+                f'WITH asset_list(value) AS (VALUES {values_placeholders}) '
+                f'DELETE FROM {table} '
+                f'WHERE EXISTS (SELECT 1 FROM asset_list WHERE value IN ({column_str}))',
+                identifiers_to_remove,
+            )
+
+    # TODO: Put the history events reset step BEFORE _remove_nft_collection_assets so that
+    # most history events are gone when it checks for data associated with old erc721 assets.
 
     perform_userdb_upgrade_steps(db=db, progress_handler=progress_handler, should_vacuum=True)

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -518,6 +518,16 @@ class Rotkehlchen:
         self.user_is_logged_in = True
         log.debug('User unlocking complete')
 
+        # Send a notification to the user if data associated with
+        # old erc721 tokens has been saved during the db upgrade.
+        # TODO: Remove this after a couple versions (added in version 1.38).
+        with self.data.db.conn.read_ctx() as cursor:
+            if cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='temp_erc721_data'").fetchone()[0] != 0:  # noqa: E501
+                self.msg_aggregator.add_warning(
+                    'Data associated with invalid ERC721 assets is present in your database. '
+                    'Please contact rotki support via our discord to resolve this issue.',
+                )
+
     def _logout(self) -> None:
         if not self.user_is_logged_in:
             return


### PR DESCRIPTION
Fixes issue with missing asset errors after the upgrade. Removes all old erc721 tokens (have no collectible id), and also removes any invalid erc20 assets with the same address as an erc721.