### PR TITLE
Fix decoding of morpho beefy vault deposits

### DIFF
--- a/rotkehlchen/chain/evm/decoding/morpho/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/morpho/decoder.py
@@ -158,7 +158,8 @@ class MorphoCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
                 (
                     event.amount == assets_amount or
                     (is_weth_vault and event.address in self.bundlers)
-                )
+                ) and
+                self.base.is_tracked(bytes_to_address(context.tx_log.topics[2]))  # owner address should be tracked  # noqa: E501
             ):
                 event.event_type = HistoryEventType.DEPOSIT
                 event.event_subtype = HistoryEventSubType.DEPOSIT_FOR_WRAPPED


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=123742390

Changes the morpho decoder to check that the owner address provided in the deposit log is actually tracked before decoding to avoid messing with other protocol's decoding (beefy in this case) when they use a morpho vault to power their own vault.
