### PR TITLE
Use DB cursors

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migrations_18.py
+++ b/rotkehlchen/data_migrations/migrations/migrations_18.py
@@ -134,7 +134,7 @@ def data_migration_18(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
         with rotki.data.db.conn.write_ctx() as write_cursor:
             write_cursor.execute(querystr, query_bindings)
 
-        rotki.data.db.conn.execute('VACUUM;')  # also since this cleans up a lot of space vacuum
+        rotki.data.db.conn.vacuum()  # also since this cleans up a lot of space vacuum
 
     @progress_step(description='Whitelisting monerium assets.')
     def whitelist_monerium_assets(rotki: 'Rotkehlchen') -> None:

--- a/rotkehlchen/db/utils.py
+++ b/rotkehlchen/db/utils.py
@@ -433,14 +433,15 @@ def unlock_database(
     if sqlcipher_version == 3:
         script += f'PRAGMA kdf_iter={KDF_ITER};'
 
-    db_connection.executescript(script)
-    # the following will fail with DatabaseError in case of wrong password.
-    # If this goes away at any point it needs to be replaced by something
-    # that checks the password is correct at this same point in the code
-    db_connection.execute('PRAGMA schema_version')
-    db_connection.execute('PRAGMA foreign_keys=ON')
-    if apply_optimizations:
-        # Optimizations for the combined trades view
-        db_connection.execute('PRAGMA cache_size = -32768')
-        # switch to WAL mode: https://www.sqlite.org/wal.html
-        db_connection.execute('PRAGMA journal_mode=WAL;')
+    with db_connection.write_ctx() as write_cursor:
+        write_cursor.executescript(script)
+        # the following will fail with DatabaseError in case of wrong password.
+        # If this goes away at any point it needs to be replaced by something
+        # that checks the password is correct at this same point in the code
+        write_cursor.execute('PRAGMA schema_version')
+        write_cursor.execute('PRAGMA foreign_keys=ON')
+        if apply_optimizations:
+            # Optimizations for the combined trades view
+            write_cursor.execute('PRAGMA cache_size = -32768')
+            # switch to WAL mode: https://www.sqlite.org/wal.html
+            write_cursor.execute('PRAGMA journal_mode=WAL;')

--- a/rotkehlchen/globaldb/asset_updates/manager.py
+++ b/rotkehlchen/globaldb/asset_updates/manager.py
@@ -488,10 +488,11 @@ class AssetsUpdater:
             )
 
         # at the very end update the current version in the DB
-        connection.execute(
-            'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
-            (ASSETS_VERSION_KEY, str(version)),
-        )
+        with connection.write_ctx() as write_cursor:
+            write_cursor.execute(
+                'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
+                (ASSETS_VERSION_KEY, str(version)),
+            )
 
     def perform_update(
             self,

--- a/rotkehlchen/tests/api/test_database.py
+++ b/rotkehlchen/tests/api/test_database.py
@@ -38,7 +38,7 @@ def test_query_db_info(
 
     if start_with_logged_in_user:
         db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
-        db.conn.execute('PRAGMA wal_checkpoint;')  # flush the wal file
+        db.conn.wal_checkpoint()  # flush the wal file
 
     response = requests.get(api_url_for(rotkehlchen_api_server, 'databaseinforesource'))
     result = assert_proper_sync_response_with_result(response)

--- a/rotkehlchen/tests/api/test_users.py
+++ b/rotkehlchen/tests/api/test_users.py
@@ -801,8 +801,8 @@ def test_user_login(
         connection_type=DBConnectionType.USER,
         sql_vm_instructions_cb=0,
     )
-    backup_connection.executescript(f"PRAGMA key='{db_password}'")  # unlock
     with backup_connection.write_ctx() as write_cursor:
+        write_cursor.executescript(f"PRAGMA key='{db_password}'")  # unlock
         write_cursor.execute("INSERT INTO settings VALUES('is_backup', 'Yes')")
     backup_connection.close()
 

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -3335,7 +3335,8 @@ def test_latest_upgrade_correctness(user_data_dir):
     result = cursor.execute("SELECT name FROM sqlite_master WHERE type='view'")
     views_after_upgrade = {x[0] for x in result}
     # also add latest tables (this will indicate if DB upgrade missed something
-    db.conn.executescript(DB_SCRIPT_CREATE_TABLES)
+    with db.conn.write_ctx() as write_cursor:
+        write_cursor.executescript(DB_SCRIPT_CREATE_TABLES)
     result = cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
     tables_after_creation = {x[0] for x in result}
     result = cursor.execute("SELECT name FROM sqlite_master WHERE type='view'")
@@ -3492,8 +3493,8 @@ def test_unfinished_upgrades(user_data_dir):
                 connection_type=DBConnectionType.USER,
                 sql_vm_instructions_cb=0,
             )
-            backup_connection.executescript("PRAGMA key='123'")  # unlock
             with backup_connection.write_ctx() as write_cursor:
+                write_cursor.executescript("PRAGMA key='123'")  # unlock
                 write_cursor.execute('INSERT INTO settings VALUES(?, ?)', ('is_backup', write_version))  # mark as a backup  # noqa: E501
             backup_connection.close()
 

--- a/rotkehlchen/tests/db/test_savepoints.py
+++ b/rotkehlchen/tests/db/test_savepoints.py
@@ -14,7 +14,9 @@ def test_unnamed_savepoints():
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=0,
     )
-    conn.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+    with conn.write_ctx() as write_cursor:
+        write_cursor.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+
     with conn.savepoint_ctx() as cursor1:
         assert len(conn.savepoints) == 1
         savepoint1 = next(iter(conn.savepoints))
@@ -30,8 +32,9 @@ def test_unnamed_savepoints():
         assert cursor1.execute('SELECT b FROM a').fetchall() == [(1,)]  # 2 should not be there
         cursor1.execute('INSERT INTO a VALUES (3)')  # add one more value after the rollback
     assert len(conn.savepoints) == 0  # check that we released successfully
-    # And make sure that the data is saved
-    assert conn.execute('SELECT b FROM a').fetchall() == [(1,), (3,)]
+
+    with conn.read_ctx() as cursor:  # And make sure that the data is saved
+        assert cursor.execute('SELECT b FROM a').fetchall() == [(1,), (3,)]
 
 
 def test_savepoint_errors():
@@ -59,8 +62,8 @@ def test_write_transaction_with_savepoint():
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=0,
     )
