### PR TITLE
Better APR calculation for heavily consolidated validators

### DIFF
--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -947,7 +947,7 @@ def test_staking_performance_division_by_zero_protection(eth2) -> None:
 
     with (
         patch('rotkehlchen.chain.ethereum.modules.eth2.beacon.BeaconInquirer.get_validator_data', return_value=[validator]),  # noqa: E501
-        patch('rotkehlchen.chain.ethereum.modules.eth2.eth2.Eth2._time_weighted_average', return_value=ZERO),  # noqa: E501
+        patch('rotkehlchen.chain.ethereum.modules.eth2.eth2.Eth2._time_weighted_balance_sum', return_value=ZERO),  # noqa: E501
     ):
         result = eth2.get_performance(
             from_ts=Timestamp(1631378127),


### PR DESCRIPTION
First fix for https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=123182241

  The original APR calculation was incorrect for consolidated validators (validators whose balance increased from 32 ETH to higher amounts like 2048 ETH). These validators showed artificially low APRs because the calculation didn't properly account for when profits
  were earned relative to balance changes.

  Root Cause

  The original formula was:
  APR = (total_profits * YEAR_IN_SECONDS / time_period) / time_weighted_average_balance

  For consolidated validators:
  - Most profits were earned when balance was low (32 ETH) over many months/years
  - Recent consolidation increased balance to high amounts (e.g., 2048 ETH)
  - Time-weighted average included both periods, inflating the denominator
  - Result: APR appeared much lower than actual performance

Note: This is still not perfect and is downcounting the APR. The reason is simple. All profit that accrues until max balance is not counted as profit with this calculation.

We would need a very different calculation for that and would need to count anything outside of deposits/consolidations also as profit which I think is not being done properly yet.
