### PR TITLE
fix: use more idiomatic empty list check in globaldb_get_setting_value

### DIFF
--- a/rotkehlchen/globaldb/utils.py
+++ b/rotkehlchen/globaldb/utils.py
@@ -42,7 +42,7 @@ def globaldb_get_setting_value(cursor: 'DBCursor', name: str, default_value: int
     )
     result = query.fetchall()
     # If setting is not set, it's the default
-    if len(result) == 0:
+    if not result:
         return default_value
 
     return int(result[0][0])


### PR DESCRIPTION
Replace 'len(result) == 0' with the more Pythonic 'not result' when checking for empty lists in the globaldb_get_setting_value function. This change follows Python's idiomatic approach for testing empty collections, making the code more readable while maintaining identical functionality