### PR TITLE
Use new AssetAmount when creating swap events

### DIFF
--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -36,8 +36,8 @@ from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.inquirer import CurrentPriceOracle
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
     deserialize_fee,
+    deserialize_fval,
     deserialize_hex_color_code,
     deserialize_timestamp,
 )
@@ -293,7 +293,7 @@ class AmountField(fields.Field):
             **_kwargs: Any,
     ) -> FVal:
         try:
-            amount = deserialize_asset_amount(value)
+            amount = deserialize_fval(value)
         except DeserializationError as e:
             raise ValidationError(str(e)) from e
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -119,6 +119,7 @@ from rotkehlchen.types import (
     SUPPORTED_SUBSTRATE_CHAINS,
     AddressbookEntry,
     AddressbookType,
+    AssetAmount,
     BlockchainAddress,
     BTCAddress,
     ChainID,
@@ -1005,12 +1006,9 @@ class CreateHistoryEventSchema(Schema):
             events = create_swap_events(
                 timestamp=data['timestamp'],
                 location=data['location'],
-                spend_asset=data['spend_asset'],
-                spend_amount=data['spend_amount'],
-                receive_asset=data['receive_asset'],
-                receive_amount=data['receive_amount'],
-                fee_amount=data['fee_amount'] or ZERO,
-                fee_asset=data['fee_asset'],
+                spend=AssetAmount(asset=data['spend_asset'], amount=data['spend_amount']),
+                receive=AssetAmount(asset=data['receive_asset'], amount=data['receive_amount']),
+                fee=AssetAmount(asset=data['fee_asset'], amount=data['fee_amount']) if data['fee_asset'] is not None else None,  # noqa: E501
                 location_label=data['location_label'],
                 unique_id=data['unique_id'],
                 spend_notes=spend_notes,

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -15,7 +15,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
-from rotkehlchen.serialization.deserialize import deserialize_asset_amount
+from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.types import ChecksumEvmAddress, Price
 from rotkehlchen.utils.misc import from_wei
 
@@ -131,10 +131,10 @@ class Liquity(HasDSProxy):
                     trove_is_active = bool(trove_info[3])
                     if not trove_is_active:
                         continue
-                    collateral = deserialize_asset_amount(
+                    collateral = deserialize_fval(
                         token_normalized_value_decimals(trove_info[1], 18),
                     )
-                    debt = deserialize_asset_amount(
+                    debt = deserialize_fval(
                         token_normalized_value_decimals(trove_info[0], 18),
                     )
                     collateral_balance = AssetBalance(
@@ -246,7 +246,7 @@ class Liquity(HasDSProxy):
 
             # get price information for the asset and deserialize the amount
             asset_price = Inquirer.find_usd_price(asset)
-            amount = deserialize_asset_amount(
+            amount = deserialize_fval(
                 token_normalized_value_decimals(gain_info, 18),
             )
             proxy_owner = self.ethereum.proxies_inquirer.proxy_to_address.get(current_address)

--- a/rotkehlchen/data_import/importers/binance.py
+++ b/rotkehlchen/data_import/importers/binance.py
@@ -22,7 +22,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
+    deserialize_fval,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import (
@@ -656,7 +656,7 @@ class BinanceImporter(BaseExchangeImporter):
                     location='binance',
                 )
                 csv_row['Coin'] = asset_from_binance(csv_row['Coin'])
-                csv_row['Change'] = deserialize_asset_amount(csv_row['Change'])
+                csv_row['Change'] = deserialize_fval(csv_row['Change'])
                 csv_row[INDEX] = index
                 multirows[timestamp].append(csv_row)
             except UnknownAsset as e:

--- a/rotkehlchen/data_import/importers/bisq_trades.py
+++ b/rotkehlchen/data_import/importers/bisq_trades.py
@@ -15,7 +15,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location, Price
+from rotkehlchen.types import AssetAmount, Location, Price
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -65,7 +65,7 @@ class BisqTradesImporter(BaseExchangeImporter):
             fee_amount = deserialize_fee(csv_row['Trade Fee BTC'])
             fee_currency = A_BTC
 
-        spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+        spend, receive = get_swap_spend_receive(
             raw_trade_type=trade_type,
             base_asset=base_asset,
             quote_asset=quote_asset,
@@ -80,15 +80,12 @@ class BisqTradesImporter(BaseExchangeImporter):
                     formatstr=timestamp_format,
                     location='Bisq',
                 )),
-                spend_amount=spend_amount,
-                spend_asset=spend_asset,
-                receive_asset=receive_asset,
-                receive_amount=receive_amount,
                 location=Location.BISQ,
-                spend_notes=f'ID: {(trade_id := csv_row["Trade ID"])}',
-                fee_asset=fee_currency,
-                fee_amount=fee_amount,
-                unique_id=trade_id,
+                spend=spend,
+                receive=receive,
+                fee=AssetAmount(asset=fee_currency, amount=fee_amount),
+                unique_id=(trade_id := csv_row['Trade ID']),
+                spend_notes=f'ID: {trade_id}',
             ),
         )
 

--- a/rotkehlchen/data_import/importers/bisq_trades.py
+++ b/rotkehlchen/data_import/importers/bisq_trades.py
@@ -11,8 +11,8 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events, get_swap_spend_receive
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_or_zero,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location, Price
@@ -53,16 +53,16 @@ class BisqTradesImporter(BaseExchangeImporter):
             quote_asset = symbol_to_asset_or_token(assets1_symbol)
 
         if base_asset == A_BTC:
-            buy_amount = deserialize_asset_amount(csv_row['Amount in BTC'])
+            buy_amount = deserialize_fval(csv_row['Amount in BTC'])
         else:
-            buy_amount = deserialize_asset_amount(csv_row['Amount'])
+            buy_amount = deserialize_fval(csv_row['Amount'])
 
         # Get trade fee
         if len(csv_row['Trade Fee BSQ']) != 0:
-            fee_amount = deserialize_fee(csv_row['Trade Fee BSQ'])
+            fee_amount = deserialize_fval_or_zero(csv_row['Trade Fee BSQ'])
             fee_currency = A_BSQ
         else:
-            fee_amount = deserialize_fee(csv_row['Trade Fee BTC'])
+            fee_amount = deserialize_fval_or_zero(csv_row['Trade Fee BTC'])
             fee_currency = A_BTC
 
         spend, receive = get_swap_spend_receive(
@@ -70,7 +70,7 @@ class BisqTradesImporter(BaseExchangeImporter):
             base_asset=base_asset,
             quote_asset=quote_asset,
             amount=buy_amount,
-            rate=Price(deserialize_asset_amount(csv_row['Price'])),
+            rate=Price(deserialize_fval(csv_row['Price'])),
         )
         self.add_history_events(
             write_cursor=write_cursor,

--- a/rotkehlchen/data_import/importers/bitcoin_tax.py
+++ b/rotkehlchen/data_import/importers/bitcoin_tax.py
@@ -20,7 +20,7 @@ from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
+    deserialize_fval,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Fee, Location, TimestampMS
@@ -198,8 +198,8 @@ class BitcoinTaxImporter(BaseExchangeImporter):
 
         asset_resolver = LOCATION_TO_ASSET_MAPPING.get(location, asset_from_common_identifier)
         base_asset = asset_resolver(csv_row['Symbol'])
-        base_amount = deserialize_asset_amount(csv_row['Volume'])
-        fee_amount = Fee(deserialize_asset_amount(csv_row['Fee'])) if csv_row['Fee'] else Fee(ZERO)
+        base_amount = deserialize_fval(csv_row['Volume'])
+        fee_amount = Fee(deserialize_fval(csv_row['Fee'])) if csv_row['Fee'] else Fee(ZERO)
         fee_asset = (
             asset_resolver(csv_row['FeeCurrency'])
             if csv_row['FeeCurrency'] and fee_amount is not None else None
@@ -223,7 +223,7 @@ class BitcoinTaxImporter(BaseExchangeImporter):
                 base_asset_amount=base_asset_amount,
                 quote_asset_amount=AssetAmount(
                     asset=asset_resolver(csv_row['Currency']),
-                    amount=deserialize_asset_amount(csv_row['Cost/Proceeds']),
+                    amount=deserialize_fval(csv_row['Cost/Proceeds']),
                 ),
                 fee_asset_amount=fee_asset_amount,
                 memo=memo,

--- a/rotkehlchen/data_import/importers/bitmex.py
+++ b/rotkehlchen/data_import/importers/bitmex.py
@@ -24,9 +24,9 @@ from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_asset_amount_force_positive,
     deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_force_positive,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import Fee, Location
@@ -60,7 +60,7 @@ class BitMEXImporter(BaseExchangeImporter):
             formatstr=timestamp_format,
             location='Bitmex Wallet History Import',
         )
-        realised_pnl = satoshis_to_btc(deserialize_asset_amount(csv_row['amount']))
+        realised_pnl = satoshis_to_btc(deserialize_fval(csv_row['amount']))
         fee = deserialize_fee(csv_row['fee']) if csv_row['fee'] != 'null' else Fee(ZERO)
         notes = f"PnL from trade on {csv_row['address']}"
         log.debug(
@@ -97,8 +97,8 @@ class BitMEXImporter(BaseExchangeImporter):
         - DeserializationError
         """
         asset = A_BTC.resolve_to_asset_with_oracles()
-        amount = deserialize_asset_amount_force_positive(csv_row['amount'])
-        fee = deserialize_fee(csv_row['fee']) if csv_row['fee'] != 'null' else Fee(ZERO)
+        amount = deserialize_fval_force_positive(csv_row['amount'])
+        fee = deserialize_fval(csv_row['fee']) if csv_row['fee'] != 'null' else Fee(ZERO)
         transact_type = csv_row['transactType']
         event_type: Final = HistoryEventType.DEPOSIT if transact_type == 'Deposit' else HistoryEventType.WITHDRAWAL  # noqa: E501
         amount = satoshis_to_btc(amount)  # bitmex stores amounts in satoshis

--- a/rotkehlchen/data_import/importers/bitstamp.py
+++ b/rotkehlchen/data_import/importers/bitstamp.py
@@ -16,8 +16,8 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import create_swap_events, get_swap_spend_receive
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_or_zero,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location, Price
@@ -63,8 +63,8 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
                 raw_trade_type=csv_row['Sub Type'],
                 base_asset=asset_from_bitstamp(amount_symbol),
                 quote_asset=asset_from_bitstamp(value_symbol),
-                amount=(swap_amount := deserialize_asset_amount(amount)),
-                rate=Price(deserialize_asset_amount(value_str) / swap_amount),
+                amount=(swap_amount := deserialize_fval(amount)),
+                rate=Price(deserialize_fval(value_str) / swap_amount),
             )
             events.extend(create_swap_events(
                 timestamp=timestamp,
@@ -74,7 +74,7 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
                 event_identifier=event_identifier,
                 fee=AssetAmount(
                     asset=asset_from_bitstamp(fee_symbol),
-                    amount=deserialize_fee(fee_str),
+                    amount=deserialize_fval_or_zero(fee_str),
                 ),
             ))
         elif csv_row['Type'] in {'Deposit', 'Withdrawal'}:
@@ -84,7 +84,7 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
                 timestamp=timestamp,
                 location=Location.BITSTAMP,
                 asset=asset_from_bitstamp(amount_symbol),
-                amount=deserialize_asset_amount(amount),
+                amount=deserialize_fval(amount),
             ))
 
         if len(events) > 0:

--- a/rotkehlchen/data_import/importers/bittrex.py
+++ b/rotkehlchen/data_import/importers/bittrex.py
@@ -18,9 +18,9 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_asset_amount_force_positive,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_force_positive,
+    deserialize_fval_or_zero,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location
@@ -93,7 +93,7 @@ class BittrexImporter(BaseExchangeImporter):
             raw_trade_type=trade_type,
             base_asset=asset_from_bittrex(base),
             quote_asset=(quote_asset := asset_from_bittrex(quote)),
-            amount=deserialize_asset_amount(amount),
+            amount=deserialize_fval(amount),
             rate=deserialize_price(rate),
         )
         return create_swap_events(
@@ -107,7 +107,7 @@ class BittrexImporter(BaseExchangeImporter):
             receive=receive,
             fee=AssetAmount(
                 asset=quote_asset,
-                amount=deserialize_fee(fee),
+                amount=deserialize_fval_or_zero(fee),
             ),
             unique_id=order_id,
             spend_notes=notes,
@@ -171,7 +171,7 @@ class BittrexImporter(BaseExchangeImporter):
                 location='Bittrex tx history import',
             )),
             asset=asset,
-            amount=deserialize_asset_amount_force_positive(amount),
+            amount=deserialize_fval_force_positive(amount),
             unique_id=(transaction_id := get_key_if_has_val(csv_row, tx_id_key)),
             extra_data=maybe_set_transaction_extra_data(
                 address=deserialize_asset_movement_address(csv_row, address_key, asset),

--- a/rotkehlchen/data_import/importers/bittrex.py
+++ b/rotkehlchen/data_import/importers/bittrex.py
@@ -23,7 +23,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location
+from rotkehlchen.types import AssetAmount, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -89,7 +89,7 @@ class BittrexImporter(BaseExchangeImporter):
             rate = csv_row['LIMIT']
             order_id = csv_row['UUID']
 
-        spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+        spend, receive = get_swap_spend_receive(
             raw_trade_type=trade_type,
             base_asset=asset_from_bittrex(base),
             quote_asset=(quote_asset := asset_from_bittrex(quote)),
@@ -103,12 +103,12 @@ class BittrexImporter(BaseExchangeImporter):
                 location='Bittrex order history import',
             )),
             location=Location.BITTREX,
-            spend_asset=spend_asset,
-            receive_asset=receive_asset,
-            spend_amount=spend_amount,
-            receive_amount=receive_amount,
-            fee_asset=quote_asset,
-            fee_amount=deserialize_fee(fee),
+            spend=spend,
+            receive=receive,
+            fee=AssetAmount(
+                asset=quote_asset,
+                amount=deserialize_fee(fee),
+            ),
             unique_id=order_id,
             spend_notes=notes,
         )

--- a/rotkehlchen/data_import/importers/blockfi_trades.py
+++ b/rotkehlchen/data_import/importers/blockfi_trades.py
@@ -16,7 +16,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location
+from rotkehlchen.types import AssetAmount, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -56,10 +56,14 @@ class BlockfiTradesImporter(BaseExchangeImporter):
                     location='BlockFi',
                 )),
                 location=Location.BLOCKFI,
-                spend_asset=asset_from_blockfi(csv_row['Sold Currency']),
-                spend_amount=sold_amount,
-                receive_asset=asset_from_blockfi(csv_row['Buy Currency']),
-                receive_amount=deserialize_asset_amount(csv_row['Buy Quantity']),
+                spend=AssetAmount(
+                    asset=asset_from_blockfi(csv_row['Sold Currency']),
+                    amount=sold_amount,
+                ),
+                receive=AssetAmount(
+                    asset=asset_from_blockfi(csv_row['Buy Currency']),
+                    amount=deserialize_asset_amount(csv_row['Buy Quantity']),
+                ),
                 spend_notes=csv_row['Type'],
                 unique_id=csv_row['Trade ID'],
             ),

--- a/rotkehlchen/data_import/importers/blockfi_trades.py
+++ b/rotkehlchen/data_import/importers/blockfi_trades.py
@@ -13,7 +13,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
+    deserialize_fval,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location
@@ -44,7 +44,7 @@ class BlockfiTradesImporter(BaseExchangeImporter):
         - UnknownAsset
         - DeserializationError
         """
-        if (sold_amount := deserialize_asset_amount(csv_row['Sold Quantity'])) == ZERO:
+        if (sold_amount := deserialize_fval(csv_row['Sold Quantity'])) == ZERO:
             raise SkippedCSVEntry('Trade has sold_amount equal to zero.')
 
         self.add_history_events(  # BlockFi does not provide fee info
@@ -62,7 +62,7 @@ class BlockfiTradesImporter(BaseExchangeImporter):
                 ),
                 receive=AssetAmount(
                     asset=asset_from_blockfi(csv_row['Buy Currency']),
-                    amount=deserialize_asset_amount(csv_row['Buy Quantity']),
+                    amount=deserialize_fval(csv_row['Buy Quantity']),
                 ),
                 spend_notes=csv_row['Type'],
                 unique_id=csv_row['Trade ID'],

--- a/rotkehlchen/data_import/importers/blockfi_transactions.py
+++ b/rotkehlchen/data_import/importers/blockfi_transactions.py
@@ -20,7 +20,7 @@ from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
+    deserialize_fval,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import Location
@@ -65,7 +65,7 @@ class BlockfiTransactionsImporter(BaseExchangeImporter):
             raise SkippedCSVEntry('Entry is unconfirmed.')
 
         asset = asset_from_blockfi(csv_row['Cryptocurrency'])
-        raw_amount = deserialize_asset_amount(csv_row['Amount'])
+        raw_amount = deserialize_fval(csv_row['Amount'])
         abs_amount = abs(raw_amount)
         entry_type = csv_row['Transaction Type']
 

--- a/rotkehlchen/data_import/importers/blockpit.py
+++ b/rotkehlchen/data_import/importers/blockpit.py
@@ -23,7 +23,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Fee, Location
+from rotkehlchen.types import AssetAmount, Fee, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -96,12 +96,18 @@ class BlockpitImporter(BaseExchangeImporter):
                 history_events=create_swap_events(
                     timestamp=ts_sec_to_ms(timestamp),
                     location=location,
-                    spend_asset=asset_resolver(csv_row['Outgoing Asset']),
-                    receive_asset=asset_resolver(csv_row['Incoming Asset']),
-                    spend_amount=deserialize_asset_amount(csv_row['Outgoing Amount']),
-                    receive_amount=amount_in,
-                    fee_amount=fee_amount,
-                    fee_asset=fee_currency,
+                    spend=AssetAmount(
+                        asset=asset_resolver(csv_row['Outgoing Asset']),
+                        amount=deserialize_asset_amount(csv_row['Outgoing Amount']),
+                    ),
+                    receive=AssetAmount(
+                        asset=asset_resolver(csv_row['Incoming Asset']),
+                        amount=amount_in,
+                    ),
+                    fee=AssetAmount(
+                        asset=fee_currency,
+                        amount=fee_amount,
+                    ),
                     spend_notes=notes,
                 ),
             )

--- a/rotkehlchen/data_import/importers/cointracking.py
+++ b/rotkehlchen/data_import/importers/cointracking.py
@@ -31,7 +31,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Fee, Location
+from rotkehlchen.types import AssetAmount, Fee, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -149,12 +149,9 @@ class CointrackingImporter(BaseExchangeImporter):
                 history_events=create_swap_events(
                     timestamp=timestamp,
                     location=location,
-                    spend_asset=quote_asset,
-                    spend_amount=quote_amount_sold,
-                    receive_asset=base_asset,
-                    receive_amount=base_amount_bought,
-                    fee_asset=fee_currency,
-                    fee_amount=fee,
+                    spend=AssetAmount(asset=quote_asset, amount=quote_amount_sold),
+                    receive=AssetAmount(asset=base_asset, amount=base_amount_bought),
+                    fee=AssetAmount(asset=fee_currency, amount=fee),
                     spend_notes=notes,
                 ),
             )

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -28,11 +28,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount_force_positive,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import (
-    Fee,
-    Location,
-    Timestamp,
-)
+from rotkehlchen.types import AssetAmount, Fee, Location, Timestamp
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -129,14 +125,11 @@ class CryptocomImporter(BaseExchangeImporter):
                 history_events=create_swap_events(
                     event_identifier=f'{CRYPTOCOM_PREFIX}{hash_csv_row_without_index(csv_row)}',
                     timestamp=timestamp,
-                    spend_asset=quote_asset,
-                    spend_amount=abs(quote_amount_sold),
-                    receive_asset=base_asset,
-                    receive_amount=abs(base_amount_bought),
+                    spend=AssetAmount(asset=quote_asset, amount=abs(quote_amount_sold)),
+                    receive=AssetAmount(asset=base_asset, amount=abs(base_amount_bought)),
+                    fee=AssetAmount(asset=fee_currency, amount=fee),
                     location=Location.CRYPTOCOM,
                     spend_notes=notes,
-                    fee_amount=fee,
-                    fee_asset=fee_currency,
                 ),
             )
 
@@ -440,14 +433,11 @@ class CryptocomImporter(BaseExchangeImporter):
                         history_events=create_swap_events(
                             event_identifier=f'{CRYPTOCOM_PREFIX}{hash_csv_row_without_index(debited_row)}',
                             timestamp=ts_sec_to_ms(timestamp),
-                            spend_asset=quote_asset,
-                            spend_amount=abs(quote_amount_sold),
-                            receive_asset=base_asset,
-                            receive_amount=abs(base_amount_bought),
+                            spend=AssetAmount(asset=quote_asset, amount=abs(quote_amount_sold)),
+                            receive=AssetAmount(asset=base_asset, amount=abs(base_amount_bought)),
+                            fee=AssetAmount(asset=fee_currency, amount=fee),
                             location=Location.CRYPTOCOM,
                             spend_notes=notes,
-                            fee_amount=fee,
-                            fee_asset=fee_currency,
                         ),
                     )
 

--- a/rotkehlchen/data_import/importers/kucoin.py
+++ b/rotkehlchen/data_import/importers/kucoin.py
@@ -11,8 +11,8 @@ from rotkehlchen.exchanges.utils import get_key_if_has_val
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.swap import create_swap_events, get_swap_spend_receive
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_or_zero,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location
@@ -74,7 +74,7 @@ class KucoinImporter(BaseExchangeImporter):
                         raw_trade_type=row[trade_type_key],
                         base_asset=asset_from_kucoin(base),
                         quote_asset=asset_from_kucoin(quote),
-                        amount=deserialize_asset_amount(row[amount_key]),
+                        amount=deserialize_fval(row[amount_key]),
                         rate=deserialize_price(row[rate_key]),
                     )
                     self.add_history_events(
@@ -90,7 +90,7 @@ class KucoinImporter(BaseExchangeImporter):
                             receive=receive,
                             fee=AssetAmount(
                                 asset=asset_from_kucoin(fee_currency),
-                                amount=deserialize_fee(get_key_if_has_val(row, fee_key)),
+                                amount=deserialize_fval_or_zero(get_key_if_has_val(row, fee_key)),
                             ) if fee_currency is not None else None,
                         ),
                     )

