### PR TITLE
Allow none when editing evm tokens

### DIFF
--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -946,6 +946,7 @@ class AllAssetsResource(BaseMethodView):
             disallowed_asset_types=[AssetType.CUSTOM_ASSET],  # custom assets are handled on a separate endpoint  # noqa: E501
             coingecko=self.rest_api.rotkehlchen.coingecko,
             cryptocompare=self.rest_api.rotkehlchen.cryptocompare,
+            is_edit=True,
         )
 
     @resource_parser.use_kwargs(make_post_schema, location='json')


### PR DESCRIPTION
In the db for some tokens when there are errors it can happen that they get stored with the decimal and symbol column as None and we send this information like this to the frontend.

The problem comes at editing when the frontend send backs the information and the backend read as None those fields. This PR makes the validation be consistent with this nullable fields

Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=110507498

![image](https://github.com/user-attachments/assets/b14d002a-d2c7-4b4a-8008-3cfd1b450233)
![image](https://github.com/user-attachments/assets/30450a96-b6e6-4466-9f8d-1137ec487196)
