### PR TITLE
Fix problem with empty event query

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3696,7 +3696,7 @@ class RestAPI:
         grouped_events_nums: list[int | None]
         grouped_events_nums, events = (
             zip(*events_result, strict=False)  # type: ignore  # mypy doesn't understand significance of boolean check.
-            if group_by_event_ids is True else
+            if group_by_event_ids is True and len(events_result) != 0 else
             ([None] * len(events_result), events_result)
         )
         result = {

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -1139,6 +1139,14 @@ def test_event_grouping(rotkehlchen_api_server: 'APIServer') -> None:
     - group of MULTI_TRADE events: spend, spend, receive, receive, fee
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+
+    # First check that querying history events grouped by id with no events works correctly.
+    # Regression test for a problem that was introduced in the changes for event grouping.
+    assert assert_proper_sync_response_with_result(response=requests.post(
+        api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+        json={'group_by_event_ids': True},
+    ))['entries_found'] == 0
+
     db = DBHistoryEvents(rotki.data.db)
     with rotki.data.db.conn.write_ctx() as write_cursor:
         db.add_history_events(


### PR DESCRIPTION
Fixes a bug where it tried to unzip an empty list when querying history events when no events were returned and group_by_event_ids was set. This problem was introduced recently in https://github.com/rotki/rotki/pull/9830 with the changes to the even grouping.
