### PR TITLE
Remove FREE_ETH_TX_LIMIT

### DIFF
--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -629,7 +629,6 @@ class EvmTransactions(ABC):  # noqa: B024
             return self.dbevmtx.get_evm_transactions(
                 cursor=cursor,
                 filter_=EvmTransactionsFilterQuery.make(tx_hash=tx_hash, chain_id=self.evm_inquirer.chain_id),  # noqa: E501
-                has_premium=True,
             )[0], tx_receipt  # all good, tx receipt is in the database
 
         log.debug(f'Querying transaction data for {tx_hash=}({self.evm_inquirer.chain_name})')
@@ -768,12 +767,9 @@ class EvmTransactions(ABC):  # noqa: B024
                     end_ts=Timestamp(0),
                 )
 
-        # Check whether the genesis tx was added
-        with self.database.conn.read_ctx() as cursor:
-            added_tx = self.dbevmtx.get_evm_transactions(
+            added_tx = self.dbevmtx.get_evm_transactions(  # Check whether the genesis tx was added  # noqa: E501
                 cursor=cursor,
                 filter_=EvmTransactionsFilterQuery.make(tx_hash=GENESIS_HASH, chain_id=self.evm_inquirer.chain_id),  # noqa: E501
-                has_premium=True,  # we don't need any limiting here
             )
 
         if len(added_tx) == 0:
@@ -896,7 +892,6 @@ class EvmTransactions(ABC):  # noqa: B024
             if len(self.dbevmtx.get_evm_transactions(
                 cursor=cursor,
                 filter_=EvmTransactionsFilterQuery.make(tx_hash=tx_hash, chain_id=self.evm_inquirer.chain_id),  # noqa: E501
-                has_premium=True,
             )) == 1 and self.dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=self.evm_inquirer.chain_id) is not None:  # noqa: E501
                 raise AlreadyExists(f'Transaction {tx_hash.hex()} is already in the DB')
 

--- a/rotkehlchen/constants/limits.py
+++ b/rotkehlchen/constants/limits.py
@@ -1,5 +1,4 @@
 from typing import Final
 
 FREE_HISTORY_EVENTS_LIMIT: Final = 100
-FREE_ETH_TX_LIMIT: Final = 100
 FREE_USER_NOTES_LIMIT: Final = 10

--- a/rotkehlchen/tests/api/test_data_purging.py
+++ b/rotkehlchen/tests/api/test_data_purging.py
@@ -135,7 +135,7 @@ def test_purge_blockchain_transaction_data(rotkehlchen_api_server: 'APIServer') 
                 )
 
     with rotki.data.db.conn.read_ctx() as cursor:
-        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)
+        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
         assert len(result) == 7
         response = requests.delete(
             api_url_for(
@@ -145,9 +145,9 @@ def test_purge_blockchain_transaction_data(rotkehlchen_api_server: 'APIServer') 
             json={'chain': 'eth'},
         )
         assert_simple_ok_response(response)
-        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)
+        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
         assert len(result) == 4
-        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(chain_id=ChainID.ETHEREUM), True)  # noqa: E501
+        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(chain_id=ChainID.ETHEREUM))  # noqa: E501
         assert len(result) == 0
         assert dbevents.get_history_events_count(
             cursor=cursor,
@@ -191,7 +191,7 @@ def test_purge_blockchain_transaction_data(rotkehlchen_api_server: 'APIServer') 
     )
     assert_simple_ok_response(response)
     with rotki.data.db.conn.read_ctx() as cursor:
-        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)
+        result = db.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
         assert len(result) == 0
         _assert_zksynclite_txs_num(cursor, tx_num=0, swap_num=0)
 

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -344,7 +344,7 @@ def test_query_transactions(rotkehlchen_api_server: 'APIServer') -> None:
 
     dbevmtx = DBEvmTx(rotki.data.db)
     with rotki.data.db.conn.read_ctx() as cursor:
-        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
 
     assert_txlists_equal(transactions[0:8], EXPECTED_AFB7_TXS + EXPECTED_4193_TXS)
 
