### PR TITLE
Correctly handle zero address in openocean

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` OpenOcean native token swaps should now be decoded correctly on chains where the native token is not ETH.
 * :feature:`9583` Allow sorting of the PnL reports table.
 * :bug:`-` Prevents too many error notifications when beaconcha.in rate limits the app for long periods of time.
 * :bug:`-` Uniswap v3 swaps in ethereum using the universal router 2 will now be decoded properly.


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11?pane=issue&itemId=100801423

On chains where ETH is the native token the token address in the openocean swap event is `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`, which is handled correctly by `get_or_create_evm_asset`, but on other chains, the address is simply a zero address when its the native token, which wasn't being handled.