### PR TITLE
Ensure that anon event logs don't break the decoding

### DIFF
--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -420,7 +420,7 @@ class EVMTransactionDecoder(ABC):
                 result = method(context)
             else:
                 result = method(context, *mapping_result[1:])
-        except (DeserializationError, ConversionError, UnknownAsset, WrongAssetType) as e:
+        except (DeserializationError, ConversionError, UnknownAsset, WrongAssetType, IndexError) as e:  # noqa: E501
             log.error(traceback.format_exc())
             self.msg_aggregator.add_error(
                 f'Decoding tx log with index {context.tx_log.log_index} of transaction '

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -436,6 +436,10 @@ class DBEvmTx:
                     (result[0],),
                 )
                 tx_receipt_log.topics = [x[0] for x in other_cursor]
+                if len(tx_receipt_log.topics) == 0:
+                    log.debug(f'Ignoring anonymous tx log in {tx_hash.hex()} at {chain_id}')
+                    continue
+
                 tx_receipt.logs.append(tx_receipt_log)
 
         return tx_receipt

--- a/rotkehlchen/tests/unit/decoders/test_eth2.py
+++ b/rotkehlchen/tests/unit/decoders/test_eth2.py
@@ -152,7 +152,7 @@ def test_deposit_with_anonymous_event(database, ethereum_inquirer, ethereum_acco
         ), EthDepositEvent(
             tx_hash=evmhash,
             validator_index=validator.validator_index,
-            sequence_index=432,
+            sequence_index=431,
             timestamp=timestamp,
             amount=FVal('32'),
             depositor=proxy_address,


### PR DESCRIPTION
Post decoding logic on several decoders wasn't handling the case of anon events
and this was making the decode logic fail. This commit:

1. Ensures that indexError is handled so the decoding logic doesn't break stopping the decoding of other transactions
2. Ensures that anon events aren't processed by the decoders to prevent indexing errors since we don't use them

Closes https://github.com/orgs/rotki/projects/11?pane=issue&itemId=97803880
