### PR TITLE
Extend EvmSwapEvents to support multi swaps

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5010,6 +5010,86 @@ Dealing with History Events
                   },
                   "grouped_events_num": 3,
                   "event_accounting_rule_status": "processed"
+              }, [{
+                  "entry": {
+                      "timestamp": 1569924575000,
+                      "event_type": "multi trade",
+                      "event_subtype": "spend",
+                      "location": "ethereum",
+                      "location_label": null,
+                      "asset": "ETH",
+                      "amount": "0.123",
+                      "identifier": 10,
+                      "entry_type": "evm swap event",
+                      "event_identifier": "10x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "sequence_index": 5,
+                      "extra_data": null,
+                      "tx_hash": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "counterparty": null,
+                      "product": null,
+                      "address": null
+                  },
+                  "event_accounting_rule_status": "not processed"
+              }, {
+                  "entry": {
+                      "timestamp": 1569924575000,
+                      "event_type": "multi trade",
+                      "event_subtype": "spend",
+                      "location": "ethereum",
+                      "location_label": null,
+                      "asset": "eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+                      "amount": "0.0032",
+                      "identifier": 7,
+                      "entry_type": "evm swap event",
+                      "event_identifier": "10x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "sequence_index": 6,
+                      "extra_data": null,
+                      "tx_hash": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "counterparty": null,
+                      "product": null,
+                      "address": null
+                  },
+                  "event_accounting_rule_status": "not processed"
+              }, {
+                  "entry": {
+                      "timestamp": 1569924575000,
+                      "event_type": "multi trade",
+                      "event_subtype": "receive",
+                      "location": "ethereum",
+                      "location_label": null,
+                      "asset": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                      "amount": "120",
+                      "identifier": 8,
+                      "entry_type": "evm swap event",
+                      "event_identifier": "10x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "sequence_index": 7,
+                      "extra_data": null,
+                      "tx_hash": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "counterparty": null,
+                      "product": null,
+                      "address": null
+                  },
+                  "event_accounting_rule_status": "not processed"
+              }, {
+                  "entry": {
+                      "timestamp": 1569924575000,
+                      "event_type": "multi trade",
+                      "event_subtype": "fee",
+                      "location": "ethereum",
+                      "location_label": null,
+                      "asset": "ETH",
+                      "amount": "0.0002",
+                      "identifier": 10,
+                      "entry_type": "evm swap event",
+                      "event_identifier": "10x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "sequence_index": 9,
+                      "extra_data": null,
+                      "tx_hash": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "counterparty": null,
+                      "product": null,
+                      "address": null
+                  },
+                  "event_accounting_rule_status": "not processed"
               }],
              "entries_found": 95,
              "entries_limit": 500,
@@ -5018,7 +5098,7 @@ Dealing with History Events
           "message": ""
       }
 
-   :resjson list decoded_events: A list of history events. Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry may also have a `has_details` flag if true. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry may have a `customized` flag set to true. If it does, it means the event has been customized/added by the user. Each entry may also have a `hidden` flag if set to true. If it does then that means it should be hidden in the UI due to consolidation of events. Also if `group_by_event_ids` exist and is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the common event identifier. The consumer has to query this endpoint again with `group_by_event_ids` set to false and with the `event_identifiers` filter set to the identifier of the events having more than 1 event. Finally `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. Following are all possible entries depending on entry type.
+   :resjson list decoded_events: A list of history events, with some events grouped into sub-lists (for instance the spend/receive/fee events making up a swap). Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry may also have a `has_details` flag if true. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry may have a `customized` flag set to true. If it does, it means the event has been customized/added by the user. Each entry may also have a `hidden` flag if set to true. If it does then that means it should be hidden in the UI due to consolidation of events. Also if `group_by_event_ids` exist and is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the common event identifier. The consumer has to query this endpoint again with `group_by_event_ids` set to false and with the `event_identifiers` filter set to the identifier of the events having more than 1 event. Finally `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. Following are all possible entries depending on entry type.
    :resjson string identifier: Common key. This is the identifier of a single event.
    :resjson string entry_type: Common key. This identifies the category of the event and determines the schema. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
    :resjson string event_identifier: Common key. An event identifier grouping multiple events under a common group. This is how we group transaction events under a transaction, staking related events under block production etc.
