### PR TITLE
Change the order querying bybit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 * :bug:`-` Some specific cases of yearn v2 vault deposit/withdrawals that had problems will now be decoded properly.
 * :bug:`-` Deleting an ethereum address will now remove the withdrawals cache for that address so re-adding it will now properly detect ethereum staking withdrawals again.
 * :bug:`-` Fix double count of cowswap fees.
+* :bug:`-` rotki will no longer exceed the two years limit when requesting trades from Bybit.
 * :bug:`-` Fix an error when merging two assets if they both appear at the same snapshot.
 * :bug:`-` Allow the rotki app to be minimized using the shortcut for each platform.
 * :bug:`-` Deleting Kusama, Polkadot, or Beaconchain RPC URL should now work properly again.

--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -332,13 +332,12 @@ class Bybit(ExchangeInterface):
         but we don't know when to stop querying into the past. What this function does is iterate
         over the 2 years period moving the queried frame in the maximum allowed time span, that is
         one week:
-        [end ts, end ts - 1 week] -> [end ts - 1w, end ts - 2w] -> ... [end ts - n*w, start ts]
+        [start_ts, start_ts + 1w] -> [start_ts + 1w, start_ts + 2w] ->...->[start_ts + n*w, end_ts]
 
         Since we have a clear limit to stop querying what we do is use the startTime/endTime keys
         to filter the data that we need.
         """
         new_trades: list[Trade] = []
-        upper_ts, lower_ts = end_ts, Timestamp(end_ts - WEEK_IN_SECONDS)
         if self.is_unified_account is True:
             # unified account can query up to 2 years into the past
             earliest_query_start_ts = Timestamp(ts_now() - DAY_IN_SECONDS * 365 * 2)
@@ -346,20 +345,22 @@ class Bybit(ExchangeInterface):
             # classic accounts can query 180 days into the past
             earliest_query_start_ts = Timestamp(ts_now() - DAY_IN_SECONDS * 180)
 
-        if end_ts <= earliest_query_start_ts:  # 0... start_ts ... end_ts ... earliest_query_start
-            return [], (start_ts, end_ts)  # entire query out of range. Bail
+        if end_ts <= earliest_query_start_ts:
+            return [], (start_ts, end_ts)  # entire query out of range
 
-        if start_ts <= earliest_query_start_ts:  # 0 ... start_ts ...  earliest_query_start ... end_ts  # noqa: E501
-            start_ts = Timestamp(earliest_query_start_ts + 60 * 5)  # margin of 5 minutes to avoid possible errors in case of delay  # noqa: E501
+        if start_ts <= earliest_query_start_ts:
+            start_ts = Timestamp(earliest_query_start_ts + 60 * 5)  # 5 minutes safety margin
+            lower_ts = start_ts
 
+        lower_ts, upper_ts = start_ts, Timestamp(start_ts + WEEK_IN_SECONDS)
         while True:
             raw_data = self._paginated_api_query(
                 endpoint='order/history',
                 options={
                     'category': 'spot',
+                    'startTime': str(ts_sec_to_ms(lower_ts)),
                     'endTime': str(ts_sec_to_ms(upper_ts)),
                     'limit': PAGINATION_LIMIT,
-                    'startTime': str(ts_sec_to_ms(lower_ts)),
                 },
             )
             for raw_trade in raw_data:
@@ -404,12 +405,12 @@ class Bybit(ExchangeInterface):
                 else:
                     new_trades.append(trade)
 
-            upper_ts = Timestamp(upper_ts - WEEK_IN_SECONDS)
-            lower_ts = Timestamp(lower_ts - WEEK_IN_SECONDS)
-            if upper_ts <= start_ts:
+            lower_ts = Timestamp(lower_ts + WEEK_IN_SECONDS)
+            upper_ts = Timestamp(upper_ts + WEEK_IN_SECONDS)
+            if lower_ts >= end_ts:
                 break
 
-            lower_ts = max(lower_ts, start_ts)  # don't query more than we need in last iteration
+            upper_ts = min(upper_ts, end_ts)  # don't query more than needed in last iteration
 
         return new_trades, (start_ts, end_ts)
 

--- a/rotkehlchen/tests/exchanges/test_bybit.py
+++ b/rotkehlchen/tests/exchanges/test_bybit.py
@@ -310,14 +310,35 @@ def test_assets_are_known(bybit_exchange: Bybit):
             test_warnings.warn(UserWarning(f'Found bybit pair that cannot be processed {ticker["symbol"]}'))  # noqa: E501
 
 
-def test_query_old_trades(bybit_exchange: Bybit) -> None:
-    """Check that we don't exceed the range that can be queried in bybit for trades"""
-    mock_fn = bybit_account_mock(is_unified=True, calls={
-        'order/history': [json.loads('{"nextPageCursor":"","category":"spot","list":[]}')] * 2,
-    })
+def test_query_trades_range(bybit_exchange: Bybit) -> None:
+    """Ensure that the correct ranges are requested when querying for trades in bybit.
+    First we query the oldest timestamp possible and we then query towards closer timestamps.
+    The query window is always 7 days.
+    """
+    range_calls = []
 
+    def mock_fn(path: str, options: dict[str, Any]) -> dict[str, Any]:
+        nonlocal range_calls
+        range_calls.append(((int(options['startTime'])) // 1000, int(options['endTime']) // 1000))
+        if (
+            options is not None and 'startTime' in options and
+            int(options['startTime']) < (ts_now() - DAY_IN_SECONDS * 365 * 2) * 1000
+        ):
+            # simulate an error on Bybit if we query a period of time that is older than the
+            # maximum allowed in the API
+            raise RemoteError(f'Invalid startTime provided: {options["startTime"]}')
+
+        return json.loads('{"nextPageCursor":"","category":"spot","list":[]}')
+
+    bybit_exchange.is_unified_account = True
     with patch.object(bybit_exchange, '_api_query', side_effect=mock_fn):
         bybit_exchange.query_online_trade_history(
-            start_ts=Timestamp(ts_now() - DAY_IN_SECONDS * 365 * 3),
-            end_ts=Timestamp(ts_now() - DAY_IN_SECONDS * 365 - DAY_IN_SECONDS * 360),
+            start_ts=Timestamp(0),
+            end_ts=(end_ts := Timestamp((now := ts_now()) - DAY_IN_SECONDS * 365)),
         )  # remoteError is raised if we don't properly query the logic
+
+    # oldest timestamp that can be queried (2 years) + 5 minutes of margin
+    oldest_plus_delta = now - DAY_IN_SECONDS * 365 * 2 + 60 * 5
+    assert range_calls[0] == (oldest_plus_delta, oldest_plus_delta + DAY_IN_SECONDS * 7)
+    assert range_calls[1][1] - range_calls[1][0] == DAY_IN_SECONDS * 7
+    assert range_calls[-1][1] == end_ts


### PR DESCRIPTION
Bybit allows to query at most 2 years of trades and you can query at most 7 days per request. We were using a sliding windows and querying from the closest timestamp to now towards the past. In slow scenarios this affected the actual time that we can query since the oldest timestamp after 7 minutes of queries is what we set initially + 7 mins and we weren't having into consideration this delay. There was a safety net of 5 mins but for some users it was exceeded.

To fix the issue now the query starts by querying the oldest possible timestamp first and goes towards the future. This prevents this issue with the time window moving.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
