### PR TITLE
Skip price queries for zero balance tokens

### DIFF
--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -13,6 +13,7 @@ from rotkehlchen.chain.ethereum.utils import (
 from rotkehlchen.chain.evm.decoding.uniswap.v3.constants import UNISWAP_V3_NFT_MANAGER_ADDRESSES
 from rotkehlchen.chain.evm.types import WeightedNode, asset_id_is_evm_token
 from rotkehlchen.chain.structures import EvmTokenDetectionData
+from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.resolver import tokenid_to_collectible_id
 from rotkehlchen.errors.misc import NotFoundError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -469,6 +470,7 @@ class EvmTokens(ABC):  # noqa: B024
                 all_tokens.update(token_list)
                 addresses_to_tokens[address] = token_list
 
+        tokens_with_balance = set()
         multicall_chunks = generate_multicall_chunks(
             addresses_to_tokens=addresses_to_tokens,
             chunk_length=chunk_size,
@@ -479,9 +481,14 @@ class EvmTokens(ABC):  # noqa: B024
                 call_order=call_order,
             )
             for address, balances in new_balances.items():
-                addresses_to_balances[address].update(balances)
+                for token, balance in balances.items():
+                    if balance == ZERO:
+                        continue  # skip any zero balance tokens
 
-        token_usd_price = cast('dict[EvmToken, Price]', Inquirer.find_usd_prices(list(all_tokens)))
+                    tokens_with_balance.add(token)
+                    addresses_to_balances[address][token] = balance
+
+        token_usd_price = cast('dict[EvmToken, Price]', Inquirer.find_usd_prices(list(tokens_with_balance)))  # noqa: E501
         return dict(addresses_to_balances), token_usd_price
 
     def _get_token_exceptions(self) -> set[ChecksumEvmAddress]:

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.evm.tokens import generate_multicall_chunks
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.structures import EvmTokenDetectionData
 from rotkehlchen.constants import ONE
-from rotkehlchen.constants.assets import A_DAI, A_OMG, A_WETH
+from rotkehlchen.constants.assets import A_CRV, A_DAI, A_OMG, A_WETH
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.db.constants import EVM_ACCOUNTS_DETAILS_TOKENS
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -83,6 +83,7 @@ def test_detect_tokens_for_addresses(rotkehlchen_api_server, ethereum_accounts):
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     tokens = rotki.chains_aggregator.ethereum.tokens
     tokens.evm_inquirer.multicall = MagicMock(side_effect=tokens.evm_inquirer.multicall)
+    Inquirer.find_usd_prices = MagicMock(side_effect=Inquirer.find_usd_prices)
     with patch(
         'rotkehlchen.globaldb.handler.GlobalDBHandler.get_token_detection_data',
         side_effect=lambda *args, **kwargs: ([  # mock the returned list to avoid changing this test with every assets version  # noqa: E501
@@ -108,6 +109,14 @@ def test_detect_tokens_for_addresses(rotkehlchen_api_server, ethereum_accounts):
         detection_result = tokens.detect_tokens(False, [addr1, addr2, addr3])
     assert A_WETH in detection_result[addr3][0], 'WETH is owned by the proxy, but should be returned in the proxy owner address'  # noqa: E501
     assert tokens.evm_inquirer.multicall.call_count == 0, 'multicall should not be used for tokens detection'  # noqa: E501
+
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        write_cursor.execute(  # Add a token that there are no actual balances for
+            'INSERT OR REPLACE INTO evm_accounts_details '
+            '(account, chain_id, key, value) VALUES (?, ?, ?, ?)',
+            (addr1, ChainID.ETHEREUM.serialize_for_db(), EVM_ACCOUNTS_DETAILS_TOKENS, A_CRV.identifier),  # noqa: E501
+        )
+
     result, token_usd_prices = tokens.query_tokens_for_addresses(
         [addr1, addr2, addr3, addr3_proxy],
     )
@@ -122,7 +131,7 @@ def test_detect_tokens_for_addresses(rotkehlchen_api_server, ethereum_accounts):
     assert A_WETH in result[addr3_proxy], 'WETH (which is owned by the proxy) is in the result of the proxy'  # noqa: E501
     assert A_WETH not in result[addr3], 'WETH is not in the result of the proxy owner address'
 
-    # test that  ignored assets are not queried
+    # test that ignored assets are not queried
     assert A_LPT not in result[addr1] and A_LPT not in result[addr2]
     found_tokens = set(result[addr1].keys()).union(
         set(result[addr2].keys()),
@@ -132,6 +141,10 @@ def test_detect_tokens_for_addresses(rotkehlchen_api_server, ethereum_accounts):
         set(result[addr3_proxy].keys()),
     )
     assert len(token_usd_prices) == len(found_tokens)
+
+    # Confirm that prices were not queried for a token in evm_accounts_details that has no balance.
+    assert A_CRV not in found_tokens
+    assert all(asset in found_tokens for asset in Inquirer.find_usd_prices.call_args_list[0][0][0])
 
 
 def test_generate_chunks():


### PR DESCRIPTION
Fixes a problem where any tokens added to evm_accounts_details under the EVM_ACCOUNTS_DETAILS_TOKENS key were getting their prices queried even if there was zero balance. We were already querying balances for the tokens right before fetching prices, so just needed to filter out the ones with zero balance.

This was noticed while working on https://github.com/rotki/rotki/pull/10207