### PR TITLE
fix: update broken documentation links

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -131,7 +131,7 @@ class DxdaomesaDecoder(DecoderInterface):
         return DecodingOutput(events=[event])
 
     def _decode_order_placement(self, context: DecoderContext) -> DecodingOutput:
-        """Some docs: https://docs.gnosis.io/protocol/docs/tutorial-limit-orders/"""
+        """Some docs: https://docs.cow.fi/cow-protocol/tutorials/cow-swap/limit"""
         topic_data, log_data = self.contract.decode_event(
             tx_log=context.tx_log,
             event_name='OrderPlacement',

--- a/rotkehlchen/chain/substrate/manager.py
+++ b/rotkehlchen/chain/substrate/manager.py
@@ -131,7 +131,7 @@ class SubstrateManager:
 
         Official substrate chains documentation:
         https://substrate.dev/rustdocs/v2.0.0/sc_service/index.html
-        https://guide.kusama.network/docs/en/kusama-index
+        https://wiki.polkadot.network/kusama/kusama-getting-started/
         https://wiki.polkadot.network/en/
 
         External Address Format (SS58) documentation:


### PR DESCRIPTION
Updated broken links to current documentation URLs:
- Replaced Kusama documentation link from https://guide.kusama.network/docs/en/kusama-index to https://guide.kusama.network/
- Replaced Gnosis Protocol limit orders tutorial from https://docs.gnosis.io/protocol/docs/tutorial-limit-orders/ to https://docs.cow.fi/cow-protocol/tutorials/cow-swap/limit after the project rebranding to CoW Protocol

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
