### PR TITLE
Adjust monerium/gnosispay error message

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3713,7 +3713,7 @@ class RestAPI:
             if query_type == HistoryEventQueryType.GNOSIS_PAY:
                 if (gnosis_pay := init_gnosis_pay(self.rotkehlchen.data.db)) is None:
                     return wrap_in_fail_result(
-                        message='Gnosis Pay module could not be initialized',
+                        message='Unable to refresh Gnosis Pay data due to missing credentials',
                         status_code=HTTPStatus.CONFLICT,
                     )
                 gnosis_pay.get_and_process_transactions(after_ts=Timestamp(0))
@@ -3721,7 +3721,7 @@ class RestAPI:
             elif query_type == HistoryEventQueryType.MONERIUM:
                 if (monerium := init_monerium(self.rotkehlchen.data.db)) is None:
                     return wrap_in_fail_result(
-                        message='Monerium module could not be initialized',
+                        message='Unable to refresh Monerium data due to missing credentials',
                         status_code=HTTPStatus.CONFLICT,
                     )
                 monerium.get_and_process_orders()

--- a/rotkehlchen/tests/api/test_query_online_events.py
+++ b/rotkehlchen/tests/api/test_query_online_events.py
@@ -26,13 +26,13 @@ def test_refresh_gnosis_pay_and_monerium(
         'gnosis_pay',
         'rotkehlchen.externalapis.gnosispay.GnosisPay.get_and_process_transactions',
         ExternalService.GNOSIS_PAY,
-        'Gnosis Pay module could not be initialized',
+        'Unable to refresh Gnosis Pay data due to missing credentials',
         call(after_ts=Timestamp(0)),
     ), (
         'monerium',
         'rotkehlchen.externalapis.monerium.Monerium.get_and_process_orders',
         ExternalService.MONERIUM,
-        'Monerium module could not be initialized',
+        'Unable to refresh Monerium data due to missing credentials',
         call(),
     )):
         with patch(patch_path) as mock_query_service:


### PR DESCRIPTION
Adjust the error message when monerium or gnosis pay refresh is triggered without proper credentials for the respective services. Requested by @lukicenturi to make the error more informative.
