### PR TITLE
Paraswap fail and post decoding kaboom

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Users will be able to see the address of each account within an xpub.
+* :bug:`-` Failed paraswap v6 swaps will no longer fail to decode in rotki.
 
 * :release:`1.38.1 <2025-03-14>`
 * :feature:`9385` Users will see the default label using the validator index when exporting validators.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Users will be able to see the address of each account within an xpub.
+* :bug:`-` An exception in the last decoding step will no longer stop transaction decoding in rotki.
 * :bug:`-` Failed paraswap v6 swaps will no longer fail to decode in rotki.
 
 * :release:`1.38.1 <2025-03-14>`

--- a/rotkehlchen/chain/evm/decoding/paraswap/v6/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/v6/decoder.py
@@ -47,7 +47,7 @@ class Paraswapv6CommonDecoder(ParaswapCommonDecoder, ABC):
         """Decode Paraswap v6 swaps in post decoding
         since they don't have any relevant log event.
         """
-        if transaction.input_data[:4] not in PARASWAP_METHODS:
+        if transaction.input_data[:4] not in PARASWAP_METHODS or len(all_logs) == 0:  # length check is to protect due to all_logs[-1] below  # noqa: E501
             return decoded_events
 
         self._decode_swap(


### PR DESCRIPTION
### [Handle failed paraswap v6 swaps](https://github.com/rotki/rotki/commit/ac94bb86a6e83a3f27edbfaa32c6515e2ba8c728) 

If a paraswap v6 swap failed with out of gas then it was not decoded
at all by rotki and the entire decoding raised an error.

### [Handle decode_safely errors for post decoding](https://github.com/rotki/rotki/commit/3bd965ccc44f5caf7855d4d77e70a634d78ce548) 

If there was a post-decoding error the decode_safely function was
returning None which was not expected and stopped all decoding.

```
[17/03/2025 23:15:59 CET] ERROR rotkehlchen.greenlets.manager Greenlet with id 127599452434112: decode 5 base transactions died with exception: object of type 'NoneType' has no len().
Exception Name: <class 'TypeError'>
Exception Info: object of type 'NoneType' has no len()
Traceback:
   File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 687, in get_and_decode_undecoded_transactions
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 734, in decode_transaction_hashes
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 792, in _decode_transaction_hashes
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 869, in _get_or_decode_transaction_events
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 642, in _decode_transaction
```