### PR TITLE
Delete btc tx events via blockchain tx endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2010,7 +2010,7 @@ Deleting locally saved blockchain transactions
 
 .. http:delete:: /api/(version)/blockchains/transactions
 
-   Doing a DELETE on the blockchain transactions endpoint will either delete locally saved transaction data. If nothing is given all transaction data will be deleted. Can specify the chain to only delete all transactions of that chain. Or even further chain and tx_hash to delete only a specific transaction's data.
+   Doing a DELETE on the blockchain transactions endpoint will delete locally saved transaction data. If nothing is given all transaction data will be deleted. Can specify the chain to only delete all transactions of that chain. Or even further chain and tx_hash to delete only a specific transaction's data (although this is only supported for EVM and EVM-like chains). If chain is Bitcoin, the cached last queried block will also be deleted to allow all txs to be requeried.
 
    **Example Request**:
 
@@ -2023,7 +2023,7 @@ Deleting locally saved blockchain transactions
       {"chain": "eth", "tx_hash": "0x6826b8646578ff457ba01bfe6a2cc77e3d6e40a849e45a97ca12dfd9150cd901"}
 
    :reqjson string chain: Optional. The name of the chain for which to delete transaction. ``"eth"``, ``"optimism"``, ``"zksync_lite"`` etc. If not given all transactions for all chains are purged. This is using the backend's SupportedBlockchain with the limitation being only chains for which we save transactions.
-   :reqjson string tx_hash: Optional. The transaction to delete. If given only the specific transaction is deleted. This should always be given in combination with the chain argument.
+   :reqjson string tx_hash: Optional. The transaction to delete. If given only the specific transaction is deleted. This should always be given in combination with the chain argument. May only be used for EVM and EVM-like chains.
 
    **Example Response**:
 

--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -383,8 +383,15 @@ class FloatingPercentageField(fields.Field[FVal]):
 
 class BlockchainField(fields.Field):
 
-    def __init__(self, *, exclude_types: Sequence[SupportedBlockchain] | None = None, **kwargs: Any) -> None:  # noqa: E501
+    def __init__(
+            self,
+            *,
+            exclude_types: Sequence[SupportedBlockchain] | None = None,
+            allow_only: Sequence[SupportedBlockchain] | None = None,
+            **kwargs: Any,
+    ) -> None:
         self.exclude_types = exclude_types
+        self.allow_only = allow_only
         super().__init__(**kwargs)
 
     def _deserialize(

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -238,11 +238,11 @@ from rotkehlchen.serialization.schemas import (
 )
 from rotkehlchen.serialization.serialize import process_result
 from rotkehlchen.types import (
+    CHAINS_WITH_TRANSACTIONS_TYPE,
     EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
     SOLANA_TOKEN_KINDS,
     SUPPORTED_CHAIN_IDS,
     SUPPORTED_EVM_CHAINS_TYPE,
-    SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
     AddressbookEntry,
     AddressbookType,
     ApiKey,
@@ -634,10 +634,10 @@ class BlockchainTransactionsResource(BaseMethodView):
     @use_kwargs(delete_schema, location='json')
     def delete(
             self,
-            chain: SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE | None,
+            chain: CHAINS_WITH_TRANSACTIONS_TYPE | None,
             tx_hash: EVMTxHash | None,
     ) -> Response:
-        return self.rest_api.delete_blockchain_transaction_data(chain=chain, tx_hash=tx_hash)
+        return self.rest_api.delete_blockchain_transaction_data(chain=chain, tx_hash=tx_hash)  # type: ignore[arg-type] # schema ensures chain is included when tx_hash is present.
 
 
 class EvmTransactionsResource(BaseMethodView):

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -86,7 +86,7 @@ class DBCacheDynamic(Enum):
     EXTRA_INTERNAL_TX: Final = f'{EXTRAINTERNALTXPREFIX}_{{chain_id}}_{{receiver}}_{{tx_hash}}', string_to_evm_address  # noqa: E501
     LAST_PRODUCED_BLOCKS_QUERY_TS: Final = 'last_produced_blocks_query_ts_{index}', _deserialize_timestamp_from_str  # noqa: E501
     BINANCE_PAIR_LAST_ID: Final = '{location}_{location_name}_{queried_pair}', _deserialize_int_from_str  # noqa: E501  # notice that location is added because it can be either binance or binance_us
-    LAST_BITCOIN_TX_BLOCK: Final = '{address}_last_tx_block', _deserialize_int_from_str
+    LAST_BITCOIN_TX_BLOCK: Final = 'last_bitcoin_tx_block_{address}', _deserialize_int_from_str
 
     @overload
     def get_db_key(self, **kwargs: Unpack[LabeledLocationArgsType]) -> str:

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -243,8 +243,9 @@ class DBEvmTx:
 
     def delete_evm_transaction_data(
             self,
-            chain: SUPPORTED_EVM_CHAINS_TYPE | None,
-            tx_hash: EVMTxHash | None,
+            write_cursor: 'DBCursor',
+            chain: SUPPORTED_EVM_CHAINS_TYPE | None = None,
+            tx_hash: EVMTxHash | None = None,
     ) -> None:
         """Deletes evm transaction related data from the DB.
         Either all data, data related to a single chain or a single chain/tx_hash only"""
@@ -268,14 +269,12 @@ class DBEvmTx:
                     (f'{entry.to_range_prefix("internaltxs")}\\_%', '\\'),
                     (f'{entry.to_range_prefix("tokentxs")}\\_%', '\\'),
                 ])