@@ -630,7 +630,7 @@ def test_query_transactions_removed_address(
     # Check that only the 3 remaining transactions from the other account are returned
     dbevmtx = DBEvmTx(rotki.data.db)
     with rotki.data.db.conn.read_ctx() as cursor:
-        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
     assert len(transactions) == 3
 
 
@@ -689,7 +689,7 @@ def test_transaction_same_hash_same_nonce_two_tracked_accounts(
         assert_simple_ok_response(response)
         dbevmtx = DBEvmTx(rotki.data.db)
         with rotki.data.db.conn.read_ctx() as cursor:
-            transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+            transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
 
         assert len(transactions) == 2
 
@@ -737,7 +737,7 @@ def test_query_transactions_check_decoded_events(
     query_transactions(rotki)
     dbevmtx = DBEvmTx(rotki.data.db)
     with rotki.data.db.conn.read_ctx() as cursor:
-        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
 
     assert len(transactions) == 4
 
@@ -983,7 +983,7 @@ def test_query_transactions_check_decoded_events(
     # requery all transactions and events. Assert they are the same (different event id though)
     query_transactions(rotki)
     with rotki.data.db.conn.read_ctx() as cursor:
-        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
 
     assert len(transactions) == 4
     returned_events = query_events(rotkehlchen_api_server, json={'location': 'ethereum'}, expected_num_with_grouping=4, expected_totals_with_grouping=4)  # noqa: E501
@@ -1286,7 +1286,7 @@ def test_no_value_eth_transfer(rotkehlchen_api_server: 'APIServer') -> None:
     assert_simple_ok_response(response)
     dbevmtx = DBEvmTx(rotki.data.db)
     with rotki.data.db.conn.read_ctx() as cursor:
-        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
 
     assert len(transactions) == 1
     assert transactions[0].tx_hash.hex() == tx_str

--- a/rotkehlchen/tests/api/test_evm_transactions.py
+++ b/rotkehlchen/tests/api/test_evm_transactions.py
@@ -121,7 +121,7 @@ def test_query_transactions(rotkehlchen_api_server: 'APIServer') -> None:
 
     dbevmtx = DBEvmTx(rotki.data.db)
     with rotki.data.db.conn.read_ctx() as cursor:
-        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(), True)  # noqa: E501
+        transactions = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make())
 
     optimism_count, mainnet_count = 0, 0
     for entry in transactions:

--- a/rotkehlchen/tests/db/test_evmtx.py
+++ b/rotkehlchen/tests/db/test_evmtx.py
@@ -93,7 +93,7 @@ def test_add_get_evm_transactions(data_dir, username, sql_vm_instructions_cb):
         assert len(errors) == 0
         assert len(warnings) == 0
         filter_query = EvmTransactionsFilterQuery.make(chain_id=ChainID.ETHEREUM)
-        returned_transactions = dbevmtx.get_evm_transactions(cursor, filter_query, True)
+        returned_transactions = dbevmtx.get_evm_transactions(cursor, filter_query)
         assert returned_transactions == [tx1, tx2]
 
         # Add the last 2 transactions. Since tx2 already exists in the DB it should be
@@ -103,7 +103,7 @@ def test_add_get_evm_transactions(data_dir, username, sql_vm_instructions_cb):
         warnings = msg_aggregator.consume_warnings()
         assert len(errors) == 0
         assert len(warnings) == 0
-        returned_transactions = dbevmtx.get_evm_transactions(cursor, filter_query, True)
+        returned_transactions = dbevmtx.get_evm_transactions(cursor, filter_query)
         assert returned_transactions == [tx1, tx2, tx3]
 
         # Now add same transactions but with other relevant address
@@ -111,9 +111,9 @@ def test_add_get_evm_transactions(data_dir, username, sql_vm_instructions_cb):
         dbevmtx.add_evm_transactions(cursor, [tx2], relevant_address=ETH_ADDRESS2)
 
         # try transaction query by tx_hash
-        result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(tx_hash=tx2_hash, chain_id=ChainID.ETHEREUM), has_premium=True)  # noqa: E501
+        result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(tx_hash=tx2_hash, chain_id=ChainID.ETHEREUM))  # noqa: E501
         assert result == [tx2], 'querying transaction by hash in bytes failed'
-        result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(tx_hash=b'dsadsad', chain_id=ChainID.ETHEREUM), has_premium=True)  # noqa: E501
+        result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(tx_hash=b'dsadsad', chain_id=ChainID.ETHEREUM))  # noqa: E501
         assert result == []
 
         # Now try transaction by relevant addresses
@@ -123,7 +123,6 @@ def test_add_get_evm_transactions(data_dir, username, sql_vm_instructions_cb):
                 accounts=[EvmAccount(ETH_ADDRESS1), EvmAccount(make_evm_address())],
                 chain_id=ChainID.ETHEREUM,
             ),
-            has_premium=True,
         )
         assert result == [tx1, tx3]
     data.logout()
@@ -280,7 +279,6 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
                 accounts=[EvmAccount(ETH_ADDRESS3, chain_id=ChainID.ETHEREUM)],
                 chain_id=ChainID.ETHEREUM,
             ),
-            has_premium=True,
         )
         # NB: If this test fails check dbhandler.write_tuples for internal transactions and
         # make sure indices at the query adding the relevant address are correct
@@ -293,7 +291,6 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
             filter_=EvmTransactionsFilterQuery.make(
                 accounts=[EvmAccount(ETH_ADDRESS1)],
                 chain_id=ChainID.ETHEREUM),
-            has_premium=True,
         )
         assert result == [tx1, tx3, tx4, tx5]
 
