### PR TITLE
Adjust api etc for bch txs/events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2010,7 +2010,7 @@ Deleting locally saved blockchain transactions
 
 .. http:delete:: /api/(version)/blockchains/transactions
 
-   Doing a DELETE on the blockchain transactions endpoint will delete locally saved transaction data. If nothing is given all transaction data will be deleted. Can specify the chain to only delete all transactions of that chain. Or even further chain and tx_hash to delete only a specific transaction's data (although this is only supported for EVM and EVM-like chains). If chain is Bitcoin, the cached last queried block will also be deleted to allow all txs to be requeried.
+   Doing a DELETE on the blockchain transactions endpoint will delete locally saved transaction data. If nothing is given all transaction data will be deleted. Can specify the chain to only delete all transactions of that chain. Or even further chain and tx_hash to delete only a specific transaction's data (although this is only supported for EVM and EVM-like chains). If chain is Bitcoin or Bitcoin Cash, the cached last queried block will also be deleted to allow all txs to be requeried.
 
    **Example Request**:
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -45,7 +45,7 @@ from rotkehlchen.chain.substrate.utils import (
     get_substrate_address_from_public_key,
     is_valid_substrate_address,
 )
-from rotkehlchen.constants.assets import A_BTC, A_ETH, A_ETH2
+from rotkehlchen.constants.assets import A_BCH, A_BTC, A_ETH, A_ETH2
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.constants.resolver import EVM_CHAIN_DIRECTIVE
 from rotkehlchen.data_import.manager import DataImportSource
@@ -806,9 +806,13 @@ class CreateHistoryEventSchema(Schema):
                 data: dict[str, Any],
                 **_kwargs: Any,
         ) -> dict[str, Any]:
-            if data['location'] == Location.BITCOIN and data['asset'] != A_BTC:
+            if (
+                ((location := data['location']) == Location.BITCOIN and data['asset'] != A_BTC) or
+                (location == Location.BITCOIN_CASH and data['asset'] != A_BCH)
+            ):
+                expected_asset = 'BTC' if location == Location.BITCOIN else 'BCH'
                 raise ValidationError(
-                    message='Bitcoin events must use BTC as the asset',
+                    message=f'{location.name.lower()} events must use {expected_asset} as the asset',  # noqa: E501
                     field_name='asset',
                 )
 

--- a/rotkehlchen/chain/bitcoin/bch/manager.py
+++ b/rotkehlchen/chain/bitcoin/bch/manager.py
@@ -14,6 +14,7 @@ from rotkehlchen.chain.bitcoin.bch.utils import (
 )
 from rotkehlchen.chain.bitcoin.manager import BitcoinCommonManager
 from rotkehlchen.chain.bitcoin.types import BitcoinTx, BtcApiCallback, BtcTxIO, BtcTxIODirection
+from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -42,6 +43,7 @@ class BitcoinCashManager(BitcoinCommonManager):
             blockchain=SupportedBlockchain.BITCOIN_CASH,
             asset=A_BCH,
             event_identifier_prefix=BCH_EVENT_IDENTIFIER_PREFIX,
