### PR TITLE
Remove the currencyconverter API

### DIFF
--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -2,8 +2,6 @@ from typing import Final
 
 from rotkehlchen.fval import FVal
 
-CURRENCYCONVERTER_API_KEY: Final = 'ecb823a26920906eafa3'
-
 ZERO: Final = FVal(0)
 ONE: Final = FVal(1)
 EXP18: Final = FVal(1e18)

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -63,7 +63,6 @@ from rotkehlchen.inquirer import (
     DEFAULT_RATE_LIMIT_WAITING_TIME,
     CurrentPriceOracle,
     Inquirer,
-    _query_currency_converterapi,
 )
 from rotkehlchen.interfaces import CurrentPriceOracleInterface
 from rotkehlchen.tests.conftest import TestEnvironment, requires_env
@@ -103,23 +102,6 @@ UNDERLYING_ASSET_PRICES = {
     A_CRV: FVal('10'),
     A_USD: FVal('1'),
 }
-
-
-@pytest.mark.skipif(
-    'CI' in os.environ,
-    reason='This test would contribute in rate limiting of these apis',
-)
-@pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_query_realtime_price_apis(inquirer):
-    """Query some of the exchange rates APIs we use.
-
-    For x-rates.com we already have a test in externalapis directory
-    """
-    result = _query_currency_converterapi(A_USD, A_EUR)
-    assert result and isinstance(result, FVal)
-    usd = A_USD.resolve_to_fiat_asset()
-    result = inquirer.query_historical_fiat_exchange_rates(usd, A_CNY, 1411603200)
-    assert result == FVal('6.133938')
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
They have removed the FREE api. We need another (hopefully multiple) backup APIs for fiat exchange rates.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
