### PR TITLE
Rename history event notes fields in the api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5016,6 +5016,81 @@ Dealing with History Events
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 3
+              }, {
+                  "entry": {
+                      "identifier": 6,
+                      "entry_type": "asset movement event",
+                      "timestamp": 1739575021000,
+                      "event_type": "deposit",
+                      "event_subtype": "deposit asset",
+                      "location": "binanceus",
+                      "location_label": "Binance US 1",
+                      "asset": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                      "amount": "200",
+                      "event_identifier": "269b64de6a51caa372a3b455341a41a9da2ae743794e81011b5da1c3b6e1195b",
+                      "sequence_index": 0,
+                      "extra_data": {
+                          "address": "0x29aE5D9A1f28f82c358f8DF5A029bC0D5452b66E",
+                          "transaction_id": "0x94a0c141c92b5acbad63aad1edea819a4aba2a39c01203eadd537436b3dd6a63"
+                      },
+                      "user_notes": "From my metamask wallet",
+                      "auto_notes": "Deposit 200 USDC to Binance US"
+                  },
+                  "event_accounting_rule_status": "has rule"
+              }, {
+                  "entry": {
+                      "identifier": 7,
+                      "entry_type": "swap event",
+                      "timestamp": 1732150909806,
+                      "event_type": "trade",
+                      "event_subtype": "spend",
+                      "location": "kraken",
+                      "location_label": null,
+                      "asset": "USD",
+                      "amount": "32.2400",
+                      "event_identifier": "9e0bfb56dbe8c3d4d3a71584740826df3f901cb0c55a11ee33887afefc7a99d7",
+                      "sequence_index": 0,
+                      "extra_data": null,
+                      "auto_notes": "Swap 32.2400 USD in Kraken"
+                  },
+                  "grouped_events_num": 3,
+                  "event_accounting_rule_status": "has rule"
+              }, {
+                  "entry": {
+                      "identifier": 8,
+                      "entry_type": "swap event",
+                      "timestamp": 1732150909806,
+                      "event_type": "trade",
+                      "event_subtype": "receive",
+                      "location": "kraken",
+                      "location_label": null,
+                      "asset": "XMR",
+                      "amount": "0.2000496400",
+                      "event_identifier": "9e0bfb56dbe8c3d4d3a71584740826df3f901cb0c55a11ee33887afefc7a99d7",
+                      "sequence_index": 1,
+                      "extra_data": null,
+                      "auto_notes": "Receive 0.2000496400 XMR after a swap in Kraken"
+                  },
+                  "grouped_events_num": 3,
+                  "event_accounting_rule_status": "processed"
+              }, {
+                  "entry": {
+                      "identifier": 9,
+                      "entry_type": "swap event",
+                      "timestamp": 1732150909806,
+                      "event_type": "trade",
+                      "event_subtype": "fee",
+                      "location": "kraken",
+                      "location_label": null,
+                      "asset": "USD",
+                      "amount": "0.1290",
+                      "event_identifier": "9e0bfb56dbe8c3d4d3a71584740826df3f901cb0c55a11ee33887afefc7a99d7",
+                      "sequence_index": 2,
+                      "extra_data": null,
+                      "auto_notes": "Spend 0.1290 USD as Kraken swap fee"
+                  },
+                  "grouped_events_num": 3,
+                  "event_accounting_rule_status": "processed"
               }],
              "entries_found": 95,
              "entries_limit": 500,
@@ -5024,7 +5099,7 @@ Dealing with History Events
           "message": ""
       }
 
