### PR TITLE
Update bitfinex endpoint for assets movements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`10079` Users will now be able to switch the chain directly from rotki on the on-chain page if they use WalletConnect.
+* :bug:`-` Asset movements from Bitfinex should be queried correctly now.
 * :bug:`-` For ETH staking MEV rewards the informational event will no longer be shown as it will be superseded by the combined MEV reward events.
 * :bug:`-` Transaction decoding will no longer fail when encountering a certain rare case of problematic spam tokens.
 * :bug:`-` Swaps receiving EURe in Gnosis that were not working for selected DEXes will now be properly decoded again.

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -176,7 +176,7 @@ class Bitfinex(ExchangeInterface):
             request_url = f'{self.base_uri}/{api_path}'
         elif endpoint == 'movements':
             method = 'post'
-            api_path = 'v2/auth/r/movements/hist'
+            api_path = 'v2/auth/r/movements/info'
             request_url = f'{self.base_uri}/{api_path}?{urlencode(call_options)}'
         elif endpoint == 'trades':
             method = 'post'


### PR DESCRIPTION
The endpoint that we have in our code is not listed in the API and also a user mentioned that it doesn't work. The endpoint https://docs.bitfinex.com/reference/movement-info has the expected structure by our code.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
