### PR TITLE
Allow exchange history events partial range query

### DIFF
--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -1539,7 +1539,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         events: list[HistoryBaseEntry] = []
         for query_func in (
             self._query_online_asset_movements,
@@ -1554,7 +1554,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                 )
                 continue
 
-        return events
+        return events, end_ts
 
     def _query_online_asset_movements(
             self,

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -31,7 +31,6 @@ from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
 )
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -60,6 +59,7 @@ from rotkehlchen.utils.serialization import jsonloads_list
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -966,7 +966,7 @@ class Bitfinex(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Return the account deposits and withdrawals on Bitfinex.
 
         Endpoint documentation:
@@ -983,7 +983,7 @@ class Bitfinex(ExchangeInterface):
             options=options,
             case='asset_movements',
         )
-        return asset_movements
+        return asset_movements, end_ts
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -351,7 +351,7 @@ class Bitmex(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence['HistoryBaseEntry']:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         self.first_connection()
         resp = self._api_query('user/walletHistory', {'currency': 'all'})
 
@@ -436,7 +436,7 @@ class Bitmex(ExchangeInterface):
                     f'asset_movement {movement}. Error was: {msg}',
                 )
                 continue
-        return movements
+        return movements, end_ts
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal, overload
 from urllib.parse import urlencode
@@ -52,6 +53,7 @@ from rotkehlchen.utils.serialization import jsonloads_dict
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -554,7 +556,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> list[AssetMovement]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         self.first_connection()
         # Should probably also query wallets/transactions for crypto deposits/withdrawals
         # but it does not seem as if they contain them
@@ -569,7 +571,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
             to_ts=end_ts,
         )
         movements.extend(crypto_movements)
-        return movements
+        return movements, end_ts
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.fval import FVal
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -233,7 +234,7 @@ class Bitstamp(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[AssetMovement]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Return the account asset movements on Bitstamp.
 
         NB: when `since_id` is used, the Bitstamp API v2 will return by default
@@ -341,7 +342,7 @@ class Bitstamp(ExchangeInterface):
             del crypto_asset_movements[idx]  # remove the crypto asset movements whose data we matched in the DB  # noqa: E501
 
         log.debug(f'Remaining Bitstamp unmatched {crypto_asset_movements=}')
-        return asset_movements
+        return asset_movements, end_ts
 
     def _query_crypto_transactions(self, offset: int) -> list[AssetMovement]:
         """Query crypto transactions to get address and transaction id.

--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -30,7 +30,6 @@ from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
 )
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -53,6 +52,7 @@ from rotkehlchen.utils.misc import combine_dicts, ts_ms_to_sec, ts_now, ts_now_i
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -626,7 +626,7 @@ class Bybit(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Query deposits and withdrawals sequentially"""
         new_movements = self._query_deposits_withdrawals(
             start_ts=start_ts,
@@ -640,7 +640,7 @@ class Bybit(ExchangeInterface):
                 query_for=HistoryEventType.WITHDRAWAL,
             ),
         )
-        return new_movements
+        return new_movements, end_ts
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -1084,10 +1084,10 @@ class Coinbase(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> list['HistoryBaseEntry']:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Make sure latest transactions are queried and saved in the DB. Since all history comes from one endpoint and can't be queried by time range this doesn't follow the same logic as another exchanges"""  # noqa: E501
         self._query_transactions()
-        return []
+        return [], end_ts
 
     def _deserialize_history_event(self, raw_data: dict[str, Any]) -> HistoryEvent | None:
         """Processes a single transaction from coinbase and deserializes it

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -507,7 +507,7 @@ class Gemini(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> 'Sequence[HistoryBaseEntry]':
+    ) -> tuple['Sequence[HistoryBaseEntry]', Timestamp]:
         result = self._get_paginated_query(
             endpoint='transfers',
             start_ts=start_ts,
@@ -562,7 +562,7 @@ class Gemini(ExchangeInterface):
 
             movements.append(movement)
 
-        return movements
+        return movements, end_ts
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/htx.py
+++ b/rotkehlchen/exchanges/htx.py
@@ -26,7 +26,6 @@ from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
 )
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -50,6 +49,7 @@ if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.exchanges.data_structures import MarginPosition
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -341,7 +341,7 @@ class Htx(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Query deposits and withdrawals sequentially
 
         This method sequentially queries for 'deposit' and 'withdrawal' types. Each type
@@ -362,7 +362,7 @@ class Htx(ExchangeInterface):
                 query_for='withdraw',
             ),
         )
