### PR TITLE
Handle tokens in DXDAO placement orders

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`-` Users will be able to see the address of each account within an xpub.
 * :bug:`-` An exception in the last decoding step will no longer stop transaction decoding in rotki.
 * :bug:`-` Failed paraswap v6 swaps will no longer fail to decode in rotki.
+* :bug:`-` DXDAO orders will no longer fail to decode in rotki.
 * :bug:`-` Users should now be again able to edit the underlying tokens for any pool tokens.
 
 * :release:`1.38.1 <2025-03-14>`

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -13,6 +13,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress
 
 from .constants import CPT_DXDAO_MESA
@@ -145,8 +146,8 @@ class DxdaomesaDecoder(DecoderInterface):
             method_name='tokenIdToAddressMap',
             arguments=[[topic_data[1]], [topic_data[2]]],
         )  # The resulting addresses are non checksummed but they can be found in the DB
-        buy_token = self.base.get_or_create_evm_asset(result[0][0])
-        sell_token = self.base.get_or_create_evm_asset(result[1][0])
+        buy_token = self.base.get_or_create_evm_asset(deserialize_evm_address(result[0][0]))
+        sell_token = self.base.get_or_create_evm_asset(deserialize_evm_address(result[1][0]))
         buy_amount = asset_normalized_value(amount=log_data[3], asset=buy_token)
         sell_amount = asset_normalized_value(amount=log_data[4], asset=sell_token)
         event = self.base.make_event_from_transaction(

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional, Protocol
 
 import gevent
 from gevent.lock import Semaphore
+from web3.exceptions import Web3Exception
 
 from rotkehlchen.accounting.structures.types import ActionType
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
@@ -118,6 +119,7 @@ def decode_safely(
         IndexError,
         ValueError,
         ConversionError,
+        Web3Exception,
     ) as e:
         log.error(traceback.format_exc())
         error_prefix = f'Decoding of transaction {tx_hash.hex()} in {chain_id.to_name()}'


### PR DESCRIPTION
- We got this traceback

```
[18/03/2025 18:34:22 W. Europe Standard Time] ERROR rotkehlchen.api.rest Greenlet with id 1602880894272: Greenlet for task 248 dies with exception: ('web3.py only accepts checksum addresses. The software that gave you this non-checksum address should be considered unsafe, please file it as a bug on their platform. Try using an ENS name instead. Or, if you must accept lower safety, use Web3.to_checksum_address(lower_case_address).', '0xf6537fe0df7f0cc0985cf00792cc98249e73efa0').
Exception Name: <class 'web3.exceptions.InvalidAddress'>
Exception Info: ('web3.py only accepts checksum addresses. The software that gave you this non-checksum address should be considered unsafe, please file it as a bug on their platform. Try using an ENS name instead. Or, if you must accept lower safety, use Web3.to_checksum_address(lower_case_address).', '0xf6537fe0df7f0cc0985cf00792cc98249e73efa0')
Traceback:
   File "src\\gevent\\greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen\api\rest.py", line 461, in _do_query_async
  File "rotkehlchen\api\rest.py", line 3027, in decode_evm_transactions
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 687, in get_and_decode_undecoded_transactions
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 734, in decode_transaction_hashes
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 792, in _decode_transaction_hashes
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 869, in _get_or_decode_transaction_events
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 587, in _decode_transaction
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 464, in decode_by_address_rules
  File "rotkehlchen\chain\evm\decoding\decoder.py", line 113, in decode_safely
  File "rotkehlchen\chain\ethereum\modules\dxdaomesa\decoder.py", line 57, in _decode_events
  File "rotkehlchen\chain\ethereum\modules\dxdaomesa\decoder.py", line 148, in _decode_order_placement
  File "rotkehlchen\chain\evm\decoding\base.py", line 369, in get_or_create_evm_asset
  File "rotkehlchen\chain\evm\decoding\base.py", line 353, in get_or_create_evm_token
  File "rotkehlchen\assets\utils.py", line 318, in get_or_create_evm_token
  File "rotkehlchen\assets\utils.py", line 88, in _query_or_get_given_token_info
  File "rotkehlchen\chain\evm\node_inquirer.py", line 1262, in get_erc20_contract_info
  File "rotkehlchen\chain\evm\node_inquirer.py", line 1239, in _query_token_contract
  File "rotkehlchen\chain\evm\node_inquirer.py", line 1239, in <listcomp>
  File "rotkehlchen\chain\evm\contracts.py", line 93, in encode
  File "web3\eth\eth.py", line 664, in contract
  File "web3\contract\contract.py", line 429, in __init__
  File "web3\_utils\normalizers.py", line 264, in normalize_address
  File "web3\_utils\validation.py", line 186, in validate_address
```

- Also handles web3 exceptions in decode_safely

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
