### PR TITLE
Fix async query on block event redecoding endpoint

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -2363,9 +2363,9 @@ class RestAPI:
     def redecode_eth2_block_events(
             self,
             block_numbers: list[int] | None,
-    ) -> Response:
+    ) -> dict[str, Any]:
         DBEth2(self.rotkehlchen.data.db).redecode_block_production_events(block_numbers)
-        return api_response(OK_RESULT, status_code=HTTPStatus.OK)
+        return OK_RESULT
 
     @async_api_call()
     def get_airdrops(self) -> dict[str, Any]:

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -1485,10 +1485,14 @@ def test_redecode_block_production_events(rotkehlchen_api_server: 'APIServer') -
             )],
         )
 
-    assert_proper_sync_response_with_result(requests.put(
-        api_url_for(rotkehlchen_api_server, 'eth2stakingeventsresource'),
-        json={'block_numbers': [block_number, block_number + 1], 'async_query': False},
-    ))
+    assert_proper_response_with_result(
+        response=requests.put(
+            api_url_for(rotkehlchen_api_server, 'eth2stakingeventsresource'),
+            json={'block_numbers': [block_number, block_number + 1], 'async_query': True},
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=True,
+    )
 
     with db.conn.read_ctx() as cursor:
         # Check raw data from the db since deserializing EthBlockEvents performs the same check


### PR DESCRIPTION
Fixes the failing async queries on the block event redecoding endpoint (https://discord.com/channels/657906918408585217/1080783409640648765/1376571903359193168) 