-    conn.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
     with conn.write_ctx() as write_cursor:
+        write_cursor.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
         write_cursor.execute('INSERT INTO a VALUES (1)')
         with conn.savepoint_ctx() as savepoint_cursor:
             savepoint_cursor.execute('INSERT INTO a VALUES (2)')
@@ -87,8 +90,8 @@ def test_write_transaction_with_savepoint_other_context():
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=0,
     )
-    conn.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
     with conn.write_ctx() as write_cursor:
+        write_cursor.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
         write_cursor.execute('INSERT INTO a VALUES (1)')
         greenlet1 = gevent.spawn(other_context, conn, True)
         gevent.sleep(.3)  # context switch for a bit to let the other greenlet run
@@ -126,7 +129,9 @@ def test_savepoint_with_write_transaction():
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=0,
     )
-    conn.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+    with conn.write_ctx() as write_cursor:
+        write_cursor.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+
     with conn.savepoint_ctx() as savepoint_cursor:
         savepoint_cursor.execute('INSERT INTO a VALUES (1)')
         with conn.write_ctx() as write_cursor:
@@ -157,7 +162,9 @@ def test_savepoint_with_write_transaction_other_context():
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=0,
     )
-    conn.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+    with conn.write_ctx() as write_cursor:
+        write_cursor.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+
     with conn.savepoint_ctx() as savepoint_cursor:
         savepoint_cursor.execute('INSERT INTO a VALUES (1)')
         greenlet1 = gevent.spawn(other_context, conn)
