### PR TITLE
improve bybit asset symbol resolver

### DIFF
--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -79,6 +79,10 @@ def bybit_symbol_to_base_quote(
         split_symbol = symbol.split('2L')
     elif '2S' in symbol:
         split_symbol = symbol.split('2S')
+    elif '3L' in symbol:
+        split_symbol = symbol.split('3L')
+    elif '3S' in symbol:
+        split_symbol = symbol.split('3S')
     elif '2' in symbol:
         split_symbol = symbol.split('2')
 


### PR DESCRIPTION
Fixes
![CleanShot 2025-02-18 at 15 40 34@2x](https://github.com/user-attachments/assets/041b1b6c-3771-48ea-9c48-0c930f4eb009)

Bybit has leverage pairs such as:
- BTC3L/USDT
- BTC3S/USDT

So this pr handles resolving them to BTC instead of throwing an error of no mapping found.