### PR TITLE
chore: fixed redundant `evm_manager` creation

### DIFF
--- a/colibri/src/main.rs
+++ b/colibri/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         coingecko,
         userdb: Arc::new(RwLock::new(DBHandler::new())),
         active_tasks: Arc::new(Mutex::new(HashSet::<String>::new())),
-        evm_manager: Arc::new(EvmInquirerManager::new(globaldb.clone())),
+        evm_manager,
     });
 
     let stateless_routes = Router::new().route("/health", routing::get(api::health::status));


### PR DESCRIPTION
removed the duplicate creation of the `evm_manager` instance.
now it's created only once and used in the state, simplifying the code.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
