### PR TITLE
fix broken link to clikraken repository

### DIFF
--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1,5 +1,5 @@
 # Good kraken and python resource:
-# https://github.com/zertrin/clikraken/tree/master/clikraken
+# https://github.com/zertrin/clikraken/tree/master/src/clikraken
 import base64
 import hashlib
 import hmac


### PR DESCRIPTION
 Update link path from /clikraken to /src/clikraken to fix 404 error