### PR TITLE
Fix maybe_upload_data_to_server deadlock

### DIFF
--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import tempfile
 import time
 from contextlib import suppress
 from copy import deepcopy
@@ -314,7 +315,9 @@ def test_export_import_db(data_dir: Path, username: str, sql_vm_instructions_cb:
     with data.db.user_write() as cursor:
         data.db.add_manually_tracked_balances(cursor, [starting_balance])
 
-    encoded_data, _ = data.compress_and_encrypt_db()
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.db') as tempdbfile:
+        tempdbpath = data.db.export_unencrypted(tempdbfile)
+        encoded_data, _ = data.compress_and_encrypt_db(tempdbpath)
     # The server would return them decoded
     data.decompress_and_decrypt_db(encoded_data)
     with data.db.user_write() as cursor:

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from http import HTTPStatus
 from typing import Literal
 from unittest.mock import patch
@@ -155,7 +156,9 @@ def setup_starting_environment(
         our_last_write_ts = rotkehlchen_instance.data.db.get_setting(cursor, name='last_write_ts')
         assert rotkehlchen_instance.data.db.get_setting(cursor, name='main_currency') == DEFAULT_TESTS_MAIN_CURRENCY  # noqa: E501
 
-    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db()
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.db') as tempdbfile:
+        tempdbpath = rotkehlchen_instance.data.db.export_unencrypted(tempdbfile)
+        _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(tempdbpath)
 
     if same_hash_with_remote:
         remote_hash = our_hash


### PR DESCRIPTION
This commit does two things:

1. Creates a test for the deadlock seen ocasionally when maybe_upload_data_to_server and redecoding happened at the same time.
2. Fixes it by making sure the new thread only does the compressing and encrypting but not the DB reading.

It's a more generic deadlock where due to the the fact that the threadpool creates a new greenlet in another thread and accesses the database in that thread and perhaps context switches out of it stuff completely lock.

The tests kind of attempts to emulate this. And ~50% of the runs of that test with the code before the commit failed with database locked error messages. While with the change it should always pass.

