### PR TITLE
fix: remove unnecessary multiline flag from regex in date formatter

### DIFF
--- a/frontend/app/src/data/date-formatter.ts
+++ b/frontend/app/src/data/date-formatter.ts
@@ -1,5 +1,5 @@
 export class DateFormatter {
-  private regex = /%-?[A-Za-z]/gm;
+  private regex = /%-?[A-Za-z]/g;
   private translations: Record<string, (date: Date, locale?: string) => string> = {
     '-d': (date, locale) => date.toLocaleDateString(locale, { day: 'numeric' }),
     '-H': date => date.getHours().toString(),


### PR DESCRIPTION
remove unnecessary flag that has no effect on the regex pattern's behavior since it doesn't use ^ or $ anchors