### PR TITLE
Use SwapEvents in bitpanda

### DIFF
--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -21,7 +21,7 @@ from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
-from rotkehlchen.exchanges.data_structures import Location, MarginPosition, Trade
+from rotkehlchen.exchanges.data_structures import Location, MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
 from rotkehlchen.fval import FVal
@@ -437,10 +437,3 @@ class Bitmex(ExchangeInterface):
                 )
                 continue
         return movements, end_ts
-
-    def query_online_trade_history(
-            self,
-            start_ts: Timestamp,
-            end_ts: Timestamp,
-    ) -> tuple[list[Trade], tuple[Timestamp, Timestamp]]:
-        return [], (start_ts, end_ts)  # noop for bitmex

--- a/rotkehlchen/history/events/structures/swap.py
+++ b/rotkehlchen/history/events/structures/swap.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.location_details import get_formatted_location_name
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryBaseEntryType
@@ -203,7 +204,9 @@ def create_swap_events(
         fee_identifier: int | None = None,
         event_identifier: str | None = None,
 ) -> list[SwapEvent]:
-    """Overload for creating swap events with a fee."""
+    """Overload for creating swap events with a fee.
+    The fee will still be omitted if the fee_amount is zero.
+    """
 
 
 def create_swap_events(
@@ -251,7 +254,7 @@ def create_swap_events(
         identifier=receive_identifier,
         event_identifier=event_identifier,
     )]
-    if fee_asset is not None:
+    if fee_asset is not None and fee_amount != ZERO:
         events.append(SwapEvent(
             timestamp=timestamp,
             location=location,

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -39,6 +39,7 @@ from rotkehlchen.types import (
     Timestamp,
     TimestampMS,
 )
+from rotkehlchen.utils.misc import ts_ms_to_sec
 
 if TYPE_CHECKING:
     from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -1708,5 +1709,5 @@ def test_partial_query_online_history_events(mock_bitfinex: 'Bitfinex') -> None:
         )
         assert api_query_mock.call_args_list == expected_calls
         assert len(events) == 8  # withdrawal/fee from one movement, and spend/receive/fee from two trades.  # noqa: E501
-        assert actual_end_ts == events[-1].timestamp / 1000
+        assert actual_end_ts == ts_ms_to_sec(events[-1].timestamp)
         assert actual_end_ts != end_ts  # There were errors and only part of the range was queried.


### PR DESCRIPTION
Related: #6097 

* Converts bitpanda to use swap events.
* Removes the unused `query_online_trade_history` function from bitmex 
* Fixes a nitpick from #9716 