### PR TITLE
refactor: merge individual history event properties

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -2,6 +2,7 @@
 import type { AddressData, BlockchainAccount } from '@/types/blockchain/accounts';
 import type {
   AddTransactionHashPayload,
+  EventData,
   HistoryEvent,
   HistoryEventEntry,
   HistoryEventRequestPayload,
@@ -27,7 +28,6 @@ import { useHistoryEvents } from '@/composables/history/events';
 import { useHistoryEventMappings } from '@/composables/history/events/mapping';
 import { useHistoryTransactions } from '@/composables/history/events/tx';
 import { useHistoryTransactionDecoding } from '@/composables/history/events/tx/decoding';
-import { useCommonTableProps } from '@/composables/use-common-table-props';
 import { usePaginationFilters } from '@/composables/use-pagination-filter';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useConfirmStore } from '@/store/confirm';
@@ -96,9 +96,8 @@ const {
   validators,
 } = toRefs(props);
 
-const nextSequence = ref<string>();
+const formData = ref<EventData>();
 const selectedGroupHeader = ref<HistoryEvent>();
-const selectedGroupEvents = ref<HistoryEvent[]>();
 const eventWithMissingRules = ref<HistoryEventEntry>();
 const accounts = ref<BlockchainAccount<AddressData>[]>([]);
 const locationOverview = ref(get(location));
@@ -177,8 +176,6 @@ const highlightedIdentifiers = computed<string[] | undefined>(() => {
 
   return highlightedIdentifier ? [highlightedIdentifier as string] : undefined;
 });
-
-const { editableItem, openDialog } = useCommonTableProps<HistoryEventEntry>();
 
 const {
   fetchData,
@@ -311,18 +308,7 @@ async function forceRedecodeEvmEvents(data: PullEvmTransactionPayload): Promise<
 
 function showForm(payload: ShowEventHistoryForm): void {
   if (payload.type === 'event') {
-    const {
-      event,
-      eventsInGroup,
-      group,
-      nextSequenceId,
-    } = payload.data;
-
-    set(selectedGroupHeader, group);
-    set(editableItem, event);
-    set(nextSequence, nextSequenceId);
-    set(selectedGroupEvents, eventsInGroup);
-    set(openDialog, true);
+    set(formData, payload.data);
   }
   else {
     const { event, group } = payload.data;
@@ -555,11 +541,7 @@ onUnmounted(() => {
       </HistoryEventsTable>
 
       <HistoryEventFormDialog
-        v-model:open="openDialog"
-        :editable-item="editableItem"
-        :group-header="selectedGroupHeader"
-        :next-sequence="nextSequence"
-        :group-events="selectedGroupEvents"
+        v-model="formData"
         @refresh="fetchAndRedecodeEvents()"
       />
 

--- a/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
@@ -10,9 +10,9 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'refresh'): void;
-  (e: 'show:form', payload: ShowEventForm): void;
-  (e: 'show:add-transaction-form'): void;
+  'refresh': [];
+  'show:form': [payload: ShowEventForm];
+  'show:add-transaction-form': [];
 }>();
 
 const { t } = useI18n();

--- a/frontend/app/src/components/history/events/forms/EthWithdrawalEventForm.vue
+++ b/frontend/app/src/components/history/events/forms/EthWithdrawalEventForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { EthWithdrawalEvent, NewEthWithdrawalEventPayload } from '@/types/history/events';
+import type { EthWithdrawalEvent, EventData, NewEthWithdrawalEventPayload } from '@/types/history/events';
 import HistoryEventAssetPriceForm from '@/components/history/events/forms/HistoryEventAssetPriceForm.vue';
 import AmountInput from '@/components/inputs/AmountInput.vue';
 import AutoCompleteWithSearchSync from '@/components/inputs/AutoCompleteWithSearchSync.vue';
@@ -18,20 +18,18 @@ import dayjs from 'dayjs';
 import { isEmpty } from 'es-toolkit/compat';
 
 interface EthWithdrawalEventFormProps {
-  editableItem?: EthWithdrawalEvent;
-  groupHeader?: EthWithdrawalEvent;
+  data?: EventData<EthWithdrawalEvent>;
 }
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
 const props = withDefaults(defineProps<EthWithdrawalEventFormProps>(), {
-  editableItem: undefined,
-  groupHeader: undefined,
+  data: undefined,
 });
 
 const { t } = useI18n();
 
-const { editableItem, groupHeader } = toRefs(props);
+const { data } = toRefs(props);
 
 const assetPriceForm = ref<InstanceType<typeof HistoryEventAssetPriceForm>>();
 
@@ -51,7 +49,7 @@ const rules = {
   eventIdentifier: {
     required: helpers.withMessage(
       t('transactions.events.form.event_identifier.validation.non_empty'),
-      requiredIf(() => !!get(editableItem)),
+      requiredIf(() => !!get(data)?.event),
     ),
   },
   timestamp: { externalServerValidation: () => true },
@@ -139,7 +137,7 @@ async function save(): Promise<boolean> {
     withdrawalAddress: get(withdrawalAddress),
   };
 
-  const edit = get(editableItem);
+  const edit = get(data)?.event;
 
   return await saveHistoryEventHandler(
     edit ? { ...payload, identifier: edit.identifier } : payload,
@@ -150,12 +148,13 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const editable = get(editableItem);
+  const formData = get(data);
+  const editable = formData?.event;
   if (editable) {
     applyEditableData(editable);
     return;
   }
-  const group = get(groupHeader);
+  const group = formData?.group;
   if (group) {
     applyGroupHeaderData(group);
     return;
@@ -163,7 +162,7 @@ function checkPropsData() {
   reset();
 }
 
-watch([groupHeader, editableItem], checkPropsData);
+watch(data, checkPropsData);
 onMounted(() => {
   checkPropsData();
 });

--- a/frontend/app/src/types/history/events/index.ts
+++ b/frontend/app/src/types/history/events/index.ts
@@ -322,14 +322,16 @@ export interface ShowMissingRuleForm {
   };
 }
 
+export interface EventData<T extends HistoryEvent = HistoryEvent> {
+  group?: T;
+  event?: T;
+  nextSequenceId?: string;
+  eventsInGroup?: T[];
+}
+
 export interface ShowEventForm {
   readonly type: 'event';
-  readonly data: {
-    group?: HistoryEvent;
-    event?: HistoryEvent;
-    nextSequenceId?: string;
-    eventsInGroup?: HistoryEvent[];
-  };
+  readonly data: EventData;
 }
 
 export type ShowEventHistoryForm = ShowEventForm | ShowMissingRuleForm;

--- a/frontend/app/tests/unit/specs/components/history/events/eth-block-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/eth-block-event-form.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@/store/balances/prices', () => ({
   }),
 }));
 