-        return new_movements
+        return new_movements, end_ts
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -26,7 +26,6 @@ from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalan
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -49,6 +48,7 @@ from rotkehlchen.utils.misc import timestamp_to_iso8601, ts_sec_to_ms
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -406,7 +406,7 @@ class Independentreserve(ExchangeInterface):
             self,
             start_ts: Timestamp,  # pylint: disable=unused-argument
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         if self.account_guids is None:
             self.query_balances()  # do a balance query to populate the account guids
         movements = []
@@ -427,7 +427,7 @@ class Independentreserve(ExchangeInterface):
                     f'Error processing IndependentReserve transactions response. '
                     f'Missing key: {e!s}.',
                 )
-                return []
+                return [], start_ts
 
             for entry in resp:
                 entry_type = entry.get('Type')
@@ -465,7 +465,7 @@ class Independentreserve(ExchangeInterface):
                     )
                     continue
 
-        return movements
+        return movements, end_ts
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -32,7 +32,6 @@ from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
 )
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -59,6 +58,7 @@ from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 
 logger = logging.getLogger(__name__)
@@ -757,7 +757,7 @@ class Kucoin(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Return the account deposits and withdrawals
 
         May raise RemoteError
@@ -783,7 +783,7 @@ class Kucoin(ExchangeInterface):
         )
         asset_movements.extend(withdrawals)
 
-        return asset_movements
+        return asset_movements, end_ts
 
     def query_online_trade_history(
             self,

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -26,7 +26,6 @@ from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
 )
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
@@ -51,6 +50,7 @@ from rotkehlchen.utils.misc import ts_sec_to_ms
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -307,7 +307,7 @@ class Okx(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """
         https://www.okx.com/docs-v5/en/#rest-api-funding-get-deposit-history
         https://www.okx.com/docs-v5/en/#rest-api-funding-get-withdrawal-history
@@ -355,7 +355,7 @@ class Okx(ExchangeInterface):
         for raw_trade in trades:
             events.extend(self.swap_events_from_okx(raw_trade))
 
-        return events
+        return events, end_ts
 
     def swap_events_from_okx(self, raw_trade: dict[str, Any]) -> list[SwapEvent]:
         """Converts a raw trade from OKX into SwapEvents.

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -29,7 +29,6 @@ from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
 )
-from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
@@ -64,6 +63,7 @@ from rotkehlchen.utils.mixins.lockable import protect_with_lock
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -551,7 +551,7 @@ class Poloniex(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence[HistoryBaseEntry]:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         result = self.api_query_dict(
             '/wallets/activity',
             {'start': start_ts, 'end': end_ts},
@@ -586,7 +586,7 @@ class Poloniex(ExchangeInterface):
                 end_ts=end_ts,
             ))
 
-        return events
+        return events, end_ts
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/woo.py
+++ b/rotkehlchen/exchanges/woo.py
@@ -201,7 +201,7 @@ class Woo(ExchangeInterface):
             self,
             start_ts: Timestamp,
             end_ts: Timestamp,
-    ) -> Sequence['HistoryBaseEntry']:
+    ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         """Return deposits/withdrawals history on Woo in a range of time."""
         movements: list[AssetMovement] = self._api_query_paginated(
             endpoint='v1/asset/history',
@@ -216,7 +216,7 @@ class Woo(ExchangeInterface):
             deserialization_method=self._deserialize_asset_movement,
             entries_key='rows',
         )
-        return movements
+        return movements, end_ts
 
     def validate_api_key(self) -> tuple[bool, str]:
         """Validates that the Woo API key is good for usage in rotki"""

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -294,7 +294,7 @@ def test_binance_query_trade_history(function_scope_binance: 'Binance'):
         return MockResponse(200, text)
 
     with patch.object(binance.session, 'request', side_effect=mock_my_trades):
