### PR TITLE
feat: update PnL report events to include entries_total

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6359,7 +6359,8 @@ Get saved events of a PnL Report
                 "type": "trade"
         }],
         "entries_found": 2,
-        "entries_limit": 1000
+        "entries_total": 10,
+        "entries_limit": 2
        },
        "message": ""
       }
@@ -6377,6 +6378,9 @@ Get saved events of a PnL Report
    :resjson int timestamp: The timestamp this event took place in.
    :resjson str type: The type of event. Can be any of the possible accounting event types.
    :resjson str group_id: Optional. Can be missing. An id signifying events that should be grouped together in the frontend. If missing no grouping needs to happen.
+   :resjson int entries_found: The number of entries found in the current query. This limited by the "limit" field and for free this is limited by FREE_PNL_EVENTS_LIMIT.
+   :resjson int entries_total: The total number of entries in the database for the requested report id, ignoring any filters.
+   :resjson int entries_limit: The limit of entries that can be returned.
 
    :statuscode 200: Report event data was successfully queried.
    :statuscode 400: Report id does not exist.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3663,9 +3663,10 @@ class RestAPI:
         if self.rotkehlchen.premium is None:
             with_limit = True
             entries_limit = FREE_PNL_EVENTS_LIMIT
+
         dbreports = DBAccountingReports(self.rotkehlchen.data.db)
         try:
-            report_data, entries_found = dbreports.get_report_data(
+            report_data, entries_found, entries_total = dbreports.get_report_data(
                 filter_=filter_query,
                 with_limit=with_limit,
             )
@@ -3678,6 +3679,7 @@ class RestAPI:
                 export_type=AccountingEventExportType.API,
             ) for x in report_data],
             'entries_found': entries_found,
+            'entries_total': entries_total,
             'entries_limit': entries_limit,
         }
         result_dict = _wrap_in_result(result, '')

