### PR TITLE
Fix typo in the onboarding flow in the en.json locale

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1855,7 +1855,7 @@
   },
   "create_account": {
     "credentials": {
-      "description": "Remember that the user you create here is {highlight}, independent of the account create on the web.",
+      "description": "Remember that the user you create here is {highlight}, independent of the account created on the web.",
       "highlight": "only enabled in the application",
       "label_password": "Password",
       "label_password_backup_reminder": "rotki saves all user data locally. I understand that if I lose my password, I lose access to my data. I have created a backup of the password.",


### PR DESCRIPTION
This pull request updates the `frontend/app/src/locales/en.json` file to correct a grammatical error in the account creation description I noticed after installing the app.