### PR TITLE
Add EigenLayer icon to airdrop assets

### DIFF
--- a/rotkehlchen/tests/unit/test_ethereum_airdrops.py
+++ b/rotkehlchen/tests/unit/test_ethereum_airdrops.py
@@ -475,7 +475,7 @@ def test_check_airdrops(
         'link': 'https://eigenfoundation.org',
         'icon': 'eigen.svg',
         'claimed': False,
-        'icon_url': 'https://raw.githubusercontent.com/rotki/data/develop/airdrops/icons/eigen.svg',
+        'icon_url': 'https://raw.githubusercontent.com/rotki/data/develop/airdrops/icons/eigenlayer.png',
         'has_decoder': True,
     }
     assert len(data[TEST_POAP1]) == 1


### PR DESCRIPTION
Include the official EigenLayer logo (`eigenlayer.png`) in the airdrop icons directory to support consistent visual representation across the application.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
