### PR TITLE
fix: change running process check to be environment-specific

### DIFF
--- a/frontend/app/electron/main/subprocess-handler.ts
+++ b/frontend/app/electron/main/subprocess-handler.ts
@@ -42,13 +42,18 @@ export class SubprocessHandler {
     );
   }
 
+  private matchProcess(processName?: string): boolean {
+    if (this.config.isDev) {
+      return processName?.includes('-m rotkehlchen') ?? false;
+    }
+    return processName?.includes('rotki-core') ?? false;
+  }
+
   async checkForBackendProcess(): Promise<number[]> {
     try {
       this.logger.log('Checking for running rotki-core processes');
       const runningProcesses = await psList({ all: true });
-      const matches = runningProcesses.filter(
-        process => process.cmd?.includes('-m rotkehlchen') || process.cmd?.includes('rotki-core'),
-      );
+      const matches = runningProcesses.filter(process => this.matchProcess(process.cmd));
       return matches.map(p => p.pid);
     }
     catch (error: any) {


### PR DESCRIPTION
This is to make it possible to run the production backend in parallel with the development application.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
