### PR TITLE
MakerDAO vault newer interactions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`-` Account labels will now be applied to all chains for which activity is auto-detected unless the existing labels differ between chains.
 * :feature:`-` rotki will now use the Etherscan V2 api. Users won't need to create a different api key for each chain since the one from https://etherscan.io will be used for all the supported chains. Finally all non mainnet etherscan api keys are removed from the app. More information available at https://docs.etherscan.io/etherscan-v2
+* :bug:`-` Newer interactions with MakerDAO (now Sky) vaults will now be properly decoded.
 * :feature:`-` Users will be able to delete multiple validators at once.
 * :feature:`-` rotki will now correctly decode single token withdrawals from Curve pools.
 * :feature:`-` Gearbox rewards transactions are now decoded properly on all supported chains.

--- a/rotkehlchen/tests/unit/decoders/test_makerdao.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.chain.ethereum.modules.makerdao.constants import CPT_VAULT
 from rotkehlchen.chain.evm.decoding.constants import CPT_GAS, CPT_SDAI
 from rotkehlchen.chain.evm.types import string_to_evm_address
-from rotkehlchen.constants.assets import A_DAI, A_ETH, A_SDAI
+from rotkehlchen.constants.assets import A_DAI, A_ETH, A_SDAI, A_WBTC
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -13,40 +13,73 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x648aA14e4424e0825A5cE739C8C68610e143FB79']])
-def test_makerdao_simple_transaction(ethereum_inquirer):
-    """Data taken from
-    https://etherscan.io/tx/0x95de47059bcc084ebb8bdd60f48fbcf05619c2af84bf612fdc27a6bbf9b5097e
-    """
+def test_makerdao_simple_transaction(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x95de47059bcc084ebb8bdd60f48fbcf05619c2af84bf612fdc27a6bbf9b5097e')  # noqa: E501
-    # We don't need any events here, we just check that no errors occurred during decoding
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert events == [
         EvmEvent(
             tx_hash=tx_hash,
             sequence_index=0,
-            timestamp=1593572988000,
+            timestamp=(timestamp := TimestampMS(1593572988000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(0.00926134),
-            location_label='0x648aA14e4424e0825A5cE739C8C68610e143FB79',
-            notes='Burn 0.00926134 ETH for gas',
+            amount=(gas := FVal('0.00926134')),
+            location_label=ethereum_accounts[0],
+            notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
         ), EvmEvent(
             tx_hash=tx_hash,
             sequence_index=1,
-            timestamp=1593572988000,
+            timestamp=timestamp,
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             asset=A_ETH,
-            amount=FVal(0.6),
-            location_label='0x648aA14e4424e0825A5cE739C8C68610e143FB79',
-            notes='Withdraw 0.6 ETH from ETH-A MakerDAO vault',
+            amount=(amount := FVal('0.6')),
+            location_label=ethereum_accounts[0],
+            notes=f'Withdraw {amount} ETH from ETH-A MakerDAO vault',
             counterparty=CPT_VAULT,
             address=string_to_evm_address('0x809aade1B623d8cDAeb86484d3366A03F8841FBc'),
             extra_data={'vault_type': 'ETH-A'},
+        ),
+    ]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0xE4916bF722d5B2d397fd2F3A925029d2c4e83B51']])
+def test_withdraw_with_transfer_after(ethereum_inquirer, ethereum_accounts):
+    """Test withdraw/deposit with the transfer coming after the log event (happens for recent vault interactions"""  # noqa: E501
+    tx_hash = deserialize_evm_tx_hash('0xb8f625820b7449ac7c83cffb4dbd33cf7c7cb64e5d69429e61df3c67c8c70d9c')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    assert events == [
+        EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=0,
+            timestamp=(timestamp := TimestampMS(1746420407000)),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            amount=(gas := FVal('0.000147117137791243')),
+            location_label=ethereum_accounts[0],
+            notes=f'Burn {gas} ETH for gas',
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            tx_hash=tx_hash,
+            sequence_index=438,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.WITHDRAWAL,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_WBTC,
+            amount=(amount := FVal('0.8')),
+            location_label=ethereum_accounts[0],
+            notes=f'Withdraw {amount} WBTC from WBTC-A MakerDAO vault',
+            counterparty=CPT_VAULT,
+            address=string_to_evm_address('0xa4aF35efa3b56d0C4F864B6484Af0C5FCD0B13e2'),
+            extra_data={'vault_type': 'WBTC-A'},
         ),
     ]
 
@@ -56,9 +89,7 @@ def test_makerdao_simple_transaction(ethereum_inquirer):
 def test_withdraw_dai_from_sdai(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6b2a1f836cfc7c28002e4ac60297daa6d79fcde892d9c3b9ca723dea2f21af5c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1695854591000)
-    sdai = A_SDAI.resolve_to_evm_token()
+    user_address, timestamp, sdai = ethereum_accounts[0], TimestampMS(1695854591000), A_SDAI.resolve_to_evm_token()  # noqa: E501
     assert events == [
         EvmEvent(
             sequence_index=0,
@@ -108,8 +139,7 @@ def test_deposit_dai_to_sdai(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x27bd72a2ccd999a44c2a7aaed9090572f34045d62e153362a34715a70ca7a6a7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1695089927000)
-    address = A_SDAI.resolve_to_evm_token().evm_address
+    timestamp, address = TimestampMS(1695089927000), A_SDAI.resolve_to_evm_token().evm_address
     assert events == [
         EvmEvent(
             sequence_index=0,


### PR DESCRIPTION
For newer makerdao vault interactions our decoder for depositing/withdrawing was not working properly since the transfer came after the log that identified the deposit/withdrawal.

With this commit I fix it and also add a test for it.

