### PR TITLE
Improvements on binance

### DIFF
--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -56,6 +56,13 @@ class ExtraTxArgType(TypedDict):
     tx_hash: str  # using str instead of EVMTxHash because DB schema is in TEXT
 
 
+class BinancePairLastTradeArgsType(TypedDict):
+    """Type of kwargs, used to get the value of `DBCacheDynamic.LAST_CRYPTOTX_OFFSET`"""
+    location: str
+    location_name: str
+    queried_pair: str
+
+
 def _deserialize_int_from_str(value: str) -> int | None:
     return int(value)
 
@@ -75,6 +82,7 @@ class DBCacheDynamic(Enum):
     WITHDRAWALS_IDX: Final = 'ethwithdrawalsidx_{address}', _deserialize_int_from_str
     EXTRA_INTERNAL_TX: Final = f'{EXTRAINTERNALTXPREFIX}_{{chain_id}}_{{receiver}}_{{tx_hash}}', string_to_evm_address  # noqa: E501
     LAST_PRODUCED_BLOCKS_QUERY_TS: Final = 'last_produced_blocks_query_ts_{index}', _deserialize_timestamp_from_str  # noqa: E501
+    BINANCE_PAIR_LAST_ID: Final = '{location}_{location_name}_{queried_pair}', _deserialize_int_from_str  # noqa: E501  # notice that location is added because it can be either binance or binance_us
 
     @overload
     def get_db_key(self, **kwargs: Unpack[LabeledLocationArgsType]) -> str:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -42,6 +42,7 @@ from rotkehlchen.constants.misc import NFT_DIRECTIVE, USERDB_NAME
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.db.cache import (
     AddressArgType,
+    BinancePairLastTradeArgsType,
     DBCacheDynamic,
     DBCacheStatic,
     ExtraTxArgType,
@@ -703,6 +704,15 @@ class DBHandler:
     def get_dynamic_cache(
             self,
             cursor: 'DBCursor',
+            name: Literal[DBCacheDynamic.BINANCE_PAIR_LAST_ID],
+            **kwargs: Unpack[BinancePairLastTradeArgsType],
+    ) -> int | None:
+        ...
+
+    @overload
+    def get_dynamic_cache(
+            self,
+            cursor: 'DBCursor',
             name: Literal[DBCacheDynamic.LAST_QUERY_TS],
             **kwargs: Unpack[LabeledLocationIdArgsType],
     ) -> Timestamp | None:
@@ -794,6 +804,16 @@ class DBHandler:
             name: Literal[DBCacheDynamic.LAST_CRYPTOTX_OFFSET],
             value: int,
             **kwargs: Unpack[LabeledLocationArgsType],
+    ) -> None:
+        ...
+
+    @overload
+    def set_dynamic_cache(
+            self,
+            write_cursor: 'DBCursor',
+            name: Literal[DBCacheDynamic.BINANCE_PAIR_LAST_ID],
+            value: int,
+            **kwargs: Unpack[BinancePairLastTradeArgsType],
     ) -> None:
         ...
 

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -19,6 +19,7 @@ from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_binance
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
+from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.constants import BINANCE_MARKETS_KEY
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.ranges import DBQueryRanges
@@ -1125,6 +1126,11 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             end_ts: Timestamp,
     ) -> tuple[list[Trade], tuple[Timestamp, Timestamp]]:
         """
+        For trades coming from api/myTrades this function won't respect the provided range and
+        will always query all the trades until now. The reason is that binance forces us to query
+        all the pairs and we use the cache at BINANCE_PAIR_LAST_ID to remember which one was the
+        last trade queried on each market speeding up the queries. For fiat payments the time
+        range is respected.
 
         May raise due to api query and unexpected id:
         - RemoteError
@@ -1133,14 +1139,27 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
         self.first_connection()
         if self.selected_pairs is not None:
             iter_markets = list(set(self.selected_pairs).intersection(set(self._symbols_to_pair.keys())))  # noqa: E501
+            log.debug(f'Will query the following binance markets: {iter_markets}')
         else:
             iter_markets = list(self._symbols_to_pair.keys())
+            log.debug('Will query all the binance markets')
 
         raw_data = []
         # Limit of results to return. 1000 is max limit according to docs
         limit = 1000
         for symbol in iter_markets:
-            last_trade_id = 0
+            with self.db.conn.read_ctx() as cursor:
+                last_trade_id = self.db.get_dynamic_cache(  # api returns trades with id >= last_trade_id  # noqa: E501
+                    cursor=cursor,
+                    name=DBCacheDynamic.BINANCE_PAIR_LAST_ID,
+                    location=self.location.serialize(),
+                    location_name=self.name,
+                    queried_pair=symbol,
+                ) or 0
+
+            log.debug(
+                f'Will query binance trades on {self.name} for {symbol=} after {last_trade_id=}',
+            )
             len_result = limit
             while len_result == limit:
                 # We know that myTrades returns a list from the api docs
@@ -1170,9 +1189,11 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
 
             raw_data.sort(key=operator.itemgetter('time'))
 
-        trades = []
+        trades: list[Trade] = []
+        last_trade_by_pair: dict[str, Trade] = {}
         for raw_trade in raw_data:
             try:
+                trade_pair = raw_trade['symbol']
                 trade = trade_from_binance(
                     binance_trade=raw_trade,
                     binance_symbols_to_pair=self.symbols_to_pair,
@@ -1205,14 +1226,24 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                 )
                 continue
 
-            # Since binance does not respect the given timestamp range, limit the range here
-            if trade.timestamp < start_ts:
-                continue
-
-            if trade.timestamp > end_ts:
-                break
-
+            # trades are ordered in asc order by us
+            last_trade_by_pair[trade_pair] = trade
             trades.append(trade)
+
+        with self.db.conn.write_ctx() as write_cursor:
+            for symbol, trade in last_trade_by_pair.items():
+                if trade.link is None:
+                    log.error(f'Missing link field in binance trade {trade}')
+                    continue
+
+                self.db.set_dynamic_cache(
+                    write_cursor=write_cursor,
+                    name=DBCacheDynamic.BINANCE_PAIR_LAST_ID,
+                    value=int(trade.link),
+                    location=self.location.serialize(),
+                    location_name=self.name,
+                    queried_pair=symbol,
+                )
 
         fiat_payments = self._query_online_fiat_payments(start_ts=start_ts, end_ts=end_ts)
         if fiat_payments:

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -293,34 +293,37 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
             # Can't mock unknown assets in binance trade query since
             # only all known pairs are queried
             payload = '[]'
-            if params.get('symbol') == 'ETHBTC':
-                payload = """[{
-                "symbol": "ETHBTC",
-                "id": 1,
-                "orderId": 1,
-                "price": "0.0063213",
-                "qty": "5.0",
-                "commission": "0.005",
-                "commissionAsset": "ETH",
-                "time": 1512561941000,
-                "isBuyer": true,
-                "isMaker": false,
-                "isBestMatch": true
-                }]"""
-            elif params.get('symbol') == 'RDNETH':
-                payload = """[{
-                "symbol": "RDNETH",
-                "id": 2,
-                "orderId": 2,
-                "price": "0.0063213",
-                "qty": "5.0",
-                "commission": "0.005",
-                "commissionAsset": "RDN",
-                "time": 1512561942000,
-                "isBuyer": false,
-                "isMaker": false,
-                "isBestMatch": true
-                }]"""
+            # ensure that if the endpoint gets queried twice we don't return new trades.
+            # The first time it's always queried with fromId = 0
+            if params['fromId'] == 0:
+                if params.get('symbol') == 'ETHBTC':
+                    payload = """[{
+                    "symbol": "ETHBTC",
+                    "id": 1,
+                    "orderId": 1,
+                    "price": "0.0063213",
+                    "qty": "5.0",
+                    "commission": "0.005",
+                    "commissionAsset": "ETH",
+                    "time": 1512561941000,
+                    "isBuyer": true,
+                    "isMaker": false,
+                    "isBestMatch": true
+                    }]"""
+                elif params.get('symbol') == 'RDNETH':
+                    payload = """[{
+                    "symbol": "RDNETH",
+                    "id": 2,
+                    "orderId": 2,
+                    "price": "0.0063213",
+                    "qty": "5.0",
+                    "commission": "0.005",
+                    "commissionAsset": "RDN",
+                    "time": 1512561942000,
+                    "isBuyer": false,
+                    "isMaker": false,
+                    "isBestMatch": true
+                    }]"""
         elif (
                 'capital/deposit' in url or
                 'capital/withdraw' in url or


### PR DESCRIPTION
- This PR tracks the last trade id pulled from binance and doesn't query all the trades every time
~- Also reads the list of markets to query from the database instead of using an attribute. The reason is that it was being incorrectly processed by the logic and causing errors when querying some pairs only. The reason of the error is that each letter of the trade pair was being processed as single string instead of considering the whole string making the intersection that we check empty.~


```
[17/02/2025 17:11:57 CET] DEBUG rotkehlchen.exchanges.binance Greenlet-7: ["'['", '\'"\'', "'G'", "'M'", "'X'", "'U'", "'S'", "'D'", "'T'", '\'"\'', "']'"]
[17/02/2025 17:11:57 CET] DEBUG rotkehlchen.exchanges.binance Greenlet-7: ["'ETHBTC'"
``` 