### PR TITLE
Fix database table is locked during upload

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -547,7 +547,7 @@ class DBHandler:
         tempdbfile.close()  # close the file to allow re-opening by export_unencrypted in windows https://github.com/rotki/rotki/issues/5051  # noqa: E501
         with self.conn.critical_section():
             # flush the wal file to have up to date information when exporting data
-            self.conn.execute('PRAGMA wal_checkpoint;')
+            self.conn.wal_checkpoint()
             self.conn.executescript(
                 f"ATTACH DATABASE '{tempdbpath}' AS plaintext KEY '';"
                 "SELECT sqlcipher_export('plaintext');"
@@ -564,7 +564,7 @@ class DBHandler:
         than the one supported.
         - AuthenticationError if the wrong password is given
         """
-        self.conn.execute('PRAGMA wal_checkpoint;')
+        self.conn.wal_checkpoint()
         self.disconnect()
         rdbpath = self.user_data_dir / USERDB_NAME
         # Make copy of existing encrypted DB before removing it

--- a/rotkehlchen/db/upgrade_manager.py
+++ b/rotkehlchen/db/upgrade_manager.py
@@ -215,7 +215,7 @@ class DBUpgradeManager:
         Reason for this is to make sure the .db file is the only thing needed for the DB
         backup as we only copy that file.
         """
-        self.db.conn.execute('PRAGMA wal_checkpoint(FULL);')
+        self.db.conn.wal_checkpoint('(FULL)')
         with self.db.conn.read_ctx() as cursor:
             current_version = self.db.get_setting(cursor, 'version')
         if current_version != upgrade.from_version:

--- a/rotkehlchen/globaldb/upgrades/manager.py
+++ b/rotkehlchen/globaldb/upgrades/manager.py
@@ -172,7 +172,7 @@ def _perform_single_upgrade(
     progress_handler.new_round(version=to_version)
 
     # WAL checkpoint at start to make sure everything is in the file we copy for backup. For more info check comment in the user DB upgrade.  # noqa: E501
-    connection.execute('PRAGMA wal_checkpoint(FULL);')
+    connection.wal_checkpoint('(FULL)')
     # Create a backup
     tmp_db_filename = f'{ts_now()}_global_db_v{upgrade.from_version}.backup'
     tmp_db_path = global_dir / tmp_db_filename

--- a/rotkehlchen/tests/db/test_wal.py
+++ b/rotkehlchen/tests/db/test_wal.py
@@ -1,0 +1,60 @@
+import gevent
+import pytest
+
+
+@pytest.mark.parametrize('sql_vm_instructions_cb', [1])
+def test_wal_checkpoint_lock_with_rotki_infrastructure(database):
+    """Test that verifies the fix for issue #5038.
+
+    It reproduces the actual scenario where multiple concurrent readers during a WAL checkpoint
+    can lead to a database locked error
+    """
+    errors, attempts, max_attempts = [], 0, 50
+
+    def db_reader():
+        """Simulate continuous global DB operations that trigger progress callbacks"""
+        while attempts < max_attempts and len(errors) == 0:
+            # These operations will trigger progress callbacks frequently
+            with database.conn.read_ctx() as cursor:
+                cursor.execute('SELECT identifier FROM assets LIMIT 50')
+                cursor.fetchall()
+
+            with database.conn.read_ctx() as cursor:
+                cursor.execute('SELECT COUNT(*) FROM assets')
+                cursor.fetchone()
+
+            gevent.sleep(0)
+
+    def checkpoint_worker():
+        """Perform WAL checkpoint operations that should trigger the bug without the fix"""
+        nonlocal attempts, errors
+
+        while attempts < max_attempts and len(errors) == 0:
+            attempts += 1
+
+            try:
+                # Add some data to ensure WAL has content to checkpoint
+                with database.user_write() as cursor:
+                    cursor.execute(
+                        'INSERT OR REPLACE INTO settings(name, value) VALUES (?, ?)',
+                        (f'test_checkpoint_{attempts}', f'value_{attempts}'),
+                    )
+
+                # This is the critical operation that fails without the lock
+                # The new wal_checkpoint() method should prevent the lock error
+                database.conn.wal_checkpoint()
+
+            except Exception as e:
+                if 'locked' in str(e).lower():
+                    errors.append(e)
+
+    greenlets = [
+        gevent.spawn(db_reader),
+        gevent.spawn(db_reader),  # Multiple readers for more callbacks
+        gevent.spawn(checkpoint_worker),
+    ]
+    gevent.joinall(greenlets, timeout=30)
+
+    # With the fix (using wal_checkpoint method with in_callback lock),
+    # there should be no 'database table is locked' errors
+    assert len(errors) == 0, f'WAL checkpoint failed with lock errors: {errors}'


### PR DESCRIPTION
Fixes #5038 again. Adding a new test for it too.

wal_checkpoint (irrespective of type) will fail with database table is locked if there is any readers on that DB that execute a progress handler.

So the solution is to acquire the progress handler lock for the DB for the duration of the checkpointing.

Abstracted that logic in a function.

