### PR TITLE
chore: improve type safety by changing `catch` error type to `unknown`

### DIFF
--- a/frontend/app/scripts/check-external-links.ts
+++ b/frontend/app/scripts/check-external-links.ts
@@ -33,10 +33,15 @@ async function checkLink(rawUrl: string): Promise<void> {
       process.exit(1); // Exit with an error status code
     }
   }
-  catch (error: any) {
+  catch (error: unknown) {
+    if (error instanceof Error) {
     console.error(`Error checking link ${url}: ${error.message}`);
-    process.exit(1); // Exit with an error status code
+  } else {
+    console.error(`Unknown error checking link ${url}`);
   }
+    process.exit(1);
+}
+
 }
 
 function getFlattenedValues(obj: Record<string, any>): string[] {


### PR DESCRIPTION
In the `catch` block, the type of the `error` variable has been changed from `any` to `unknown`. This is a safer approach, as the error could potentially be an instance of something other than `Error`. 