### PR TITLE
fix: refresh transactions for newly added account

### DIFF
--- a/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
+++ b/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
@@ -1,0 +1,127 @@
+import type { Exchange } from '@/types/exchanges';
+import type { TaskMeta } from '@/types/task';
+import { groupBy, omit } from 'es-toolkit';
+import { useHistoryEventsApi } from '@/composables/api/history/events';
+import { useModules } from '@/composables/session/modules';
+import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
+import { useNotificationsStore } from '@/store/notifications';
+import { useSessionSettingsStore } from '@/store/settings/session';
+import { useTaskStore } from '@/store/tasks';
+import { OnlineHistoryEventsQueryType } from '@/types/history/events/schemas';
+import { Module } from '@/types/modules';
+import { TaskType } from '@/types/task-type';
+import { isTaskCancelled } from '@/utils';
+import { awaitParallelExecution } from '@/utils/await-parallel-execution';
+import { logger } from '@/utils/logging';
+
+interface UseRefreshHandlersReturn {
+  queryAllExchangeEvents: (exchanges?: Exchange[]) => Promise<void>;
+  queryOnlineEvent: (queryType: OnlineHistoryEventsQueryType) => Promise<void>;
+}
+
+export function useRefreshHandlers(): UseRefreshHandlersReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { notify } = useNotificationsStore();
+  const { queryExchangeEvents, queryOnlineHistoryEvents } = useHistoryEventsApi();
+  const { awaitTask } = useTaskStore();
+  const { isModuleEnabled } = useModules();
+  const isEth2Enabled = isModuleEnabled(Module.ETH2);
+  const { apiKey, credential } = useExternalApiKeys(t);
+
+  const queryOnlineEvent = async (queryType: OnlineHistoryEventsQueryType): Promise<void> => {
+    const eth2QueryTypes: OnlineHistoryEventsQueryType[] = [
+      OnlineHistoryEventsQueryType.ETH_WITHDRAWALS,
+      OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS,
+    ];
+
+    if (!get(isEth2Enabled) && eth2QueryTypes.includes(queryType))
+      return;
+
+    if (!get(apiKey('gnosis_pay')) && queryType === OnlineHistoryEventsQueryType.GNOSIS_PAY) {
+      return;
+    }
+
+    if (!get(credential('monerium')) && queryType === OnlineHistoryEventsQueryType.MONERIUM) {
+      return;
+    }
+
+    logger.debug(`querying for ${queryType} events`);
+    const taskType = TaskType.QUERY_ONLINE_EVENTS;
+    const { taskId } = await queryOnlineHistoryEvents({
+      asyncQuery: true,
+      queryType,
+    });
+
+    const taskMeta = {
+      description: t('actions.online_events.task.description', {
+        queryType,
+      }),
+      queryType,
+      title: t('actions.online_events.task.title'),
+    };
+
+    try {
+      await awaitTask<boolean, TaskMeta>(taskId, taskType, taskMeta, true);
+    }
+    catch (error: any) {
+      if (!isTaskCancelled(error)) {
+        logger.error(error);
+        notify({
+          display: true,
+          message: t('actions.online_events.error.description', {
+            error,
+            queryType,
+          }),
+          title: t('actions.online_events.error.title'),
+        });
+      }
+    }
+    logger.debug(`finished querying for ${queryType} events`);
+  };
+
+  const queryExchange = async (payload: Exchange): Promise<void> => {
+    logger.debug(`querying exchange events for ${payload.location} (${payload.name})`);
+    const exchange = omit(payload, ['krakenAccountType']);
+    const taskType = TaskType.QUERY_EXCHANGE_EVENTS;
+    const taskMeta = {
+      description: t('actions.exchange_events.task.description', exchange),
+      exchange,
+      title: t('actions.exchange_events.task.title'),
+    };
+
+    try {
+      const { taskId } = await queryExchangeEvents(exchange);
+      await awaitTask<boolean, TaskMeta>(taskId, taskType, taskMeta, true);
+    }
+    catch (error: any) {
+      if (!isTaskCancelled(error)) {
+        logger.error(error);
+        notify({
+          display: true,
+          message: t('actions.exchange_events.error.description', {
+            error,
+            ...exchange,
+          }),
+          title: t('actions.exchange_events.error.title'),
+        });
+      }
+    }
+  };
+
+  const queryAllExchangeEvents = async (exchanges?: Exchange[]): Promise<void> => {
+    const { connectedExchanges } = storeToRefs(useSessionSettingsStore());
+    const selectedExchanges = exchanges ?? get(connectedExchanges);
+    const groupedExchanges = Object.entries(groupBy(selectedExchanges, exchange => exchange.location));
+
+    await awaitParallelExecution(groupedExchanges, ([group]) => group, async ([_group, exchanges]) => {
+      for (const exchange of exchanges) {
+        await queryExchange(exchange);
+      }
+    }, 2);
+  };
+
+  return {
+    queryAllExchangeEvents,
+    queryOnlineEvent,
+  };
+}

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
@@ -340,23 +340,24 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     }
     finally {
       finishRefresh();
-
-      // After refresh is complete, check if there are pending accounts to refresh
-      if (get(hasPendingAccounts)) {
-        logger.info('Processing pending accounts after refresh completion');
-        const pendingAccounts = getPendingAccountsForRefresh();
-        // Recursively call refreshTransactions to handle pending accounts
-        setTimeout(() => {
-          refreshTransactions({
-            ...params,
-            payload: {
-              ...params.payload,
-              accounts: pendingAccounts,
-            },
-          }).catch(error => logger.error('Failed to refresh pending accounts', error));
-        }, 100);
-      }
     }
