### PR TITLE
Fixes on coinbase trades/transaction decoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`9308` Fix some cases of Coinbase events that were not properly understood in rotki.
 * :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.
 * :bug:`-` Deleting an ethereum address will now remove the withdrawals cache for that address so re-adding it will now properly detect ethereum staking withdrawals again.
 * :bug:`-` Fix double count of cowswap fees.

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -81,10 +81,12 @@ PRIVATE_KEY_RE: re.Pattern = re.compile(
 )
 
 
-def trade_from_conversion(trade_a: dict[str, Any], trade_b: dict[str, Any]) -> Trade | None:
-    """Turn information from a conversion into a trade
+def trade_from_conversion(tx_a: dict[str, Any], tx_b: dict[str, Any] | None) -> Trade | None:
+    """Turn tx information from conversion into a trade
 
     Sometimes the amounts can be negative which breaks rotki's logic which is why we use abs().
+    Also sometimes there may not be a second transaction, in which case it's a sell for USD seen
+    as native_amount of the first transaction.
 
     May raise:
     - UnknownAsset due to Asset instantiation
@@ -92,56 +94,69 @@ def trade_from_conversion(trade_a: dict[str, Any], trade_b: dict[str, Any]) -> T
     - KeyError due to dict entries missing an expected entry
     """
     # Check that the status is complete
-    if trade_a['status'] != 'completed':
+    if tx_a['status'] != 'completed':
         return None
 
-    # Trade b will represent the asset we are converting to
-    if trade_b['amount']['amount'].startswith('-'):
-        trade_a, trade_b = trade_b, trade_a
+    timestamp = deserialize_timestamp_from_date(tx_a['updated_at'], 'iso8601', 'coinbase')
+    if tx_b is not None:
+        # Trade b will represent the asset we are converting to
+        if tx_b['amount']['amount'].startswith('-'):
+            tx_a, tx_b = tx_b, tx_a
 
-    timestamp = deserialize_timestamp_from_date(trade_a['updated_at'], 'iso8601', 'coinbase')
-    tx_amount = AssetAmount(abs(deserialize_asset_amount(trade_a['amount']['amount'])))
-    tx_asset = asset_from_coinbase(trade_a['amount']['currency'], time=timestamp)
-    native_amount = abs(deserialize_asset_amount(trade_b['amount']['amount']))
-    native_asset = asset_from_coinbase(trade_b['amount']['currency'], time=timestamp)
-    amount = tx_amount
+        tx_amount = AssetAmount(abs(deserialize_asset_amount(tx_a['amount']['amount'])))
+        tx_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
+        native_amount = abs(deserialize_asset_amount(tx_b['amount']['amount']))
+        native_asset = asset_from_coinbase(tx_b['amount']['currency'], time=timestamp)
+
+        # Obtain fee amount in the native currency using data from both trades
+        amount_after_fee = deserialize_asset_amount(tx_b['native_amount']['amount'])
+        amount_before_fee = deserialize_asset_amount(tx_a['native_amount']['amount'])
+        # amount_after_fee + amount_before_fee is a negative amount and the fee needs to be positive  # noqa: E501
+        conversion_native_fee_amount = abs(amount_after_fee + amount_before_fee)
+        if ZERO not in {tx_amount, conversion_native_fee_amount, amount_before_fee, amount_after_fee}:  # noqa: E501
+            # To get the asset in which the fee is nominated we pay attention to the creation
+            # date of each event. As per our hypothesis the fee is nominated in the asset
+            # for which the first transaction part was initialized
+            time_created_a = deserialize_timestamp_from_date(
+                date=tx_a['created_at'],
+                formatstr='iso8601',
+                location='coinbase',
+            )
+            time_created_b = deserialize_timestamp_from_date(
+                date=tx_b['created_at'],
+                formatstr='iso8601',
+                location='coinbase',
+            )
+            if time_created_a < time_created_b:
+                # We have the fee amount in the native currency. To get it in the
+                # converted asset we have to get the rate
+                asset_native_rate = tx_amount / abs(amount_before_fee)
+                fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
+                fee_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
+            else:
+                tx_b_amount = abs(deserialize_asset_amount(tx_b['amount']['amount']))
+                asset_native_rate = tx_b_amount / abs(amount_after_fee)
+                fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
+                fee_asset = asset_from_coinbase(tx_b['amount']['currency'], time=timestamp)
+        else:
+            fee_amount = Fee(ZERO)
+            fee_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
+
+    else:  # only one transaction
+        tx_amount = AssetAmount(abs(deserialize_asset_amount(tx_a['amount']['amount'])))
+        tx_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
+        native_amount = abs(deserialize_asset_amount(tx_a['native_amount']['amount']))
+        native_asset = asset_from_coinbase(tx_a['native_amount']['currency'], time=timestamp)
+        # For a single transaction fee may or may not exist in the transaction.
+        if (fee_data := tx_a['trade'].get('fee')) is not None:
+            fee_asset = asset_from_coinbase(fee_data['currency'])
+            fee_amount = Fee(abs(deserialize_asset_amount(fee_data['amount'])))
+        else:
+            fee_asset, fee_amount = None, None
+
     # The rate is how much you get/give in quotecurrency if you buy/sell 1 unit of base currency
     rate = Price(native_amount / tx_amount)
-
-    # Obtain fee amount in the native currency using data from both trades
-    amount_after_fee = deserialize_asset_amount(trade_b['native_amount']['amount'])
-    amount_before_fee = deserialize_asset_amount(trade_a['native_amount']['amount'])
-    # amount_after_fee + amount_before_fee is a negative amount and the fee needs to be positive
-    conversion_native_fee_amount = abs(amount_after_fee + amount_before_fee)
-    if ZERO not in {tx_amount, conversion_native_fee_amount, amount_before_fee, amount_after_fee}:
-        # To get the asset in which the fee is nominated we pay attention to the creation
-        # date of each event. As per our hypothesis the fee is nominated in the asset
-        # for which the first transaction part was initialized
-        time_created_a = deserialize_timestamp_from_date(
-            date=trade_a['created_at'],
-            formatstr='iso8601',
-            location='coinbase',
-        )
-        time_created_b = deserialize_timestamp_from_date(
-            date=trade_b['created_at'],
-            formatstr='iso8601',
-            location='coinbase',
-        )
-        if time_created_a < time_created_b:
-            # We have the fee amount in the native currency. To get it in the
-            # converted asset we have to get the rate
-            asset_native_rate = tx_amount / abs(amount_before_fee)
-            fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
-            fee_asset = asset_from_coinbase(trade_a['amount']['currency'], time=timestamp)
-        else:
-            trade_b_amount = abs(deserialize_asset_amount(trade_b['amount']['amount']))
-            asset_native_rate = trade_b_amount / abs(amount_after_fee)
-            fee_amount = Fee(conversion_native_fee_amount * asset_native_rate)
-            fee_asset = asset_from_coinbase(trade_b['amount']['currency'], time=timestamp)
-    else:
-        fee_amount = Fee(ZERO)
-        fee_asset = asset_from_coinbase(trade_a['amount']['currency'], time=timestamp)
-
+    amount = tx_amount
     return Trade(
         timestamp=timestamp,
         location=Location.COINBASE,
@@ -153,7 +168,7 @@ def trade_from_conversion(trade_a: dict[str, Any], trade_b: dict[str, Any]) -> T
         rate=rate,
         fee=fee_amount,
         fee_currency=fee_asset,
-        link=str(trade_a['trade']['id']),
+        link=str(tx_a['trade']['id']),
     )
 
 
@@ -628,14 +643,14 @@ class Coinbase(ExchangeInterface):
             log.debug('Coinbase API query returned no transactions')
             return trades, history_events
 
-        trade_pairs = defaultdict(list)  # Maps every trade id to their two transactions
+        transaction_pairs = defaultdict(list)  # Maps every trade id to their two transactions
         trades = []
         for transaction in transactions:
             log.debug(f'Processing coinbase {transaction=}')
             tx_type = transaction.get('type')
             if tx_type == 'trade':  # Analyze conversions of coins. We address them as sells
                 try:
-                    trade_pairs[transaction['trade']['id']].append(transaction)
+                    transaction_pairs[transaction['trade']['id']].append(transaction)
                 except KeyError:
                     log.error(
                         f'Transaction of type trade doesnt have the '
@@ -665,7 +680,7 @@ class Coinbase(ExchangeInterface):
             ):
                 log.warning(f'Found unknown coinbase transaction type: {transaction}')
 
-        self._process_trades_from_conversion(trade_pairs=trade_pairs, trades=trades)
+        self._process_trades_from_conversion(transaction_pairs=transaction_pairs, trades=trades)
 
         with self.db.user_write() as write_cursor:  # Remember last transaction id for account
             write_cursor.execute(
@@ -675,19 +690,14 @@ class Coinbase(ExchangeInterface):
 
         return trades, history_events
 
-    def _process_trades_from_conversion(self, trade_pairs: dict[str, list], trades: list[Trade]) -> None:  # noqa: E501
-        """Processes the trade pairs to create trades from conversions"""
-        for trade_id, trades_conversion in trade_pairs.items():
-            # Assert that in fact we have two trades
-            if len(trades_conversion) != 2:
-                log.error(
-                    f'Conversion with id {trade_id} doesnt '
-                    f'have two transactions. {trades_conversion}',
-                )
-                continue
+    def _process_trades_from_conversion(self, transaction_pairs: dict[str, list], trades: list[Trade]) -> None:  # noqa: E501
+        """Processes the transaction pairs to create trades from conversions"""
+        for conversion_transactions in transaction_pairs.values():
+            tx_1 = conversion_transactions[0]
+            tx_2 = None if len(conversion_transactions) == 1 else conversion_transactions[1]
 
             try:
-                if (trade := trade_from_conversion(trades_conversion[0], trades_conversion[1])) is not None:  # noqa: E501
+                if (trade := trade_from_conversion(tx_1, tx_2)) is not None:
                     trades.append(trade)
 
             except UnknownAsset as e:
@@ -712,7 +722,7 @@ class Coinbase(ExchangeInterface):
                 )
                 log.error(
                     'Error processing a coinbase conversion',
-                    trade=trades_conversion[0],
+                    trade=conversion_transactions[0],
                     error=msg,
                 )
                 continue

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -915,10 +915,9 @@ def test_asset_conversion_choosing_fee_asset(mock_coinbase):
 def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
     """Test that coinbase trade history query works fine for advanced_trade_fill"""
     coinbase = function_scope_coinbase
-
     mock_transactions_response = """
 { "data": [{
-            "id": "REDACTED",
+            "id": "id1",
             "type": "advanced_trade_fill",
             "status": "completed",
             "amount": {
@@ -933,12 +932,12 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "created_at": "2024-03-07T08:12:51Z",
             "updated_at": "2024-03-07T08:12:51Z",
             "resource": "transaction",
-            "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+            "resource_path": "/v2/accounts/REDACTED/transactions/id1",
             "instant_exchange": false,
             "advanced_trade_fill": {
                 "fill_price": "0.9174",
                 "product_id": "USDC-EUR",
-                "order_id": "REDACTED",
+                "order_id": "orderid1",
                 "commission": "0",
                 "order_side": "sell"
             },
@@ -951,7 +950,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "hide_native_amount": false
         },
         {
-            "id": "REDACTED",
+            "id": "id2",
             "type": "advanced_trade_fill",
             "status": "completed",
             "amount": {
@@ -966,12 +965,12 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "created_at": "2024-03-07T09:12:51Z",
             "updated_at": "2024-03-07T09:12:51Z",
             "resource": "transaction",
-            "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+            "resource_path": "/v2/accounts/REDACTED/transactions/id2",
             "instant_exchange": false,
             "advanced_trade_fill": {
                 "fill_price": "0.9174",
                 "product_id": "USDC-EUR",
-                "order_id": "REDACTED",
+                "order_id": "orderid2",
                 "commission": "0",
                 "order_side": "sell"
             },
@@ -984,7 +983,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "hide_native_amount": false
         },
         {
-            "id": "REDACTED",
+            "id": "id3",
             "type": "advanced_trade_fill",
             "status": "completed",
             "amount": {
@@ -999,12 +998,12 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "created_at": "2024-03-07T09:12:51Z",
             "updated_at": "2024-03-07T09:12:51Z",
             "resource": "transaction",
-            "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+            "resource_path": "/v2/accounts/REDACTED/transactions/id3",
             "instant_exchange": false,
             "advanced_trade_fill": {
                 "fill_price": "3334.341",
                 "product_id": "ETH-USDC",
-                "order_id": "REDACTED",
+                "order_id": "orderid3",
                 "commission": "0.0000005",
                 "order_side": "sell"
             },
@@ -1017,7 +1016,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "hide_native_amount": false
         },
         {
-            "id": "REDACTED",
+            "id": "id4",
             "type": "advanced_trade_fill",
             "status": "completed",
             "amount": {
@@ -1032,12 +1031,12 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "created_at": "2024-03-07T09:12:51Z",
             "updated_at": "2024-03-07T09:12:51Z",
             "resource": "transaction",
-            "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+            "resource_path": "/v2/accounts/REDACTED/transactions/id4",
             "instant_exchange": false,
             "advanced_trade_fill": {
                 "fill_price": "170.12",
                 "product_id": "SOL-USDC",
-                "order_id": "REDACTED",
+                "order_id": "orderid4",
                 "commission": "0.5710371002622",
                 "order_side": "buy"
             },
@@ -1050,7 +1049,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "hide_native_amount": false
         },
         {
-            "id": "REDACTED",
+            "id": "id5",
             "type": "advanced_trade_fill",
             "status": "completed",
             "amount": {
@@ -1065,12 +1064,12 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
             "created_at": "2024-03-07T09:12:51Z",
             "updated_at": "2024-03-07T09:12:51Z",
             "resource": "transaction",
-            "resource_path": "/v2/accounts/REDACTED/transactions/REDACTED",
+            "resource_path": "/v2/accounts/REDACTED/transactions/id5",
             "instant_exchange": false,
             "advanced_trade_fill": {
                 "fill_price": "3334.341",
                 "product_id": "ETH-USDC",
-                "order_id": "REDACTED",
+                "order_id": "orderid3",
                 "commission": "0.0000005",
                 "order_side": "sell"
             },
@@ -1109,7 +1108,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
         rate=FVal('0.9174'),
         fee=ZERO,
         fee_currency=A_EUR,
-        link='REDACTED',
+        link='id1',
     ), Trade(
         timestamp=1709802771,
         location=Location.COINBASE,
@@ -1120,7 +1119,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
         rate=FVal('0.9174'),
         fee=ZERO,
         fee_currency=A_EUR,
-        link='REDACTED',
+        link='id2',
     ), Trade(
         timestamp=1709802771,
         location=Location.COINBASE,
@@ -1131,7 +1130,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
         rate=FVal('3334.341'),
         fee=FVal('0.0000005'),
         fee_currency=A_USDC,
-        link='REDACTED',
+        link='id3',
     ), Trade(
         timestamp=1709802771,
         location=Location.COINBASE,
@@ -1142,7 +1141,7 @@ def test_coinbase_query_trade_history_advanced_fill(function_scope_coinbase):
         rate=FVal('170.12'),
         fee=FVal('0.5710371002622'),
         fee_currency=A_USDC,
-        link='REDACTED',
+        link='id4',
     )]
     assert trades == expected_trades
 
@@ -1179,7 +1178,7 @@ def test_advancedtrade_missing_order_side(mock_coinbase):
         base_asset=A_ETH,
         quote_asset=A_USD,
         trade_type=TradeType.BUY,
-        amount=FVal('205.5'),
+        amount=FVal('0.105600147994367992106967040420961757844215372914975180111201323727402596067872'),
         rate=FVal('1946.02'),
         fee=FVal('0.85'),
         fee_currency=A_USD,


### PR DESCRIPTION
A lot of changes.

In 1.38 we will need to cleanup coinbase automatically created transactions: https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=95212608

This should fix #9308 