### PR TITLE
Add db upgrade removing old accounting rules

### DIFF
--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -93,6 +93,7 @@ EVENT_CATEGORY_MAPPINGS = {  # possible combinations of types and subtypes mappe
         HistoryEventSubType.DEPOSIT_FOR_WRAPPED: {DEFAULT: EventCategory.STAKE_DEPOSIT},
         HistoryEventSubType.REWARD: {DEFAULT: EventCategory.STAKING_REWARD},
         HistoryEventSubType.REMOVE_ASSET: {DEFAULT: EventCategory.UNSTAKE},
+        HistoryEventSubType.REDEEM_WRAPPED: {DEFAULT: EventCategory.UNSTAKE},
         HistoryEventSubType.BLOCK_PRODUCTION: {DEFAULT: EventCategory.CREATE_BLOCK},
         HistoryEventSubType.MEV_REWARD: {DEFAULT: EventCategory.MEV_REWARD},
         HistoryEventSubType.FEE: {DEFAULT: EventCategory.FEE},

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -2964,6 +2964,11 @@ def test_upgrade_db_46_to_47(user_data_dir, messages_aggregator):
         result = cursor.execute('SELECT identifier, tx_hash, counterparty, product, address FROM evm_events_info').fetchall()  # noqa: E501
         assert result == []
 
+        assert cursor.execute(  # verify that all old counterparty specific rules for these types are removed  # noqa: E501
+            'SELECT counterparty FROM accounting_rules WHERE (type=? AND subtype=?) OR (type=? AND subtype=?)',  # noqa: E501
+            ('deposit', 'deposit asset', 'withdrawal', 'remove asset'),
+        ).fetchall() == [('NONE',), ('NONE',)]  # Keep the rules with null counterparty
+
     db.logout()
 
 


### PR DESCRIPTION
Remove old accounting rules via a db upgrade since the accounting rule updates don't support deletion yet as noted here: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=96831912

Only removes the counterparty specific rules - the base rules are still needed since `deposit asset` and `remove asset` are still being used sometimes.

Also adds the `STAKING/REDEEM_WRAPPED` combination. `STAKING/DEPOSIT_FOR_WRAPPED` is [being used for gmx](https://github.com/rotki/rotki/blob/develop/rotkehlchen/tests/unit/decoders/test_gmx.py#L234) - but not `REDEEM_WRAPPED`, so this wasn't added initially. But now we've added an [accounting rule for staking / redeem wrapped](https://github.com/rotki/data/blob/develop/updates/accounting_rules/v5.json#L59), which shows in the app with an unknown `Resulting combination` unless its defined here.