### PR TITLE
Ensure that exported events are sorted by timestamp

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Some specific 0x settler swaps in Optimism will now be properly decoded.
+* :bug:`-` When exporting history as CSV the events will now properly appear sorted by timestamp.
 
 * :release:`1.39.0 <2025-06-04>`
 * :feature:`-` DigixDAO DGD refunds will now be properly decoded.

--- a/rotkehlchen/tests/utils/history_base_entry.py
+++ b/rotkehlchen/tests/utils/history_base_entry.py
@@ -266,8 +266,8 @@ def predefined_events_to_insert() -> list['HistoryBaseEntry']:
 def add_entries(events_db: 'DBHistoryEvents') -> list['HistoryBaseEntry']:
     """Add history events to the database"""
     entries = predefined_events_to_insert()
-    for entry in entries:
-        with events_db.db.conn.write_ctx() as write_cursor:
+    with events_db.db.conn.write_ctx() as write_cursor:
+        for entry in entries:
             identifier = events_db.add_history_event(
                 write_cursor=write_cursor,
                 event=entry,


### PR DESCRIPTION
This PR changes the logic to ensure that the returned events appear with the desired sorting criteria.

Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=113986119