--- a/rotkehlchen/data_import/importers/kucoin.py
+++ b/rotkehlchen/data_import/importers/kucoin.py
@@ -15,7 +15,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location
+from rotkehlchen.types import AssetAmount, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ class KucoinImporter(BaseExchangeImporter):
                     self.total_entries += 1
                     base, quote = row[tokens_key].split(splitter)
                     fee_currency = get_key_if_has_val(row, fee_currency_key)
-                    spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(  # noqa: E501
+                    spend, receive = get_swap_spend_receive(
                         raw_trade_type=row[trade_type_key],
                         base_asset=asset_from_kucoin(base),
                         quote_asset=asset_from_kucoin(quote),
@@ -86,12 +86,12 @@ class KucoinImporter(BaseExchangeImporter):
                                 location='Kucoin order history import',
                             )),
                             location=Location.KUCOIN,
-                            spend_asset=spend_asset,
-                            spend_amount=spend_amount,
-                            receive_asset=receive_asset,
-                            receive_amount=receive_amount,
-                            fee_asset=asset_from_kucoin(fee_currency) if fee_currency is not None else None,  # type: ignore[arg-type]  # noqa: E501  # fee currency is an asset
-                            fee_amount=deserialize_fee(get_key_if_has_val(row, fee_key)),
+                            spend=spend,
+                            receive=receive,
+                            fee=AssetAmount(
+                                asset=asset_from_kucoin(fee_currency),
+                                amount=deserialize_fee(get_key_if_has_val(row, fee_key)),
+                            ) if fee_currency is not None else None,
                         ),
                     )
                     self.imported_entries += 1

