### PR TITLE
Add a cursor clearing for interface error retrying

### DIFF
--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -5,7 +5,7 @@ but heavily modified"""
 import random
 import sqlite3
 from collections.abc import Generator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from enum import Enum, auto
 from pathlib import Path
 from types import TracebackType
@@ -93,6 +93,8 @@ class DBCursor:
         except (sqlcipher.InterfaceError, sqlite3.InterfaceError):  # pylint: disable=no-member
             # Long story. Don't judge me. https://github.com/rotki/rotki/issues/5432
             logger.debug(f'{statement} with {bindings} failed due to https://github.com/rotki/rotki/issues/5432. Retrying')  # noqa: E501
+            with suppress(Exception):  # Try to clear any partial results
+                self._cursor.fetchall()
             self._cursor.execute(statement, *bindings)
 
         if __debug__:


### PR DESCRIPTION
Related to https://github.com/rotki/rotki/issues/5432

We got this exception in 1.39.1

```
[24/07/2025 23:29:52 CEST] DEBUG rotkehlchen.db.drivers.gevent SELECT start_ts, end_ts FROM used_query_ranges WHERE name=? with (('GNOSISinternaltxs_0x5F4b6233071ce16aCCF71c7779e43ab322C2788D',),) failed due to https://github.com/rotki/rotki/issues/5432. Retrying
[24/07/2025 23:29:52 CEST] DEBUG rotkehlchen.chain.evm.transactions Greenlet-12: Querying gnosis internal transactions for 0x5F4b6233071ce16aCCF71c7779e43ab322C2788D -> 1753305721 - 1753392591
[24/07/2025 23:29:52 CEST] DEBUG rotkehlchen.externalapis.etherscan Greenlet-12: Querying etherscan for gnosis: https://api.etherscan.io/v2/api with params: {'module': 'account', 'action': 'txlistinternal', 'apikey': 'XXX', 'chainid': '100', 'sort': 'asc', 'address': '0x5F4b6233071ce16aCCF71c7779e43ab322C2788D', 'startBlock': '41239873', 'endBlock': '41256747'}
[24/07/2025 23:29:52 CEST] ERROR rotkehlchen.api.rest Greenlet with id 140305329810880: Greenlet for task 110 dies with exception: tuple index out of range.
Exception Name: <class 'IndexError'>
Exception Info: tuple index out of range
Traceback:
   File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/api/rest.py", line 474, in _do_query_async
  File "rotkehlchen/api/rest.py", line 2748, in refresh_evm_transactions
  File "rotkehlchen/chain/evm/transactions.py", line 179, in query_chain
  File "rotkehlchen/chain/evm/transactions.py", line 78, in wrapper
  File "rotkehlchen/chain/evm/transactions.py", line 140, in single_address_query_transactions
  File "rotkehlchen/chain/evm/transactions.py", line 366, in _get_internal_transactions_for_ranges
  File "rotkehlchen/db/ranges.py", line 29, in get_location_query_ranges
  File "rotkehlchen/db/dbhandler.py", line 1127, in
  get_used_query_range
 ```

The only way this can happen is if somehow the cursor or DB state is
corrupt and the retry cursor execute goes in with corrupt data and
then the result is unexpected and causes this IndexError.

To try and mitigate this we clear the cursor with a fetchall before
the retry. This is not tested, and is really just an assumption that
would not hurt.

