### PR TITLE
fix(binance): avoid query all binance pairs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-
+* :bug:`10309` Users will now be required to specify the market pairs when adding a Binance API key to avoid rate limiting and getting stuck when querying the historical events.
 * :feature:`-` Users will now be able to persist privacy mode and scramble settings through an interface-only setting.
 * :bug:`10347` rotki will prioritize the native token in the asset selector on the on-chain send menu.
 * :bug:`10344` Users will now see the net worth on the tray that respects the scramble setting.

--- a/frontend/app/src/components/helper/BinancePairsSelector.vue
+++ b/frontend/app/src/components/helper/BinancePairsSelector.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Severity } from '@rotki/common';
+import { backoff } from '@shared/utils';
 import { useExchangeApi } from '@/composables/api/balances/exchanges';
 import { useNotificationsStore } from '@/store/notifications';
 
@@ -9,12 +10,18 @@ defineOptions({
 
 const props = defineProps<{
   name: string;
+  edit: boolean;
   location: string;
   errorMessages?: string[];
 }>();
 
-const emit = defineEmits<{ (e: 'update:selection', pairs: string[]): void }>();
-const { errorMessages, location, name } = toRefs(props);
+const emit = defineEmits<{
+  (e: 'update:selection', pairs: string[]): void;
+}>();
+
+const MAX_RETRIES = 3;
+
+const { edit, errorMessages, location, name } = toRefs(props);
 
 const updateSelection = (value: string[]) => emit('update:selection', value);
 
@@ -33,26 +40,14 @@ const api = useExchangeApi();
 
 const { notify } = useNotificationsStore();
 
-onMounted(async () => {
-  set(loading, true);
+async function queryAllMarkets() {
   try {
-    set(queriedMarkets, await api.queryBinanceUserMarkets(get(name), get(location)));
-  }
-  catch (error: any) {
-    const title = t('binance_market_selector.query_user.title');
-    const description = t('binance_market_selector.query_user.error', {
-      message: error.message,
-    });
-    notify({
-      display: true,
-      message: description,
-      severity: Severity.ERROR,
-      title,
-    });
-  }
-
-  try {
-    set(allMarkets, await api.queryBinanceMarkets(get(location)));
+    const markets = await backoff(
+      MAX_RETRIES,
+      () => api.queryBinanceMarkets(get(location)),
+      1000, // Initial delay of 1 second
+    );
+    set(allMarkets, markets);
   }
   catch (error: any) {
     const title = t('binance_market_selector.query_all.title');
@@ -66,38 +61,91 @@ onMounted(async () => {
       title,
     });
   }
+}
 
+async function loadUserMarkets() {
+  if (get(edit)) {
+    try {
+      const markets = await api.queryBinanceUserMarkets(get(name), get(location));
+      set(queriedMarkets, markets);
+      set(selection, markets);
+    }
+    catch (error: any) {
+      const title = t('binance_market_selector.query_user.title');
+      const description = t('binance_market_selector.query_user.error', {
+        message: error.message,
+      });
+      notify({
+        display: true,
+        message: description,
+        severity: Severity.ERROR,
+        title,
+      });
+    }
+  }
+}
+
+async function refreshMarkets(refreshUserMarkets = false) {
+  set(loading, true);
+  if (refreshUserMarkets) {
+    await loadUserMarkets();
+  }
+  await queryAllMarkets();
   set(loading, false);
-  set(selection, get(queriedMarkets));
+}
+
+onMounted(() => {
+  refreshMarkets(true);
 });
 </script>
 
 <template>
-  <RuiAutoComplete
-    v-bind="$attrs"
-    :options="allMarkets"
-    :loading="loading"
-    :disabled="loading"
-    :error-messages="errorMessages"
-    hide-selected
-    chips
-    clearable
-    auto-select-first
-    variant="outlined"
-    :label="t('binance_market_selector.default_label')"
-    class="binance-market-selector"
-    :model-value="selection"
-    :item-height="54"
-    @update:model-value="onSelectionChange($event)"
-  >
-    <template #item="data">
-      <div class="binance-market-selector__list__item flex justify-between grow">
-        <div class="binance-market-selector__list__item__address-label">
-          <RuiChip size="sm">
-            {{ data.item }}
-          </RuiChip>
+  <div class="flex items-start gap-2">
+    <RuiAutoComplete
+      v-bind="$attrs"
+      :options="allMarkets"
+      :loading="loading"
+      :disabled="loading"
+      :error-messages="errorMessages"
+      hide-selected
+      chips
+      clearable
+      auto-select-first
+      variant="outlined"
+      :label="t('binance_market_selector.default_label')"
+      class="binance-market-selector"
+      :model-value="selection"
+      :item-height="54"
+      @update:model-value="onSelectionChange($event)"
+    >
+      <template #item="data">
+        <div class="binance-market-selector__list__item flex justify-between grow">
+          <div class="binance-market-selector__list__item__address-label">
+            <RuiChip size="sm">
+              {{ data.item }}
+            </RuiChip>
+          </div>
         </div>
-      </div>
-    </template>
-  </RuiAutoComplete>
+      </template>
+    </RuiAutoComplete>
+    <RuiTooltip
+      :popper="{ placement: 'top' }"
+      :open-delay="400"
+    >
+      <template #activator>
+        <RuiButton
+          class="mt-1"
+          variant="text"
+          icon
+          color="primary"
+          :loading="loading"
+          :disabled="loading"
+          @click="refreshMarkets()"
+        >
+          <RuiIcon name="lu-refresh-ccw" />
+        </RuiButton>
+      </template>
+      {{ t('binance_market_selector.refresh_tooltip') }}
+    </RuiTooltip>
+  </div>
 </template>

--- a/frontend/app/src/components/helper/BinancePairsSelector.vue
+++ b/frontend/app/src/components/helper/BinancePairsSelector.vue
@@ -7,21 +7,14 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = withDefaults(
-  defineProps<{
-    label?: string;
-    outlined?: boolean;
-    name: string;
-    location: string;
-  }>(),
-  {
-    label: '',
-    outlined: false,
-  },
-);
+const props = defineProps<{
+  name: string;
+  location: string;
+  errorMessages?: string[];
+}>();
 
 const emit = defineEmits<{ (e: 'update:selection', pairs: string[]): void }>();
-const { location, name } = toRefs(props);
+const { errorMessages, location, name } = toRefs(props);
 
 const updateSelection = (value: string[]) => emit('update:selection', value);
 
@@ -85,12 +78,13 @@ onMounted(async () => {
     :options="allMarkets"
     :loading="loading"
     :disabled="loading"
-    hide-details
+    :error-messages="errorMessages"
     hide-selected
     chips
     clearable
+    auto-select-first
     variant="outlined"
-    :label="label || t('binance_market_selector.default_label')"
+    :label="t('binance_market_selector.default_label')"
     class="binance-market-selector"
     :model-value="selection"
     :item-height="54"

--- a/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -352,11 +352,20 @@ defineExpose({
     <BinancePairsSelector
       v-if="isBinance"
       :name="modelValue.name"
+      :edit="editMode"
       :location="modelValue.location"
       :error-messages="toMessages(v$.binanceMarkets)"
       @update:selection="modelValue = { ...modelValue, binanceMarkets: $event }"
     />
   </div>
+
+  <RuiAlert
+    v-if="isBinance"
+    class="mt-4"
+    type="info"
+  >
+    {{ t('exchange_keys_form.binance_markets_required') }}
+  </RuiAlert>
 
   <RuiAlert
     v-if="showKeyWaitingTimeWarning"

--- a/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ValidationErrors } from '@/types/api/errors';
 import { toSentenceCase } from '@rotki/common';
 import useVuelidate from '@vuelidate/core';
 import { helpers, requiredIf, requiredUnless } from '@vuelidate/validators';
@@ -17,6 +18,7 @@ import { toMessages } from '@/utils/validation';
 const modelValue = defineModel<ExchangeFormData>({ required: true });
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { required: true });
+const errorMessages = defineModel<ValidationErrors>('errorMessages', { default: () => ({}) });
 
 const editKeys = ref<boolean>(false);
 
@@ -193,7 +195,7 @@ const v$ = useVuelidate({
   name: nameProp,
   newName: newNameProp,
   passphrase,
-}, { $autoDirty: true });
+}, { $autoDirty: true, $externalResults: errorMessages });
 
 function onExchangeChange(exchange?: string) {
   const name = exchange ?? '';

--- a/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -94,6 +94,7 @@ const apiSecretModel = refWithAsterisk(apiSecret);
 
 const passphrase = useRefPropVModel(modelValue, 'passphrase');
 const krakenAccountType = useRefPropVModel(modelValue, 'krakenAccountType');
+const binanceMarkets = useRefPropVModel(modelValue, 'binanceMarkets');
 
 const name = computed<string>({
   get() {
@@ -112,6 +113,7 @@ const name = computed<string>({
 useFormStateWatcher({
   apiKey,
   apiSecret,
+  binanceMarkets,
   krakenAccountType,
   name,
   passphrase,
@@ -160,6 +162,12 @@ const v$ = useVuelidate({
       requiredIf(logicAnd(sensitiveFieldEditable, requiresApiSecret)),
     ),
   },
+  binanceMarkets: {
+    required: helpers.withMessage(
+      t('exchange_keys_form.validation.non_empty'),
+      requiredIf(isBinance),
+    ),
+  },
   name: {
     required: helpers.withMessage(
       t('exchange_keys_form.name.non_empty'),
@@ -181,6 +189,7 @@ const v$ = useVuelidate({
 }, {
   apiKey,
   apiSecret,
+  binanceMarkets,
   name: nameProp,
   newName: newNameProp,
   passphrase,
@@ -342,6 +351,7 @@ defineExpose({
       v-if="isBinance"
       :name="modelValue.name"
       :location="modelValue.location"
+      :error-messages="toMessages(v$.binanceMarkets)"
       @update:selection="modelValue = { ...modelValue, binanceMarkets: $event }"
     />
   </div>

--- a/frontend/app/src/composables/message-handling/binance-pairs-missing.ts
+++ b/frontend/app/src/composables/message-handling/binance-pairs-missing.ts
@@ -1,0 +1,29 @@
+import type { BinancePairsMissingData, CommonMessageHandler } from '@/types/websocket-messages';
+import { type Notification, Priority, Severity } from '@rotki/common';
+import { Routes } from '@/router/routes';
+
+export function useBinancePairsMissingHandler(t: ReturnType<typeof useI18n>['t']): CommonMessageHandler<BinancePairsMissingData> {
+  const router = useRouter();
+
+  const handle = (data: BinancePairsMissingData): Notification => {
+    const { location, name } = data;
+
+    return {
+      action: {
+        action: async () => router.push({
+          path: Routes.API_KEYS_EXCHANGES.toString(),
+          query: { location, name },
+        }),
+        label: t('notification_messages.binance_pairs_missing.action'),
+        persist: true,
+      },
+      display: true,
+      message: t('notification_messages.binance_pairs_missing.message', { name }),
+      priority: Priority.ACTION,
+      severity: Severity.WARNING,
+      title: t('notification_messages.binance_pairs_missing.title'),
+    };
+  };
+
+  return { handle };
+}

--- a/frontend/app/src/composables/message-handling/index.ts
+++ b/frontend/app/src/composables/message-handling/index.ts
@@ -4,6 +4,7 @@ import { useSessionApi } from '@/composables/api/session';
 import {
   useAccountingRuleConflictMessageHandler,
 } from '@/composables/message-handling/accounting-rule-conflict-message';
+import { useBinancePairsMissingHandler } from '@/composables/message-handling/binance-pairs-missing';
 import { useCalendarReminderHandler } from '@/composables/message-handling/calendar-reminder';
 import { useCsvImportResultHandler } from '@/composables/message-handling/csv-import-result';
 import { useMissingApiKeyHandler } from '@/composables/message-handling/missing-api-key';
@@ -64,6 +65,7 @@ export function useMessageHandling(): UseMessageHandling {
   const { setStakingQueryStatus: setLiquityStakingQueryStatus } = useLiquityStore();
   const solanaTokenMigrationStore = useSolanaTokenMigrationStore();
   const { handle: handleMissingApiKeyMessage } = useMissingApiKeyHandler(t);
+  const { handle: handleBinancePairsMissingMessage } = useBinancePairsMissingHandler(t);
   const { handle: handleAccountingRuleConflictMessage } = useAccountingRuleConflictMessageHandler(t);
   const { handle: handleCalendarReminder } = useCalendarReminderHandler(t);
   const { handle: handleCsvImportResult } = useCsvImportResultHandler(t);
@@ -274,6 +276,9 @@ export function useMessageHandling(): UseMessageHandling {
     else if (type === SocketMessageType.SOLANA_TOKENS_MIGRATION) {
       solanaTokenMigrationStore.setIdentifiers(message.data.identifiers);
       addNotification(await handleSolanaTokensMigration(message.data));
+    }
+    else if (type === SocketMessageType.BINANCE_PAIRS_MISSING) {
+      addNotification(await handleBinancePairsMissingMessage(message.data));
     }
     else if (type === SocketMessageType.DATABASE_UPLOAD_PROGRESS) {
       handleDatabaseUploadProgress(message.data);

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3539,6 +3539,11 @@
     "backend": {
       "title": "Backend"
     },
+    "binance_pairs_missing": {
+      "action": "Configure pairs",
+      "message": "Your Binance API key \"{name}\" is missing required market pairs configuration. This may cause rate limiting issues. Please configure the pairs you want to track.",
+      "title": "Binance Market Pairs Required"
+    },
     "csv_import_result": {
       "errors": "The following errors occurred during import:",
       "rows": "(Row: {rows}) | (Rows: {rows})",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1444,7 +1444,8 @@
     "query_user": {
       "error": "Couldn't get the list of markets selected to be queried for binance.",
       "title": "Query selected Binance markets"
-    }
+    },
+    "refresh_tooltip": "Refresh Binance market pairs"
   },
   "blockchain_account_selector": {
     "all": "all",
@@ -2227,6 +2228,7 @@
     }
   },
   "exchange_keys_form": {
+    "binance_markets_required": "Binance market pairs are required to avoid rate limiting. This limitation comes from the Binance API itself which enforces strict rate limits when querying all trading pairs.",
     "edit": {
       "activate_tooltip": "Edit the api keys for the exchange.",
       "deactivate_tooltip": "Cancel the edit of the api keys for the exchange."

--- a/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
@@ -176,44 +176,32 @@ export function useExchanges(): UseExchangesReturn {
   };
 
   const setupExchange = async (exchange: ExchangeFormData): Promise<boolean> => {
-    try {
-      const success = await callSetupExchange(exchange);
-      const { krakenAccountType, location, mode, name, newName } = exchange;
-      const exchangeEntry: Exchange = {
-        krakenAccountType,
-        location,
-        name,
-      };
+    const success = await callSetupExchange(exchange);
+    const { krakenAccountType, location, mode, name, newName } = exchange;
+    const exchangeEntry: Exchange = {
+      krakenAccountType,
+      location,
+      name,
+    };
 
-      if (mode !== 'edit') {
-        addExchange(exchangeEntry);
-      }
-      else {
-        editExchange({
-          exchange: exchangeEntry,
-          newName,
-        });
-      }
-
-      startPromise(
-        fetchExchangeBalances({
-          ignoreCache: false,
-          location,
-        }),
-      );
-
-      return success;
+    if (mode !== 'edit') {
+      addExchange(exchangeEntry);
     }
-    catch (error: any) {
-      setMessage({
-        description: t('actions.balances.exchange_setup.description', {
-          error: error.message,
-          exchange: exchange.location,
-        }),
-        title: t('actions.balances.exchange_setup.title'),
+    else {
+      editExchange({
+        exchange: exchangeEntry,
+        newName,
       });
-      return false;
     }
+
+    startPromise(
+      fetchExchangeBalances({
+        ignoreCache: false,
+        location,
+      }),
+    );
+
+    return success;
   };
 
   return {

--- a/frontend/app/src/modules/onchain/use-transaction-manager.ts
+++ b/frontend/app/src/modules/onchain/use-transaction-manager.ts
@@ -96,7 +96,7 @@ export function useTransactionManager(): {
     addRecentTransaction,
     getRecentTransactionByTxHash,
     handleTransactionSuccess,
-    recentTransactions: readonly(recentTransactions) as Readonly<Ref<RecentTransaction[]>>,
+    recentTransactions,
     updateTransactionStatus,
   };
 }

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -155,13 +155,24 @@ onBeforeMount(() => {
   resetNonSyncingExchanges();
 });
 
-onMounted(async () => {
-  const { query } = get(route);
+watch(route, async (route) => {
+  const { query } = route;
+
   if (query.add) {
     addExchange();
     await router.replace({ query: {} });
   }
-});
+  else if (query.location && query.name) {
+    // Find the exchange to edit based on location and name from query params
+    const exchangeToEdit = get(rows).find(
+      ex => ex.location === query.location && ex.name === query.name,
+    );
+    if (exchangeToEdit) {
+      editExchange(exchangeToEdit);
+      await router.replace({ query: {} });
+    }
+  }
+}, { immediate: true });
 </script>
 
 <template>

--- a/frontend/app/src/types/websocket-messages/base.ts
+++ b/frontend/app/src/types/websocket-messages/base.ts
@@ -22,6 +22,7 @@ export type BalanceSnapshotError = z.infer<typeof BalanceSnapshotError>;
 export const SocketMessageType = {
   ACCOUNTING_RULE_CONFLICT: 'accounting_rule_conflict',
   BALANCES_SNAPSHOT_ERROR: 'balance_snapshot_error',
+  BINANCE_PAIRS_MISSING: 'binance_pairs_missing',
   CALENDAR_REMINDER: 'calendar_reminder',
   DATA_MIGRATION_STATUS: 'data_migration_status',
   DATABASE_UPLOAD_PROGRESS: 'database_upload_progress',

--- a/frontend/app/src/types/websocket-messages/messages.ts
+++ b/frontend/app/src/types/websocket-messages/messages.ts
@@ -5,6 +5,7 @@ import { BalanceSnapshotError, LegacyMessageData, SocketMessageType } from './ba
 import { HistoryEventsQueryData } from './history';
 import {
   AccountingRuleConflictData,
+  BinancePairsMissingData,
   ExchangeUnknownAssetData,
   GnosisPaySessionKeyExpiredData,
   MissingApiKey,
@@ -111,6 +112,11 @@ const SolanaTokensMigrationMessage = z.object({
   type: z.literal(SocketMessageType.SOLANA_TOKENS_MIGRATION),
 });
 
+const BinancePairsMissingMessage = z.object({
+  data: BinancePairsMissingData,
+  type: z.literal(SocketMessageType.BINANCE_PAIRS_MISSING),
+});
+
 const DatabaseUploadProgressMessage = z.object({
   data: DatabaseUploadProgress,
   type: z.literal(SocketMessageType.DATABASE_UPLOAD_PROGRESS),
@@ -135,6 +141,7 @@ export const WebsocketMessage = z.discriminatedUnion('type', [
   ProgressUpdatesMessage,
   GnosisPaySessionKeyExpiredMessage,
   SolanaTokensMigrationMessage,
+  BinancePairsMissingMessage,
   DatabaseUploadProgressMessage,
 ]).or(UnknownWebsocketMessage);
 

--- a/frontend/app/src/types/websocket-messages/notifications.ts
+++ b/frontend/app/src/types/websocket-messages/notifications.ts
@@ -53,3 +53,10 @@ export const SolanaTokensMigrationData = z.object({
 });
 
 export type SolanaTokensMigrationData = z.infer<typeof SolanaTokensMigrationData>;
+
+export const BinancePairsMissingData = z.object({
+  location: z.string(),
+  name: z.string(),
+});
+
+export type BinancePairsMissingData = z.infer<typeof BinancePairsMissingData>;


### PR DESCRIPTION
Frontend part of https://github.com/rotki/rotki/issues/10309

- [x] Prevent user to leave binance market pairs empty when adding the api keys
- [x] User will see a notification if they have binance api key and didn't specify the market pairs in the past