### PR TITLE
Remove vendored OpenSSL usage from rusqlite

### DIFF
--- a/colibri/Cargo.lock
+++ b/colibri/Cargo.lock
@@ -2364,7 +2364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -2649,15 +2648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.1+3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,7 +2655,6 @@ checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/colibri/Cargo.toml
+++ b/colibri/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 log = "0.4.22"
 simplelog = "0.12.2"
 # For the asynchronous Rest API
-reqwest = { version = "0.12.2", features = ["json"]}
-tokio = { version = "1.43.0", features = ["rt-multi-thread", "fs"]}
+reqwest = { version = "0.12.2", features = ["json"] }
+tokio = { version = "1.43.0", features = ["rt-multi-thread", "fs"] }
 axum = "0.7"
 # for serialization of structs via the API
 serde = { version = "1.0.217", features = ["derive"] }
@@ -22,26 +22,26 @@ dirs = "6.0.0"
 # for CLI args parsing
 clap = { version = "4.5.26", features = ["string"] }
 # for globalDB and other sqlite operations
-rusqlite = { version = "0.32.1", features = ["bundled", "bundled-sqlcipher-vendored-openssl"] }
-async-sqlite = {version = "0.4.0" }
+rusqlite = { version = "0.32.1", features = ["bundled", "bundled-sqlcipher"] }
+async-sqlite = { version = "0.4.0" }
 # for cors and network
-tower-http = {version = "0.6.2", features = ["cors", "trace"]}
+tower-http = { version = "0.6.2", features = ["cors", "trace"] }
 http = "1.0"
 # for detailed logs when requests happen. Tracing in maintained by the tokio team and it helps
 # to log events in multithread environments. It is used by axum (also by tokio) to signal when
 # a request happens and keeps information about it. We use tracing to extract those events and
 # log them.
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"]}
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 # Used to keep log files that rotate when they reach certain size. Is not available in tracing
 # directly (they have a PR but not merged)
 file-rotate = "0.7.6"
 # used when parsing cors. It is from rust itself
 glob = "0.3.2"
 # used for smart contract interaction
-alloy = {version = "0.12.3", features = ["contract"]}
+alloy = { version = "0.12.3", features = ["contract"] }
 base64 = "0.22.1"
 
 [dev-dependencies]
 mockito = "1.6.1"
-tokio = { version = "*", features = ["test-util"]}
+tokio = { version = "*", features = ["test-util"] }


### PR DESCRIPTION
**Summary**
- Remove vendored OpenSSL usage from `rusqlite` by dropping the `bundled-sqlcipher-vendored-openssl` feature.
- Rely on the system-installed OpenSSL (e.g., via Homebrew) instead.

**Why This Change?**
- Homebrew no longer provides `openssl@1.1`, causing build failures when attempting to compile vendored OpenSSL.
- This switch ensures compatibility with modern macOS systems and keeps the build environment simpler.

**Testing**
- Verified locally with `cargo clippy --all -- -D warnings` and any existing tests to ensure no regressions.