-        events = binance.query_online_history_events(
+        events, _ = binance.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=Timestamp(1638529919),
         )
@@ -401,7 +401,7 @@ def test_binance_query_trade_history_unexpected_data(function_scope_binance):
         )
         binance.selected_pairs = query_specific_markets
         with patch_get, patch_response:
-            events = binance.query_online_history_events(
+            events, _ = binance.query_online_history_events(
                 start_ts=Timestamp(0),
                 end_ts=Timestamp(1564301134),
             )
@@ -504,7 +504,7 @@ def test_binance_query_deposits_withdrawals(function_scope_binance: 'Binance') -
         return MockResponse(200, response_str)
 
     with patch.object(binance.session, 'request', side_effect=mock_get_history_events):
-        movements = binance.query_online_history_events(
+        movements, _ = binance.query_online_history_events(
             start_ts=Timestamp(start_ts),
             end_ts=Timestamp(end_ts),
         )
@@ -541,7 +541,7 @@ def test_binance_query_deposits_withdrawals_unexpected_data(function_scope_binan
             return MockResponse(200, response_str)
 
         with patch.object(binance.session, 'request', side_effect=mock_get_history_events):
-            movements = binance.query_online_history_events(
+            movements, _ = binance.query_online_history_events(
                 start_ts=Timestamp(start_ts),
                 end_ts=Timestamp(end_ts),
             )
@@ -750,7 +750,7 @@ def test_binance_query_deposits_withdrawals_gte_90_days(function_scope_binance):
     get_fiat_withdraw_result = get_fiat_withdraw_result()
 
     with patch.object(binance.session, 'request', side_effect=mock_get_history_events):
-        movements = binance.query_online_history_events(
+        movements, _ = binance.query_online_history_events(
             start_ts=Timestamp(start_ts),
             end_ts=Timestamp(end_ts),
         )

--- a/rotkehlchen/tests/exchanges/test_binance_us.py
+++ b/rotkehlchen/tests/exchanges/test_binance_us.py
@@ -65,10 +65,11 @@ def test_binanceus_trades_location(function_scope_binance):
         return MockResponse(200, text)
 
     with patch.object(binance.session, 'request', side_effect=mock_my_trades):
-        assert binance.query_online_history_events(
+        events, _ = binance.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=Timestamp(1564301134),
-        ) == [SwapEvent(
+        )
+        assert events == [SwapEvent(
             timestamp=TimestampMS(1499865549590),
             location=Location.BINANCEUS,
             event_subtype=HistoryEventSubType.SPEND,
@@ -111,7 +112,7 @@ def test_binanceus_deposits_withdrawals_location(function_scope_binance):
         return MockResponse(200, response_str)
 
     with patch.object(binance.session, 'request', side_effect=mock_get_history_events):
-        movements = binance.query_online_history_events(
+        movements, _ = binance.query_online_history_events(
             start_ts=Timestamp(start_ts),
             end_ts=Timestamp(end_ts),
         )

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -168,7 +168,7 @@ def test_api_key_err_auth_nonce(mock_bitfinex: 'Bitfinex') -> None:
         assert result is False
         assert msg == API_ERR_AUTH_NONCE_MESSAGE
 
-        movements = mock_bitfinex.query_online_history_events(Timestamp(0), Timestamp(1))
+        movements, _ = mock_bitfinex.query_online_history_events(Timestamp(0), Timestamp(1))
         assert movements == []
         errors = mock_bitfinex.msg_aggregator.consume_errors()
         assert len(errors) == 1
@@ -1166,7 +1166,7 @@ def test_query_online_deposits_withdrawals_case_1(mock_bitfinex: 'Bitfinex') -> 
     with ExitStack() as stack:
         stack.enter_context(api_limit_patch)
         api_query_mock = stack.enter_context(api_query_patch)
-        asset_movements = mock_bitfinex.query_online_history_events(
+        asset_movements, _ = mock_bitfinex.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=Timestamp(int(datetime.datetime.now(tz=datetime.UTC).timestamp())),
         )
@@ -1398,7 +1398,7 @@ def test_query_online_deposits_withdrawals_case_2(mock_bitfinex: 'Bitfinex') -> 
     with ExitStack() as stack:
         stack.enter_context(api_limit_patch)
         stack.enter_context(api_query_patch)
-        asset_movements = mock_bitfinex.query_online_history_events(
+        asset_movements, _ = mock_bitfinex.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=Timestamp(int(datetime.datetime.now(tz=datetime.UTC).timestamp())),
         )

--- a/rotkehlchen/tests/exchanges/test_bitmex.py
+++ b/rotkehlchen/tests/exchanges/test_bitmex.py
@@ -146,7 +146,7 @@ def test_bitmex_api_withdrawals_deposit_unexpected_data(sandbox_bitmex: 'Bitmex'
             return MockResponse(200, input_str)
 
         with patch.object(sandbox_bitmex.session, 'get', side_effect=mock_get_history_events):
-            movements = sandbox_bitmex.query_online_history_events(
+            movements, _ = sandbox_bitmex.query_online_history_events(
                 start_ts=Timestamp(0),
                 end_ts=now,
             )
@@ -201,7 +201,7 @@ def test_bitmex_api_withdrawals_deposit_unknown_asset(mock_bitmex: 'Bitmex') -> 
         return MockResponse(200, TEST_BITMEX_WITHDRAWAL.replace('"XBt"', '"dadsdsa"'))
 
     with patch.object(mock_bitmex.session, 'request', side_effect=mock_get_response):
-        movements = mock_bitmex.query_online_history_events(
+        movements, _ = mock_bitmex.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=ts_now(),
         )

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -101,7 +101,7 @@ def test_validate_api_key_err_auth_nonce(mock_bitstamp):
         assert result is False
         assert msg == API_ERR_AUTH_NONCE_MESSAGE
 
-        movements = mock_bitstamp.query_online_history_events(0, 1)
+        movements, _ = mock_bitstamp.query_online_history_events(0, 1)
         assert movements == []
         errors = mock_bitstamp.msg_aggregator.consume_errors()
         assert len(errors) == 2  # since we do 2 queries underneath

--- a/rotkehlchen/tests/exchanges/test_bybit.py
+++ b/rotkehlchen/tests/exchanges/test_bybit.py
@@ -256,7 +256,7 @@ def test_deposit_withdrawals(bybit_exchange: Bybit) -> None:
         ],
     })
     with patch.object(bybit_exchange, '_api_query', side_effect=mock_fn):
-        movements = bybit_exchange.query_online_history_events(
+        movements, _ = bybit_exchange.query_online_history_events(
             start_ts=Timestamp(1701200010),
             end_ts=Timestamp(1701300880),
         )

--- a/rotkehlchen/tests/exchanges/test_htx.py
+++ b/rotkehlchen/tests/exchanges/test_htx.py
@@ -115,7 +115,7 @@ def test_deposit_withdrawals(htx_exchange: Htx) -> None:
         ],
     })
     with patch.object(htx_exchange, '_query', side_effect=mock_fn):
-        movements = htx_exchange.query_online_history_events(
+        movements, _ = htx_exchange.query_online_history_events(
             start_ts=Timestamp(1612492580),
             end_ts=Timestamp(1714746851),
         )

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -168,8 +168,6 @@ def test_querying_balances(kraken):
         assert isinstance(entry, Balance)
 
 
-# TODO: Add support for partial range queries to all exchanges and re-enable this test
-@pytest.mark.skip('This functionality has been temporarily removed')
 def test_querying_rate_limit_exhaustion(kraken, database):
     """Test that if kraken api rates limit us we don't get stuck in an infinite loop
     and also that we return what we managed to retrieve until rate limit occurred.

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -810,7 +810,7 @@ def test_query_asset_movements_sandbox(
     with ExitStack() as stack:
         stack.enter_context(months_in_seconds_patch)
         stack.enter_context(api_query_patch)
-        asset_movements = sandbox_kucoin.query_online_history_events(
+        asset_movements, _ = sandbox_kucoin.query_online_history_events(
             start_ts=Timestamp(1612556651),
             end_ts=Timestamp(1612556654),
         )

--- a/rotkehlchen/tests/exchanges/test_okx.py
+++ b/rotkehlchen/tests/exchanges/test_okx.py
@@ -531,10 +531,11 @@ def test_okx_query_trades(mock_okx: 'Okx') -> None:
         return MockResponse(200, data)
 
     with patch.object(mock_okx.session, 'request', side_effect=mock_okx_trades):
-        assert mock_okx.query_online_history_events(
+        events, _ = mock_okx.query_online_history_events(
             Timestamp(1609103082),
             Timestamp(1672175105),
-        ) == [SwapEvent(
+        )
+        assert events == [SwapEvent(
             timestamp=TimestampMS(1665846604080),
             location=Location.OKX,
             event_subtype=HistoryEventSubType.SPEND,
@@ -820,7 +821,7 @@ def test_okx_query_deposits_withdrawals(mock_okx: 'Okx') -> None:
             'request',
             side_effect=mock_okx_deposits_withdrawals,
     ):
-        asset_movements = mock_okx.query_online_history_events(
+        asset_movements, _ = mock_okx.query_online_history_events(
             Timestamp(1609103082),
             Timestamp(1672175105),
         )

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -142,10 +142,11 @@ def test_query_trade_history(poloniex: 'Poloniex'):
         return MockResponse(200, '{"withdrawals": [], "deposits": []}')
 
     with patch.object(poloniex.session, 'get', side_effect=mock_api_return):
-        assert poloniex.query_online_history_events(
+        events, _ = poloniex.query_online_history_events(
             start_ts=Timestamp(1500000000),
             end_ts=Timestamp(1565732120),
-        ) == [SwapEvent(
+        )
+        assert events == [SwapEvent(
             timestamp=TimestampMS(1539713117000),
             location=Location.POLONIEX,
             event_subtype=HistoryEventSubType.SPEND,
@@ -203,7 +204,7 @@ def test_query_trade_history_unexpected_data(poloniex):
             return MockResponse(200, '{"withdrawals": [], "deposits": []}')
 
         with patch.object(poloniex.session, 'get', side_effect=mock_api_return):
-            events = poloniex.query_online_history_events(
+            events, _ = poloniex.query_online_history_events(
                 start_ts=Timestamp(1500000000),
                 end_ts=Timestamp(1565732120),
             )
@@ -320,7 +321,7 @@ def test_poloniex_deposits_withdrawal_unknown_asset(poloniex: 'Poloniex') -> Non
 
     with patch.object(poloniex.session, 'get', side_effect=mock_api_return):
         # Test that after querying the api only ETH and BTC assets are there
-        asset_movements = poloniex.query_online_history_events(
+        asset_movements, _ = poloniex.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=Timestamp(1488994442),
         )
@@ -419,7 +420,7 @@ def test_poloniex_deposits_withdrawal_null_fee(poloniex: 'Poloniex'):
         )
 
     with patch.object(poloniex.session, 'get', side_effect=mock_api_return):
-        asset_movements = poloniex.query_online_history_events(
+        asset_movements, _ = poloniex.query_online_history_events(
             start_ts=Timestamp(0),
             end_ts=Timestamp(1488994442),
         )
@@ -450,7 +451,7 @@ def test_poloniex_deposits_withdrawal_unexpected_data(poloniex):
             return MockResponse(200, given_movements)
 
         with patch.object(poloniex.session, 'get', side_effect=mock_api_return):
-            asset_movements = poloniex.query_online_history_events(
+            asset_movements, _ = poloniex.query_online_history_events(
                 start_ts=0,
                 end_ts=1488994442,
             )


### PR DESCRIPTION
Related: #6097 and [this note](https://github.com/orgs/rotki/projects/11?pane=issue&itemId=102361655)

Makes it possible for an exchange to only return events from part of the range queried if there are errors part way through querying the range. Currently only utilized by Kraken since it was doing something similar before by using custom logic that didn't conform to the exchange interface. Now this is supported by the exchange interface itself so it can be used in any exchange where it might be useful.
