### PR TITLE
Fix rainbow swap fee decoding

### DIFF
--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -52,7 +52,9 @@ class IndexArgType(TypedDict):
 class ExtraTxArgType(TypedDict):
     """Type of kwargs, used to get the value of `DBCacheDynamic.EXTRA_INTERNAL_TX`"""
     chain_id: int
-    receiver: ChecksumEvmAddress
+    # Receiver is optional since in at least one decoder (rainbow) the receiver address
+    # of the needed internal transaction is unknown.
+    receiver: ChecksumEvmAddress | None
     tx_hash: str  # using str instead of EVMTxHash because DB schema is in TEXT
 
 


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=109177215

Rainbow swap fees are calculated using data from the internal transactions, but the app only queries internal transactions that are linked to user addresses, which omits the transactions needed here. The tests overlooked this since `get_decoded_events_of_transaction` queries all internal transactions for a given tx_hash.

This PR fixes this by making the rainbow decoder query all the internal transactions for the transactions it decodes using `get_and_ensure_internal_txns_of_parent_in_db` which is used somewhat similarly in several other decoders (although there were some changes required to that function as well).