### PR TITLE
fix: only allow even addition to existing transactions

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventForm.vue
+++ b/frontend/app/src/components/history/events/HistoryEventForm.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import type {
-  GroupEventData,
-  StandaloneEventData,
-} from '@/modules/history/management/forms/form-types';
+import type { GroupEventData, StandaloneEventData } from '@/modules/history/management/forms/form-types';
 import AssetMovementEventForm from '@/modules/history/management/forms/AssetMovementEventForm.vue';
 import EthBlockEventForm from '@/modules/history/management/forms/EthBlockEventForm.vue';
 import EthDepositEventForm from '@/modules/history/management/forms/EthDepositEventForm.vue';
 import EthWithdrawalEventForm from '@/modules/history/management/forms/EthWithdrawalEventForm.vue';
 import EvmEventForm from '@/modules/history/management/forms/EvmEventForm.vue';
 import EvmSwapEventForm from '@/modules/history/management/forms/EvmSwapEventForm.vue';
+import { EVM_EVENTS, isEvmTypeEvent } from '@/modules/history/management/forms/form-guards';
 import OnlineHistoryEventForm from '@/modules/history/management/forms/OnlineHistoryEventForm.vue';
 import SwapEventForm from '@/modules/history/management/forms/SwapEventForm.vue';
 import { HistoryEventEntryType } from '@rotki/common';
@@ -38,15 +36,14 @@ const isEvmGroupAdd = computed<boolean>(() => {
   if (data.type !== 'group-add') {
     return false;
   }
-  const type = data.group.entryType;
-  return type === HistoryEventEntryType.EVM_EVENT || type === HistoryEventEntryType.EVM_SWAP_EVENT;
+  return isEvmTypeEvent(data.group.entryType);
 });
 
