### PR TITLE
Fix liquity event order for DSProxy borrowing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The order of borrowing and fee events in liquity DSProxy events should now be correct.
 * :bug:`-` Binance CSV import now correctly handles complex trade entries that span multiple rows.
 * :bug:`-` Balancer pool token price errors are now properly handled instead of breaking portfolio snapshots.
 * :feature:`-` Users will now be able to redecode the ETH block events.

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -254,6 +254,10 @@ class LiquityDecoder(DecoderInterface):
             counterparty=CPT_LIQUITY,
             address=context.tx_log.address,
         )
+        max_seq_index = 0  # put ordering logic here too since some times fee is seen last
+        for decoded_event in context.decoded_events:
+            max_seq_index = max(max_seq_index, decoded_event.sequence_index)
+        event.sequence_index = max_seq_index + 1
         return DecodingOutput(event=event)
 
     def _decode_lqty_staking_deposits(


### PR DESCRIPTION
In cases of DSProxy related borrowing from liquity, the order of the fee and borrow events was wrong, which would result in missing acquisitions. This is now fixed.

