### PR TITLE
fix: fix incorrect usage of datetime.UTC

### DIFF
--- a/tools/profiling/trace.py
+++ b/tools/profiling/trace.py
@@ -22,7 +22,7 @@ class TraceProfiler:
         self.datadir = datadir
         self.profiling = True
 
-        now = datetime.datetime.now(tz=datetime.UTC)
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
         trace_file = f'{now:%Y%m%d_%H%M}_trace.pickle'
         trace_path = os.path.join(self.datadir, trace_file)
         self.trace_stream = open(trace_path, 'wb')  # noqa: SIM115  # we close at stop()


### PR DESCRIPTION
I noticed that in the code, there was an incorrect reference to `datetime.UTC` which doesn’t exist.
Instead, I’ve updated it to `datetime.timezone.utc`, which is the correct usage.