### PR TITLE
chore: fix isinstance() type check syntax error

### DIFF
--- a/rotkehlchen/accounting/structures/balance.py
+++ b/rotkehlchen/accounting/structures/balance.py
@@ -54,7 +54,7 @@ class Balance:
         )
 
     def __mul__(self, other: Any) -> 'Balance':
-        if not isinstance(other, (int | FVal)):
+        if not isinstance(other, (int, FVal)):
             raise InputError(f'Tried to multiply balance with {type(other)}')
 
         return Balance(


### PR DESCRIPTION
Fixed a mistake in `isinstance()` where the `|` operator was used for type union:  

```python
if not isinstance(other, (int | FVal)):  # Incorrect
```  

The `|` operator is valid in type annotations starting from Python 3.9, but `isinstance()` requires a tuple of types. This caused a `SyntaxError` in Python <3.10 and a `TypeError` in newer versions.  

Now it's correct:  

```python
if not isinstance(other, (int, FVal)):  # Fixed
```