--- a/rotkehlchen/data_import/importers/nexo.py
+++ b/rotkehlchen/data_import/importers/nexo.py
@@ -25,7 +25,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_asset_amount_force_positive,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location
+from rotkehlchen.types import AssetAmount, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -186,10 +186,11 @@ class NexoImporter(BaseExchangeImporter):
                     event_identifier=f'{NEXO_PREFIX}{hash_csv_row(csv_row)}',
                     timestamp=ts_sec_to_ms(timestamp),
                     location=Location.NEXO,
-                    spend_asset=asset_from_nexo(csv_row['Input Currency']),
-                    spend_amount=deserialize_asset_amount_force_positive(csv_row['Input Amount']),
-                    receive_asset=asset,
-                    receive_amount=amount,
+                    spend=AssetAmount(
+                        asset=asset_from_nexo(csv_row['Input Currency']),
+                        amount=deserialize_asset_amount_force_positive(csv_row['Input Amount']),
+                    ),
+                    receive=AssetAmount(asset=asset, amount=amount),
                     unique_id=transaction,
                     spend_notes=f'{entry_type} from Nexo',
                 ),

--- a/rotkehlchen/data_import/importers/rotki_events.py
+++ b/rotkehlchen/data_import/importers/rotki_events.py
@@ -15,7 +15,7 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.serialization.deserialize import deserialize_asset_amount
+from rotkehlchen.serialization.deserialize import deserialize_fval
 
 from .constants import ROTKI_EVENT_PREFIX
 
@@ -66,7 +66,7 @@ class RotkiGenericEventsImporter(BaseExchangeImporter):
             event_type=event_type,
             event_subtype=event_subtype,
             asset=asset,
-            amount=deserialize_asset_amount(csv_row['Amount']),
+            amount=deserialize_fval(csv_row['Amount']),
             notes=csv_row['Description'],
         )
         events.append(history_event)

