### PR TITLE
Allow manually refreshing the beefy vault cache

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Users can now manually reset cached Beefy Finance vault data to trigger re-pulling the data during decoding.
 * :bug:`-` Fix an issue where significant layout shifts occur due to the history events status banner suddenly appearing on the dashboard.
 * :bug:`-` Users will be able to see the history event location label, even if the scramble setting is enabled.
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4784,6 +4784,12 @@ class RestAPI:
                         'DELETE FROM unique_cache WHERE key LIKE ?',
                         (f'{CacheType.MERKL_REWARD_PROTOCOLS.serialize()}%',),
                     )
+            case ProtocolsWithCache.BEEFY_FINANCE:
+                with GlobalDBHandler().conn.write_ctx() as write_cursor:
+                    write_cursor.execute(
+                        'DELETE FROM unique_cache WHERE key LIKE ?',
+                        (f'{CacheType.BEEFY_VAULTS.serialize()}%',),
+                    )
 
         failed_to_update = []
         for (cache, cache_type, query_method, chain_id, inquirer) in cache_rules:

--- a/rotkehlchen/chain/evm/decoding/utils.py
+++ b/rotkehlchen/chain/evm/decoding/utils.py
@@ -243,6 +243,7 @@ def get_vault_price(
         return ZERO_PRICE
 
     if (
+        vault_token.underlying_tokens is None or
         len(vault_token.underlying_tokens) == 0 or
         (underlying_token := get_token(
             evm_address=vault_token.underlying_tokens[0].address,

--- a/rotkehlchen/tests/api/test_caching.py
+++ b/rotkehlchen/tests/api/test_caching.py
@@ -138,6 +138,8 @@ def test_protocol_data_refresh(rotkehlchen_api_server: 'APIServer') -> None:
         'spark',
         'balancer v1',
         'balancer v2',
+        'merkl',
+        'beefy finance',
     }.issubset(set(result))
 
     with ExitStack() as stack:
@@ -186,7 +188,7 @@ def test_protocol_data_refresh(rotkehlchen_api_server: 'APIServer') -> None:
             'rotkehlchen.api.rest.query_balancer_data',
             new=MagicMock(),
         ))
-        patched_merkl_cache = stack.enter_context(patch(
+        patched_globaldb_handler = stack.enter_context(patch(
             'rotkehlchen.api.rest.GlobalDBHandler',
             new=MagicMock(),
         ))
@@ -205,7 +207,8 @@ def test_protocol_data_refresh(rotkehlchen_api_server: 'APIServer') -> None:
             (ProtocolsWithCache.ETH_BLOCKS, patched_eth_withdrawals_cache, 1),
             (ProtocolsWithCache.BALANCER_V1, patched_balancer_query, 3),  # supported on 3 chains
             (ProtocolsWithCache.BALANCER_V2, patched_balancer_query, 6),  # supported on 6 chains
-            (ProtocolsWithCache.MERKL, patched_merkl_cache, 1),
+            (ProtocolsWithCache.MERKL, patched_globaldb_handler, 1),
+            (ProtocolsWithCache.BEEFY_FINANCE, patched_globaldb_handler, 1),
         ):
             patched_obj.reset_mock()
             response = requests.post(api_url_for(

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -1312,6 +1312,7 @@ class ProtocolsWithCache(SerializableEnumNameMixin):
     BALANCER_V1 = auto()
     BALANCER_V2 = auto()
     MERKL = auto()
+    BEEFY_FINANCE = auto()
     # TODO: ETH_WITHDRAWALS and ETH_BLOCKS should be removed
     #  once https://github.com/rotki/rotki/issues/9302 is implemented
     ETH_WITHDRAWALS = auto()


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=124528067

Note that this simply allows resetting the cache of the number of vaults and last queried ts so that the beefy vault data is re-pulled during the next decoding - similar to how merkl works here as well. I think this makes sense in this case since the beefy vaults can take some time to pull and its better to do it during decoding where there are visible progress updates rather than trying to repull the data for all chains here.