### PR TITLE
Fix incorrect file reference in merge log message

### DIFF
--- a/.github/scripts/merge-latest.mjs
+++ b/.github/scripts/merge-latest.mjs
@@ -24,7 +24,7 @@ function exitIfNotExists(file) {
 exitIfNotExists(file1);
 exitIfNotExists(file2);
 
-consola.info(`merging ${file1} and ${file3} to ${file3}`);
+consola.info(`merging ${file1} and ${file2} to ${file3}`);
 
 consola.info(`reading file: ${file1}`);
 const yaml1 = yaml.load(fs.readFileSync(file1, 'utf8'));


### PR DESCRIPTION
This pull request corrects an incorrect file reference in the log message of the merge-latest.mjs script. Previously, the message mistakenly referenced file3 twice instead of file2. This fix ensures accurate logging of the merge operation.