--- a/rotkehlchen/data_import/importers/rotki_trades.py
+++ b/rotkehlchen/data_import/importers/rotki_trades.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
-from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import (
     BaseExchangeImporter,
     process_rotki_generic_import_csv_fields,
@@ -13,7 +12,7 @@ from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
-from rotkehlchen.serialization.deserialize import deserialize_asset_amount
+from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.types import AssetAmount
 
 if TYPE_CHECKING:
@@ -37,8 +36,8 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
         - UnknownAsset
         - KeyError
         """
-        spend_amount = deserialize_asset_amount(csv_row['Spend Amount'])
-        receive_amount = deserialize_asset_amount(csv_row['Receive Amount'])
+        spend_amount = deserialize_fval(csv_row['Spend Amount'])
+        receive_amount = deserialize_fval(csv_row['Receive Amount'])
         spend_asset, fee, fee_currency, location, timestamp = process_rotki_generic_import_csv_fields(csv_row, 'Spend Currency')  # noqa: E501
         receive_asset = symbol_to_asset_or_token(csv_row['Receive Currency'])
         self.add_history_events(
@@ -49,7 +48,7 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
                 spend=AssetAmount(asset=spend_asset, amount=spend_amount),
                 receive=AssetAmount(asset=receive_asset, amount=receive_amount),
                 spend_notes=csv_row['Description'],
-                fee=AssetAmount(asset=fee_currency, amount=fee or ZERO) if fee_currency is not None else None,  # noqa: E501
+                fee=AssetAmount(asset=fee_currency, amount=fee) if fee_currency is not None and fee is not None else None,  # noqa: E501
             ),
         )
 

--- a/rotkehlchen/data_import/importers/rotki_trades.py
+++ b/rotkehlchen/data_import/importers/rotki_trades.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
+from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import (
     BaseExchangeImporter,
     process_rotki_generic_import_csv_fields,
@@ -13,6 +14,7 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.serialization.deserialize import deserialize_asset_amount
+from rotkehlchen.types import AssetAmount
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -44,13 +46,10 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
             history_events=create_swap_events(
                 timestamp=timestamp,
                 location=location,
-                spend_asset=spend_asset,
-                spend_amount=spend_amount,
-                receive_asset=receive_asset,
-                receive_amount=receive_amount,
+                spend=AssetAmount(asset=spend_asset, amount=spend_amount),
+                receive=AssetAmount(asset=receive_asset, amount=receive_amount),
                 spend_notes=csv_row['Description'],
-                fee_amount=fee,  # type: ignore[arg-type]
-                fee_asset=fee_currency,  # type: ignore[arg-type]
+                fee=AssetAmount(asset=fee_currency, amount=fee or ZERO) if fee_currency is not None else None,  # noqa: E501
             ),
         )
 

--- a/rotkehlchen/data_import/importers/shapeshift_trades.py
+++ b/rotkehlchen/data_import/importers/shapeshift_trades.py
@@ -12,8 +12,8 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_or_zero,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location
@@ -52,11 +52,11 @@ class ShapeshiftTradesImporter(BaseExchangeImporter):
         )
         # Use asset_from_kraken since the mapping is the same as in kraken
         buy_asset = asset_from_kraken(csv_row['outputCurrency'])
-        buy_amount = deserialize_asset_amount(csv_row['outputAmount'])
+        buy_amount = deserialize_fval(csv_row['outputAmount'])
         sold_asset = asset_from_kraken(csv_row['inputCurrency'])
-        sold_amount = deserialize_asset_amount(csv_row['inputAmount'])
-        rate = deserialize_asset_amount(csv_row['rate'])
-        fee = deserialize_fee(csv_row['minerFee'])
+        sold_amount = deserialize_fval(csv_row['inputAmount'])
+        rate = deserialize_fval(csv_row['rate'])
+        fee = deserialize_fval_or_zero(csv_row['minerFee'])
         in_addr = csv_row['inputAddress']
         out_addr = csv_row['outputAddress']
         notes = f"""

--- a/rotkehlchen/data_import/importers/shapeshift_trades.py
+++ b/rotkehlchen/data_import/importers/shapeshift_trades.py
@@ -16,7 +16,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location
+from rotkehlchen.types import AssetAmount, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -86,12 +86,9 @@ Trade from ShapeShift with ShapeShift Deposit Address:
             history_events=create_swap_events(
                 location=Location.SHAPESHIFT,
                 timestamp=ts_sec_to_ms(timestamp),
-                spend_asset=sold_asset,
-                receive_asset=buy_asset,
-                spend_amount=sold_amount,
-                receive_amount=buy_amount,
-                fee_asset=buy_asset,  # Assumption that minerFee is denominated in outputCurrency
-                fee_amount=fee,
+                spend=AssetAmount(asset=sold_asset, amount=sold_amount),
+                receive=AssetAmount(asset=buy_asset, amount=buy_amount),
+                fee=AssetAmount(asset=buy_asset, amount=fee),  # Assumption that minerFee is denominated in outputCurrency  # noqa: E501
                 spend_notes=notes,
             ),
         )

--- a/rotkehlchen/data_import/importers/uphold_transactions.py
+++ b/rotkehlchen/data_import/importers/uphold_transactions.py
@@ -19,7 +19,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import Location
+from rotkehlchen.types import AssetAmount, Location
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -102,12 +102,9 @@ Activity from uphold with uphold transaction id:
                         history_events=create_swap_events(
                             timestamp=ts_sec_to_ms(timestamp),
                             location=Location.UPHOLD,
-                            spend_asset=origin_asset,
-                            spend_amount=origin_amount,
-                            receive_asset=destination_asset,
-                            receive_amount=destination_amount,
-                            fee_asset=fee_asset,
-                            fee_amount=fee,
+                            spend=AssetAmount(asset=origin_asset, amount=origin_amount),
+                            receive=AssetAmount(asset=destination_asset, amount=destination_amount),  # noqa: E501
+                            fee=AssetAmount(asset=fee_asset, amount=fee),
                             spend_notes=notes,
                         ),
                     )
@@ -139,13 +136,10 @@ Activity from uphold with uphold transaction id:
                     history_events=create_swap_events(
                         timestamp=ts_sec_to_ms(timestamp),
                         location=Location.UPHOLD,
-                        spend_asset=origin_asset,
-                        spend_amount=origin_amount,
-                        receive_asset=destination_asset,
-                        receive_amount=destination_amount,
-                        fee_asset=fee_asset,
+                        spend=AssetAmount(asset=origin_asset, amount=origin_amount),
+                        receive=AssetAmount(asset=destination_asset, amount=destination_amount),
+                        fee=AssetAmount(asset=fee_asset, amount=fee),
                         spend_notes=notes,
-                        fee_amount=fee,
                     ),
                 )
             else:
@@ -177,12 +171,9 @@ Activity from uphold with uphold transaction id:
                     history_events=create_swap_events(
                         timestamp=ts_sec_to_ms(timestamp),
                         location=Location.UPHOLD,
-                        spend_asset=origin_asset,
-                        spend_amount=origin_amount,
-                        receive_asset=destination_asset,
-                        receive_amount=destination_amount,
-                        fee_asset=fee_asset,
-                        fee_amount=fee,
+                        spend=AssetAmount(asset=origin_asset, amount=origin_amount),
+                        receive=AssetAmount(asset=destination_asset, amount=destination_amount),
+                        fee=AssetAmount(asset=fee_asset, amount=fee),
                         spend_notes=notes,
                     ),
                 )

--- a/rotkehlchen/data_import/importers/uphold_transactions.py
+++ b/rotkehlchen/data_import/importers/uphold_transactions.py
@@ -15,8 +15,8 @@ from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_or_zero,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import AssetAmount, Location
@@ -55,14 +55,14 @@ class UpholdTransactionsImporter(BaseExchangeImporter):
         )
         destination = csv_row['Destination']
         destination_asset = asset_from_uphold(csv_row['Destination Currency'])
-        destination_amount = deserialize_asset_amount(csv_row['Destination Amount'])
+        destination_amount = deserialize_fval(csv_row['Destination Amount'])
         origin = csv_row['Origin']
         origin_asset = asset_from_uphold(csv_row['Origin Currency'])
-        origin_amount = deserialize_asset_amount(csv_row['Origin Amount'])
+        origin_amount = deserialize_fval(csv_row['Origin Amount'])
         if csv_row['Fee Amount'] == '':
             fee = FVal(ZERO)
         else:
