### PR TITLE
chore: bump pyinstaller to 6.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM ghcr.io/astral-sh/uv:python3.11-bookworm AS backend-build-stage
 ARG TARGETARCH
 ARG ROTKI_VERSION
 ENV PACKAGE_FALLBACK_VERSION=$ROTKI_VERSION
-ARG PYINSTALLER_VERSION=v6.7.0
+ARG PYINSTALLER_VERSION=v6.15.0
 
 WORKDIR /app
 COPY pyproject.toml uv.lock* ./

--- a/package.py
+++ b/package.py
@@ -19,7 +19,7 @@ from setuptools_scm import get_version
 
 rotki_version = get_version()
 
-pyinstaller_version = os.environ.get('PYINSTALLER_VERSION', '6.7.0')
+pyinstaller_version = os.environ.get('PYINSTALLER_VERSION', '6.15.0')
 BACKEND_PREFIX = 'rotki-core'
 SUPPORTED_ARCHS = [
     'AMD64',  # Windows


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
