### PR TITLE
Add blockcypher btc tx querying

### DIFF
--- a/rotkehlchen/chain/bitcoin/constants.py
+++ b/rotkehlchen/chain/bitcoin/constants.py
@@ -1,10 +1,21 @@
 from typing import Final
 
 BLOCKCHAIN_INFO_BASE_URL: Final = 'https://blockchain.info'
+BLOCKCYPHER_BASE_URL: Final = 'https://api.blockcypher.com/v1/btc/main'
 BLOCKSTREAM_BASE_URL: Final = 'https://blockstream.info/api'
 MEMPOOL_SPACE_BASE_URL: Final = 'https://mempool.space/api'
 
 BLOCKSTREAM_MEMPOOL_TX_PAGE_LENGTH: Final = 25
+
+BLOCKCYPHER_TX_IO_LIMIT: Final = 200
+BLOCKCYPHER_TX_LIMIT: Final = 50
+
+# This is rather small as the free rate limit is 3 requests/sec, with each batched item counting
+# as a single request. This would appear to mean that there could be 3 batched items, but from
+# actual testing it seems only 2 work correctly, so apparently the actual request being made
+# is counted as an additional request above the number of items batched.
+# See https://www.blockcypher.com/dev/bitcoin/#rate-limits-and-tokens
+BLOCKCYPHER_BATCH_SIZE: Final = 2
 
 # Combined with the tx id to create the event identifiers for bitcoin transactions.
 BTC_EVENT_IDENTIFIER_PREFIX: Final = 'btc_'

--- a/rotkehlchen/chain/bitcoin/types.py
+++ b/rotkehlchen/chain/bitcoin/types.py
@@ -4,7 +4,11 @@ from typing import Any, NamedTuple
 
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
-from rotkehlchen.serialization.deserialize import deserialize_timestamp
+from rotkehlchen.serialization.deserialize import (
+    deserialize_int,
+    deserialize_timestamp,
+    deserialize_timestamp_from_date,
+)
 from rotkehlchen.types import BTCAddress, Timestamp
 from rotkehlchen.utils.misc import satoshis_to_btc
 
@@ -23,25 +27,25 @@ class BtcTxIODirection(Enum):
 class BtcTxIO(NamedTuple):
     """Represents an individual input/output of a Bitcoin transaction."""
     value: FVal
-    script: bytes
-    address: BTCAddress | None
+    script: bytes | None  # optional since blockcypher omits the script for input TxIOs
+    address: BTCAddress | None  # address may be missing for scripts such as op_return
     direction: BtcTxIODirection
 
     @classmethod