@@ -5083,6 +5163,7 @@ Dealing with History Events
 
          :reqjson int sequence_index: This is an index that tries to provide the order of history entries for a single event_identifier.
          :reqjson string location: The location of the entry. Such as "ethereum", "optimism", etc.
+         :reqjson object amount: The amount of the event.
          :reqjson string asset: The asset identifier for this entry
          :reqjson string event_identifier: The event identifier to be used for the event.
          :reqjson string event_type: The main event type of the entry. Possible event types can be seen in the `HistoryEventType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L54>`_.
@@ -5123,6 +5204,7 @@ Dealing with History Events
          :reqjson string[optional] event_identifier: The event identifier to be used for the event.
          :reqjson int sequence_index: This is an index that tries to provide the order of history entries for a single event_identifier.
          :reqjson string location: The location of the entry. Such as "ethereum", "optimism", etc.
+         :reqjson object amount: The amount of the event.
          :reqjson string asset: The asset identifier for this entry
          :reqjson string event_type: The main event type of the entry. Possible event types can be seen in the `HistoryEventType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L54>`_.
          :reqjson string event_subtype: The subtype for the entry. Possible event types can be seen in the `HistoryEventSubType enum <https://github.com/rotki/rotki/blob/59aa288dacd1776e62682e711a916f32a14c04c2/rotkehlchen/accounting/structures/types.py#L72>`_.
@@ -5157,6 +5239,7 @@ Dealing with History Events
             }
 
          :reqjson string[optional] event_identifier: The event identifier to be used for the event.
+         :reqjson object amount: The amount of the event.
          :reqjson int block_number: This is the number of the block where the event took place.
          :reqjson int validator_index: This is the index of the validator.
          :reqjson string fee_recipient: an evm address field to specify the fee recipient in an "eth block event".
@@ -5188,6 +5271,7 @@ Dealing with History Events
 
          :reqjson string tx_hash: This is the transaction hash of the evm event
          :reqjson int sequence_index: This is an index that tries to provide the order of history entries for a single event_identifier.
+         :reqjson object amount: The amount of the event.
          :reqjson int validator_index: This is the index of the validator.
          :reqjson string[optional] event_identifier: The event identifier to be used for the event.
          :reqjson string depositor: an evm address field to specify the depositor in an "eth deposit event".
@@ -5216,6 +5300,7 @@ Dealing with History Events
             }
 
          :reqjson string[optional] event_identifier: The event identifier to be used for the event.
+         :reqjson object amount: The amount of the event.
          :reqjson int validator_index: This is the index of the validator.
          :reqjson string withdrawal_address: an evm address field to specify the withdrawer in an "eth withdrawal event".
          :reqjson bool is_exit: true if the "eth withdrawal event" is an exit event.
@@ -5248,6 +5333,7 @@ Dealing with History Events
             }
 
          :reqjson string event_type: The type of asset movement event ("deposit" or "withdrawal")
+         :reqjson object amount: The amount being moved.
          :reqjson string asset: The identifier of the asset being moved (e.g. "ETH", "BTC")
          :reqjson string location: The location/exchange where the movement occurred
          :reqjson string[optional] fee: The fee amount charged for the movement. If provided, fee_asset must also be provided
@@ -5312,14 +5398,22 @@ Dealing with History Events
                 "entry_type": "evm swap event",
                 "timestamp": 1569924575000,
                 "location": "ethereum",
