### PR TITLE
Fix incorrect variable reference in merge log output

### DIFF
--- a/.github/scripts/merge-latest.mjs
+++ b/.github/scripts/merge-latest.mjs
@@ -24,7 +24,7 @@ function exitIfNotExists(file) {
 exitIfNotExists(file1);
 exitIfNotExists(file2);
 
-consola.info(`merging ${file1} and ${file3} to ${file3}`);
+consola.info(`merging ${file1} and ${file2} to ${file3}`);
 
 consola.info(`reading file: ${file1}`);
 const yaml1 = yaml.load(fs.readFileSync(file1, 'utf8'));


### PR DESCRIPTION
The original message referenced a variable file3, which is undefined in this context. This could lead to confusion when reading logs or debugging.
By updating it to use file2, the log now accurately reflects the actual merge process and improves clarity.
