### PR TITLE
Multimev txs block

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8340,7 +8340,8 @@ Getting eth2 staking performance
           "result": {
               "sums": {
                   "apr": "0.0597652039949379861158979362586657031468575710584143257025001370766265371913491",
-                  "execution": "0.951964836013963505",
+                  "execution_blocks": "0.451964836013963505",
+                  "execution_mev": "0.31964836013963505",
                   "exits": "0.0014143880000005993",
                   "outstanding_consensus_pnl": "0.000829238",
                   "sum": "3.2351487110139639043",
@@ -8349,14 +8350,16 @@ Getting eth2 staking performance
               "validators": {
                   "432840": {
                       "apr": "0.0466762036714707128052091929912369373004480648295118244406922158753010413605874",
-                      "execution": "0.93361811418473",
+                      "execution_blocks": "0.63361811418473",
+                      "execution_mev": "0.361811418473",
                       "exits": "0.0014143880000005993",
                       "sum": "2.5266283731847305993",
                       "withdrawals": "1.591595871"
                   },
                   "624729": {
                       "apr": "0.0130890003234672733106887432674287658464095062289025012618079212013254958307617",
-                      "execution": "0.018346721829233505",
+                      "execution_blocks": "0.016346721829233505",
+                      "execution_mev": "0.012346721829233505",
                       "outstanding_consensus_pnl": "0.000829238",
                       "sum": "0.708520337829233305",
                       "withdrawals": "0.6893443779999998"
@@ -8371,7 +8374,8 @@ Getting eth2 staking performance
    :resjson object sums: Sums of all the pages of the results
    :resjson object validator: Mapping of validator index to performance for the current page
    :resjson string apr: The APR of returns for the given timerange for the validator.
-   :resjson string execution: The sum of execution layer ETH PnL for the validator.
+   :resjson string execution_blocks: The sum of the block rewards of the validator sent to the fee recipient if that recipient is tracked.
+   :resjson string execution_mev: The sum of MEV rewards for blocks proposed by the validator if the MEV fee recipient is tracked.
    :resjson string withdrawals: The sum of consensus layer withdrawals ETH pnl for the validator
    :resjson string exits: The sum of the exit ETH PnL for the validator
    :resjson string outstanding_consensus_pnl: If a recent timerange is queried we also take into account not yet withdrawn ETH gathering in the consensus layer.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :feature:`-` For the asset amount and value graph, users can now choose to use historical events and prices as the source, instead of snapshots.
+* :feature:`1379` For the asset amount and value graph, users can now choose to use historical events and prices as the source, instead of snapshots.
+* :bug:`-` Block production events will no longer blindly trust the MEV relay for the MEV reward but instead track exact transactions sent to fee recipient as MEV reward. Also covering the rare case of multiple MEV reward transactions for a single block.
 * :bug:`-` A problem with decoding WETH events in transactions from safes or other smart contracts on arbitrum will now be fixed.
 * :feature:`-` Extrafi optimism incentive rewards sent directly to the wallet will now be properly seen as defi rewards.
 * :feature:`-` History events export will now include the symbol or name of the asset to improve readability of entries.
@@ -34,7 +35,7 @@ Changelog
 * :bug:`-` Deleting an ethereum address will now remove the withdrawals cache for that address so re-adding it will now properly detect ethereum staking withdrawals again.
 * :bug:`-` Fix double count of cowswap fees.
 * :bug:`-` Fix an error when merging two assets if they both appear at the same snapshot.
-* :bug:`-` Allow the rotki app to be minimized using the shortcut for each platform.
+* :bug:`-` Allow rotki app to be minimized using the shortcut for each platform.
 * :bug:`-` Deleting Kusama, Polkadot, or Beaconchain RPC URL should now work properly again.
 * :bug:`-` Some curve event edge cases will now be properly decoded and accounted for.
 * :bug:`-` rotki should now warn you again when gnosis pay authentication token expires.

--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -26,6 +26,8 @@ EVENT_CATEGORY_MAPPINGS = {  # possible combinations of types and subtypes mappe
         HistoryEventSubType.APPLY: {DEFAULT: EventCategory.APPLY},
         HistoryEventSubType.APPROVE: {DEFAULT: EventCategory.APPROVAL},
         HistoryEventSubType.ATTEST: {DEFAULT: EventCategory.ATTEST},
+        HistoryEventSubType.MEV_REWARD: {DEFAULT: EventCategory.MEV_REWARD},
+        HistoryEventSubType.BLOCK_PRODUCTION: {DEFAULT: EventCategory.CREATE_BLOCK},
     },
     HistoryEventType.RECEIVE: {
         HistoryEventSubType.REWARD: {DEFAULT: EventCategory.CLAIM_REWARD},

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1328,9 +1328,13 @@ class HistorySkippedExternalEventResource(BaseMethodView):
 
 class HistoryEventResource(BaseMethodView):
 
-    put_schema = CreateHistoryEventSchema()
     post_schema = HistoryEventSchema()
     delete_schema = HistoryEventsDeletionSchema()
+
+    def make_put_schema(self) -> CreateHistoryEventSchema:
+        return CreateHistoryEventSchema(
+            dbhandler=self.rest_api.rotkehlchen.data.db,
+        )
 
     def make_patch_schema(self) -> EditHistoryEventSchema:
         return EditHistoryEventSchema(
@@ -1343,7 +1347,7 @@ class HistoryEventResource(BaseMethodView):
         return self.rest_api.get_history_events(filter_query=filter_query, group_by_event_ids=group_by_event_ids)  # noqa: E501
 
     @require_loggedin_user()
-    @use_kwargs(put_schema, location='json')
+    @resource_parser.use_kwargs(make_put_schema, location='json')
     def put(self, events: list['HistoryBaseEntry']) -> Response:
         return self.rest_api.add_history_events(events)
 

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -74,17 +74,20 @@ class DBAccountingRules:
             counterparty: str | None,
             rule: 'BaseEventSettings',
             links: dict[LINKABLE_ACCOUNTING_PROPERTIES, LINKABLE_ACCOUNTING_SETTINGS_NAME],
+            force_update: bool = False,
     ) -> int:
         """
         Add a single accounting rule to the database. It returns the identifier
         of the created rule.
         May raise:
-        - InputError: If the combination of type, subtype and counterparty already exists.
+        - InputError: If the combination of type, subtype and counterparty already exists
+        and we are not force updating.
         """
+        verb = 'INSERT OR REPLACE' if force_update else 'INSERT'
         with self.db.conn.write_ctx() as write_cursor:
             try:
                 write_cursor.execute(
-                    'INSERT INTO accounting_rules(type, subtype, counterparty, taxable, '
+                    f'{verb} INTO accounting_rules(type, subtype, counterparty, taxable, '
                     'count_entire_amount_spend, count_cost_basis_pnl, '
                     'accounting_treatment) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING identifier',
                     (

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -181,10 +181,23 @@ class RotkiDataUpdater:
             new_default_nodes=new_default_nodes,
         )
 
-    def update_accounting_rules(self, data: list[dict[str, Any]], version: int) -> None:
+    def update_accounting_rules(
+            self,
+            data: list[dict[str, Any]],
+            version: int,
+            force_updates: bool = True,
+    ) -> None:
         """
         Add remote rules to the user database. In case of conflict we notify the user sending
-        a ws message
+        a ws message unless this is a forced update.
+
+        The issue with not using forced updates is that we can't replace/edit older rules other
+        than just updating them until this accounting rule updating methodology is rethought.
+        https://github.com/orgs/rotki/projects/11?pane=issue&itemId=96831912
+
+        So at the moment the only way to update a rule is to just rewrite it with different
+        attributes and have it update.
+        TODO: This is hacky. At the moment it's always force updating.
         """
         log.info(f'Applying update for accounting rules to v{version}')
         rules_db = DBAccountingRules(self.user_db)
@@ -212,6 +225,7 @@ class RotkiDataUpdater:
                     counterparty=counterparty,
                     rule=rule,
                     links=rule_data.get('links', {}),
+                    force_update=force_updates,
                 )
             except InputError as e:
                 # there is a conflict in the rule. Notify the frontend about it

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -1118,7 +1118,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         elif entry['sequence_index'] == 2:
             assert entry['identifier'] == 1
             assert entry['event_identifier'] == event_identifier
-            assert entry['entry_type'] == 'evmc event'
+            assert entry['entry_type'] == 'evm event'
             assert entry['balance']['amount'] == mev_reward
             assert entry['tx_hash'] == tx_hash.hex()  # pylint: disable=no-member
             assert entry['notes'] == f'Receive {mev_reward} ETH from {mevbot_address} as mev reward for block {block_number} in {tx_hash.hex()}'  # pylint: disable=no-member  # noqa: E501

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -630,6 +630,7 @@ def test_add_get_edit_delete_eth2_validators(
             timestamp=TimestampMS(1671379127000),
             balance=Balance(FVal(1)),
             fee_recipient=make_evm_address(),
+            fee_recipient_tracked=True,
             block_number=42,
             is_mev_reward=True,
         )]

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -437,10 +437,11 @@ def initialize_mock_rotkehlchen_instance(
             user_db=rotki.data.db,
         )
 
-        data_updater.update_accounting_rules(
-            data=json.loads(latest_accounting_rules.read_text(encoding='utf-8'))['accounting_rules'],
-            version=999999,  # only for logs
-        )
+        for version, jsonfile in latest_accounting_rules:
+            data_updater.update_accounting_rules(
+                data=json.loads(jsonfile.read_text(encoding='utf-8'))['accounting_rules'],
+                version=version,
+            )
         with accountant.db.conn.read_ctx() as cursor:
             db_settings = accountant.db.get_settings(cursor)
 

--- a/rotkehlchen/tests/integration/test_eth2.py
+++ b/rotkehlchen/tests/integration/test_eth2.py
@@ -144,18 +144,20 @@ def test_withdrawals(eth2: 'Eth2', database, ethereum_accounts, query_method):
     assert account1_events == 47
 
 
-@pytest.mark.vcr
+# @pytest.mark.vcr
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2023-04-24 21:00:00 GMT')
-def test_block_production(eth2: 'Eth2', database):
+@pytest.mark.parametrize('ethereum_accounts', [[
+    '0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b', '0x76b23B82c8dCf1635a9DF63Fe6D9AafAaF042A9B',
+]])
+def test_block_production(eth2: 'Eth2', database, ethereum_accounts):
     """Test that providing validators that have both pure block production and running
     mev-boost works and detects the block production events.
     """
     dbevents = DBHistoryEvents(database)
     dbeth2 = DBEth2(database)
     vindex1, vindex2 = 45555, 56562
-    vindex1_address = string_to_evm_address('0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b')
-    vindex2_address = string_to_evm_address('0x76b23B82c8dCf1635a9DF63Fe6D9AafAaF042A9B')
+    vindex1_address, vindex2_address = ethereum_accounts[0], ethereum_accounts[1]
     with database.user_write() as write_cursor:
         dbeth2.add_or_update_validators(write_cursor, [
             ValidatorDetails(
@@ -174,22 +176,20 @@ def test_block_production(eth2: 'Eth2', database):
     with database.conn.read_ctx() as cursor:
         events = dbevents.get_history_events(
             cursor=cursor,
-            filter_query=HistoryEventFilterQuery.make(),
+            filter_query=HistoryEventFilterQuery.make(to_ts=Timestamp(1682370000)),
             has_premium=True,
             group_by_event_ids=False,
         )
 
-    assert events == [EthBlockEvent(
-        identifier=12,
+    expected_events = [EthBlockEvent(
         validator_index=vindex1,
         timestamp=TimestampMS(1666693607000),
         balance=Balance(FVal('0.126419309459217215')),
         fee_recipient=string_to_evm_address('0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990'),
-        fee_recipient_tracked=True,
+        fee_recipient_tracked=False,
         block_number=15824493,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=13,
         validator_index=vindex1,
         timestamp=TimestampMS(1666693607000),
         balance=Balance(FVal('0.126458404824519798')),
@@ -198,16 +198,14 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=15824493,
         is_mev_reward=True,
     ), EthBlockEvent(
-        identifier=10,
         validator_index=vindex1,
         timestamp=TimestampMS(1668068651000),
         balance=Balance(FVal('0.095134860916352597')),
         fee_recipient=string_to_evm_address('0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5'),
-        fee_recipient_tracked=True,
+        fee_recipient_tracked=False,
         block_number=15938405,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=11,
         validator_index=vindex1,
         timestamp=TimestampMS(1668068651000),
         balance=Balance(FVal('0.109978419256414016')),
@@ -216,7 +214,6 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=15938405,
         is_mev_reward=True,
     ), EthBlockEvent(
-        identifier=9,
         validator_index=vindex2,
         timestamp=TimestampMS(1670267915000),
         balance=Balance(FVal('0.025900962606266958')),
@@ -225,7 +222,6 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=16120623,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=8,
         validator_index=vindex2,
         timestamp=TimestampMS(1671379127000),
         balance=Balance(FVal('0.02290370247079784')),
@@ -234,7 +230,6 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=16212625,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=7,
         validator_index=vindex2,
         timestamp=TimestampMS(1674734363000),
         balance=Balance(FVal('0.012922327272245232')),
@@ -243,7 +238,6 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=16490846,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=6,
         validator_index=vindex2,
         timestamp=TimestampMS(1675143275000),
         balance=Balance(FVal('0.016091543022603308')),
@@ -252,16 +246,14 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=16524748,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=4,
         validator_index=vindex1,
         timestamp=TimestampMS(1675926299000),
         balance=Balance(FVal('0.156090536122554115')),
         fee_recipient=string_to_evm_address('0xAAB27b150451726EC7738aa1d0A94505c8729bd1'),
-        fee_recipient_tracked=True,
+        fee_recipient_tracked=False,
         block_number=16589592,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=5,
         validator_index=vindex1,
         timestamp=TimestampMS(1675926299000),
         balance=Balance(FVal('0.155599501480976115')),
@@ -270,7 +262,6 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=16589592,
         is_mev_reward=True,
     ), EthBlockEvent(
-        identifier=3,
         validator_index=vindex2,
         timestamp=TimestampMS(1676596919000),
         balance=Balance(FVal('0.004759289463309382')),
@@ -279,16 +270,14 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=16645139,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=1,
         validator_index=vindex1,
         timestamp=TimestampMS(1681593839000),
         balance=Balance(FVal('0.013231650982632651')),
         fee_recipient=string_to_evm_address('0xFeebabE6b0418eC13b30aAdF129F5DcDd4f70CeA'),
-        fee_recipient_tracked=True,
+        fee_recipient_tracked=False,
         block_number=17055026,
         is_mev_reward=False,
     ), EthBlockEvent(
-        identifier=2,
         validator_index=vindex1,
         timestamp=TimestampMS(1681593839000),
         balance=Balance(FVal('0.013233591104431482')),
@@ -297,6 +286,9 @@ def test_block_production(eth2: 'Eth2', database):
         block_number=17055026,
         is_mev_reward=True,
     )]
+    for x in events:  # do not compare identifiers
+        x.identifier = None
+    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -568,7 +560,7 @@ def test_block_with_mev_and_block_reward_and_multiple_mev_txs(
         identifier=1 + counter,
         event_identifier=f'BP1_{block_number}',
         tx_hash=tx_hash,
-        sequence_index=3 + counter,
+        sequence_index=2 + counter,
         timestamp=timestamp,
         location=Location.ETHEREUM,
         event_type=HistoryEventType.STAKING,
@@ -578,5 +570,6 @@ def test_block_with_mev_and_block_reward_and_multiple_mev_txs(
         location_label=user_address,
         address=mevbot_address,
         notes=f'Receive {amount} ETH from {mevbot_address} as mev reward for block {block_number} in {tx_hash.hex()}',  # noqa: E501
+        extra_data={'validator_index': vindex},
     ) for counter, (tx_hash, amount) in enumerate(tx_hashes_and_amounts)]
     assert events == expected_events

--- a/rotkehlchen/tests/unit/accounting/evm/test_aave.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_aave.py
@@ -98,10 +98,36 @@ def test_v2_withdraw(accountant: 'Accountant'):
             free_amount=ZERO,
             taxable_amount=FVal(1000),
             price=Price(ONE),
-            pnl=PNL(taxable=ZERO, free=ZERO),  # Deposits are not taxable
+            pnl=PNL(taxable=ZERO, free=ZERO),
             cost_basis=None,
             index=0,
             extra_data={'tx_hash': HASH1.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Receive 1000 aDAI from AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS1,
+            asset=Asset('eip155:1/erc20:0x028171bCA77440897B824Ca71D1c56caC55b68A3'),
+            free_amount=FVal(1000),
+            taxable_amount=ZERO,
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),
+            cost_basis=None,
+            index=1,
+            extra_data={'tx_hash': HASH1.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Return 1050 aDAI to AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS2,
+            asset=Asset('eip155:1/erc20:0x028171bCA77440897B824Ca71D1c56caC55b68A3'),
+            free_amount=ZERO,
+            taxable_amount=FVal(1050),
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),
+            cost_basis=None,
+            index=2,
+            extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
         ), ProcessedAccountingEvent(
             event_type=AccountingEventType.TRANSACTION_EVENT,
             notes=f'Gained 50 DAI on Aave v2 as interest rate for {USER_ADDRESS}',
@@ -113,7 +139,7 @@ def test_v2_withdraw(accountant: 'Accountant'):
             price=Price(ONE),
             pnl=PNL(taxable=FVal(50), free=ZERO),  # $50 interest gained
             cost_basis=None,
-            index=1,
+            index=3,
             extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
         ), ProcessedAccountingEvent(
             event_type=AccountingEventType.TRANSACTION_EVENT,
@@ -126,11 +152,11 @@ def test_v2_withdraw(accountant: 'Accountant'):
             price=Price(ONE),
             pnl=PNL(taxable=ZERO, free=ZERO),
             cost_basis=None,
-            index=2,
+            index=4,
             extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
         ),
     ]
-    expected_events[1].count_cost_basis_pnl = True  # can't be set by init()
+    expected_events[3].count_cost_basis_pnl = True  # can't be set by init()
     assert pot.processed_events == expected_events
 
 
@@ -192,12 +218,25 @@ def test_v2_payback(accountant: 'Accountant'):
 
     matched_acquisitions = [MatchedAcquisition(
         amount=FVal(50),
-        event=AssetAcquisitionEvent(amount=FVal(1000), timestamp=TS1, rate=Price(ONE), index=0),
+        event=AssetAcquisitionEvent(amount=FVal(1000), timestamp=TS1, rate=Price(ONE), index=1),
         taxable=True,
     )]
     matched_acquisitions[0].event.remaining_amount = FVal(950)  # can't be set by init
     expected_events = [
         ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Receive 1000 variableDebtREN from AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS1,
+            asset=Asset('eip155:1/erc20:0xcd9D82d33bd737De215cDac57FE2F7f04DF77FE0'),
+            free_amount=FVal(1000),
+            taxable_amount=FVal(0),
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),
+            cost_basis=None,
+            index=0,
+            extra_data={'tx_hash': HASH1.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
             event_type=AccountingEventType.TRANSACTION_EVENT,
             notes='Borrow 1000 REN from AAVE v2 with variable APY 0.80%',
             location=Location.ETHEREUM,
@@ -206,10 +245,23 @@ def test_v2_payback(accountant: 'Accountant'):
             free_amount=FVal(1000),
             taxable_amount=ZERO,
             price=Price(ONE),
-            pnl=PNL(taxable=ZERO, free=ZERO),  # Deposits are not taxable
+            pnl=PNL(taxable=ZERO, free=ZERO),
             cost_basis=None,
-            index=0,
+            index=1,
             extra_data={'tx_hash': HASH1.hex()},  # pylint: disable=no-member
+        ), ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Return 1050 variableDebtREN to AAVE v2',
+            location=Location.ETHEREUM,
+            timestamp=TS2,
+            asset=Asset('eip155:1/erc20:0xcd9D82d33bd737De215cDac57FE2F7f04DF77FE0'),
+            free_amount=ZERO,
+            taxable_amount=FVal(1050),
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=ZERO),
+            cost_basis=None,
+            index=2,
+            extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
         ), ProcessedAccountingEvent(
             event_type=AccountingEventType.TRANSACTION_EVENT,
             notes=f'Lost 50 REN as debt during payback to Aave v2 loan for {USER_ADDRESS}',
@@ -227,7 +279,7 @@ def test_v2_payback(accountant: 'Accountant'):
                 matched_acquisitions=matched_acquisitions,
                 is_complete=True,
             ),
-            index=1,
+            index=3,
             extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
         ), ProcessedAccountingEvent(
             event_type=AccountingEventType.TRANSACTION_EVENT,
@@ -240,10 +292,10 @@ def test_v2_payback(accountant: 'Accountant'):
             price=Price(ONE),
             pnl=PNL(taxable=ZERO, free=ZERO),
             cost_basis=None,
-            index=2,
+            index=4,
             extra_data={'tx_hash': HASH2.hex()},  # pylint: disable=no-member
         ),
     ]
-    expected_events[1].count_cost_basis_pnl = True  # can't be set by init()
-    expected_events[1].count_entire_amount_spend = True  # can't be set by init()
+    expected_events[3].count_cost_basis_pnl = True  # can't be set by init()
+    expected_events[3].count_entire_amount_spend = True  # can't be set by init()
     assert pot.processed_events == expected_events

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -708,6 +708,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
                 timestamp=timestampms,
                 balance=Balance(block_reward_1),
                 fee_recipient=vindex1_address,
+                fee_recipient_tracked=True,
                 block_number=block_number,
                 is_mev_reward=False,
             ), EthBlockEvent(
@@ -715,6 +716,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
                 timestamp=TimestampMS(timestampms + (1 * (HOUR_IN_SECONDS * 1000))),
                 balance=Balance(mev_reward_1),
                 fee_recipient=vindex1_address,
+                fee_recipient_tracked=True,
                 block_number=block_number,
                 is_mev_reward=True,
             ), EthBlockEvent(
@@ -722,6 +724,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
                 timestamp=TimestampMS(timestampms + (2 * (HOUR_IN_SECONDS * 1000))),
                 balance=Balance(block_reward_2),  # since mev builder gets it we shouldn't count it
                 fee_recipient=mev_builder_address,
+                fee_recipient_tracked=True,
                 block_number=block_number + 1,
                 is_mev_reward=False,
             ), EthBlockEvent(
@@ -729,6 +732,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
                 timestamp=TimestampMS(timestampms + (3 * (HOUR_IN_SECONDS * 1000))),
                 balance=Balance(mev_reward_2),
                 fee_recipient=vindex2_address,
+                fee_recipient_tracked=True,
                 block_number=block_number + 1,
                 is_mev_reward=True,
             ), EvmEvent(
@@ -765,6 +769,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
                 timestamp=TimestampMS(timestampms + (7 * (HOUR_IN_SECONDS * 1000))),
                 balance=Balance(no_mev_block_reward_2),
                 fee_recipient=vindex2_address,
+                fee_recipient_tracked=True,
                 block_number=16212625,
                 is_mev_reward=False,
             ), EthWithdrawalEvent(
@@ -853,6 +858,7 @@ def test_eth_validators_performance_recent(eth2, database, ethereum_accounts):
                 timestamp=TimestampMS(1666693607000),
                 balance=Balance(block_reward_1),
                 fee_recipient=ethereum_accounts[0],
+                fee_recipient_tracked=True,
                 block_number=15824493,
                 is_mev_reward=False,
             ),
@@ -932,6 +938,7 @@ def test_combine_block_with_tx_events(eth2, database):
                 timestamp=timestampms,
                 balance=Balance(FVal('0.126419309459217215')),
                 fee_recipient=mev_builder_address,
+                fee_recipient_tracked=True,
                 block_number=block_number,
                 is_mev_reward=False,
             ), EthBlockEvent(
@@ -939,6 +946,7 @@ def test_combine_block_with_tx_events(eth2, database):
                 timestamp=timestampms,
                 balance=Balance(mev_reward),
                 fee_recipient=vindex1_address,
+                fee_recipient_tracked=True,
                 block_number=block_number,
                 is_mev_reward=True,
             ), EvmEvent(

--- a/rotkehlchen/tests/utils/history_base_entry.py
+++ b/rotkehlchen/tests/utils/history_base_entry.py
@@ -166,6 +166,7 @@ def predefined_events_to_insert() -> list['HistoryBaseEntry']:
         timestamp=TimestampMS(1691693607000),
         balance=Balance(FVal('0.126419309459217215')),
         fee_recipient=string_to_evm_address('0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990'),
+        fee_recipient_tracked=True,
         block_number=15824493,
         is_mev_reward=False,
     )]