-            fee = deserialize_fee(csv_row['Fee Amount'])
+            fee = deserialize_fval_or_zero(csv_row['Fee Amount'])
         fee_asset = asset_from_uphold(csv_row['Fee Currency'] or csv_row['Origin Currency'])
         transaction_type = csv_row['Type']
         notes = f"""

--- a/rotkehlchen/data_import/utils.py
+++ b/rotkehlchen/data_import/utils.py
@@ -11,7 +11,7 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_asset_amount, deserialize_timestamp
+from rotkehlchen.serialization.deserialize import deserialize_fval, deserialize_timestamp
 from rotkehlchen.types import Fee, Location, TimestampMS
 
 if TYPE_CHECKING:
@@ -180,7 +180,7 @@ def process_rotki_generic_import_csv_fields(
         location = Location.EXTERNAL
 
     timestamp = TimestampMS(deserialize_timestamp(csv_row['Timestamp']))
-    fee = Fee(deserialize_asset_amount(csv_row['Fee'])) if csv_row['Fee'] else None
+    fee = Fee(deserialize_fval(csv_row['Fee'])) if csv_row['Fee'] else None
     asset_mapping = LOCATION_TO_ASSET_MAPPING.get(location, asset_from_common_identifier)
     asset = asset_mapping(csv_row[currency_colname])
     fee_currency = (

--- a/rotkehlchen/db/upgrades/v47_v48.py
+++ b/rotkehlchen/db/upgrades/v47_v48.py
@@ -88,8 +88,8 @@ def upgrade_trade_to_swap_events(
         receive=receive,
         fee=AssetAmount(
             asset=Asset(row[8]),
-            amount=FVal(row[7] or 0),
-        ) if row[8] is not None else None,
+            amount=FVal(row[7]),
+        ) if row[8] is not None and row[7] is not None else None,
         location_label=location_label,
         unique_id=link,
         spend_notes=row[10],

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -27,7 +27,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_date,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, ExchangeAuthCredentials, Timestamp
+from rotkehlchen.types import ApiKey, ApiSecret, AssetAmount, ExchangeAuthCredentials, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import iso8601ts_to_timestamp, ts_sec_to_ms
 
@@ -248,12 +248,9 @@ class Bitcoinde(ExchangeInterface):
                 location='bitcoinde',
             )),
             location=self.location,
-            spend_asset=spend_asset,
-            spend_amount=spend_amount,
-            receive_asset=receive_asset,
-            receive_amount=receive_amount,
-            fee_asset=A_EUR,
-            fee_amount=deserialize_fee(raw_trade['fee_currency_to_pay']),
+            spend=AssetAmount(asset=spend_asset, amount=spend_amount),
+            receive=AssetAmount(asset=receive_asset, amount=receive_amount),
+            fee=AssetAmount(asset=A_EUR, amount=deserialize_fee(raw_trade['fee_currency_to_pay'])),
             location_label=self.name,
             unique_id=raw_trade['trade_id'],
         )

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -48,6 +48,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Location,
     Timestamp,
@@ -512,7 +513,7 @@ class Bitfinex(ExchangeInterface):
                 f'Raw trade: {raw_result}',
             )
 
-        spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+        spend, receive = get_swap_spend_receive(
             raw_trade_type='buy' if (amount := deserialize_asset_amount(raw_result[4])) >= ZERO else 'sell',  # noqa: E501
             base_asset=asset_from_bitfinex(bitfinex_name=bfx_base_asset_symbol),
             quote_asset=asset_from_bitfinex(bitfinex_name=bfx_quote_asset_symbol),
@@ -522,12 +523,12 @@ class Bitfinex(ExchangeInterface):
         return create_swap_events(
             timestamp=deserialize_timestamp_ms_from_intms(raw_result[2]),
             location=self.location,
-            spend_asset=spend_asset,
-            spend_amount=spend_amount,
-            receive_asset=receive_asset,
-            receive_amount=receive_amount,
-            fee_asset=asset_from_bitfinex(bitfinex_name=raw_result[10]),
-            fee_amount=abs(deserialize_fee(raw_result[9])),
+            spend=spend,
+            receive=receive,
+            fee=AssetAmount(
+                asset=asset_from_bitfinex(bitfinex_name=raw_result[10]),
+                amount=abs(deserialize_fee(raw_result[9])),
+            ),
             location_label=self.name,
             unique_id=str(raw_result[0]),
         )

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -41,7 +41,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_int_from_str,
 )
-from rotkehlchen.types import ApiKey, ExchangeAuthCredentials, Location, Timestamp
+from rotkehlchen.types import ApiKey, AssetAmount, ExchangeAuthCredentials, Location, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now, ts_sec_to_ms
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
@@ -277,7 +277,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
                     entry['attributes']['best_fee_collection']['attributes']['wallet_transaction']['attributes']['fee'],
                 )
 
-            spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+            spend, receive = get_swap_spend_receive(
                 raw_trade_type=entry['attributes']['type'],
                 base_asset=crypto_asset,
                 quote_asset=fiat_asset,
@@ -287,12 +287,9 @@ class Bitpanda(ExchangeWithoutApiSecret):
             return create_swap_events(
                 timestamp=ts_sec_to_ms(time),
                 location=self.location,
-                spend_asset=spend_asset,
-                spend_amount=spend_amount,
-                receive_asset=receive_asset,
-                receive_amount=receive_amount,
-                fee_asset=A_BEST,
-                fee_amount=fee,
+                spend=spend,
+                receive=receive,
+                fee=AssetAmount(asset=A_BEST, amount=fee),
                 location_label=self.name,
                 unique_id=entry['id'],
             )

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -36,9 +36,9 @@ from rotkehlchen.history.events.structures.swap import (
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
     deserialize_asset_movement_event_type,
-    deserialize_fee,
+    deserialize_fval,
+    deserialize_fval_or_zero,
     deserialize_int_from_str,
 )
 from rotkehlchen.types import ApiKey, AssetAmount, ExchangeAuthCredentials, Location, Timestamp
@@ -194,8 +194,8 @@ class Bitpanda(ExchangeWithoutApiSecret):
                     f'bitpanda asset with id {asset_id} in the mapping',
                 )
                 return []
-            amount = deserialize_asset_amount(entry['attributes']['amount'])
-            fee = deserialize_fee(entry['attributes']['fee'])
+            amount = deserialize_fval(entry['attributes']['amount'])
+            fee = deserialize_fval_or_zero(entry['attributes']['fee'])
             tx_id = entry['id']
 
             transaction_id = entry['attributes'].get('tx_id')
@@ -273,7 +273,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
 
             fee = ZERO
             if entry['attributes']['bfc_used'] is True:
-                fee = deserialize_fee(
+                fee = deserialize_fval_or_zero(
                     entry['attributes']['best_fee_collection']['attributes']['wallet_transaction']['attributes']['fee'],
                 )
 
@@ -281,7 +281,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
                 raw_trade_type=entry['attributes']['type'],
                 base_asset=crypto_asset,
                 quote_asset=fiat_asset,
-                amount=deserialize_asset_amount(entry['attributes']['amount_cryptocoin']),
+                amount=deserialize_fval(entry['attributes']['amount_cryptocoin']),
                 rate=deserialize_price(entry['attributes']['price']),
             )
             return create_swap_events(
@@ -458,7 +458,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
                 symbol_key = 'fiat_symbol'
 
             try:
-                amount = deserialize_asset_amount(entry['attributes']['balance'])
+                amount = deserialize_fval(entry['attributes']['balance'])
                 asset = asset_from_bitpanda(entry['attributes'][symbol_key])
             except UnknownAsset as e:
                 self.send_unknown_asset_message(

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -46,6 +46,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Location,
     Timestamp,
@@ -803,7 +804,7 @@ class Bitstamp(ExchangeInterface):
                 f'amounts are negative: {raw_trade}',
             )
 
-        spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+        spend, receive = get_swap_spend_receive(
             raw_trade_type='buy' if base_asset_amount >= ZERO else 'sell',
             base_asset=trade_pair_data.base_asset,
             quote_asset=trade_pair_data.quote_asset,
@@ -813,12 +814,12 @@ class Bitstamp(ExchangeInterface):
         return create_swap_events(
             timestamp=ts_sec_to_ms(deserialize_timestamp_from_bitstamp_date(raw_trade['datetime'])),
             location=self.location,
-            spend_asset=spend_asset,
-            spend_amount=spend_amount,
-            receive_asset=receive_asset,
-            receive_amount=receive_amount,
-            fee_asset=trade_pair_data.quote_asset,
-            fee_amount=deserialize_fee(raw_trade['fee']),
+            spend=spend,
+            receive=receive,
+            fee=AssetAmount(
+                asset=trade_pair_data.quote_asset,
+                amount=deserialize_fee(raw_trade['fee']),
+            ),
             location_label=self.name,
             unique_id=(reference := str(raw_trade['id'])),
             extra_data={'reference': reference},

--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -38,11 +38,7 @@ from rotkehlchen.history.events.structures.swap import (
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
-    deserialize_fval,
-)
+from rotkehlchen.serialization.deserialize import deserialize_fval, deserialize_fval_or_zero
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
@@ -381,7 +377,7 @@ class Bybit(ExchangeInterface):
                         raw_trade_type=raw_trade['side'],
                         base_asset=base_asset,
                         quote_asset=quote_asset,
-                        amount=deserialize_asset_amount(raw_trade['qty']),
+                        amount=deserialize_fval(raw_trade['qty']),
                         rate=deserialize_price(raw_trade['avgPrice' if raw_trade['orderType'] == 'Market' else 'price']),  # noqa: E501
                     )
                     events.extend(create_swap_events(
@@ -606,9 +602,9 @@ class Bybit(ExchangeInterface):
                     location_label=self.name,
                     event_type=query_for,
                     asset=coin,
-                    amount=deserialize_asset_amount(movement['amount']),
+                    amount=deserialize_fval(movement['amount']),
                     fee_asset=coin,
-                    fee=deserialize_fee(movement[fee_key]) if len(movement[fee_key]) else Fee(ZERO),  # noqa: E501,
+                    fee=deserialize_fval_or_zero(movement[fee_key]) if len(movement[fee_key]) else Fee(ZERO),  # noqa: E501,
                     unique_id=movement[id_key],
                     extra_data=maybe_set_transaction_extra_data(
                         address=None,

--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -377,7 +377,7 @@ class Bybit(ExchangeInterface):
                     continue
 
                 try:
-                    spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(  # noqa: E501
+                    spend, receive = get_swap_spend_receive(
                         raw_trade_type=raw_trade['side'],
                         base_asset=base_asset,
                         quote_asset=quote_asset,
@@ -387,10 +387,8 @@ class Bybit(ExchangeInterface):
                     events.extend(create_swap_events(
                         timestamp=TimestampMS(int(raw_trade['updatedTime'])),
                         location=self.location,
-                        spend_asset=spend_asset,
-                        spend_amount=spend_amount,
-                        receive_asset=receive_asset,
-                        receive_amount=receive_amount,
+                        spend=spend,
+                        receive=receive,
                         location_label=self.name,
                         unique_id=raw_trade['orderId'],
                     ))

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -14,8 +14,8 @@ from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.types import EventDirection
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
     deserialize_fee,
+    deserialize_fval,
     deserialize_optional,
     deserialize_timestamp,
 )
@@ -159,7 +159,7 @@ class Trade(AccountingEventMixin):
             base_asset=Asset(entry[3]).check_existence(),
             quote_asset=Asset(entry[4]).check_existence(),
             trade_type=TradeType.deserialize_from_db(entry[5]),
-            amount=deserialize_asset_amount(entry[6]),
+            amount=deserialize_fval(entry[6]),
             rate=deserialize_price(entry[7]),
             fee=deserialize_optional(entry[8], deserialize_fee),
             fee_currency=deserialize_optional(entry[9], Asset),
@@ -375,7 +375,7 @@ class MarginPosition(AccountingEventMixin):
             location=Location.deserialize(data['location']),
             open_time=deserialize_timestamp(data['open_time']),
             close_time=deserialize_timestamp(data['close_time']),
-            profit_loss=deserialize_asset_amount(data['profit_loss']),
+            profit_loss=deserialize_fval(data['profit_loss']),
             pl_currency=Asset(data['pl_currency']).check_existence(),
             fee=deserialize_fee(data['fee']),
             fee_currency=Asset(data['fee_currency']).check_existence(),
@@ -397,7 +397,7 @@ class MarginPosition(AccountingEventMixin):
             location=Location.deserialize_from_db(entry[1]),
             open_time=open_time,
             close_time=deserialize_timestamp(entry[3]),
-            profit_loss=deserialize_asset_amount(entry[4]),
+            profit_loss=deserialize_fval(entry[4]),
             pl_currency=Asset(entry[5]).check_existence(),
             fee=deserialize_fee(entry[6]),
             fee_currency=Asset(entry[7]).check_existence(),
@@ -502,8 +502,8 @@ class Loan(AccountingEventMixin):
             close_time=deserialize_timestamp(data['close_time']),
             currency=Asset(data['currency']).check_existence(),
             fee=deserialize_fee(data['fee']),
-            earned=deserialize_asset_amount(data['earned']),
-            amount_lent=deserialize_asset_amount(data['amount_lent']),
+            earned=deserialize_fval(data['earned']),
+            amount_lent=deserialize_fval(data['amount_lent']),
         )
 
     @staticmethod
@@ -546,7 +546,7 @@ def deserialize_trade(data: dict[str, Any]) -> Trade:
         - DeserializationError: If any of the trade dict entries is not as expected
     """
     rate = deserialize_price(data['rate'])
