### PR TITLE
Update gevent/greenlet to 25.4.2/3.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-gevent==24.11.1
-greenlet==3.1.1
+gevent==25.4.2
+greenlet==3.2.3
 gevent-websocket==0.10.1  # like the below is abandoned
 wsaccel==0.6.7  # recommended for acceleration of gevent-websocket. But abandoned.
 web3==7.10.0


### PR DESCRIPTION
Want to get the fix for that deadlock we were having here: https://github.com/gevent/gevent/issues/1957

Not going got 25.5.1 due to 

> Note that this changes the minimum supported versions of various operating systems. Linux now requires kernel 3.10 and glibc 2.17, up from 2.6.32 and glibc 2.12; macOS now requires version 11, up from version 10.15; Windows now requires Windows 10 and Visual Studio 2017, up from Windows 8 and VS 2015; finally, FreeBSD now requires version 12, up from version 10.

I would like to make sure this won't limit our own requirements further. cc @kelsos 