### PR TITLE
Add post decoding swap processing

### DIFF
--- a/rotkehlchen/chain/evm/decoding/metamask/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/metamask/decoder.py
@@ -113,7 +113,7 @@ class MetamaskCommonDecoder(DecoderInterface):
 
         if not (fee_raw and fee_asset_address):
             # if fee is not found then we have already updated the events so exit
-            return DEFAULT_DECODING_OUTPUT
+            return DecodingOutput(process_swaps=True)
 
         if fee_asset is None:  # if fee_asset is not determined yet
             if (  # determine it from in_event/out_event
@@ -137,7 +137,7 @@ class MetamaskCommonDecoder(DecoderInterface):
         fee_event = self.base.make_event_from_transaction(
             transaction=context.transaction,
             tx_log=context.tx_log,
-            event_type=HistoryEventType.SPEND,
+            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.FEE,
             asset=fee_asset,
             amount=fee_amount,
@@ -147,7 +147,7 @@ class MetamaskCommonDecoder(DecoderInterface):
             address=context.transaction.to_address,
         )
 
-        return DecodingOutput(event=fee_event)
+        return DecodingOutput(event=fee_event, process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/pendle/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/pendle/decoder.py
@@ -318,7 +318,7 @@ class PendleCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
             ordered_events=[out_event, in_event],
             events_list=context.decoded_events,
         )
-        return DecodingOutput(action_items=action_items)
+        return DecodingOutput(action_items=action_items, process_swaps=True)
 
     def _decode_sy_pt_yt_events(
             self,

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -81,12 +81,14 @@ class DecodingOutput:
     - refresh_balances may be set to True if the user's on-chain balances in some protocols has
     changed (for example if the user has deposited / withdrawn funds from a curve gauge).
     - reload_decoders can be None in which case nothing happens. Or a set of decoders names for which to reload data. The decoder's name is the class name without the Decoder suffix. For example Eigenlayer for EigenlayerDecoder
+    - process_swaps indicates whether there are swaps that need to be converted into EvmSwapEvents.
     """  # noqa: E501
     event: Optional['EvmEvent'] = None
     action_items: list[ActionItem] = field(default_factory=list)
     matched_counterparty: str | None = None
     refresh_balances: bool = False
     reload_decoders: set[str] | None = None
+    process_swaps: bool = False
 
 
 class TransferEnrichmentOutput(NamedTuple):
@@ -97,9 +99,11 @@ class TransferEnrichmentOutput(NamedTuple):
     and is used in post-decoding rules like in the case of balancer.
     - refresh_balances may be set to True if the user's on-chain balances in some protocols has
     changed (for example if the user has deposited / withdrawn funds from a curve gauge).
+    - process_swaps indicates whether there are swaps that need to be converted into EvmSwapEvents.
     """
     matched_counterparty: str | None = None
     refresh_balances: bool = False
+    process_swaps: bool = False
 
 
 DEFAULT_DECODING_OUTPUT: Final = DecodingOutput()

--- a/rotkehlchen/history/events/structures/evm_event.py
+++ b/rotkehlchen/history/events/structures/evm_event.py
@@ -158,7 +158,7 @@ class EvmEvent(HistoryBaseEntry):  # hash in superclass
         return self._serialize_evm_event_tuple_for_db()
 
     def serialize(self) -> dict[str, Any]:
-        return super().serialize() | {
+        return HistoryBaseEntry.serialize(self) | {  # not using super() since it has unexpected results due to diamond shaped inheritance.  # noqa: E501
             'tx_hash': self.tx_hash.hex(),
             'counterparty': self.counterparty,
             'product': self.product.serialize() if self.product is not None else None,

--- a/rotkehlchen/history/events/structures/evm_swap.py
+++ b/rotkehlchen/history/events/structures/evm_swap.py
@@ -98,9 +98,7 @@ class EvmSwapEvent(EvmEvent, SwapEvent):
 
     def serialize(self) -> dict[str, Any]:
         """Serialize the event for api."""
-        serialized_data = EvmEvent.serialize(self)
-        serialized_data['auto_notes'] = self._generate_auto_notes()
-        return serialized_data
+        return EvmEvent.serialize(self)
 
     @classmethod
     def deserialize(cls: type['EvmSwapEvent'], data: dict[str, Any]) -> 'EvmSwapEvent':

--- a/rotkehlchen/history/events/structures/swap.py
+++ b/rotkehlchen/history/events/structures/swap.py
@@ -139,24 +139,22 @@ class SwapEvent(HistoryBaseEntry):
             notes=entry[8] or None,
         )
 
-    def _generate_auto_notes(self) -> str:
-        """Generate a description of this event. Used in serialize().
+    def serialize(self) -> dict[str, Any]:
+        """Serialize the event for api, and generate the auto_notes.
         May raise UnknownAsset, but this would be an edge case as the asset should already have
         been checked for existence when it was deserialized from an API or from the database.
         """
+        serialized_data = super().serialize()
         location_name = get_formatted_location_name(self.location)
         asset_symbol = self.asset.symbol_or_name()
         if self.event_subtype == HistoryEventSubType.SPEND:
-            return f'Swap {self.amount} {asset_symbol} in {location_name}'
+            auto_notes = f'Swap {self.amount} {asset_symbol} in {location_name}'
         elif self.event_subtype == HistoryEventSubType.RECEIVE:
-            return f'Receive {self.amount} {asset_symbol} after a swap in {location_name}'
+            auto_notes = f'Receive {self.amount} {asset_symbol} after a swap in {location_name}'
         else:  # Fee
-            return f'Spend {self.amount} {asset_symbol} as {location_name} swap fee'
+            auto_notes = f'Spend {self.amount} {asset_symbol} as {location_name} swap fee'
 
-    def serialize(self) -> dict[str, Any]:
-        """Serialize the event for api."""
-        serialized_data = super().serialize()
-        serialized_data['auto_notes'] = self._generate_auto_notes()
+        serialized_data['auto_notes'] = auto_notes
         return serialized_data
 
     @classmethod

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -1069,7 +1069,6 @@ def test_add_edit_evm_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
         'event_identifier': 'test_id',
         'sequence_index': 123,
         'extra_data': None,
-        'auto_notes': 'Swap 50 USDT in Ethereum',
         'tx_hash': '0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f',
         'counterparty': 'some counterparty',
         'product': 'pool',

--- a/rotkehlchen/tests/unit/decoders/test_llamazip.py
+++ b/rotkehlchen/tests/unit/decoders/test_llamazip.py
@@ -14,6 +14,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
@@ -38,12 +39,11 @@ def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_account
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.OPTIMISM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),
             amount=FVal(spend_amount),
@@ -51,19 +51,15 @@ def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_account
             notes=f'Swap {spend_amount} DAI in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=string_to_evm_address('0x03aF20bDAaFfB4cC0A521796a223f7D85e2aAc31'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.OPTIMISM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
             amount=FVal(receive_amount),
-            location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} ETH as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=OPTIMISM_ROUTER_ADDRESSES[0],
         ),
     ]
 
@@ -87,12 +83,11 @@ def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_account
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.OPTIMISM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
             amount=FVal(spend_amount),
@@ -100,19 +95,15 @@ def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_account
             notes=f'Swap {spend_amount} ETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=OPTIMISM_ROUTER_ADDRESSES[0],
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.OPTIMISM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
             amount=FVal(receive_amount),
-            location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} USDC.e as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=OPTIMISM_ROUTER_ADDRESSES[0],
         ),
     ]
 
@@ -136,12 +127,11 @@ def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accou
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.OPTIMISM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),
             amount=FVal(spend_amount),
@@ -149,19 +139,15 @@ def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accou
             notes=f'Swap {spend_amount} DAI in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=string_to_evm_address('0xbf16ef186e715668AA29ceF57e2fD7f9D48AdFE6'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.OPTIMISM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
             amount=FVal(receive_amount),
-            location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} USDC.e as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=OPTIMISM_ROUTER_ADDRESSES[0],
         ),
     ]
 
@@ -200,12 +186,11 @@ def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one
             location_label=arbitrum_one_accounts[0],
             notes=f'Revoke USDC.e spending approval of {arbitrum_one_accounts[0]} by {ARBITRUM_ROUTER_ADDRESSES[0]}',  # noqa: E501
             address=ARBITRUM_ROUTER_ADDRESSES[0],
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=3,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=a_usdce,
             amount=FVal(spend_amount),
@@ -213,19 +198,15 @@ def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one
             notes=f'Swap {spend_amount} USDC.e in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=string_to_evm_address('0xC31E54c7a869B9FcBEcc14363CF510d1c41fa443'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=4,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
             amount=FVal(receive_amount),
-            location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} ETH as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=ARBITRUM_ROUTER_ADDRESSES[0],
         ),
     ]
 
@@ -252,12 +233,11 @@ def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
             amount=FVal(spend_amount),
@@ -265,19 +245,15 @@ def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one
             notes=f'Swap {spend_amount} ETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=ARBITRUM_ROUTER_ADDRESSES[0],
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9'),
             amount=FVal(receive_amount),
-            location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} USDT as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=ARBITRUM_ROUTER_ADDRESSES[0],
         ),
     ]
 
@@ -316,12 +292,11 @@ def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_o
             location_label=arbitrum_one_accounts[0],
             notes=f'Revoke WETH spending approval of {arbitrum_one_accounts[0]} by {ARBITRUM_ROUTER_ADDRESSES[0]}',  # noqa: E501
             address=ARBITRUM_ROUTER_ADDRESSES[0],
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=a_weth,
             amount=FVal(spend_amount),
@@ -329,19 +304,15 @@ def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_o
             notes=f'Swap {spend_amount} WETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=string_to_evm_address('0x2f5e87C9312fa29aed5c179E456625D79015299c'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=3,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:42161/erc20:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f'),
             amount=FVal(receive_amount),
-            location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} WBTC as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=ARBITRUM_ROUTER_ADDRESSES[0],
         ),
     ]
 
@@ -368,12 +339,11 @@ def test_llamazip_arbitrum_swap_eth_to_arb(arbitrum_one_inquirer, arbitrum_one_a
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
             amount=FVal(spend_amount),
@@ -381,18 +351,14 @@ def test_llamazip_arbitrum_swap_eth_to_arb(arbitrum_one_inquirer, arbitrum_one_a
             notes=f'Swap {spend_amount} ETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
             address=ARBITRUM_ROUTER_ADDRESSES[1],
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.ARBITRUM_ONE,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:42161/erc20:0x912CE59144191C1204E64559FE8253a0e49E6548'),
             amount=FVal(receive_amount),
-            location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} ARB as the result of a swap in LlamaZip',
-            counterparty=CPT_LLAMAZIP,
-            address=ARBITRUM_ROUTER_ADDRESSES[1],
         ),
     ]

--- a/rotkehlchen/tests/unit/decoders/test_metamask.py
+++ b/rotkehlchen/tests/unit/decoders/test_metamask.py
@@ -30,6 +30,7 @@ from rotkehlchen.constants.assets import (
 )
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.constants import A_OPTIMISM_USDT
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
@@ -83,12 +84,11 @@ def test_metamask_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
         location_label=user_address,
         notes=f'Set LUX spending approval of {user_address} by {METAMASK_ROUTER_ETH} to {approval_amount}',  # noqa: E501
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=3,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_LUX,
         amount=FVal(swap_amount),
@@ -96,32 +96,24 @@ def test_metamask_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount} LUX in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=4,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} ETH as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=134,
+        sequence_index=5,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
         amount=FVal(metamask_fee),
-        location_label=user_address,
         notes=f'Spend {metamask_fee} ETH as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
     )]
     assert expected_events == events
 
@@ -148,12 +140,11 @@ def test_metamask_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
         location_label=user_address,
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=1,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ETH,
         amount=FVal(swap_amount),
@@ -161,32 +152,24 @@ def test_metamask_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount} ETH in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=2,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_OTACON,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} OTACON as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=214,
+        sequence_index=3,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} ETH as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
     )]
     assert expected_events == events
 
@@ -213,12 +196,11 @@ def test_metamask_swap_usdt_to_token(ethereum_inquirer, ethereum_accounts):
         location_label=user_address,
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=1,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDT,
         amount=FVal(swap_amount),
@@ -226,32 +208,24 @@ def test_metamask_swap_usdt_to_token(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount} USDT in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=2,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_INU,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} INU as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=141,
+        sequence_index=3,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_USDT,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} USDT as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
     )]
     assert expected_events == events
 
@@ -278,12 +252,11 @@ def test_metamask_swap_token_to_usdc(ethereum_inquirer, ethereum_accounts):
         location_label=user_address,
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=1,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_MOG,
         amount=FVal(swap_amount),
@@ -291,32 +264,24 @@ def test_metamask_swap_token_to_usdc(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount} Mog in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=2,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_USDC,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} USDC as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=418,
+        sequence_index=3,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_USDC,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} USDC as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
     )]
     assert expected_events == events
 
@@ -355,12 +320,11 @@ def test_metamask_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
         location_label=user_address,
         notes=f'Set AAVE spending approval of {user_address} by {METAMASK_ROUTER_ETH} to {approval_amount}',  # noqa: E501
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=290,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_AAVE,
         amount=FVal(swap_amount),
@@ -368,32 +332,24 @@ def test_metamask_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount} AAVE in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=291,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_INJ,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} INJ as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=317,
+        sequence_index=292,
         timestamp=timestamp,
         location=Location.ETHEREUM,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_AAVE,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} AAVE as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ETH,
     )]
     assert expected_events == events
 
@@ -423,12 +379,11 @@ def test_metamask_swap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
         location_label=user_address,
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=1,
         timestamp=timestamp,
         location=Location.ARBITRUM_ONE,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ARBITRUM_USDC,
         amount=FVal(swap_amount),
@@ -436,32 +391,24 @@ def test_metamask_swap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
         notes=f'Swap {swap_amount} USDC in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_ARB,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=2,
         timestamp=timestamp,
         location=Location.ARBITRUM_ONE,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} ETH as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ARB,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=11,
+        sequence_index=3,
         timestamp=timestamp,
         location=Location.ARBITRUM_ONE,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ARBITRUM_USDC,
         amount=FVal(metamask_fee),
-        location_label=user_address,
         notes=f'Spend {metamask_fee} USDC as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_ARB,
     )]
     assert expected_events == events
 
@@ -488,12 +435,11 @@ def test_metamask_swap_optimism(optimism_inquirer, optimism_accounts):
         location_label=user_address,
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=1,
         timestamp=timestamp,
         location=Location.OPTIMISM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_OPTIMISM_USDT,
         amount=FVal(swap_amount),
@@ -501,32 +447,24 @@ def test_metamask_swap_optimism(optimism_inquirer, optimism_accounts):
         notes=f'Swap {swap_amount} USDT in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_OPT,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=2,
         timestamp=timestamp,
         location=Location.OPTIMISM,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_OPTIMISM_USDC,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} USDC as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_OPT,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=19,
+        sequence_index=3,
         timestamp=timestamp,
         location=Location.OPTIMISM,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_OPTIMISM_USDT,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} USDT as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_OPT,
     )]
     assert expected_events == events
 
@@ -568,12 +506,11 @@ def test_metamask_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
         location_label=user_address,
         notes=f'Set USDC spending approval of {user_address} by {METAMASK_ROUTER_MATIC} to {approval_amount}',  # noqa: E501
         address=METAMASK_ROUTER_MATIC,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=245,
         timestamp=timestamp,
         location=Location.POLYGON_POS,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_POLYGON_USDC,
         amount=FVal(swap_amount),
@@ -581,32 +518,24 @@ def test_metamask_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
         notes=f'Swap {swap_amount} USDC in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_MATIC,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=246,
         timestamp=timestamp,
         location=Location.POLYGON_POS,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_POLYGON_POS_MATIC,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} POL as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_MATIC,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=256,
+        sequence_index=247,
         timestamp=timestamp,
         location=Location.POLYGON_POS,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_POLYGON_USDC,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} USDC as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_MATIC,
     )]
     assert expected_events == events
 
@@ -646,12 +575,11 @@ def test_metamask_swap_binance_sc(
         location_label=user_address,
         notes=f'Set BSC-USD spending approval of {user_address} by {METAMASK_ROUTER_BSC} to {approve_amount}',  # noqa: E501
         address=METAMASK_ROUTER_BSC,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=72,
         timestamp=timestamp,
         location=Location.BINANCE_SC,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=a_bsc_usd,
         amount=FVal(swap_amount),
@@ -659,30 +587,22 @@ def test_metamask_swap_binance_sc(
         notes=f'Swap {swap_amount} BSC-USD in metamask',
         counterparty=CPT_METAMASK_SWAPS,
         address=METAMASK_ROUTER_BSC,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=73,
         timestamp=timestamp,
         location=Location.BINANCE_SC,
-        event_type=HistoryEventType.TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_BSC_BNB,
         amount=FVal(received_amount),
-        location_label=user_address,
         notes=f'Receive {received_amount} BNB as the result of a metamask swap',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_BSC,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
-        sequence_index=80,
+        sequence_index=74,
         timestamp=timestamp,
         location=Location.BINANCE_SC,
-        event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_BSC_BNB,
         amount=FVal(fee_amount),
-        location_label=user_address,
         notes=f'Spend {fee_amount} BNB as metamask fees',
-        counterparty=CPT_METAMASK_SWAPS,
-        address=METAMASK_ROUTER_BSC,
     )]

--- a/rotkehlchen/tests/unit/decoders/test_pendle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pendle.py
@@ -13,6 +13,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import globaldb_set_general_cache_values
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import CacheType, Location, TimestampMS, deserialize_evm_tx_hash
@@ -431,12 +432,11 @@ def test_swap_using_kyber(ethereum_inquirer, ethereum_accounts):
             location_label=user_address,
             notes=f'Revoke EIGEN spending approval of {user_address} by 0x888888888889758F76e7103c6CbF23ABbF58F946',  # noqa: E501
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=959,
             timestamp=timestamp,
             location=Location.ETHEREUM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:1/erc20:0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83'),
             amount=FVal(out_amount),
@@ -444,19 +444,15 @@ def test_swap_using_kyber(ethereum_inquirer, ethereum_accounts):
             notes=f'Swap {out_amount} EIGEN in Pendle',
             counterparty=CPT_PENDLE,
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=960,
             timestamp=timestamp,
             location=Location.ETHEREUM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
             amount=FVal(in_amount),
-            location_label=user_address,
             notes=f'Receive {in_amount} USDC from Pendle swap',
-            counterparty=CPT_PENDLE,
-            address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
         ),
     ]
     assert events == expected_events
@@ -485,12 +481,11 @@ def test_swap_using_kyber_2(ethereum_inquirer, ethereum_accounts):
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.ETHEREUM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:1/erc20:0x58D97B57BB95320F9a05dC918Aef65434969c2B2'),
             amount=FVal(out_amount),
@@ -498,19 +493,15 @@ def test_swap_using_kyber_2(ethereum_inquirer, ethereum_accounts):
             notes=f'Swap {out_amount} MORPHO in Pendle',
             counterparty=CPT_PENDLE,
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.ETHEREUM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
             amount=FVal(in_amount),
-            location_label=user_address,
             notes=f'Receive {in_amount} ETH from Pendle swap',
-            counterparty=CPT_PENDLE,
-            address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
         ),
     ]
     assert events == expected_events
@@ -538,12 +529,11 @@ def test_swap_using_odos(ethereum_inquirer, ethereum_accounts):
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=1,
             timestamp=timestamp,
             location=Location.ETHEREUM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
             amount=FVal(out_amount),
@@ -551,19 +541,15 @@ def test_swap_using_odos(ethereum_inquirer, ethereum_accounts):
             notes=f'Swap {out_amount} USDC in Pendle',
             counterparty=CPT_PENDLE,
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
-        ), EvmEvent(
+        ), EvmSwapEvent(
             tx_hash=tx_hash,
             sequence_index=2,
             timestamp=timestamp,
             location=Location.ETHEREUM,
-            event_type=HistoryEventType.TRADE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:1/erc20:0x4c9EDD5852cd905f086C759E8383e09bff1E68B3'),
             amount=FVal(in_amount),
-            location_label=user_address,
             notes=f'Receive {in_amount} USDe from Pendle swap',
-            counterparty=CPT_PENDLE,
-            address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
         ),
     ]
     assert events == expected_events


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=106071652

Adds logic in post decoding to process swaps into EvmSwapEvents.

This would affect all the decoding tests involving swaps, so I also added a temporary check, so that it only does this for a few counterparties whose tests I've updated. This check will need removed and the rest of the tests updated in a subsequent PR.