### PR TITLE
Improve trade type handling in get_swap_spend_receive

### DIFF
--- a/rotkehlchen/data_import/importers/bisq_trades.py
+++ b/rotkehlchen/data_import/importers/bisq_trades.py
@@ -9,7 +9,11 @@ from rotkehlchen.db.drivers.gevent import DBCursor
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
-from rotkehlchen.history.events.structures.swap import create_swap_events, get_swap_spend_receive
+from rotkehlchen.history.events.structures.swap import (
+    create_swap_events,
+    deserialize_trade_type_is_buy,
+    get_swap_spend_receive,
+)
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
     deserialize_fval_or_zero,
@@ -66,7 +70,7 @@ class BisqTradesImporter(BaseExchangeImporter):
             fee_currency = A_BTC
 
         spend, receive = get_swap_spend_receive(
-            raw_trade_type=trade_type,
+            is_buy=deserialize_trade_type_is_buy(trade_type),
             base_asset=base_asset,
             quote_asset=quote_asset,
             amount=buy_amount,

--- a/rotkehlchen/data_import/importers/bitstamp.py
+++ b/rotkehlchen/data_import/importers/bitstamp.py
@@ -13,7 +13,11 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
 )
-from rotkehlchen.history.events.structures.swap import create_swap_events, get_swap_spend_receive
+from rotkehlchen.history.events.structures.swap import (
+    create_swap_events,
+    deserialize_trade_type_is_buy,
+    get_swap_spend_receive,
+)
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -60,7 +64,7 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
             value_str, value_symbol = csv_row['Value'].split(' ')
             fee_str, fee_symbol = csv_row['Fee'].split(' ')
             spend, receive = get_swap_spend_receive(
-                raw_trade_type=csv_row['Sub Type'],
+                is_buy=deserialize_trade_type_is_buy(csv_row['Sub Type']),
                 base_asset=asset_from_bitstamp(amount_symbol),
                 quote_asset=asset_from_bitstamp(value_symbol),
                 amount=(swap_amount := deserialize_fval(amount)),

--- a/rotkehlchen/data_import/importers/kucoin.py
+++ b/rotkehlchen/data_import/importers/kucoin.py
@@ -9,7 +9,11 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.utils import get_key_if_has_val
 from rotkehlchen.history.deserialization import deserialize_price
-from rotkehlchen.history.events.structures.swap import create_swap_events, get_swap_spend_receive
+from rotkehlchen.history.events.structures.swap import (
+    create_swap_events,
+    deserialize_trade_type_is_buy,
+    get_swap_spend_receive,
+)
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
     deserialize_fval_or_zero,
@@ -71,7 +75,7 @@ class KucoinImporter(BaseExchangeImporter):
                     base, quote = row[tokens_key].split(splitter)
                     fee_currency = get_key_if_has_val(row, fee_currency_key)
                     spend, receive = get_swap_spend_receive(
-                        raw_trade_type=row[trade_type_key],
+                        is_buy=deserialize_trade_type_is_buy(row[trade_type_key]),
                         base_asset=asset_from_kucoin(base),
                         quote_asset=asset_from_kucoin(quote),
                         amount=deserialize_fval(row[amount_key]),

--- a/rotkehlchen/db/upgrades/v47_v48.py
+++ b/rotkehlchen/db/upgrades/v47_v48.py
@@ -44,7 +44,7 @@ def upgrade_trade_to_swap_events(
     - ValueError
     """
     spend, receive = get_swap_spend_receive(
-        raw_trade_type='buy' if row[4] in {'A', 'C'} else 'sell',  # A,C = buy, settlement buy; B,D = sell, settlement sell  # noqa: E501
+        is_buy=row[4] in {'A', 'C'},  # A,C = buy, settlement buy; B,D = sell, settlement sell
         base_asset=Asset(row[2]),
         quote_asset=Asset(row[3]),
         amount=FVal(row[5]),

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -148,7 +148,7 @@ def trade_from_binance(
         )
 
     spend, receive = get_swap_spend_receive(
-        raw_trade_type='buy' if binance_trade['isBuyer'] else 'sell',
+        is_buy=binance_trade['isBuyer'],
         base_asset=binance_pair.base_asset,
         quote_asset=binance_pair.quote_asset,
         amount=deserialize_fval(binance_trade['qty']),
@@ -1296,7 +1296,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras):
                 return []
 
             spend, receive = get_swap_spend_receive(
-                raw_trade_type='buy' if is_buy else 'sell',
+                is_buy=is_buy,
                 base_asset=asset_from_binance(raw_data['cryptoCurrency']),
                 quote_asset=(fiat_asset := asset_from_binance(raw_data['fiatCurrency'])),
                 amount=deserialize_fval_force_positive(raw_data['obtainAmount']),

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -513,7 +513,7 @@ class Bitfinex(ExchangeInterface):
             )
 
         spend, receive = get_swap_spend_receive(
-            raw_trade_type='buy' if (amount := deserialize_fval(raw_result[4])) >= ZERO else 'sell',  # noqa: E501
+            is_buy=(amount := deserialize_fval(raw_result[4])) >= ZERO,
             base_asset=asset_from_bitfinex(bitfinex_name=bfx_base_asset_symbol),
             quote_asset=asset_from_bitfinex(bitfinex_name=bfx_quote_asset_symbol),
             amount=abs(amount),

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -31,6 +31,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.inquirer import Inquirer
@@ -277,7 +278,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
                 )
 
             spend, receive = get_swap_spend_receive(
-                raw_trade_type=entry['attributes']['type'],
+                is_buy=deserialize_trade_type_is_buy(entry['attributes']['type']),
                 base_asset=crypto_asset,
                 quote_asset=fiat_asset,
                 amount=deserialize_fval(entry['attributes']['amount_cryptocoin']),

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -807,7 +807,7 @@ class Bitstamp(ExchangeInterface):
             )
 
         spend, receive = get_swap_spend_receive(
-            raw_trade_type='buy' if base_asset_amount >= ZERO else 'sell',
+            is_buy=base_asset_amount >= ZERO,
             base_asset=trade_pair_data.base_asset,
             quote_asset=trade_pair_data.quote_asset,
             amount=abs(base_asset_amount),

--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -33,6 +33,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
@@ -374,7 +375,7 @@ class Bybit(ExchangeInterface):
 
                 try:
                     spend, receive = get_swap_spend_receive(
-                        raw_trade_type=raw_trade['side'],
+                        is_buy=deserialize_trade_type_is_buy(raw_trade['side']),
                         base_asset=base_asset,
                         quote_asset=quote_asset,
                         amount=deserialize_fval(raw_trade['qty']),

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -38,6 +38,7 @@ from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -914,7 +915,7 @@ class Coinbase(ExchangeInterface):
             amount /= rate
 
         spend, receive = get_swap_spend_receive(
-            raw_trade_type=order_side,
+            is_buy=deserialize_trade_type_is_buy(order_side),
             base_asset=asset_from_coinbase(asset_identifiers[0], time=timestamp),
             quote_asset=quote_asset,
             amount=abs(amount),

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -32,6 +32,7 @@ from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.inquirer import Inquirer
@@ -470,7 +471,7 @@ class Gemini(ExchangeInterface):
 
                     base, quote = gemini_symbol_to_base_quote(symbol)
                     spend, receive = get_swap_spend_receive(
-                        raw_trade_type=entry['type'],
+                        is_buy=deserialize_trade_type_is_buy(entry['type']),
                         base_asset=base,
                         quote_asset=quote,
                         amount=deserialize_fval(entry['amount']),

--- a/rotkehlchen/exchanges/htx.py
+++ b/rotkehlchen/exchanges/htx.py
@@ -28,6 +28,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
@@ -442,7 +443,7 @@ class Htx(ExchangeInterface):
 
                 try:
                     spend, receive = get_swap_spend_receive(
-                        raw_trade_type=trade_type,
+                        is_buy=deserialize_trade_type_is_buy(trade_type),
                         base_asset=base_asset,
                         quote_asset=quote_asset,
                         amount=deserialize_fval(raw_trade['filled-amount']),

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -348,7 +348,7 @@ class Independentreserve(ExchangeInterface):
                     continue
 
                 spend, receive = get_swap_spend_receive(
-                    raw_trade_type='buy' if 'Bid' in raw_trade['OrderType'] else 'sell',
+                    is_buy='Bid' in raw_trade['OrderType'],
                     base_asset=(base_asset := independentreserve_asset(raw_trade['PrimaryCurrencyCode'])),  # noqa: E501
                     quote_asset=independentreserve_asset(raw_trade['SecondaryCurrencyCode']),
                     amount=(amount := (FVal(raw_trade['Volume']) - FVal(raw_trade['Outstanding']))),  # noqa: E501

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -35,6 +35,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
@@ -610,7 +611,7 @@ class Kucoin(ExchangeInterface):
                 trade_id = raw_result['id']
 
             spend, receive = get_swap_spend_receive(
-                raw_trade_type=raw_result['side'],
+                is_buy=deserialize_trade_type_is_buy(raw_result['side']),
                 base_asset=base_asset,
                 quote_asset=quote_asset,
                 amount=amount,

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -29,6 +29,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
@@ -371,7 +372,7 @@ class Okx(ExchangeInterface):
                     f'Expected pair {raw_trade["instId"]} to contain a "-"',
                 ) from e
             spend, receive = get_swap_spend_receive(
-                raw_trade_type=raw_trade['side'],
+                is_buy=deserialize_trade_type_is_buy(raw_trade['side']),
                 base_asset=asset_from_okx(base_asset_str),
                 quote_asset=asset_from_okx(quote_asset_str),
                 amount=deserialize_fval(raw_trade['accFillSz']),

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -32,6 +32,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
@@ -79,7 +80,7 @@ def trade_from_poloniex(poloniex_trade: dict[str, Any]) -> list[SwapEvent]:
     """
     try:
         spend, receive = get_swap_spend_receive(
-            raw_trade_type=poloniex_trade['side'],
+            is_buy=deserialize_trade_type_is_buy(poloniex_trade['side']),
             base_asset=asset_from_poloniex(get_pair_position_str((pair := poloniex_trade['symbol']), 'first')),  # noqa: E501
             quote_asset=asset_from_poloniex(get_pair_position_str(pair, 'second')),
             amount=deserialize_fval(poloniex_trade['quantity']),

--- a/rotkehlchen/exchanges/woo.py
+++ b/rotkehlchen/exchanges/woo.py
@@ -28,6 +28,7 @@ from rotkehlchen.history.events.structures.asset_movement import (
 from rotkehlchen.history.events.structures.swap import (
     SwapEvent,
     create_swap_events,
+    deserialize_trade_type_is_buy,
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventType
@@ -177,7 +178,7 @@ class Woo(ExchangeInterface):
             ) from e
 
         spend, receive = get_swap_spend_receive(
-            raw_trade_type=trade['side'],
+            is_buy=deserialize_trade_type_is_buy(trade['side']),
             base_asset=asset_from_woo(base_asset_symbol),
             quote_asset=asset_from_woo(quote_asset_symbol),
             amount=deserialize_fval(trade['executed_quantity']),


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=102361655

Moves the trade type deserialization into a separate `deserialize_trade_type_is_buy` function returning True for buy and False for sell, and changes `get_swap_spend_receive` to take an `is_buy` bool flag.

This eliminates passing `buy` and `sell` strings and running the deserialization logic unnecessarily.