### PR TITLE
Re-enable onchain curve pool query

### DIFF
--- a/rotkehlchen/chain/evm/decoding/curve/constants.py
+++ b/rotkehlchen/chain/evm/decoding/curve/constants.py
@@ -79,3 +79,7 @@ CURVE_ADDRESS_PROVIDER: Final = string_to_evm_address('0x5ffe7FB82894076ECB99A30
 CURVE_SWAP_ROUTER_NG: Final = string_to_evm_address('0xF0d4c12A5768D806021F80a262B4d39d26C58b8D')
 DEPOSIT_AND_STAKE_ZAP: Final = string_to_evm_address('0x37c5ab57AF7100Bdc9B668d766e193CCbF6614FD')
 CHILD_LIQUIDITY_GAUGE_FACTORY: Final = string_to_evm_address('0xabC000d88f23Bb45525E447528DBF656A9D55bf5')  # noqa: E501
+# Maximum number of pools to query from the onchain metaregistry. Querying too many pools onchain
+# takes a very long time.  When testing this ~500 pools took ~10 minutes. Setting the max to 50
+# here so it should only spend about 1 minute on each chain.
+MAX_ONCHAIN_POOLS_QUERY: Final = 50

--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.assets.asset import UnderlyingToken
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
@@ -12,12 +13,10 @@ from rotkehlchen.chain.evm.decoding.curve.constants import (
     CURVE_CHAIN_ID,
     CURVE_METAREGISTRY_METHODS,
     IGNORED_CURVE_POOLS,
+    MAX_ONCHAIN_POOLS_QUERY,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
-from rotkehlchen.chain.evm.utils import (
-    maybe_notify_cache_query_status,
-    maybe_notify_new_pools_status,
-)
+from rotkehlchen.chain.evm.utils import maybe_notify_cache_query_status
 from rotkehlchen.constants import ONE
 from rotkehlchen.db.addressbook import DBAddressbook
 from rotkehlchen.errors.misc import (
@@ -52,19 +51,21 @@ from rotkehlchen.utils.network import request_get_dict
 if TYPE_CHECKING:
 
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
-    from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class CurvePoolData(NamedTuple):
+@dataclass
+class CurvePoolData:
     pool_address: ChecksumEvmAddress
-    pool_name: str
+    pool_name: str | None
     lp_token_address: ChecksumEvmAddress
     gauge_address: ChecksumEvmAddress | None
+    # Coins in the pool. Has the LP token of the base pool for metapools.
     coins: list[ChecksumEvmAddress]
+    # All underlying coins in a meta-pool, including the coins from the base pool. None for non-metapools.  # noqa: E501
     underlying_coins: list[ChecksumEvmAddress] | None
 
 
@@ -106,6 +107,155 @@ def read_curve_pools_and_gauges(chain_id: ChainID) -> tuple[dict[ChecksumEvmAddr
     return curve_pools, curve_gauges
 
 
+def _ensure_single_pool_curve_tokens_existence(
+        evm_inquirer: 'EvmNodeInquirer',
+        pool: CurvePoolData,
+) -> CurvePoolData | None:
+    encounter = TokenEncounterInfo(
+        description=f'Querying curve pools for {evm_inquirer.chain_id.to_name()}',
+        should_notify=False,
+    )
+    # Ensure pool coins exist in the globaldb.
+    # We have to create underlying tokens only if pool utilizes them.
+    underlying_token_names = []
+    if pool.underlying_coins is None:
+        # If underlying coins is None, it means that pool doesn't utilize them.
+        # If underlying coins list is equal to coins then there are no underlying coins as well.  # noqa: E501
+        for token_address in pool.coins:
+            if token_address == ETH_SPECIAL_ADDRESS:
+                underlying_token_names.append('ETH')
+                continue
+
+            try:  # ensure token exists
+                underlying_token_names.append(get_or_create_evm_token(
+                    userdb=evm_inquirer.database,
+                    evm_address=token_address,
+                    chain_id=evm_inquirer.chain_id,
+                    evm_inquirer=evm_inquirer,
+                    encounter=encounter,
+                ).symbol)
+            except NotERC20Conformant as e:
+                log.error(
+                    f'Skipping pool {pool} because {token_address} is not a '
+                    f'valid ERC20 token. {e}',
+                )
+                continue
+
+    elif len(pool.coins) == len(pool.underlying_coins):
+        # Coins and underlying coins lists represent a
+        # mapping of coin -> underlying coin (each coin always has one underlying coin).
+        for token_address, underlying_token_address in zip(pool.coins, pool.underlying_coins, strict=True):  # noqa: E501
+            if token_address == ETH_SPECIAL_ADDRESS:
+                underlying_token_names.append('ETH')
+                continue
+
+            try:  # ensure underlying token exists
+                get_or_create_evm_token(
+                    userdb=evm_inquirer.database,
+                    evm_address=underlying_token_address,
+                    chain_id=evm_inquirer.chain_id,
+                    evm_inquirer=evm_inquirer,
+                    encounter=encounter,
+                )
+            except NotERC20Conformant as e:
+                log.error(
+                    f'Skipping pool {pool} because {underlying_token_address} is not a '
+                    f'valid ERC20 token. {e}',
+                )
+                continue
+
+            if underlying_token_address == token_address:  # they are the same token. Stop here
+                continue  # can happen for a pool to have token's underlying token as itself
+
+            try:  # and ensure token exists
+                underlying_token_names.append(get_or_create_evm_token(
+                    userdb=evm_inquirer.database,
+                    evm_address=token_address,
+                    chain_id=evm_inquirer.chain_id,
+                    evm_inquirer=evm_inquirer,
+                    underlying_tokens=[UnderlyingToken(
+                        address=underlying_token_address,
+                        token_kind=EvmTokenKind.ERC20,
+                        weight=ONE,
+                    )],
+                    encounter=encounter,
+                ).symbol)
+            except NotERC20Conformant as e:
+                log.error(
+                    f'Skipping pool {pool} because {token_address} is not a '
+                    f'valid ERC20 token. {e}',
+                )
+                continue
+
+    else:  # Otherwise just ensure that coins and underlying coins exist in our assets database  # noqa: E501
+        for token_address in set(pool.coins + pool.underlying_coins):
+            if token_address == ETH_SPECIAL_ADDRESS:
+                underlying_token_names.append('ETH')
+                continue
+
+            try:
+                underlying_token_names.append(get_or_create_evm_token(
+                    userdb=evm_inquirer.database,
+                    evm_address=token_address,
+                    chain_id=evm_inquirer.chain_id,
+                    evm_inquirer=evm_inquirer,
+                    encounter=encounter,
+                ).symbol)
+            except NotERC20Conformant as e:
+                log.error(
+                    f'Skipping coin {token_address} because it is not a '
+                    f'valid ERC20 token. {e}',
+                )
+                continue
+
+    if pool.pool_name is None:
+        pool.pool_name = '/'.join(underlying_token_names)
+
+    # finally ensure lp token and gauge token exists in the globaldb. Since they are created
+    # by curve, they should always be an ERC20
+    try:
+        pool_lp_token = get_or_create_evm_token(
+            userdb=evm_inquirer.database,
+            evm_address=pool.lp_token_address,
+            chain_id=evm_inquirer.chain_id,
+            evm_inquirer=evm_inquirer,
+            protocol=CURVE_POOL_PROTOCOL,
+            encounter=encounter,
+        )
+    except NotERC20Conformant as e:
+        log.error(  # should only fail if the node is not up to date
+            f'Failed to check integrity of the curve pool {pool.lp_token_address} '
+            f'due to {e}. Skipping',
+        )
+        return None
+
+    if pool.gauge_address is not None:
+        try:
+            # Old gauges don't have the name/symbol/decimals methods. They use 18 decimals but
+            # the name and symbol differ and in the latest versions it is configurable. To be
+            # in sync with the onchain name we use the contract values and only
+            # if they are missing we resort to the fallback name and symbol.
+            get_or_create_evm_token(
+                userdb=evm_inquirer.database,
+                evm_address=pool.gauge_address,
+                chain_id=evm_inquirer.chain_id,
+                evm_inquirer=evm_inquirer,
+                encounter=encounter,
+                underlying_tokens=[UnderlyingToken(
+                    address=pool.lp_token_address,
+                    token_kind=EvmTokenKind.ERC20,
+                    weight=ONE,
+                )],
+                fallback_decimals=18,  # all gauges have 18 decimals https://t.me/curvefi/654915  # noqa: E501
+                fallback_name=f'{pool_lp_token.name} Gauge Deposit',
+                fallback_symbol=f'{pool_lp_token.symbol}-gauge',
+            )
+        except NotERC20Conformant:
+            log.warning(f'Curve gauge {pool.gauge_address} is not a valid ERC20 token.')
+
+    return pool
+
+
 def _ensure_curve_tokens_existence(
         evm_inquirer: 'EvmNodeInquirer',
         all_pools: list[CurvePoolData],
@@ -118,10 +268,7 @@ def _ensure_curve_tokens_existence(
     and return it.
     """
     verified_pools, last_notified_ts, all_pools_length = [], Timestamp(0), len(all_pools)
-    encounter = TokenEncounterInfo(
-        description=f'Querying curve pools for {evm_inquirer.chain_id.to_name()}',
-        should_notify=False,
-    )
+
     for idx, pool in enumerate(all_pools):
         last_notified_ts = maybe_notify_cache_query_status(
             msg_aggregator=msg_aggregator,
@@ -131,165 +278,40 @@ def _ensure_curve_tokens_existence(
             processed=idx + 1,
             total=all_pools_length,
         )
+        if (verified_pool := _ensure_single_pool_curve_tokens_existence(
+            evm_inquirer=evm_inquirer,
+            pool=pool,
+        )) is not None:
+            verified_pools.append(verified_pool)
 
-        # Ensure pool coins exist in the globaldb.
-        # We have to create underlying tokens only if pool utilizes them.
-        if pool.underlying_coins is None or pool.underlying_coins == pool.coins:
-            # If underlying coins is None, it means that pool doesn't utilize them.
-            # If underlying coins list is equal to coins then there are no underlying coins as well.  # noqa: E501
-            for token_address in pool.coins:
-                if token_address == ETH_SPECIAL_ADDRESS:
-                    continue
-                # ensure token exists
-                try:
-                    get_or_create_evm_token(
-                        userdb=evm_inquirer.database,
-                        evm_address=token_address,
-                        chain_id=evm_inquirer.chain_id,
-                        evm_inquirer=evm_inquirer,
-                        encounter=encounter,
-                    )
-                except NotERC20Conformant as e:
-                    log.error(
-                        f'Skipping pool {pool} because {token_address} is not a '
-                        f'valid ERC20 token. {e}',
-                    )
-                    continue
-        elif len(pool.coins) == len(pool.underlying_coins):
-            # Coins and underlying coins lists represent a
-            # mapping of coin -> underlying coin (each coin always has one underlying coin).
-            for token_address, underlying_token_address in zip(pool.coins, pool.underlying_coins, strict=True):  # noqa: E501
-                if token_address == ETH_SPECIAL_ADDRESS:
-                    continue
-                # ensure underlying token exists
-                try:
-                    get_or_create_evm_token(
-                        userdb=evm_inquirer.database,
-                        evm_address=underlying_token_address,
-                        chain_id=evm_inquirer.chain_id,
-                        evm_inquirer=evm_inquirer,
-                        encounter=encounter,
-                    )
-                except NotERC20Conformant as e:
-                    log.error(
-                        f'Skipping pool {pool} because {underlying_token_address} is not a '
-                        f'valid ERC20 token. {e}',
-                    )
-                    continue
-
-                if underlying_token_address == token_address:  # they are the same token. Stop here
-                    continue  # can happen for a pool to have token's underlying token as itself
-
-                try:
-                    # and ensure token exists
-                    get_or_create_evm_token(
-                        userdb=evm_inquirer.database,
-                        evm_address=token_address,
-                        chain_id=evm_inquirer.chain_id,
-                        evm_inquirer=evm_inquirer,
-                        underlying_tokens=[UnderlyingToken(
-                            address=underlying_token_address,
-                            token_kind=EvmTokenKind.ERC20,
-                            weight=ONE,
-                        )],
-                        encounter=encounter,
-                    )
-                except NotERC20Conformant as e:
-                    log.error(
-                        f'Skipping pool {pool} because {token_address} is not a '
-                        f'valid ERC20 token. {e}',
-                    )
-                    continue
-        else:
-            # Otherwise just ensure that coins and underlying coins exist in our assets database  # noqa: E501
-            for token_address in set(pool.coins + pool.underlying_coins):
-                if token_address == ETH_SPECIAL_ADDRESS:
-                    continue
-                try:
-                    get_or_create_evm_token(
-                        userdb=evm_inquirer.database,
-                        evm_address=token_address,
-                        chain_id=evm_inquirer.chain_id,
-                        evm_inquirer=evm_inquirer,
-                        encounter=encounter,
-                    )
-                except NotERC20Conformant as e:
-                    log.error(
-                        f'Skipping coin {token_address} because it is not a '
-                        f'valid ERC20 token. {e}',
-                    )
-                    continue
-
-        # finally ensure lp token and gauge token exists in the globaldb. Since they are created
-        # by curve, they should always be an ERC20
-        try:
-            pool_lp_token = get_or_create_evm_token(
-                userdb=evm_inquirer.database,
-                evm_address=pool.lp_token_address,
-                chain_id=evm_inquirer.chain_id,
-                evm_inquirer=evm_inquirer,
-                protocol=CURVE_POOL_PROTOCOL,
-                encounter=encounter,
-            )
-        except NotERC20Conformant as e:
-            log.error(  # should only fail if the node is not up to date
-                f'Failed to check integrity of the curve pool {pool.lp_token_address} '
-                f'due to {e}. Skipping',
-            )
-            continue
-
-        if pool.gauge_address is not None:
-            try:
-                # Old gauges don't have the name/symbol/decimals methods. They use 18 decimals but
-                # the name and symbol differ and in the latest versions it is configurable. To be
-                # in sync with the onchain name we use the contract values and only
-                # if they are missing we resort to the fallback name and symbol.
-                get_or_create_evm_token(
-                    userdb=evm_inquirer.database,
-                    evm_address=pool.gauge_address,
-                    chain_id=evm_inquirer.chain_id,
-                    evm_inquirer=evm_inquirer,
-                    encounter=encounter,
-                    underlying_tokens=[UnderlyingToken(
-                        address=pool.lp_token_address,
-                        token_kind=EvmTokenKind.ERC20,
-                        weight=ONE,
-                    )],
-                    fallback_decimals=18,  # all gauges have 18 decimals https://t.me/curvefi/654915  # noqa: E501
-                    fallback_name=f'{pool_lp_token.name} Gauge Deposit',
-                    fallback_symbol=f'{pool_lp_token.symbol}-gauge',
-                )
-            except NotERC20Conformant:
-                log.warning(f'Curve gauge {pool.gauge_address} is not a valid ERC20 token.')
-
-        verified_pools.append(pool)
     return verified_pools
 
 
 def _save_curve_data_to_cache(
-        database: 'DBHandler',
+        evm_inquirer: 'EvmNodeInquirer',
         new_data: list[CurvePoolData],
-        chain_id: ChainID,
 ) -> None:
     """Stores data received about curve pools and gauges in the cache"""
-    db_addressbook = DBAddressbook(db_handler=database)
-    chain_id_str = str(chain_id.serialize_for_db())
+    db_addressbook = DBAddressbook(db_handler=evm_inquirer.database)
+    chain_id_str = str(evm_inquirer.chain_id.serialize_for_db())
     for pool in new_data:
-        addresbook_entries = [AddressbookEntry(
-            address=pool.pool_address,
-            name=pool.pool_name,
-            blockchain=chain_id.to_blockchain(),
-        )]
-        if pool.gauge_address is not None:
-            addresbook_entries.append(AddressbookEntry(
-                address=pool.gauge_address,
-                name=f'Curve gauge for {pool.pool_name}',
-                blockchain=chain_id.to_blockchain(),
-            ))
+        addressbook_entries = []
+        if pool.pool_name is not None:
+            addressbook_entries = [AddressbookEntry(
+                address=pool.pool_address,
+                name=pool.pool_name,
+                blockchain=evm_inquirer.blockchain,
+            )]
+            if pool.gauge_address is not None:
+                addressbook_entries.append(AddressbookEntry(
+                    address=pool.gauge_address,
+                    name=f'Curve gauge for {pool.pool_name}',
+                    blockchain=evm_inquirer.blockchain,
+                ))
         with GlobalDBHandler().conn.write_ctx() as write_cursor:
             db_addressbook.add_or_update_addressbook_entries(
                 write_cursor=write_cursor,
-                entries=addresbook_entries,
+                entries=addressbook_entries,
             )
             globaldb_set_general_cache_values(
                 write_cursor=write_cursor,
@@ -350,8 +372,14 @@ def _query_curve_data_from_api(
 
             coins = [deserialize_evm_address(x['address']) for x in api_pool_data['coins']]
             underlying_coins = None
-            if 'underlyingCoins' in api_pool_data:
-                underlying_coins = [deserialize_evm_address(x['address']) for x in api_pool_data['underlyingCoins']]  # noqa: E501
+            if (
+                'underlyingCoins' in api_pool_data and
+                (u_coins := [
+                    deserialize_evm_address(x['address'])
+                    for x in api_pool_data['underlyingCoins']
+                ]) != coins
+            ):
+                underlying_coins = u_coins
 
             processed_new_pools.append(CurvePoolData(
                 pool_address=pool_address,
@@ -376,7 +404,7 @@ def _query_curve_data_from_chain(
         evm_inquirer: 'EvmNodeInquirer',
         existing_pools: set[ChecksumEvmAddress],
         msg_aggregator: 'MessagesAggregator',
-) -> list[CurvePoolData]:
+) -> None:
     """
     Query all curve information(lp tokens, pools, gagues, pool coins) from metaregistry.
 
@@ -390,85 +418,123 @@ def _query_curve_data_from_chain(
             method_name='get_address',
             arguments=[7],
         ))
-    except DeserializationError as e:
-        log.error(f'Curve address provider returned an invalid address for metaregistry. {e}')
-        return []
+    except (RemoteError, DeserializationError) as e:
+        log.error(
+            f'Failed to retrieve metaregistry address from the Curve '
+            f'address provider on {evm_inquirer.chain_name} due to {e!s}',
+        )
+        return
 
     metaregistry = EvmContract(
         address=metaregistry_address,
         abi=evm_inquirer.contracts.abi('CURVE_METAREGISTRY'),  # type: ignore[call-overload]  # for some reason mypy doesn't properly see argument type
         deployed_block=0,  # deployment_block is not used and the contract is dynamic
     )
-    pool_count = metaregistry.call(node_inquirer=evm_inquirer, method_name='pool_count')
-    new_pools: list[CurvePoolData] = []
+    try:
+        pool_count = metaregistry.call(node_inquirer=evm_inquirer, method_name='pool_count')
+    except RemoteError as e:
+        log.error(
+            'Failed to retrieve Curve pool count from the metaregistry '
+            f'on {evm_inquirer.chain_name} due to {e!s}',
+        )
+        return
+
+    if (existing_pool_count := len(existing_pools)) == pool_count:
+        return
+    if (new_pool_count := pool_count - existing_pool_count) > MAX_ONCHAIN_POOLS_QUERY:
+        pool_count = existing_pool_count + MAX_ONCHAIN_POOLS_QUERY
+        new_pool_count = MAX_ONCHAIN_POOLS_QUERY
+        log.info(
+            f'Tried to query {new_pool_count} {evm_inquirer.chain_name} Curve pools. '
+            f'Too many pools to query onchain. Only querying {new_pool_count}.',
+        )
+
     last_notified_ts = Timestamp(0)
-    for pool_index in range(pool_count):
-        last_notified_ts = maybe_notify_new_pools_status(
+    pools_to_skip = IGNORED_CURVE_POOLS | existing_pools
+    for pool_index in range((start_idx := pool_count - new_pool_count), pool_count):
+        last_notified_ts = maybe_notify_cache_query_status(
             msg_aggregator=msg_aggregator,
             last_notified_ts=last_notified_ts,
             protocol=CPT_CURVE,
             chain=evm_inquirer.chain_id,
-            get_new_pools_count=lambda: len(new_pools),
+            processed=(processed := pool_index - start_idx),
+            total=new_pool_count,
         )
 
-        raw_address = metaregistry.call(
-            node_inquirer=evm_inquirer,
-            method_name='pool_list',
-            arguments=[pool_index],
-        )
         try:
-            pool_address = deserialize_evm_address(raw_address)
-        except DeserializationError as e:
-            log.error(f'Could not deserialize curve pool address {raw_address}. {e}')
-            continue
+            if (pool_address := deserialize_evm_address(metaregistry.call(
+                node_inquirer=evm_inquirer,
+                method_name='pool_list',
+                arguments=[pool_index],
+            ))) in pools_to_skip:
+                continue
 
-        if pool_address in IGNORED_CURVE_POOLS or pool_address in existing_pools:
-            continue
-
-        calls = [
-            (
-                metaregistry_address,
-                metaregistry.encode(method_name=method_name, arguments=[pool_address]),
+            log.debug(
+                f'Processing Curve pool {processed}/{new_pool_count} {pool_address} '
+                f'on {evm_inquirer.chain_name}.',
             )
-            for method_name in CURVE_METAREGISTRY_METHODS
-        ]
-        raw_pool_properties = evm_inquirer.multicall_2(calls=calls, require_success=True)
-        decoded_pool_properties = [
-            metaregistry.decode(result=result[1], method_name=method_name, arguments=[pool_address])  # noqa: E501
-            for result, method_name in zip(raw_pool_properties, CURVE_METAREGISTRY_METHODS, strict=True)  # length should be same due to the call # noqa: E501
-        ]
-        try:
-            pool_name: str = decoded_pool_properties[0][0]
-            gauge_address = deserialize_evm_address(decoded_pool_properties[1][0])
-            lp_token_address = deserialize_evm_address(decoded_pool_properties[2][0])
-            coins_raw = decoded_pool_properties[3][0]
-            underlying_coins_raw = decoded_pool_properties[4][0]
-            coins = []
-            for raw_coin_address in coins_raw:
-                if raw_coin_address == ZERO_ADDRESS:
-                    break
-                coins.append(deserialize_evm_address(raw_coin_address))
-            underlying_coins = []
-            for raw_underlying_coin_address in underlying_coins_raw:
-                if raw_underlying_coin_address == ZERO_ADDRESS:
-                    break
-                underlying_coins.append(deserialize_evm_address(raw_underlying_coin_address))
+            raw_pool_properties = evm_inquirer.multicall_2(
+                calls=[(
+                    metaregistry_address,
+                    metaregistry.encode(method_name=method_name, arguments=[pool_address]),
+                ) for method_name in CURVE_METAREGISTRY_METHODS],
+                require_success=False,
+            )
+        except (RemoteError, DeserializationError) as e:
+            log.error(
+                f'Failed to retrieve Curve pool address for index {pool_index} '
+                f'from the metaregistry on {evm_inquirer.chain_name} due to {e!s}',
+            )
+            continue
 
-            new_pools.append(CurvePoolData(
-                pool_address=pool_address,
-                pool_name=pool_name,
-                lp_token_address=lp_token_address,
-                gauge_address=gauge_address if gauge_address != ZERO_ADDRESS else None,
-                coins=coins,
-                underlying_coins=underlying_coins if len(underlying_coins) > 0 else None,
-            ))
+        decoded_pool_properties: list[Any] = []
+        for (success, result), method_name in zip(raw_pool_properties, CURVE_METAREGISTRY_METHODS, strict=True):  # length should be same due to the call  # noqa: E501
+            if success is False:
+                if method_name == 'get_pool_name':  # There are a number of pools (especially later ones) where the pool name query fails  # noqa: E501
+                    decoded_pool_properties.append(None)  # Pool name will be constructed from the underlying tokens later instead  # noqa: E501
+                    continue
+                else:
+                    break
+
+            decoded_pool_properties.append(metaregistry.decode(
+                result=result,
+                method_name=method_name,
+                arguments=[pool_address],
+            )[0])
+
+        if len(decoded_pool_properties) != len(CURVE_METAREGISTRY_METHODS):
+            log.error(
+                f'Failed to query properties of curve pool {pool_address} '
+                f'on {evm_inquirer.chain_name}. Skipping.',
+            )
+            continue
+
+        try:
+            pool_name, gauge_address, lp_token_address, coins_raw, underlying_coins_raw = decoded_pool_properties  # noqa: E501
+            gauge_address = deserialize_evm_address(gauge_address)
+            lp_token_address = deserialize_evm_address(lp_token_address)
+            coins = [deserialize_evm_address(x) for x in coins_raw if x != ZERO_ADDRESS]
+            u_coins = [deserialize_evm_address(x) for x in underlying_coins_raw if x != ZERO_ADDRESS]  # noqa: E501
+            underlying_coins = None if u_coins == coins or len(u_coins) == 0 else u_coins
         except DeserializationError as e:
             log.error(
                 f'Could not deserialize evm address while decoding curve pool {pool_address} '
                 f'information from metaregistry: {e}',
             )
+            continue
 
-    return new_pools
+        if (pool := _ensure_single_pool_curve_tokens_existence(
+            evm_inquirer=evm_inquirer,
+            pool=CurvePoolData(
+                pool_address=pool_address,
+                pool_name=pool_name,
+                lp_token_address=lp_token_address,
+                gauge_address=gauge_address if gauge_address != ZERO_ADDRESS else None,
+                coins=coins,
+                underlying_coins=underlying_coins,
+            ),
+        )) is not None:
+            _save_curve_data_to_cache(evm_inquirer=evm_inquirer, new_data=[pool])
 
 
 def query_curve_data(
@@ -486,18 +552,31 @@ def query_curve_data(
             string_to_evm_address(address[0])
             for address in cursor.execute(
                 'SELECT value FROM unique_cache WHERE key LIKE ?',
-                (f'{compute_cache_key((CacheType.CURVE_POOL_ADDRESS, str(inquirer.chain_id.serialize_for_db())))}%',),  # noqa: E501
+                (compute_cache_key((
+                    CacheType.CURVE_POOL_ADDRESS,
+                    str(inquirer.chain_id.serialize_for_db()),
+                    '0x%',  # Include the beginning `0x` of the address to avoid matching chain id 10 when using chain id 1  # noqa: E501
+                )),),
             )
         }
 
+    pools_data: list[CurvePoolData] = []
     try:
-        pools_data: list[CurvePoolData] = _query_curve_data_from_api(
+        pools_data = _query_curve_data_from_api(
             chain_id=inquirer.chain_id,
             existing_pools=existing_pools,
         )
     except (RemoteError, UnableToDecryptRemoteData) as e:
-        log.error(f'Could not query curve api due to: {e}.')
-        return None
+        log.error(f'Could not query curve api due to: {e}. Will query the metaregistry on chain')
+        inquirer.greenlet_manager.spawn_and_track(
+            after_seconds=None,
+            task_name='Query Curve pools from the onchain metaregistry',
+            exception_is_error=False,
+            method=_query_curve_data_from_chain,
+            evm_inquirer=inquirer,
+            existing_pools=existing_pools,
+            msg_aggregator=msg_aggregator,
+        )
 
     if len(pools_data) == 0:
         # if no new pools, update the last_queried_ts of db entries
@@ -514,12 +593,7 @@ def query_curve_data(
         all_pools=pools_data,
         msg_aggregator=msg_aggregator,
     )
-
-    _save_curve_data_to_cache(
-        database=inquirer.database,
-        new_data=verified_pools,
-        chain_id=inquirer.chain_id,
-    )
+    _save_curve_data_to_cache(evm_inquirer=inquirer, new_data=verified_pools)
     return verified_pools
 
 


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11?pane=issue&itemId=111026071

* Queries only new pools, rather than trying to query all pools and will only process a maximum of 50 new pools per chain at a time.
* Runs the onchain pool query in a separate greenlet in order to not block the decoding.
* Saves the pools and tokens as it goes so if it is stopped partway through the progress is saved. In relation to this change, a large portion of code is moved from `_ensure_curve_tokens_existence` into `_ensure_single_pool_curve_tokens_existence` for more easily saving the tokens for a single pool at a time.
* Improves handling of pool names - on more recent pools the metaregistry `get_pool_name` function fails. Now we construct the pool name from the underlying tokens if the name is not available from the metaregistry.