@@ -191,7 +198,9 @@ def test_open_savepoint_with_savepoint_other_context():
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=0,
     )
-    conn.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+    with conn.write_ctx() as write_cursor:
+        write_cursor.execute('CREATE TABLE a(b INTEGER PRIMARY KEY)')
+
     with conn.savepoint_ctx() as savepoint_cursor:
         savepoint_cursor.execute('INSERT INTO a VALUES (1)')
         greenlet1 = gevent.spawn(other_context, conn, True)
@@ -243,5 +252,5 @@ def test_rollback_in_savepoints():
 
     # leaving the with statement should have released the savepoint and trying to release
     # again the savepoint should raise an error because we have already released it.
-    with pytest.raises(rsqlite.OperationalError):
-        conn.execute("RELEASE SAVEPOINT 'mysave'")
+    with pytest.raises(rsqlite.OperationalError), conn.write_ctx() as write_cursor:
+        write_cursor.execute("RELEASE SAVEPOINT 'mysave'")

--- a/rotkehlchen/tests/db/test_wal.py
+++ b/rotkehlchen/tests/db/test_wal.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.parametrize('sql_vm_instructions_cb', [1])
-def test_wal_checkpoint_lock_with_rotki_infrastructure(database):
+def test_wal_checkpoint_lock(database):
     """Test that verifies the fix for issue #5038.
 
     It reproduces the actual scenario where multiple concurrent readers during a WAL checkpoint
@@ -34,8 +34,8 @@ def test_wal_checkpoint_lock_with_rotki_infrastructure(database):
 
             try:
                 # Add some data to ensure WAL has content to checkpoint
-                with database.user_write() as cursor:
-                    cursor.execute(
+                with database.user_write() as write_cursor:
+                    write_cursor.execute(
                         'INSERT OR REPLACE INTO settings(name, value) VALUES (?, ?)',
                         (f'test_checkpoint_{attempts}', f'value_{attempts}'),
                     )

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -642,8 +642,9 @@ def test_upload_data_to_server_db_locked(rotkehlchen_instance):
         the plaintext DB is not attached. Which is also the fix. To make that
         export occur under a critical section
         """
-        result = db.conn.execute('SELECT * FROM pragma_database_list;')
-        assert len(result.fetchall()) == 1, 'the plaintext DB should not be attached here'
+        with db.conn.read_ctx() as cursor:
+            result = cursor.execute('SELECT * FROM pragma_database_list;')
+            assert len(result.fetchall()) == 1, 'the plaintext DB should not be attached here'
 
     with db.user_write() as cursor:
         last_ts = rotkehlchen_instance.data.db.get_static_cache(

--- a/rotkehlchen/tests/unit/globaldb/test_asset_updates.py
+++ b/rotkehlchen/tests/unit/globaldb/test_asset_updates.py
@@ -407,16 +407,17 @@ INSERT INTO assets(identifier, name, type) VALUES('NEW-ASSET-2', 'name4', 'B'); 
     )
 
     # Should have stayed unchanged since one of the insertions was incorrect
