### PR TITLE
Correctly count trades in asset balance graphs

### DIFF
--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -128,7 +128,8 @@ class DBNestedFilter(DBFilter):
             filterstrings.append(f'({operator.join(filters)})')
             bindings.extend(single_bindings)
 
-        return filterstrings, bindings
+        operator = ' AND ' if self.and_op else ' OR '
+        return [f'({operator.join(filterstrings)})'], bindings
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=96493730

Fixes two things:
* Trades were not being queries correctly from the db - it was doing an `AND` when checking `base_asset` and `quote_asset` instead of an `OR`.
* In the logic for processing the queried events, it was finding a negative amount and failing when processing trades, since it was trying to process the amounts for both the spend and receive assets of the trade. Now it only processes the amount for the asset(s) whose balances are actually being queried.