+
+    // After refresh is complete, check if there are pending accounts to refresh
+    if (!get(hasPendingAccounts))
+      return;
+
+    logger.info('Processing pending accounts after refresh completion');
+    const pendingAccounts = getPendingAccountsForRefresh();
+    // Recursively call refreshTransactions to handle pending accounts
+    setTimeout(() => {
+      refreshTransactions({
+        ...params,
+        payload: {
+          ...params.payload,
+          accounts: pendingAccounts,
+        },
+      }).catch(error => logger.error('Failed to refresh pending accounts', error));
+    }, 100);
   };
 
   return {

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
@@ -1,17 +1,15 @@
 import type { RefreshTransactionsParams, TransactionSyncParams } from './types';
-import type { Exchange } from '@/types/exchanges';
-import { groupBy, omit } from 'es-toolkit';
+import { groupBy } from 'es-toolkit';
 import { useHistoryEventsApi } from '@/composables/api/history/events';
 import { useHistoryTransactionDecoding } from '@/composables/history/events/tx/decoding';
+import { useRefreshHandlers } from '@/composables/history/events/tx/refresh-handlers';
 import { useHistoryTransactionAccounts } from '@/composables/history/events/tx/use-history-transaction-accounts';
 import { useSupportedChains } from '@/composables/info/chains';
-import { useModules } from '@/composables/session/modules';
-import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useStatusUpdater } from '@/composables/status';
 import { useHistoryStore } from '@/store/history';
 import { useTxQueryStatusStore } from '@/store/history/query-status/tx-query-status';
+import { useHistoryRefreshStateStore } from '@/store/history/refresh-state';
 import { useNotificationsStore } from '@/store/notifications';
-import { useSessionSettingsStore } from '@/store/settings/session';
 import { useTaskStore } from '@/store/tasks';
 import {
   type BitcoinChainAddress,
@@ -21,7 +19,6 @@ import {
   type TransactionRequestPayload,
 } from '@/types/history/events';
 import { OnlineHistoryEventsQueryType } from '@/types/history/events/schemas';
-import { Module } from '@/types/modules';
 import { Section, Status } from '@/types/status';
 import { BackendCancelledTaskError, type TaskMeta } from '@/types/task';
 import { TaskType } from '@/types/task-type';
@@ -38,13 +35,8 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { notify } = useNotificationsStore();
   const queue = new LimitedParallelizationQueue(1);
-  const {
-    fetchTransactionsTask,
-    queryExchangeEvents,
-    queryOnlineHistoryEvents,
-  } = useHistoryEventsApi();
+  const { fetchTransactionsTask } = useHistoryEventsApi();
 
-  const { connectedExchanges } = storeToRefs(useSessionSettingsStore());
   const { awaitTask, isTaskRunning } = useTaskStore();
   const { initializeQueryStatus, removeQueryStatus } = useTxQueryStatusStore();
   const { getChain, getChainName, isEvmLikeChains } = useSupportedChains();
@@ -153,61 +145,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     }
   };
 
