### PR TITLE
improve per-asset historical prices endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14149,7 +14149,8 @@ Historical Balance Queries
     :reqjsonarr integer interval: The time interval between price queries in seconds
     :reqjsonarr integer from_timestamp: The start timestamp of the query range
     :reqjsonarr integer to_timestamp: The end timestamp of the query range
-     :reqjson integer only_cache_period: (Optional) Time period in seconds around each timestamp to search for cached prices. If omitted, falls back to querying historical prices
+    :reqjsonarr integer exclude_timestamps: (Optional) List of timestamps to exclude from price queries.
+    :reqjson integer only_cache_period: (Optional) Time period in seconds around each timestamp to search for cached prices. If omitted, falls back to querying historical prices
     :reqjsonarr boolean async_query: (Optional) Whether to process the request asynchronously
 
     **Example Response:**
@@ -14167,13 +14168,15 @@ Historical Balance Queries
               "1672617600": "19500",
               "1672704000": "19800"
             },
-            "no_prices_timestamps": [1672790400, 1672876800]
+            "no_prices_timestamps": [1672790400, 1672876800],
+            "rate_limited_prices_timestamps": [1672790400, 1672876800]
           },
           "status_code": 200
         }
 
       :resjson object prices: Mapping of timestamps to price values in user's profit currency
       :resjson list[integer] no_prices_timestamps: List of timestamps where price data was not available
+      :resjson list[integer] rate_limited_prices_timestamps: List of timestamps where price queries were rate-limited by the data provider
       :statuscode 200: Historical prices returned
       :statuscode 400: Malformed query
       :statuscode 401: User is not logged in

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -3345,6 +3345,7 @@ class HistoricalPricesPerAssetResource(BaseMethodView):
             async_query: bool,
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
+            exclude_timestamps: set[Timestamp],
             only_cache_period: int | None = None,
     ) -> Response:
         return self.rest_api.get_historical_prices_per_asset(
@@ -3354,4 +3355,5 @@ class HistoricalPricesPerAssetResource(BaseMethodView):
             to_timestamp=to_timestamp,
             from_timestamp=from_timestamp,
             only_cache_period=only_cache_period,
+            exclude_timestamps=exclude_timestamps,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3870,6 +3870,7 @@ class HistoricalPricesPerAssetSchema(AsyncQueryArgumentSchema, TimestampRangeSch
         load_default=None,
         validate=webargs.validate.Range(min=1, error='Cache period must be a positive integer'),
     )
+    exclude_timestamps = fields.List(TimestampField(), load_default=list)
     asset = AssetField(expected_type=Asset, required=True)
 
     @validates_schema
@@ -3896,6 +3897,7 @@ class HistoricalPricesPerAssetSchema(AsyncQueryArgumentSchema, TimestampRangeSch
         - Rounds up `to_timestamp` to nearest multiple of interval
         """
         interval = data['interval']
+        data['exclude_timestamps'] = set(data['exclude_timestamps'])
         data['from_timestamp'] = (data['from_timestamp'] // interval) * interval
         data['to_timestamp'] = ((data['to_timestamp'] + interval - 1) // interval) * interval
 


### PR DESCRIPTION
- add `exclude_timestamps` to request.
- filter out future timestamps when generating timestamps
- separate between no prices found and ratelimit errors.