-    assert connection.execute("SELECT name FROM assets WHERE identifier='ETH'").fetchone()[0] == 'Ethereum'  # noqa: E501
-    assert connection.execute("SELECT symbol FROM common_asset_details WHERE identifier='ETH'").fetchone()[0] == 'ETH'  # noqa: E501
-    # BTC should have been updated since the insertion were correct
-    assert connection.execute("SELECT name FROM assets WHERE identifier='BTC'").fetchone()[0] == 'name2'  # noqa: E501
-    assert connection.execute("SELECT symbol FROM common_asset_details WHERE identifier='BTC'").fetchone()[0] == 'symbol2'  # noqa: E501
-    # NEW-ASSET-1 should have not been added since the insertions were incorrect
-    assert connection.execute("SELECT * FROM assets WHERE identifier='NEW-ASSET-1'").fetchone() is None  # noqa: E501
-    # NEW-ASSET-2 should have been added since the insertions were correct
-    assert connection.execute("SELECT name FROM assets WHERE identifier='NEW-ASSET-2'").fetchone()[0] == 'name4'  # noqa: E501
-    assert connection.execute("SELECT symbol FROM common_asset_details WHERE identifier='NEW-ASSET-2'").fetchone()[0] == 'symbol4'  # noqa: E501
+    with connection.read_ctx() as cursor:
+        assert cursor.execute("SELECT name FROM assets WHERE identifier='ETH'").fetchone()[0] == 'Ethereum'  # noqa: E501
+        assert cursor.execute("SELECT symbol FROM common_asset_details WHERE identifier='ETH'").fetchone()[0] == 'ETH'  # noqa: E501
+        # BTC should have been updated since the insertion were correct
+        assert cursor.execute("SELECT name FROM assets WHERE identifier='BTC'").fetchone()[0] == 'name2'  # noqa: E501
+        assert cursor.execute("SELECT symbol FROM common_asset_details WHERE identifier='BTC'").fetchone()[0] == 'symbol2'  # noqa: E501
+        # NEW-ASSET-1 should have not been added since the insertions were incorrect
+        assert cursor.execute("SELECT * FROM assets WHERE identifier='NEW-ASSET-1'").fetchone() is None  # noqa: E501
+        # NEW-ASSET-2 should have been added since the insertions were correct
+        assert cursor.execute("SELECT name FROM assets WHERE identifier='NEW-ASSET-2'").fetchone()[0] == 'name4'  # noqa: E501
+        assert cursor.execute("SELECT symbol FROM common_asset_details WHERE identifier='NEW-ASSET-2'").fetchone()[0] == 'symbol4'  # noqa: E501
 
 
 def test_updates_assets_collections_errors(assets_updater: AssetsUpdater):

--- a/rotkehlchen/tests/unit/globaldb/test_upgrades.py
+++ b/rotkehlchen/tests/unit/globaldb/test_upgrades.py
@@ -1277,7 +1277,7 @@ def test_unfinished_upgrades(globaldb: GlobalDBHandler, messages_aggregator):
     with pytest.raises(DBUpgradeError):
         create_globaldb(globaldb._data_directory, 0, messages_aggregator)
 
-    globaldb.conn.execute('PRAGMA wal_checkpoint;')  # flush the wal file
+    globaldb.conn.wal_checkpoint()  # flush the wal file
 
     # Add a backup
     backup_path = globaldb._data_directory / GLOBALDIR_NAME / f'{ts_now()}_global_db_v2.backup'  # type: ignore  # _data_directory is definitely not null here

--- a/rotkehlchen/utils/progress.py
+++ b/rotkehlchen/utils/progress.py
@@ -104,7 +104,7 @@ def perform_userdb_upgrade_steps(
 
     if should_vacuum:  # TODO: Probably can generalize this to a given post-transaction step
         progress_handler.new_step('Vacuuming database.')
-        db.conn.execute('VACUUM;')
+        db.conn.vacuum()
 
 
 def perform_globaldb_upgrade_steps(
@@ -126,7 +126,7 @@ def perform_globaldb_upgrade_steps(
 
     if should_vacuum:  # TODO: Probably can generalize this to a given post-transaction step
         progress_handler.new_step('Vacuuming database.')
-        connection.execute('VACUUM;')
+        connection.vacuum()
 
 
 def perform_userdb_migration_steps(
@@ -146,4 +146,4 @@ def perform_userdb_migration_steps(
 
     if should_vacuum:  # TODO: Probably can generalize this to a given post-transaction step
         progress_handler.new_step('Vacuuming database.')
-        rotki.data.db.conn.execute('VACUUM;')
+        rotki.data.db.conn.vacuum()


### PR DESCRIPTION
There were some places in the code where we directly used connection.execute/executemany/executescript.

This returns a new cursor which ends up being unused and dangling and waiting to be picked up by the garbage collector.

So now we simply use normal cursors in all those places

Also removed all connection.execute/executemany/executescript from our version of DBConnection so we are forced to always use cursors.

