### PR TITLE
feat: use pytest markers for test-assets target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,24 +24,7 @@ docker-image:
 
 
 test-assets:
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_binance.py::test_binance_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_binance_us.py::test_binance_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_bitfinex.py::test_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_bitstamp.py::test_bitstamp_exchange_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_coinbase.py::test_coverage_of_products
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_kraken.py::test_coverage_of_kraken_balances
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_iconomi.py::test_iconomi_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_kucoin.py::test_kucoin_exchange_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_poloniex.py::test_poloniex_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_gemini.py::test_gemini_all_symbols_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_okx.py::test_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/unit/test_assets.py::test_coingecko_identifiers_are_reachable
-	uv run pytestgeventwrapper.py rotkehlchen/tests/unit/test_assets.py::test_cryptocompare_asset_support
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_independentreserve.py::test_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/unit/test_zerionsdk.py::test_protocol_names_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/unit/test_zerionsdk.py::test_query_all_protocol_balances_for_account
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_woo.py::test_woo_assets_are_known
-	uv run pytestgeventwrapper.py rotkehlchen/tests/exchanges/test_bybit.py::test_assets_are_known
+	uv run pytestgeventwrapper.py -m asset_test rotkehlchen/tests
 
 create-cassettes:
 	RECORD_CASSETTES=true uv run pytestgeventwrapper.py -m vcr rotkehlchen/tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -522,3 +522,12 @@ reportAssignmentType = false
 
 exclude = ["**/tests"]
 pythonVersion = "3.11"
+
+
+# -- pytest config section --
+
+[tool.pytest.ini_options]
+markers = [
+    "asset_test: tests that check for asset coverage and definitions",
+    "vcr: tests that use vcrpy cassettes",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,8 +524,6 @@ exclude = ["**/tests"]
 pythonVersion = "3.11"
 
 
-# -- pytest config section --
-
 [tool.pytest.ini_options]
 markers = [
     "asset_test: tests that check for asset coverage and definitions",

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -251,6 +251,7 @@ def test_trade_from_binance(function_scope_binance):
     'CI' in os.environ,
     reason='https://twitter.com/LefterisJP/status/1598107187184037888',
 )
+@pytest.mark.asset_test
 def test_binance_assets_are_known(inquirer, globaldb):  # pylint: disable=unused-argument
     for asset in get_exchange_asset_symbols(Location.BINANCE):
         assert is_asset_symbol_unsupported(globaldb, Location.BINANCE, asset) is False, f'Binance assets {asset} should not be unsupported'  # noqa: E501

--- a/rotkehlchen/tests/exchanges/test_binance_us.py
+++ b/rotkehlchen/tests/exchanges/test_binance_us.py
@@ -29,6 +29,7 @@ def test_name():
     assert exchange.name == 'binanceus1'
 
 
+@pytest.mark.asset_test
 def test_binance_assets_are_known(inquirer, globaldb):  # pylint: disable=unused-argument
     exchange_data = requests.get('https://api.binance.us/api/v3/exchangeInfo').json()
     binance_assets = set()

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -133,6 +133,7 @@ def test_name():
     assert exchange.name == 'bitfinex1'
 
 
+@pytest.mark.asset_test
 def test_assets_are_known(mock_bitfinex, globaldb):
     """This tests only exchange (trades) assets (not margin, nor futures ones).
     """

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -39,6 +39,7 @@ def test_name():
     assert exchange.name == 'bitstamp1'
 
 
+@pytest.mark.asset_test
 def test_bitstamp_exchange_assets_are_known(mock_bitstamp):
     request_url = f'{mock_bitstamp.base_uri}/v2/trading-pairs-info'
     try:

--- a/rotkehlchen/tests/exchanges/test_bybit.py
+++ b/rotkehlchen/tests/exchanges/test_bybit.py
@@ -292,6 +292,7 @@ def test_deposit_withdrawals(bybit_exchange: Bybit) -> None:
     ]
 
 
+@pytest.mark.asset_test
 @pytest.mark.skipif(
     'CI' in os.environ,
     reason='Cannot connect to server due to cloudflare blocking the github server',

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -1704,6 +1704,7 @@ def test_advancedtrade_missing_order_side(mock_coinbase):
     )]
 
 
+@pytest.mark.asset_test
 def test_coverage_of_products():
     """Test that we can process all assets from coinbase"""
     data = requests.get('https://api.exchange.coinbase.com/currencies')

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -69,6 +69,7 @@ def test_gemini_wrong_key(sandbox_gemini):
     assert 'Invalid API Key or API secret' in msg
 
 
+@pytest.mark.asset_test
 @pytest.mark.skipif('CI' in os.environ, reason='temporarily skip gemini in CI')
 @pytest.mark.parametrize('gemini_test_base_uri', ['https://api.gemini.com'])
 def test_gemini_all_symbols_are_known(sandbox_gemini, globaldb):

--- a/rotkehlchen/tests/exchanges/test_iconomi.py
+++ b/rotkehlchen/tests/exchanges/test_iconomi.py
@@ -1,6 +1,8 @@
 import warnings as test_warnings
 from unittest.mock import patch
 