-   :resjson list decoded_events: A list of history events. Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry may also have a `has_details` flag if true. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry may have a `customized` flag set to true. If it does, it means the event has been customized/added by the user. Each entry may also have a `hidden` flag if set to true. If it does then that means it should be hidden in the UI due to consolidation of events. Also if `group_by_event_ids` exist and is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the common event identifier. The consumer has to query this endpoint again with `group_by_event_ids` set to false and with the `event_identifiers` filter set to the identifier of the events having more than 1 event. If the event has a ``"notes"`` field that is auto-generated by default and not edited then the key ``"default_notes"`` will exit and be true. Finally `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. Following are all possible entries depending on entry type.
+   :resjson list decoded_events: A list of history events. Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry may also have a `has_details` flag if true. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry may have a `customized` flag set to true. If it does, it means the event has been customized/added by the user. Each entry may also have a `hidden` flag if set to true. If it does then that means it should be hidden in the UI due to consolidation of events. Also if `group_by_event_ids` exist and is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the common event identifier. The consumer has to query this endpoint again with `group_by_event_ids` set to false and with the `event_identifiers` filter set to the identifier of the events having more than 1 event. Finally `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. Following are all possible entries depending on entry type.
    :resjson string identifier: Common key. This is the identifier of a single event.
    :resjson string entry_type: Common key. This identifies the category of the event and determines the schema. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
    :resjson string event_identifier: Common key. An event identifier grouping multiple events under a common group. This is how we group transaction events under a transaction, staking related events under block production etc.
@@ -5037,7 +5112,8 @@ Dealing with History Events
    :resjson string event_type: Common key. The type of the event. Valid values are retrieved from the backend.
    :resjson string event_subtype: Common key. The subtype of the event. Valid values are retrieved from the backend.
    :resjson string location_label: Common key. The location_label of the event. This means different things depending on event category. For evm events it's the initiating address. For withdrawal events the recipient address. For block production events the fee recipient.
-   :resjson string notes: Common key. String description of the event.
+   :resjson string user_notes: Common key. Custom notes for the event set by the user. Can be missing.
+   :resjson string auto_notes: Common key. Autogenerated string description of the event. Can be missing.
    :resjson string tx_hash: Evm event & eth deposit key. The transaction hash of the event as a hex string.
    :resjson string counterparty: Evm event & eth deposit key. The counterparty of the event. This is most of the times a protocol such as uniswap, but can also be an exchange name such as kraken. Possible values are requested by the backend.
    :resjson string product: Evm event & eth deposit key. This is the product type with which the event interacts. Such as pool, staking contract etc. Possible values are requested by the backend.
@@ -5083,7 +5159,7 @@ Dealing with History Events
                "event_subtype": "approve",
                "asset": "eip155:1/erc20:0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
                "location_label": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12",
-               "notes": "Approve 1 SAI of 0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12 for spending by 0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE"
+               "user_notes": "Approve 1 SAI of 0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12 for spending by 0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE"
             }
 
          :reqjson int sequence_index: This is an index that tries to provide the order of history entries for a single event_identifier.
@@ -5093,7 +5169,7 @@ Dealing with History Events
          :reqjson string event_type: The main event type of the entry. Possible event types can be seen in the `HistoryEventType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L54>`_.
          :reqjson string event_subtype: The subtype for the entry. Possible event types can be seen in the `HistoryEventSubType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L72>`_.
          :reqjson string[optional] location_label: location_label is a string field that allows to provide more information about the location. For example when we use this structure in blockchains can be used to specify the source address.
-         :reqjson string[optional] notes: This is a description of the event entry in plain text explaining what is being done. This is supposed to be shown to the user.
+         :reqjson string[optional] user_notes: This is the user editable part of the description of the event entry in plain text explaining what is being done.
 
    .. tab:: Evm Event
 
@@ -5118,7 +5194,7 @@ Dealing with History Events
                "asset": "eip155:1/erc20:0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
                "amount": "1.542",
                "location_label": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12",
-               "notes": "Approve 1 SAI of 0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12 for spending by 0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE",
+               "user_notes": "Approve 1 SAI of 0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12 for spending by 0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE",
                "event_subtype": "approve",
                "counterparty": "0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE",
                "extra_data": {}
