### PR TITLE
Bitcoin balance queries should work for linux binary again

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`9547` Bitcoin balance query should work again for users of the linux binary.
+
 * :release:`1.38.0 <2025-02-28>`
 * :bug:`-` Fix selected binance trading pairs not being properly loaded when restarting rotki.
 * :bug:`-` rotki will now skip balance queries for exited validators, reducing API rate limits and improving performance.

--- a/rotkehlchen/chain/bitcoin/ripemd160.py
+++ b/rotkehlchen/chain/bitcoin/ripemd160.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2021 Pieter Wuille
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""pure Python RIPEMD160 implementation.
+
+Probably here temporarily due to https://github.com/rotki/rotki/issues/9547
+
+"""
+
+# Message schedule indexes for the left path.
+ML = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8,
+    3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12,
+    1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2,
+    4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15, 13,
+]
+
+# Message schedule indexes for the right path.
+MR = [
+    5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12,
+    6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2,
+    15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13,
+    8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14,
+    12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14, 0, 3, 9, 11,
+]
+
+# Rotation counts for the left path.
+RL = [
+    11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8,
+    7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12,
+    11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5,
+    11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12,
+    9, 15, 5, 11, 6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6,
+]
+
+# Rotation counts for the right path.
+RR = [
+    8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6,
+    9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11,
+    9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5,
+    15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8,
+    8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11,
+]
+
+# K constants for the left path.
+KL = [0, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e]
+
+# K constants for the right path.
+KR = [0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0]
+
+
+def fi(x: int, y: int, z: int, i: int) -> int:
+    """The f1, f2, f3, f4, and f5 functions from the specification."""
+    if i == 0:
+        return x ^ y ^ z
+    elif i == 1:
+        return (x & y) | (~x & z)
+    elif i == 2:
+        return (x | ~y) ^ z
+    elif i == 3:
+        return (x & z) | (y & ~z)
+    elif i == 4:
+        return x ^ (y | ~z)
+
+    raise AssertionError('Should never happen')
+
+
+def rol(x: int, i: int) -> int:
+    """Rotate the bottom 32 bits of x left by i bits."""
+    return ((x << i) | ((x & 0xffffffff) >> (32 - i))) & 0xffffffff
+
+
+def compress(
+        h0: int, h1: int, h2: int, h3: int, h4: int, block: bytes,
+) -> tuple[int, int, int, int, int]:
+    """Compress state (h0, h1, h2, h3, h4) with block."""
+    # Left path variables.
+    al, bl, cl, dl, el = h0, h1, h2, h3, h4
+    # Right path variables.
+    ar, br, cr, dr, er = h0, h1, h2, h3, h4
+    # Message variables.
+    x = [int.from_bytes(block[4 * i:4 * (i + 1)], 'little') for i in range(16)]
+
+    # Iterate over the 80 rounds of the compression.
+    for j in range(80):
+        rnd = j >> 4
+        # Perform left side of the transformation.
+        al = rol(al + fi(bl, cl, dl, rnd) + x[ML[j]] + KL[rnd], RL[j]) + el
+        al, bl, cl, dl, el = el, al, bl, rol(cl, 10), dl
+        # Perform right side of the transformation.
+        ar = rol(ar + fi(br, cr, dr, 4 - rnd) + x[MR[j]] + KR[rnd], RR[j]) + er
+        ar, br, cr, dr, er = er, ar, br, rol(cr, 10), dr
+
+    # Compose old state, left transform, and right transform into new state.
+    return h1 + cl + dr, h2 + dl + er, h3 + el + ar, h4 + al + br, h0 + bl + cr
+
+
+def ripemd160(data: bytes) -> bytes:
+    """Compute the RIPEMD-160 hash of data."""
+    # Initialize state.
+    state = (0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0)
+    # Process full 64-byte blocks in the input.
+    for b in range(len(data) >> 6):
+        state = compress(*state, data[64 * b:64 * (b + 1)])
+    # Construct final blocks (with padding and size).
+    pad = b'\x80' + b'\x00' * ((119 - len(data)) & 63)
+    fin = data[len(data) & ~63:] + pad + (8 * len(data)).to_bytes(8, 'little')
+    # Process final blocks.
+    for b in range(len(fin) >> 6):
+        state = compress(*state, fin[64 * b:64 * (b + 1)])
+    # Produce output.
+    return b''.join((h & 0xffffffff).to_bytes(4, 'little') for h in state)

--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import platform
 from enum import Enum, auto
 from typing import Any
 
@@ -90,10 +91,16 @@ def is_valid_base58_address(value: str) -> bool:
     return value == base58check.b58encode(abytes).decode()
 
 
-def hash160(msg: bytes) -> bytes:
-    h = hashlib.new('ripemd160')
-    h.update(hashlib.sha256(msg).digest())
-    return h.digest()
+if platform.system() == 'Linux':
+    from .ripemd160 import ripemd160
+    def hash160(msg: bytes) -> bytes:
+        return ripemd160(hashlib.sha256(msg).digest())
+
+else:
+    def hash160(msg: bytes) -> bytes:
+        h = hashlib.new('ripemd160')
+        h.update(hashlib.sha256(msg).digest())
+        return h.digest()
 
 
 def _calculate_hash160_and_checksum(prefix: bytes, data: bytes) -> tuple[bytes, bytes]:

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -91,14 +91,14 @@ class RotkiDataUpdater:
             if min_version is not None:
                 p_min_version = pversion.parse(min_version)
                 if p_min_version > self.version:
-                    log.warning(f'Not updating {update_type.value} to {update_version=} due to {min_version=}')  # noqa: E501
+                    log.warning(f'Not updating {update_type.value} to {update_version=} due to {min_version=} and {self.version=}')  # noqa: E501
                     break  # stop iteration since all next versions will also hit this. User needs to update  # noqa: E501
 
             max_version = version_info.get('max_version', None)
             if max_version is not None:
                 p_max_version = pversion.parse(max_version)
                 if p_max_version < self.version:
-                    log.warning(f'Not updating {update_type.value} to {update_version=} due to {max_version=}')  # noqa: E501
+                    log.warning(f'Not updating {update_type.value} to {update_version=} due to {max_version=} and {self.version=}')  # noqa: E501
                     continue  # probably can never apply this update. Check next one
 
             file_url = f'https://raw.githubusercontent.com/rotki/data/{self.branch}/updates/{update_type.value}/v{update_version}.json'

--- a/rotkehlchen/tests/fixtures/__init__.py
+++ b/rotkehlchen/tests/fixtures/__init__.py
@@ -1,6 +1,7 @@
 from rotkehlchen.tests.fixtures.accounting import *  # noqa: F403
 from rotkehlchen.tests.fixtures.assets import *  # noqa: F403
 from rotkehlchen.tests.fixtures.blockchain import *  # noqa: F403
+from rotkehlchen.tests.fixtures.dataupdates import *  # noqa: F403
 from rotkehlchen.tests.fixtures.db import *  # noqa: F403
 from rotkehlchen.tests.fixtures.eth2 import *  # noqa: F403
 from rotkehlchen.tests.fixtures.exchanges import *  # noqa: F403

--- a/rotkehlchen/tests/fixtures/dataupdates.py
+++ b/rotkehlchen/tests/fixtures/dataupdates.py
@@ -1,0 +1,26 @@
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+from packaging.version import Version
+
+from rotkehlchen.db.updates import RotkiDataUpdater
+from rotkehlchen.utils.version_check import VersionCheckResult
+
+
+@pytest.fixture(name='our_version')
+def fixture_our_version():
+    """Allow mocking our rotki version since in CI version is 0 and hard to control"""
+    return None
+
+
+@pytest.fixture(name='data_updater')
+def fixture_data_updater(messages_aggregator, database, our_version):
+    """Initialize the DataUpdater object, optionally mocking our rotki version"""
+    with ExitStack() as stack:
+        if our_version is not None:
+            stack.enter_context(patch('rotkehlchen.db.updates.get_current_version', return_value=VersionCheckResult(our_version=Version(our_version))))  # noqa: E501
+        return RotkiDataUpdater(
+            msg_aggregator=messages_aggregator,
+            user_db=database,
+        )

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
@@ -13,7 +13,6 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.constants.misc import GLOBALDIR_NAME, ONE
 from rotkehlchen.db.constants import UpdateType
-from rotkehlchen.db.updates import RotkiDataUpdater
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.asset_updates.manager import AssetsUpdater
 from rotkehlchen.tests.fixtures.globaldb import create_globaldb
@@ -32,7 +31,7 @@ from rotkehlchen.types import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.updates import RotkiDataUpdater
     from rotkehlchen.globaldb.handler import GlobalDBHandler
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -450,10 +449,11 @@ def test_oracle_ids_in_asset_collections(globaldb: 'GlobalDBHandler'):
         pytest.fail('oracle IDs do not match:\n' + '\n'.join(mismatches))
 
 
+@pytest.mark.parametrize('our_version', ['1.38.0'])  # set latest version so data can be updated
 def test_remote_updates_consistency_with_packaged_db(
         tmpdir_factory: 'pytest.TempdirFactory',
         messages_aggregator: 'MessagesAggregator',
-        database: 'DBHandler',
+        data_updater: 'RotkiDataUpdater',
 ):
     """Test that the remote updates are consistent with the packaged db for:
     - Location asset mappings
