### PR TITLE
Fix aerodrome lp token prices

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :bug:`-` Correctly handle a remote error in the Aerodrome/Velodrome pool querying logic.
+* :bug:`-` Prices for Aerodrome LP tokens will now be found and the associated balances shown correctly.
+* :bug:`-` A rare error with velodrome events decoding should now be fixed and the relevant events properly decoded.
 * :bug:`-` Some mainnet to optimism bridging transactions that were not seen correctly will now be properly decoded.
 * :bug:`9308` Fix some cases of Coinbase events that were not properly understood in rotki.
 * :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.

--- a/rotkehlchen/chain/evm/utils.py
+++ b/rotkehlchen/chain/evm/utils.py
@@ -15,6 +15,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.types import (
+    AERODROME_POOL_PROTOCOL,
     UNISWAP_PROTOCOL,
     VELODROME_POOL_PROTOCOL,
     ChainID,
@@ -36,6 +37,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 LP_TOKEN_AS_POOL_PROTOCOL_TO_ABI_NAME: Final[dict[str, 'LP_TOKEN_AS_POOL_CONTRACT_ABIS']] = {
     VELODROME_POOL_PROTOCOL: 'VELO_V2_LP',
+    AERODROME_POOL_PROTOCOL: 'VELO_V2_LP',
     UNISWAP_PROTOCOL: 'UNISWAP_V2_LP',
 }
 FVAL_ERROR_NAME: Final = 'token supply'

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -106,11 +106,13 @@ ProtocolsWithPriceLogic = (
     CURVE_POOL_PROTOCOL,
     VELODROME_POOL_PROTOCOL,
     HOP_PROTOCOL_LP,
+    AERODROME_POOL_PROTOCOL,
 )
 
 LP_TOKEN_AS_POOL_PROTOCOLS = (  # In these protocols the LP token of a pool and the pool itself are the same contract  # noqa: E501
     UNISWAP_PROTOCOL,
     VELODROME_POOL_PROTOCOL,
+    AERODROME_POOL_PROTOCOL,
 )
 LP_TOKEN_AS_POOL_CONTRACT_ABIS = Literal['VELO_V2_LP', 'UNISWAP_V2_LP']  # These contract are both the pool and the LP token of the pool  # noqa: E501
 


### PR DESCRIPTION
Apparently prices for aerodrome LP tokens was never implemented correctly, which prevented aerodrome balances from showing. Now the prices should be found correctly. Since aerodrome is very similar to velodrome, `AERODROME_POOL_PROTOCOL` just needed added several places to make it query the price in the same way that it does for tokens with `VELODROME_POOL_PROTOCOL`.

Also fixes the changelog nitpick from https://github.com/rotki/rotki/pull/9323
