### PR TITLE
chore(ci): update pnpm and codecov actions to latest versions

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -48,7 +48,7 @@ jobs:
           cache-on-failure: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           package_json_file: frontend/package.json
 
@@ -96,7 +96,7 @@ jobs:
         working-directory: ./frontend
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           flags: frontend_integration
           env_vars: GROUP


### PR DESCRIPTION
This PR updates two GitHub Actions to their latest major versions in the task_e2e_tests.yml workflow:

pnpm/action-setup from v3 → v4

codecov/codecov-action from v4 → v5

These updates ensure improved performance, compatibility with newer Node.js and coverage tooling, and better caching mechanisms.

No logic or behavior has changed — just dependency upgrades.

 Confirmation:
[pnpm/action-setup@v4 release](https://github.com/pnpm/action-setup/releases/tag/v4)

[codecov/codecov-action@v5 release](https://github.com/codecov/codecov-action/releases/tag/v5)