-describe('ethBlockEventForm.vue', () => {
+describe('forms/EthBlockEventForm.vue', () => {
   let wrapper: VueWrapper<InstanceType<typeof EthBlockEventForm>>;
   let pinia: Pinia;
 
@@ -31,7 +31,7 @@ describe('ethBlockEventForm.vue', () => {
     assets: { [asset.symbol]: asset },
   };
 
-  const groupHeader: EthBlockEvent = {
+  const group: EthBlockEvent = {
     identifier: 11336,
     entryType: HistoryEventEntryType.ETH_BLOCK_EVENT,
     eventIdentifier: 'BP1_444',
@@ -77,8 +77,8 @@ describe('ethBlockEventForm.vue', () => {
       ...options,
     });
 
-  describe('should prefill the fields based on the props', () => {
-    it('no `groupHeader`, nor `editableItem` are passed', async () => {
+  describe('should prefill the fields based on the prop', () => {
+    it('should show the default state when opening the form without any data', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
 
@@ -91,21 +91,21 @@ describe('ethBlockEventForm.vue', () => {
       expect((wrapper.find('[data-cy=isMevReward] input').element as HTMLInputElement).checked).toBeFalsy();
     });
 
-    it('`groupHeader` are passed', async () => {
+    it('should update the relevant fields when the `group` property is updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader });
+      await wrapper.setProps({ data: { group } });
 
       expect((wrapper.find('[data-cy=blockNumber] input').element as HTMLInputElement).value).toBe(
-        groupHeader.blockNumber.toString(),
+        group.blockNumber.toString(),
       );
 
       expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
+        group.validatorIndex.toString(),
       );
 
       expect((wrapper.find('[data-cy=feeRecipient] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
@@ -113,25 +113,25 @@ describe('ethBlockEventForm.vue', () => {
       expect((wrapper.find('[data-cy=isMevReward] input').element as HTMLInputElement).checked).toBeFalsy();
     });
 
-    it('`groupHeader` and `editableItem` are passed', async () => {
+    it('should update the fields when the `group` and `event` properties are updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, editableItem: groupHeader });
+      await wrapper.setProps({ data: { group, event: group } });
 
       expect((wrapper.find('[data-cy=blockNumber] input').element as HTMLInputElement).value).toBe(
-        groupHeader.blockNumber.toString(),
+        group.blockNumber.toString(),
       );
 
       expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
+        group.validatorIndex.toString(),
       );
 
       expect((wrapper.find('[data-cy=feeRecipient] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
+        group.amount.toString(),
       );
 
       expect((wrapper.find('[data-cy=isMevReward] input').element as HTMLInputElement).checked).toBeTruthy();

--- a/frontend/app/tests/unit/specs/components/history/events/eth-deposit-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/eth-deposit-event-form.spec.ts
@@ -35,7 +35,7 @@ describe('ethDepositEventForm.vue', () => {
     assets: { [asset.symbol]: asset },
   };
 
-  const groupHeader: EthDepositEvent = {
+  const group: EthDepositEvent = {
     identifier: 11344,
     entryType: HistoryEventEntryType.ETH_DEPOSIT_EVENT,
     eventIdentifier: '10x3849ac4b278cac18f0e52a7d1a1dc1c14b1b4f50d6c11087e9a6591fd7b62d08',
@@ -84,7 +84,7 @@ describe('ethDepositEventForm.vue', () => {
     });
 
   describe('should prefill the fields based on the props', () => {
-    it('no `groupHeader`, `editableItem`, nor `nextSequence` are passed', async () => {
+    it('should show the default state when opening the form without any data', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
 
@@ -102,26 +102,26 @@ describe('ethDepositEventForm.vue', () => {
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value).toBe('0');
     });
 
-    it('`groupHeader` and `nextSequence` are passed', async () => {
+    it('should update when data contains a `group` and a `nextSequenceId` property', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, nextSequence: '10' });
+      await wrapper.setProps({ data: { group, nextSequenceId: '10' } });
 
       await wrapper.find('[data-cy=eth-deposit-event-form__advance] .accordion__header').trigger('click');
       vi.advanceTimersToNextTimer();
 
       expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
+        group.validatorIndex.toString(),
       );
 
-      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(groupHeader.txHash);
+      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(group.txHash);
 
       expect((wrapper.find('[data-cy=eventIdentifier] input').element as HTMLInputElement).value).toBe(
-        groupHeader.eventIdentifier,
+        group.eventIdentifier,
       );
 
       expect((wrapper.find('[data-cy=depositor] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
@@ -129,34 +129,34 @@ describe('ethDepositEventForm.vue', () => {
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value).toBe('10');
     });
 
-    it('`groupHeader`, `editableItem`, and `nextSequence` are passed', async () => {
+    it('it should update the fields when all properties in data are updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, editableItem: groupHeader });
+      await wrapper.setProps({ data: { group, event: group } });
 
       await wrapper.find('[data-cy=eth-deposit-event-form__advance] .accordion__header').trigger('click');
       vi.advanceTimersToNextTimer();
 
       expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
+        group.validatorIndex.toString(),
       );
 
-      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(groupHeader.txHash);
+      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(group.txHash);
 
       expect((wrapper.find('[data-cy=eventIdentifier] input').element as HTMLInputElement).value).toBe(
-        groupHeader.eventIdentifier,
+        group.eventIdentifier,
       );
 
       expect((wrapper.find('[data-cy=depositor] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
+        group.amount.toString(),
       );
 
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value.replace(',', '')).toBe(
-        groupHeader.sequenceIndex.toString(),
+        group.sequenceIndex.toString(),
       );
     });
   });

--- a/frontend/app/tests/unit/specs/components/history/events/eth-withdrawal-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/eth-withdrawal-event-form.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@/store/balances/prices', () => ({
   }),
 }));
 
-describe('ethWithdrawalEventForm.vue', () => {
+describe('forms/EthWithdrawalEventForm.vue', () => {
   let wrapper: VueWrapper<InstanceType<typeof EthWithdrawalEventForm>>;
   let pinia: Pinia;
 
@@ -31,7 +31,7 @@ describe('ethWithdrawalEventForm.vue', () => {
     assets: { [asset.symbol]: asset },
   };
 
-  const groupHeader: EthWithdrawalEvent = {
+  const group: EthWithdrawalEvent = {
     identifier: 11343,
     entryType: HistoryEventEntryType.ETH_WITHDRAWAL_EVENT,
     eventIdentifier: 'EW_123_19647',
@@ -77,7 +77,7 @@ describe('ethWithdrawalEventForm.vue', () => {
     });
 
   describe('should prefill the fields based on the props', () => {
-    it('no `groupHeader`, nor `editableItem` are passed', async () => {
+    it('should show the default state when opening the form without any data', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
 
@@ -88,17 +88,17 @@ describe('ethWithdrawalEventForm.vue', () => {
       expect((wrapper.find('[data-cy=isExited] input').element as HTMLInputElement).checked).toBeFalsy();
     });
 
-    it('`groupHeader` passed', async () => {
+    it('should update the fields when `group` updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader });
+      await wrapper.setProps({ data: { group } });
 
       expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
+        group.validatorIndex.toString(),
       );
 
       expect((wrapper.find('[data-cy=withdrawalAddress] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
@@ -106,21 +106,21 @@ describe('ethWithdrawalEventForm.vue', () => {
       expect((wrapper.find('[data-cy=isExited] input').element as HTMLInputElement).checked).toBeFalsy();
     });
 
-    it('`groupHeader` and `editableItem` are passed', async () => {
+    it('it should update the fields when all properties in data are updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, editableItem: groupHeader });
+      await wrapper.setProps({ data: { group, event: group } });
 
       expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
+        group.validatorIndex.toString(),
       );
 
       expect((wrapper.find('[data-cy=withdrawalAddress] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
+        group.amount.toString(),
       );
 
       expect((wrapper.find('[data-cy=isExited] input').element as HTMLInputElement).checked).toBeTruthy();

--- a/frontend/app/tests/unit/specs/components/history/events/evm-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/evm-event-form.spec.ts
@@ -22,7 +22,7 @@ vi.mock('@/store/balances/prices', () => ({
   }),
 }));
 
-describe('evmEventForm.vue', () => {
+describe('forms/EvmEventForm.vue', () => {
   let wrapper: VueWrapper<InstanceType<typeof EvmEventForm>>;
   let pinia: Pinia;
 
@@ -38,7 +38,7 @@ describe('evmEventForm.vue', () => {
     assets: { [asset.symbol]: asset },
   };
 
-  const groupHeader: EvmHistoryEvent = {
+  const group: EvmHistoryEvent = {
     identifier: 14344,
     eventIdentifier: '10x4ba949779d936631dc9eb68fa9308c18de51db253aeea919384c728942f95ba9',
     sequenceIndex: 2411,
@@ -90,7 +90,7 @@ describe('evmEventForm.vue', () => {
     });
 
   describe('should prefill the fields based on the props', () => {
-    it('no `groupHeader`, `editableItem`, nor `nextSequence` are passed', async () => {
+    it('should show the default state when opening the form without any data', async () => {
       wrapper = createWrapper();
       await vi.advanceTimersToNextTimerAsync();
 
@@ -103,19 +103,19 @@ describe('evmEventForm.vue', () => {
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value).toBe('0');
     });
 
-    it('`groupHeader` and `nextSequence` are passed', async () => {
+    it('should update the proper fields when `group` and `nextSequenceId` are updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, nextSequence: '10' });
+      await wrapper.setProps({ data: { group, nextSequenceId: '10' } });
 
-      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(groupHeader.txHash);
+      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(group.txHash);
 
       expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.address,
+        group.address,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
@@ -127,37 +127,37 @@ describe('evmEventForm.vue', () => {
       ).toBe('');
     });
 
-    it('`groupHeader`, `editableItem`, and `nextSequence` are passed', async () => {
+    it('it should update the fields when all properties in data are updated', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, editableItem: groupHeader, nextSequence: '10' });
+      await wrapper.setProps({ data: { group, event: group, nextSequenceId: '10' } });
 
-      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(groupHeader.txHash);
+      expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(group.txHash);
 
       expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.address,
+        group.address,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
+        group.amount.toString(),
       );
 
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value.replace(',', '')).toBe(
-        groupHeader.sequenceIndex.toString(),
+        group.sequenceIndex.toString(),
       );
 
       expect(
         (wrapper.find('[data-cy=notes] textarea:not([aria-hidden="true"])').element as HTMLTextAreaElement).value,
-      ).toBe(groupHeader.notes);
+      ).toBe(group.notes);
     });
   });
 
   it('should show all eventTypes options correctly', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { historyEventTypesData } = useHistoryEventMappings();
@@ -166,7 +166,7 @@ describe('evmEventForm.vue', () => {
   });
 
   it('should show all eventSubTypes options correctly', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { historyEventSubTypesData } = useHistoryEventMappings();
@@ -177,7 +177,7 @@ describe('evmEventForm.vue', () => {
   });
 
   it('should show all counterparties options correctly', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { counterparties } = useHistoryEventCounterpartyMappings();
@@ -186,7 +186,7 @@ describe('evmEventForm.vue', () => {
   });
 
   it('should show correct eventSubtypes options, based on selected eventType and counterparty', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { historyEventTypeGlobalMapping } = useHistoryEventMappings();
@@ -209,7 +209,7 @@ describe('evmEventForm.vue', () => {
   });
 
   it('should show product options, based on selected counterparty', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     expect(wrapper.find('[data-cy=product]').attributes('disabled')).toBe('true');

--- a/frontend/app/tests/unit/specs/components/history/events/online-history-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/online-history-event-form.spec.ts
@@ -32,7 +32,7 @@ describe('onlineHistoryEventForm.vue', () => {
     assets: { [asset.symbol]: asset },
   };
 
-  const groupHeader: OnlineHistoryEvent = {
+  const group: OnlineHistoryEvent = {
     identifier: 449,
     entryType: HistoryEventEntryType.HISTORY_EVENT,
     eventIdentifier: 'STJ6KRHJYGA',
@@ -90,15 +90,17 @@ describe('onlineHistoryEventForm.vue', () => {
     it('`groupHeader` and `nextSequence` are passed', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, nextSequence: '10' });
+      await wrapper.setProps({
+        data: { group, nextSequenceId: '10' },
+      });
       vi.advanceTimersToNextTimer();
 
       expect((wrapper.find('[data-cy=eventIdentifier] input').element as HTMLInputElement).value).toBe(
-        groupHeader.eventIdentifier,
+        group.eventIdentifier,
       );
 
       expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
@@ -113,33 +115,35 @@ describe('onlineHistoryEventForm.vue', () => {
     it('`groupHeader`, `editableItem`, and `nextSequence` are passed', async () => {
       wrapper = createWrapper();
       vi.advanceTimersToNextTimer();
-      await wrapper.setProps({ groupHeader, editableItem: groupHeader, nextSequence: '10' });
+      await wrapper.setProps({
+        data: { group, event: group, nextSequenceId: '10' },
+      });
       vi.advanceTimersToNextTimer();
 
       expect((wrapper.find('[data-cy=eventIdentifier] input').element as HTMLInputElement).value).toBe(
-        groupHeader.eventIdentifier,
+        group.eventIdentifier,
       );
 
       expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
+        group.locationLabel,
       );
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
+        group.amount.toString(),
       );
 
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value.replace(',', '')).toBe(
-        groupHeader.sequenceIndex.toString(),
+        group.sequenceIndex.toString(),
       );
 
       expect(
         (wrapper.find('[data-cy=notes] textarea:not([aria-hidden="true"])').element as HTMLTextAreaElement).value,
-      ).toBe(groupHeader.notes);
+      ).toBe(group.notes);
     });
   });
 
   it('should show all eventTypes options correctly', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { historyEventTypesData } = useHistoryEventMappings();
@@ -148,7 +152,7 @@ describe('onlineHistoryEventForm.vue', () => {
   });
 
   it('should show all eventSubTypes options correctly', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { historyEventSubTypesData } = useHistoryEventMappings();
@@ -159,7 +163,7 @@ describe('onlineHistoryEventForm.vue', () => {
   });
 
   it('should show correct eventSubtypes options, based on selected eventType', async () => {
-    wrapper = createWrapper({ props: { groupHeader } });
+    wrapper = createWrapper({ props: { groupHeader: group } });
     vi.advanceTimersToNextTimer();
 
     const { historyEventTypeGlobalMapping } = useHistoryEventMappings();


### PR DESCRIPTION
The properties are always related and updated together. There is no reason to pass them separately.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
