### PR TITLE
Add pytest-icdiff

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 -r requirements_lint.txt
 
 pytest==8.3.4
+pytest-icdiff==0.9
 pytest-xdist==3.6.1
 bump2version==1.0.1
 pytest-cov==5.0.0


### PR DESCRIPTION
When running tests it's often hard to see what's missing. I tried pytest-clarity which helped but its last commit was more than 4 years ago and it needed to be ran with `-vv` for helpful output.

Then I settled on pytest-icdiff which also has helpful output by default and its last commit is still not recent but closer (12/2023)



### Normal -vv output

![2025-05-05_11-07](https://github.com/user-attachments/assets/9a8c1c1d-385d-4214-89c7-8d3fe7bef080)

### pytest-clarity -vv output

![2025-05-05_11-06](https://github.com/user-attachments/assets/a748ebc5-36e9-420a-9907-ffc687a31979)

### pytest-icdiff normal output

![2025-05-05_11-17](https://github.com/user-attachments/assets/bea4184d-f563-44b0-b57c-596f27460cbf)
