### PR TITLE
Calendar matching should be exact

### DIFF
--- a/rotkehlchen/db/calendar.py
+++ b/rotkehlchen/db/calendar.py
@@ -9,7 +9,6 @@ from rotkehlchen.db.filtering import (
     DBFilterQuery,
     DBMultiIntegerFilter,
     DBOptionalChainAddressesFilter,
-    DBSubStringFilter,
     DBTimestampFilter,
     FilterWithTimestamp,
 )
@@ -200,22 +199,22 @@ class CalendarFilterQuery(DBFilterQuery, FilterWithTimestamp):
                 optional_chain_addresses=addresses,
             ))
         if name is not None:
-            filters.append(DBSubStringFilter(
+            filters.append(DBEqualsFilter(
                 and_op=True,
-                field='name',
-                search_string=name,
+                column='name',
+                value=name,
             ))
         if description is not None:
-            filters.append(DBSubStringFilter(
+            filters.append(DBEqualsFilter(
                 and_op=True,
-                field='description',
-                search_string=description,
+                column='description',
+                value=description,
             ))
         if counterparty is not None:
-            filters.append(DBSubStringFilter(
+            filters.append(DBEqualsFilter(
                 and_op=True,
-                field='counterparty',
-                search_string=counterparty,
+                column='counterparty',
+                value=counterparty,
             ))
         if identifiers is not None:
             filters.append(DBMultiIntegerFilter(

--- a/rotkehlchen/tests/api/test_calendar.py
+++ b/rotkehlchen/tests/api/test_calendar.py
@@ -171,10 +171,10 @@ def test_basic_calendar_operations(
         'entries_limit': -1,
     }
 
-    # query with name substring
+    # query with exact name match
     response = requests.post(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
-        json={'name': 'renewal'} | future_ts,
+        json={'name': 'ENS renewal'} | future_ts,
     )
     assert assert_proper_sync_response_with_result(response) == {
         'entries': [ens_json_event],
@@ -183,10 +183,10 @@ def test_basic_calendar_operations(
         'entries_limit': -1,
     }
 
-    # query with description substring
+    # query with exact name match (should find CRV unlock)
     response = requests.post(
         url=api_url_for(rotkehlchen_api_server, 'calendarresource'),
-        json={'name': 'Unlock'} | future_ts,
+        json={'name': 'CRV unlock'} | future_ts,
     )
     assert assert_proper_sync_response_with_result(response) == {
         'entries': [curve_json_event],


### PR DESCRIPTION
There is no reason to do substring matching for name, description and counterparty. In fact doing so could very well be the thing that contributed to the traceback a user saw.

```
[24/07/2025 09:50:08 Mountain Daylight Time] DEBUG rotkehlchen.greenlets.manager Greenlet-3: Spawning task manager task "Maybe create calendar reminders"
[24/07/2025 09:50:08 Mountain Daylight Time] ERROR rotkehlchen.greenlets.manager Greenlet with id 1838122746432: Maybe create calendar reminders died with exception: Could not update calendar entry due to UNIQUE constraint failed: calendar.name, calendar.address, calendar.blockchain.
Exception Name: <class 'rotkehlchen.errors.misc.InputError'>
Exception Info: Could not update calendar entry due to UNIQUE constraint failed: calendar.name, calendar.address, calendar.blockchain
Traceback:
   File "src\\gevent\\greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen\tasks\calendar.py", line 529, in maybe_create_calendar_reminders
  File "rotkehlchen\tasks\calendar.py", line 321, in maybe_create_ens_reminders
  File "rotkehlchen\tasks\calendar.py", line 239, in create_or_update_calendar_entry_from_event
  File "rotkehlchen\tasks\calendar.py", line 201, in create_or_update_calendar_entry
  File "rotkehlchen\db\calendar.py", line 315, in update_calendar_entry
```

This traceback makes no sense and should not happen, unless the "get" calendar entry from DB function returns a different one that the one you think it should. Which can happen due to the substring matching.

Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=121364523