### PR TITLE
ci: bump linux image builder to ubuntu-22.04

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -287,7 +287,7 @@ jobs:
     needs: [ 'lint-backend', 'check-changes' ]
     uses: ./.github/workflows/task_backend_tests.yml
     with:
-      os: ubuntu-20.04
+      os: ubuntu-22.04
       test_environment: ${{needs.check-changes.outputs.test_environment}}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/task_backend_tests.yml
     if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     with:
-      os: ubuntu-20.04
+      os: ubuntu-22.04
       test_environment: nightly
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -111,7 +111,7 @@ jobs:
     env:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: create_draft
     permissions:
       id-token: write


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.