@@ -5132,7 +5208,7 @@ Dealing with History Events
          :reqjson string event_type: The main event type of the entry. Possible event types can be seen in the `HistoryEventType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L54>`_.
          :reqjson string event_subtype: The subtype for the entry. Possible event types can be seen in the `HistoryEventSubType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L72>`_.
          :reqjson string[optional] location_label: location_label is a string field that allows to provide more information about the location. For example when we use this structure in blockchains can be used to specify the source address.
-         :reqjson string[optional] notes: This is a description of the event entry in plain text explaining what is being done. This is supposed to be shown to the user.
+         :reqjson string[optional] user_notes: This is the user editable part of the description of the event entry in plain text explaining what is being done.
          :reqjson string[optional] counterparty: An identifier for a potential counterparty of the event entry. For a send it's the target. For a receive it's the sender. For bridged transfer it's the bridge's network identifier. For a protocol interaction it's the protocol.
          :reqjson string[optional] address: Any relevant address that this event interacted with.
          :reqjson object[optional] extra_data: An object containing any other data to be stored.
@@ -5247,7 +5323,7 @@ Dealing with History Events
                 "fee_asset": "ETH",
                 "address": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12",
                 "transaction_id": "0x64f1982504ab714037467fdd45d3ecf5a6356361403fc97dd325101d8c038c4e",
-                "notes": ["Example note", ""],
+                "user_notes": ["Example note", ""],
                 "event_identifier": "AM_xxxxxxxxxx"
             }
 
@@ -5259,7 +5335,7 @@ Dealing with History Events
          :reqjson string[optional] address: The address involved in the movement
          :reqjson string[optional] transaction_id: The transaction hash of the movement.
          :reqjson string[optional] unique_id: A unique identifier for this asset movement used in conjunction with the location to generate the event_identifier. It's generally the uuid of the event in the exchange.
-         :resjson list notes[optional]: Custom notes for each of the underlying events. Each note will be appended after the autogenerated event description.
+         :resjson list user_notes[optional]: Custom notes for each of the underlying events. Each note will be appended after the autogenerated event description.
          :reqjson string[optional] event_identifier: Custom identifier for the event (overrides the value generated from unique_id and location)
 
    .. tab:: Swap Event
@@ -5285,7 +5361,7 @@ Dealing with History Events
                 "fee_amount": "0.000004",
                 "fee_asset": "ETH",
                 "unique_id": "xxxxxxxxx",
-                "notes": ["Example note", "", ""]
+                "user_notes": ["Example note", "", ""]
             }
 
          :reqjson string location: The location/exchange where the swap occurred
@@ -5296,7 +5372,7 @@ Dealing with History Events
          :reqjson string[optional] fee: The fee amount charged for the swap. If provided, fee_asset must also be provided
          :reqjson string[optional] fee_asset: The identifier of the asset in which the fee was paid. If provided, fee must also be provided
          :reqjson string[optional] unique_id: A unique identifier for this swap used in conjunction with the location to generate the event_identifier. It's generally the uuid of the event in the exchange if its an exchange event.
-         :resjson list notes[optional]: Custom notes for each of the underlying events. Each note will be appended after the autogenerated event description.
+         :resjson list user_notes[optional]: Custom notes for each of the underlying events. Each note will be appended after the autogenerated event description.
          :reqjson string[optional] event_identifier: Custom identifier for the event (overrides the value generated from unique_id and location)
 
    :reqjson string entry_type: The type of the event that will be processed. Different validation is used based on the value for this field. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
@@ -5344,12 +5420,13 @@ Dealing with History Events
           "asset": "eip155:1/erc20:0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
           "amount": "1.542",
           "location_label": "0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12",
-          "notes": "Approve 1 SAI of 0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12 for spending by 0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE",
+          "user_notes": "Approve 1 SAI of 0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12 for spending by 0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE",
           "event_subtype": "approve",
           "counterparty": "0xdf869FAD6dB91f437B59F1EdEFab319493D4C4cE"
       }
 
    The request object uses all the same arguments for each entry type as the `add event endpoint <add_event_args_label_>`_, with the addition of the identifier which signifies which entry will be edited.
