### PR TITLE
Fix SwapEvent identifiers in migration 20

### DIFF
--- a/rotkehlchen/data_migrations/constants.py
+++ b/rotkehlchen/data_migrations/constants.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-LAST_DATA_MIGRATION: Final = 19
+LAST_DATA_MIGRATION: Final = 20

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -9,6 +9,7 @@ from rotkehlchen.data_migrations.migrations.migration_3 import data_migration_3
 from rotkehlchen.data_migrations.migrations.migration_5 import data_migration_5
 from rotkehlchen.data_migrations.migrations.migration_10 import data_migration_10
 from rotkehlchen.data_migrations.migrations.migration_11 import data_migration_11
+from rotkehlchen.data_migrations.migrations.migration_20 import data_migration_20
 from rotkehlchen.data_migrations.migrations.migrations_13 import data_migration_13
 from rotkehlchen.data_migrations.migrations.migrations_14 import data_migration_14
 from rotkehlchen.data_migrations.migrations.migrations_18 import data_migration_18
@@ -41,6 +42,7 @@ MIGRATION_LIST = [  # remember to bump LAST_DATA_MIGRATION if editing this
     MigrationRecord(version=14, function=data_migration_14),
     MigrationRecord(version=18, function=data_migration_18),
     MigrationRecord(version=19, function=data_migration_19),
+    MigrationRecord(version=20, function=data_migration_20),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migration_20.py
+++ b/rotkehlchen/data_migrations/migrations/migration_20.py
@@ -1,0 +1,148 @@
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING, NamedTuple
+
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.utils.progress import perform_userdb_migration_steps, progress_step
+
+if TYPE_CHECKING:
+    from rotkehlchen.data_migrations.progress import MigrationProgressHandler
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class SwapEventData(NamedTuple):
+    """Data structure for a swap event during migration"""
+    identifier: int
+    event_identifier: str
+    subtype: str
+    sequence_index: int
+
+
+@enter_exit_debug_log()
+def data_migration_20(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
+    """
+    Introduced at v1.39.1
+
+    Fix SwapEvent identifiers that were generated differently for spend/receive/fee parts
+    before the fix in PR 10103. This migration groups SwapEvents by timestamp, location,
+    and location_label, then ensures they all share the same event_identifier.
+    """
+    @progress_step(description='Fixing SwapEvent identifiers')
+    def _fix_swap_event_identifiers(rotki: 'Rotkehlchen') -> None:
+        """
+        Fix SwapEvent identifiers by grouping related spend/receive/fee events.
+
+        The migration handles these cases:
+        1. Simple swaps: spend + receive events that have different identifiers
+        2. Swaps with fees: spend + receive + fee events with different identifiers
+        3. Multiple swaps at same timestamp/location: Groups them by sequence order
+        4. Already correct swaps: Skips swaps that already share the same identifier
+        """
+        db = rotki.data.db
+
+        # Cache serialized enum values to avoid repeated serialization
+        spend_subtype = HistoryEventSubType.SPEND.serialize()
+        receive_subtype = HistoryEventSubType.RECEIVE.serialize()
+        fee_subtype = HistoryEventSubType.FEE.serialize()
+        trade_type = HistoryEventType.TRADE.serialize()
+
+        # Collect all identifier updates that need to be made
+        updates_to_apply = []
+
+        with db.conn.read_ctx() as cursor:
+            # Get all SwapEvents ordered by timestamp, location, and sequence
+            swap_events_cursor = cursor.execute("""
+                SELECT
+                    identifier,
+                    event_identifier,
+                    timestamp,
+                    location,
+                    location_label,
+                    subtype,
+                    sequence_index
+                FROM history_events
+                WHERE entry_type = ? AND type = ?
+                ORDER BY timestamp, location, location_label, sequence_index
+            """, (HistoryBaseEntryType.SWAP_EVENT.serialize_for_db(), trade_type))
+
+            # Group events by (timestamp, location, location_label)
+            # This groups all events that could potentially be part of the same swap(s)
+            event_groups = defaultdict(list)
+            for row in swap_events_cursor:
+                (
+                    identifier, event_identifier, timestamp, location,
+                    location_label, subtype, sequence_index,
+                ) = row
+                key = (timestamp, location, location_label or '')
+                event_groups[key].append(SwapEventData(
+                    identifier=identifier,
+                    event_identifier=event_identifier,
+                    subtype=subtype,
+                    sequence_index=sequence_index,
+                ))
+
+        # Process each timestamp/location group
+        for group_key, events in event_groups.items():
+            # Check if all events already share the same identifier
+            unique_identifiers = {event.event_identifier for event in events}
+            if len(unique_identifiers) == 1:
+                continue  # Already fixed, skip this group
+
+            # Separate events by subtype while preserving their order
+            spend_events = []
+            receive_events = []
+            fee_events = []
+
+            for event in events:
+                if event.subtype == spend_subtype:
+                    spend_events.append(event)
+                elif event.subtype == receive_subtype:
+                    receive_events.append(event)
+                elif event.subtype == fee_subtype:
+                    fee_events.append(event)
+
+            # Match spend and receive events based on their order
+            # For multiple swaps at the same timestamp/location, we rely on sequence_index
+            # to determine which spend goes with which receive
+            num_swaps = min(len(spend_events), len(receive_events))
+
+            for i in range(num_swaps):
+                spend = spend_events[i]
+                receive = receive_events[i]
+
+                # Use the spend event's identifier as the canonical identifier
+                canonical_id = spend.event_identifier
+
+                # Update receive event if it has a different identifier
+                if receive.event_identifier != canonical_id:
+                    updates_to_apply.append((canonical_id, receive.identifier))
+
+                # Match fee events to swaps based on order
+                # If there are N swaps and N fees, fee[i] belongs to swap[i]
+                if i < len(fee_events):
+                    fee = fee_events[i]
+                    if fee.event_identifier != canonical_id:
+                        updates_to_apply.append((canonical_id, fee.identifier))
+
+            # Log edge cases where we have unmatched events
+            if len(spend_events) != len(receive_events):
+                log.warning(
+                    f'Unmatched swap events at timestamp={group_key[0]}, '
+                    f'location={group_key[1]}, location_label={group_key[2]}: '
+                    f'{len(spend_events)} spends, {len(receive_events)} receives',
+                )
+
+        # Apply all updates in a single transaction
+        if updates_to_apply:
+            with db.user_write() as write_cursor:
+                write_cursor.executemany(
+                    'UPDATE history_events SET event_identifier = ? WHERE identifier = ?',
+                    updates_to_apply,
+                )
+
+    perform_userdb_migration_steps(rotki, progress_handler, should_vacuum=True)

--- a/rotkehlchen/tests/data_migrations/test_migration_20.py
+++ b/rotkehlchen/tests/data_migrations/test_migration_20.py
@@ -1,0 +1,347 @@
+"""Test for data migration 20 - fixing SwapEvent identifiers"""
+from unittest.mock import patch
+
+import pytest
+
+from rotkehlchen.constants import ONE
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_USD
+from rotkehlchen.data_migrations.manager import MIGRATION_LIST, DataMigrationManager
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
+from rotkehlchen.history.events.structures.swap import SwapEvent, create_swap_events
+from rotkehlchen.history.events.structures.types import HistoryEventSubType
+from rotkehlchen.history.events.utils import create_event_identifier
+from rotkehlchen.tests.data_migrations.test_migrations import MockRotkiForMigrations
+from rotkehlchen.types import AssetAmount, Location, TimestampMS
+
+
+def create_broken_swap_events(
+        db: DBHandler,
+        timestamp: TimestampMS,
+        location: Location,
+        location_label: str | None = None,
+) -> tuple[str, str, str]:
+    """Create SwapEvents with different identifiers like they were created before the fix"""
+    # Each event creates its own identifier (the bug)
+    spend_event = SwapEvent(
+        timestamp=timestamp,
+        location=location,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=A_ETH,
+        amount=ONE,
+        event_identifier=create_event_identifier(
+            location=location,
+            timestamp=timestamp,
+            asset=A_ETH,
+            amount=ONE,
+            unique_id='spend',
+        ),
+        location_label=location_label,
+    )
+
+    receive_event = SwapEvent(
+        timestamp=timestamp,
+        location=location,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=A_BTC,
+        amount=ONE * 2,
+        event_identifier=create_event_identifier(
+            location=location,
+            timestamp=timestamp,
+            asset=A_BTC,
+            amount=ONE * 2,
+            unique_id='receive',
+        ),
+        location_label=location_label,
+    )
+
+    fee_event = SwapEvent(
+        timestamp=timestamp,
+        location=location,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_USD,
+        amount=ONE / 10,
+        event_identifier=create_event_identifier(
+            location=location,
+            timestamp=timestamp,
+            asset=A_USD,
+            amount=ONE / 10,
+            unique_id='fee',
+        ),
+        location_label=location_label,
+    )
+
+    # Add to database
+    db_events = DBHistoryEvents(db)
+    with db.user_write() as write_cursor:
+        db_events.add_history_events(write_cursor, history=[spend_event, receive_event, fee_event])
+
+    return spend_event.event_identifier, receive_event.event_identifier, fee_event.event_identifier
+
+
+@pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
+@pytest.mark.parametrize('data_migration_version', [19])
+def test_migration_20_fix_swap_identifiers(database: DBHandler) -> None:
+    """Test that migration 20 correctly fixes SwapEvent identifiers"""
+    rotki = MockRotkiForMigrations(database)
+
+    # Create broken swaps with different identifiers
+    ts1 = TimestampMS(1000000)
+    ts2 = TimestampMS(2000000)
+
+    # Swap 1: ETH -> BTC with fee
+    spend_id1, receive_id1, fee_id1 = create_broken_swap_events(
+        db=database,
+        timestamp=ts1,
+        location=Location.BINANCE,
+        location_label='binance1',
+    )
+
+    # Swap 2: ETH -> BTC without fee
+    spend_event2 = SwapEvent(
+        timestamp=ts2,
+        location=Location.KRAKEN,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=A_ETH,
+        amount=ONE * 5,
+        event_identifier=create_event_identifier(
+            location=Location.KRAKEN,
+            timestamp=ts2,
+            asset=A_ETH,
+            amount=ONE * 5,
+            unique_id='spend2',
+        ),
+    )
+
+    receive_event2 = SwapEvent(
+        timestamp=ts2,
+        location=Location.KRAKEN,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=A_BTC,
+        amount=ONE * 10,
+        event_identifier=create_event_identifier(
+            location=Location.KRAKEN,
+            timestamp=ts2,
+            asset=A_BTC,
+            amount=ONE * 10,
+            unique_id='receive2',
+        ),
+    )
+
+    db_events = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        db_events.add_history_events(write_cursor, history=[spend_event2, receive_event2])
+
+    spend_id2 = spend_event2.event_identifier
+    receive_id2 = receive_event2.event_identifier
+
+    # Also create a correctly linked swap (should not be touched by migration)
+    correct_events = create_swap_events(
+        timestamp=TimestampMS(3000000),
+        location=Location.COINBASE,
+        spend=AssetAmount(asset=A_ETH, amount=ONE * 3),
+        receive=AssetAmount(asset=A_BTC, amount=ONE * 6),
+        event_identifier='correct_swap_id',
+    )
+
+    with database.user_write() as write_cursor:
+        db_events.add_history_events(write_cursor, history=correct_events)
+
+    correct_id = correct_events[0].event_identifier
+
+    # Verify the broken state before migration
+    with database.conn.read_ctx() as cursor:
+        # First swap has 3 different identifiers
+        events1 = cursor.execute(
+            """SELECT event_identifier, subtype FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?
+               ORDER BY sequence_index""",
+            (ts1, Location.BINANCE.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+        assert len(events1) == 3
+        assert events1[0][0] == spend_id1
+        assert events1[1][0] == receive_id1
+        assert events1[2][0] == fee_id1
+        assert events1[0][0] != events1[1][0] != events1[2][0]  # All different
+
+        # Second swap has 2 different identifiers
+        events2 = cursor.execute(
+            """SELECT event_identifier, subtype FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?
+               ORDER BY sequence_index""",
+            (ts2, Location.KRAKEN.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+        assert len(events2) == 2
+        assert events2[0][0] == spend_id2
+        assert events2[1][0] == receive_id2
+        assert events2[0][0] != events2[1][0]  # Different
+
+        # Correct swap already has same identifier
+        correct_events_check = cursor.execute(
+            """SELECT event_identifier FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?""",
+            (3000000, Location.COINBASE.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+        assert all(event[0] == correct_id for event in correct_events_check)
+
+    # Run the migration
+    with patch(
+        'rotkehlchen.data_migrations.manager.MIGRATION_LIST',
+        new=[MIGRATION_LIST[10]],  # Migration 20 is at index 10
+    ):
+        migration_manager = DataMigrationManager(rotki)
+        migration_manager.maybe_migrate_data()
+
+    # Verify the fix after migration
+    with database.conn.read_ctx() as cursor:
+        # First swap should now have same identifier (spend's identifier)
+        events1_fixed = cursor.execute(
+            """SELECT event_identifier, subtype FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?
+               ORDER BY sequence_index""",
+            (ts1, Location.BINANCE.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+        assert len(events1_fixed) == 3
+        assert events1_fixed[0][0] == spend_id1  # Spend keeps its ID
+        assert events1_fixed[1][0] == spend_id1  # Receive now has spend's ID
+        assert events1_fixed[2][0] == spend_id1  # Fee now has spend's ID
+
+        # Second swap should now have same identifier
+        events2_fixed = cursor.execute(
+            """SELECT event_identifier, subtype FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?
+               ORDER BY sequence_index""",
+            (ts2, Location.KRAKEN.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+        assert len(events2_fixed) == 2
+        assert events2_fixed[0][0] == spend_id2  # Spend keeps its ID
+        assert events2_fixed[1][0] == spend_id2  # Receive now has spend's ID
+
+        # Correct swap should remain unchanged
+        correct_events_check = cursor.execute(
+            """SELECT event_identifier FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?""",
+            (3000000, Location.COINBASE.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+        assert all(event[0] == correct_id for event in correct_events_check)
+
+
+@pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
+@pytest.mark.parametrize('data_migration_version', [19])
+def test_migration_20_edge_case_multiple_swaps(database: DBHandler) -> None:
+    """Test the edge case where multiple swaps happen at same timestamp/location"""
+    rotki = MockRotkiForMigrations(database)
+
+    ts = TimestampMS(1000000)
+    location = Location.BINANCE
+
+    # Create two broken swaps at same timestamp/location
+    # Swap 1: ETH -> BTC
+    swap1_events = [
+        SwapEvent(
+            timestamp=ts,
+            location=location,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=ONE,
+            event_identifier=create_event_identifier(
+                location=location,
+                timestamp=ts,
+                asset=A_ETH,
+                amount=ONE,
+                unique_id='swap1_spend',
+            ),
+        ),
+        SwapEvent(
+            timestamp=ts,
+            location=location,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_BTC,
+            amount=ONE * 2,
+            event_identifier=create_event_identifier(
+                location=location,
+                timestamp=ts,
+                asset=A_BTC,
+                amount=ONE * 2,
+                unique_id='swap1_receive',
+            ),
+        ),
+    ]
+
+    # Swap 2: BTC -> ETH (reverse)
+    swap2_events = [
+        SwapEvent(
+            timestamp=ts,
+            location=location,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_BTC,
+            amount=ONE * 3,
+            event_identifier=create_event_identifier(
+                location=location,
+                timestamp=ts,
+                asset=A_BTC,
+                amount=ONE * 3,
+                unique_id='swap2_spend',
+            ),
+        ),
+        SwapEvent(
+            timestamp=ts,
+            location=location,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_ETH,
+            amount=ONE * 4,
+            event_identifier=create_event_identifier(
+                location=location,
+                timestamp=ts,
+                asset=A_ETH,
+                amount=ONE * 4,
+                unique_id='swap2_receive',
+            ),
+        ),
+    ]
+
+    db_events = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        db_events.add_history_events(write_cursor, history=swap1_events + swap2_events)
+
+    # Run the migration
+    with patch(
+        'rotkehlchen.data_migrations.manager.MIGRATION_LIST',
+        new=[MIGRATION_LIST[10]],  # Migration 20 is at index 10
+    ):
+        migration_manager = DataMigrationManager(rotki)
+        migration_manager.maybe_migrate_data()
+
+    # Verify the fix - each swap should be grouped correctly
+    with database.conn.read_ctx() as cursor:
+        all_events = cursor.execute(
+            """SELECT event_identifier, subtype, asset, amount FROM history_events
+               WHERE timestamp = ? AND location = ? AND entry_type = ?
+               ORDER BY identifier""",
+            (ts, location.serialize_for_db(),
+             HistoryBaseEntryType.SWAP_EVENT.serialize_for_db()),
+        ).fetchall()
+
+        # Group by event_identifier to verify correct pairing
+        id_groups: dict[str, list[tuple[str, str, str]]] = {}
+        for event_id, subtype, asset, amount in all_events:
+            if event_id not in id_groups:
+                id_groups[event_id] = []
+            id_groups[event_id].append((subtype, asset, amount))
+
+        # Should have 2 distinct event identifiers (2 swaps)
+        assert len(id_groups) == 2
+
+        # Each group should have a spend and receive
+        for events in id_groups.values():
+            subtypes = [e[0] for e in events]
+            assert HistoryEventSubType.SPEND.serialize() in subtypes
+            assert HistoryEventSubType.RECEIVE.serialize() in subtypes
+            assert len(events) == 2


### PR DESCRIPTION
## Summary
- Adds migration 20 to fix SwapEvent identifiers that were generated differently for spend/receive/fee parts before PR 10103
- Groups SwapEvents by timestamp, location, and location_label to ensure they share the same event_identifier