+import pytest
+
 from rotkehlchen.assets.converters import asset_from_iconomi
 from rotkehlchen.constants.assets import A_ETH, A_EUR, A_REP
 from rotkehlchen.errors.asset import UnknownAsset
@@ -118,6 +120,7 @@ def test_query_trade_history(function_scope_iconomi):
     )]
 
 
+@pytest.mark.asset_test
 def test_iconomi_assets_are_known(
         database,
         inquirer,  # pylint: disable=unused-argument

--- a/rotkehlchen/tests/exchanges/test_independentreserve.py
+++ b/rotkehlchen/tests/exchanges/test_independentreserve.py
@@ -26,6 +26,7 @@ def test_location():
     assert exchange.name == 'independentreserve1'
 
 
+@pytest.mark.asset_test
 def test_assets_are_known():
     exchange = Independentreserve('independentreserve1', 'a', b'a', object(), object())
     response = exchange._api_query('get', 'Public', 'GetValidPrimaryCurrencyCodes')

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -86,6 +86,7 @@ def test_name():
     assert exchange.name == 'kraken1'
 
 
+@pytest.mark.asset_test
 def test_coverage_of_kraken_balances():
     response = requests.get('https://api.kraken.com/0/public/Assets')
     got_assets = set(response.json()['result'].keys())

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -45,6 +45,7 @@ def test_name():
     assert exchange.name == 'kucoin1'
 
 
+@pytest.mark.asset_test
 def test_kucoin_exchange_assets_are_known(mock_kucoin, globaldb):
     request_url = f'{mock_kucoin.base_uri}/api/v1/currencies'
     try:

--- a/rotkehlchen/tests/exchanges/test_okx.py
+++ b/rotkehlchen/tests/exchanges/test_okx.py
@@ -1,6 +1,8 @@
 import warnings as test_warnings
 from unittest.mock import patch
 
+import pytest
+
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_okx
 from rotkehlchen.constants.assets import A_ETH, A_USDC, A_USDT
@@ -23,6 +25,7 @@ def test_name():
     assert exchange.name == 'okx1'
 
 
+@pytest.mark.asset_test
 def test_assets_are_known(mock_okx: Okx, globaldb):
     currencies = mock_okx._api_query(OkxEndpoint.CURRENCIES)
     okx_assets = {currency['ccy'] for currency in currencies['data']}

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -292,6 +292,7 @@ def test_query_trade_history_unexpected_data(poloniex):
     mock_poloniex_and_query(given_input, expected_warnings_num=0, expected_errors_num=0)
 
 
+@pytest.mark.asset_test
 def test_poloniex_assets_are_known(poloniex: 'Poloniex', globaldb: 'GlobalDBHandler'):
     for asset in get_exchange_asset_symbols(Location.POLONIEX):
         assert is_asset_symbol_unsupported(globaldb, Location.POLONIEX, asset) is False, f'Poloniex assets {asset} should not be unsupported'  # noqa: E501

--- a/rotkehlchen/tests/exchanges/test_woo.py
+++ b/rotkehlchen/tests/exchanges/test_woo.py
@@ -2,6 +2,7 @@ import warnings as test_warnings
 from json.decoder import JSONDecodeError
 from unittest.mock import MagicMock, call, patch
 
+import pytest
 import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
@@ -25,6 +26,7 @@ def test_name():
     assert exchange.name == 'woo'
 
 
+@pytest.mark.asset_test
 def test_woo_assets_are_known(mock_woo):
     request_url = f'{mock_woo.base_uri}/v1/public/token'
     try:

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -97,6 +97,7 @@ def test_ethereum_tokens():
         EvmToken('BTC')
 
 
+@pytest.mark.asset_test
 def test_cryptocompare_asset_support(cryptocompare):
     """Try to detect if a token that we have as not supported by cryptocompare got added"""
     cc_assets = cryptocompare.all_coins()
@@ -615,6 +616,7 @@ def test_case_does_not_matter_for_asset_constructor():
     'CI' in os.environ,
     reason='SLOW TEST -- it executes locally every time we check the assets so can be skipped',
 )
+@pytest.mark.asset_test
 def test_coingecko_identifiers_are_reachable(socket_enabled):  # pylint: disable=unused-argument
     """
     Test that all assets have a coingecko entry and that all the identifiers exist in coingecko


### PR DESCRIPTION
## Summary
- Optimized the `test-assets` Makefile target to use pytest markers instead of running pytest 18 separate times
- This significantly improves performance by running pytest only once

## Changes
- Added pytest markers configuration to `pyproject.toml`
- Added `@pytest.mark.asset_test` decorator to all 16 asset-related test functions
- Simplified Makefile `test-assets` target from 18 individual pytest calls to a single command: `python pytestgeventwrapper.py -m asset_test rotkehlchen/tests`

## Note
During implementation, discovered that 2 tests referenced in the Makefile no longer exist as `test_zerionsdk.py` file has been removed:
- `test_protocol_names_are_known`
- `test_query_all_protocol_balances_for_account`

The marker-based approach correctly handles this by only collecting existing tests (16 instead of 18).

## Test plan
- [x] Run `make test-assets` to verify all asset tests are executed
- [x] Verify that `python pytestgeventwrapper.py -m asset_test --collect-only` shows 16 tests collected