### PR TITLE
set protocol spark savings vault tokens

### DIFF
--- a/rotkehlchen/chain/evm/decoding/base.py
+++ b/rotkehlchen/chain/evm/decoding/base.py
@@ -314,6 +314,7 @@ class BaseDecoderTools:
             self,
             address: ChecksumEvmAddress,
             encounter: 'TokenEncounterInfo | None' = None,
+            protocol: str | None = None,
     ) -> EvmToken:
         """A version of get_create_evm_token to be called from the decoders"""
         return get_or_create_evm_token(
@@ -322,6 +323,7 @@ class BaseDecoderTools:
             chain_id=self.evm_inquirer.chain_id,
             evm_inquirer=self.evm_inquirer,
             encounter=encounter,
+            protocol=protocol,
         )
 
     def get_or_create_evm_asset(self, address: ChecksumEvmAddress) -> CryptoAsset:

--- a/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
@@ -123,6 +123,7 @@ class SparksavingsCommonDecoder(SparkCommonDecoder):
 
         vault_token = self.base.get_or_create_evm_token(
             address=context.tx_log.address,
+            protocol=CPT_SPARK,
             encounter=(encounter := TokenEncounterInfo(should_notify=False)),
         )
         underlying_token = self.base.get_or_create_evm_token(

--- a/rotkehlchen/tests/unit/decoders/test_spark.py
+++ b/rotkehlchen/tests/unit/decoders/test_spark.py
@@ -308,7 +308,7 @@ def test_susdc_ethereum_deposit(ethereum_inquirer, ethereum_accounts):
             location=Location.ETHEREUM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
-            asset=Asset('eip155:1/erc20:0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE'),
+            asset=(susdc_token := Asset('eip155:1/erc20:0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE')),  # noqa: E501
             amount=FVal(received_amount),
             location_label=user_address,
             notes=f'Receive {received_amount} sUSDC from depositing into Spark Savings',
@@ -316,6 +316,7 @@ def test_susdc_ethereum_deposit(ethereum_inquirer, ethereum_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
+    assert susdc_token.resolve_to_evm_token().protocol == CPT_SPARK
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])


### PR DESCRIPTION
sets the protocol for spark savings vault tokens (sUSDC, sUSDS, sxDAI) to **"spark"** so that asset balances are properly grouped in the dashboard.

also, `BaseDecoderTools.get_or_create_evm_token()`  was updated to accept `protocol` as an argument.