### PR TITLE
Add ts validation for setting historical prices

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2892,7 +2892,7 @@ class ManualPriceSchema(Schema):
 
 
 class TimedManualPriceSchema(ManualPriceSchema):
-    timestamp = TimestampField(required=True)
+    timestamp = TimestampUntilNowField(required=True)
 
 
 class SnapshotTimestampQuerySchema(Schema):

--- a/rotkehlchen/tests/api/test_historical_assets_price.py
+++ b/rotkehlchen/tests/api/test_historical_assets_price.py
@@ -86,19 +86,20 @@ def test_get_historical_assets_price(
 
 
 @pytest.mark.freeze_time('2025-08-13 08:00:00 GMT')
-def test_get_historical_assets_price_error(
+def test_historical_assets_price_future_ts_error(
         rotkehlchen_api_server: APIServer,
 ) -> None:
-    """Test error when querying historical asset price with an invalid timestamp."""
-    response = requests.post(
-        api_url_for(rotkehlchen_api_server, 'historicalassetspriceresource'),
-        json={'assets_timestamp': [['BTC', 10000000000]], 'target_asset': 'USD'},
-    )
-    assert_error_response(
-        response=response,
-        contained_in_msg='Given date cannot be in the future',
-        status_code=HTTPStatus.BAD_REQUEST,
-    )
+    """Test error when setting or querying historical asset price with an invalid timestamp."""
+    url = api_url_for(rotkehlchen_api_server, 'historicalassetspriceresource')
+    for request_fnc, json in (
+        (requests.put, {'from_asset': 'ETH', 'to_asset': 'USD', 'price': '1234', 'timestamp': 10000000000}),  # noqa: E501
+        (requests.post, {'assets_timestamp': [['BTC', 10000000000]], 'target_asset': 'USD'}),
+    ):
+        assert_error_response(
+            response=request_fnc(url=url, json=json),
+            contained_in_msg='Given date cannot be in the future',
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
 
 
 def _assert_expected_prices(


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=124219458

adds timestamp validation for when we set the ts as well as just the query (was added in #10446). Note that I'm not adding this for the delete endpoint since I think it would make sense to always be able to delete even if somehow a future ts got in the db.