### PR TITLE
Changes how ignored assets are skipped in the token detection after decoding

### DIFF
--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -54,7 +54,6 @@ from rotkehlchen.db.constants import EVM_EVENT_FIELDS, HISTORY_BASE_ENTRY_FIELDS
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.drivers.gevent import DBCursor
 from rotkehlchen.db.filtering import EVM_EVENT_JOIN
-from rotkehlchen.db.history_events import filter_ignore_asset_query
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import NotERC20Conformant, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -441,7 +440,8 @@ def maybe_detect_new_tokens(database: 'DBHandler') -> None:
         for event_data in cursor.execute(
             # events that are the earliest events of distinct assets after last_save_time
             f'SELECT {HISTORY_BASE_ENTRY_FIELDS}, '
-            f'{EVM_EVENT_FIELDS} {EVM_EVENT_JOIN} {filter_ignore_asset_query()} '
+            f'{EVM_EVENT_FIELDS} {EVM_EVENT_JOIN} LEFT JOIN multisettings ms ON '
+            'asset = ms.value AND ms.name = "ignored_asset" '
             'AND timestamp >= ? GROUP BY asset, location_label;',
             (ts_sec_to_ms(last_save_time),),
         ):


### PR DESCRIPTION
Right now we use a subquery to check in the ignored assets if we should skip or not a decoded event. This is suboptimal since the query becomes slower when the number of events and ignored assets grow.

Using left join is faster and can be optimized further with the usage of indexes if we decide to add them. In our test suite I run some of the tests affected by this logic and saw the following changes in time execution under similar environments. Experiment 1 is the baseline of develop and the second experiment is the change in this PR

```
┌─────────────────────────────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬────────────────┬──────────┐
│ test_name                       ┆ set_1_avg ┆ set_1_min ┆ set_1_max ┆ set_1_std ┆ set_2_avg ┆ set_2_min ┆ set_2_max ┆ set_2_std ┆ avg_difference ┆ speed up │
│ ---                             ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---            ┆ ---      │
│ str                             ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64            ┆ f64      │
╞═════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪════════════════╪══════════╡
│ rotkehlchen/tests/unit/test_ev… ┆ 3.276     ┆ 3.17      ┆ 3.43      ┆ 0.101637  ┆ 3.312     ┆ 3.22      ┆ 3.46      ┆ 0.095237  ┆ 0.036          ┆ 0.98913  │
│ rotkehlchen/tests/db/test_hist… ┆ 7.812     ┆ 7.75      ┆ 7.97      ┆ 0.090111  ┆ 7.684     ┆ 7.64      ┆ 7.7       ┆ 0.026077  ┆ -0.128         ┆ 1.016658 │
│ rotkehlchen/tests/api/test_his… ┆ 12.772    ┆ 12.51     ┆ 12.93     ┆ 0.175841  ┆ 12.586    ┆ 12.45     ┆ 12.89     ┆ 0.180776  ┆ -0.186         ┆ 1.014778 │
└─────────────────────────────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴────────────────┴──────────┘
```

The tests run were

- rotkehlchen/tests/unit/test_evm_tx_decoding.py::test_token_detection_after_decoding
- rotkehlchen/tests/api/test_history_base_entry.py
- rotkehlchen/tests/db/test_history_events.py

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
