### PR TITLE
Log version of special dependencies

### DIFF
--- a/rotkehlchen/db/misc.py
+++ b/rotkehlchen/db/misc.py
@@ -7,16 +7,18 @@ import re
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 
-def detect_sqlcipher_version() -> int:
-    """Returns the major part of the version of the system's sqlcipher package"""
+def get_sqlcipher_version_string() -> str:
+    """Retrieve SQLCipher version used by the app"""
     conn = sqlcipher.connect(':memory:')  # pylint: disable=no-member
-    query = conn.execute('PRAGMA cipher_version;')
-    version = query.fetchall()[0][0]
-
-    match = re.search(r'(\d+).(\d+).(\d+)', version)
-    if not match:
-        raise ValueError(f'Could not process the version returned by sqlcipher: {version}')
-
-    sqlcipher_version = int(match.group(1))
+    version = conn.execute('PRAGMA cipher_version;').fetchone()[0]
     conn.close()
-    return sqlcipher_version
+    return version
+
+
+def detect_sqlcipher_version() -> int:
+    """Returns the major part of the version for SQLCipher"""
+    version = get_sqlcipher_version_string()
+    if not (match := re.search(r'(\d+).(\d+).(\d+)', version)):
+        raise ValueError(f'Could not process the version returned by SQLCipher: {version}')
+
+    return int(match.group(1))

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -1,11 +1,14 @@
+import importlib.metadata
 import logging
 import os
 import signal
+import sqlite3
 
 import gevent
 
 from rotkehlchen.api.server import APIServer, RestAPI
 from rotkehlchen.args import app_args
+from rotkehlchen.db.misc import get_sqlcipher_version_string
 from rotkehlchen.logging import TRACE, RotkehlchenLogsAdapter, add_logging_level, configure_logging
 from rotkehlchen.rotkehlchen import Rotkehlchen
 
@@ -47,6 +50,11 @@ class RotkehlchenServer:
         self.stop_event.set()
 
     def main(self) -> None:
+        # log version of some special dependencies
+        log.info(f'sqlite version: {sqlite3.sqlite_version}')
+        log.info(f'gevent version: {gevent.__version__}')
+        log.info(f'rotki-pysqlcipher version: {importlib.metadata.version("rotki-pysqlcipher3")}')
+        log.info(f'SQLCipher version: {get_sqlcipher_version_string()}')
         # disable printing hub exceptions in stderr. With using the hub to do various
         # tasks that should raise exceptions and have them handled outside the hub
         # printing them in stdout is now too much spam (and would worry users too)

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -621,8 +621,8 @@ def test_sqlcipher_detect_version():
         def __init__(self, version):
             self.version = version
 
-        def fetchall(self):
-            return [[self.version]]
+        def fetchone(self):
+            return (self.version,)
 
     class ConnectionMock:
         def __init__(self, version):


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=122330582

``` 
[31/07/2025 19:06:54 CEST] INFO rotkehlchen.server Main Greenlet: sqlite version: 3.46.0
[31/07/2025 19:06:54 CEST] INFO rotkehlchen.server Main Greenlet: gevent version: 25.4.2
[31/07/2025 19:06:54 CEST] INFO rotkehlchen.server Main Greenlet: rotki-pysqlcipher version: 2024.10.1
[31/07/2025 19:06:54 CEST] INFO rotkehlchen.server Main Greenlet: SQLCipher version: 4.6.1 community
```