### PR TITLE
Use SwapEvents in bitstamp

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -99,7 +99,7 @@ from rotkehlchen.history.events.structures.eth2 import (
     EthWithdrawalEvent,
 )
 from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct
-from rotkehlchen.history.events.structures.swap import create_swap_events
+from rotkehlchen.history.events.structures.swap import SwapEventExtraData, create_swap_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.icons import ALLOWED_ICON_EXTENSIONS
@@ -1081,6 +1081,10 @@ class CreateHistoryEventSchema(Schema):
                     field_name='fee_notes',
                 )
 
+            extra_data: SwapEventExtraData = {}
+            if (unique_id := data['unique_id']) is not None:
+                extra_data['reference'] = unique_id
+
             context_schema = CreateHistoryEventSchema.history_event_context.get()['schema']
             events = create_swap_events(
                 timestamp=data['timestamp'],
@@ -1106,6 +1110,7 @@ class CreateHistoryEventSchema(Schema):
                     data=data,
                     subtype=HistoryEventSubType.FEE,
                 ),
+                extra_data=extra_data,
             )
             return {'events': events}
 

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -859,6 +859,7 @@ def test_add_edit_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
             amount=FVal('50'),
             notes='Note1',
             event_identifier='test_id',
+            extra_data={'reference': 'TRADE1'},
         ), SwapEvent(
             identifier=2,
             timestamp=TimestampMS(1569924575000),
@@ -886,6 +887,7 @@ def test_add_edit_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
             amount=FVal('0.01'),
             unique_id='TRADE2',
             notes='Example note',
+            extra_data={'reference': 'TRADE2'},
         ), SwapEvent(
             identifier=4,
             timestamp=TimestampMS(1569924576000),
@@ -918,6 +920,6 @@ def test_add_edit_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
         'entry_type': 'swap event',
         'event_identifier': '4074f41ac078988b05b7058775f111a3119888fc968f94ee9ed6a132918a3b83',
         'sequence_index': 0,
-        'extra_data': None,
+        'extra_data': {'reference': 'TRADE2'},
         'auto_notes': 'Swap 0.01 ETH in Bitfinex',
     }


### PR DESCRIPTION
Related: #6097 

* Converts bitstamp to use swap events.
* Adds support for swap events to have `reference` in their extra_data like we do for asset movements, since bitstamp relies on this to retrieve the trade ids.