### PR TITLE
fix(frontend): disable toggle location link if not evm chain

### DIFF
--- a/frontend/app/src/modules/history/management/forms/common/ToggleLocationLink.vue
+++ b/frontend/app/src/modules/history/management/forms/common/ToggleLocationLink.vue
@@ -10,10 +10,17 @@ const props = withDefaults(defineProps<{
 
 const locationLimited = ref<boolean>(true);
 
-const { matchChain } = useSupportedChains();
+const { isEvm, matchChain } = useSupportedChains();
 const { t } = useI18n({ useScope: 'global' });
 
-const isDisabled = computed<boolean>(() => props.disabled || props.location === undefined || !matchChain(props.location));
+const isDisabled = computed<boolean>(() => {
+  if (props.disabled || props.location === undefined) {
+    return true;
+  }
+
+  const chain = matchChain(props.location);
+  return !chain || !get(isEvm(chain));
+});
 
 const tooltipText = computed<string>(() => {
   if (get(isDisabled)) {
@@ -27,12 +34,12 @@ const tooltipText = computed<string>(() => {
 
 function updateModel() {
   const location = props.location;
-  if (!get(locationLimited) || location === undefined || !matchChain(location)) {
+  if (!get(locationLimited) || !isDefined(location) || get(isDisabled)) {
     set(modelValue, undefined);
+    return;
   }
-  else {
-    set(modelValue, location.replace(' ', '_'));
-  }
+
+  set(modelValue, location.replace(' ', '_'));
 }
 
 watch(locationLimited, () => {


### PR DESCRIPTION
the evm filter should be applied to asset select, only if the location is evm chain
<img width="853" height="823" alt="image" src="https://github.com/user-attachments/assets/0c80ec88-b14f-4982-bedb-785efc7c9a16" />