+            cache_key=DBCacheDynamic.LAST_BCH_TX_BLOCK,
             api_callbacks=[BtcApiCallback(
                 name='haskoin',
                 balances_fn=self._query_haskoin_balances,

--- a/rotkehlchen/chain/bitcoin/btc/manager.py
+++ b/rotkehlchen/chain/bitcoin/btc/manager.py
@@ -16,6 +16,7 @@ from rotkehlchen.chain.bitcoin.btc.constants import (
 from rotkehlchen.chain.bitcoin.manager import BitcoinCommonManager
 from rotkehlchen.chain.bitcoin.types import BitcoinTx, BtcApiCallback, BtcTxIO, BtcTxIODirection
 from rotkehlchen.constants.assets import A_BTC
+from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
@@ -43,6 +44,7 @@ class BitcoinManager(BitcoinCommonManager):
             blockchain=SupportedBlockchain.BITCOIN,
             asset=A_BTC,
             event_identifier_prefix=BTC_EVENT_IDENTIFIER_PREFIX,
+            cache_key=DBCacheDynamic.LAST_BTC_TX_BLOCK,
             api_callbacks=[BtcApiCallback(
                 name='blockchain.info',
                 balances_fn=self._query_blockchain_info_balances,

--- a/rotkehlchen/chain/bitcoin/manager.py
+++ b/rotkehlchen/chain/bitcoin/manager.py
@@ -46,6 +46,7 @@ class BitcoinCommonManager:
             blockchain: Literal[SupportedBlockchain.BITCOIN, SupportedBlockchain.BITCOIN_CASH],
             asset: Asset,
             event_identifier_prefix: str,
+            cache_key: Literal[DBCacheDynamic.LAST_BTC_TX_BLOCK, DBCacheDynamic.LAST_BCH_TX_BLOCK],
             api_callbacks: list[BtcApiCallback],
     ) -> None:
         """Common class for the bitcoin and bitcoin cash managers."""
@@ -55,6 +56,7 @@ class BitcoinCommonManager:
         self.location = Location.from_chain(self.blockchain)
         self.asset = asset
         self.event_identifier_prefix = event_identifier_prefix
+        self.cache_key = cache_key
         self.api_callbacks = api_callbacks
 
     def refresh_tracked_accounts(self) -> None:
@@ -190,7 +192,7 @@ class BitcoinCommonManager:
             for address in addresses:
                 block_height = self.database.get_dynamic_cache(
                     cursor=cursor,
-                    name=DBCacheDynamic.LAST_BITCOIN_TX_BLOCK,
+                    name=self.cache_key,
                     address=address,
                 ) or 0
                 accounts_by_latest_query[block_height].append(address)
@@ -230,7 +232,7 @@ class BitcoinCommonManager:
             for address in addresses:
                 self.database.set_dynamic_cache(
                     write_cursor=write_cursor,
-                    name=DBCacheDynamic.LAST_BITCOIN_TX_BLOCK,
+                    name=self.cache_key,
                     value=new_block_height,
                     address=address,
                 )

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -86,7 +86,8 @@ class DBCacheDynamic(Enum):
     EXTRA_INTERNAL_TX: Final = f'{EXTRAINTERNALTXPREFIX}_{{chain_id}}_{{receiver}}_{{tx_hash}}', string_to_evm_address  # noqa: E501
     LAST_PRODUCED_BLOCKS_QUERY_TS: Final = 'last_produced_blocks_query_ts_{index}', _deserialize_timestamp_from_str  # noqa: E501
     BINANCE_PAIR_LAST_ID: Final = '{location}_{location_name}_{queried_pair}', _deserialize_int_from_str  # noqa: E501  # notice that location is added because it can be either binance or binance_us
-    LAST_BITCOIN_TX_BLOCK: Final = 'last_bitcoin_tx_block_{address}', _deserialize_int_from_str
+    LAST_BTC_TX_BLOCK: Final = 'last_btc_tx_block_{address}', _deserialize_int_from_str
+    LAST_BCH_TX_BLOCK: Final = 'last_bch_tx_block_{address}', _deserialize_int_from_str
 
     @overload
     def get_db_key(self, **kwargs: Unpack[LabeledLocationArgsType]) -> str:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -762,7 +762,7 @@ class DBHandler:
     def get_dynamic_cache(
             self,
             cursor: 'DBCursor',
-            name: Literal[DBCacheDynamic.LAST_BITCOIN_TX_BLOCK],
+            name: Literal[DBCacheDynamic.LAST_BTC_TX_BLOCK, DBCacheDynamic.LAST_BCH_TX_BLOCK],
             **kwargs: Unpack[AddressArgType],
     ) -> int | None:
         ...
@@ -898,7 +898,7 @@ class DBHandler:
     def set_dynamic_cache(
             self,
             write_cursor: 'DBCursor',
-            name: Literal[DBCacheDynamic.LAST_BITCOIN_TX_BLOCK],
+            name: Literal[DBCacheDynamic.LAST_BTC_TX_BLOCK, DBCacheDynamic.LAST_BCH_TX_BLOCK],
             value: int,
             **kwargs: Unpack[AddressArgType],
     ) -> None:

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -845,6 +845,18 @@ class Location(DBCharEnumMixIn):
             case _:  # should never happen
                 raise AssertionError(f'Got in Location.from_chain for {chain}')
 
+    def is_evm(self) -> bool:
+        return self in EVM_LOCATIONS
+
+    def is_evmlike(self) -> bool:
+        return self in EVMLIKE_LOCATIONS
+
+    def is_evm_or_evmlike(self) -> bool:
+        return self in EVM_EVMLIKE_LOCATIONS
+
+    def is_bitcoin(self) -> bool:
+        return self in BITCOIN_LOCATIONS
+
 
 EVM_LOCATIONS_TYPE = Literal[Location.ETHEREUM, Location.OPTIMISM, Location.POLYGON_POS, Location.ARBITRUM_ONE, Location.BASE, Location.GNOSIS, Location.SCROLL, Location.BINANCE_SC]  # noqa: E501
 EVM_LOCATIONS: tuple[EVM_LOCATIONS_TYPE, ...] = typing.get_args(EVM_LOCATIONS_TYPE)
@@ -852,8 +864,10 @@ EVMLIKE_LOCATIONS_TYPE = Literal[Location.ZKSYNC_LITE]
 EVMLIKE_LOCATIONS: tuple[EVMLIKE_LOCATIONS_TYPE, ...] = typing.get_args(EVMLIKE_LOCATIONS_TYPE)
 EVM_EVMLIKE_LOCATIONS_TYPE = EVM_LOCATIONS_TYPE | EVMLIKE_LOCATIONS_TYPE
 EVM_EVMLIKE_LOCATIONS: tuple[EVM_EVMLIKE_LOCATIONS_TYPE, ...] = EVM_LOCATIONS + EVMLIKE_LOCATIONS
-
-BLOCKCHAIN_LOCATIONS_TYPE: TypeAlias = EVM_EVMLIKE_LOCATIONS_TYPE | Literal[Location.BITCOIN, Location.BITCOIN_CASH]  # noqa: E501
+BITCOIN_LOCATIONS_TYPE = Literal[Location.BITCOIN, Location.BITCOIN_CASH]
+BITCOIN_LOCATIONS: tuple[BITCOIN_LOCATIONS_TYPE, ...] = typing.get_args(BITCOIN_LOCATIONS_TYPE)
+BLOCKCHAIN_LOCATIONS_TYPE: TypeAlias = EVM_EVMLIKE_LOCATIONS_TYPE | BITCOIN_LOCATIONS_TYPE
+BLOCKCHAIN_LOCATIONS: tuple[BLOCKCHAIN_LOCATIONS_TYPE, ...] = EVM_EVMLIKE_LOCATIONS + BITCOIN_LOCATIONS  # noqa: E501
 
 
 class ExchangeAuthCredentials(NamedTuple):


### PR DESCRIPTION
Related: #2880 and https://github.com/orgs/rotki/projects/11?pane=issue&itemId=116283961

* Allows deleting bch events
* Adds validation to ensure bch events can only have an asset of BCH
* Makes btc and bch use different DBCacheDynamic keys for their last cached block to allow deleting separately and also to avoid address collisions (very unlikely but possible with legacy addresses)

~~NOTE: this PR builds on changes in #10272 so only pay attention to the second commit here until that is merged.~~ 10272 is merged now.