### PR TITLE
Fix historical price query RemoteError

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Getting historical prices for an asset graph should not fail with RemoteError anymore.
 * :bug:`-` Editing an AssetMovement with a reference should now work fine again.
 * :bug:`-` Users will be able to see the address of each account within an xpub.
 * :bug:`-` An exception in the last decoding step will no longer stop transaction decoding in rotki.

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -432,6 +432,7 @@ class APIServer:
             f'start rotki api {request.method} {request.path}',
             view_args=request.view_args,
             query_string=request.query_string,
+            json_data=request.json if request.is_json else None,
         )
 
     @staticmethod

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -3920,12 +3920,12 @@ class HistoricalPricesPerAssetSchema(AsyncQueryArgumentSchema, TimestampRangeSch
         """Align timestamps to interval boundaries.
 
         - Rounds down `from_timestamp` to nearest multiple of interval
-        - Rounds up `to_timestamp` to nearest multiple of interval
+        - Rounds up `to_timestamp` to nearest multiple of interval but also makes
+        sure it's not in the future
         """
         interval = data['interval']
         data['from_timestamp'] = (data['from_timestamp'] // interval) * interval
-        data['to_timestamp'] = ((data['to_timestamp'] + interval - 1) // interval) * interval
-
+        data['to_timestamp'] = min(((data['to_timestamp'] + interval - 1) // interval) * interval, ts_now())  # noqa: E501
         return data
 
 


### PR DESCRIPTION
There was an uncaught RemoteError due to the `can_query_history()` of the uniswap oracle actually making remote calls which can raise.

I handled it by making sure that it's all handled inside the `can_query_history()` and it just returns true/false