-                "location_label": "0x6e15887E2CEC81434C16D587709f64603b39b545",
-                "spend_amount": "0.16",
-                "spend_asset": "ETH",
-                "receive_amount": "0.003",
-                "receive_asset": "eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-                "fee_amount": "0.0002",
-                "fee_asset": "ETH",
-                "user_notes": ["Example note", "", ""],
+                "spend_amounts": ["0.16", "0.07"],
+                "spend_assets": ["ETH", "eip155:1/ erc20:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
+                "receive_amounts": ["0.003"],
+                "receive_assets": ["eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"],
+                "fee_amounts": ["0.0002"],
+                "fee_assets": ["ETH"],
+                "user_notes": {
+                    "spend": ["Swap 0.16 ETH", "Swap 0.07 WETH"],
+                    "receive": ["Receive 0.003 WBTC after swap"],
+                    "fee": ["Pay 0.0002 ETH as swap fee"]
+                },
+                "location_labels": {
+                    "spend": ["0x6e15887E2CEC81434C16D587709f64603b39b545", "0x6e15887E2CEC81434C16D587709f64603b39b545"],
+                    "receive": ["0x213B71067BE19cd5dBea3600Db0626859Ff15E78"],
+                    "fee": ["0x6e15887E2CEC81434C16D587709f64603b39b545"]
+                },
                 "sequence_index": 0,
                 "tx_hash": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
                 "counterparty": "some counterparty",
@@ -5329,23 +5423,22 @@ Dealing with History Events
          :reqjson string tx_hash: This is the transaction hash of the evm event
          :reqjson int sequence_index: This is an index that tries to provide the order of history entries for a single event_identifier. This value will be the index of the first event in the swap event group, and other events in the group will be given consecutive indexes after this value.
          :reqjson string location: The location/exchange where the swap occurred
-         :reqjson string spend_amount: The amount being spent
-         :reqjson string spend_asset: The identifier of the asset being spent (e.g. "USD", "BTC")
-         :reqjson string receive_amount: The amount being received
-         :reqjson string receive_asset: The identifier of the asset being received (e.g. "USD", "BTC")
-         :reqjson string[optional] fee_amount: The fee amount charged for the swap. If provided, fee_asset must also be provided
-         :reqjson string[optional] fee_asset: The identifier of the asset in which the fee was paid. If provided, fee must also be provided
-         :resjson list user_notes[optional]: Custom notes for each of the underlying events. Each note will be appended after the autogenerated event description.
+         :reqjson list[string] spend_amounts: The amounts being spent
+         :reqjson list[string] spend_assets: The identifiers of the assets being spent (e.g. "USD", "BTC")
+         :reqjson list[string] receive_amounts: The amounts being received
+         :reqjson list[string] receive_assets: The identifiers of the assets being received (e.g. "USD", "BTC")
+         :reqjson list[string][optional] fee_amounts: The fees charged for the swap. If provided, fee_assets must also be provided.
+         :reqjson list[string][optional] fee_assets: The identifiers of the assets in which the fees were paid. If provided, fee_amounts must also be provided
+         :reqjson object[optional] user_notes: Custom notes for each of the underlying events. Organized in lists under the keys ``spend``, ``receive``, and ``fee``.
+         :reqjson object[optional] location_labels: The user addresses that performed the swap. Organized in lists under the keys ``spend``, ``receive``, and ``fee``.
          :reqjson string[optional] event_identifier: Custom identifier for the event.
-         :reqjson string[optional] location_label: A string field that provides more information about the location. For evm swaps this is the user address that performed the swap.
          :reqjson string[optional] counterparty: An identifier for a potential counterparty of the event entry. For evm swaps this is the protocol that the swap interacted with.
          :reqjson string[optional] product: A defi product that this event is associated with (pool, gauge, etc).
          :reqjson string[optional] address: Any relevant address that this event interacted with.
          :reqjson object[optional] extra_data: An object containing any other data to be stored.
 
-   :reqjson string entry_type: The type of the event that will be processed. Different validation is used based on the value for this field. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
+   :reqjson string entry_type: The type of the event that will be processed. Different validation is used based on the value for this field. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``, ``"asset movement event"``, ``"swap event"``, ``"evm swap event"``.
    :reqjson int timestamp: The timestamp of the entry **in milliseconds**.
-   :reqjson object amount: The amount of the event.
 
    **Example Response**:
 
@@ -5394,7 +5487,8 @@ Dealing with History Events
       }
 
    The request object uses all the same arguments for each entry type as the `add event endpoint <add_event_args_label_>`_, with the addition of the identifier which signifies which entry will be edited.
-   When dealing with event types where multiple events are added/edited as a unit (such as swap events and asset movements), use the identifier of the primary event in the group, i.e. for asset movements, the identifier of the deposit/withdrawal event, and for swap events, the identifier of the spend event.
+   When dealing with event types where all the events for an event_identifier are added/edited as a group (such as swap events and asset movements), use the identifier of the primary event in the group, i.e. for asset movements, the identifier of the deposit/withdrawal event, and for swap events, the identifier of the spend event.
+   For events that are edited as a group but may have other events/groups with the same event_identifier (such as evm swap events), specify the identifiers of all the events in the group, for example: ``"identifiers: {"spend": [1,2], "receive": [3], "fee": [4]}``
 
    **Example Response**:
 

