### PR TITLE
Ignore deposit/withdrawal events in asset graphs

### DIFF
--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -1009,6 +1009,7 @@ class Coinbase(ExchangeInterface):
                         )
                     else:
                         fee = deserialize_fee(raw_fee['amount'])
+                        amount = AssetAmount(amount - fee)  # fee is deducted from withdrawal amount  # noqa: E501
 
             if 'network' in raw_data:
                 transaction_hash = get_key_if_has_val(raw_data['network'], 'hash')

--- a/rotkehlchen/tests/api/test_historical_balances.py
+++ b/rotkehlchen/tests/api/test_historical_balances.py
@@ -13,6 +13,7 @@ from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.types import (
     HistoryEventSubType,
@@ -72,6 +73,13 @@ def fixture_setup_historical_data(rotkehlchen_api_server: 'APIServer') -> None:
             asset=A_BTC,
             balance=Balance(amount=FVal('0.5')),
             notes='BTC partial spend',
+        ),
+        AssetMovement(  # AssetMovements should be ignored
+            timestamp=ts_sec_to_ms(Timestamp(START_TS + DAY_IN_SECONDS * 2)),
+            location=Location.COINBASE,
+            event_type=HistoryEventType.WITHDRAWAL,
+            asset=A_BTC,
+            balance=Balance(FVal('3')),
         ),
     ]
     with db.user_write() as write_cursor:
@@ -245,7 +253,7 @@ def test_get_historical_asset_amounts_over_time_with_negative_amount(
     assert len(result['times']) == len(result['values'])
     assert len(result['times']) == 2
 
-    assert result['last_event_identifier'] == [4, events[0].event_identifier]
+    assert result['last_event_identifier'] == [5, events[0].event_identifier]
     assert result['times'][0] == START_TS  # Initial timestamp
     assert result['times'][1] == START_TS + DAY_IN_SECONDS * 2  # First spend
     assert result['values'][0] == '2'  # Initial balance
@@ -303,7 +311,7 @@ def test_get_historical_assets_in_collection_amounts_over_time(
     assert len(result['times']) == len(result['values'])
     assert len(result['times']) == 2
 
-    assert result['last_event_identifier'] == [4, events[0].event_identifier]
+    assert result['last_event_identifier'] == [5, events[0].event_identifier]
     assert result['times'][0] == START_TS  # Initial timestamp
     assert result['times'][1] == START_TS + DAY_IN_SECONDS * 2  # First spend
     assert result['values'][0] == '2'  # Initial balance

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -477,7 +477,7 @@ def test_coinbase_query_history_events(
         event_type=HistoryEventType.WITHDRAWAL,
         timestamp=TimestampMS(1566726126000),
         asset=A_ETH,
-        balance=Balance(FVal('0.05770427')),
+        balance=Balance(FVal('0.05749427')),
         extra_data={
             'address': '0x6dcD6449dbCa615e40d696328209686eA95327b2',
             'transaction_id': '0x558bfa4d2a4ef598ddb92233459c00eda9e6c14cda75e6773b90208cb6938169',


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11?pane=issue&itemId=96697911
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=96493730

Two commits:
* Ignore deposit/withdrawal events in asset graphs
* Fix double count of coinbase withdrawal fees