### PR TITLE
Fix aerodrome/velodrome pool querying

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Correctly handle a remote error in the Aerodrome/Velodrome pool querying logic.
 * :bug:`-` Some mainnet to optimism bridging transactions that were not seen correctly will now be properly decoded.
 * :bug:`9308` Fix some cases of Coinbase events that were not properly understood in rotki.
 * :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -250,7 +250,12 @@ def test_velodrome_cache(optimism_inquirer):
     assert all(entry in addressbook_entries for entry in VELODROME_SOME_EXPECTED_ADDRESBOOK_ENTRIES)  # noqa: E501
     assert all((identifier,) in asset_identifiers for identifier in VELODROME_SOME_EXPECTED_ASSETS)
 
-    assert mock_notify.call_args_list == [make_call_object(CPT_VELODROME, ChainID.OPTIMISM, 0, 0)]
+    # New messages are sent only after a delay of 5 secs and the test runs fast
+    # due to the vcr, so only the first message from each loop gets sent.
+    assert mock_notify.call_args_list == [
+        make_call_object(CPT_VELODROME, ChainID.OPTIMISM, 0, 200),
+        make_call_object(CPT_VELODROME, ChainID.OPTIMISM, 1, 282),
+    ]
 
 
 class MockEvmContract:


### PR DESCRIPTION
Its seems that at present there are exactly 2000 aerodrome pools, which triggers a bug in our logic where it tries to query a chunk of pools that doesn't exist, which resulted in a remote error. Now the remote error should be handled gracefully, and it will continue with adding the pools it has queried instead of exiting the logic with an error.

Also I adjusted where the pool querying status messages were being sent in this logic, to better reflect what is actually happening. Previously the messages indicating how many pools were processed were on a loop that finished in several seconds, while the other loop (where I've moved it to now) took a number of minutes to complete.