--- a/rotkehlchen/api/rest_helpers/history_events.py
+++ b/rotkehlchen/api/rest_helpers/history_events.py
@@ -1,9 +1,9 @@
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryBaseEntryType
-from rotkehlchen.history.events.structures.types import HistoryEventSubType
 
 if TYPE_CHECKING:
     from rotkehlchen.db.drivers.gevent import DBCursor
@@ -15,6 +15,7 @@ def edit_grouped_events_with_optional_fee(
         write_cursor: 'DBCursor',
         events: list[HistoryBaseEntry],
         events_type: HistoryBaseEntryType,
+        identifiers: dict[str, list[int]] | None = None,
 ) -> None:
     """
     Handle grouped events, including fee-related modifications:
@@ -22,38 +23,34 @@ def edit_grouped_events_with_optional_fee(
     - Create fee entry if it wasn't present before
     - Update existing events when modifications occur
 
+    Evm swaps are more complex and must rely on the identifiers specified. This is handled
+    in edit_grouped_evm_swap_events.
+
     May raise:
     - InputError
     """
-    db = events_db.db
-    with db.conn.read_ctx() as read_cursor:
-        if (result := read_cursor.execute(  # Get the event_identifier and beginning sequence index of the group, selecting by the identifier of the first event.  # noqa: E501
-            'SELECT event_identifier, sequence_index FROM history_events WHERE identifier=?',
-            (events[0].identifier,),
-        ).fetchone()) is not None:
-            event_identifier, sequence_index = result
-        else:
-            raise InputError(f'Tried to edit event with id {events[0].identifier} but could not find it in the DB')  # noqa: E501
+    if (result := write_cursor.execute(  # Get the event_identifier, selecting by the identifier of the first event.  # noqa: E501
+        'SELECT event_identifier FROM history_events WHERE identifier=?',
+        (events[0].identifier,),
+    ).fetchone()) is not None:
+        event_identifier = result[0]
+    else:
+        raise InputError(f'Tried to edit event with id {events[0].identifier} but could not find it in the DB')  # noqa: E501
 
-        if (entry_type := events[0].entry_type) == HistoryBaseEntryType.EVM_SWAP_EVENT:
-            # There can be multiple groups of EvmSwapEvents in a single transaction.
-            # Only count events in this group using the consecutive sequence indexes of the
-            # spend/receive/fee events.
-            existing_event_count = read_cursor.execute(
-                'SELECT COUNT(*) FROM history_events WHERE event_identifier=? AND entry_type=? '
-                'AND ((subtype=? AND sequence_index=?) OR (subtype=? AND sequence_index=?) '
-                'OR (subtype=? AND sequence_index=?))',
-                (event_identifier, entry_type.serialize_for_db(),
-                 HistoryEventSubType.SPEND.serialize(), sequence_index,
-                 HistoryEventSubType.RECEIVE.serialize(), sequence_index + 1,
-                 HistoryEventSubType.FEE.serialize(), sequence_index + 2),
-            ).fetchone()[0]
-        else:  # Other types of grouped events will only have one group per event_identifier.
-            existing_event_count = read_cursor.execute(
-                'SELECT COUNT(*) FROM history_events WHERE event_identifier=?',
-                (event_identifier,),
-            ).fetchone()[0]
+    if events_type == HistoryBaseEntryType.EVM_SWAP_EVENT:
+        edit_grouped_evm_swap_events(  # Evm swaps must be handled differently.
+            events_db=events_db,
+            write_cursor=write_cursor,
+            events=events,
+            identifiers=identifiers,  # type: ignore[arg-type]  # will not be none for evm swaps
+            event_identifier=event_identifier,
+        )
+        return
 
+    existing_event_count = write_cursor.execute(
+        'SELECT COUNT(*) FROM history_events WHERE event_identifier=?',
+        (event_identifier,),
+    ).fetchone()[0]
     no_fee_num = 1 if events_type == HistoryBaseEntryType.ASSET_MOVEMENT_EVENT else 2
     with_fee_num = no_fee_num + 1
 