-    amount = deserialize_asset_amount(data['amount'])
+    amount = deserialize_fval(data['amount'])
     trade_type = TradeType.deserialize(data['trade_type'])
     location = Location.deserialize(data['location'])
 

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -46,6 +46,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Location,
     Timestamp,
@@ -468,7 +469,7 @@ class Gemini(ExchangeInterface):
                         continue  # Skip already processed trade
 
                     base, quote = gemini_symbol_to_base_quote(symbol)
-                    spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(  # noqa: E501
+                    spend, receive = get_swap_spend_receive(
                         raw_trade_type=entry['type'],
                         base_asset=base,
                         quote_asset=quote,
@@ -478,12 +479,12 @@ class Gemini(ExchangeInterface):
                     swap_events.extend(create_swap_events(
                         timestamp=ts_sec_to_ms(timestamp),
                         location=self.location,
-                        spend_asset=spend_asset,
-                        spend_amount=spend_amount,
-                        receive_asset=receive_asset,
-                        receive_amount=receive_amount,
-                        fee_asset=asset_from_gemini(entry['fee_currency']),
-                        fee_amount=deserialize_fee(entry['fee_amount']),
+                        spend=spend,
+                        receive=receive,
+                        fee=AssetAmount(
+                            asset=asset_from_gemini(entry['fee_currency']),
+                            amount=deserialize_fee(entry['fee_amount']),
+                        ),
                         location_label=self.name,
                         unique_id=unique_id,
                     ))

--- a/rotkehlchen/exchanges/htx.py
+++ b/rotkehlchen/exchanges/htx.py
@@ -41,6 +41,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     Fee,
     Location,
     Timestamp,
@@ -441,7 +442,7 @@ class Htx(ExchangeInterface):
                     continue
 
                 try:
-                    spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(  # noqa: E501
+                    spend, receive = get_swap_spend_receive(
                         raw_trade_type=trade_type,
                         base_asset=base_asset,
                         quote_asset=quote_asset,
@@ -451,12 +452,12 @@ class Htx(ExchangeInterface):
                     events.extend(create_swap_events(
                         timestamp=deserialize_timestamp_ms_from_intms(raw_trade['created-at']),
                         location=self.location,
-                        spend_asset=spend_asset,
-                        spend_amount=spend_amount,
-                        receive_asset=receive_asset,
-                        receive_amount=receive_amount,
-                        fee_asset=fee_asset,
-                        fee_amount=deserialize_fee(raw_trade['filled-fees']) if raw_trade['filled-fees'] else Fee(ZERO),  # noqa: E501
+                        spend=spend,
+                        receive=receive,
+                        fee=AssetAmount(
+                            asset=fee_asset,
+                            amount=deserialize_fee(raw_trade['filled-fees']) if raw_trade['filled-fees'] else Fee(ZERO),  # noqa: E501
+                        ),
                         location_label=self.name,
                         unique_id=str(raw_trade['id']),
                     ))

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -27,7 +27,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_fval,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, Timestamp
+from rotkehlchen.types import ApiKey, ApiSecret, AssetAmount, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_sec_to_ms
 
@@ -287,12 +287,18 @@ class Iconomi(ExchangeInterface):
                 events.extend(create_swap_events(
                     timestamp=ts_sec_to_ms(timestamp),
                     location=self.location,
-                    spend_asset=asset_from_iconomi(tx['source_ticker']),
-                    spend_amount=deserialize_asset_amount(tx['source_amount']),
-                    receive_asset=asset_from_iconomi(tx['target_ticker']),
-                    receive_amount=deserialize_asset_amount(tx['target_amount']),
-                    fee_asset=asset_from_iconomi(tx['fee_ticker']),
-                    fee_amount=deserialize_fee(tx['fee_amount']),
+                    spend=AssetAmount(
+                        asset=asset_from_iconomi(tx['source_ticker']),
+                        amount=deserialize_asset_amount(tx['source_amount']),
+                    ),
+                    receive=AssetAmount(
+                        asset=asset_from_iconomi(tx['target_ticker']),
+                        amount=deserialize_asset_amount(tx['target_amount']),
+                    ),
+                    fee=AssetAmount(
+                        asset=asset_from_iconomi(tx['fee_ticker']),
+                        amount=deserialize_fee(tx['fee_amount']),
+                    ),
                     location_label=self.name,
                     unique_id=str(tx['transactionId']),
                 ))

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -22,11 +22,7 @@ from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalan
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fee,
-    deserialize_fval,
-)
+from rotkehlchen.serialization.deserialize import deserialize_fval, deserialize_fval_or_zero
 from rotkehlchen.types import ApiKey, ApiSecret, AssetAmount, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_sec_to_ms
@@ -188,7 +184,7 @@ class Iconomi(ExchangeInterface):
                     continue
 
                 try:
-                    amount = deserialize_asset_amount(balance_info['balance'])
+                    amount = deserialize_fval(balance_info['balance'])
                 except (DeserializationError, KeyError) as e:
                     msg = str(e)
                     if isinstance(e, KeyError):
@@ -289,15 +285,15 @@ class Iconomi(ExchangeInterface):
                     location=self.location,
                     spend=AssetAmount(
                         asset=asset_from_iconomi(tx['source_ticker']),
-                        amount=deserialize_asset_amount(tx['source_amount']),
+                        amount=deserialize_fval(tx['source_amount']),
                     ),
                     receive=AssetAmount(
                         asset=asset_from_iconomi(tx['target_ticker']),
-                        amount=deserialize_asset_amount(tx['target_amount']),
+                        amount=deserialize_fval(tx['target_amount']),
                     ),
                     fee=AssetAmount(
                         asset=asset_from_iconomi(tx['fee_ticker']),
-                        amount=deserialize_fee(tx['fee_amount']),
+                        amount=deserialize_fval_or_zero(tx['fee_amount']),
                     ),
                     location_label=self.name,
                     unique_id=str(tx['transactionId']),

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -35,8 +35,8 @@ from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
     deserialize_asset_movement_event_type,
+    deserialize_fval,
     deserialize_timestamp_from_date,
 )
 from rotkehlchen.types import (
@@ -102,7 +102,7 @@ def _asset_movement_from_independentreserve(raw_tx: dict) -> AssetMovement | Non
 
     if raw_amount is None:  # skip
         return None   # Can end up being None for some things like this: 'Comment': 'Initial balance after Bitcoin fork'  # noqa: E501
-    amount = deserialize_asset_amount(raw_amount)
+    amount = deserialize_fval(raw_amount)
 
     return AssetMovement(
         location=Location.INDEPENDENTRESERVE,
@@ -258,7 +258,7 @@ class Independentreserve(ExchangeInterface):
             try:
                 asset = independentreserve_asset(entry['CurrencyCode'])
                 usd_price = Inquirer.find_usd_price(asset=asset)
-                amount = deserialize_asset_amount(entry['TotalBalance'])
+                amount = deserialize_fval(entry['TotalBalance'])
                 account_guids.append(entry['AccountGuid'])
             except UnsupportedAsset as e:
                 log.error(

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -42,6 +42,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Timestamp,
 )
@@ -346,7 +347,7 @@ class Independentreserve(ExchangeInterface):
                 if timestamp < start_ts or timestamp > end_ts:
                     continue
 
-                spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+                spend, receive = get_swap_spend_receive(
                     raw_trade_type='buy' if 'Bid' in raw_trade['OrderType'] else 'sell',
                     base_asset=(base_asset := independentreserve_asset(raw_trade['PrimaryCurrencyCode'])),  # noqa: E501
                     quote_asset=independentreserve_asset(raw_trade['SecondaryCurrencyCode']),
@@ -356,12 +357,12 @@ class Independentreserve(ExchangeInterface):
                 events.extend(create_swap_events(
                     timestamp=ts_sec_to_ms(timestamp),
                     location=self.location,
-                    spend_asset=spend_asset,
-                    spend_amount=spend_amount,
-                    receive_asset=receive_asset,
-                    receive_amount=receive_amount,
-                    fee_asset=base_asset,
-                    fee_amount=FVal(raw_trade['FeePercent']) * amount,
+                    spend=spend,
+                    receive=receive,
+                    fee=AssetAmount(
+                        asset=base_asset,
+                        amount=FVal(raw_trade['FeePercent']) * amount,
+                    ),
                     location_label=self.name,
                     unique_id=str(raw_trade['OrderGuid']),
                 ))

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -53,6 +53,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Location,
     Timestamp,
@@ -625,10 +626,8 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
             return create_swap_events(
                 timestamp=timestamp,
                 location=Location.KRAKEN,
-                spend_asset=spend_asset,
-                spend_amount=spend_amount,
-                receive_asset=receive_asset,
-                receive_amount=receive_amount,
+                spend=AssetAmount(asset=spend_asset, amount=spend_amount),
+                receive=AssetAmount(asset=receive_asset, amount=receive_amount),
                 unique_id=exchange_uuid,
             )
 
@@ -644,22 +643,18 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
             return []
 
         # If kfee was found we use it as the fee for the trade
+        fee = None
         if kfee_part is not None and fee_part is None:
-            fee = kfee_part.amount
-            fee_asset = A_KFEE
-        else:
-            fee = fee_part.amount if fee_part is not None else ZERO
-            fee_asset = fee_part.asset if fee_part is not None else A_USD
+            fee = AssetAmount(asset=A_KFEE, amount=kfee_part.amount)
+        elif fee_part is not None:
+            fee = AssetAmount(asset=fee_part.asset, amount=fee_part.amount)
 
         return create_swap_events(
             timestamp=timestamp,
             location=Location.KRAKEN,
-            spend_asset=spend_part.asset,
-            spend_amount=spend_part.amount,
-            receive_asset=receive_part.asset,
-            receive_amount=receive_part.amount,
-            fee_asset=fee_asset,
-            fee_amount=fee,
+            spend=AssetAmount(asset=spend_part.asset, amount=spend_part.amount),
+            receive=AssetAmount(asset=receive_part.asset, amount=receive_part.amount),
+            fee=fee,
             unique_id=exchange_uuid,
         )
 
@@ -726,10 +721,8 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
                 swap_events.extend(create_swap_events(
                     timestamp=a1.timestamp,
                     location=Location.KRAKEN,
-                    spend_asset=spend_event.asset,
-                    spend_amount=spend_event.amount,
-                    receive_asset=receive_event.asset,
-                    receive_amount=receive_event.amount,
+                    spend=AssetAmount(asset=spend_event.asset, amount=spend_event.amount),
+                    receive=AssetAmount(asset=receive_event.asset, amount=receive_event.amount),
                     unique_id='adjustment' + a1.event_identifier + a2.event_identifier,
                 ))
                 # Remove these adjustments since they are now represented by SwapEvents

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -46,10 +46,7 @@ from rotkehlchen.history.events.structures.base import (
 from rotkehlchen.history.events.structures.swap import SwapEvent, create_swap_events
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import (
-    deserialize_asset_amount,
-    deserialize_fval,
-)
+from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
@@ -393,7 +390,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
         assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
         for kraken_name, amount_ in kraken_balances.items():
             try:
-                amount = deserialize_asset_amount(amount_)
+                amount = deserialize_fval(amount_)
                 if amount == ZERO:
                     continue
 
@@ -925,7 +922,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras):
                         f'Encountered kraken historic event type we do not process. {raw_event}',
                     )
 
-                fee_amount = deserialize_asset_amount(raw_event['fee'])
+                fee_amount = deserialize_fval(raw_event['fee'])
                 # check for failed events (events that cancel each other out -- like failed
                 if (  # withdrawals). Compare if amounts cancel themselves out (also fee if exists)
                         len(events) == 2 and idx == 1 and

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -49,6 +49,7 @@ from rotkehlchen.serialization.deserialize import (
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Location,
     Timestamp,
@@ -609,7 +610,7 @@ class Kucoin(ExchangeInterface):
                 rate = deserialize_price(raw_result['dealPrice'])
                 trade_id = raw_result['id']
 
-            spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+            spend, receive = get_swap_spend_receive(
                 raw_trade_type=raw_result['side'],
                 base_asset=base_asset,
                 quote_asset=quote_asset,
@@ -619,12 +620,12 @@ class Kucoin(ExchangeInterface):
             return create_swap_events(
                 timestamp=timestamp_ms,
                 location=self.location,
-                spend_asset=spend_asset,
-                spend_amount=spend_amount,
-                receive_asset=receive_asset,
-                receive_amount=receive_amount,
-                fee_asset=fee_currency,
-                fee_amount=deserialize_fee(raw_result['fee']),
+                spend=spend,
+                receive=receive,
+                fee=AssetAmount(
+                    asset=fee_currency,
+                    amount=deserialize_fee(raw_result['fee']),
+                ),
                 location_label=self.name,
                 unique_id=str(trade_id),
             )

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -38,6 +38,7 @@ from rotkehlchen.serialization.deserialize import deserialize_asset_amount, dese
 from rotkehlchen.types import (
     ApiKey,
     ApiSecret,
+    AssetAmount,
     ExchangeAuthCredentials,
     Fee,
     Location,
@@ -369,7 +370,7 @@ class Okx(ExchangeInterface):
                 raise DeserializationError(
                     f'Expected pair {raw_trade["instId"]} to contain a "-"',
                 ) from e
-            spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+            spend, receive = get_swap_spend_receive(
                 raw_trade_type=raw_trade['side'],
                 base_asset=asset_from_okx(base_asset_str),
                 quote_asset=asset_from_okx(quote_asset_str),
@@ -408,12 +409,9 @@ class Okx(ExchangeInterface):
             return create_swap_events(
                 timestamp=timestamp,
                 location=self.location,
-                spend_asset=spend_asset,
-                spend_amount=spend_amount,
-                receive_asset=receive_asset,
-                receive_amount=receive_amount,
-                fee_asset=fee_asset,
-                fee_amount=fee_amount,
+                spend=spend,
+                receive=receive,
+                fee=AssetAmount(asset=fee_asset, amount=fee_amount),
                 location_label=self.name,
                 unique_id=unique_id,
             )

--- a/rotkehlchen/exchanges/woo.py
+++ b/rotkehlchen/exchanges/woo.py
@@ -38,7 +38,14 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fee,
     deserialize_timestamp_from_floatstr,
 )
-from rotkehlchen.types import ApiKey, ApiSecret, ExchangeAuthCredentials, Location, Timestamp
+from rotkehlchen.types import (
+    ApiKey,
+    ApiSecret,
+    AssetAmount,
+    ExchangeAuthCredentials,
+    Location,
+    Timestamp,
+)
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import ts_now_in_ms, ts_sec_to_ms
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
@@ -169,7 +176,7 @@ class Woo(ExchangeInterface):
                 f'Could not split symbol {symbol} into base and quote asset',
             ) from e
 
-        spend_asset, spend_amount, receive_asset, receive_amount = get_swap_spend_receive(
+        spend, receive = get_swap_spend_receive(
             raw_trade_type=trade['side'],
             base_asset=asset_from_woo(base_asset_symbol),
             quote_asset=asset_from_woo(quote_asset_symbol),
@@ -179,12 +186,12 @@ class Woo(ExchangeInterface):
         return create_swap_events(
             timestamp=ts_sec_to_ms(deserialize_timestamp_from_floatstr(trade['executed_timestamp'])),
             location=self.location,
-            spend_asset=spend_asset,
-            spend_amount=spend_amount,
-            receive_asset=receive_asset,
-            receive_amount=receive_amount,
-            fee_asset=asset_from_woo(trade['fee_asset']),
-            fee_amount=deserialize_fee(trade['fee']),
+            spend=spend,
+            receive=receive,
+            fee=AssetAmount(
+                asset=asset_from_woo(trade['fee_asset']),
+                amount=deserialize_fee(trade['fee']),
+            ),
             location_label=self.name,
             unique_id=str(trade['id']),
         )

--- a/rotkehlchen/history/events/structures/asset_movement.py
+++ b/rotkehlchen/history/events/structures/asset_movement.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
     from rotkehlchen.accounting.mixins.event import AccountingEventMixin
     from rotkehlchen.accounting.pot import AccountingPot
-    from rotkehlchen.types import Fee
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -42,7 +41,7 @@ class AssetMovementExtraData(TypedDict):
     # Internal reference used in exchanges.
     reference: NotRequired[str]
     # Internal use only. Used for matching the corresponding crypto_transaction. Removed before being saved to the DB.  # noqa: E501
-    fee: NotRequired['Fee']
+    fee: NotRequired['FVal']
     # blockchain where the transaction happened. We use string since
     # it can be a non supported blockchain
     blockchain: NotRequired[str]

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -215,21 +215,26 @@ def deserialize_timestamp_from_intms(value: Any) -> Timestamp:
 
 def deserialize_fval(
         value: AcceptableFValInitInput,
-        name: str,
-        location: str,
+        name: str | None = None,
+        location: str | None = None,
 ) -> FVal:
     try:
         result = FVal(value)
     except ValueError as e:
-        raise DeserializationError(f'Failed to deserialize value entry: {e!s} for {name} during {location}') from e  # noqa: E501
+        msg = f'Failed to deserialize value entry: {e!s}'
+        if name is not None:
+            msg += f' for {name}'
+        if location is not None:
+            msg += f' during {location}'
+        raise DeserializationError(msg) from e
 
     return result
 
 
 def deserialize_optional_to_optional_fval(
         value: AcceptableFValInitInput | None,
-        name: str,
-        location: str,
+        name: str | None = None,
+        location: str | None = None,
 ) -> FVal | None:
     """
     Deserializes an FVal from a field that was optional and if None returns None
@@ -242,8 +247,8 @@ def deserialize_optional_to_optional_fval(
 
 def deserialize_fval_or_zero(
         value: AcceptableFValInitInput | None,
-        name: str,
-        location: str,
+        name: str | None = None,
+        location: str | None = None,
 ) -> FVal:
     """
     Deserializes an FVal from a field that was optional and if None returns ZERO
@@ -254,17 +259,12 @@ def deserialize_fval_or_zero(
     return deserialize_fval(value=value, name=name, location=location)
 
 
-def deserialize_asset_amount(amount: AcceptableFValInitInput) -> FVal:
-    try:
-        result = FVal(FVal(amount))
-    except ValueError as e:
-        raise DeserializationError(f'Failed to deserialize an amount entry: {e!s}') from e
-
-    return result
-
-
-def deserialize_asset_amount_force_positive(amount: AcceptableFValInitInput) -> FVal:
-    """Acts exactly like deserialize_asset_amount but also forces the number to be positive
+def deserialize_fval_force_positive(
+        value: AcceptableFValInitInput,
+        name: str | None = None,
+        location: str | None = None,
+) -> FVal:
+    """Acts exactly like deserialize_fval but also forces the number to be positive
 
     Is needed for some places like some exchanges that list the withdrawal amounts as
     negative numbers because it's a withdrawal.
@@ -272,8 +272,7 @@ def deserialize_asset_amount_force_positive(amount: AcceptableFValInitInput) -> 
     May raise:
     - DeserializationError
     """
-    result = deserialize_asset_amount(amount)
-    if result < ZERO:
+    if (result := deserialize_fval(value=value, name=name, location=location)) < ZERO:
         result = FVal(abs(result))
     return result
 

--- a/rotkehlchen/tests/api/test_manually_tracked_balances.py
+++ b/rotkehlchen/tests/api/test_manually_tracked_balances.py
@@ -546,7 +546,7 @@ def test_add_edit_manually_tracked_balances_errors(
     )
     assert_error_response(
         response=response,
-        contained_in_msg='Failed to deserialize an amount entry',
+        contained_in_msg='Failed to deserialize value entry',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -61,7 +61,7 @@ from rotkehlchen.tests.utils.history import prices
 from rotkehlchen.tests.utils.kraken import KRAKEN_DELISTED, MockKraken
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.tests.utils.pnl_report import query_api_create_and_get_report
-from rotkehlchen.types import Location, Timestamp, TimestampMS
+from rotkehlchen.types import AssetAmount, Location, Timestamp, TimestampMS
 
 if TYPE_CHECKING:
     from rotkehlchen.api.server import APIServer
@@ -1134,12 +1134,9 @@ def test_kraken_event_serialization_with_custom_asset(database):
     swap_events = create_swap_events(
         timestamp=TimestampMS(10000000000),
         location=Location.KRAKEN,
-        spend_asset=custom_asset,
-        spend_amount=ONE,
-        receive_asset=custom_asset,
-        receive_amount=ONE,
-        fee_asset=custom_asset,
-        fee_amount=ONE,
+        spend=AssetAmount(asset=custom_asset, amount=ONE),
+        receive=AssetAmount(asset=custom_asset, amount=ONE),
+        fee=AssetAmount(asset=custom_asset, amount=ONE),
     )
     for idx, expected_notes in enumerate((
         'Swap 1 Gold Bar in Kraken',

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb.py
@@ -53,7 +53,7 @@ from rotkehlchen.globaldb.cache import (
 )
 from rotkehlchen.globaldb.handler import GLOBAL_DB_VERSION, GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
-from rotkehlchen.serialization.deserialize import deserialize_asset_amount
+from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.tests.utils.globaldb import (
@@ -592,9 +592,9 @@ def test_global_db_restore(globaldb, database):
 
     # Try to reset DB it if we have a trade that uses a custom asset
     buy_asset = symbol_to_asset_or_token('LOLZ2')
-    buy_amount = deserialize_asset_amount(1)
+    buy_amount = deserialize_fval(1)
     sold_asset = symbol_to_asset_or_token('LOLZ')
-    sold_amount = deserialize_asset_amount(2)
+    sold_amount = deserialize_fval(2)
     rate = Price(buy_amount / sold_amount)
     trade = Trade(
         timestamp=Timestamp(12312312),

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -236,6 +236,11 @@ T_TradeID = str
 TradeID = NewType('TradeID', T_TradeID)
 
 
+class AssetAmount(NamedTuple):
+    asset: 'Asset'
+    amount: FVal
+
+
 class ChainID(Enum):
     """This class maps each EVM chain to their chain id. This is used to correctly identify EVM
     assets and use it where these ids are needed.


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=102361655

Two commits:
* Use new AssetAmount when creating swap events - implements new AssetAmount class and uses it with creat_swap_events
* Use deserialize_fval where type is now FVal - removes `deserialize_asset_amount` replacing it with `deserialize_fval` and also replaces `deserialize_fee` with `deserialize_fval_or_zero` in a number of places, although `deserialize_fee` is still used for some things like MarginPositions.