### PR TITLE
ci: make docker meta not update latest and prefix tag with v

### DIFF
--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -497,6 +497,9 @@ jobs:
         with:
           images: |
             ${{ github.repository }}
+          flavor: |
+            latest=false
+            prefix=v,onlatest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

So here is the documentation:
https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input

and 
![image](https://github.com/user-attachments/assets/3ac6422e-317f-4061-9f4b-803975877752)

Tags were prefixed with v before so I added it again.