### PR TITLE
chore: update frontend build stage to use node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM node:20-bookworm AS frontend-build-stage
+FROM --platform=$BUILDPLATFORM node:22-bookworm AS frontend-build-stage
 
 ARG BUILDARCH
 ENV CYPRESS_INSTALL_BINARY=0


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