@@ -78,3 +75,61 @@ def edit_grouped_events_with_optional_fee(
 
     for event in events_to_edit:
         events_db.edit_history_event(write_cursor=write_cursor, event=event)
+
+
+def edit_grouped_evm_swap_events(
+        events_db: 'DBHistoryEvents',
+        write_cursor: 'DBCursor',
+        events: list[HistoryBaseEntry],
+        identifiers: dict[str, list[int]],
+        event_identifier: str,
+) -> None:
+    """Handle editing of grouped evm swap events.
+    Determines which events to add, edit, or remove using the `identifiers` dict
+    and the `events` list as follows:
+    - Inserts events that have no identifier.
+    - Edits events whose identifier is set.
+    - Removes events whose identifier is present in `identifiers`,
+       but have no corresponding event in `events`.
+
+    May raise InputError if a new event is added that collides
+    with the sequence index of an existing event.
+    """
+    edited_identifiers, new_events = defaultdict(list), []
+    for event in events:
+        if event.identifier is None:  # No existing identifier - this is a new event.
+            new_events.append(event)
+        else:  # Already has an identifier - edit existing event.
+            events_db.edit_history_event(write_cursor=write_cursor, event=event)
+            edited_identifiers[event.event_subtype.serialize()].append(event.identifier)
+
+    if identifiers != edited_identifiers:  # There are identifiers with no corresponding events - these events need to be deleted.  # noqa: E501
+        ids_to_delete = []
+        for key, id_list in identifiers.items():
+            if id_list == edited_identifiers[key]:
+                continue
+
+            ids_to_delete.extend(list(set(id_list) - set(edited_identifiers[key])))
+
+        write_cursor.executemany(
+            'DELETE FROM history_events WHERE identifier=?',
+            [(identifier,) for identifier in ids_to_delete],
+        )
+
+    for event in new_events:
+        if write_cursor.execute(  # Check if this event will hit a sequence_index that is already in use.  # noqa: E501
+            'SELECT COUNT(*) FROM history_events WHERE event_identifier=? AND sequence_index=?',
+            (event_identifier, event.sequence_index),
+        ).fetchone()[0] != 0:
+            raise InputError(
+                f'Tried to insert an event with event_identifier {event_identifier} and '
+                f'sequence_index {event.sequence_index}, but an event already exists at '
+                'that sequence_index.',
+            )
+
+        # Add the new event marking it as customized since its being manually added by the user.
+        events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=event,
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+        )

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1253,8 +1253,8 @@ class HistoryEventResource(BaseMethodView):
 
     @require_loggedin_user()
     @resource_parser.use_kwargs(make_patch_schema, location='json')
-    def patch(self, events: list['HistoryBaseEntry']) -> Response:
-        return self.rest_api.edit_history_events(events)
+    def patch(self, events: list['HistoryBaseEntry'], identifiers: dict[str, list[int]] | None = None) -> Response:  # noqa: E501
+        return self.rest_api.edit_history_events(events, identifiers)
 
     @require_loggedin_user()
     @use_kwargs(delete_schema, location='json')

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -6,11 +6,7 @@ from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
-    DecoderContext,
-    DecodingOutput,
-)
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.transactions import EvmTransactions
 from rotkehlchen.constants.misc import ZERO
@@ -178,15 +174,7 @@ class OdosCommonDecoderBase(DecoderInterface):
             output_tokens=output_tokens,
         ))
         maybe_reshuffle_events(
-            ordered_events=(out_in_fee_events := out_events + in_events + fee_events),
+            ordered_events=out_events + in_events + fee_events,
             events_list=context.decoded_events,
         )
-        if len(out_events) > 1 or len(in_events) > 1 or len(fee_events) > 1:
-            # Multiple events of a single type is incompatible with normal swaps,
-            # so convert to type MULTI_TRADE, and don't set the process_swaps flag.
-            for event in out_in_fee_events:
-                event.event_type = HistoryEventType.MULTI_TRADE
-
-            return DEFAULT_DECODING_OUTPUT
-
         return DecodingOutput(process_swaps=True)

--- a/rotkehlchen/history/events/structures/evm_swap.py
+++ b/rotkehlchen/history/events/structures/evm_swap.py
@@ -34,6 +34,10 @@ class EvmSwapEvent(EvmEvent, SwapEvent):
             ],
             asset: Asset,
             amount: 'FVal',
+            event_type: Literal[
+                HistoryEventType.TRADE,
+                HistoryEventType.MULTI_TRADE,
+            ] = HistoryEventType.TRADE,
             location_label: str | None = None,
             notes: str | None = None,
             identifier: int | None = None,
@@ -49,7 +53,7 @@ class EvmSwapEvent(EvmEvent, SwapEvent):
             sequence_index=sequence_index,
             timestamp=timestamp,
             location=location,
