### PR TITLE
Add support for POST endpoints in beacon node & beaconcha.in APIs

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/eth2/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/constants.py
@@ -11,4 +11,4 @@ CPT_ETH2: Final = 'eth2'
 
 BEACONCHAIN_MAX_EPOCH: Final = 9223372036854775807  # This is INT64 MAX. Beacon node API actually returns 18446744073709551615 which is UINT64 MAX # noqa: E501
 
-DEFAULT_VALIDATOR_CHUNK_SIZE: Final = 80
+DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE: Final = 100  # Maximum number of validators allowed per beaconcha.in API request  # noqa: E501

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -83,7 +83,6 @@ def _prepare_clean_validators(rotkehlchen_api_server: 'APIServer') -> None:
 
 @pytest.mark.vcr(
     filter_query_parameters=['apikey'],
-    allow_playback_repeats=True,
     match_on=['beaconchain_matcher'],
 )
 @pytest.mark.freeze_time('2024-06-20 18:18:00 GMT')
@@ -313,10 +312,10 @@ def test_staking_performance(
             ]},
     )
     result = assert_proper_sync_response_with_result(response)
-    expected_withdrawals_str, expected_outstanding_consensus_str = '0.931083313', '0.012038559'
+    expected_withdrawals_str, expected_outstanding_consensus_str = '0.931083313', '0.004313006'
     # we don't compare directly the dict values because they come from the database and sqlite
     # handles REAL SUM in a non-accurate way to the decimal point, plus it differs between OSes.
-    expected_execution_blocks, expected_withdrawals, expected_outstanding_consensus, expected_apr = FVal('0.050711686670683926'), FVal(expected_withdrawals_str), FVal(expected_outstanding_consensus_str), FVal('0.0357145299327897914654288755952596541234774409066056206397907463329126771149047')  # noqa: E501
+    expected_execution_blocks, expected_withdrawals, expected_outstanding_consensus, expected_apr = FVal('0.050711686670683926'), FVal(expected_withdrawals_str), FVal(expected_outstanding_consensus_str), FVal('0.035473696762025140316173838831466687839186696867031144007246316068503435499705')  # noqa: E501
     expected_sum = expected_execution_blocks + expected_withdrawals + expected_execution_mev + expected_outstanding_consensus  # noqa: E501
     assert FVal(result['sums'].pop('execution_blocks')).is_close(expected_execution_blocks)
     assert FVal(result['sums'].pop('execution_mev')).is_close(expected_execution_mev)
