### PR TITLE
Add fallback bch apis

### DIFF
--- a/rotkehlchen/chain/bitcoin/bch/constants.py
+++ b/rotkehlchen/chain/bitcoin/bch/constants.py
@@ -1,6 +1,8 @@
 from typing import Final
 
 HASKOIN_BASE_URL: Final = 'https://api.haskoin.com'
+BLOCKCHAIN_INFO_HASKOIN_BASE_URL: Final = 'https://api.blockchain.info/haskoin-store'
+MELROY_BASE_URL: Final = 'https://explorer.melroy.org/api'
 
 # With ~130 addresses it starts returning 414 (URI too long)
 HASKOIN_BATCH_SIZE: Final = 100

--- a/rotkehlchen/tests/unit/test_bitcoin_cash.py
+++ b/rotkehlchen/tests/unit/test_bitcoin_cash.py
@@ -1,8 +1,14 @@
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from marshmallow import ValidationError
 
+from rotkehlchen.chain.bitcoin.bch.constants import (
+    BLOCKCHAIN_INFO_HASKOIN_BASE_URL,
+    HASKOIN_BASE_URL,
+    MELROY_BASE_URL,
+)
 from rotkehlchen.chain.bitcoin.bch.utils import (
     force_address_to_legacy_address,
     force_addresses_to_legacy_addresses,
@@ -10,7 +16,9 @@ from rotkehlchen.chain.bitcoin.bch.utils import (
     legacy_to_cash_address,
     validate_bch_address_input,
 )
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
+from rotkehlchen.utils.network import request_get
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.bitcoin.bch.manager import BitcoinCashManager
@@ -85,11 +93,33 @@ def test_query_bch_has_transactions_and_balances(
         bitcoin_cash_manager: 'BitcoinCashManager',
         bch_accounts: list['BTCAddress'],
 ) -> None:
-    """Test that the bch have_transactions and get_balances work correctly."""
-    user_address, expected_balance = bch_accounts[0], FVal('5.32670615')
-    assert bitcoin_cash_manager.have_transactions(
-        accounts=bch_accounts,
-    ) == {user_address: (True, expected_balance)}
-    assert bitcoin_cash_manager.get_balances(
-        accounts=bch_accounts,
-    ) == {user_address: expected_balance}
+    """Test that the bch have_transactions and get_balances work correctly from all apis."""
+    user_address, expected_balance = bch_accounts[0], FVal('5.33798911')
+    for api in (
+        HASKOIN_BASE_URL,
+        BLOCKCHAIN_INFO_HASKOIN_BASE_URL,
+        MELROY_BASE_URL,
+    ):
+
+        def mock_request_get(url: str, *args, api_url=api, **kwargs):
+            """Mock request_get to fail requests to apis other than the one we want to test."""
+            if api_url not in url:
+                raise RemoteError('Skip to next api')
+            elif 'health' in url:
+                return {'ok': True}
+
+            return request_get(url, *args, **kwargs)
+
+        with patch(
+            'rotkehlchen.utils.network.request_get',
+            side_effect=mock_request_get,
+        ):
+            assert bitcoin_cash_manager.have_transactions(
+                accounts=bch_accounts,
+            ) == {user_address: (True, expected_balance)}
+            assert bitcoin_cash_manager.get_balances(
+                accounts=bch_accounts,
+            ) == {user_address: expected_balance}
+
+        # reset health status so it tries to query health again in the next loop iteration
+        bitcoin_cash_manager.last_haskoin_health = {}


### PR DESCRIPTION
Related: #https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=122041210
Related: #2880

* adds two fallback apis:
    - `api.blockchain.info/haskoin-store` - same format as the existing haskoin api
    - `explorer.melroy.org` - same format as the blockstream.info and mempool.space apis that we use for btc. This one doesn't have txs implemented yet since on btc these apis had issues with p2pk txs not working right, but this shouldn't be a problem on bch since it never used p2pk as far as I know. Will see about adding this in another PR.
* adds health check logic for the haskoin apis since the current state of haskoin.com doesn't fail with normal requests but returns bad data, and needs the health endpoint checked to know not to query it.