### PR TITLE
Fix beefy vault traceback

### DIFF
--- a/rotkehlchen/assets/utils.py
+++ b/rotkehlchen/assets/utils.py
@@ -122,6 +122,8 @@ def edit_token_and_clean_cache(
     """
     Update information regarding name and decimals for an ethereum token.
     If name is missing in the database and is not provided then query the blockchain for it
+    May raise:
+        - InputError if there is an error while editing the token
     """
     updated_fields = False
 
@@ -275,6 +277,7 @@ def get_or_create_evm_token(
     and the given address does not have any of symbol, decimals and name
     - NotERC721Conformant exception if an ethereum manager is given to query
     and the given address does not conform to ERC721 spec
+    - InputError if there is an error while editing the token
     """
     identifier = evm_address_to_identifier(
         address=evm_address,

--- a/rotkehlchen/chain/evm/decoding/beefy_finance/utils.py
+++ b/rotkehlchen/chain/evm/decoding/beefy_finance/utils.py
@@ -48,6 +48,8 @@ def _process_beefy_vault(
     - NotERC20Conformant
     - DeserializationError
     - KeyError
+    - InputError if there is an error while editing a token (if the underlying token is the same
+      as the vault token for example)
     """
     underlying_token = get_or_create_evm_token(
         userdb=database,

--- a/rotkehlchen/chain/evm/decoding/utils.py
+++ b/rotkehlchen/chain/evm/decoding/utils.py
@@ -9,7 +9,12 @@ from rotkehlchen.assets.utils import get_token
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.constants.prices import ZERO_PRICE
-from rotkehlchen.errors.misc import NotERC20Conformant, NotERC721Conformant, RemoteError
+from rotkehlchen.errors.misc import (
+    InputError,
+    NotERC20Conformant,
+    NotERC721Conformant,
+    RemoteError,
+)
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import (
@@ -190,7 +195,7 @@ def update_cached_vaults(
     for vault in vault_list:
         try:
             process_vault(database, vault)
-        except (NotERC20Conformant, NotERC721Conformant, DeserializationError, KeyError) as e:
+        except (NotERC20Conformant, NotERC721Conformant, DeserializationError, KeyError, InputError) as e:  # noqa: E501
             error = f'missing key {e!s}' if isinstance(e, KeyError) else f'{e!s}'
             log.error(
                 f'Failed to store token information for {display_name} vault '


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=122546245

Correctly handle the exception when the underlying token is the same as the vault token. This is not the final solution, but this error should be handled there since its a possibility and will prevent the traceback in develop until we get proper handling of this type of vault implemented.

Its not immediately obvious how to handle this type of vault but I'm experminting with a few things and have also asked about it in the beefy discord (https://discord.com/channels/755231190134554696/758368074968858645/1401954474968219718)