-  const { isModuleEnabled } = useModules();
-  const isEth2Enabled = isModuleEnabled(Module.ETH2);
-
-  const { apiKey, credential } = useExternalApiKeys(t);
-
-  const queryOnlineEvent = async (queryType: OnlineHistoryEventsQueryType): Promise<void> => {
-    const eth2QueryTypes: OnlineHistoryEventsQueryType[] = [
-      OnlineHistoryEventsQueryType.ETH_WITHDRAWALS,
-      OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS,
-    ];
-
-    if (!get(isEth2Enabled) && eth2QueryTypes.includes(queryType))
-      return;
-
-    if (!get(apiKey('gnosis_pay')) && queryType === OnlineHistoryEventsQueryType.GNOSIS_PAY) {
-      return;
-    }
-
-    if (!get(credential('monerium')) && queryType === OnlineHistoryEventsQueryType.MONERIUM) {
-      return;
-    }
-
-    logger.debug(`querying for ${queryType} events`);
-    const taskType = TaskType.QUERY_ONLINE_EVENTS;
-    const { taskId } = await queryOnlineHistoryEvents({
-      asyncQuery: true,
-      queryType,
-    });
-
-    const taskMeta = {
-      description: t('actions.online_events.task.description', {
-        queryType,
-      }),
-      queryType,
-      title: t('actions.online_events.task.title'),
-    };
-
-    try {
-      await awaitTask<boolean, TaskMeta>(taskId, taskType, taskMeta, true);
-    }
-    catch (error: any) {
-      if (!isTaskCancelled(error)) {
-        logger.error(error);
-        notify({
-          display: true,
-          message: t('actions.online_events.error.description', {
-            error,
-            queryType,
-          }),
-          title: t('actions.online_events.error.title'),
-        });
-      }
-    }
-    logger.debug(`finished querying for ${queryType} events`);
-  };
+  const { queryAllExchangeEvents, queryOnlineEvent } = useRefreshHandlers();
 
   const refreshTransactionsHandler = async (
     params: TransactionSyncParams,
@@ -241,63 +179,99 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     logger.debug(`finished refreshing ${type} transactions for ${accounts.length} addresses`);
   };
 
