### PR TITLE
Correctly query beefy boost vault token prices

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Beefy Finance boost vault tokens will now be properly priced.
 * :bug:`-` Curve swap transactions that use the new router will now be decoded properly across supported EVM chains.
 * :bug:`-` Fix an issue where the buttons to refresh Gnosis Pay and Monerium events were always disabled initially.
 * :bug:`10517` Morpho transactions that perform multiple actions in one go are now decoded properly.

--- a/rotkehlchen/chain/evm/decoding/beefy_finance/utils.py
+++ b/rotkehlchen/chain/evm/decoding/beefy_finance/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import UnderlyingToken
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token, get_token
@@ -16,7 +16,7 @@ from rotkehlchen.errors.misc import (
     UnableToDecryptRemoteData,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.serialization.deserialize import deserialize_evm_address, deserialize_int
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import (
     CacheType,
     ChainID,
@@ -37,14 +37,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
+BEEFY_API_BASE_URL: Final = 'https://api.beefy.finance'
+
+
+def _get_chain_name_for_api(chain: ChainID) -> str:
+    """Convert a chain id to the name used in the Beefy API.
+    See the names used in the response of https://api.beefy.finance/config
+    """
+    if chain == ChainID.POLYGON_POS:
+        return 'polygon'
+    elif chain == ChainID.ARBITRUM_ONE:
+        return 'arbitrum'
+    elif chain == ChainID.BINANCE_SC:
+        return 'bsc'
+
+    return chain.name.lower()
+
 
 def _query_beefy_vaults_api(chain: ChainID) -> list[dict[str, Any]] | None:
     """Query Beefy finance API for all vaults on the given chain."""
     try:
-        return request_get(url=f'https://api.beefy.finance/vaults/all/{chain.value}')  # type: ignore[return-value]  # we get a list of dictionaries from the api
+        vaults: list[dict[str, Any]] = request_get(  # type: ignore  # we get a list of dicts from the api
+            url=f'{BEEFY_API_BASE_URL}/vaults/all/{chain.value}',
+        )
+        vaults.extend(request_get(
+            url=f'{BEEFY_API_BASE_URL}/boosts/{_get_chain_name_for_api(chain)}',
+        ))
     except (RemoteError, UnableToDecryptRemoteData) as e:
         log.error(f'Failed to retrieve Beefy vaults for {chain} due to {e!s}')
         return None
+
+    return vaults
 
 
 def _process_beefy_vault(
@@ -64,19 +87,15 @@ def _process_beefy_vault(
         description='Querying Beefy finance vaults',
         should_notify=False,
     )
-    if (vault_type := vault['type']) in ('standard', 'gov'):
-        # in standard and gov vaults the `tokenAddress` is the vault address, so add it as the
-        # earned token's underlying token to be used when querying the price.
+    if (vault_type := vault.get('type')) is None or vault_type in ('standard', 'gov'):
+        # in boost (no type key), standard, and gov vaults the `tokenAddress` is the vault address,
+        # so add it as the earned token's underlying token to be used when querying the price.
         underlying_tokens = [UnderlyingToken(
             address=get_or_create_evm_token(
                 userdb=database,
                 evm_inquirer=evm_inquirer,
                 evm_address=deserialize_evm_address(vault['tokenAddress']),
                 chain_id=evm_inquirer.chain_id,
-                decimals=deserialize_int(
-                    value=vault['tokenDecimals'],
-                    location='beefy token decimals',
-                ),
                 encounter=encounter,
             ).evm_address,
             token_kind=TokenKind.ERC20,
@@ -187,8 +206,35 @@ def query_beefy_vault_price(
         vault_token: 'EvmToken',
         evm_inquirer: 'EvmNodeInquirer',
 ) -> Price:
-    """Gets the token price for a Beefy vault."""
-    if vault_token.symbol.startswith('moo'):  # standard vault - https://docs.beefy.finance/developer-documentation/vault-contract  # noqa: E501
+    """Gets the token price for a Beefy vault token.
+
+    Handles the following types of vault tokens:
+    * moo (standard vault) https://docs.beefy.finance/developer-documentation/vault-contract
+    * rmoo (boosted standard vault) https://docs.beefy.finance/beefy-products/boost
+    * cow (clm vault) https://docs.beefy.finance/beefy-products/clm
+    * rcow (reward pool token for clm vault) https://docs.beefy.finance/beefy-products/clm#how-does-the-clm-pool-work
+
+    Note that rmoo and rcow are 1:1 with their underlying moo or cow token, so simply use
+    the underlying token as the vault token for these.
+    """
+    if vault_token.symbol.startswith('rmoo') or vault_token.symbol.startswith('rcow'):
+        if (
+            vault_token.underlying_tokens is not None and
+            len(vault_token.underlying_tokens) == 1 and
+            (underlying_token := get_token(
+                evm_address=vault_token.underlying_tokens[0].address,
+                chain_id=evm_inquirer.chain_id,
+            )) is not None
+        ):
+            vault_token = underlying_token
+        else:
+            log.error(
+                f'Unexpected underlying tokens {vault_token.underlying_tokens} for '
+                f'Beefy token {vault_token} on {evm_inquirer.chain_name}',
+            )
+            return ZERO_PRICE
+
+    if vault_token.symbol.startswith('moo'):
         return get_vault_price(
             inquirer=inquirer,
             vault_token=vault_token,
@@ -197,24 +243,12 @@ def query_beefy_vault_price(
             vault_abi=BEEFY_VAULT_ABI,
             pps_method='getPricePerFullShare',
         )
-    elif vault_token.symbol.startswith('cow'):  # clm vault - https://docs.beefy.finance/beefy-products/clm  # noqa: E501
+    elif vault_token.symbol.startswith('cow'):
         return _query_beefy_cow_token_price(
             inquirer=inquirer,
             evm_inquirer=evm_inquirer,
             vault_token=vault_token,
         )
-    elif vault_token.symbol.startswith('rcow'):  # reward pool token for clm vault - https://docs.beefy.finance/beefy-products/clm#how-does-the-clm-pool-work  # noqa: E501
-        if len(vault_token.underlying_tokens) == 1 and (cow_token := get_token(
-            evm_address=vault_token.underlying_tokens[0].address,  # rcow token is 1:1 with the underlying cow token  # noqa: E501
-            chain_id=evm_inquirer.chain_id,
-        )) is not None:
-            return _query_beefy_cow_token_price(
-                inquirer=inquirer,
-                evm_inquirer=evm_inquirer,
-                vault_token=cow_token,
-            )
-
-        log.error(f'Unexpected underlying tokens for Beefy reward pool token {vault_token} on {evm_inquirer.chain_name}')  # noqa: E501
     else:
         log.error(f'Unexpected Beefy token symbol for token {vault_token} on {evm_inquirer.chain_name}')  # noqa: E501
 


### PR DESCRIPTION
Related: https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=126389573


Adds querying of the boosts api endpoint (boosted vaults are not included in the main `vaults` endpoint) and modifies the price logic to properly price the boost `rmoo` tokens.