### PR DESCRIPTION
- All block events with sequence index 0 represent the block
production event and its block proposal fee. If the fee recipient is
not tracked then it's an info event
- All block events with sequence index 1, if existing, represent the
amount the MEV relayer claims the mev fee recipient earned. This is
always an info event as it does not represent actual transactions.
- All receive transactions in produced blocks with mev fee recipient
as receiver will be moved at sequence_index 2++ of the block event
identifier.
- We also need a DB upgrade that correctly sets info type to non
tracked fee recipient block events and also resets any sequence index > 1 events so the new logic can run and combine them properly.
- In the performance endpoint of eth staking the "execution" key of each individual validator and in the sums no longer exists. It's now split into two. "execution_blocks" and "execution_mev".
- When adding or removing an address we need to re-evaluate the
informational type of block production events.
- Update the accounting rules fixture logic for tests
- [[Hacky] Accounting rules updates are now forced.](https://github.com/rotki/rotki/pull/9382/commits/a2eac86c3182bec60253d21d6a13877f10489337) 
a2eac86
Related: https://github.com/rotki/data/pull/162
This forced update is only there to allow us editing the accounting
rules. With the current methodology there is no other way to do so.
Related TODO:
https://github.com/orgs/rotki/projects/11?pane=issue&itemId=96831912