@@ -335,7 +334,6 @@ def test_staking_performance(
 
 @pytest.mark.vcr(
     filter_query_parameters=['apikey'],
-    allow_playback_repeats=True,
     match_on=['beaconchain_matcher'],
 )
 @pytest.mark.parametrize('ethereum_accounts', [[
@@ -407,7 +405,7 @@ def test_staking_performance_filtering_pagination(
         assert get_balances.call_count == 1  # make sure cache works
 
     # now filter by validator state
-    active_validators, exited_validators = 180, 222
+    active_validators, exited_validators = 1, 401
     for status, expected_num in (('active', active_validators), ('exited', exited_validators)):
         response = requests.put(
             api_url_for(
@@ -867,7 +865,6 @@ def test_add_delete_validator_errors(
 
 @pytest.mark.vcr(
     filter_query_parameters=['apikey'],
-    allow_playback_repeats=True,
     match_on=['beaconchain_matcher'],
 )
 @pytest.mark.freeze_time('2024-02-04 00:00:00 GMT')
@@ -1073,7 +1070,8 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
         json={'group_by_event_ids': True},
     )
     result = assert_proper_sync_response_with_result(response)
-    assert len(result['entries']) == result['entries_found'] == result['entries_total'] == 7
+    assert len(result['entries']) == result['entries_found'] == 7
+    assert result['entries_total'] == 21
     event_identifier = None
     for entry in result['entries']:
         if entry['entry']['block_number'] == block_number:
@@ -1095,11 +1093,11 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
     )
     result = assert_proper_sync_response_with_result(response)
     assert len(result['entries']) == result['entries_found'] == 3
-    assert result['entries_total'] == 12
+    assert result['entries_total'] == 34
     for outer_entry in result['entries']:
         entry = outer_entry['entry']
         if entry['sequence_index'] == 0:
-            assert entry['identifier'] == 10
+            assert entry['identifier'] == 32
             assert entry['event_identifier'] == event_identifier
             assert entry['entry_type'] == 'eth block event'
             assert entry['event_type'] == 'informational'  # fee recipient not tracked
@@ -1107,7 +1105,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
             assert entry['validator_index'] == vindex1
             assert entry['amount'] == '0.126419309459217215'
         elif entry['sequence_index'] == 1:
-            assert entry['identifier'] == 11
+            assert entry['identifier'] == 33
             assert entry['event_identifier'] == event_identifier
             assert entry['entry_type'] == 'eth block event'
             assert entry['event_type'] == 'informational'
@@ -1194,7 +1192,6 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
 
 @pytest.mark.vcr(
     filter_query_parameters=['apikey'],
-    allow_playback_repeats=True,
     match_on=['beaconchain_matcher'],
 )
 @pytest.mark.freeze_time('2024-02-11 15:06:00 GMT')

--- a/rotkehlchen/tests/integration/test_eth2.py
+++ b/rotkehlchen/tests/integration/test_eth2.py
@@ -448,7 +448,7 @@ def test_details_with_beacon_node(eth2: 'Eth2'):
     """
     with patch(  # create the beacon node attribute
         'rotkehlchen.chain.ethereum.modules.eth2.beacon.BeaconNode.query',
-        new=lambda *args: {'version': 1},
+        new=lambda *args, **kwargs: {'version': 1},
     ):
         eth2.beacon_inquirer.set_rpc_endpoint('http://42.42.42.42:6969/')
 

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -163,7 +163,7 @@ def mock_query_validator_daily_stats(beaconchain: 'BeaconChain', network_mocking
 
     return patch.object(
         beaconchain.session,
-        'get',
+        'request',
         new=mock_query if network_mocking else requests.get,
     )
 

--- a/rotkehlchen/tests/utils/blockchain.py
+++ b/rotkehlchen/tests/utils/blockchain.py
@@ -207,7 +207,7 @@ def mock_beaconchain(
 
         return MockResponse(200, response)
 
-    return patch.object(beaconchain.session, 'get', wraps=mock_requests_get)
+    return patch.object(beaconchain.session, 'request', wraps=mock_requests_get)
 
 
 def mock_etherscan_query(

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -208,7 +208,7 @@ def patch_etherscan_request(etherscan, mock_data: dict[str, Any]):
 
 
 BEACONCHAIN_ETH1_CALL_RE = re.compile(r'https://beaconcha.in/api/v1/validator/eth1/(.*)')
-BEACONCHAIN_VALIDATOR_CALL_RE = re.compile(r'https://beaconcha.in/api/v1/validator/(.*)')
+BEACONCHAIN_VALIDATOR_CALL_RE = re.compile(r'https://beaconcha.in/api/v1/validator')
 BEACONCHAIN_OTHER_CALL_RE = re.compile(r'https://beaconcha.in/api/v1/validator/(.*)/(.*)')
 
 
@@ -232,9 +232,8 @@ def patch_eth2_requests(eth2, mock_data):
                 'validatorindex': entry[2],
             } for entry in validator_data]
 
-        elif (validator_match := BEACONCHAIN_VALIDATOR_CALL_RE.search(url)) is not None:
-            encoded_args = validator_match.group(1)
-            arg_len = len(encoded_args.split(','))
+        elif BEACONCHAIN_VALIDATOR_CALL_RE.search(url) is not None:
+            arg_len = len(kwargs['json']['indicesOrPubkey'].split(','))
             validator_data = mock_data.get('validator')
             assert len(validator_data) == arg_len, 'Mocked beaconchain validator response does not match arguments'  # noqa: E501
             response_data['data'] = validator_data
@@ -260,7 +259,7 @@ def patch_eth2_requests(eth2, mock_data):
         return MockResponse(200, json.dumps(response_data, separators=(',', ':')))
     return patch.object(
         eth2.beacon_inquirer.beaconchain.session,
-        'get',
+        'request',
         wraps=mock_beaconchain_query,
     )
 


### PR DESCRIPTION
Both beacon nodes and beaconcha.in now provide POST endpoints for validator queries:
- https://ethereum.github.io/beacon-APIs/#/Beacon/postStateValidators
- https://beaconcha.in/api/v1/docs/index.html#/Validator/post_api_v1_validator

This removes the URL length limit, allowing us to increase batch size from 80 to 100 validators per request.