@@ -303,7 +300,6 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
                 accounts=[EvmAccount(address_4)],
                 chain_id=ChainID.ETHEREUM,
             ),
-            has_premium=True,
         )
         assert result == [tx3]
 
@@ -313,7 +309,6 @@ def test_query_also_internal_evm_transactions(data_dir, username, sql_vm_instruc
                 accounts=[EvmAccount(ETH_ADDRESS3)],
                 chain_id=ChainID.ETHEREUM,
             ),
-            has_premium=True,
         )
         assert result == [tx1, tx3, tx4]
     data.logout()

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -155,7 +155,6 @@ def test_etherscan_get_transactions_genesis_block(eth_transactions):
         regular_tx_in_db = dbtx.get_evm_transactions(
             cursor=cursor,
             filter_=EvmTransactionsFilterQuery.make(),
-            has_premium=True,
         )
         internal_tx_in_db = dbtx.get_evm_internal_transactions(
             parent_tx_hash=GENESIS_HASH,

--- a/rotkehlchen/tests/integration/test_gnosischain.py
+++ b/rotkehlchen/tests/integration/test_gnosischain.py
@@ -41,7 +41,6 @@ def test_gnosischain_specific_chain_data(
                 assert len(dbevmtx.get_evm_transactions(
                     cursor=cursor,
                     filter_=EvmTransactionsFilterQuery.make(tx_hash=tx_hash, chain_id=ChainID.GNOSIS),  # noqa: E501
-                    has_premium=True,
                 )) == 1
                 assert dbevmtx.get_receipt(
                     cursor=cursor,

--- a/rotkehlchen/tests/integration/test_transactions.py
+++ b/rotkehlchen/tests/integration/test_transactions.py
@@ -56,7 +56,6 @@ def test_get_transaction_receipt(
         results = dbevmtx.get_evm_transactions(
             cursor=cursor,
             filter_=filter_query,
-            has_premium=True,
         )
     assert len(results) == 1
     assert results[0] == transactions[0]

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -130,7 +130,6 @@ def test_tx_decode(ethereum_transaction_decoder, database):
                 tx_hash=approve_tx_hash,
                 chain_id=ChainID.ETHEREUM,
             ),
-            has_premium=True,
         )
     decoder = ethereum_transaction_decoder
     with patch.object(decoder, '_decode_transaction', wraps=decoder._decode_transaction) as decode_mock:  # noqa: E501
@@ -305,7 +304,6 @@ def test_genesis_remove_address(
         genesis_tx = dbevmtx.get_evm_transactions(
             cursor=cursor,
             filter_=EvmTransactionsFilterQuery.make(tx_hash=GENESIS_HASH),
-            has_premium=True,
         )
 
     assert len(genesis_tx) == 0, 'Genesis transaction should have been deleted'

--- a/rotkehlchen/tests/unit/test_optimism_transactions.py
+++ b/rotkehlchen/tests/unit/test_optimism_transactions.py
@@ -49,7 +49,6 @@ def test_query_transactions_no_fee(optimism_transactions, optimism_accounts):
         transactions = dbevmtx.get_evm_transactions(
             cursor=cursor,
             filter_=EvmTransactionsFilterQuery.make(tx_hash=tx_hash),
-            has_premium=True,
         )
         assert_tx_okay(transactions, should_have_l1=True)
 
@@ -61,7 +60,6 @@ def test_query_transactions_no_fee(optimism_transactions, optimism_accounts):
         transactions = dbevmtx.get_evm_transactions(
             cursor=cursor,
             filter_=EvmTransactionsFilterQuery.make(tx_hash=tx_hash),
-            has_premium=True,
         )
         assert_tx_okay(transactions, should_have_l1=False)
 

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -261,7 +261,7 @@ def setup_ethereum_transactions_test(
         with database.user_write() as cursor:
             dbevmtx.add_evm_transactions(cursor, evm_transactions=[transaction1], relevant_address=TEST_ADDR1)  # noqa: E501
             dbevmtx.add_evm_transactions(cursor, evm_transactions=[transaction2], relevant_address=TEST_ADDR2)  # noqa: E501
-            result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(chain_id=ChainID.ETHEREUM), True)  # noqa: E501
+            result = dbevmtx.get_evm_transactions(cursor, EvmTransactionsFilterQuery.make(chain_id=ChainID.ETHEREUM))  # noqa: E501
         assert result == transactions
 
     expected_receipt1 = EvmTxReceipt(


### PR DESCRIPTION
We had different limits in the past but we checked the logic around this one and it seems to be used only in `ensure_tx_data_exists` and `ensure_genesis_tx_data_exists`.

After discussing it in discord we said to remove it since it is not really limiting the user. We keep `FREE_HISTORY_EVENTS_LIMIT` but we mentioned that we want to change it along the tiers.

