### PR TITLE
Sanitizing Rotki Backend Start-Up Arguments in Docker Entrypoint

### DIFF
--- a/packaging/docker/entrypoint.py
+++ b/packaging/docker/entrypoint.py
@@ -20,6 +20,20 @@ logging.basicConfig(level=logging.DEBUG)
 DEFAULT_LOG_LEVEL = 'critical'
 
 
+def sanitize_args_for_popen(args: list[Any]) -> list[str]:
+    """
+    Sanitizes the arguments for `subprocess.Popen` by converting them to strings.
+
+    Ratio: `subprocess.Popen` expects a list of strings and PathLikes as arguments.
+    Some configuration values may be of type `int` or other types. Casting them to
+    string ensures that `subprocess.Popen` can handle them correctly.
+
+    :param args: The list of arguments to sanitize.
+    :return: A sanitized list of arguments.
+    """
+    return [str(arg) for arg in args]
+
+
 def check_core_api_availability(retries: int = 30, wait_seconds: int = 10) -> bool:
     """
     Checks the availability of the core backend API by sending a ping request.
@@ -192,9 +206,11 @@ base_args = [
     '0.0.0.0',
 ]
 
-cmd = base_args + config_args
+# Arguments needs to be sanitized for `subprocess.Popen`, as it does not accept `int`
+cmd = sanitize_args_for_popen(base_args + config_args)
 
 logger.info('starting rotki backend')
+logger.debug('backend arguments: %s', cmd)
 
 rotki = subprocess.Popen(cmd)
 

--- a/packaging/docker/entrypoint.py
+++ b/packaging/docker/entrypoint.py
@@ -20,20 +20,6 @@ logging.basicConfig(level=logging.DEBUG)
 DEFAULT_LOG_LEVEL = 'critical'
 
 
-def sanitize_args_for_popen(args: list[Any]) -> list[str]:
-    """
-    Sanitizes the arguments for `subprocess.Popen` by converting them to strings.
-
-    Ratio: `subprocess.Popen` expects a list of strings and PathLikes as arguments.
-    Some configuration values may be of type `int` or other types. Casting them to
-    string ensures that `subprocess.Popen` can handle them correctly.
-
-    :param args: The list of arguments to sanitize.
-    :return: A sanitized list of arguments.
-    """
-    return [str(arg) for arg in args]
-
-
 def check_core_api_availability(retries: int = 30, wait_seconds: int = 10) -> bool:
     """
     Checks the availability of the core backend API by sending a ping request.
@@ -207,10 +193,9 @@ base_args = [
 ]
 
 # Arguments needs to be sanitized for `subprocess.Popen`, as it does not accept `int`
-cmd = sanitize_args_for_popen(base_args + config_args)
+cmd = [str(arg) for arg in (base_args + config_args)]
 
-logger.info('starting rotki backend')
-logger.debug('backend arguments: %s', cmd)
+logger.info(f'starting rotki backend with arguments {cmd}')
 
 rotki = subprocess.Popen(cmd)
 


### PR DESCRIPTION
Python's `subprocess.Popen` accepts a list of strings and PathLikes as arguments to start a process. The `entrypoint.py` script reads environment variables and settings from a config file, casting numeric-expected values to `int` as a first line of defense against mis-configuration. The casted values are added to the arguments list for `subprocess.Popen`. When such values are configured, the startup fails because of an exception from `Popen`.

This fix introduces a quick sanitize of the arguments list, just for the use with `subprocess.Popen`, keeping the defense line intact.

For a later refactoring, a proper value validation should be considered. This could provide better / more helpful error messages in case of a misconfiguration.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
