### PR TITLE
Catch web3 AttributeError

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -582,6 +582,7 @@ class EvmNodeInquirer(ABC, LockableQueryMixIn):
                     Web3Exception,
                     TypeError,  # happened at the web3 level calling `apply_result_formatters` when the RPC node returned `None` in the response's result # noqa: E501
                     ValueError,  # not removing yet due to possibility of raising from missing trie error  # noqa: E501
+                    AttributeError,  # happened at the web3 level when response is a string instead of dict # noqa: E501
             ) as e:
                 log.warning(
                     f'Failed to query {node_info.name} with position on the query list {node_idx} '


### PR DESCRIPTION
Probably this is an error that should also not be raised in the first place by web3.py

Handles: https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=120745154

This must have happened when some kind of error is raised by by the rpc node and instead of a dictionary a plain string error is returned.

Seen by Yabir:
```
[21/07/2025 09:32:04 CEST] ERROR rotkehlchen.api.rest Greenlet with id 4632723648: Greenlet for task 11 dies with exception: 'str' object has no attribute 'get'.
Exception Name: <class 'AttributeError'>
Exception Info: 'str' object has no attribute 'get'
Traceback:
   File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "/Users/yabirgb/work/rotki/rotkehlchen/api/rest.py", line 479, in _do_query_async
    result = command(self, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/api/rest.py", line 889, in query_blockchain_balances
    balances = self.rotkehlchen.chains_aggregator.query_balances(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/utils/mixins/lockable.py", line 48, in wrapper
    return f(wrappingobj, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/utils/mixins/cacheable.py", line 119, in wrapper
    result = f(wrappingobj, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/aggregator.py", line 580, in query_balances
    getattr(self, query_method)(ignore_cache=ignore_cache)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/utils/mixins/lockable.py", line 48, in wrapper
    return f(wrappingobj, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/utils/mixins/cacheable.py", line 119, in wrapper
    result = f(wrappingobj, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/aggregator.py", line 1024, in query_optimism_balances
    self.query_evm_chain_balances(chain=SupportedBlockchain.OPTIMISM)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/aggregator.py", line 1011, in query_evm_chain_balances
    self.query_evm_tokens(manager=manager, balances=chain_balances)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/aggregator.py", line 963, in query_evm_tokens
    balance_result, token_usd_price = manager.tokens.query_tokens_for_addresses(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/evm/tokens.py", line 492, in query_tokens_for_addresses
    token_usd_price = cast('dict[EvmToken, Price]', Inquirer.find_usd_prices(list(tokens_with_balance)))  # noqa: E501
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/inquirer.py", line 874, in find_usd_prices
    return Inquirer.find_prices(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/inquirer.py", line 817, in find_prices
    for asset, price_and_oracle in Inquirer._find_prices(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/inquirer.py", line 776, in _find_prices
    found_prices.update(Inquirer._query_oracle_instances(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/inquirer.py", line 568, in _query_oracle_instances
    prices, unpriced_assets = Inquirer._try_oracle_price_query(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/inquirer.py", line 492, in _try_oracle_price_query
    prices = oracle_instance.query_multiple_current_prices(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/interfaces.py", line 74, in query_multiple_current_prices
    if (price := self.query_current_price(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/oracles/uniswap.py", line 340, in query_current_price
    return self.get_price(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/oracles/uniswap.py", line 293, in get_price
    route = self.find_route(from_token, to_token)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/oracles/uniswap.py", line 213, in find_route
    found_first_link = self._find_pool_for(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/oracles/uniswap.py", line 174, in _find_pool_for
    pools = self.get_pool(asset, link_asset)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/utils/mixins/cacheable.py", line 119, in wrapper
    result = f(wrappingobj, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/ethereum/oracles/uniswap.py", line 549, in get_pool
    result = self.uniswap_factories[token_0.chain_id].call(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/evm/contracts.py", line 46, in call
    return node_inquirer.call_contract(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/evm/node_inquirer.py", line 718, in call_contract
    return self._query(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/evm/node_inquirer.py", line 538, in _query
    success, _ = self.attempt_connect(node=node_info)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/rotkehlchen/chain/evm/node_inquirer.py", line 477, in attempt_connect
    current_block = web3.eth.block_number  # pylint: disable=no-member
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/eth/eth.py", line 145, in block_number
    return self.get_block_number()
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/module.py", line 112, in caller
    result = w3.manager.request_blocking(
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/manager.py", line 231, in request_blocking
    response = self._make_request(method, params)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/manager.py", line 163, in _make_request
    return request_func(method, params)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/middleware/base.py", line 56, in middleware
    return self.response_processor(method, make_request(method, params))
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/middleware/base.py", line 56, in middleware
    return self.response_processor(method, make_request(method, params))
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/middleware/formatting.py", line 169, in response_processor
    return _apply_response_formatters(
    ^^^^^^^^^^^^^^^^^
  File "cytoolz/functoolz.pyx", line 268, in cytoolz.functoolz.curry.__call__
    return self.func(*args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/yabirgb/work/rotki/.venv/lib/python3.11/site-packages/web3/middleware/formatting.py", line 80, in _apply_response_formatters
    if response.get("result") is not None and method in result_formatters:
```

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
