### PR TITLE
Remove debug log

### DIFF
--- a/colibri/src/main.rs
+++ b/colibri/src/main.rs
@@ -89,7 +89,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // Check if the origin matches any of our glob patterns
                 for pattern in &cors_patterns {
                     if pattern.matches(origin_str) {
-                        error!("matched on {}", pattern);
                         return true;
                     }
                     error!("failed to match CORS on {}", pattern);


### PR DESCRIPTION
Removes a log that was there for debugging and didn't get removed when merging the PR. It just spams the logs

![image](https://github.com/user-attachments/assets/c6e639c6-d60b-417a-be90-0563e35a235a)
