### PR TITLE
Upgrade `coincurve` to version 21.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ content-hash==2.0.0
 rotki-pysqlcipher3==2024.10.1
 requests==2.32.3
 urllib3==2.3.0
-coincurve==20.0.0
+coincurve==21.0.0
 base58check==1.0.2
 bech32==1.2.0
 jsonschema==4.23.0


### PR DESCRIPTION
This upgrades `coincurve` to [v21.0.0](https://github.com/ofek/coincurve/releases/tag/v21.0.0) which brings performance improvements and removes all runtime dependencies!