-const historyEventEntryTypes = computed(() => {
+const historyEventEntryTypes = computed<HistoryEventEntryType[]>(() => {
   if (get(isEvmGroupAdd)) {
-    return [HistoryEventEntryType.EVM_SWAP_EVENT, HistoryEventEntryType.EVM_EVENT];
+    return [...EVM_EVENTS];
   }
-  return Object.values(HistoryEventEntryType).filter(value => value !== HistoryEventEntryType.EVM_SWAP_EVENT);
+  return Object.values(HistoryEventEntryType).filter(value => !isEvmTypeEvent(value));
 });
 
 const formComponents: Record<HistoryEventEntryType, Component> = {

--- a/frontend/app/src/modules/history/management/forms/form-guards.ts
+++ b/frontend/app/src/modules/history/management/forms/form-guards.ts
@@ -13,3 +13,12 @@ export function isGroupEditableHistoryEvent(event: HistoryEvent): event is Group
 export function isEvmSwapEvent(event: HistoryEvent): event is EvmSwapEvent {
   return event.entryType === HistoryEventEntryType.EVM_SWAP_EVENT;
 }
+
+export const EVM_EVENTS = [
+  HistoryEventEntryType.EVM_EVENT,
+  HistoryEventEntryType.EVM_SWAP_EVENT,
+] as const;
+
+export function isEvmTypeEvent(type: HistoryEventEntryType): boolean {
+  return Array.prototype.includes.call(EVM_EVENTS, type);
+}

--- a/frontend/app/src/modules/history/management/forms/history-event-form.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/history-event-form.spec.ts
@@ -1,11 +1,12 @@
+import type { EvmHistoryEvent } from '@/types/history/events';
 import HistoryEventForm from '@/components/history/events/HistoryEventForm.vue';
+import { isEvmTypeEvent } from '@/modules/history/management/forms/form-guards';
 import { useBalancePricesStore } from '@/store/balances/prices';
 import { setupDayjs } from '@/utils/date';
-import { HistoryEventEntryType, One } from '@rotki/common';
-import { mount, type VueWrapper } from '@vue/test-utils';
-import flushPromises from 'flush-promises';
+import { bigNumberify, HistoryEventEntryType, One } from '@rotki/common';
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/store/balances/prices', () => ({
   useBalancePricesStore: vi.fn().mockReturnValue({
@@ -18,39 +19,41 @@ vi.mock('json-editor-vue', () => ({
   template: '<input />',
 }));
 
-const formTypesYouCanAddTo = Object.values(HistoryEventEntryType).filter(type => type !== HistoryEventEntryType.EVM_SWAP_EVENT);
+const formTypesYouCanAddTo = Object.values(HistoryEventEntryType).filter(type => !isEvmTypeEvent(type));
+
+type Wrapper = VueWrapper<InstanceType<typeof HistoryEventForm>>;
+
+async function createWrapper(
+  options: ComponentMountingOptions<typeof HistoryEventForm> = {
+    props: {
+      data: { nextSequenceId: '0', type: 'add' },
+    },
+  },
+): Promise<Wrapper> {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const wrapper = mount(HistoryEventForm, {
+    global: {
+      plugins: [pinia],
+      stubs: {
+        RuiAutoComplete: false,
+        Teleport: true,
+        TransitionGroup: false,
+      },
+    },
+    ...options,
+  });
+  await vi.advanceTimersToNextTimerAsync();
+  return wrapper;
+}
 
 describe('component/HistoryEventForm.vue', () => {
-  let wrapper: VueWrapper<InstanceType<typeof HistoryEventForm>>;
-
-  const createWrapper = (): VueWrapper<InstanceType<typeof HistoryEventForm>> => {
-    const pinia = createPinia();
-    setActivePinia(pinia);
-    return mount(HistoryEventForm, {
-      global: {
-        plugins: [pinia],
-        stubs: {
-          RuiAutoComplete: false,
-          Teleport: true,
-          TransitionGroup: false,
-        },
-      },
-      props: {
-        data: { nextSequenceId: '0', type: 'add' },
-      },
-    });
-  };
+  let wrapper: Wrapper;
 
   beforeAll(() => {
     setupDayjs();
     vi.mocked(useBalancePricesStore().getHistoricPrice).mockResolvedValue(One);
     vi.useFakeTimers();
-  });
-
-  beforeEach(async () => {
-    wrapper = createWrapper();
-    await nextTick();
-    await flushPromises();
   });
 
   afterEach(() => {
@@ -61,9 +64,10 @@ describe('component/HistoryEventForm.vue', () => {
     vi.useRealTimers();
   });
 
-  it('should default to history event form', () => {
+  it('should default to history event form', async () => {
     expect.assertions(2);
 
+    wrapper = await createWrapper();
     const entryTypeInput = wrapper.find('[data-cy=entry-type] input');
     const entryTypeElement = entryTypeInput.element as HTMLInputElement;
 
@@ -72,6 +76,7 @@ describe('component/HistoryEventForm.vue', () => {
   });
 
   it.each(formTypesYouCanAddTo)('changes to proper form %s', async (value: string) => {
+    wrapper = await createWrapper();
     await wrapper.find('[data-cy=entry-type] [data-id=activator]').trigger('click');
     await vi.advanceTimersToNextTimerAsync();
 
@@ -86,5 +91,42 @@ describe('component/HistoryEventForm.vue', () => {
 
     const id = value.split(/ /g).join('-');
     expect(wrapper.find(`[data-cy=${id}-form]`).exists(), `id: ${id}`).toBeTruthy();
+  });
+
+  it('should only allow two options on an existing transaction', async () => {
+    const group: EvmHistoryEvent = {
+      address: '0x30a2EBF10f34c6C4874b0bDD5740690fD2f3B70C',
+      amount: bigNumberify(5),
+      asset: 'ETH',
+      counterparty: null,
+      entryType: HistoryEventEntryType.EVM_EVENT,
+      eventIdentifier: '10x4ba949779d936631dc9eb68fa9308c18de51db253aeea919384c728942f95ba9',
+      eventSubtype: '',
+      eventType: 'receive',
+      identifier: 14344,
+      location: 'ethereum',
+      locationLabel: '0xfDb7EEc5eBF4c4aC7734748474123aC25C6eDCc8',
+      product: null,
+      sequenceIndex: 2411,
+      timestamp: 1686495083,
+      txHash: '0x4ba949779d936631dc9eb68fa9308c18de51db253aeea919384c728942f95ba9',
+      userNotes: '',
+    };
+    wrapper = await createWrapper({
+      props: {
+        data: {
+          group,
+          nextSequenceId: '2412',
+          type: 'group-add',
+        },
+      },
+    });
+    await wrapper.find('[data-cy=entry-type] [data-id=activator]').trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const options = wrapper.find('[role="menu-content"]').findAll('button');
+    expect(options).toHaveLength(2);
+    expect(options.at(0)!.text()).toBe(HistoryEventEntryType.EVM_EVENT);
+    expect(options.at(1)!.text()).toBe(HistoryEventEntryType.EVM_SWAP_EVENT);
   });
 });


### PR DESCRIPTION
Disables the addition of evm events from the top addition button.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
