### PR TITLE
Fix broken link in Bitcoin address generation docstring

### DIFF
--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -119,7 +119,7 @@ def pubkey_to_base58_address(data: bytes) -> BTCAddress:
 
     Source:
     https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses#How_to_create_Bitcoin_Address
-    https://hackernoon.com/how-to-generate-bitcoin-addresses-technical-address-generation-explanation-rus3z9e
+    https://hackernoon.com/basics-of-paper-wallets-a40639dec8b2
 
     May raise:
     - ValueError, TypeError due to b58encode

--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -119,7 +119,7 @@ def pubkey_to_base58_address(data: bytes) -> BTCAddress:
 
     Source:
     https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses#How_to_create_Bitcoin_Address
-    https://hackernoon.com/basics-of-paper-wallets-a40639dec8b2
+    https://web.archive.org/web/20210608034604/https://hackernoon.com/how-to-generate-bitcoin-addresses-technical-address-generation-explanation-rus3z9e
 
     May raise:
     - ValueError, TypeError due to b58encode


### PR DESCRIPTION
Replaced the outdated Hackernoon link in the pubkey_to_base58_address docstring with a currently working article: "Basics of Paper Wallets" (https://hackernoon.com/basics-of-paper-wallets-a40639dec8b2). This ensures that the documentation references a valid and relevant resource for technical details on Bitcoin address generation. No functional code changes were made.