-    def deserialize_from_blockstream_mempool(
+    def deserialize_from_blockcypher(
             cls,
             data: dict[str, Any],
             direction: BtcTxIODirection,
     ) -> 'BtcTxIO':
-        try:
-            return BtcTxIO(
-                value=satoshis_to_btc(data['value']),
-                script=bytes.fromhex(data['scriptpubkey']),
-                address=data.get('scriptpubkey_address'),
-                direction=direction,
-            )
-        except KeyError as e:
-            raise DeserializationError(f'Missing key {e!s}') from e
+        return BtcTxIO(
+            value=satoshis_to_btc(
+                data.get('value', 0) if direction == BtcTxIODirection.OUTPUT
+                else data.get('output_value', 0),
+            ),
+            script=bytes.fromhex(script) if (script := data.get('script')) is not None else None,
+            address=addresses[0] if (addresses := data['addresses']) is not None else None,
+            direction=direction,
+        )
 
     @classmethod
     def deserialize_from_blockchain_info(
@@ -49,15 +53,26 @@ class BtcTxIO(NamedTuple):
             data: dict[str, Any],
             direction: BtcTxIODirection,
     ) -> 'BtcTxIO':
+        return BtcTxIO(
+            value=satoshis_to_btc(data['value']),
+            script=bytes.fromhex(data['script']),
+            address=data.get('addr'),
+            direction=direction,
+        )
+
+    @classmethod
+    def deserialize(
+            cls,
+            data: dict[str, Any],
+            direction: BtcTxIODirection,
+            deserialize_fn: Callable[[dict[str, Any], BtcTxIODirection], 'BtcTxIO'],
+    ) -> 'BtcTxIO':
         try:
-            return BtcTxIO(
-                value=satoshis_to_btc(data['value']),
-                script=bytes.fromhex(data['script']),
-                address=data.get('addr'),
-                direction=direction,
-            )
+            return deserialize_fn(data, direction)
         except KeyError as e:
             raise DeserializationError(f'Missing key {e!s}') from e
+        except ValueError as e:
+            raise DeserializationError(f'Invalid hexadecimal script in TxIO {data}') from e
 
     @classmethod
     def deserialize_list(
@@ -66,57 +81,76 @@ class BtcTxIO(NamedTuple):
             direction: BtcTxIODirection,
             deserialize_fn: Callable[[dict[str, Any], BtcTxIODirection], 'BtcTxIO'],
     ) -> list['BtcTxIO']:
-        return [deserialize_fn(raw_tx_io, direction) for raw_tx_io in data_list]
+        return [cls.deserialize(
+            data=raw_tx_io,
+            direction=direction,
+            deserialize_fn=deserialize_fn,
+        ) for raw_tx_io in data_list]
 
 
 class BitcoinTx(NamedTuple):
     tx_id: str
     timestamp: Timestamp
+    block_height: int
     fee: FVal
     inputs: list[BtcTxIO]
     outputs: list[BtcTxIO]
+    multi_io: bool = False
 
     @classmethod
-    def deserialize_from_blockstream_mempool(cls, data: dict[str, Any]) -> 'BitcoinTx':
-        try:
-            return cls(
-                tx_id=data['txid'],
-                timestamp=deserialize_timestamp(data['status']['block_time']),
-                fee=satoshis_to_btc(data['fee']),
-                inputs=BtcTxIO.deserialize_list(
-                    data_list=[vin['prevout'] for vin in data['vin']],
-                    direction=BtcTxIODirection.INPUT,
-                    deserialize_fn=BtcTxIO.deserialize_from_blockstream_mempool,
-                ),
-                outputs=BtcTxIO.deserialize_list(
-                    data_list=data['vout'],
-                    direction=BtcTxIODirection.OUTPUT,
-                    deserialize_fn=BtcTxIO.deserialize_from_blockstream_mempool,
-                ),
-            )
-        except KeyError as e:
-            raise DeserializationError(f'Missing key {e!s}') from e
+    def deserialize_from_blockcypher(cls, data: dict[str, Any]) -> 'BitcoinTx':
+        return cls(
+            tx_id=data['hash'],
+            timestamp=deserialize_timestamp_from_date(
+                date=data['confirmed'],
+                formatstr='iso8601',
+                location='blockcypher bitcoin tx',
+            ),
+            block_height=deserialize_int(data['block_height']),
+            fee=satoshis_to_btc(data['fees']),
+            inputs=BtcTxIO.deserialize_list(
+                data_list=data['inputs'],
+                direction=BtcTxIODirection.INPUT,
+                deserialize_fn=BtcTxIO.deserialize_from_blockcypher,
+            ),
+            outputs=BtcTxIO.deserialize_list(
+                data_list=data['outputs'],
+                direction=BtcTxIODirection.OUTPUT,
+                deserialize_fn=BtcTxIO.deserialize_from_blockcypher,
+            ),
+        )
 
     @classmethod
     def deserialize_from_blockchain_info(cls, data: dict[str, Any]) -> 'BitcoinTx':
-        try:
-            return cls(
-                tx_id=data['hash'],
-                timestamp=deserialize_timestamp(data['time']),
-                fee=satoshis_to_btc(data['fee']),
-                inputs=BtcTxIO.deserialize_list(
-                    data_list=[vin['prev_out'] for vin in data['inputs']],
-                    direction=BtcTxIODirection.INPUT,
-                    deserialize_fn=BtcTxIO.deserialize_from_blockchain_info,
-                ),
-                outputs=BtcTxIO.deserialize_list(
-                    data_list=data['out'],
-                    direction=BtcTxIODirection.OUTPUT,
-                    deserialize_fn=BtcTxIO.deserialize_from_blockchain_info,
-                ),
-            )
-        except KeyError as e:
-            raise DeserializationError(f'Missing key {e!s}') from e
+        inputs = [vin['prev_out'] for vin in data['inputs']]
+        outputs = data['out']
+        multi_io = False
+        if (
+            (vin_sz := data['vin_sz']) > 1 and
+            (vout_sz := data['vout_sz']) > 1 and
+            (len(inputs) != vin_sz or len(outputs) != vout_sz)
+        ):
+            # This api omits some TxIOs if they don't directly affect the addresses queried.
+            # Set multi_io to ensure proper many-to-many decoding if some TxIOs are missing.
+            multi_io = True
+
+        return cls(
+            tx_id=data['hash'],
+            timestamp=deserialize_timestamp(data['time']),
+            block_height=deserialize_int(data['block_height']),
+            fee=satoshis_to_btc(data['fee']),
+            inputs=BtcTxIO.deserialize_list(
+                data_list=inputs,
+                direction=BtcTxIODirection.INPUT,
+                deserialize_fn=BtcTxIO.deserialize_from_blockchain_info,
+            ),
+            outputs=BtcTxIO.deserialize_list(
+                data_list=outputs,
+                direction=BtcTxIODirection.OUTPUT,
+                deserialize_fn=BtcTxIO.deserialize_from_blockchain_info,
+            ),
+            multi_io=multi_io,
+        )
 
 
 def string_to_btc_address(value: str) -> BTCAddress:

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -86,7 +86,7 @@ class DBCacheDynamic(Enum):
     EXTRA_INTERNAL_TX: Final = f'{EXTRAINTERNALTXPREFIX}_{{chain_id}}_{{receiver}}_{{tx_hash}}', string_to_evm_address  # noqa: E501
     LAST_PRODUCED_BLOCKS_QUERY_TS: Final = 'last_produced_blocks_query_ts_{index}', _deserialize_timestamp_from_str  # noqa: E501
     BINANCE_PAIR_LAST_ID: Final = '{location}_{location_name}_{queried_pair}', _deserialize_int_from_str  # noqa: E501  # notice that location is added because it can be either binance or binance_us
-    LAST_BITCOIN_TX_TS: Final = '{address}_last_tx_ts', _deserialize_timestamp_from_str
+    LAST_BITCOIN_TX_BLOCK: Final = '{address}_last_tx_block', _deserialize_int_from_str
 
     @overload
     def get_db_key(self, **kwargs: Unpack[LabeledLocationArgsType]) -> str:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -766,9 +766,9 @@ class DBHandler:
     def get_dynamic_cache(
             self,
             cursor: 'DBCursor',
-            name: Literal[DBCacheDynamic.LAST_BITCOIN_TX_TS],
+            name: Literal[DBCacheDynamic.LAST_BITCOIN_TX_BLOCK],
             **kwargs: Unpack[AddressArgType],
-    ) -> Timestamp | None:
+    ) -> int | None:
         ...
 
     def get_dynamic_cache(
@@ -902,8 +902,8 @@ class DBHandler:
     def set_dynamic_cache(
             self,
             write_cursor: 'DBCursor',
-            name: Literal[DBCacheDynamic.LAST_BITCOIN_TX_TS],
-            value: Timestamp,
+            name: Literal[DBCacheDynamic.LAST_BITCOIN_TX_BLOCK],
+            value: int,
             **kwargs: Unpack[AddressArgType],
     ) -> None:
         ...

--- a/rotkehlchen/tests/api/test_bitcoin_transactions.py
+++ b/rotkehlchen/tests/api/test_bitcoin_transactions.py
@@ -1,14 +1,16 @@
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
 import requests
 
 from rotkehlchen.chain.bitcoin.constants import BTC_EVENT_IDENTIFIER_PREFIX
+from rotkehlchen.chain.bitcoin.types import BitcoinTx
 from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -23,23 +25,37 @@ if TYPE_CHECKING:
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[]])
 @pytest.mark.parametrize('btc_accounts', [['bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4']])