+   When dealing with event types where multiple events are added/edited as a unit (such as swap events and asset movements), use the identifier of the primary event in the group, i.e. for asset movements, the identifier of the deposit/withdrawal event, and for swap events, the identifier of the spend event.
 
    **Example Response**:
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -845,7 +845,7 @@ class CreateHistoryEventSchema(Schema):
             required=True,
         )
         asset = AssetField(required=True, expected_type=Asset, form_with_incomplete_data=True)
-        notes = fields.String(load_default=None)
+        user_notes = fields.String(load_default=None)
         sequence_index = fields.Integer(required=True)
         location_label = fields.String(load_default=None)
 
@@ -859,6 +859,7 @@ class CreateHistoryEventSchema(Schema):
                 data: dict[str, Any],
                 **_kwargs: Any,
         ) -> dict[str, Any]:
+            data['notes'] = data.pop('user_notes')
             return {'events': [HistoryEvent(**data)]}
 
     class CreateEvmEventSchema(BaseEventSchema):
@@ -877,6 +878,7 @@ class CreateHistoryEventSchema(Schema):
                 data: dict[str, Any],
                 **_kwargs: Any,
         ) -> dict[str, Any]:
+            data['notes'] = data.pop('user_notes')
             return {'events': [EvmEvent(**data)]}
 
     class CreateEthBlockEventEventSchema(BaseSchema):
@@ -968,7 +970,7 @@ class CreateHistoryEventSchema(Schema):
         event_identifier = fields.String(required=False, load_default=None)
         asset = AssetField(required=True, expected_type=Asset, form_with_incomplete_data=True)
         fee_asset = AssetField(load_default=None, required=False, expected_type=Asset, form_with_incomplete_data=True)  # noqa: E501
-        notes = fields.List(fields.String(), required=False, validate=validate.Length(min=1, max=2))  # noqa: E501
+        user_notes = fields.List(fields.String(), required=False, validate=validate.Length(min=1, max=2))  # noqa: E501
 
         @post_load
         def make_history_base_entry(
@@ -976,7 +978,7 @@ class CreateHistoryEventSchema(Schema):
                 data: dict[str, Any],
                 **_kwargs: Any,
         ) -> dict[str, Any]:
-            if (notes := data.get('notes')) is None:
+            if (notes := data.get('user_notes')) is None:
                 movement_notes, fee_notes = None, None
             elif len(notes) == 1:
                 movement_notes, fee_notes = notes[0], None
@@ -1055,12 +1057,12 @@ class CreateHistoryEventSchema(Schema):
         fee_asset = AssetField(required=False, load_default=None, expected_type=Asset, form_with_incomplete_data=True)  # noqa: E501
         location_label = fields.String(required=False, load_default=None)
         unique_id = fields.String(required=False, load_default=None)
-        notes = fields.List(fields.String(), required=False, validate=validate.Length(min=2, max=3))  # noqa: E501
+        user_notes = fields.List(fields.String(), required=False, validate=validate.Length(min=2, max=3))  # noqa: E501
         event_identifier = fields.String(required=False, load_default=None)
 
         @post_load
         def make_history_base_entry(self, data: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
-            if (notes := data.get('notes')) is None:
+            if (notes := data.get('user_notes')) is None:
                 spend_notes, receive_notes, fee_notes = None, None, None
             elif len(notes) == 2:
                 spend_notes, receive_notes = notes

--- a/rotkehlchen/history/events/structures/asset_movement.py
+++ b/rotkehlchen/history/events/structures/asset_movement.py
@@ -145,8 +145,7 @@ class AssetMovement(HistoryBaseEntry[AssetMovementExtraData | None]):
         )
 
     def serialize(self) -> dict[str, Any]:
