### PR TITLE
Fix curve lp divide by zero error

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Fix division by zero error when querying price for LP tokens of empty curve pools.
 * :bug:`10149` Users will now be able to update the historical price within the swap event form.
 * :bug:`10148` History event should not be marked as a customized event if the user only updates the historical price.
 * :bug:`-` Swaps that only differ in their timestamps will now be properly imported from Binance CSVs.

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -979,6 +979,8 @@ class Inquirer:
             node_inquirer=evm_manager.node_inquirer,
             method_name='totalSupply',
         )
+        if total_supply == 0:  # pool is empty
+            return ZERO_PRICE  # avoid division by zero below and skip unneeded network calls.
 
         # Query balances for each token in the pool
         contract = EvmContract(

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -179,7 +179,7 @@ def is_etherscan_rate_limited(response: dict[str, Any]) -> bool:
     """Checks if etherscan is rate limited.
     Suppression is for errors parsing when response does not match etherscan"""
     rate_limited = False
-    with suppress(json.JSONDecodeError, KeyError, UnicodeDecodeError, ValueError):
+    with suppress(json.JSONDecodeError, KeyError, UnicodeDecodeError, ValueError, TypeError):
         body = jsonloads_dict(response['body']['string'])
         rate_limited = (
             int(body.get('status', 0)) == 0 and

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -525,6 +525,18 @@ def test_find_curve_lp_token_price(inquirer: 'Inquirer', blockchain: 'ChainsAggr
         ))).is_close(price)
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_zero_supply_curve_lp_price(inquirer_defi: 'Inquirer'):
+    """Regression test for a division by zero error when querying the price of a curve lp token
+    for a pool with zero supply."""
+    with patch('rotkehlchen.chain.evm.decoding.curve.curve_cache.request_get_dict'):
+        assert inquirer_defi.find_usd_price(
+            asset=Asset('eip155:1/erc20:0xdBE35AAD9f07c631ECD29d72b9D1c226D099729e'),
+        ) == ZERO_PRICE
+
+
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_kfee_price(inquirer):


### PR DESCRIPTION
Fixes a problem where a price query on a curve pool with zero supply was resulting in a division by zero error.

Also fixes a problem in `is_etherscan_rate_limited` that was preventing the cassette from recording correctly. This change has already been made in develop.