### PR TITLE
Bugfixes/9157

### DIFF
--- a/frontend/app/src/components/calendar/CalendarDateNavigator.vue
+++ b/frontend/app/src/components/calendar/CalendarDateNavigator.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import DateTimePicker from '@/components/inputs/DateTimePicker.vue';
-import { DateFormat } from '@/types/date-format';
-import { convertFromTimestamp, convertToTimestamp } from '@/utils/date';
 import dayjs, { type Dayjs } from 'dayjs';
 
 const model = defineModel<Dayjs>({ required: true });
@@ -18,22 +16,26 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const datePicker = ref();
-const datetime = ref<string>('0');
 
-watch(
-  model,
-  (model) => {
-    set(datetime, convertFromTimestamp(get(model).unix()));
+const datetime = computed<number | null>({
+  get: () => {
+    const modelValue = get(model);
+    return modelValue ? modelValue.valueOf() : null;
   },
-  {
-    immediate: true,
+  set: (timestamp: number | null) => {
+    if (timestamp) {
+      set(model, dayjs(timestamp));
+    }
+    else {
+      set(model, null);
+    }
   },
-);
+});
 
 function goToSelectedDate() {
-  const timestamp = convertToTimestamp(get(datetime), DateFormat.DateMonthYearHourMinuteSecond, true);
-
-  set(model, dayjs(timestamp));
+  if (get(datetime)) {
+    set(model, dayjs(get(datetime)));
+  }
 }
 </script>
 
@@ -46,7 +48,7 @@ function goToSelectedDate() {
       :disabled="visibleDate.isSame(today, 'day')"
       @click="emit('set-today')"
     >
-      {{ t('calendar.today') }}
+      {{ t("calendar.today") }}
     </RuiButton>
     <RuiMenu wrapper-class="h-full">
       <template #activator="{ attrs }">

--- a/frontend/app/src/components/display/DateDisplay.vue
+++ b/frontend/app/src/components/display/DateDisplay.vue
@@ -27,9 +27,7 @@ const { dateDisplayFormat } = storeToRefs(useGeneralSettingsStore());
 const { shouldShowAmount } = storeToRefs(useSessionSettingsStore());
 
 const dateFormat = computed<string>(() => {
-  const display = get(showTimezone)
-    ? get(dateDisplayFormat)
-    : get(dateDisplayFormat).replace('%z', '').replace('%Z', '').trim();
+  const display = get(showTimezone) ? get(dateDisplayFormat) : get(dateDisplayFormat).replace('%z', '').replace('%Z', '').trim();
 
   if (get(noTime))
     return display.split(' ')[0];

--- a/frontend/app/src/components/history/trades/ExternalTradeForm.vue
+++ b/frontend/app/src/components/history/trades/ExternalTradeForm.vue
@@ -80,16 +80,10 @@ const rules = {
     required: helpers.withMessage(t('external_trade_form.validation.non_empty_base'), required),
   },
   fee: {
-    required: helpers.withMessage(
-      t('external_trade_form.validation.non_empty_fee'),
-      requiredIf(refIsTruthy(feeCurrency)),
-    ),
+    required: helpers.withMessage(t('external_trade_form.validation.non_empty_fee'), requiredIf(refIsTruthy(feeCurrency))),
   },
   feeCurrency: {
-    required: helpers.withMessage(
-      t('external_trade_form.validation.non_empty_fee_currency'),
-      requiredIf(refIsTruthy(feeModel)),
-    ),
+    required: helpers.withMessage(t('external_trade_form.validation.non_empty_fee_currency'), requiredIf(refIsTruthy(feeModel))),
   },
   quoteAmount: { externalServerValidation },
   quoteAsset: {
@@ -112,14 +106,10 @@ const states = {
   timestamp: datetime,
 };
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-  },
-);
+const v$ = useVuelidate(rules, states, {
+  $autoDirty: true,
+  $externalResults: errors,
+});
 
 useFormStateWatcher(states, stateUpdated);
 
@@ -128,13 +118,9 @@ function triggerFeeValidator() {
   get(feeCurrencyInput)?.autoCompleteInput?.validate(true);
 }
 
-const quoteHint = computed<string>(() =>
-  get(type) === 'buy' ? t('external_trade_form.buy_quote') : t('external_trade_form.sell_quote'),
-);
+const quoteHint = computed<string>(() => (get(type) === 'buy' ? t('external_trade_form.buy_quote') : t('external_trade_form.sell_quote')));
 
-const shouldRenderSummary = computed<boolean>(
-  () => !!(get(type) && get(base) && get(quote) && get(amountModel) && get(rateModel)),
-);
+const shouldRenderSummary = computed<boolean>(() => !!(get(type) && get(base) && get(quote) && get(amountModel) && get(rateModel)));
 
 const fetching = useIsTaskRunning(TaskType.FETCH_HISTORIC_PRICE);
 
@@ -178,7 +164,7 @@ function onQuoteAmountChange() {
     set(rate, get(numericQuoteAmount).div(get(amount)));
 }
 
-watch([datetime, quote, base], async () => {
+watch([timestamp, quote, base], async () => {
   await fetchPrice();
 });
 
@@ -206,7 +192,7 @@ defineExpose({
     class="external-trade-form"
   >
     <DateTimePicker
-      v-model="datetime"
+      v-model="timestamp"
       limit-now
       data-cy="date"
       :label="t('common.datetime')"
@@ -306,7 +292,7 @@ defineExpose({
           keypath="external_trade_form.summary.buy"
         >
           <template #label>
-            <strong>{{ t('external_trade_form.summary.label') }}</strong>
+            <strong>{{ t("external_trade_form.summary.label") }}</strong>
           </template>
           <template #amount>
             <strong>
@@ -337,7 +323,7 @@ defineExpose({
           keypath="external_trade_form.summary.sell"
         >
           <template #label>
-            <strong>{{ t('external_trade_form.summary.label') }}</strong>
+            <strong>{{ t("external_trade_form.summary.label") }}</strong>
           </template>
           <template #amount>
             <strong>

--- a/frontend/app/src/components/price-manager/historic/HistoricPriceForm.vue
+++ b/frontend/app/src/components/price-manager/historic/HistoricPriceForm.vue
@@ -8,7 +8,6 @@ import DateTimePicker from '@/components/inputs/DateTimePicker.vue';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useFormStateWatcher } from '@/composables/form';
 import { bigNumberifyFromRef } from '@/utils/bignumbers';
-import { convertFromTimestamp, convertToTimestamp } from '@/utils/date';
 import { useRefPropVModel } from '@/utils/model';
 import { toMessages } from '@/utils/validation';
 import useVuelidate from '@vuelidate/core';
@@ -33,13 +32,6 @@ const fromAsset = useRefPropVModel(modelValue, 'fromAsset');
 const toAsset = useRefPropVModel(modelValue, 'toAsset');
 const price = useRefPropVModel(modelValue, 'price');
 const timestamp = useRefPropVModel(modelValue, 'timestamp');
-
-const datetime = computed({
-  get: () => convertFromTimestamp(get(timestamp)),
-  set: (value: string) => {
-    set(timestamp, convertToTimestamp(value));
-  },
-});
 
 const fromAssetSymbol = assetSymbol(fromAsset);
 const toAssetSymbol = assetSymbol(toAsset);
@@ -66,15 +58,11 @@ const rules = {
 const states = {
   fromAsset,
   price,
-  timestamp: datetime,
+  timestamp,
   toAsset,
 };
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
+const v$ = useVuelidate(rules, states, { $autoDirty: true, $externalResults: errors });
 
 useFormStateWatcher(states, stateUpdated);
 
@@ -102,7 +90,7 @@ defineExpose({
       />
     </div>
     <DateTimePicker
-      v-model="datetime"
+      v-model="timestamp"
       :label="t('common.datetime')"
       :disabled="editMode"
       :error-messages="toMessages(v$.timestamp)"

--- a/frontend/app/src/components/profitloss/ReportGenerator.vue
+++ b/frontend/app/src/components/profitloss/ReportGenerator.vue
@@ -3,7 +3,6 @@ import type { ProfitLossReportPeriod } from '@/types/reports';
 import RangeSelector from '@/components/helper/date/RangeSelector.vue';
 import CardTitle from '@/components/typography/CardTitle.vue';
 import { Routes } from '@/router/routes';
-import { convertToTimestamp } from '@/utils/date';
 
 const emit = defineEmits<{
   (e: 'generate', data: ProfitLossReportPeriod): void;
@@ -13,25 +12,19 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const range = ref({ end: '', start: '' });
+const range = ref<{ start: number | null; end: number | null }>({ end: null, start: null });
+
 const valid = ref<boolean>(false);
-
-const startTimestamp = computed<number>(() => convertToTimestamp(get(range).start));
-
-const endTimestamp = computed<number>(() => convertToTimestamp(get(range).end));
 
 function generate() {
   emit('generate', {
-    end: get(endTimestamp),
-    start: get(startTimestamp),
+    end: range.value.end,
+    start: range.value.start,
   });
 }
 
 function exportReportData() {
-  emit('export-data', {
-    end: get(endTimestamp),
-    start: get(startTimestamp),
-  });
+  emit('export-data', { end: range.value.end, start: range.value.start });
 }
 
 function importReportData() {
@@ -46,7 +39,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
     <template #custom-header>
       <div class="flex justify-between px-4 py-2">
         <CardTitle>
-          {{ t('common.actions.generate') }}
+          {{ t("common.actions.generate") }}
         </CardTitle>
         <RuiTooltip
           :popper="{ placement: 'top' }"
@@ -63,7 +56,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
               </RuiButton>
             </RouterLink>
           </template>
-          <span>{{ t('profit_loss_report.settings_tooltip') }}</span>
+          <span>{{ t("profit_loss_report.settings_tooltip") }}</span>
         </RuiTooltip>
       </div>
     </template>
@@ -84,7 +77,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
             <template #prepend>
               <RuiIcon name="lu-scroll-text" />
             </template>
-            {{ t('common.actions.generate') }}
+            {{ t("common.actions.generate") }}
           </RuiButton>
         </div>
         <div>
@@ -101,7 +94,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
                 <template #prepend>
                   <RuiIcon name="lu-bug" />
                 </template>
-                {{ t('profit_loss_reports.debug.title') }}
+                {{ t("profit_loss_reports.debug.title") }}
               </RuiButton>
             </template>
             <div class="py-2">
@@ -112,7 +105,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
                 <template #prepend>
                   <RuiIcon name="lu-file-down" />
                 </template>
-                {{ t('profit_loss_reports.debug.export_data') }}
+                {{ t("profit_loss_reports.debug.export_data") }}
               </RuiButton>
               <RuiButton
                 variant="list"
@@ -121,7 +114,7 @@ const accountSettingsRoute = Routes.SETTINGS_ACCOUNTING;
                 <template #prepend>
                   <RuiIcon name="lu-file-up" />
                 </template>
-                {{ t('profit_loss_reports.debug.import_data') }}
+                {{ t("profit_loss_reports.debug.import_data") }}
               </RuiButton>
             </div>
           </RuiMenu>

--- a/frontend/app/src/components/profitloss/ReportHeader.vue
+++ b/frontend/app/src/components/profitloss/ReportHeader.vue
@@ -15,13 +15,13 @@ defineProps<{
   >
     <template #start>
       <DateDisplay
-        :timestamp="period.start"
+        :timestamp="period.start ?? 0"
         class="font-medium"
       />
     </template>
     <template #end>
       <DateDisplay
-        :timestamp="period.end"
+        :timestamp="period.end ?? 0"
         class="font-medium"
       />
     </template>

--- a/frontend/app/src/components/profitloss/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/components/profitloss/ReportProfitLossEventAction.vue
@@ -7,7 +7,6 @@ import DateTimePicker from '@/components/inputs/DateTimePicker.vue';
 import { useAssetPricesApi } from '@/composables/api/assets/prices';
 import { useBalancePricesStore } from '@/store/balances/prices';
 import { useMessageStore } from '@/store/message';
-import { convertFromTimestamp } from '@/utils/date';
 import { toMessages } from '@/utils/validation';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
@@ -39,7 +38,7 @@ async function openEditHistoricPriceDialog() {
   set(fetchingPrice, false);
 }
 
-const datetime = computed<string>(() => convertFromTimestamp(get(event).timestamp));
+const datetime = computed<number>(() => get(event).timestamp);
 
 const { t } = useI18n();
 
@@ -105,7 +104,7 @@ async function updatePrice() {
           <template #prepend>
             <RuiIcon name="lu-pencil-line" />
           </template>
-          {{ t('profit_loss_events.edit_historic_price') }}
+          {{ t("profit_loss_events.edit_historic_price") }}
         </RuiButton>
       </div>
     </RuiMenu>
@@ -116,7 +115,7 @@ async function updatePrice() {
     >
       <RuiCard>
         <template #header>
-          {{ t('profit_loss_events.edit_historic_price') }}
+          {{ t("profit_loss_events.edit_historic_price") }}
         </template>
 
         <form class="flex flex-col gap-4">
@@ -151,7 +150,7 @@ async function updatePrice() {
         </form>
 
         <div class="text-body-2 text-rui-text-secondary">
-          {{ t('profit_loss_events.edit_price_warning') }}
+          {{ t("profit_loss_events.edit_price_warning") }}
         </div>
 
         <template #footer>
@@ -161,13 +160,13 @@ async function updatePrice() {
             color="primary"
             @click="showDialog = false"
           >
-            {{ t('common.actions.cancel') }}
+            {{ t("common.actions.cancel") }}
           </RuiButton>
           <RuiButton
             color="primary"
             @click="updatePrice()"
           >
-            {{ t('price_form.update_price') }}
+            {{ t("price_form.update_price") }}
           </RuiButton>
         </template>
       </RuiCard>

--- a/frontend/app/src/pages/reports/index.vue
+++ b/frontend/app/src/pages/reports/index.vue
@@ -72,8 +72,11 @@ async function generate(period: ProfitLossReportPeriod) {
   if (get(pinned)?.name === 'report-actionable-card')
     set(pinned, null);
 
-  const formatDate = (timestamp: number) =>
-    displayDateFormatter.format(new Date(timestamp * 1000), get(dateDisplayFormat));
+  const formatDate = (timestamp: number | null) => {
+    if (timestamp === null)
+      return '';
+    return displayDateFormatter.format(new Date(timestamp * 1000), get(dateDisplayFormat));
+  };
 
   const reportId = await generateReport(period);
 
@@ -114,6 +117,10 @@ async function generate(period: ProfitLossReportPeriod) {
 const { setMessage } = useMessageStore();
 
 async function exportData({ end, start }: ProfitLossReportPeriod) {
+  if (start === null || end === null) {
+    throw new Error('start and end values cannot be null');
+  }
+
   const payload: ProfitLossReportDebugPayload = {
     fromTimestamp: start,
     toTimestamp: end,
@@ -134,9 +141,7 @@ async function exportData({ end, start }: ProfitLossReportPeriod) {
 
     if (appSession) {
       message = {
-        description: result
-          ? t('profit_loss_reports.debug.export_message.success')
-          : t('profit_loss_reports.debug.export_message.failure'),
+        description: result ? t('profit_loss_reports.debug.export_message.success') : t('profit_loss_reports.debug.export_message.failure'),
         success: !!result,
         title: t('profit_loss_reports.debug.export_message.title'),
       };
@@ -174,9 +179,7 @@ async function importData() {
 
   try {
     const path = getPath(file);
-    const { taskId } = path
-      ? await importReportData(path)
-      : await uploadReportData(file);
+    const { taskId } = path ? await importReportData(path) : await uploadReportData(file);
 
     const { result } = await awaitTask<boolean, TaskMeta>(taskId, taskType, {
       title: t('profit_loss_reports.debug.import_message.title'),
@@ -240,7 +243,7 @@ const progress = computed(() => reportsStore.progress);
           class="mt-2"
           @click="clearError()"
         >
-          {{ t('common.actions.close') }}
+          {{ t("common.actions.close") }}
         </RuiButton>
       </template>
     </ErrorScreen>
@@ -259,9 +262,9 @@ const progress = computed(() => reportsStore.progress);
         >
           {{ processingState }}
         </div>
-        {{ t('profit_loss_report.loading_message') }}
+        {{ t("profit_loss_report.loading_message") }}
       </template>
-      {{ t('profit_loss_report.loading_hint') }}
+      {{ t("profit_loss_report.loading_hint") }}
     </ProgressScreen>
     <RuiDialog
       v-model="importDataDialog"
@@ -269,7 +272,7 @@ const progress = computed(() => reportsStore.progress);
     >
       <RuiCard>
         <template #header>
-          {{ t('profit_loss_reports.debug.import_data_dialog.title') }}
+          {{ t("profit_loss_reports.debug.import_data_dialog.title") }}
         </template>
         <FileUpload
           ref="reportDebugDataUploader"
@@ -284,7 +287,7 @@ const progress = computed(() => reportsStore.progress);
             color="primary"
             @click="importDataDialog = false"
           >
-            {{ t('common.actions.cancel') }}
+            {{ t("common.actions.cancel") }}
           </RuiButton>
           <RuiButton
             color="primary"
@@ -292,7 +295,7 @@ const progress = computed(() => reportsStore.progress);
             :loading="importDataLoading"
             @click="importData()"
           >
-            {{ t('common.actions.import') }}
+            {{ t("common.actions.import") }}
           </RuiButton>
         </template>
       </RuiCard>

--- a/frontend/app/src/types/reports.ts
+++ b/frontend/app/src/types/reports.ts
@@ -113,8 +113,8 @@ export const ProfitLossReportOverview = z.object({
 export type ProfitLossReportOverview = z.infer<typeof ProfitLossReportOverview>;
 
 export interface ProfitLossReportPeriod {
-  readonly start: number;
-  readonly end: number;
+  readonly start: number | null;
+  readonly end: number | null;
 }
 
 export interface ProfitLossReportDebugPayload {

--- a/frontend/app/src/utils/date.ts
+++ b/frontend/app/src/utils/date.ts
@@ -30,12 +30,7 @@ export function getDateInputISOFormat(format: DateFormat): string {
   }[format];
 }
 
-export function changeDateFormat(
-  date: string,
-  fromFormat: DateFormat,
-  toFormat: DateFormat,
-  milliseconds: boolean = false,
-): string {
+export function changeDateFormat(date: string, fromFormat: DateFormat, toFormat: DateFormat, milliseconds: boolean = false): string {
   if (!date)
     return '';
 

--- a/frontend/app/tests/e2e/support/commands.ts
+++ b/frontend/app/tests/e2e/support/commands.ts
@@ -128,7 +128,7 @@ function checkForTaskCompletion(result: { result?: { task_id?: number } }): void
     }
 
     // introduce some delay between tries since we don't want to stress the backend
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
+
     cy.wait(WAIT_TIME_MS);
 
     currentRetry++;
@@ -202,7 +202,6 @@ function assertNoRunningTasks() {
   cy.get(selector)
     .should('not.exist')
     .then(() => {
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(1000);
 
       cy.get('body').then(($body) => {

--- a/frontend/app/tests/unit/specs/components/history/events/eth-block-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/eth-block-event-form.spec.ts
@@ -6,6 +6,7 @@ import { useBalancePricesStore } from '@/store/balances/prices';
 import { setupDayjs } from '@/utils/date';
 import { bigNumberify, HistoryEventEntryType, One } from '@rotki/common';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -43,8 +44,7 @@ describe('ethBlockEventForm.vue', () => {
     eventType: 'staking',
     eventSubtype: 'mev reward',
     locationLabel: '0x106B62Fdd27B748CF2Da3BacAB91a2CaBaeE6dCa',
-    notes:
-      'Validator 12 produced block 444 with 100 ETH going to 0x106B62Fdd27B748CF2Da3BacAB91a2CaBaeE6dCa as the mev reward',
+    notes: 'Validator 12 produced block 444 with 100 ETH going to 0x106B62Fdd27B748CF2Da3BacAB91a2CaBaeE6dCa as the mev reward',
     validatorIndex: 122,
     blockNumber: 444,
   };
@@ -93,20 +93,14 @@ describe('ethBlockEventForm.vue', () => {
 
     it('`groupHeader` are passed', async () => {
       wrapper = createWrapper();
-      vi.advanceTimersToNextTimer();
       await wrapper.setProps({ groupHeader });
+      await flushPromises();
 
-      expect((wrapper.find('[data-cy=blockNumber] input').element as HTMLInputElement).value).toBe(
-        groupHeader.blockNumber.toString(),
-      );
+      expect((wrapper.find('[data-cy=blockNumber] input').element as HTMLInputElement).value).toBe(groupHeader.blockNumber.toString());
 
-      expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
-      );
+      expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(groupHeader.validatorIndex.toString());
 
-      expect((wrapper.find('[data-cy=feeRecipient] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
-      );
+      expect((wrapper.find('[data-cy=feeRecipient] .input-value').element as HTMLInputElement).value).toBe(groupHeader.locationLabel);
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
 
@@ -115,24 +109,17 @@ describe('ethBlockEventForm.vue', () => {
 
     it('`groupHeader` and `editableItem` are passed', async () => {
       wrapper = createWrapper();
-      vi.advanceTimersToNextTimer();
       await wrapper.setProps({ groupHeader, editableItem: groupHeader });
+      await nextTick();
+      await flushPromises();
 
-      expect((wrapper.find('[data-cy=blockNumber] input').element as HTMLInputElement).value).toBe(
-        groupHeader.blockNumber.toString(),
-      );
+      expect((wrapper.find('[data-cy=blockNumber] input').element as HTMLInputElement).value).toBe(groupHeader.blockNumber.toString());
 
-      expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(
-        groupHeader.validatorIndex.toString(),
-      );
+      expect((wrapper.find('[data-cy=validatorIndex] input').element as HTMLInputElement).value).toBe(groupHeader.validatorIndex.toString());
 
-      expect((wrapper.find('[data-cy=feeRecipient] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
-      );
+      expect((wrapper.find('[data-cy=feeRecipient] .input-value').element as HTMLInputElement).value).toBe(groupHeader.locationLabel);
 
-      expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
-      );
+      expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(groupHeader.amount.toString());
 
       expect((wrapper.find('[data-cy=isMevReward] input').element as HTMLInputElement).checked).toBeTruthy();
     });

--- a/frontend/app/tests/unit/specs/components/history/events/evm-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/evm-event-form.spec.ts
@@ -92,7 +92,7 @@ describe('evmEventForm.vue', () => {
   describe('should prefill the fields based on the props', () => {
     it('no `groupHeader`, `editableItem`, nor `nextSequence` are passed', async () => {
       wrapper = createWrapper();
-      await vi.advanceTimersToNextTimerAsync();
+      await vi.runAllTimersAsync();
 
       expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe('');
 
@@ -101,7 +101,7 @@ describe('evmEventForm.vue', () => {
       expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe('');
 
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value).toBe('0');
-    });
+    }, 10000);
 
     it('`groupHeader` and `nextSequence` are passed', async () => {
       wrapper = createWrapper();
@@ -110,21 +110,15 @@ describe('evmEventForm.vue', () => {
 
       expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(groupHeader.txHash);
 
-      expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
-      );
+      expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(groupHeader.locationLabel);
 
-      expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.address,
-      );
+      expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe(groupHeader.address);
 
       expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe('0');
 
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value).toBe('10');
 
-      expect(
-        (wrapper.find('[data-cy=notes] textarea:not([aria-hidden="true"])').element as HTMLTextAreaElement).value,
-      ).toBe('');
+      expect((wrapper.find('[data-cy=notes] textarea:not([aria-hidden="true"])').element as HTMLTextAreaElement).value).toBe('');
     });
 
     it('`groupHeader`, `editableItem`, and `nextSequence` are passed', async () => {
@@ -134,25 +128,17 @@ describe('evmEventForm.vue', () => {
 
       expect((wrapper.find('[data-cy=txHash] input').element as HTMLInputElement).value).toBe(groupHeader.txHash);
 
-      expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.locationLabel,
-      );
+      expect((wrapper.find('[data-cy=locationLabel] .input-value').element as HTMLInputElement).value).toBe(groupHeader.locationLabel);
 
-      expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe(
-        groupHeader.address,
-      );
+      expect((wrapper.find('[data-cy=address] .input-value').element as HTMLInputElement).value).toBe(groupHeader.address);
 
-      expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(
-        groupHeader.amount.toString(),
-      );
+      expect((wrapper.find('[data-cy=amount] input').element as HTMLInputElement).value).toBe(groupHeader.amount.toString());
 
       expect((wrapper.find('[data-cy=sequenceIndex] input').element as HTMLInputElement).value.replace(',', '')).toBe(
         groupHeader.sequenceIndex.toString(),
       );
 
-      expect(
-        (wrapper.find('[data-cy=notes] textarea:not([aria-hidden="true"])').element as HTMLTextAreaElement).value,
-      ).toBe(groupHeader.notes);
+      expect((wrapper.find('[data-cy=notes] textarea:not([aria-hidden="true"])').element as HTMLTextAreaElement).value).toBe(groupHeader.notes);
     });
   });
 
@@ -171,9 +157,7 @@ describe('evmEventForm.vue', () => {
 
     const { historyEventSubTypesData } = useHistoryEventMappings();
 
-    expect(wrapper.findAll('[data-cy=eventSubtype] .selections span')).toHaveLength(
-      get(historyEventSubTypesData).length,
-    );
+    expect(wrapper.findAll('[data-cy=eventSubtype] .selections span')).toHaveLength(get(historyEventSubTypesData).length);
   });
 
   it('should show all counterparties options correctly', async () => {
@@ -204,8 +188,7 @@ describe('evmEventForm.vue', () => {
     const spans = wrapper.findAll('[data-cy=eventSubtype] .selections span');
     expect(spans).toHaveLength(keysFromGlobalMappings.length);
 
-    for (let i = 0; i < keysFromGlobalMappings.length; i++)
-      expect(keysFromGlobalMappings.includes(spans.at(i)!.text())).toBeTruthy();
+    for (let i = 0; i < keysFromGlobalMappings.length; i++) expect(keysFromGlobalMappings.includes(spans.at(i)!.text())).toBeTruthy();
   });
 
   it('should show product options, based on selected counterparty', async () => {

--- a/frontend/app/tests/unit/specs/components/history/events/history-event-form.spec.ts
+++ b/frontend/app/tests/unit/specs/components/history/events/history-event-form.spec.ts
@@ -66,20 +66,25 @@ describe('component/HistoryEventForm.vue', () => {
     expect(wrapper.find('[data-cy=history-event-form]').exists()).toBeTruthy();
   });
 
-  it.each(Object.values(HistoryEventEntryType))('changes to proper form %s', async (value: string) => {
-    await wrapper.find('[data-cy="entry-type"] [data-id="activator"]').trigger('click');
-    await vi.advanceTimersToNextTimerAsync();
+  it.each(Object.values(HistoryEventEntryType))(
+    'changes to proper form %s',
+    async (value: string) => {
+      await wrapper.find('[data-cy="entry-type"] [data-id="activator"]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
 
-    const options = wrapper.find('[role="menu-content"]').findAll('button');
-    for (const option of options) {
-      if (option.text() === value) {
-        await option.trigger('click');
-        await vi.advanceTimersToNextTimerAsync();
-        break;
+      const options = wrapper.find('[role="menu-content"]').findAll('button');
+      for (const option of options) {
+        if (option.text() === value) {
+          await option.trigger('click');
+          await vi.advanceTimersToNextTimerAsync();
+          break;
+        }
       }
-    }
 
-    const id = value.split(/ /g).join('-');
-    expect(wrapper.find(`[data-cy=${id}-form]`).exists()).toBeTruthy();
-  });
+      const id = value.split(/ /g).join('-');
+      await nextTick();
+      expect(wrapper.find(`[data-cy=${id}-form]`).exists()).toBeTruthy();
+    },
+    10000,
+  );
 });

--- a/frontend/app/tests/unit/specs/components/input/date-time-picker.spec.ts
+++ b/frontend/app/tests/unit/specs/components/input/date-time-picker.spec.ts
@@ -49,7 +49,7 @@ describe('components/DateTimePicker.vue', () => {
   it('should show indicator when format is wrong', async () => {
     wrapper = createWrapper({
       props: {
-        modelValue: '',
+        modelValue: null,
       },
     });
     await nextTick();
@@ -70,7 +70,7 @@ describe('components/DateTimePicker.vue', () => {
   it('should allow seconds value to be optional', async () => {
     wrapper = createWrapper({
       props: {
-        modelValue: '',
+        modelValue: null,
       },
     });
     await nextTick();
@@ -84,7 +84,7 @@ describe('components/DateTimePicker.vue', () => {
     wrapper = createWrapper({
       props: {
         milliseconds: true,
-        modelValue: '',
+        modelValue: null,
       },
     });
     await nextTick();
@@ -93,13 +93,17 @@ describe('components/DateTimePicker.vue', () => {
     await nextTick();
     expect(wrapper.find('.text-rui-error').exists()).toBeFalsy();
     expect(wrapper.emitted()).toHaveProperty('update:modelValue');
-    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['12/12/2021 12:12:12.333']);
+
+    // convert the expected date string to a timestamp for comparison
+    const expectedTimestamp = new Date('2021-12-12T12:12:12.333').getTime();
+    const emittedValue = (wrapper.emitted('update:modelValue')![0] as any)[0];
+    expect(emittedValue).toBeCloseTo(expectedTimestamp, -2); // precision adjustment
   });
 
   it('should show trim value when the length of the input exceed the max length allowed', async () => {
     wrapper = createWrapper({
       props: {
-        modelValue: '',
+        modelValue: null,
       },
     });
     await nextTick();
@@ -124,7 +128,7 @@ describe('components/DateTimePicker.vue', () => {
     vi.setSystemTime(date);
 
     wrapper = createWrapper({
-      props: { limitNow: true, modelValue: '' },
+      props: { limitNow: true, modelValue: null },
     });
     await nextTick();
 
@@ -144,7 +148,7 @@ describe('components/DateTimePicker.vue', () => {
     vi.setSystemTime(date);
 
     wrapper = createWrapper({
-      props: { limitNow: true, modelValue: '' },
+      props: { limitNow: true, modelValue: null },
     });
     await nextTick();
 
@@ -154,7 +158,11 @@ describe('components/DateTimePicker.vue', () => {
 
     expect((wrapper.find('input').element as HTMLInputElement).value).toBe('01/01/2023 01:01:01');
     expect(wrapper.emitted()).toHaveProperty('update:modelValue');
-    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['01/01/2023 01:01:01']);
+    const emittedValue = (wrapper.emitted('update:modelValue')![0] as any)[0];
+    const expectedTimestamp = date.getTime();
+    expect(emittedValue).toBe(expectedTimestamp);
+
+    vi.useRealTimers();
   });
 
   it('should work with format YYYY-MM-DD', async () => {
@@ -164,7 +172,7 @@ describe('components/DateTimePicker.vue', () => {
     });
 
     wrapper = createWrapper({
-      props: { modelValue: '12/12/2021 12:12:12' },
+      props: { modelValue: new Date('12/12/2021 12:12:12').getTime() },
     });
 
     await nextTick();
@@ -184,7 +192,7 @@ describe('components/DateTimePicker.vue', () => {
     it('should render and emit the value correctly', async () => {
       wrapper = createWrapper({
         props: {
-          modelValue: '12/12/2021 12:12:12',
+          modelValue: new Date('12/12/2021 12:12:12').getTime(),
         },
       });
 
@@ -216,7 +224,7 @@ describe('components/DateTimePicker.vue', () => {
       vi.setSystemTime(date);
 
       wrapper = createWrapper({
-        props: { limitNow: true, modelValue: '' },
+        props: { limitNow: true, modelValue: null },
       });
       await nextTick();
 
@@ -246,7 +254,7 @@ describe('components/DateTimePicker.vue', () => {
       vi.setSystemTime(date);
 
       wrapper = createWrapper({
-        props: { limitNow: true, modelValue: '' },
+        props: { limitNow: true, modelValue: null },
       });
       await nextTick();
 


### PR DESCRIPTION
Closes #9157

## Description

This PR refactors the DateTimePicker to use timestamp and update related components and tests:

- refactored the DateTimePicker to accept and display the date as a timestamp instead of a string, supporting milliseconds and second;

- updated components that utilize DateTimePicker to reflect these changes and ensure compatibility with the new timestamp format;

- change unit tests to expect a number (timestamp) instead of a string.