-        """Serialize the event for api.
-        Autogenerates the event notes, appending any notes added by the user in a second sentence.
+        """Serialize the event for api, and generate the auto_notes.
         May raise UnknownAsset, but this would be an edge case as the asset should already have
         been checked for existence when it was deserialized from an API or from the database.
         """
@@ -154,13 +153,13 @@ class AssetMovement(HistoryBaseEntry[AssetMovementExtraData | None]):
         location_name = get_formatted_location_name(self.location)
         asset_symbol = self.asset.symbol_or_name()
         if self.event_subtype == HistoryEventSubType.FEE:
-            description = f'Pay {self.amount} {asset_symbol} as {location_name} {str(self.event_type).lower()} fee'  # noqa: E501
+            auto_notes = f'Pay {self.amount} {asset_symbol} as {location_name} {str(self.event_type).lower()} fee'  # noqa: E501
         elif self.event_type == HistoryEventType.DEPOSIT:
-            description = f'Deposit {self.amount} {asset_symbol} to {location_name}'
+            auto_notes = f'Deposit {self.amount} {asset_symbol} to {location_name}'
         else:  # withdrawal
-            description = f'Withdraw {self.amount} {asset_symbol} from {location_name}'
+            auto_notes = f'Withdraw {self.amount} {asset_symbol} from {location_name}'
 
-        serialized_data['description'] = description
+        serialized_data['auto_notes'] = auto_notes
         return serialized_data
 
     @classmethod

--- a/rotkehlchen/history/events/structures/swap.py
+++ b/rotkehlchen/history/events/structures/swap.py
@@ -102,8 +102,7 @@ class SwapEvent(HistoryBaseEntry):
         )
 
     def serialize(self) -> dict[str, Any]:
-        """Serialize the event for api.
-        Autogenerates the event notes, appending any notes added by the user in a second sentence.
+        """Serialize the event for api, and generate the auto_notes.
         May raise UnknownAsset, but this would be an edge case as the asset should already have
         been checked for existence when it was deserialized from an API or from the database.
         """
@@ -111,13 +110,13 @@ class SwapEvent(HistoryBaseEntry):
         location_name = get_formatted_location_name(self.location)
         asset_symbol = self.asset.symbol_or_name()
         if self.event_subtype == HistoryEventSubType.SPEND:
-            description = f'Swap {self.amount} {asset_symbol} in {location_name}'
+            auto_notes = f'Swap {self.amount} {asset_symbol} in {location_name}'
         elif self.event_subtype == HistoryEventSubType.RECEIVE:
-            description = f'Receive {self.amount} {asset_symbol} after a swap in {location_name}'
+            auto_notes = f'Receive {self.amount} {asset_symbol} after a swap in {location_name}'
         else:  # Fee
-            description = f'Spend {self.amount} {asset_symbol} as {location_name} swap fee'
+            auto_notes = f'Spend {self.amount} {asset_symbol} as {location_name} swap fee'
 
