### PR TITLE
Allow refreshing balances of a single exchange account

### DIFF
--- a/frontend/app/src/composables/balances/refresh.ts
+++ b/frontend/app/src/composables/balances/refresh.ts
@@ -12,7 +12,7 @@ import { awaitParallelExecution } from '@/utils/await-parallel-execution';
 
 export const useRefresh = createSharedComposable(() => {
   const { fetchBlockchainBalances, fetchLoopringBalances } = useBlockchainBalances();
-  const { fetchConnectedExchangeBalances } = useExchanges();
+  const { fetchConnectedExchangeBalances, fetchSelectedExchangeBalances } = useExchanges();
   const { blockchainRefreshButtonBehaviour } = storeToRefs(useFrontendSettingsStore());
   const { massDetecting } = storeToRefs(useBlockchainTokensStore());
   const { txEvmChains } = useSupportedChains();
@@ -63,10 +63,15 @@ export const useRefresh = createSharedComposable(() => {
       await fetchConnectedExchangeBalances(true);
   };
 
+  const refreshExchangeBalance = async (exchangeLocation: string): Promise<void> => {
+    await fetchSelectedExchangeBalances(exchangeLocation);
+  };
+
   return {
     handleBlockchainRefresh,
     massDetectTokens,
     refreshBalance,
     refreshBlockchainBalances,
+    refreshExchangeBalance,
   };
 });

--- a/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
@@ -19,6 +19,7 @@ import { isTaskCancelled } from '@/utils';
 
 interface UseExchangesReturn {
   fetchConnectedExchangeBalances: (refresh?: boolean) => Promise<void>;
+  fetchSelectedExchangeBalances: (exchangeLocation: string) => Promise<void>;
   fetchExchangeBalances: (payload: ExchangeBalancePayload) => Promise<void>;
   addExchange: (exchange: Exchange) => void;
   editExchange: (payload: EditExchange) => void;
@@ -102,6 +103,12 @@ export function useExchanges(): UseExchangesReturn {
     }
   };
 
+  const fetchSelectedExchangeBalances = async (exchangeLocation: string): Promise<void> => {
+    await fetchExchangeBalances({
+      ignoreCache: true,
+      location: exchangeLocation,
+    });
+  };
   const addExchange = (exchange: Exchange): void => {
     setConnectedExchanges([...get(connectedExchanges), exchange]);
   };
@@ -214,6 +221,7 @@ export function useExchanges(): UseExchangesReturn {
     editExchange,
     fetchConnectedExchangeBalances,
     fetchExchangeBalances,
+    fetchSelectedExchangeBalances,
     removeExchange,
     setupExchange,
   };


### PR DESCRIPTION
Closes  https://github.com/rotki/rotki/issues/1525

## Checklist

- [ ] The PR modified the frontend only, as the backend already had the query exchange balances API, which can be used to retrieve the balances of a single exchange account