### PR TITLE
docs: fix spelling issues 

### DIFF
--- a/frontend/app/electron/main/process-manager.ts
+++ b/frontend/app/electron/main/process-manager.ts
@@ -168,7 +168,7 @@ export class ProcessManager {
 
     for (const pid of pids) args.push('/PID', pid.toString());
 
-    this.log(`Preparing to call "taskill ${args.join(' ')}" on the rotki-core processes`);
+    this.log(`Preparing to call "taskkill ${args.join(' ')}" on the rotki-core processes`);
 
     try {
       spawnSync('taskkill', args);

--- a/rotkehlchen/tests/unit/test_substrate_manager.py
+++ b/rotkehlchen/tests/unit/test_substrate_manager.py
@@ -160,6 +160,6 @@ def test_connect_to_own_node(polkadot_manager: 'SubstrateManager'):
     polkadot_manager.own_rpc_endpoint = 'http://localhost:1234'
     polkadot_manager.attempt_connections()
     assert [task.task_name for task in polkadot_manager.greenlet_manager.greenlets] == [
-        'polkadot manager connection to own node node',
+        'polkadot manager connection to own node',
         'polkadot manager connection to parity node',
     ]


### PR DESCRIPTION
Yop, spotted and fixed a few wording hiccups:

`taskill` - `taskkill` 
`node node` - `node`
