### PR TITLE
Add api validation limiting bitcoin event asset to BTC

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -45,7 +45,7 @@ from rotkehlchen.chain.substrate.utils import (
     get_substrate_address_from_public_key,
     is_valid_substrate_address,
 )
-from rotkehlchen.constants.assets import A_ETH, A_ETH2
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_ETH2
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.constants.resolver import EVM_CHAIN_DIRECTIVE
 from rotkehlchen.data_import.manager import DataImportSource
@@ -797,6 +797,12 @@ class CreateHistoryEventSchema(Schema):
                 data: dict[str, Any],
                 **_kwargs: Any,
         ) -> dict[str, Any]:
+            if data['location'] == Location.BITCOIN and data['asset'] != A_BTC:
+                raise ValidationError(
+                    message='Bitcoin events must use BTC as the asset',
+                    field_name='asset',
+                )
+
             data['notes'] = data.pop('user_notes')
             return {'events': [HistoryEvent(**data)]}
 


### PR DESCRIPTION
Related: #2880 

Adds validation on the api to ensure bitcoin events only get their asset set to BTC as discussed in [discord](https://discord.com/channels/657906918408585217/683245846070165504/1386701494975336560)