### PR TITLE
fix: broken links

### DIFF
--- a/frontend/app/shared/README.md
+++ b/frontend/app/shared/README.md
@@ -2,4 +2,4 @@
 
 Utilities and logic shared between `main` and `renderer`.
 
-Only code that is shared between [src](./src) and [electron](./electron) should go here.
+Only code that is shared between [src](../src) and [electron](../electron) should go here.

--- a/frontend/app/src/data/psl.ts
+++ b/frontend/app/src/data/psl.ts
@@ -1,5 +1,5 @@
 // Public suffixes list
-// Source: https://github.com/lupomontero/psl/blob/main/data/rules.json
+// Source: https://github.com/lupomontero/psl/blob/main/data/rules.js
 import psl from '@/data/psl.json';
 
 export const pslSuffixes: Set<string> = new Set(psl.psl);

--- a/frontend/app/src/data/psl.ts
+++ b/frontend/app/src/data/psl.ts
@@ -1,5 +1,5 @@
 // Public suffixes list
-// Source: https://github.com/lupomontero/psl/blob/main/data/rules.js
+// Source: https://github.com/lupomontero/psl/blob/c445ac9c9ebe7a795335e11b1d4831c1bed8dbb2/data/rules.json
 import psl from '@/data/psl.json';
 
 export const pslSuffixes: Set<string> = new Set(psl.psl);


### PR DESCRIPTION
Hi! I fixes broken links in the repository. The outdated links in frontend/app/shared/README.md and frontend/app/src/data/psl.ts have been updated to point to the correct and current locations. 

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
