### PR TITLE
fix: change the default root layout to plain

### DIFF
--- a/frontend/app/src/modules/layout/LayoutWrapper.vue
+++ b/frontend/app/src/modules/layout/LayoutWrapper.vue
@@ -12,7 +12,7 @@ const layouts = {
 const route = useRoute();
 
 const layout = computed(() => {
-  const defaultLayout: keyof typeof layouts = route.path === '/' ? 'auth' : 'default';
+  const defaultLayout: keyof typeof layouts = route.path === '/' ? 'plain' : 'default';
   const layoutName = route.meta.layout || defaultLayout;
   return layouts[layoutName as keyof typeof layouts] || layouts[defaultLayout];
 });


### PR DESCRIPTION
This is because the auth and default layout trigger pinging the backend which is not needed.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
