### PR TITLE
Fix order during initial coinbase tx query

### DIFF
--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -398,7 +398,7 @@ class Coinbase(ExchangeInterface):
             # this next_uri will be used in next iteration
             next_uri = json_ret['pagination']['next_uri']
             if not next_uri:
-                # As per the docs: https://developers.coinbase.com/api/v2?python#pagination
+                # As per the docs: https://docs.cdp.coinbase.com/coinbase-app/docs/pagination
                 # once we get an empty next_uri we are done
 
                 break
@@ -558,10 +558,9 @@ class Coinbase(ExchangeInterface):
         - RemoteError
         """
         history_events: list[HistoryEvent | AssetMovement | SwapEvent] = []
-        options = {}
+        options = {'order': 'asc'}
         if last_tx_id is not None:
             options['starting_after'] = last_tx_id
-            options['order'] = 'asc'
         transactions = self._api_query(f'accounts/{account_id}/transactions', options=options)
         transaction_pairs: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)  # Maps every trade id to their two transactions  # noqa: E501
         if len(transactions) == 0:

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -1408,6 +1408,7 @@ TRANSACTIONS_RESPONSE = """{
 
 def mock_normal_coinbase_query(url, **kwargs):  # pylint: disable=unused-argument
     if 'transactions' in url:
+        assert 'order=asc' in url  # regression test for improperly ordered queries
         return MockResponse(200, TRANSACTIONS_RESPONSE)
     if 'accounts' in url:
         # keep it simple just return a single ID and ignore the rest of the fields


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11?pane=issue&itemId=113368012

the order was only being set to `asc` when `last_tx_id` was present. So on the first time querying (or when querying after purging) the order was defaulting to descending.

It seems this didn't really cause much trouble other than that the next time it went to query it requeried a lot of events since it started from the first event instead of the last event. But after that everything was fine.

The reason we were seeing the `starting_after` in the log without any `order` is due to the way pagination works here: https://github.com/rotki/rotki/blob/5e32f51473dbd54d810213322ffa637d5ca3afc9/rotkehlchen/exchanges/coinbase.py#L399
This `next_uri` would only have the `starting_after` set since we hadn't set `order` in the first query.