### PR TITLE
ignore constant inflow & outflow tokens in optimism

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` rotki will now exclude Superfluid's Constant Inflow and Outflow NFTs from your balances, fixing misleading balance summaries.
 * :bug:`-` rotki will no longer incorrectly count previously owned NFTs from a collection as part of current balance.
 * :feature:`-` Monerium transactions on Arbitrum and Scroll blockchains are now properly decoded.
 * :feature:`-` Users can see the compact view of swap events in the history events section.

--- a/rotkehlchen/chain/arbitrum_one/manager.py
+++ b/rotkehlchen/chain/arbitrum_one/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import CurveManagerMixin, EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import ArbitrumOneAccountingAggregator
 from .decoding.decoder import ArbitrumOneTransactionDecoder
@@ -27,7 +28,11 @@ class ArbitrumOneManager(EvmManager, CurveManagerMixin):
             transactions=transactions,
             tokens=ArbitrumOneTokens(
                 database=node_inquirer.database,
-                arbitrum_one_inquirer=node_inquirer,
+                evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0x0043d7c85C8b96a49A72A92C0B48CdC4720437d7'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0x051e766e2d8dc65ae2bFCF084A50AD0447634227'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=ArbitrumOneTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/arbitrum_one/tokens.py
+++ b/rotkehlchen/chain/arbitrum_one/tokens.py
@@ -1,14 +1,5 @@
-from typing import TYPE_CHECKING
-
 from rotkehlchen.chain.evm.tokens import EvmTokens
-
-if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
-
-    from .node_inquirer import ArbitrumOneInquirer
 
 
 class ArbitrumOneTokens(EvmTokens):
-
-    def __init__(self, database: 'DBHandler', arbitrum_one_inquirer: 'ArbitrumOneInquirer') -> None:  # noqa: E501
-        super().__init__(database=database, evm_inquirer=arbitrum_one_inquirer)
+    ...

--- a/rotkehlchen/chain/base/manager.py
+++ b/rotkehlchen/chain/base/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import CurveManagerMixin, EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import BaseAccountingAggregator
 from .decoding.decoder import BaseTransactionDecoder
@@ -27,7 +28,11 @@ class BaseManager(EvmManager, CurveManagerMixin):
             transactions=transactions,
             tokens=BaseTokens(
                 database=node_inquirer.database,
-                base_inquirer=node_inquirer,
+                evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0x2d51962A9EE4D3C2819EF585eab7412c2a2C31Ac'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0xD3C78bb5a16Ea4ab584844eeb8F90Ac710c16355'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=BaseTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/base/tokens.py
+++ b/rotkehlchen/chain/base/tokens.py
@@ -1,14 +1,5 @@
-from typing import TYPE_CHECKING
-
 from rotkehlchen.chain.evm.tokens import EvmTokens
-
-if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
-
-    from .node_inquirer import BaseInquirer
 
 
 class BaseTokens(EvmTokens):
-
-    def __init__(self, database: 'DBHandler', base_inquirer: 'BaseInquirer') -> None:
-        super().__init__(database=database, evm_inquirer=base_inquirer)
+    ...

--- a/rotkehlchen/chain/binance_sc/manager.py
+++ b/rotkehlchen/chain/binance_sc/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import CurveManagerMixin, EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import BinanceSCAccountingAggregator
 from .decoding.decoder import BinanceSCTransactionDecoder
@@ -24,6 +25,10 @@ class BinanceSCManager(EvmManager, CurveManagerMixin):
             tokens=BinanceSCTokens(
                 database=node_inquirer.database,
                 evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0xbF7BCcE8D60A9C3F6bFaEc9346Aa85B9f781a4e9'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0xcb05535bd212eCFC4B7b9db81d6C2C768b726776'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=BinanceSCTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/ethereum/tokens.py
+++ b/rotkehlchen/chain/ethereum/tokens.py
@@ -54,6 +54,7 @@ class EthereumTokens(EvmTokensWithDSProxy):
         super().__init__(
             database=database,
             evm_inquirer=ethereum_inquirer,
+            token_exceptions=None,
         )
         dai = A_DAI.resolve_to_evm_token()
         weth = A_WETH.resolve_to_evm_token()

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -143,9 +143,11 @@ class EvmTokens(ABC):  # noqa: B024
             self,
             database: 'DBHandler',
             evm_inquirer: 'EvmNodeInquirer',
+            token_exceptions: set[ChecksumEvmAddress] | None = None,
     ):
         self.db = database
         self.evm_inquirer = evm_inquirer
+        self.token_exceptions = token_exceptions if token_exceptions is not None else set()
 
     def get_token_balances(
             self,
@@ -504,16 +506,17 @@ class EvmTokens(ABC):  # noqa: B024
 
         Each chain needs to implement any chain-specific exceptions here.
         """
-        return set()
+        return self.token_exceptions
 
 
 class EvmTokensWithDSProxy(EvmTokens, ABC):
     def __init__(
             self,
             database: 'DBHandler',
-            evm_inquirer: 'EvmNodeInquirerWithDSProxy',
+            evm_inquirer: 'EvmNodeInquirer',
+            token_exceptions: set[ChecksumEvmAddress] | None = None,
     ):
-        super().__init__(database=database, evm_inquirer=evm_inquirer)
+        super().__init__(database=database, evm_inquirer=evm_inquirer, token_exceptions=token_exceptions)  # noqa: E501
         self.evm_inquirer: EvmNodeInquirerWithDSProxy  # set explicit type
 
     def _query_new_tokens(self, addresses: Sequence[ChecksumEvmAddress]) -> None:

--- a/rotkehlchen/chain/gnosis/manager.py
+++ b/rotkehlchen/chain/gnosis/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import CurveManagerMixin, EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import GnosisAccountingAggregator
 from .decoding.decoder import GnosisTransactionDecoder
@@ -23,7 +24,11 @@ class GnosisManager(EvmManager, CurveManagerMixin):
             transactions=transactions,
             tokens=GnosisTokens(
                 database=node_inquirer.database,
-                gnosis_inquirer=node_inquirer,
+                evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0x1497440B4E92DC4ca0F76223b28C20Cb9cB8a0f1'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0xfC00dEE8a980110c5608A823a5B3af3872635456'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=GnosisTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/gnosis/tokens.py
+++ b/rotkehlchen/chain/gnosis/tokens.py
@@ -8,19 +8,13 @@ from rotkehlchen.chain.gnosis.modules.giveth.constants import (
 from rotkehlchen.chain.gnosis.modules.monerium.constants import GNOSIS_MONERIUM_LEGACY_ADDRESSES
 
 if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.types import ChecksumEvmAddress
-
-    from .node_inquirer import GnosisInquirer
 
 
 class GnosisTokens(EvmTokens):
 
-    def __init__(self, database: 'DBHandler', gnosis_inquirer: 'GnosisInquirer') -> None:
-        super().__init__(database=database, evm_inquirer=gnosis_inquirer)
-
     # -- methods that need to be implemented per chain
     def _per_chain_token_exceptions(self) -> set['ChecksumEvmAddress']:
-        return GNOSIS_MONERIUM_LEGACY_ADDRESSES | {
+        return super()._per_chain_token_exceptions() | GNOSIS_MONERIUM_LEGACY_ADDRESSES | {
             GIVPOW_ADDRESS, GNOSIS_GIVPOWERSTAKING_WRAPPER,
         }

--- a/rotkehlchen/chain/optimism/manager.py
+++ b/rotkehlchen/chain/optimism/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import CurveManagerMixin, EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import OptimismAccountingAggregator
 from .decoding.decoder import OptimismTransactionDecoder
@@ -27,7 +28,11 @@ class OptimismManager(EvmManager, CurveManagerMixin):
             transactions=transactions,
             tokens=OptimismTokens(
                 database=node_inquirer.database,
-                optimism_inquirer=node_inquirer,
+                evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0x0C6D90a98426bfD572a5c5Be572a7f6Bd1C5ED76'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0xFb2b126660BE2fdEBa254b1F6e4348644E8482e7'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=OptimismTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/optimism/tokens.py
+++ b/rotkehlchen/chain/optimism/tokens.py
@@ -3,23 +3,20 @@ from typing import TYPE_CHECKING
 from rotkehlchen.chain.evm.tokens import EvmTokens
 from rotkehlchen.chain.optimism.modules.giveth.constants import GIVPOW_ADDRESS
 from rotkehlchen.constants.assets import A_OPTIMISM_ETH
-from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
-
-    from .node_inquirer import OptimismInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 
 class OptimismTokens(EvmTokens):
 
-    def __init__(self, database: 'DBHandler', optimism_inquirer: 'OptimismInquirer') -> None:
-        super().__init__(database=database, evm_inquirer=optimism_inquirer)
-
     # -- methods that need to be implemented per chain
-    def _per_chain_token_exceptions(self) -> set[ChecksumEvmAddress]:
+    def _per_chain_token_exceptions(self) -> set['ChecksumEvmAddress']:
         """
         Optimism ETH ERC20 token mirrors the user's balance on the chain.
         To avoid double counting, we exclude the token from the balance query.
         """
-        return {A_OPTIMISM_ETH.resolve_to_evm_token().evm_address, GIVPOW_ADDRESS}
+        return super()._per_chain_token_exceptions() | {
+            A_OPTIMISM_ETH.resolve_to_evm_token().evm_address,
+            GIVPOW_ADDRESS,
+        }

--- a/rotkehlchen/chain/polygon_pos/manager.py
+++ b/rotkehlchen/chain/polygon_pos/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import CurveManagerMixin, EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import PolygonPOSAccountingAggregator
 from .decoding.decoder import PolygonPOSTransactionDecoder
@@ -27,7 +28,11 @@ class PolygonPOSManager(EvmManager, CurveManagerMixin):
             transactions=transactions,
             tokens=PolygonPOSTokens(
                 database=node_inquirer.database,
-                polygon_pos_inquirer=node_inquirer,
+                evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0x55909bB8cd8276887Aae35118d60b19755201c68'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0x554e2bbaCF43FD87417b7201A9F1649a3ED89d68'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=PolygonPOSTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/polygon_pos/tokens.py
+++ b/rotkehlchen/chain/polygon_pos/tokens.py
@@ -5,25 +5,21 @@ from rotkehlchen.chain.polygon_pos.modules.monerium.constants import (
     POLYGON_MONERIUM_LEGACY_ADDRESSES,
 )
 from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC
-from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
-
-    from .node_inquirer import PolygonPOSInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 
 class PolygonPOSTokens(EvmTokens):
 
-    def __init__(self, database: 'DBHandler', polygon_pos_inquirer: 'PolygonPOSInquirer') -> None:
-        super().__init__(database=database, evm_inquirer=polygon_pos_inquirer)
-
     # -- methods that need to be implemented per chain
-    def _per_chain_token_exceptions(self) -> set[ChecksumEvmAddress]:
+    def _per_chain_token_exceptions(self) -> set['ChecksumEvmAddress']:
         """
         Polygon MATIC ERC20 token mirrors the user's balance on the chain.
         To avoid double counting, we exclude the token from the balance query.
         """
-        return {
-            A_POLYGON_POS_MATIC.resolve_to_evm_token().evm_address,
-        } | POLYGON_MONERIUM_LEGACY_ADDRESSES
+        return (
+                POLYGON_MONERIUM_LEGACY_ADDRESSES |
+                super()._per_chain_token_exceptions() |
+                {A_POLYGON_POS_MATIC.resolve_to_evm_token().evm_address}
+        )

--- a/rotkehlchen/chain/scroll/manager.py
+++ b/rotkehlchen/chain/scroll/manager.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.manager import EvmManager
+from rotkehlchen.chain.evm.types import string_to_evm_address
 
 from .accountant import ScrollAccountingAggregator
 from .decoding.decoder import ScrollTransactionDecoder
@@ -23,7 +24,11 @@ class ScrollManager(EvmManager):
             transactions=transactions,
             tokens=ScrollTokens(
                 database=node_inquirer.database,
-                scroll_inquirer=node_inquirer,
+                evm_inquirer=node_inquirer,
+                token_exceptions={
+                    string_to_evm_address('0x8c24Fc82c8fDd763F08E654212fc27e577EbD934'),  # Constant Inflow Token  # noqa: E501
+                    string_to_evm_address('0x0de05fe0fF8F5eA9475CA8425e2D05Dd38ccED84'),  # Constant Outflow Token  # noqa: E501
+                },
             ),
             transactions_decoder=ScrollTransactionDecoder(
                 database=node_inquirer.database,

--- a/rotkehlchen/chain/scroll/tokens.py
+++ b/rotkehlchen/chain/scroll/tokens.py
@@ -1,14 +1,5 @@
-from typing import TYPE_CHECKING
-
 from rotkehlchen.chain.evm.tokens import EvmTokens
-
-if TYPE_CHECKING:
-    from rotkehlchen.db.dbhandler import DBHandler
-
-    from .node_inquirer import ScrollInquirer
 
 
 class ScrollTokens(EvmTokens):
-
-    def __init__(self, database: 'DBHandler', scroll_inquirer: 'ScrollInquirer') -> None:
-        super().__init__(database=database, evm_inquirer=scroll_inquirer)
+    ...


### PR DESCRIPTION
these tokens return a hardcoded balance of 1 for all addresses, which can appear after interacting with superfluid protocol. excluding them prevents confusion in balance summaries.

https://explorer.superfluid.org/base-mainnet/supertokens -> [Select any token] -> `CONSTANT_INFLOW_NFT` & `CONSTANT_OUTFLOW_NFT` methods