### PR TITLE
Fix bridging eth to optimism

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :bug:`-` A rare error with velodrome events decoding should now be fixed and the relevant events properly decoded.
 * :bug:`-` Some mainnet to optimism bridging transactions that were not seen correctly will now be properly decoded.
 * :bug:`9308` Fix some cases of Coinbase events that were not properly understood in rotki.
+* :bug:`-` Bridging ETH from Ethereum to Optimism will be correctly decoded for new transactions.
 * :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.
 * :bug:`-` Deleting an ethereum address will now remove the withdrawals cache for that address so re-adding it will now properly detect ethereum staking withdrawals again.
 * :bug:`-` Fix double count of cowswap fees.

--- a/rotkehlchen/chain/base/modules/superchain_bridge/decoder.py
+++ b/rotkehlchen/chain/base/modules/superchain_bridge/decoder.py
@@ -31,7 +31,7 @@ class SuperchainBridgeDecoder(SuperchainL2SideBridgeCommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            native_asset=A_ETH.resolve_to_crypto_asset(),
+            native_assets=(A_ETH,),
             bridge_addresses=(
                 # Normal Bridge
                 string_to_evm_address('0x4200000000000000000000000000000000000010'),

--- a/rotkehlchen/chain/optimism/modules/superchain_bridge/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/superchain_bridge/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.evm.decoding.superchain_bridge.l2.decoder import (
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.types import string_to_evm_address
-from rotkehlchen.constants.assets import A_OPTIMISM_ETH
+from rotkehlchen.constants.assets import A_ETH, A_OPTIMISM_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class SuperchainBridgeDecoder(SuperchainL2SideBridgeCommonDecoder):
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
-            native_asset=A_OPTIMISM_ETH.resolve_to_crypto_asset(),
+            native_assets=(A_OPTIMISM_ETH, A_ETH),
             bridge_addresses=(
                 # Normal Bridge
                 string_to_evm_address('0x4200000000000000000000000000000000000010'),


### PR DESCRIPTION
It seems that now instead of emmiting an event from 0xdead with the amount transfered (and no eth transfer) the system creates a normal internal eth transfer when bridging ETH from mainnet to OP. This commit fixes the logic to correctly decoded both new and old transactions.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
