### PR TITLE
Fix issue with nodes that didn't connect properly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Fix a rare issue calling RPC nodes when there is an error connecting to them.
+
 * :release:`1.38.2 <2025-03-26>`
 * :bug:`-` Fix the issue where the "Add new event here" button is missing from the "more" menu in the event group.
 * :bug:`-` Fix the issue where pressing Enter while focused on autocomplete doesn't submit the form.

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -531,25 +531,26 @@ class EvmNodeInquirer(ABC, LockableQueryMixIn):
         for node_idx, weighted_node in enumerate(call_order):
             node_info = weighted_node.node_info
             web3node = self.web3_mapping.get(node_info, None)
-            if (
-                web3node is None and
-                node_info.name != self.etherscan_node_name and
-                node_info.name not in self.failed_to_connect_nodes
-            ):
-                success, _ = self.attempt_connect(node=node_info)
-                if success is False:
-                    self.failed_to_connect_nodes.add(node_info.name)
+            if web3node is None:
+                if node_info.name in self.failed_to_connect_nodes:
                     continue
 
-                if (web3node := self.web3_mapping.get(node_info, None)) is None:
-                    log.error(f'Unexpected missing node {node_info} at {self.chain_id}')
-                    continue
+                if node_info.name != self.etherscan_node_name:
+                    success, _ = self.attempt_connect(node=node_info)
+                    if success is False:
+                        self.failed_to_connect_nodes.add(node_info.name)
+                        continue
 
-            if (
-                web3node is not None and
+                    if (web3node := self.web3_mapping.get(node_info, None)) is None:
+                        log.error(f'Unexpected missing node {node_info} at {self.chain_id}')
+                        continue
+
+            if web3node is not None and (
                 method.__name__ in self.methods_that_query_past_data and
                 web3node.is_pruned is True
             ):
+                # If the block_identifier is different from 'latest'
+                # this query should be routed to an archive node
                 continue
 
             try:


### PR DESCRIPTION
it was possible for a node to fail to get connected and still be queried. This happens for nodes that aren't available right now but have been marked as active

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
