### PR TITLE
fix: typo and update user guide reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@ Closes #(issue_number)
 
 ## Checklist
 
-- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
+- [ ] The PR modified the frontend, and updated the [user guide](hhttps://docs.rotki.com/usage-guides/) to reflect the changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@ Closes #(issue_number)
 
 ## Checklist
 
-- [ ] The PR modified the frontend, and updated the [user guide](hhttps://docs.rotki.com/usage-guides/) to reflect the changes.
+- [ ] The PR modified the frontend, and updated the [user guide](https://docs.rotki.com/usage-guides/) to reflect the changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@ Closes #(issue_number)
 
 ## Checklist
 
-- [ ] The PR modified the frontend, and updated the [user guide](https://docs.rotki.com/usage-guides/) to reflect the changes.
+- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -939,7 +939,7 @@ class GlobalDBHandler:
                 # should not really happen since API should check for this
                 msg = (
                     f'Ethereum token with address {entry.evm_address} can not be put '
-                    f'in the DB due to asset with identifier {entry.identifier} dosent exist'
+                    f'in the DB due to asset with identifier {entry.identifier} doesnt exist'
                 )
             else:
                 msg = f'Ethereum token with identifier {entry.identifier} already exists in the DB'


### PR DESCRIPTION
This PR fixes typos in the repository. The changes include:

1. Correcting a typo in rotkehlchen/globaldb/handler.py (changed "dosent" to "doesn't").
2. Updating the link in .github/pull_request_template.md to point to the correct user guide location.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
