### PR TITLE
Fix swaps receiving EURe in gnosis where both v1/v2 received

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :feature:`10079` Users will now be able to switch the chain directly from rotki on the on-chain page if they use WalletConnect.
 * :bug:`-` For ETH staking MEV rewards the informational event will no longer be shown as it will be superseded by the combined MEV reward events.
 * :bug:`-` Transaction decoding will no longer fail when encountering a certain rare case of problematic spam tokens.
+* :bug:`-` Swaps receiving EURe in Gnosis that were not working for selected DEXes will now be properly decoded again.
 * :bug:`-` Some specific 0x settler swaps in Optimism will now be properly decoded.
 * :bug:`-` When exporting history as CSV the events will now properly appear sorted by timestamp.
 * :bug:`10087` Users will now be able to use the electron app wallet bridge when using Windows.

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -760,6 +760,35 @@ class EVMTransactionDecoder(ABC):
                 if rules_decoding_output.process_swaps:
                     process_swaps = True
 
+        if monerium_special_handling_event is True:
+            # When events that need special handling exist iterate over the decoded events and
+            # exchange the legacy assets by the v2 assets. Also delete v2 events to
+            # avoid duplications. In the case of this exception handling, v2 events exist only
+            # for the case of interacting with the v1 tokens since interacting
+            # with v2 doesn't emit v1 transfers.
+            new_events = []  # we create a new list to avoid remove operations and modifying while iterating  # noqa: E501
+            replacement_assets = self.exceptions_mappings.values()
+            potential_duplicates = set()
+            for event in events:
+                if (replacement := self.exceptions_mappings.get(event.asset.identifier)) is not None:  # noqa: E501
+                    if (event_key := (replacement, event.amount, event.maybe_get_direction())) in potential_duplicates:  # noqa: E501
+                        continue  # skip if duplicate
+
+                    event.asset = replacement  # otherwise change the asset
+                    potential_duplicates.add(event_key)  # and mark as potential duplicate
+
+                elif event.asset.identifier in replacement_assets:
+                    if (event.asset, event.amount, event.maybe_get_direction()) in potential_duplicates:  # noqa: E501
+                        continue  # skip the duplicated event
+                    # else add it as potential duplicate
+                    potential_duplicates.add((event.asset, event.amount, event.maybe_get_direction()))  # noqa: E501
+
+                new_events.append(event)
+
+            events = new_events
+
+        # should run after monerium special handling as in paraswap decoder, during post-decoding,
+        # the extra EURe event receive is seen as a receival
         events, maybe_modified = self.run_all_post_decoding_rules(
             transaction=transaction,
             decoded_events=events,
@@ -768,24 +797,6 @@ class EVMTransactionDecoder(ABC):
         )
         if maybe_modified:
             process_swaps = True  # a swap may have been created in post decoding
-
-        if monerium_special_handling_event is True:
-            # When events that need special handling exist iterate over the decoded events and
-            # exchange the legacy assets by the v2 assets. Also delete v2 events to
-            # avoid duplications. In the case of this exception handling, v2 events exist only
-            # for the case of interacting with the v1 tokens since interacting
-            # with v2 doesn't emit v1 transfers.
-            new_events = []  # we create a new list to avoid remove operations and modifying while iterating  # noqa: E501
-            replacements = self.exceptions_mappings.values()
-            for event in events:
-                if (replacement := self.exceptions_mappings.get(event.asset.identifier)) is not None:  # noqa: E501
-                    event.asset = replacement
-                elif event.asset.identifier in replacements:
-                    continue  # skip the duplicated event
-
-                new_events.append(event)
-
-            events = new_events
 
         if len(events) == 0 and (eth_event := self._get_eth_transfer_event(transaction)) is not None:  # noqa: E501
             events = [eth_event]

--- a/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.types import ChecksumEvmAddress
@@ -111,7 +112,7 @@ def test_swap_amount_in(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xbF4EBEa7279DE8517f60BD5fdbe9AebE03De90ED']])
 def test_gnosis_swap_amount_in(
-        gnosis_inquirer: 'BaseInquirer',
+        gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
     tx_hash = deserialize_evm_tx_hash('0x421c23d305703a57ea0b64cfc75e8f13b6db2ef30fba321ae19eecd1b91695bc')  # noqa: E501
@@ -807,3 +808,53 @@ def test_swap_on_augustus_rfq(
         counterparty=CPT_PARASWAP,
         address=PARASWAP_AUGUSTUS_V6_ROUTER,
     )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_accounts', [['0x70F256DC42E7f6eC5c59466A4Eb3e888d4A4dceE']])
+def test_eure_receive_swap(
+        gnosis_inquirer: 'GnosisInquirer',
+        gnosis_accounts: list['ChecksumEvmAddress'],
+):
+    """Regression test for a bug where swaps in Gnosis receiving EURe were not decoded properly"""
+    tx_hash = deserialize_evm_tx_hash('0x81130d4e9695b1e03c5960e51864740a7d6a3c3cab7b708f717dc5f18caad079')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
+    user_address, timestamp, gas_amount, spend_amount, receive_amount = gnosis_accounts[0], TimestampMS(1749200310000), '0.000105481', '2497.622499', '2185.911263467705546005'  # noqa: E501
+    expected_events = [EvmEvent(
+        tx_hash=tx_hash,
+        sequence_index=0,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_XDAI,
+        amount=FVal(gas_amount),
+        location_label=user_address,
+        notes=f'Burn {gas_amount} XDAI for gas',
+        counterparty=CPT_GAS,
+    ), EvmSwapEvent(
+        tx_hash=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=Asset('eip155:100/erc20:0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0'),  # USDC.e
+        amount=FVal(spend_amount),
+        location_label=user_address,
+        notes=f'Swap {spend_amount} USDC.e in paraswap',
+        counterparty=CPT_PARASWAP,
+        address=PARASWAP_AUGUSTUS_V6_ROUTER,
+    ), EvmSwapEvent(
+        tx_hash=tx_hash,
+        sequence_index=2,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),  # EURe
+        amount=FVal(receive_amount),
+        location_label=user_address,
+        notes=f'Receive {receive_amount} EURe as the result of a swap in paraswap',
+        counterparty=CPT_PARASWAP,
+        address=PARASWAP_AUGUSTUS_V6_ROUTER,
+    )]
+    assert events == expected_events


### PR DESCRIPTION
There is two bugs here.

1. The receival was actually removed due to that special monerium handling logic.
2. Specific to paraswap, and before removing it, it was seeing that the user was geting two in events and was considering them of refunds and as such reducing the actual amount of send, in some cases making it look as if you are swapping negative numbers
