### PR TITLE
Add head endpoint for checking assets status

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -205,7 +205,7 @@ jobs:
           category: "/language:python"
 
   lint-colibri:
-    name: 'Colibri lint'
+    name: 'Colibri lint and test'
     needs: ['check-changes', 'check-typos']
     if: ${{ github.event_name != 'push' && needs.check-changes.outputs.colibri_tasks }}
     runs-on: ubuntu-latest
@@ -216,6 +216,10 @@ jobs:
         with:
           cache-on-failure: true
       - run: cargo check --workspace && cargo clippy --workspace
+        working-directory: ./colibri
+        env:
+          RUSTFLAGS: -Dwarnings
+      - run: cargo test
         working-directory: ./colibri
         env:
           RUSTFLAGS: -Dwarnings

--- a/colibri/.gitignore
+++ b/colibri/.gitignore
@@ -1,0 +1,1 @@
+colibri.log*

--- a/colibri/Cargo.lock
+++ b/colibri/Cargo.lock
@@ -30,6 +30,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +101,16 @@ dependencies = [
  "anstyle",
  "once_cell",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -203,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +262,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets",
+]
 
 [[package]]
 name = "clap"
@@ -258,14 +310,20 @@ dependencies = [
  "axum",
  "clap",
  "dirs",
+ "file-rotate",
+ "http",
  "log",
  "md5",
+ "mockito",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "simplelog",
  "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -273,6 +331,16 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "core-foundation"
@@ -289,6 +357,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -388,6 +465,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "file-rotate"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+dependencies = [
+ "chrono",
+ "flate2",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -663,6 +760,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,10 +1006,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -930,6 +1075,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,10 +1116,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"
@@ -1037,6 +1225,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1311,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1359,50 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1248,6 +1557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,10 +1640,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simplelog"
@@ -1486,6 +1816,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1878,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -1605,6 +1946,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1981,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1634,6 +2003,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1682,6 +2081,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1801,12 +2206,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -1972,6 +2408,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/colibri/Cargo.toml
+++ b/colibri/Cargo.toml
@@ -24,3 +24,19 @@ clap = { version = "4.5.26", features = ["string"] }
 # for globalDB and other sqlite operations
 rusqlite = { version = "0.32.1", features = ["bundled", "bundled-sqlcipher-vendored-openssl"] }
 async-sqlite = {version = "0.4.0" }
+# for cors and network
+tower-http = {version = "0.6.2", features = ["cors", "trace"]}
+http = "1.0"
+# for detailed logs when requests happen. Tracing in maintained by the tokio team and it helps
+# to log events in multithread environments. It is used by axum (also by tokio) to signal when
+# a request happens and keeps information about it. We use tracing to extract those events and
+# log them.
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"]}
+# Used to keep log files that rotate when they reach certain size. Is not available in tracing
+# directly (they have a PR but not merged)
+file-rotate = "0.7.6"
+
+[dev-dependencies]
+mockito = "1.6.1"
+tokio = { version = "*", features = ["test-util"]}

--- a/colibri/src/api.rs
+++ b/colibri/src/api.rs
@@ -1,11 +1,13 @@
+mod constants;
 pub mod database;
 pub mod health;
 pub mod icons;
 mod utils;
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::coingecko;
 use crate::database::DBHandler;
@@ -17,4 +19,5 @@ pub struct AppState {
     pub globaldb: Arc<globaldb::GlobalDB>,
     pub coingecko: Arc<coingecko::Coingecko>,
     pub userdb: Arc<RwLock<DBHandler>>,
+    pub active_tasks: Arc<Mutex<HashSet<String>>>,
 }

--- a/colibri/src/api/constants.rs
+++ b/colibri/src/api/constants.rs
@@ -1,0 +1,1 @@
+pub const QUERY_ICONS_TASK_PREFIX: &str = "query_icons";

--- a/colibri/src/api/icons.rs
+++ b/colibri/src/api/icons.rs
@@ -1,13 +1,31 @@
-use crate::api::AppState;
+use crate::api::{constants::QUERY_ICONS_TASK_PREFIX, AppState};
 use crate::icons;
 use axum::{extract::Query, extract::State, response::IntoResponse};
+use log::error;
+use reqwest::StatusCode;
 use serde::Deserialize;
-use std::sync::Arc;
+use std::{sync::Arc, time::SystemTime};
+use tokio::fs;
 
+const HOUR_IN_SECS: u64 = 60 * 60;
+const MAX_ICON_RECHECK_PERIOD: u64 = HOUR_IN_SECS * 12;
+
+/// Used when requesting an asset locally
 #[derive(Deserialize)]
 pub struct AssetIconRequest {
+    // id of the asset to be queried
     asset_id: String,
+    // hash used to inform the consumer if the file has changed locally or not
     match_header: Option<String>,
+}
+
+/// Used when checking the state of an icon locally
+#[derive(Deserialize)]
+pub struct AssetIconCheck {
+    // id of the asset to be queried
+    asset_id: String,
+    // true if we should delete the local file and pull it again
+    force_refresh: Option<bool>,
 }
 
 /// The handler for the get icon endpoint
@@ -19,12 +37,18 @@ pub async fn get_icon(
     State(state): State<Arc<AppState>>,
     Query(payload): Query<AssetIconRequest>,
 ) -> impl IntoResponse {
-    match icons::get_or_query_icon(
-        state.globaldb.clone(),
-        state.coingecko.clone(),
+    let path = icons::get_asset_path(
+        &payload.asset_id,
+        state.data_dir.as_path(),
+        state.globaldb.as_ref(),
+    )
+    .await;
+
+    match icons::get_icon(
         state.data_dir.clone(),
         &payload.asset_id,
         payload.match_header,
+        path,
     )
     .await
     {
@@ -32,4 +56,118 @@ pub async fn get_icon(
         (status, Some(headers), None) => (status, headers).into_response(),
         (status, _, _) => status.into_response(),
     }
+}
+
+/// The handler for the HEAD icon endpoint
+///
+/// First check if the file exists locally. If the file is not empty it means
+/// that we have the image locally and we can serve it. Otherwise if the file
+/// has 0 size it means that the last time it was queried the icon couldn't be
+/// found remotely. Additionally if that query was more than MAX_ICON_RECHECK_PERIOD
+/// hours ago we will retry. If on the other hand we queried it less than
+/// MAX_ICON_RECHECK_PERIOD hours ago then we treat it as if the icon doesn't exist.
+///
+/// If force_refresh is set to true then we ignore the local file and force a query
+/// of the icon.
+pub async fn check_icon(
+    State(state): State<Arc<AppState>>,
+    Query(payload): Query<AssetIconCheck>,
+) -> impl IntoResponse {
+    let path = icons::get_asset_path(
+        &payload.asset_id,
+        state.data_dir.as_path(),
+        state.globaldb.as_ref(),
+    )
+    .await;
+
+    match icons::find_icon(state.data_dir.as_path(), &path, &payload.asset_id).await {
+        Some(found_path) => {
+            match fs::metadata(found_path.clone()).await {
+                Ok(metadata) => {
+                    // if file is non empty then everything is okey
+                    if metadata.len() > 0 {
+                        match payload.force_refresh {
+                            // check if we need to repull it
+                            Some(true) => {
+                                if let Err(error) = fs::remove_file(found_path).await {
+                                    error!(
+                                        "Failed to delete file {} when force refresh was set due to {}",
+                                        path.display(),
+                                        error,
+                                    );
+                                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                                };
+                                return query_icon_from_payload(state, payload, path)
+                                    .await
+                                    .into_response();
+                            }
+                            None | Some(false) => return StatusCode::OK.into_response(),
+                        }
+                    }
+
+                    // check when was the last time that the file got updated
+                    if let Ok(time) = metadata.modified() {
+                        if let Ok(duration) = SystemTime::now().duration_since(time) {
+                            if duration.as_secs() < MAX_ICON_RECHECK_PERIOD {
+                                // It was queried recently so don't try again
+                                StatusCode::NOT_FOUND.into_response()
+                            } else {
+                                let _ = fs::remove_file(found_path).await;
+                                // Since we tried long ago enough retry again
+                                tokio::spawn(icons::query_icon_remotely(
+                                    payload.asset_id,
+                                    state.data_dir.clone(),
+                                    state.coingecko.clone(),
+                                ));
+                                StatusCode::ACCEPTED.into_response()
+                            }
+                        } else {
+                            error!("Error calculating elapsed duration");
+                            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                        }
+                    } else {
+                        // This shouldn't happen as we ship to platforms with metadata on files
+                        error!("Platform doesn't support last modified ts");
+                        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to query icon for {} due to {}", payload.asset_id, e);
+                    StatusCode::NOT_FOUND.into_response()
+                }
+            }
+        }
+        None => {
+            // There is no local reference to the file, query it. Ensure that if it is requested
+            // again only one task handles it.
+            query_icon_from_payload(state, payload, path)
+                .await
+                .into_response()
+        }
+    }
+}
+
+/// Helper function to update the status of the query in the shared state
+/// and start the query of an icon remotely.
+async fn query_icon_from_payload(
+    state: Arc<AppState>,
+    payload: AssetIconCheck,
+    path: std::path::PathBuf,
+) -> StatusCode {
+    let task_name = format!("{}_{}", QUERY_ICONS_TASK_PREFIX, payload.asset_id);
+    let mut tasks_guard = state.active_tasks.lock().await;
+    if !tasks_guard.insert(task_name.clone()) {
+        return StatusCode::ACCEPTED;
+    };
+    drop(tasks_guard); // this drop releases the mutex guard allowing other tasks to acquire it.
+
+    tokio::spawn({
+        let active_tasks = state.active_tasks.clone();
+        let task_key = task_name.clone();
+        async move {
+            icons::query_icon_remotely(payload.asset_id, path, state.coingecko.clone()).await;
+            active_tasks.lock().await.remove(&task_key);
+        }
+    });
+    StatusCode::ACCEPTED
 }

--- a/colibri/src/globaldb.rs
+++ b/colibri/src/globaldb.rs
@@ -63,3 +63,58 @@ impl GlobalDB {
         })
     }
 }
+
+/// macro that creates a copy of the globaldb in the rotkehlchen data folder
+/// and stores it in a temp folder
+#[cfg(test)]
+#[macro_export]
+macro_rules! create_globaldb {
+    () => {{
+        use crate::globaldb::GlobalDB;
+        use std::{env, fs, path::PathBuf};
+
+        let tmp_dir = env::temp_dir().join("global");
+        fs::create_dir_all(tmp_dir.clone()).expect("Failed to create temp folder for globaldb");
+        let root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        fs::copy(
+            (root_path.parent())
+                .unwrap()
+                .join("rotkehlchen")
+                .join("data")
+                .join("global.db"),
+            tmp_dir.join("global.db"),
+        )
+        .expect("Failed to copy globaldb in create_globaldb macro");
+        GlobalDB::new(tmp_dir.join("global.db"))
+    }};
+}
+
+#[cfg(test)]
+mod test {
+    use std::env;
+
+    /// Test that the collections and coingecko ids are queried correctly.
+    #[tokio::test]
+    async fn test_query_asset_data() {
+        let globaldb = create_globaldb!().await.unwrap();
+        let wsteth = "eip155:1/erc20:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"; // wsteth
+        let random_token = "eip155:1/erc20:0x7694e242C36B3Dd9481C6FDCc8F7C91Fc5BEc2bA";
+        assert_eq!(
+            globaldb.get_coingecko_id(wsteth).await.unwrap(),
+            Some("wrapped-steth".to_string())
+        );
+        assert_eq!(globaldb.get_coingecko_id(random_token).await.unwrap(), None);
+
+        assert_eq!(
+            globaldb.get_collection_main_asset(wsteth).await.unwrap(),
+            Some(wsteth.to_string()),
+        );
+        assert_eq!(
+            globaldb
+                .get_collection_main_asset(random_token)
+                .await
+                .unwrap(),
+            None,
+        );
+    }
+}

--- a/colibri/src/icons.rs
+++ b/colibri/src/icons.rs
@@ -9,6 +9,9 @@ use std::time::Duration;
 use crate::coingecko;
 use crate::globaldb;
 
+const SMOLDAPP_BASE_URL: &str =
+    "https://raw.githubusercontent.com/SmolDapp/tokenAssets/refs/heads/main/tokens";
+
 pub enum FileTypeError {
     UnsupportedFileType,
 }
@@ -49,9 +52,9 @@ fn extract_chain_id_and_address(identifier: &str) -> Option<(u64, String)> {
 async fn query_token_icon_and_extension(
     chain_id: u64,
     address: &str,
+    base_url: &str,
 ) -> Option<(Bytes, &'static str)> {
     let client = Client::new();
-    let base_url = "https://raw.githubusercontent.com/SmolDapp/tokenAssets/refs/heads/main/tokens";
     let lower_address = address.to_ascii_lowercase();
 
     let urls = vec![
@@ -81,8 +84,8 @@ async fn query_token_icon_and_extension(
                     }
                 } else if let Ok(text) = response.text().await {
                     error!(
-                        "Got non success response status {} with text: {} ",
-                        status, text
+                        "Got non success response status when querying SmolDapp for the icon of {} with format {}. {} with text: {} ",
+                        address, extension, status, text
                     );
                 } else {
                     error!("Got non success response status {}", status);
@@ -109,30 +112,24 @@ fn url_encode_identifier(input: &str) -> String {
 }
 
 // Find the icon in the custom path if existing, otherwise find the icon in the normal path
-async fn find_icon(datadir: &Path, normalpath: &Path, asset_id: &str) -> Option<(Bytes, String)> {
+pub async fn find_icon(datadir: &Path, normalpath: &Path, asset_id: &str) -> Option<PathBuf> {
     let custom_path = datadir
         .join("images/assets/all/")
         .join(url_encode_identifier(asset_id));
-    if let Some(result) = search_icon_in_path(&custom_path).await {
-        return Some(result);
+    if let Some(asset_path) = search_icon_in_path(&custom_path).await {
+        return Some(asset_path);
     }
+
     search_icon_in_path(normalpath).await
 }
 
-// Find the icon in the path and if existing return its data its extension
-async fn search_icon_in_path(path: &Path) -> Option<(Bytes, String)> {
+// Find the icon in the path and if existing return its path
+async fn search_icon_in_path(path: &Path) -> Option<PathBuf> {
     if let Ok(mut entries) = tokio::fs::read_dir(path.parent().unwrap_or(Path::new("."))).await {
         while let Some(entry) = entries.next_entry().await.transpose() {
             if let Ok(entry) = entry {
-                // for entry in entries.filter_map(Result::ok) {
                 if entry.path().file_stem() == path.file_stem() {
-                    if let Some(extension) = entry.path().extension() {
-                        if let Some(ext_str) = extension.to_str() {
-                            if let Ok(contents) = tokio::fs::read(entry.path()).await {
-                                return Some((Bytes::from(contents), ext_str.to_string()));
-                            }
-                        }
-                    }
+                    return Some(entry.path());
                 }
             }
         }
@@ -140,19 +137,24 @@ async fn search_icon_in_path(path: &Path) -> Option<(Bytes, String)> {
     None
 }
 
-/// Gets the given icon from the user's system if it's already
-/// downloaded or asks for it from the icon sources. Returns it if found
-pub async fn get_or_query_icon(
-    globaldb: Arc<globaldb::GlobalDB>,
-    coingecko: Arc<coingecko::Coingecko>,
-    data_dir: PathBuf,
+/// Given the path for an icon return its bytes and the extension of the file
+async fn retrieve_icon_bytes(path: PathBuf) -> Option<(Bytes, String)> {
+    if let Some(extension) = path.extension() {
+        if let Some(ext_str) = extension.to_str() {
+            if let Ok(contents) = tokio::fs::read(path.as_path()).await {
+                return Some((Bytes::from(contents), ext_str.to_string()));
+            }
+        }
+    }
+
+    None
+}
+
+pub async fn get_asset_path(
     asset_id: &str,
-    match_header: Option<String>,
-) -> (
-    StatusCode,
-    Option<[(&'static str, &'static str); 2]>,
-    Option<Bytes>,
-) {
+    data_dir: &Path,
+    globaldb: &globaldb::GlobalDB,
+) -> PathBuf {
     let new_asset_id = match globaldb.get_collection_main_asset(asset_id).await {
         Err(e) => {
             error!(
@@ -164,67 +166,138 @@ pub async fn get_or_query_icon(
         Ok(result) => result.unwrap_or_else(|| asset_id.to_string()),
     };
     const ASSETS_PATH: &str = "images/assets/all/";
-    let path = data_dir
+    data_dir
         .join(ASSETS_PATH)
-        .join(format!("{}_small", url_encode_identifier(&new_asset_id)));
+        .join(format!("{}_small", url_encode_identifier(&new_asset_id)))
+}
 
-    match find_icon(&data_dir, &path, asset_id).await {
-        Some((bytes, extension)) => {
-            let headers = match get_headers(&extension) {
-                Err(FileTypeError::UnsupportedFileType) => {
-                    return (StatusCode::NOT_FOUND, None, None);
-                }
-                Ok(headers) => headers,
-            };
-            let hash = format!("{:x}", md5::compute(&bytes));
-            if match_header.as_ref().is_none_or(|h| hash != *h) {
-                return (StatusCode::OK, Some(headers), Some(bytes));
-            }
-            (StatusCode::NOT_MODIFIED, Some(headers), None)
-        }
-        _ => {
-            // we have to query it
-            let (icon_bytes, extension) = match extract_chain_id_and_address(&new_asset_id) {
-                Some((chain_id, address)) => {
-                    match query_token_icon_and_extension(chain_id, &address).await {
-                        Some((bytes, ext)) => (bytes, ext),
-                        None => match coingecko.query_asset_image(&new_asset_id).await {
-                            Some(bytes) => (bytes, "png"),
-                            None => return (StatusCode::NOT_FOUND, None, None),
-                        },
+/// Gets the given icon from the user's system if it's already
+/// downloaded or asks for it from the icon sources. Returns it if found
+pub async fn get_icon(
+    data_dir: PathBuf,
+    asset_id: &str,
+    match_header: Option<String>,
+    asset_path: PathBuf,
+) -> (
+    StatusCode,
+    Option<[(&'static str, &'static str); 2]>,
+    Option<Bytes>,
+) {
+    match find_icon(&data_dir, &asset_path, asset_id).await {
+        Some(found_path) => match retrieve_icon_bytes(found_path).await {
+            Some((bytes, extension)) => {
+                let headers = match get_headers(&extension) {
+                    Err(FileTypeError::UnsupportedFileType) => {
+                        return (StatusCode::NOT_FOUND, None, None);
                     }
+                    Ok(headers) => headers,
+                };
+                let hash = format!("{:x}", md5::compute(&bytes));
+                if match_header.as_ref().is_none_or(|h| hash != *h) {
+                    return (StatusCode::OK, Some(headers), Some(bytes));
                 }
+                (StatusCode::NOT_MODIFIED, Some(headers), None)
+            }
+            _ => (StatusCode::NOT_FOUND, None, None),
+        },
+        _ => (StatusCode::NOT_FOUND, None, None),
+    }
+}
+
+// Writes a zero bytes file to mark that we already tried to query this icon
+// and that it was not possible to find it in our sources for icons.
+async fn write_zero_bytes_file(path: &Path) {
+    let _ = tokio::fs::write(path.with_extension("svg"), [])
+        .await
+        .map_err(|e| {
+            error!(
+                "Unable to write zero bytes file {} due to {}",
+                path.display(),
+                e
+            );
+        });
+    debug!("Wrote zero bytes file {}", path.display());
+}
+
+/// query icon remotely from SmolDapp and coingecko. Returns if the image was found (boolean)
+pub async fn query_icon_remotely(
+    asset_id: String,
+    path: PathBuf,
+    coingecko: Arc<coingecko::Coingecko>,
+) {
+    let (icon_bytes, extension) = match extract_chain_id_and_address(&asset_id) {
+        Some((chain_id, address)) => {
+            match query_token_icon_and_extension(chain_id, &address, SMOLDAPP_BASE_URL).await {
+                Some((bytes, ext)) => (bytes, ext),
+                None => match coingecko.query_asset_image(&asset_id).await {
+                    Some(bytes) => (bytes, "png"),
+                    None => {
+                        debug!(
+                            "Icon not found for asset {}. Writing zero bytes file",
+                            asset_id
+                        );
+                        write_zero_bytes_file(path.as_path()).await;
+                        return;
+                    }
+                },
+            }
+        }
+        None => {
+            // If we can't extract chain_id and address, try coingecko directly
+            match coingecko.query_asset_image(&asset_id).await {
+                Some(bytes) => (bytes, "png"),
                 None => {
-                    // If we can't extract chain_id and address, try coingecko directly
-                    match coingecko.query_asset_image(&new_asset_id).await {
-                        Some(bytes) => (bytes, "png"),
-                        None => return (StatusCode::NOT_FOUND, None, None),
-                    }
-                }
-            };
-
-            let headers = match get_headers(extension) {
-                Err(FileTypeError::UnsupportedFileType) => {
-                    return (StatusCode::NOT_FOUND, None, None);
-                }
-                Ok(headers) => headers,
-            };
-            // also write the file into the file system
-            match tokio::fs::write(path.with_extension(extension), &icon_bytes).await {
-                Ok(_) => (StatusCode::OK, Some(headers), Some(icon_bytes)),
-                Err(e) => {
-                    error!(
-                        "Unable to write {} to the file system due to {}",
-                        path.display(),
-                        e
+                    debug!(
+                        "Icon not found in coingecko for asset {}. Writing zero bytes file.",
+                        asset_id
                     );
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Some(headers),
-                        Some(icon_bytes),
-                    )
+                    write_zero_bytes_file(path.as_path()).await;
+                    return;
                 }
             }
         }
+    };
+
+    // also write the file into the file system
+    let _ = tokio::fs::write(path.with_extension(extension), &icon_bytes)
+        .await
+        .map_err(|e| {
+            error!(
+                "Unable to write {} to the file system due to {}",
+                path.display(),
+                e
+            );
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::icons::query_token_icon_and_extension;
+    use axum::body::Bytes;
+    use mockito;
+
+    #[tokio::test]
+    async fn test_smoldapp_icons() {
+        let mut server = mockito::Server::new_async().await;
+        let chain = 100;
+        let address = "0x177127622c4a00f3d409b75571e12cb3c8973d3c";
+        let data = b"cowswap_icon";
+
+        // mock successful query
+        server
+            .mock("GET", format!("/{}/{}/logo.svg", chain, address).as_str())
+            .with_body(data)
+            .create();
+
+        let r = query_token_icon_and_extension(chain, address, server.url().as_str()).await;
+        assert_eq!(r, Some((Bytes::from_static(data), "svg")));
+
+        // mock bad query
+        server
+            .mock("GET", format!("/{}/{}/logo.svg", 10, address).as_str())
+            .with_status(404)
+            .create();
+        let r = query_token_icon_and_extension(10, address, server.url().as_str()).await;
+        assert_eq!(r, None);
     }
 }

--- a/colibri/src/logging.rs
+++ b/colibri/src/logging.rs
@@ -1,0 +1,40 @@
+use crate::args::Args;
+
+use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
+use std::sync::Mutex;
+use tracing_subscriber::filter::EnvFilter;
+
+// Configure logging for the app. We allow logging to a system file
+// or to the stdout. If logs are stored in files they are rotated
+// based on size and there is a max of `max_logfiles_num` files saved.
+pub fn config_logging(args: Args) {
+    let filter = EnvFilter::builder()
+        .with_default_directive(args.log_level.into())
+        .parse("")
+        .unwrap();
+
+    let log_to_file = FileRotate::new(
+        args.logfile_path.clone(),
+        AppendCount::new(args.max_logfiles_num),
+        ContentLimit::BytesSurpassed(10usize.pow(6) * args.max_size_in_mb),
+        Compression::None,
+        #[cfg(unix)]
+        None,
+    );
+
+    if !args.log_to_stdout {
+        tracing_subscriber::fmt()
+            .with_target(false)
+            .with_ansi(false)
+            .with_env_filter(filter)
+            .with_writer(Mutex::new(log_to_file))
+            .compact()
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_target(false)
+            .with_env_filter(filter)
+            .compact()
+            .init();
+    }
+}


### PR DESCRIPTION
- configures the logging in the app.
- Add options to set the debug level and if we want to log to the terminal or file.
- adds new endpoint for icons with verb head that queries the icons if they are needed or returns if they exists/can't be found
- verb get on icons only returns 200 or 404
- add unit tests for icons
- add .gitignore