@@ -470,8 +470,7 @@ def test_remote_updates_consistency_with_packaged_db(
         sql_vm_instructions_cb=0,
         messages_aggregator=messages_aggregator,
     )
-    rotki_updater = RotkiDataUpdater(msg_aggregator=messages_aggregator, user_db=database)
-    rotki_updater.check_for_updates(updates=[
+    data_updater.check_for_updates(updates=[
         UpdateType.LOCATION_ASSET_MAPPINGS,
         UpdateType.LOCATION_UNSUPPORTED_ASSETS,
     ])

--- a/rotkehlchen/tests/unit/test_data_updates.py
+++ b/rotkehlchen/tests/unit/test_data_updates.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
-from packaging.version import Version
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -28,7 +27,6 @@ from rotkehlchen.types import (
     Location,
     SupportedBlockchain,
 )
-from rotkehlchen.utils.version_check import VersionCheckResult
 
 if TYPE_CHECKING:
     from gevent import DBCursor
@@ -287,24 +285,6 @@ def make_mock_github_response(latest: int, min_version: str | None = None, max_v
         return MockResponse(200, json.dumps(result))
 
     return mock_github_response
-
-
-@pytest.fixture(name='our_version')
-def fixture_our_version():
-    """Allow mocking our rotki version since in CI version is 0 and hard to control"""
-    return None
-
-
-@pytest.fixture(name='data_updater')
-def fixture_data_updater(messages_aggregator, database, our_version):
-    """Initialize the DataUpdater object, optionally mocking our rotki version"""
-    with ExitStack() as stack:
-        if our_version is not None:
-            stack.enter_context(patch('rotkehlchen.db.updates.get_current_version', return_value=VersionCheckResult(our_version=Version(our_version))))  # noqa: E501
-        return RotkiDataUpdater(
-            msg_aggregator=messages_aggregator,
-            user_db=database,
-        )
 
 
 def reset_update_type_mappings(data_updater: RotkiDataUpdater) -> None:


### PR DESCRIPTION
Fix #9547

For now simply using a python only implementation by Pieter Wuille from bitcoin's repository:
https://github.com/bitcoin/bitcoin/blob/ad3e9e1f214d739e098c6ebbd300da5df1026a44/test/functional/test_framework/ripemd160.py
