### PR TITLE
Add more bybit quote assets and improve gemini asset test

### DIFF
--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -142,7 +142,7 @@ class Bybit(ExchangeInterface):
         }
         self.is_unified_account = False
         self.history_events_db = DBHistoryEvents(self.db)
-        self.four_letter_assets = {'USDT', 'USDC', 'USDE'}  # known quote assets
+        self.four_letter_assets = {'USDT', 'USDC', 'USDE', 'USDQ', 'USDR'}  # known quote assets
         with GlobalDBHandler().conn.read_ctx() as cursor:
             cursor.execute(
                 'SELECT exchange_symbol FROM location_asset_mappings WHERE (location IS ? OR location IS NULL) AND LENGTH(exchange_symbol) = 4;',  # noqa: E501

--- a/rotkehlchen/tests/exchanges/test_bybit.py
+++ b/rotkehlchen/tests/exchanges/test_bybit.py
@@ -305,7 +305,7 @@ def test_assets_are_known(bybit_exchange: Bybit):
         try:
             bybit_symbol_to_base_quote(
                 symbol=ticker['symbol'],
-                four_letter_assets={'USDC', 'USDE', 'USDT'},
+                four_letter_assets={'USDC', 'USDE', 'USDT', 'USDQ', 'USDR'},
             )
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -28,8 +28,6 @@ from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_now
 
-UNSUPPORTED_GEMINI_PAIRS = {'btcgusdperp', 'ethgusdperp', 'pepegusdperp'}
-
 
 @pytest.mark.skipif('CI' in os.environ, reason='temporarily skip gemini in CI')
 def test_gemini_validate_key(sandbox_gemini):
@@ -88,7 +86,7 @@ def test_gemini_all_symbols_are_known(sandbox_gemini, globaldb):
             assert quote is not None
 
         except UnprocessableTradePair as e:
-            if symbol not in UNSUPPORTED_GEMINI_PAIRS:
+            if symbol[-4:] != 'perp':
                 test_warnings.warn(UserWarning(
                     f'UnprocessableTradePair in Gemini. {e}',
                 ))


### PR DESCRIPTION
* Adds usdq and usdr to the hardcoded list of bybit four letter quote assets.
* Skips all gemini pairs ending in `perp` instead of hardcoding a list of them (there are quite a number of them now).