-        serialized_data['description'] = description
+        serialized_data['auto_notes'] = auto_notes
         return serialized_data
 
     @classmethod

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -1132,7 +1132,7 @@ def test_query_combined_mev_reward_and_block_production_events(rotkehlchen_api_s
             assert entry['entry_type'] == 'evm event'
             assert entry['amount'] == mev_reward
             assert entry['tx_hash'] == tx_hash.hex()  # pylint: disable=no-member
-            assert entry['notes'] == f'Receive {mev_reward} ETH from {mevbot_address} as mev reward for block {block_number} in {tx_hash.hex()}'  # pylint: disable=no-member  # noqa: E501
+            assert entry['user_notes'] == f'Receive {mev_reward} ETH from {mevbot_address} as mev reward for block {block_number} in {tx_hash.hex()}'  # pylint: disable=no-member  # noqa: E501
         else:
             raise AssertionError('Should not get to this sequence index')
 

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -815,7 +815,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'spend',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Burn 0.00863351371344 ETH for gas',
+            'user_notes': 'Burn 0.00863351371344 ETH for gas',
             'product': None,
             'sequence_index': 0,
             'timestamp': 1642802807000,
@@ -836,7 +836,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'spend',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Send 0.096809163374771208 ETH to 0xA090e606E30bD747d4E6245a1517EbE430F0057e',
+            'user_notes': 'Send 0.096809163374771208 ETH to 0xA090e606E30bD747d4E6245a1517EbE430F0057e',  # noqa: E501
             'product': None,
             'sequence_index': 1,
             'timestamp': 1642802807000,
@@ -859,7 +859,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'spend',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Burn 0.017690836625228792 ETH for gas',
+            'user_notes': 'Burn 0.017690836625228792 ETH for gas',
             'product': None,
             'sequence_index': 0,
             'timestamp': 1642802735000,
@@ -880,7 +880,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'spend',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Send 1166 USDT from 0x6e15887E2CEC81434C16D587709f64603b39b545 to 0xb5d85CBf7cB3EE0D56b3bB207D5Fc4B82f43F511',  # noqa: E501
+            'user_notes': 'Send 1166 USDT from 0x6e15887E2CEC81434C16D587709f64603b39b545 to 0xb5d85CBf7cB3EE0D56b3bB207D5Fc4B82f43F511',  # noqa: E501
             'product': None,
             'sequence_index': 308,
             'timestamp': 1642802735000,
@@ -903,7 +903,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'receive',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Receive 0.125 ETH from 0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf',
+            'user_notes': 'Receive 0.125 ETH from 0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf',
             'product': None,
             'sequence_index': 0,
             'timestamp': 1642802651000,
@@ -926,7 +926,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'receive',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Receive 1166 USDT from 0xE21c192cD270286DBBb0fBa10a8B8D9957d431E5 to 0x6e15887E2CEC81434C16D587709f64603b39b545',  # noqa: E501
+            'user_notes': 'Receive 1166 USDT from 0xE21c192cD270286DBBb0fBa10a8B8D9957d431E5 to 0x6e15887E2CEC81434C16D587709f64603b39b545',  # noqa: E501
             'product': None,
             'sequence_index': 385,
             'timestamp': 1642802286000,
@@ -943,7 +943,7 @@ def test_query_transactions_check_decoded_events(
     event['amount'] = '2500'
     event['event_type'] = 'spend'
     event['event_subtype'] = 'payback debt'
-    event['notes'] = 'Edited event'
+    event['user_notes'] = 'Edited event'
     tx2_events[1]['customized'] = True
     response = requests.patch(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),
@@ -963,7 +963,7 @@ def test_query_transactions_check_decoded_events(
             'event_type': 'deposit',
             'location': 'ethereum',
             'location_label': '0x6e15887E2CEC81434C16D587709f64603b39b545',
-            'notes': 'Some kind of deposit',
+            'user_notes': 'Some kind of deposit',
             'product': 'pool',
             'sequence_index': 1,
             'timestamp': 1642802286000,

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -667,7 +667,7 @@ def test_add_edit_asset_movements(rotkehlchen_api_server: 'APIServer') -> None:
             'unique_id': 'BITFINEX-344',
             'asset': 'ETH',
             'fee_asset': 'ETH',
-            'notes': ['Main event note', 'Fee event note'],
+            'user_notes': ['Main event note', 'Fee event note'],
         },
     ]
     for entry in entries:
@@ -703,13 +703,13 @@ def test_add_edit_asset_movements(rotkehlchen_api_server: 'APIServer') -> None:
         'location_label': None,
         'asset': 'ETH',
         'amount': '0.0569',
-        'notes': 'Main event note',
+        'user_notes': 'Main event note',
         'identifier': 2,
         'entry_type': 'asset movement event',
         'event_identifier': '7e4d3805a88cbbcdc35badc4547044be803724146c7b9f0165cadd62c1616205',
         'sequence_index': 0,
         'extra_data': {'reference': 'BITFINEX-344'},
-        'description': 'Withdraw 0.0569 ETH from Bitfinex',
+        'auto_notes': 'Withdraw 0.0569 ETH from Bitfinex',
     }
 
     # test editing unknown fails