-                with self.db.user_write() as write_cursor:
-                    write_cursor.executemany(
-                        'DELETE FROM used_query_ranges WHERE name LIKE ? ESCAPE ?;',
-                        query_ranges_tuples,
-                    )
+                write_cursor.executemany(
+                    'DELETE FROM used_query_ranges WHERE name LIKE ? ESCAPE ?;',
+                    query_ranges_tuples,
+                )
 
-        with self.db.user_write() as write_cursor:  # finally delete transactions
-            write_cursor.execute(delete_query, delete_bindings)
+        write_cursor.execute(delete_query, delete_bindings)  # finally delete transactions
 
     def get_transaction_hashes_no_receipt(
             self,

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -189,7 +189,7 @@ def test_tx_decode(ethereum_transaction_decoder, database):
         assert write_cursor.execute('SELECT COUNT(*) from evm_events_info').fetchone()[0] == 2
         assert write_cursor.execute('SELECT COUNT(*) from evm_tx_mappings').fetchone()[0] == 1
 
-        dbevents.reset_evm_events_for_redecode(write_cursor, Location.ETHEREUM)
+        dbevents.reset_events_for_redecode(write_cursor, Location.ETHEREUM)
         # after deletion we only keep the customized event
         assert write_cursor.execute('SELECT event_identifier from history_events').fetchall() == [(events[1].event_identifier,)]  # noqa: E501
         assert write_cursor.execute('SELECT identifier from evm_events_info').fetchall() == [(events[1].identifier,)]  # noqa: E501

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -899,8 +899,8 @@ class Location(DBCharEnumMixIn):
         return ChainID.POLYGON_POS.value
 
     @staticmethod
-    def from_chain(chain: SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE) -> 'BLOCKCHAIN_LOCATIONS_TYPE':
-        assert chain in SUPPORTED_EVM_EVMLIKE_CHAINS
+    def from_chain(chain: CHAINS_WITH_TRANSACTIONS_TYPE) -> 'BLOCKCHAIN_LOCATIONS_TYPE':
+        assert chain in CHAINS_WITH_TRANSACTIONS
         match chain:
             case SupportedBlockchain.ETHEREUM:
                 return Location.ETHEREUM
@@ -920,6 +920,8 @@ class Location(DBCharEnumMixIn):
                 return Location.BINANCE_SC
             case SupportedBlockchain.ZKSYNC_LITE:
                 return Location.ZKSYNC_LITE
+            case SupportedBlockchain.BITCOIN:
+                return Location.BITCOIN
             case _:  # should never happen
                 raise AssertionError(f'Got in Location.from_chain for {chain}')
 
@@ -931,8 +933,7 @@ EVMLIKE_LOCATIONS: tuple[EVMLIKE_LOCATIONS_TYPE, ...] = typing.get_args(EVMLIKE_
 EVM_EVMLIKE_LOCATIONS_TYPE = EVM_LOCATIONS_TYPE | EVMLIKE_LOCATIONS_TYPE
 EVM_EVMLIKE_LOCATIONS: tuple[EVM_EVMLIKE_LOCATIONS_TYPE, ...] = EVM_LOCATIONS + EVMLIKE_LOCATIONS
 
-# For now Location enum has only evmlike chains. This will change so keep separate variable
-BLOCKCHAIN_LOCATIONS_TYPE: TypeAlias = EVM_EVMLIKE_LOCATIONS_TYPE
+BLOCKCHAIN_LOCATIONS_TYPE: TypeAlias = EVM_EVMLIKE_LOCATIONS_TYPE | Literal[Location.BITCOIN]
 
 
 class ExchangeAuthCredentials(NamedTuple):


### PR DESCRIPTION
Related: #2880 and https://github.com/orgs/rotki/projects/11?pane=issue&itemId=116283961

Allows deleting btc tx data from the db via `DELETE /blockchains/transactions` as requested by frontend in [discord](https://discord.com/channels/657906918408585217/1390719860538867762/1390720453030576182)