### PR TITLE
fix: adds proper error tracking on pinia reset plugin

### DIFF
--- a/frontend/app/src/store/plugins.ts
+++ b/frontend/app/src/store/plugins.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'es-toolkit';
+import { logger } from '@/utils/logging';
 import type { PiniaPluginContext, StoreGeneric } from 'pinia';
 
 export function StoreResetPlugin({ store }: PiniaPluginContext): void {
@@ -33,5 +34,12 @@ export function StoreTrackPlugin({ store }: PiniaPluginContext): void {
  * Resets the state of all the installed pinia stores.
  */
 export function resetState(): void {
-  for (const store of storeMap.values()) store.$reset();
+  for (const [name, store] of storeMap) {
+    try {
+      store.$reset();
+    }
+    catch (error: any) {
+      logger.error(`error while clearing the ${name} store`, error);
+    }
+  }
 }

--- a/frontend/app/src/store/use-account-import-progress-store.ts
+++ b/frontend/app/src/store/use-account-import-progress-store.ts
@@ -77,7 +77,7 @@ export const useAccountImportProgressStore = defineStore('import-progress', (): 
   return {
     importingAccounts,
     increment,
-    progress: readonly(progress),
+    progress,
     progressPercentage,
     setTotal,
     skip,


### PR DESCRIPTION
It seems that marking a ref as readonly interferes with state reset

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