-            event_type=HistoryEventType.TRADE,
+            event_type=event_type,
             event_subtype=event_subtype,
             asset=asset,
             amount=amount,
@@ -88,7 +92,8 @@ class EvmSwapEvent(EvmEvent, SwapEvent):
             asset=Asset(entry[6]).check_existence(),
             amount=amount,
             notes=entry[8] or None,
-            event_subtype=HistoryEventSubType.deserialize(entry[10]),  # type: ignore  # should always be correct from the DB
+            event_type=HistoryEventType.deserialize(entry[9]),  # type: ignore  # event type and subtype should always be correct from the DB
+            event_subtype=HistoryEventSubType.deserialize(entry[10]),  # type: ignore
             extra_data=cls.deserialize_extra_data(entry=entry, extra_data=entry[11]),
             tx_hash=deserialize_evm_tx_hash(entry[12]),
             counterparty=entry[13],

--- a/rotkehlchen/tests/unit/decoders/test_odos_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v2.py
@@ -221,7 +221,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         location_label=ethereum_accounts[0],
         notes=f'Revoke SAPO spending approval of {ethereum_accounts[0]} by {ETH_ROUTER}',
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=225,
         timestamp=timestamp,
@@ -234,7 +234,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount_barron} BARRON in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=226,
         timestamp=timestamp,
@@ -247,7 +247,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount_sapo} SAPO in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=227,
         timestamp=timestamp,
@@ -260,7 +260,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=228,
         timestamp=timestamp,
@@ -295,7 +295,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=1,
         timestamp=timestamp,
@@ -308,7 +308,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount} ETH in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=2,
         timestamp=timestamp,
@@ -321,7 +321,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Receive {received_amount_sfrax} sFRAX as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=3,
         timestamp=timestamp,
@@ -334,7 +334,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Receive {received_amount_rgusd} rgUSD as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=4,
         timestamp=timestamp,
@@ -347,7 +347,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Spend {odos_fees_sfrax} sFRAX as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=5,
         timestamp=timestamp,
@@ -394,7 +394,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         location_label=ethereum_accounts[0],
         notes=f'Revoke swETH spending approval of {ethereum_accounts[0]} by {ETH_ROUTER}',
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=248,
         timestamp=timestamp,
@@ -407,7 +407,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount_sweth} swETH in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=249,
         timestamp=timestamp,
@@ -420,7 +420,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Swap {swap_amount_usdc} USDC in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=250,
         timestamp=timestamp,
@@ -433,7 +433,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Receive {received_amount_eth} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=251,
         timestamp=timestamp,
@@ -446,7 +446,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Receive {received_amount_cbeth} cbETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=252,
         timestamp=timestamp,
@@ -459,7 +459,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         notes=f'Spend {odos_fees_cbeth} cbETH as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
         address=ETH_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=253,
         timestamp=timestamp,
@@ -625,7 +625,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         location_label=optimism_accounts[0],
         notes=f'Set USDC.e spending approval of {optimism_accounts[0]} by {OP_ROUTER} to {approval_amount}',  # noqa: E501
         address=OP_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=89,
         timestamp=timestamp,
@@ -638,7 +638,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         notes=f'Swap {swap_amount_usdc} USDC in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=OP_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=90,
         timestamp=timestamp,
@@ -651,7 +651,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         notes=f'Swap {swap_amount_usdce} USDC.e in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=OP_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=91,
         timestamp=timestamp,
@@ -664,7 +664,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
         address=OP_ROUTER,
-    ), EvmEvent(
+    ), EvmSwapEvent(
         tx_hash=tx_hash,
         sequence_index=92,
         timestamp=timestamp,


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=106071652

* Updates the EvmSwapEvent class to support having a type of either TRADE or MULTI_TRADE
* Changes the evm swap api schema and the associated `edit_grouped_events_with_optional_fee` to allow editing multi swaps
* Extends the swap processing logic to also process multi swaps. We had discussed that maybe we would just make the decoders that needed multiswaps directly create EvmSwapEvents, but this actually looked more complicated to implement. The changes required to process multi swaps like other swaps were relatively simple.
* Changed the schema and swap processing to allow `location_label` to be different for each the event in a group, since sometimes the initiator/sender of a swap can be different from the receiver as mentioned in [discord](https://discord.com/channels/657906918408585217/1080783409640648765/1366336145562275900)
* Also updated the api docs to reflect the recent changes with grouping and the changes in this PR to the evm swap add/editing.