-  const queryExchange = async (payload: Exchange): Promise<void> => {
-    logger.debug(`querying exchange events for ${payload.location} (${payload.name})`);
-    const exchange = omit(payload, ['krakenAccountType']);
-    const taskType = TaskType.QUERY_EXCHANGE_EVENTS;
-    const taskMeta = {
-      description: t('actions.exchange_events.task.description', exchange),
-      exchange,
-      title: t('actions.exchange_events.task.title'),
-    };
-
-    try {
-      const { taskId } = await queryExchangeEvents(exchange);
-      await awaitTask<boolean, TaskMeta>(taskId, taskType, taskMeta, true);
-    }
-    catch (error: any) {
-      if (!isTaskCancelled(error)) {
-        logger.error(error);
-        notify({
-          display: true,
-          message: t('actions.exchange_events.error.description', {
-            error,
-            ...exchange,
-          }),
-          title: t('actions.exchange_events.error.title'),
-        });
-      }
-    }
-  };
-
-  const queryAllExchangeEvents = async (exchanges?: Exchange[]): Promise<void> => {
-    const selectedExchanges = exchanges ?? get(connectedExchanges);
-    const groupedExchanges = Object.entries(groupBy(selectedExchanges, exchange => exchange.location));
-
-    await awaitParallelExecution(groupedExchanges, ([group]) => group, async ([_group, exchanges]) => {
-      for (const exchange of exchanges) {
-        await queryExchange(exchange);
-      }
-    }, 2);
-  };
+  const {
+    addPendingAccounts,
+    finishRefresh,
+    getNewAccounts,
+    getPendingAccountsForRefresh,
+    hasPendingAccounts,
+    isRefreshing,
+    shouldRefreshAll,
+    startRefresh,
+  } = useHistoryRefreshStateStore();
 
   const refreshTransactions = async (params: RefreshTransactionsParams = {}): Promise<void> => {
     const { chains = [], disableEvmEvents = false, payload = {}, userInitiated = false } = params;
-    if (fetchDisabled(userInitiated)) {
-      logger.info('skipping transaction refresh');
-      return;
-    }
-
     const { accounts, exchanges, queries } = payload;
     const fullRefresh = Object.keys(payload).length === 0;
 
-    const evmAccounts: EvmChainAddress[] = [];
-    const evmLikeAccounts: EvmChainAddress[] = [];
-    const bitcoinAccounts: BitcoinChainAddress[] = [];
+    // Get current accounts first to check if we have new ones
+    let currentEvmAccounts: EvmChainAddress[] = [];
+    let currentEvmLikeAccounts: EvmChainAddress[] = [];
+    let currentBitcoinAccounts: BitcoinChainAddress[] = [];
 
     if (accounts && accounts.length > 0) {
       // Separate accounts by type
       accounts.forEach((account) => {
+        if ('evmChain' in account) {
+          if (isEvmLikeChains(account.evmChain)) {
+            currentEvmLikeAccounts.push(account);
+          }
+          else {
+            currentEvmAccounts.push(account);
+          }
+        }
+        else if ('chain' in account) {
+          currentBitcoinAccounts.push(account);
+        }
+      });
+    }
+    else if (fullRefresh) {
+      // Always get all accounts on full refresh to check for new ones
+      currentEvmAccounts = getEvmAccounts(chains);
+      currentEvmLikeAccounts = getEvmLikeAccounts(chains);
+      currentBitcoinAccounts = getBitcoinAccounts(chains);
+    }
+
+    const allCurrentAccounts = [...currentEvmAccounts, ...currentEvmLikeAccounts, ...currentBitcoinAccounts];
+    const newAccountsList = getNewAccounts(allCurrentAccounts);
+    const hasNewAccounts = newAccountsList.length > 0;
+
+    if (hasNewAccounts) {
+      logger.info(`Found ${newAccountsList.length} new accounts to refresh`, newAccountsList);
+    }
+
+    // Skip refresh only if fetchDisabled returns true AND there are no new accounts
+    if (fetchDisabled(userInitiated) && !hasNewAccounts) {
+      logger.info('skipping transaction refresh - no new accounts');
+      return;
+    }
+
+    if (hasNewAccounts) {
+      logger.info('Proceeding with refresh due to new accounts');
+    }
+
+    // Use the already separated accounts
+    let evmAccounts = currentEvmAccounts;
+    let evmLikeAccounts = currentEvmLikeAccounts;
+    let bitcoinAccounts = currentBitcoinAccounts;
+
+    // Check if we need to refresh based on new accounts
+    const allAccounts = allCurrentAccounts;
+    // If refresh is already running, add new accounts to pending
+    if (get(isRefreshing)) {
+      const newAccounts = getNewAccounts(allAccounts);
+      if (newAccounts.length > 0) {
+        addPendingAccounts(newAccounts);
+        logger.info(`Added ${newAccounts.length} accounts to pending queue`);
+      }
+      return;
+    }
+
+    // Check if we should refresh all accounts (includes new accounts check)
+    if (fullRefresh && shouldRefreshAll(allAccounts)) {
+      // Reset to refresh all accounts including new ones
+      evmAccounts = getEvmAccounts(chains);
+      evmLikeAccounts = getEvmLikeAccounts(chains);
+      bitcoinAccounts = getBitcoinAccounts(chains);
+    }
+    else if (hasNewAccounts) {
+      // If we have new accounts (either full or partial refresh), refresh only those
+      logger.info('Refreshing only new accounts');
+      evmAccounts = [];
+      evmLikeAccounts = [];
+      bitcoinAccounts = [];
+      newAccountsList.forEach((account) => {
         if ('evmChain' in account) {
           if (isEvmLikeChains(account.evmChain)) {
             evmLikeAccounts.push(account);
@@ -311,13 +285,10 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
         }
       });
     }
-    else if (fullRefresh && !disableEvmEvents) {
-      evmAccounts.push(...getEvmAccounts(chains));
-      evmLikeAccounts.push(...getEvmLikeAccounts(chains));
-      bitcoinAccounts.push(...getBitcoinAccounts(chains));
-    }
 
-    if (evmAccounts.length + evmLikeAccounts.length + bitcoinAccounts.length > 0) {
+    const accountsToRefresh = [...evmAccounts, ...evmLikeAccounts, ...bitcoinAccounts];
+    if (accountsToRefresh.length > 0) {
+      startRefresh(accountsToRefresh);
       setStatus(Status.REFRESHING);
       initializeQueryStatus(evmAccounts);
       resetUndecodedTransactionsStatus();
@@ -329,15 +300,15 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
 
       const asyncOperations: Promise<void>[] = [];
 
-      if (fullRefresh || (accounts && accounts.length > 0)) {
+      if (evmAccounts.length > 0) {
         asyncOperations.push(refreshTransactionsHandler({ accounts: evmAccounts, type: TransactionChainType.EVM }));
       }
 
-      if (fullRefresh || (accounts && bitcoinAccounts.length > 0)) {
+      if (bitcoinAccounts.length > 0) {
         asyncOperations.push(refreshTransactionsHandler({ accounts: bitcoinAccounts, type: TransactionChainType.BITCOIN }));
       }
 
-      if (fullRefresh) {
+      if (evmLikeAccounts.length > 0) {
         asyncOperations.push(refreshTransactionsHandler({ accounts: evmLikeAccounts, type: TransactionChainType.EVMLIKE }));
       }
 
@@ -366,6 +337,25 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     catch (error) {
       logger.error(error);
       resetStatus();
+    }
+    finally {
+      finishRefresh();
+
+      // After refresh is complete, check if there are pending accounts to refresh
+      if (get(hasPendingAccounts)) {
+        logger.info('Processing pending accounts after refresh completion');
+        const pendingAccounts = getPendingAccountsForRefresh();
+        // Recursively call refreshTransactions to handle pending accounts
+        setTimeout(() => {
+          refreshTransactions({
+            ...params,
+            payload: {
+              ...params.payload,
+              accounts: pendingAccounts,
+            },
+          }).catch(error => logger.error('Failed to refresh pending accounts', error));
+        }, 100);
+      }
     }
   };
 

--- a/frontend/app/src/store/history/refresh-state.ts
+++ b/frontend/app/src/store/history/refresh-state.ts
@@ -1,0 +1,195 @@
+import type { BitcoinChainAddress, EvmChainAddress } from '@/types/history/events';
+import { get, set } from '@vueuse/core';
+import { logger } from '@/utils/logging';
+
+interface RefreshState {
+  isRefreshing: boolean;
+  lastRefreshTime: number | null;
+  accountsAtLastRefresh: Set<string>;
+  pendingAccounts: Set<string>;
+  accountsBeingRefreshed: Set<string>;
+}
+
+export const useHistoryRefreshStateStore = defineStore('history/refresh-state', () => {
+  const state = ref<RefreshState>({
+    accountsAtLastRefresh: new Set<string>(),
+    accountsBeingRefreshed: new Set<string>(),
+    isRefreshing: false,
+    lastRefreshTime: null,
+    pendingAccounts: new Set<string>(),
+  });
+
+  const isRefreshing = computed<boolean>(() => get(state).isRefreshing);
+  const lastRefreshTime = computed<number | null>(() => get(state).lastRefreshTime);
+  const accountsAtLastRefresh = computed<Set<string>>(() => get(state).accountsAtLastRefresh);
+  const pendingAccounts = computed<Set<string>>(() => get(state).pendingAccounts);
+  const accountsBeingRefreshed = computed<Set<string>>(() => get(state).accountsBeingRefreshed);
+
+  const createAccountKey = (account: EvmChainAddress | BitcoinChainAddress): string => {
+    if ('evmChain' in account) {
+      return `${account.evmChain}:${account.address}`;
+    }
+    return `${account.chain}:${account.address}`;
+  };
+
+  const startRefresh = (accounts: Array<EvmChainAddress | BitcoinChainAddress>): void => {
+    const currentState = get(state);
+    const accountKeys = new Set(accounts.map(createAccountKey));
+
+    // Merge with existing accounts if we're refreshing pending accounts
+    const mergedAccountKeys = new Set([...currentState.accountsAtLastRefresh, ...accountKeys]);
+
+    // Mark these accounts as being refreshed
+    const newAccountsBeingRefreshed = new Set([...currentState.accountsBeingRefreshed, ...accountKeys]);
+
+    logger.info(`Starting refresh for ${accounts.length} accounts, total tracked: ${mergedAccountKeys.size}`);
+
+    set(state, {
+      accountsAtLastRefresh: mergedAccountKeys,
+      accountsBeingRefreshed: newAccountsBeingRefreshed,
+      isRefreshing: true,
+      lastRefreshTime: Date.now(),
+      pendingAccounts: new Set<string>(),
+    });
+  };
+
+  const finishRefresh = (): void => {
+    const currentState = get(state);
+    const pendingAccountKeys = currentState.pendingAccounts;
+
+    // If there are pending accounts, move them to be refreshed next
+    if (pendingAccountKeys.size > 0) {
+      set(state, {
+        accountsAtLastRefresh: currentState.accountsAtLastRefresh,
+        accountsBeingRefreshed: new Set<string>(), // Clear the accounts being refreshed
+        isRefreshing: false,
+        lastRefreshTime: currentState.lastRefreshTime,
+        pendingAccounts: pendingAccountKeys,
+      });
+    }
+    else {
+      set(state, {
+        ...currentState,
+        accountsBeingRefreshed: new Set<string>(), // Clear the accounts being refreshed
+        isRefreshing: false,
+      });
+    }
+  };
+
+  const addPendingAccounts = (accounts: Array<EvmChainAddress | BitcoinChainAddress>): void => {
+    const currentState = get(state);
+    const newPendingAccounts = new Set(currentState.pendingAccounts);
+
+    accounts.forEach((account) => {
+      const key = createAccountKey(account);
+      // Only add to pending if not already refreshed AND not currently being refreshed
+      if (!currentState.accountsAtLastRefresh.has(key) && !currentState.accountsBeingRefreshed.has(key)) {
+        newPendingAccounts.add(key);
+      }
+    });
+
+    set(state, {
+      ...currentState,
+      pendingAccounts: newPendingAccounts,
+    });
+  };
+
+  const getNewAccounts = (
+    currentAccounts: Array<EvmChainAddress | BitcoinChainAddress>,
+  ): Array<EvmChainAddress | BitcoinChainAddress> => {
+    const currentState = get(state);
+    const lastRefreshedAccounts = currentState.accountsAtLastRefresh;
+    const accountsBeingRefreshed = currentState.accountsBeingRefreshed;
+
+    logger.debug(`Checking for new accounts. Current: ${currentAccounts.length}, Last refreshed: ${lastRefreshedAccounts.size}, Being refreshed: ${accountsBeingRefreshed.size}`);
+
+    const newAccounts = currentAccounts.filter((account) => {
+      const key = createAccountKey(account);
+      // Exclude accounts that have been refreshed OR are currently being refreshed
+      return !lastRefreshedAccounts.has(key) && !accountsBeingRefreshed.has(key);
+    });
+
+    if (newAccounts.length > 0) {
+      logger.info(`Found ${newAccounts.length} new accounts (excluding ${accountsBeingRefreshed.size} being refreshed)`, newAccounts.map(createAccountKey));
+    }
+
+    return newAccounts;
+  };
+
+  const getPendingAccountsForRefresh = (): Array<EvmChainAddress | BitcoinChainAddress> => {
+    const currentState = get(state);
+    const accountsBeingRefreshed = currentState.accountsBeingRefreshed;
+    // Filter out accounts that are currently being refreshed
+    const pendingKeys = Array.from(currentState.pendingAccounts).filter(key => !accountsBeingRefreshed.has(key));
+    const result: Array<EvmChainAddress | BitcoinChainAddress> = [];
+
+    pendingKeys.forEach((key) => {
+      const [chain, address] = key.split(':');
+      if (chain && address) {
+        // Check if it's a bitcoin chain (simple heuristic - could be improved)
+        if (chain.toLowerCase() === 'btc' || chain.toLowerCase() === 'bch') {
+          result.push({ address, chain });
+        }
+        else {
+          result.push({ address, evmChain: chain });
+        }
+      }
+    });
+
+    if (result.length > 0) {
+      logger.info(`Preparing ${result.length} pending accounts for refresh (excluded ${accountsBeingRefreshed.size} being refreshed)`);
+    }
+
+    return result;
+  };
+
+  const hasPendingAccounts = computed<boolean>(() => get(state).pendingAccounts.size > 0);
+
+  const shouldRefreshAll = (
+    currentAccounts: Array<EvmChainAddress | BitcoinChainAddress>,
+  ): boolean => {
+    const currentState = get(state);
+
+    // If never refreshed, refresh all
+    if (currentState.lastRefreshTime === null) {
+      return true;
+    }
+
+    // If not currently refreshing and there are new accounts, refresh all
+    if (!currentState.isRefreshing) {
+      const newAccounts = getNewAccounts(currentAccounts);
+      return newAccounts.length > 0;
+    }
+
+    return false;
+  };
+
+  const reset = (): void => {
+    set(state, {
+      accountsAtLastRefresh: new Set<string>(),
+      accountsBeingRefreshed: new Set<string>(),
+      isRefreshing: false,
+      lastRefreshTime: null,
+      pendingAccounts: new Set<string>(),
+    });
+  };
+
+  return {
+    accountsAtLastRefresh,
+    accountsBeingRefreshed,
+    addPendingAccounts,
+    finishRefresh,
+    getNewAccounts,
+    getPendingAccountsForRefresh,
+    hasPendingAccounts,
+    isRefreshing,
+    lastRefreshTime,
+    pendingAccounts,
+    reset,
+    shouldRefreshAll,
+    startRefresh,
+  };
+});
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useHistoryRefreshStateStore, import.meta.hot));


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=122511446

 Problem: When users add a new account and return to the history events page, the new account's transactions weren't being fetched automatically.

  What I did to solve it:

  1. Created a tracking store (useHistoryRefreshStateStore)

  - Remembers which accounts were refreshed during the last refresh
  - Tracks accounts currently being refreshed (prevents duplicates)
  - Queues new accounts if refresh is already running

  2. Modified refresh detection logic

  - Before: The page would skip refresh on return (not first visit)
  - After: Checks if there are new accounts - if yes, refreshes them even on return
  - The key change: if (fetchDisabled && !hasNewAccounts) return - only skip if no new accounts

  3. Fixed account fetching

  - Before: Only fetched accounts when !disableEvmEvents was true
  - After: Always fetch all accounts to properly detect new ones
  - This fixed the issue where Bitcoin (BCH) accounts weren't being detected

  4. Simplified refresh conditions

  - Before: Complex conditions like fullRefresh || (accounts && bitcoinAccounts.length > 0)
  - After: Simple check - if accounts exist, refresh them: if (bitcoinAccounts.length > 0)

  5. Added proper queuing

  - If refresh is running when new account is added, queue it
  - After current refresh finishes, automatically start refreshing queued accounts
  - Prevents same account from being refreshed multiple times simultaneously

  Result: Now when you add any account (EVM, Bitcoin, etc.) and go back to history events, it automatically fetches that account's transactions without re-fetching existing accounts.
