### PR TITLE
Two Zerox settler contracts in optimism were not checksummed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Some specific 0x settler swaps in Optimism will now be properly decoded.
+
 * :release:`1.39.0 <2025-06-04>`
 * :feature:`-` DigixDAO DGD refunds will now be properly decoded.
 * :feature:`-` Users will be able to perform quick actions for an asset (such as ignoring the asset) by right-clicking the asset icon.

--- a/rotkehlchen/chain/optimism/modules/zerox/constants.py
+++ b/rotkehlchen/chain/optimism/modules/zerox/constants.py
@@ -13,7 +13,7 @@ ZEROX_FLASH_WALLET: Final = string_to_evm_address(
 SETTLER_ROUTERS: Final = {
     string_to_evm_address('0x7600F49428e551AF89D5C6b8e77B8cF3e198F936'),  # V1.4 commit: 0x336fda7ac33e46626cba703a82a53ad517aa8336000000000000000000000000  # noqa: E501
     string_to_evm_address('0x1a3b48EA0C6e9A52511A196A287fa8371e5Ee7a0'),  # V1.6 commit: 0xa5a3b402765eb2940a6e29efa81a58e222d0ae6a000000000000000000000000  # noqa: E501
-    string_to_evm_address('0x733d95e5cb3ca43eab2752f1d4f1a0d2686965c6'),  # V1.7 commit: 0x3ae13a6a1d3eea900d733ebc1d1ba9d772e6b415000000000000000000000000  # noqa: E501
-    string_to_evm_address('0x70ca548cf343b63e5b0542f0f3ec84c61ca1086f'),  # V1.8 commit: 0xa6f39ee20f0c4dfe1265f5d203dfc4f3f05ca003000000000000000000000000  # noqa: E501
+    string_to_evm_address('0x733D95e5CB3Ca43Eab2752f1D4f1A0d2686965C6'),  # V1.7 commit: 0x3ae13a6a1d3eea900d733ebc1d1ba9d772e6b415000000000000000000000000  # noqa: E501
+    string_to_evm_address('0x70cA548cF343B63E5B0542F0F3EC84c61Ca1086f'),  # V1.8 commit: 0xa6f39ee20f0c4dfe1265f5d203dfc4f3f05ca003000000000000000000000000  # noqa: E501
     string_to_evm_address('0x402867B638339ad8Bec6e5373cfa95Da0b462c85'),  # V1.9 commit: 0xffc129424fbe525c124e52cff5225afbfb610534000000000000000000000000  # noqa: E501
 }

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
@@ -450,7 +450,7 @@ def test_oracle_ids_in_asset_collections(globaldb: 'GlobalDBHandler'):
         pytest.fail('oracle IDs do not match:\n' + '\n'.join(mismatches))
 
 
-@pytest.mark.parametrize('our_version', ['1.38.0'])  # set latest version so data can be updated
+@pytest.mark.parametrize('our_version', ['1.39.0'])  # set latest version so data can be updated
 def test_remote_updates_consistency_with_packaged_db(
         tmpdir_factory: 'pytest.TempdirFactory',
         messages_aggregator: 'MessagesAggregator',


### PR DESCRIPTION
And as such the transactions touching them were not getting decoded properly

Not really related but this should close:
https://github.com/rotki/rotki/issues/9601

I just noticed it since the only example transaction on that issue was not decoding even though the issue was supposed to have been solved.

