### PR TITLE
fix: fix CLI command declaration typo

### DIFF
--- a/frontend/scripts/copy-data.ts
+++ b/frontend/scripts/copy-data.ts
@@ -162,7 +162,7 @@ function resolveDataDirectory(): string {
 
 const cli = cac();
 
-cli.command('[]', 'Copy data from the data folder to the develop_data folder')
+cli.command('', 'Copy data from the data folder to the develop_data folder')
   .option('--replace', 'Replaces the existing data in the develop_data folder with data from the data folder', {
     default: false,
   })


### PR DESCRIPTION
Noticed a typo in the CLI command declaration—square brackets `[]` were likely unintentional since `cac()` doesn't use this syntax. Updated it to an empty string `''`, which should be the correct way to define a command without arguments.  

**This fix prevents potential parsing issues or unexpected behavior.**