### PR TITLE
fix: improve history account refresh functionality

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2808,6 +2808,12 @@
     "fee_description": "{notes} with fee: {feeText}",
     "swap_description": "Swap {spendAmount} {spendAsset} for {receiveAmount} {receiveAsset}"
   },
+  "history_refresh_button": {
+    "confirm_refresh": {
+      "message": "Are you sure you want to proceed with refreshing all your account transactions and exchange events? This action can take a significant amount of time.",
+      "title": "Confirm history refresh"
+    }
+  },
   "history_refresh_chain_selection": {
     "back_to_chain": "Back to chain selection",
     "refresh": "Refresh {accounts} accounts",

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshButton.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshButton.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { EvmChainAddress } from '@/types/history/events';
 import HistoryRefreshChainSelection from '@/modules/history/refresh/HistoryRefreshChainSelection.vue';
+import { useConfirmStore } from '@/store/confirm';
 
 defineProps<{
   processing: boolean;
@@ -9,6 +10,17 @@ defineProps<{
 const emit = defineEmits<{ refresh: [accounts?: EvmChainAddress[]] }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+const { show } = useConfirmStore();
+
+function confirmRefresh() {
+  show({
+    message: t('history_refresh_button.confirm_refresh.message'),
+    title: t('history_refresh_button.confirm_refresh.title'),
+  }, () => {
+    emit('refresh');
+  });
+}
 </script>
 
 <template>
@@ -23,7 +35,7 @@ const { t } = useI18n({ useScope: 'global' });
           variant="outlined"
           color="primary"
           class="rounded-r-none"
-          @click="emit('refresh')"
+          @click="confirmRefresh()"
         >
           <template #prepend>
             <RuiIcon name="lu-refresh-ccw" />

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshChainItem.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshChainItem.vue
@@ -45,5 +45,9 @@ function toggleSelect(): void {
       horizontal
     />
     <div class="grow" />
+    <RuiIcon
+      name="lu-chevron-right"
+      class="mx-2 text-rui-text-secondary"
+    />
   </div>
 </template>

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshChainSelection.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshChainSelection.vue
@@ -28,7 +28,7 @@ const { getAddresses } = useAccountAddresses();
 const { t } = useI18n({ useScope: 'global' });
 
 const filtered = computed<EvmChainInfo[]>(() => {
-  const chains = [...get(txEvmChains)];
+  const chains = [...get(txEvmChains)].filter(item => getAddresses(item.id)?.length > 0);
   const query = getTextToken(get(search));
   if (!query)
     return chains;
@@ -106,6 +106,8 @@ function toggleAllChains() {
 
 function reset() {
   set(selection, emptySelection());
+  set(selectedChain, undefined);
+  set(search, '');
 }
 
 function refresh() {


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

- Filter out chains without accounts
- Add confirmation to global reset
- Add arrow icon for to chain to indicate that it has an extra level
- Excludes online events from refreshing when accounts are selected