### PR TITLE
Handle exception in safe multisig with indexed args

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` rotki should decode newer safe multisig owner addition/removal transactions properly now.
 * :feature:`9965` Users will now be able to chose which chains and addresses they can refresh history events for.
 * :bug:`-` Users will now see the correct latest price on the asset chart when the currently selected currency is not USD.
 * :feature:`9937` Users will now only see a failed/disconnected state when an RPC node fails to connect, the default non-connected state has been changed to Ready to avoid confusion.


### PR DESCRIPTION
Solve:
https://github.com/orgs/rotki/projects/11?pane=issue&itemId=111916858

Newer implementations of safe multisig have the add/remove owner as indexed arguments. This places them in the topics and not in the data.

