### PR TITLE
Fix import of binance trades with only differing timestamps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Swaps that only differ in their timestamps will now be properly imported from Binance CSVs.
 * :bug:`10158` PnL reports will now properly handle events with the same timestamp.
 * :bug:`10146` Users will now be able to filter assets in the history events filter if a non-EVM location is selected.
 * :bug:`10150` The history events page will be refreshed automatically when an asset is ignored or marked as spam.

--- a/rotkehlchen/data_import/importers/binance.py
+++ b/rotkehlchen/data_import/importers/binance.py
@@ -221,13 +221,9 @@ class BinanceTradeEntry(BinanceMultipleEntry):
             if operation in {'Transaction Buy', 'Transaction Spend', 'Transaction Fee'}:
                 key = (operation, coin)
                 if key not in aggregated_data:
-                    aggregated_data[key] = {
-                        'Operation': operation,
-                        'Coin': coin,
-                        'Change': ZERO,
-                        INDEX: row[INDEX],  # Keep the first row's index
-                    }
-                aggregated_data[key]['Change'] += change
+                    aggregated_data[key] = row
+                else:
+                    aggregated_data[key]['Change'] += change
             else:
                 other_data.append(row)
 

--- a/rotkehlchen/tests/data/binance_history.csv
+++ b/rotkehlchen/tests/data/binance_history.csv
@@ -179,3 +179,7 @@ User_ID,UTC_Time,Account,Operation,Coin,Change,Remark
 1,2024-05-16 12:57:55,Spot,Transaction Buy,HIGH,4.23900000,
 1,2024-05-16 12:57:55,Spot,Transaction Spend,BTC,-0.00452769,
 1,2024-05-16 12:57:55,Spot,Transaction Buy,HIGH,141.40200000,
+1,2024-09-12 10:15:06,Spot,Transaction Spend,ETH,-0.54321,
+1,2024-09-12 10:15:06,Spot,Transaction Buy,USDT,1234,
+1,2024-09-12 10:15:11,Spot,Transaction Spend,ETH,-0.54321,
+1,2024-09-12 10:15:11,Spot,Transaction Buy,USDT,1234,

