### PR TITLE
improve error handling in balancer pool price query

### DIFF
--- a/rotkehlchen/chain/evm/decoding/balancer/utils.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/utils.py
@@ -1,4 +1,5 @@
 import logging
+from decimal import DecimalException
 from typing import TYPE_CHECKING, Any, Literal
 
 import requests
@@ -8,10 +9,12 @@ from rotkehlchen.chain.evm.decoding.balancer.constants import (
     BALANCER_API_URL,
     BALANCER_POOL_ABI,
     CHAIN_ID_TO_BALANCER_API_MAPPINGS,
+    CPT_BALANCER_V1,
     GET_POOL_PRICE_QUERY,
     GET_POOLS_COUNT_QUERY,
     GET_POOLS_QUERY,
 )
+from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -111,26 +114,38 @@ def get_balancer_pool_price(
     May raise:
     - RemoteError
     """
-    pool_id = evm_inquirer.call_contract(
-        abi=BALANCER_POOL_ABI,
-        method_name='getPoolId',
-        contract_address=pool_token.evm_address,
-    )
-    data = query_balancer_api(
-        query=GET_POOL_PRICE_QUERY,
-        variables={
-            'chain': CHAIN_ID_TO_BALANCER_API_MAPPINGS[pool_token.chain_id],
-            'poolId': '0x' + pool_id.hex(),
-        },
-    )
+    # For v1 pool tokens, pool id is the pool address since they don't implement getPoolId
+    if pool_token.protocol == CPT_BALANCER_V1:
+        pool_id = str(pool_token.evm_address)
+    else:
+        try:
+            result = evm_inquirer.call_contract(
+                abi=BALANCER_POOL_ABI,
+                method_name='getPoolId',
+                contract_address=pool_token.evm_address,
+            )
+            pool_id = f'0x{result.hex()}'
+        except RemoteError as e:
+            log.error(
+                f'Failed to get pool id for balancer pool {pool_token.evm_address} '
+                f'on {evm_inquirer.chain_name} due to {e!s}',
+            )
+            return ZERO_PRICE
+
     try:
+        data = query_balancer_api(
+            query=GET_POOL_PRICE_QUERY,
+            variables={
+                'chain': CHAIN_ID_TO_BALANCER_API_MAPPINGS[pool_token.chain_id],
+                'poolId': pool_id,
+            },
+        )
         pool_data = data['poolGetPool']['dynamicData']
-        total_liquidity = FVal(pool_data['totalLiquidity'])
-        total_supply = FVal(pool_data['totalSupply'])
-        return Price(total_liquidity / total_supply)
-    except (ValueError, KeyError) as e:
+        return Price(FVal(pool_data['totalLiquidity']) / FVal(pool_data['totalSupply']))
+    except (ValueError, KeyError, RemoteError, DecimalException) as e:
         msg = f'missing key {e!s}' if isinstance(e, KeyError) else str(e)
-        raise RemoteError(
+        log.error(
             f'Balancer pool price for {pool_token.evm_address} query '
-            f'on {pool_token.chain_id.to_name()} failed due to {msg}',
-        ) from e
+            f'on {evm_inquirer.chain_name} failed due to {msg}',
+        )
+        return ZERO_PRICE


### PR DESCRIPTION
closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=111965499

fixes balancer v1 pool price fetching by:
1. using pool address as pool id for v1 tokens since they don't implement the `getPoolId` method.
2. adding proper exception handling so snapshots don't fail
3. gracefully handling api errors and missing data

the protocol versions were already correctly labeled in the database. confirmed in global db and also by @/kelsos