--- a/rotkehlchen/tests/api/test_reports.py
+++ b/rotkehlchen/tests/api/test_reports.py
@@ -1,0 +1,149 @@
+from http import HTTPStatus
+
+import pytest
+import requests
+
+from rotkehlchen.accounting.constants import FREE_PNL_EVENTS_LIMIT
+from rotkehlchen.accounting.mixins.event import AccountingEventType
+from rotkehlchen.accounting.pnl import PNL
+from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
+from rotkehlchen.api.server import APIServer
+from rotkehlchen.constants import ONE, ZERO
+from rotkehlchen.constants.assets import A_DAI, A_ETH
+from rotkehlchen.db.reports import DBAccountingReports
+from rotkehlchen.db.settings import DBSettings
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.api import (
+    api_url_for,
+    assert_error_response,
+    assert_proper_response,
+)
+from rotkehlchen.tests.utils.constants import A_GBP
+from rotkehlchen.types import Location, Price, Timestamp
+from rotkehlchen.utils.misc import timestamp_to_date
+
+
+def setup_report_events(database) -> tuple[int, list[ProcessedAccountingEvent]]:
+    """Input events to the DB for testing"""
+    timestamp_1_secs, timestamp_2_secs, eth_price_ts_1, eth_price_ts_2, half_amount, hundred = Timestamp(1741634066), Timestamp(1741634100), FVal('2000'), FVal('2200'), FVal(0.5), FVal('100')  # noqa: E501
+    dbreport = DBAccountingReports(database)
+    settings = DBSettings(
+        main_currency=A_GBP,
+        calculate_past_cost_basis=False,
+        include_gas_costs=False,
+        pnl_csv_have_summary=False,
+        pnl_csv_with_formulas=True,
+        taxfree_after_period=15,
+    )
+
+    report_id = dbreport.add_report(
+        first_processed_timestamp=timestamp_1_secs,
+        start_ts=timestamp_1_secs,
+        end_ts=timestamp_2_secs,
+        settings=settings,
+    )
+
+    events = [
+        ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Received 1 ETH',
+            location=Location.ETHEREUM,
+            timestamp=timestamp_1_secs,
+            asset=A_ETH,
+            free_amount=ONE,
+            taxable_amount=ZERO,
+            price=Price(eth_price_ts_1),
+            pnl=PNL(free=ZERO, taxable=eth_price_ts_1),
+            cost_basis=None,
+            index=0,
+            extra_data={},
+        ), ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Send 0.5 ETH to 0xABC',
+            location=Location.ETHEREUM,
+            timestamp=timestamp_2_secs,
+            asset=A_ETH,
+            free_amount=ZERO,
+            taxable_amount=half_amount,
+            price=Price(eth_price_ts_2),
+            pnl=PNL(taxable=half_amount, free=ONE),
+            cost_basis=None,
+            index=1,
+            extra_data={},
+        ), ProcessedAccountingEvent(
+            event_type=AccountingEventType.TRANSACTION_EVENT,
+            notes='Received 100 DAI',
+            location=Location.ETHEREUM,
+            timestamp=timestamp_2_secs,
+            asset=A_DAI,
+            free_amount=hundred,
+            taxable_amount=ZERO,
+            price=Price(ONE),
+            pnl=PNL(taxable=ZERO, free=hundred),
+            cost_basis=None,
+            index=0,
+            extra_data={},
+        ),
+    ]
+
+    for event in events:
+        dbreport.add_report_data(
+            report_id=report_id,
+            time=event.timestamp,
+            ts_converter=timestamp_to_date,
+            event=event,
+        )
+
+    return report_id, events
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True, False])
+def test_get_report_data_with_premium(
+        rotkehlchen_api_server: APIServer,
+        start_with_valid_premium: bool,
+) -> None:
+    """Test that getting report data works correctly with premium subscription active"""
+    # First create a report and added events
+    report_id, events = setup_report_events(rotkehlchen_api_server.rest_api.rotkehlchen.data.db)
+
+    # Query report data with no filters
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'per_report_data_resource', report_id=report_id),
+    )
+    assert_proper_response(response)
+    data = response.json()
+    assert data['message'] == ''
+    assert 'entries' in data['result']
+    assert 'entries_found' in data['result']
+    assert 'entries_total' in data['result']
+    assert 'entries_limit' in data['result']
+    assert len(data['result']['entries']) == len(events)
+    assert data['result']['entries_found'] == len(events)
+    assert data['result']['entries_total'] == len(events)
+    assert data['result']['entries_limit'] == -1 if start_with_valid_premium else FREE_PNL_EVENTS_LIMIT  # noqa: E501
+
+    # Test pagination limits
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'per_report_data_resource', report_id=report_id),
+        json={'offset': 0, 'limit': 1},
+    )
+    assert_proper_response(response)
+    data = response.json()
+    assert len(data['result']['entries']) == 1
+    assert data['result']['entries_found'] == 1
+    assert data['result']['entries_total'] == len(events)
+    assert data['result']['entries_limit'] == -1 if start_with_valid_premium else FREE_PNL_EVENTS_LIMIT  # noqa: E501
+
+
+def test_get_report_data_invalid_report(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """Test that requesting invalid report ID is handled correctly"""
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'per_report_data_resource', report_id=1),
+    )
+    assert_error_response(
+        response=response,
+        contained_in_msg='Tried to get PnL events from non existing report with id 1',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )

--- a/rotkehlchen/tests/db/test_reports.py
+++ b/rotkehlchen/tests/db/test_reports.py
@@ -170,7 +170,7 @@ def test_report_events_sort_by_columns(database):
                 report_id=report_id,
             )
 
-            results, _ = dbreport.get_report_data(filter_=filter_query, with_limit=True)
+            results, _, _ = dbreport.get_report_data(filter_=filter_query, with_limit=True)
             for idx, event in enumerate(results):
                 field_value_fn = test_case['check_field']
                 field_value = field_value_fn(event)


### PR DESCRIPTION
Summary
The entries_found field returns all the events of a report id, this should return all the events that the query requested, e.g. if there is a limit its value should be the same as the limit. And the entries_total field should return the total number of events that this report id has.
Also added tests to the endpoint: `/reports/<int:report_id>/data` .