### PR TITLE
Avoid querying all binance markets

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5836,7 +5836,7 @@ Querying exchange history events
    :resjson str message: Error message if any errors occurred.
    :statuscode 200: Events were queried successfully
    :statuscode 400: Provided JSON is in some way malformed.
-   :statuscode 409: Module for the given events is not active.
+   :statuscode 409: Module for the given events is not active or no market pairs are selected (when querying Binance).
    :statuscode 500: Internal rotki error.
    :statuscode 502: The exchange api could not be reached or returned an unexpected response.
 

--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -617,3 +617,23 @@ Solana tokens that require manual migration by the user.
 
 
 - ``identifiers``: Asset identifiers that need to manually migrated to solana tokens.
+
+
+Binance Missing Market Pairs
+=================================
+
+Trades were queried from a binance exchange, but no market pairs are selected to query.
+
+::
+
+    {
+        "type": "binance_pairs_missing",
+        "data": {
+            "location": "binance",
+            "name": "Binance 1"
+        }
+    }
+
+
+- ``location``: Location of the binance exchange. Either ``binance`` or ``binanceus``
+- ``name``: Name of the exchange.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -815,6 +815,11 @@ class RestAPI:
                 message=str(e),
                 status_code=HTTPStatus.BAD_GATEWAY,
             )
+        except InputError as e:
+            return wrap_in_fail_result(
+                message=str(e),
+                status_code=HTTPStatus.CONFLICT,
+            )
 
         return OK_RESULT
 

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -30,6 +30,7 @@ class WSMessageType(StrEnum):
     GNOSISPAY_SESSIONKEY_EXPIRED = auto()
     SOLANA_TOKENS_MIGRATION = auto()
     DATABASE_UPLOAD_PROGRESS = auto()
+    BINANCE_PAIRS_MISSING = auto()
 
 
 class ProgressUpdateSubType(StrEnum):

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -70,7 +70,6 @@ from rotkehlchen.types import (
     ChainID,
     ChecksumEvmAddress,
     ExchangeLocationID,
-    Location,
     Optional,
     SupportedBlockchain,
     Timestamp,
@@ -411,9 +410,7 @@ class TaskManager:
         queriable_exchanges = []
         with self.database.conn.read_ctx() as cursor:
             for exchange in self.exchange_manager.iterate_exchanges():
-                if exchange.location in (Location.BINANCE, Location.BINANCEUS):
-                    continue  # skip binance due to the way their history is queried
-                queried_range = self.database.get_used_query_range(cursor, f'{exchange.location!s}_trades')  # noqa: E501
+                queried_range = self.database.get_used_query_range(cursor, f'{exchange.location!s}_history_events_{exchange.name}')  # noqa: E501
                 end_ts = queried_range[1] if queried_range else 0
                 if now - max(self.last_exchange_query_ts[exchange.location_id()], end_ts) > EXCHANGE_QUERY_FREQUENCY:  # noqa: E501
                     queriable_exchanges.append(exchange)

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -449,6 +449,7 @@ def test_binance_query_trade_history_unexpected_data(function_scope_binance):
     """Test that turning a binance trade that contains unexpected data is handled gracefully"""
     binance = function_scope_binance
     binance.cache_ttl_secs = 0
+    original_selected_pairs = binance.selected_pairs
 
     def mock_my_trades(url, params, **kwargs):  # pylint: disable=unused-argument
         if params.get('symbol') == 'BNBBTC' or params.get('symbol') == 'doesnotexist':
@@ -464,7 +465,7 @@ def test_binance_query_trade_history_unexpected_data(function_scope_binance):
             'rotkehlchen.tests.exchanges.test_binance.BINANCE_MYTRADES_RESPONSE',
             new=input_trade_str,
         )
-        binance.selected_pairs = query_specific_markets
+        binance.selected_pairs = query_specific_markets if query_specific_markets is not None else original_selected_pairs  # noqa: E501
         with patch_get, patch_response:
             events, _ = binance.query_online_history_events(
                 start_ts=Timestamp(0),

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -720,6 +720,7 @@ def create_test_binance(
         json_data = json.loads(f.read())
 
     binance._symbols_to_pair = create_binance_symbols_to_pair(json_data, location)
+    binance.selected_pairs = list(binance._symbols_to_pair.keys())
     binance.first_connection_made = True
     return binance
 


### PR DESCRIPTION
Backend part of #10309 

Avoids ever querying all binance markets, and adds an api error when history events are queried for binance with no markets set.