### PR TITLE
fix: dead links

### DIFF
--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
@@ -58,7 +58,7 @@ class SuperchainL1SideCommonBridgeDecoder(DecoderInterface, ABC):
 
         See:
              https://github.com/makerdao/optimism-dai-bridge
-             https://docs.optimism.io/builders/app-developers/bridging/custom-bridge
+             https://docs.optimism.io/app-developers/bridging/custom-bridge
         """
         if context.tx_log.topics[0] not in {
             ETH_DEPOSIT_INITIATED,

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
@@ -63,7 +63,7 @@ class SuperchainL2SideBridgeCommonDecoder(DecoderInterface, ABC):
 
         See:
              https://github.com/makerdao/optimism-dai-bridge
-             https://docs.optimism.io/builders/app-developers/bridging/custom-bridge
+             https://docs.optimism.io/app-developers/bridging/custom-bridge
         """
         if context.tx_log.topics[0] not in {DEPOSIT_FINALIZED, WITHDRAWAL_INITIATED}:
             return DEFAULT_DECODING_OUTPUT


### PR DESCRIPTION
Hey! I fixes dead links in the Superchain bridge decoder files. The original links pointing to Optimism's documentation for custom bridging were outdated and have been updated to the correct URLs.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