@@ -743,9 +743,9 @@ def test_add_edit_asset_movements(rotkehlchen_api_server: 'APIServer') -> None:
         ))
         assert len(saved_events) == 3
         fields_to_exclude = {
-            'notes', 'extra_data', 'event_subtype', 'sequence_index',
+            'user_notes', 'extra_data', 'event_subtype', 'sequence_index',
             'location_label', 'unique_id', 'event_identifier',
-            'fee', 'fee_asset', 'timestamp', 'description',
+            'fee', 'fee_asset', 'timestamp', 'auto_notes',
         }
         for idx, event in enumerate(saved_events):
             serialized_event = event.serialize()
@@ -820,7 +820,7 @@ def test_add_edit_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
             'fee_amount': '0.000004',
             'fee_asset': 'ETH',
             'unique_id': 'TRADE2',
-            'notes': ['Example note', '', ''],
+            'user_notes': ['Example note', '', ''],
         },
     ]
     for entry in entries:
@@ -842,7 +842,7 @@ def test_add_edit_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
 
     # Edit the event identifier of the first entry and add a fee
     entry = entries[0].copy()
-    entry['fee_amount'], entry['fee_asset'], entry['event_identifier'], entry['notes'] = '0.1', 'USD', 'test_id', ['Note1', 'Note2', 'Note3']  # noqa: E501
+    entry['fee_amount'], entry['fee_asset'], entry['event_identifier'], entry['user_notes'] = '0.1', 'USD', 'test_id', ['Note1', 'Note2', 'Note3']  # noqa: E501
     requests.patch(api_url_for(rotkehlchen_api_server, 'historyeventresource'), json=entry)
     with rotki.data.db.conn.read_ctx() as cursor:
         assert (events := db.get_history_events(
@@ -913,11 +913,11 @@ def test_add_edit_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
         'location_label': None,
         'asset': 'ETH',
         'amount': '0.01',
-        'notes': 'Example note',
+        'user_notes': 'Example note',
         'identifier': 3,
         'entry_type': 'swap event',
         'event_identifier': '4074f41ac078988b05b7058775f111a3119888fc968f94ee9ed6a132918a3b83',
         'sequence_index': 0,
         'extra_data': None,
-        'description': 'Swap 0.01 ETH in Bitfinex',
+        'auto_notes': 'Swap 0.01 ETH in Bitfinex',
     }

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -67,13 +67,13 @@ def assert_csv_export_response(
         'asset_symbol',
         'amount',
         'fiat_value',
-        'notes',
         'identifier',
         'entry_type',
         'event_identifier',
         'sequence_index',
         'direction',
-    )
+        'extra_data',
+    )  # skip auto_notes and user_notes here since they may or may not be present
 
     extra_headers = (
         # evm event

--- a/rotkehlchen/tests/api/test_pnl_csv.py
+++ b/rotkehlchen/tests/api/test_pnl_csv.py
@@ -328,7 +328,7 @@ def test_encoding(
 
         events = debug_data['events']
         assert len(events) == 1, 'Should have one event'
-        assert unicode_notes in events[0]['notes'], 'Should have exported the unicode notes'
+        assert unicode_notes in events[0]['user_notes'], 'Should have exported the unicode notes'
 
 
 @pytest.mark.parametrize('have_decoders', [True])

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -1104,7 +1104,7 @@ def test_kraken_event_serialization_with_custom_asset(database):
         'Receive 1 Gold Bar after a swap in Kraken',
         'Spend 1 Gold Bar as Kraken swap fee',
     )):
-        assert swap_events[idx].serialize()['description'] == expected_notes
+        assert swap_events[idx].serialize()['auto_notes'] == expected_notes
 
     for event_type in {HistoryEventType.DEPOSIT, HistoryEventType.WITHDRAWAL}:
         asset_movements = create_asset_movement_with_fee(
@@ -1117,10 +1117,10 @@ def test_kraken_event_serialization_with_custom_asset(database):
             fee=ONE,
         )
         if event_type == HistoryEventType.DEPOSIT:
-            assert asset_movements[0].serialize()['description'] == 'Deposit 1 Gold Bar to Kraken'
+            assert asset_movements[0].serialize()['auto_notes'] == 'Deposit 1 Gold Bar to Kraken'
         else:
