### PR TITLE
fix: separate rpc node states to avoid confusion

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Users will now see the correct latest price on the asset chart when the currently selected currency is not USD.
+* :feature:`9937` Users will now only see a failed/disconnected state when an RPC node fails to connect, the default non-connected state has been changed to Ready to avoid confusion.
 * :feature:`-` Account labels will now be applied to all chains for which activity is auto-detected unless the existing labels differ between chains.
 * :feature:`-` rotki will now use the Etherscan V2 api. Users won't need to create a different api key for each chain since the one from https://etherscan.io will be used for all the supported chains. Finally all non mainnet etherscan api keys are removed from the app. More information available at https://docs.etherscan.io/etherscan-v2
 * :bug:`-` Newer interactions with MakerDAO (now Sky) vaults will now be properly decoded.

--- a/frontend/app/src/locales/cn.json
+++ b/frontend/app/src/locales/cn.json
@@ -1637,7 +1637,8 @@
       "title": "删除 {chain} RPC 节点"
     },
     "connected": {
-      "false": "未连接",
+      "failure": "失败",
+      "false": "准备就绪",
       "true": "已连接"
     },
     "delete_error": {

--- a/frontend/app/src/locales/de.json
+++ b/frontend/app/src/locales/de.json
@@ -80,6 +80,12 @@
     "never": "Niemals",
     "refresh": "Αktualisieren"
   },
+  "evm_rpc_node_manager": {
+    "connected": {
+      "failure": "Fehlgeschlagen",
+      "false": "Bereit"
+    }
+  },
   "managed_asset_content": {
     "add_asset": "Vermögenswert hinzufügen"
   },

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2159,7 +2159,8 @@
       "title": "Delete {chain} RPC Node"
     },
     "connected": {
-      "false": "Not connected",
+      "failure": "Failed",
+      "false": "Ready",
       "true": "Connected"
     },
     "connectivity": "Connectivity",

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -1577,7 +1577,8 @@
       "title": "Delete {chain} RPC Node"
     },
     "connected": {
-      "false": "Not connected",
+      "failure": "Fallido",
+      "false": "Listo",
       "true": "Connected"
     },
     "delete_error": {

--- a/frontend/app/src/locales/fr.json
+++ b/frontend/app/src/locales/fr.json
@@ -1801,7 +1801,8 @@
       "title": "Supprimer le nœud RPC {chain}"
     },
     "connected": {
-      "false": "Non connecté",
+      "failure": "Échec",
+      "false": "Prêt",
       "true": "Connecté"
     },
     "delete_error": {

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -1593,7 +1593,8 @@
       "title": "Delete {chain} RPC Node"
     },
     "connected": {
-      "false": "Not connected",
+      "failure": "Απέτυχε",
+      "false": "Έτοιμο",
       "true": "Connected"
     },
     "delete_error": {
@@ -2534,7 +2535,7 @@
       },
       "overview": "Overview",
       "ranges": {
-        "one_day": "1D",
+        "one_day": 1.0,
         "one_month": "1M",
         "one_week": "1W",
         "one_year": "1Y"

--- a/frontend/app/src/modules/prices/use-price-utils.ts
+++ b/frontend/app/src/modules/prices/use-price-utils.ts
@@ -118,8 +118,9 @@ export function usePriceUtils(): UsePriceUtilsReturn {
      * Hacky way to prevent double conversion (try to replicate `match_main_currency` that has been removed)
      * @param {MaybeRef<string>} asset
      */
-  const isAssetPriceInCurrentCurrency = (asset: MaybeRef<string>): ComputedRef<boolean> =>
-    computed(() => (get(isAssetPriceEqualToCurrentCurrency(asset)) || !!get(assetPricesWithCurrentCurrency)[get(asset)]?.value));
+  function isAssetPriceInCurrentCurrency(asset: MaybeRef<string>): ComputedRef<boolean> {
+    return computed(() => (get(isAssetPriceEqualToCurrentCurrency(asset)) || !!get(assetPricesWithCurrentCurrency)[get(asset)]?.value));
+  }
 
   function hasCachedPrice(asset: string): boolean {
     return (get(assetPricesWithCurrentCurrency)[asset]?.value ?? get(prices)[asset]?.value) !== undefined;

--- a/frontend/app/src/store/session/periodic.ts
+++ b/frontend/app/src/store/session/periodic.ts
@@ -6,6 +6,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
   const lastBalanceSave = ref(0);
   const lastDataUpload = ref(0);
   const connectedNodes = ref<Record<string, string[]>>({});
+  const failedToConnect = ref<Record<string, string[]>>({});
   const periodicRunning = ref(false);
 
   const { notify } = useNotificationsStore();
@@ -24,7 +25,12 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
         return;
       }
 
-      const { connectedNodes: connected, lastBalanceSave: balance, lastDataUploadTs: upload } = result;
+      const {
+        connectedNodes: connected,
+        failedToConnect: failed,
+        lastBalanceSave: balance,
+        lastDataUploadTs: upload,
+      } = result;
 
       if (get(lastBalanceSave) !== balance)
         set(lastBalanceSave, balance);
@@ -33,6 +39,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
         set(lastDataUpload, upload);
 
       set(connectedNodes, connected);
+      set(failedToConnect, failed);
     }
     catch (error: any) {
       notify({
@@ -51,6 +58,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
   return {
     check,
     connectedNodes,
+    failedToConnect,
     lastBalanceSave,
     lastDataUpload,
   };

--- a/frontend/app/src/types/session/index.ts
+++ b/frontend/app/src/types/session/index.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 export const PeriodicClientQueryResult = z.object({
   connectedNodes: z.record(z.array(z.string())),
+  failedToConnect: z.record(z.array(z.string())).optional(),
   lastBalanceSave: z.number(),
   lastDataUploadTs: z.number(),
 });


### PR DESCRIPTION
Uses ready state as the default not connected,
changes the non-connected stated due to error to failure.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