+@pytest.mark.parametrize('use_blockcypher', [True, False])
 def test_query_transactions(
         rotkehlchen_api_server: 'APIServer',
         btc_accounts: list['BTCAddress'],
+        use_blockcypher: bool,
 ) -> None:
     """Test that bitcoin transactions are properly queried via the api.
     Since there are quite a number of transactions, only check decoding of first and last txs.
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    bitcoin_manager = rotki.chains_aggregator.bitcoin_manager
     async_query = random.choice([False, True])
+    original_blockchain_info_query = bitcoin_manager._query_blockchain_info_transactions
+
+    def mock_blockchain_info_query(**kwargs: Any) -> tuple[int, list[BitcoinTx]]:
+        """Raise a remote error so it tries the next api if we want to use blockcypher."""
+        if use_blockcypher:
+            raise RemoteError('Use blockcypher api instead.')
+
+        return original_blockchain_info_query(**kwargs)
+
+    query_patch = patch.object(bitcoin_manager, '_query_blockchain_info_transactions', new=mock_blockchain_info_query)  # noqa: E501
     for json, expected_len in (
-        ({'async_query': async_query, 'to_timestamp': 1740000000}, 78),  # query partial range first  # noqa: E501
-        ({'async_query': async_query}, 87),  # then query the rest
+        ({'async_query': async_query, 'to_timestamp': 1740000000}, 67),  # query partial range first  # noqa: E501
+        ({'async_query': async_query}, 76),  # then query the rest
     ):
-        response = requests.post(
-            api_url_for(rotkehlchen_api_server, 'blockchaintransactionsresource'),
-            json=json,
-        )
+        with query_patch:
+            response = requests.post(
+                api_url_for(rotkehlchen_api_server, 'blockchaintransactionsresource'),
+                json=json,
+            )
         assert assert_proper_response_with_result(response, rotkehlchen_api_server, async_query)
         with rotki.data.db.conn.read_ctx() as cursor:
             events = DBHistoryEvents(rotki.data.db).get_history_events(
@@ -51,11 +67,15 @@ def test_query_transactions(
             )
         assert len(events) == expected_len
 
-    assert events[85:] == [HistoryEvent(
-        identifier=79,
+    assert events[74:] == [HistoryEvent(
+        identifier=68,
         event_identifier=(event_identifier := f'{BTC_EVENT_IDENTIFIER_PREFIX}67c97abe049b671a02e537eb901cd600430ddaa5b09b50434969e360ada748bf'),  # noqa: E501
         sequence_index=0,
-        timestamp=(timestamp := TimestampMS(1747979393000)),
+        # The two apis disagree on the timestamp here. Seems to be a bug in blockchain.info.
+        # I've seen it switch between two different timestamps when repeating the same query.
+        # The timestamps are relatively close though, and the timestamp isn't included in the
+        # history event unique constraint, so it should be fine.
+        timestamp=(timestamp := TimestampMS(1747980089000) if use_blockcypher else TimestampMS(1747979393000)),  # noqa: E501
         location=Location.BITCOIN,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -64,7 +84,7 @@ def test_query_transactions(
         location_label=(user_address := btc_accounts[0]),
         notes=f'Spend {fee_amount} BTC for fees',
     ), HistoryEvent(
-        identifier=80,
+        identifier=69,
         event_identifier=event_identifier,
         sequence_index=1,
         timestamp=timestamp,
@@ -77,7 +97,7 @@ def test_query_transactions(
         notes=f'Send {spend_amount} BTC to bc1pg8vm7hk9ashas2mxkv5g74lxn26w3qr9lqyxrql7tg95j7xja5kqjz3na4',  # noqa: E501
     )]
     assert events[0] == HistoryEvent(
-        identifier=78,
+        identifier=67,
         event_identifier=f'{BTC_EVENT_IDENTIFIER_PREFIX}0d39207fd965314941546a698e5f76277818e8b95f41b2e02dfe1901db86acf1',
         sequence_index=0,
         timestamp=TimestampMS(1519764871000),
@@ -91,7 +111,10 @@ def test_query_transactions(
     )
 
     # Ensure the cached latest tx timestamp is respected and no decoding is attempted.
-    with patch.object(rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator.bitcoin_manager, 'decode_transaction') as mock_decode_tx:  # noqa: E501
+    with (
+        query_patch,
+        patch.object(bitcoin_manager, 'decode_transaction') as mock_decode_tx,
+    ):
         response = requests.post(
             api_url_for(rotkehlchen_api_server, 'blockchaintransactionsresource'),
             json=json,

--- a/rotkehlchen/tests/unit/test_bitcoin_transactions.py
+++ b/rotkehlchen/tests/unit/test_bitcoin_transactions.py
@@ -147,10 +147,16 @@ def test_1input_2output(bitcoin_manager: 'BitcoinManager', btc_accounts: list[BT
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('btc_accounts', [['bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4']])
-def test_op_return(bitcoin_manager: 'BitcoinManager', btc_accounts: list[BTCAddress]) -> None:
+@pytest.mark.parametrize('use_blockcypher', [True, False])
+def test_op_return(
+        bitcoin_manager: 'BitcoinManager',
+        btc_accounts: list[BTCAddress],
+        use_blockcypher: bool,
+) -> None:
     assert get_decoded_events_of_bitcoin_tx(
         bitcoin_manager=bitcoin_manager,
         tx_id=(tx_id := 'eb4d2def800c4993928a6f8cc3dd350933a1fb71e6706902025f29a061e5547f'),
+        use_blockcypher=use_blockcypher,
     ) == [HistoryEvent(
         event_identifier=(event_identifier := f'{BTC_EVENT_IDENTIFIER_PREFIX}{tx_id}'),
         sequence_index=0,
@@ -415,12 +421,19 @@ def test_3input_2output(bitcoin_manager: 'BitcoinManager', btc_accounts: list[BT
     )]
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('btc_accounts', [['1PJJygLB42VsaTgo2twFPgRT8CNz1bpGNE']])
-def test_p2pk(bitcoin_manager: 'BitcoinManager', btc_accounts: list[BTCAddress]) -> None:
+@pytest.mark.parametrize('use_blockcypher', [True, False])
+def test_p2pk(
+        bitcoin_manager: 'BitcoinManager',
+        btc_accounts: list[BTCAddress],
+        use_blockcypher: bool,
+) -> None:
     """This is an old tx that used P2PK instead of P2PKH and has no fee."""
     assert get_decoded_events_of_bitcoin_tx(
         bitcoin_manager=bitcoin_manager,
         tx_id=(tx_id := '1db6251a9afce7025a2061a19e63c700dffc3bec368bd1883decfac353357a9d'),
+        use_blockcypher=use_blockcypher,
     ) == [HistoryEvent(
         event_identifier=f'{BTC_EVENT_IDENTIFIER_PREFIX}{tx_id}',
         sequence_index=0,

--- a/rotkehlchen/tests/utils/bitcoin.py
+++ b/rotkehlchen/tests/utils/bitcoin.py
@@ -1,6 +1,10 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.bitcoin.constants import BLOCKCHAIN_INFO_BASE_URL
+from rotkehlchen.chain.bitcoin.constants import (
+    BLOCKCHAIN_INFO_BASE_URL,
+    BLOCKCYPHER_BASE_URL,
+    BLOCKCYPHER_TX_IO_LIMIT,
+)
 from rotkehlchen.chain.bitcoin.types import BitcoinTx
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.utils.network import request_get_dict
@@ -12,11 +16,17 @@ if TYPE_CHECKING:
 def get_decoded_events_of_bitcoin_tx(
         bitcoin_manager: 'BitcoinManager',
         tx_id: str,
+        use_blockcypher: bool = False,
 ) -> list[HistoryEvent]:
     """Convenience function to query a bitcoin tx by its id and decode it."""
     bitcoin_manager.refresh_tracked_accounts()
-    return bitcoin_manager.decode_transaction(
-        tx=BitcoinTx.deserialize_from_blockchain_info(
+    if use_blockcypher:
+        tx = bitcoin_manager._process_raw_tx_from_blockcypher(
+            data=request_get_dict(f'{BLOCKCYPHER_BASE_URL}/txs/{tx_id}?limit={BLOCKCYPHER_TX_IO_LIMIT}'),
+        )
+    else:
+        tx = BitcoinTx.deserialize_from_blockchain_info(
             data=request_get_dict(f'{BLOCKCHAIN_INFO_BASE_URL}/rawtx/{tx_id}'),
-        ),
-    )
+        )
+
+    return bitcoin_manager.decode_transaction(tx=tx)


### PR DESCRIPTION
Related #2880 

* Replaces blockstream/mempool (since they don't correctly include p2pk txs) with blockcypher for tx querying.
* Removes `_maybe_derive_p2pk_address` since now all the APIs we're using decode the address for p2pk correctly.
* Fixes a bug with blockchain.info where some types of TxIOs are omitted when the txs are queried via the `/multiaddr` endpoint (queries using the single address `/rawaddr` endpoint instead which gets the full data - could just requery the individual txs that need it, but that would result in more queries).