-            assert asset_movements[0].serialize()['description'] == 'Withdraw 1 Gold Bar from Kraken'  # noqa: E501
-        assert asset_movements[1].serialize()['description'] == f'Pay 1 Gold Bar as Kraken {event_type.name.lower()} fee'  # noqa: E501
+            assert asset_movements[0].serialize()['auto_notes'] == 'Withdraw 1 Gold Bar from Kraken'  # noqa: E501
+        assert asset_movements[1].serialize()['auto_notes'] == f'Pay 1 Gold Bar as Kraken {event_type.name.lower()} fee'  # noqa: E501
 
     for event_type, event_subtype, expected_notes in (
             (HistoryEventType.STAKING, HistoryEventSubType.REWARD, 'Gain 1 Gold Bar from Kraken staking'),  # noqa: E501
@@ -1137,4 +1137,4 @@ def test_kraken_event_serialization_with_custom_asset(database):
             amount=ONE,
             location_label='my kraken',
         )
-        assert event.serialize()['notes'] == expected_notes
+        assert event.serialize()['auto_notes'] == expected_notes

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -60,7 +60,6 @@ def test_serialize_with_invalid_type_subtype():
             'identifier': None,
             'location': 'kraken',
             'location_label': None,
-            'notes': None,
             'sequence_index': 1,
             'timestamp': 1,
         },

--- a/rotkehlchen/tests/utils/history_base_entry.py
+++ b/rotkehlchen/tests/utils/history_base_entry.py
@@ -29,11 +29,11 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 KEYS_IN_ENTRY_TYPE: dict[HistoryBaseEntryType, set[str]] = {
-    HistoryBaseEntryType.HISTORY_EVENT: {'sequence_index', 'location', 'event_type', 'event_subtype', 'asset', 'notes', 'event_identifier'},  # noqa: E501
+    HistoryBaseEntryType.HISTORY_EVENT: {'sequence_index', 'location', 'event_type', 'event_subtype', 'asset', 'user_notes', 'event_identifier'},  # noqa: E501
     HistoryBaseEntryType.ETH_BLOCK_EVENT: {'validator_index', 'is_exit_or_blocknumber', 'block_number', 'event_subtype', 'fee_recipient', 'location_label', 'is_mev_reward'},  # noqa: E501
     HistoryBaseEntryType.ETH_DEPOSIT_EVENT: {'tx_hash', 'validator_index', 'sequence_index', 'event_identifier'},  # noqa: E501
     HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT: {'validator_index', 'is_exit_or_blocknumber', 'is_exit'},  # noqa: E501
-    HistoryBaseEntryType.EVM_EVENT: {'tx_hash', 'sequence_index', 'location', 'event_type', 'event_subtype', 'asset', 'notes', 'counterparty', 'product', 'address', 'extra_data', 'event_identifier'},  # noqa: E501
+    HistoryBaseEntryType.EVM_EVENT: {'tx_hash', 'sequence_index', 'location', 'event_type', 'event_subtype', 'asset', 'user_notes', 'counterparty', 'product', 'address', 'extra_data', 'event_identifier'},  # noqa: E501
     HistoryBaseEntryType.ASSET_MOVEMENT_EVENT: {'location', 'event_type', 'asset', 'event_identifier', 'extra_data'},  # noqa: E501
     HistoryBaseEntryType.SWAP_EVENT: {'location', 'asset', 'event_identifier'},
 }


### PR DESCRIPTION
Backend part of [this note](https://github.com/orgs/rotki/projects/11?pane=issue&itemId=103747916)

* Renames the field names used for history event notes in the api (old: `notes` and `description`, new: `user_notes` and `auto_notes`)
* Changes the api docs to reflect the field name changes and also adds some more info relating to swap events and asset movements.
* Uses `auto_notes` for kraken staking events
* Removes the `default_notes` flag

Note that this will make all the notes disappear when running the app in develop until the frontend is also updated. 