### PR TITLE
refactor: simplify regex pattern in coinbase module

### DIFF
--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -78,7 +78,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 CB_EVENTS_PREFIX = 'CBE_'
 CB_VERSION = '2019-08-25'  # the latest api version we know rotki works fine for: https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/versioning  # noqa: E501
-LEGACY_RE: re.Pattern = re.compile(r'^[\w]+$')
+LEGACY_RE: re.Pattern = re.compile(r'^\w+$')
 NEW_RE: re.Pattern = re.compile(r'^organizations/[\w-]+/apiKeys/[\w-]+$')
 PRIVATE_KEY_RE: re.Pattern = re.compile(
     r'^-----BEGIN EC PRIVATE KEY-----\n'


### PR DESCRIPTION
Removed unnecessary character class brackets around \w in LEGACY_RE pattern. The pattern [\w]+ is functionally identical to \w+ but the latter is  cleaner and follows regex best practices.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