--- a/rotkehlchen/tests/utils/dataimport.py
+++ b/rotkehlchen/tests/utils/dataimport.py
@@ -2513,7 +2513,7 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
             location_label='CSV import',
             notes='1.29642000 USDT realized profit on binance USD-MFutures',
         ), SwapEvent(
-            event_identifier='BNC_be0583092c912bbeb15a6dbe61e69093a869164ac1feeca375036b1a1d33f0c8',
+            event_identifier='BNC_c6e5a5527ed3ad65bc2bceffdb2a432f5335e04768a0b86256c653a40d12229a',
             timestamp=TimestampMS(1695981386000),
             location=Location.BINANCE,
             event_subtype=HistoryEventSubType.SPEND,
@@ -2522,7 +2522,7 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
             notes='Imported from binance CSV file. Binance operation: Buy / Sell',
             identifier=71,
         ), SwapEvent(
-            event_identifier='BNC_be0583092c912bbeb15a6dbe61e69093a869164ac1feeca375036b1a1d33f0c8',
+            event_identifier='BNC_c6e5a5527ed3ad65bc2bceffdb2a432f5335e04768a0b86256c653a40d12229a',
             timestamp=TimestampMS(1695981386000),
             location=Location.BINANCE,
             event_subtype=HistoryEventSubType.RECEIVE,
@@ -2530,7 +2530,7 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
             amount=FVal('0.01700000'),
             identifier=72,
         ), SwapEvent(
-            event_identifier='BNC_be0583092c912bbeb15a6dbe61e69093a869164ac1feeca375036b1a1d33f0c8',
+            event_identifier='BNC_c6e5a5527ed3ad65bc2bceffdb2a432f5335e04768a0b86256c653a40d12229a',
             timestamp=TimestampMS(1695981386000),
             location=Location.BINANCE,
             event_subtype=HistoryEventSubType.FEE,
@@ -2563,7 +2563,7 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
             amount=FVal('0.00003605'),
             identifier=76,
         ), SwapEvent(
-            event_identifier='BNC_e483a8113ec41413e994787c73d945ee286b50c9a8f2a059f2698ca0dc978a58',
+            event_identifier='BNC_2ede3e3de73269b127690a1758dee9b896a1ae3b43b05caedd3e34860022aec8',
             timestamp=TimestampMS(1715864275000),
             location=Location.BINANCE,
             event_subtype=HistoryEventSubType.SPEND,
@@ -2572,7 +2572,7 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
             identifier=77,
             notes='Imported from binance CSV file. Binance operation: Buy / Sell',
         ), SwapEvent(
-            event_identifier='BNC_e483a8113ec41413e994787c73d945ee286b50c9a8f2a059f2698ca0dc978a58',
+            event_identifier='BNC_2ede3e3de73269b127690a1758dee9b896a1ae3b43b05caedd3e34860022aec8',
             timestamp=TimestampMS(1715864275000),
             location=Location.BINANCE,
             event_subtype=HistoryEventSubType.RECEIVE,
@@ -2580,13 +2580,47 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
             amount=FVal('2011.67800000'),
             identifier=78,
         ), SwapEvent(
-            event_identifier='BNC_e483a8113ec41413e994787c73d945ee286b50c9a8f2a059f2698ca0dc978a58',
+            event_identifier='BNC_2ede3e3de73269b127690a1758dee9b896a1ae3b43b05caedd3e34860022aec8',
             timestamp=TimestampMS(1715864275000),
             location=Location.BINANCE,
             event_subtype=HistoryEventSubType.FEE,
             asset=Asset('eip155:1/erc20:0x71Ab77b7dbB4fa7e017BC15090b2163221420282'),
             amount=FVal('2.01167800'),
             identifier=79,
+        ), SwapEvent(
+            event_identifier='BNC_de70f198dc94c110e5921f12684714cb2f5375e3396373d26b9fa699def5394a',
+            timestamp=TimestampMS(1726136106000),
+            location=Location.BINANCE,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=FVal('0.54321'),
+            identifier=80,
+            notes='Imported from binance CSV file. Binance operation: Buy / Sell',
+        ), SwapEvent(
+            event_identifier='BNC_de70f198dc94c110e5921f12684714cb2f5375e3396373d26b9fa699def5394a',
+            timestamp=TimestampMS(1726136106000),
+            location=Location.BINANCE,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_USDT,
+            amount=FVal('1234'),
+            identifier=81,
+        ), SwapEvent(
+            event_identifier='BNC_accc00aaa9c5c1e1b1562b25c18756e98b32a6b6605fea24bfeda63edb70219b',
+            timestamp=TimestampMS(1726136111000),
+            location=Location.BINANCE,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=FVal('0.54321'),
+            identifier=82,
+            notes='Imported from binance CSV file. Binance operation: Buy / Sell',
+        ), SwapEvent(
+            event_identifier='BNC_accc00aaa9c5c1e1b1562b25c18756e98b32a6b6605fea24bfeda63edb70219b',
+            timestamp=TimestampMS(1726136111000),
+            location=Location.BINANCE,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_USDT,
+            amount=FVal('1234'),
+            identifier=83,
         ),
     ]
 
@@ -2604,8 +2638,8 @@ def assert_binance_import_results(rotki: Rotkehlchen, websocket_connection: Webs
         'data': {
             'subtype': 'csv_import_result',
             'source_name': 'Binance',
-            'total': 180,
-            'processed': 174,
+            'total': 184,
+            'processed': 178,
             'messages': [
                 {'msg': 'Failed to deserialize a timestamp from a null entry in binance', 'rows': [4], 'is_error': True},  # noqa: E501
                 {'msg': 'Unknown asset "" provided.', 'rows': [5], 'is_error': True},


### PR DESCRIPTION
Fixes a problem we noticed while working with https://github.com/rotki/rotki/issues/10144, where if there were two binance trades that were identical except for the timestamp, only one got imported. This was due to the timestamp not being included in the aggregated rows and then those rows being used to create the event_identifier via `hash_binance_csv_row`, resulting in swap events with duplicate event_identifiers.

