### PR TITLE
Fix rate limiting handling for beaconchain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Prevents too many error notifications when beaconcha.in rate limits the app for long periods of time.
 * :bug:`-` Uniswap v3 swaps in ethereum using the universal router 2 will now be decoded properly.
 * :bug:`9547` Bitcoin balance query should work again for users of the linux binary.
 

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -552,6 +552,7 @@ class TaskManager:
         """Schedules the blocks production query if enough time has passed"""
         if (
             self.chains_aggregator.get_module('eth2') is None or
+            self.chains_aggregator.beaconchain.is_rate_limited() or
             self.chains_aggregator.beaconchain.produced_blocks_lock.locked() or
             len(indices := self.chains_aggregator.beaconchain.get_outdated_validators_to_query_for_blocks()) == 0  # noqa: E501
         ):


### PR DESCRIPTION
There were two things wrong:

- the retry logic was raising exception.RetryError for rate limits and 500 errors. Since those are errors that we handle manually I made it to not raise an exception in those cases.
- In the case of beaconchain to prevent requests to their API when we are rate limit I store the next timestamp when we can query and if we are before that moment I don't even try the request.
- The background task that checks for produced blocks won't fire if beaconchain is rate limited

