### PR TITLE
chore: fix version check and JSON parsing issues

### DIFF
--- a/frontend/scripts/check-versions.js
+++ b/frontend/scripts/check-versions.js
@@ -1,9 +1,10 @@
 import { execSync } from 'node:child_process';
 import process from 'node:process';
 import semver from 'semver';
-import pkg from '../package.json' with { type: 'json' };
+import fs from 'node:fs';
 
-const pnpmVersion = `${execSync('pnpm --version')}`.trim();
+const pnpmVersion = execSync('pnpm --version').toString().trim();
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const requiredPnpmVersion = pkg.engines.pnpm;
 const requiredNodeVersion = pkg.engines.node;
 


### PR DESCRIPTION
Fixed the retrieval of `pnpm` version by using `execSync('pnpm --version').toString().trim()` to avoid issues with extra spaces or newlines.

Replaced `import pkg from '../package.json' with { type: 'json' }` with `fs.readFileSync` for better compatibility with different Node.js versions.

Removed unnecessary `semver.valid` check since `pnpmVersion` and `process.version` are always strings, allowing direct use of `semver.satisfies`.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
