### PR TITLE
fix: wrong link to the solana token migration guide

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Users can now access the Solana token migration guide using the correct link.
 * :bug:`-` Fix an issue where some amounts in the history event notes are not scrambled/blurred when the privacy mode/scramble setting is activated.
 * :bug:`-` Historical price data will now display correctly for all supported assets instead of showing empty results in some cases.
 * :feature:`-` Users can now manually reset cached Beefy Finance vault data to trigger re-pulling the data during decoding.

--- a/frontend/app/shared/external-links.ts
+++ b/frontend/app/shared/external-links.ts
@@ -31,7 +31,7 @@ export const externalLinks = {
     gnosisPayKey: `${USAGE_GUIDE_URL}api-keys#gnosis-pay`,
     importBlockchainAccounts: `${USAGE_GUIDE_URL}accounts-and-balances#import-and-export-blockchain-accounts-csv`,
     importAddressBook: `${USAGE_GUIDE_URL}address-book#importing-address-book-names-csv`,
-    solanaTokenMigration: `${USAGE_GUIDE_URL}solana-tokens-migration`,
+    solanaTokenMigration: `${GITHUB_BASE_URL}releases/tag/v1.40.0`,
   },
   coingeckoAsset: `https://www.coingecko.com/en/coins/$symbol`,
   cryptocompareAsset: `https://www.cryptocompare.com/coins/$symbol/overview`,

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4309,7 +4309,7 @@
   },
   "solana_token_migration": {
     "hint": "You can find more information about migrating Solana tokens in our {0}.",
-    "usage_guide": "usage guide"
+    "release_notes": "release notes"
   },
   "sorting_selector": {
     "desc": {

--- a/frontend/app/src/modules/asset-manager/solana-token-migration/SolanaTokenMigrationDialog.vue
+++ b/frontend/app/src/modules/asset-manager/solana-token-migration/SolanaTokenMigrationDialog.vue
@@ -161,7 +161,7 @@ function isUniqueConstraintError(errorMessage: string): boolean {
               tag="div"
             >
               <ExternalLink
-                :text="t('solana_token_migration.usage_guide')"
+                :text="t('solana_token_migration.release_notes')"
                 :url="externalLinks.usageGuideSection.solanaTokenMigration"
               />
             </i18n-t>


### PR DESCRIPTION
Fix https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=125801105