### PR TITLE
Fix gnosispay data redecoding due to API bug

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Some Gnosis pay transactions that were missing merchant data should now redecode again properly.
 * :bug:`-` Fix error message in "Add transaction by tx hash" form is not reset.
 * :feature:`-` Allow user to filter by identifier in asset table, and asset dropdown.
 * :bug:`9586` Adding a new Bitpanda exchange account should now work correctly again.

--- a/rotkehlchen/externalapis/gnosispay.py
+++ b/rotkehlchen/externalapis/gnosispay.py
@@ -35,7 +35,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 # the seconds around a transaction to search for when querying the API
-GNOSIS_PAY_TX_TIMESTAMP_RANGE = 10
+GNOSIS_PAY_TX_TIMESTAMP_RANGE = 30
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
@@ -142,6 +142,7 @@ class GnosisPay:
                 log.debug(f'Ignoring gnosis pay data entry {data}')
                 return None  # only use Approved/Reversal for payments
 
+            log.debug(f'Deserializing gnosis pay transaction: {data}')
             if (city := data['merchant']['city'].rstrip()).startswith('+') or city.replace('-', '').isdigit():  # noqa: E501
                 city = None
             tx_currency_symbol = data['transactionCurrency']['symbol']
@@ -337,6 +338,7 @@ class GnosisPay:
             log.error(f'Could not query Gnosis Pay API due to {e!s}')
             return None
 
+        log.debug(f'Gnosis api query returned {len(data)} transactions')
         # since this may contain more transactions than the one we need dont
         # let the query go to waste and update data for all
         for entry in data:


### PR DESCRIPTION
So our logic is trying to redecode gnosis pay transactions by asking for the gnosis pay data -10 seconds and +10 seconds from the transaction hash.

For a very limited rare case of transactions that returned an empty list.

Which is a bug in the API of gnosis pay.

By increasing the range to -30 / + 30 it seems to return the transactions for the cases we tested that were missing. This also needs to be reported to gnosis pay API.

Also adding few more logs.