### PR TITLE
fix: check for empty string when loading certificates

### DIFF
--- a/package.py
+++ b/package.py
@@ -376,7 +376,7 @@ class WindowsPackaging:
             logger.info('WIN_CSC_LINK already set skipping')
             return True
 
-        if certificate is None:
+        if certificate is None or certificate == '':
             logger.info(f'{WIN_CERTIFICATE} is not set skipping signing')
             return False
 
@@ -420,7 +420,7 @@ class MacPackaging:
             logger.info('CSC_LINK already set skipping')
             return True
 
-        if certificate is None:
+        if certificate is None or certificate == '':
             logger.info(f'{MAC_CERTIFICATE} is not set skipping signing')
             return False
 


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
