### PR TITLE
Improve balancer v2 swap decoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Balancer V2 swaps that swap multiple times before reaching the desired token or that swap to the chain's native token will now be properly decoded.
 * :bug:`10556` Editing ZKSync lite history events will be possible again.
 * :bug:`-` Beefy Finance reward pool and boost vault tokens will now be properly priced.
 * :bug:`-` Account delegation transactions will now be properly decoded and processed.

--- a/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
@@ -2,13 +2,11 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN
 from rotkehlchen.chain.ethereum.utils import (
     asset_normalized_value,
-    token_normalized_value_decimals,
 )
-from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
+from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.balancer_cache import (
     read_balancer_pools_and_gauges_from_cache,
 )
@@ -17,23 +15,21 @@ from rotkehlchen.chain.evm.decoding.balancer.decoder import BalancerCommonDecode
 from rotkehlchen.chain.evm.decoding.balancer.v2.constants import V2_SWAP, VAULT_ADDRESS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
-    FAILED_ENRICHMENT_OUTPUT,
-    ActionItem,
     DecoderContext,
     DecodingOutput,
-    EnricherContext,
-    TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import CacheType, ChecksumEvmAddress
+from rotkehlchen.types import CacheType, ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+    from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+    from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -63,11 +59,11 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
                 cache_type=CacheType.BALANCER_V2_POOLS,
             ),
         )
+        self.wrapped_native_token = CHAIN_TO_WRAPPED_TOKEN[self.evm_inquirer.blockchain].resolve_to_evm_token()  # noqa: E501
 
     def decode_vault_events(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] == V2_SWAP:
-            return self._decode_swap_creation(context)
-
+            return DecodingOutput(matched_counterparty=CPT_BALANCER_V2)
         if context.tx_log.topics[0] == POOL_BALANCE_CHANGED_TOPIC:
             return self._decode_join_or_exit(context)
 
@@ -138,107 +134,71 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
     def _decode_pool_events(self, context: DecoderContext) -> DecodingOutput:
         return DEFAULT_DECODING_OUTPUT  # no-op
 
-    def _decode_swap_creation(self, context: DecoderContext) -> DecodingOutput:
-        """Decode swaps in Balancer v2. A SWAP event is created at transaction start containing
-        token and amount information, followed by transfer executions.
-
-        The swap event must be detected and transfer amounts matched against it. Special handling
-        is needed when native asset is swapped - it's wrapped before sending, so the token shows
-        as wrapped native asset, but we have a native asset transfer from user.
-        """
-        # The transfer event appears after the swap event, so we need to propagate information
-        from_token_address = bytes_to_address(context.tx_log.topics[2])
-        to_token_address = bytes_to_address(context.tx_log.topics[3])
-        amount_in = int.from_bytes(context.tx_log.data[0:32])
-        amount_out = int.from_bytes(context.tx_log.data[32:64])
-
-        # Create action item to propagate the information about the swap to the transfer enrichers
-        to_token = self.base.get_or_create_evm_token(to_token_address)
-        to_amount = asset_normalized_value(
-            amount=amount_out,
-            asset=to_token,
-        )
-        action_item = ActionItem(
-            action='skip & keep',
-            from_event_type=HistoryEventType.RECEIVE,
-            from_event_subtype=HistoryEventSubType.NONE,
-            asset=to_token,
-            amount=to_amount,
-            to_event_type=None,
-            to_event_subtype=None,
-            to_counterparty=CPT_BALANCER_V2,
-            to_notes=None,
-            extra_data={
-                'from_token': from_token_address,
-                'amount_in': amount_in,
-            },
-        )
-
-        # For native asset swaps, it's wrapped and the native transfer happens before SWAP.
-        # Detect such event if not already found.
-        if (
-            len(context.action_items) == 0 and
-            CHAIN_TO_WRAPPED_TOKEN[self.evm_inquirer.chain_id.to_blockchain()].resolve_to_evm_token().evm_address == from_token_address  # noqa: E501
-        ):
-            # When swapping native asset, transfer precedes V2_SWAP.
-            # Check if native asset was swapped
-            amount_of_eth = token_normalized_value_decimals(
-                token_amount=amount_in,
-                token_decimals=DEFAULT_TOKEN_DECIMALS,
-            )
-            for event in context.decoded_events:
-                if (
-                    event.asset == self.evm_inquirer.native_token and event.amount == amount_of_eth and  # noqa: E501
-                    event.event_type == HistoryEventType.SPEND and
-                    event.event_subtype == HistoryEventSubType.NONE
-                ):
-                    event.event_type = HistoryEventType.TRADE
-                    event.event_subtype = HistoryEventSubType.SPEND
-                    event.notes = f'Swap {event.amount} {self.evm_inquirer.native_token.symbol} in Balancer v2'  # noqa: E501
-                    event.counterparty = CPT_BALANCER_V2
-
-        return DecodingOutput(action_items=[action_item], process_swaps=True)
-
-    def _maybe_enrich_balancer_v2_transfers(
+    def _handle_post_decoding(
             self,
-            context: EnricherContext,
-    ) -> TransferEnrichmentOutput:
+            transaction: 'EvmTransaction',
+            decoded_events: list['EvmEvent'],
+            all_logs: list['EvmTxReceiptLog'],
+    ) -> list['EvmEvent']:
+        """Decode swaps in Balancer v2. SWAP tx_log events are created at the tx start containing
+        token and amount information, followed by transfer executions. Since tokens may be swapped
+        multiple times before reaching the desired token, the tokens and amounts from all present
+        swap logs must be matched against the events.
+
+        Native assets are wrapped/unwrapped before/after the swap, so the token shows as a
+        wrapped native asset, but we have a native asset transfer from the user.
         """
-        Enrich transfer transactions to account for swaps in balancer v2 protocol.
-        May raise:
-        - UnknownAsset
-        - WrongAssetType
-        """
-        if context.action_items is None or len(context.action_items) == 0 or context.transaction.to_address != VAULT_ADDRESS:  # noqa: E501
-            return FAILED_ENRICHMENT_OUTPUT
+        token_amounts_spent, token_amounts_received = set(), set()
+        for tx_log in all_logs:
+            if tx_log.topics[0] == V2_SWAP:
+                token_amounts_spent.add((
+                    (from_token := self.base.get_or_create_evm_token(bytes_to_address(tx_log.topics[2]))),  # noqa: E501
+                    asset_normalized_value(amount=int.from_bytes(tx_log.data[0:32]), asset=from_token),  # noqa: E501
+                ))
+                token_amounts_received.add((
+                    (to_token := self.base.get_or_create_evm_token(bytes_to_address(tx_log.topics[3]))),  # noqa: E501
+                    asset_normalized_value(amount=int.from_bytes(tx_log.data[32:64]), asset=to_token),  # noqa: E501
+                ))
 
-        if context.action_items[-1].extra_data is None:
-            return FAILED_ENRICHMENT_OUTPUT
+        spend_event, receive_event = None, None
+        for event in decoded_events:
+            if (
+                event.event_subtype != HistoryEventSubType.NONE or
+                event.address != VAULT_ADDRESS
+            ):
+                continue  # This event isn't associated with a balancer swap
 
-        asset = context.event.asset.resolve_to_evm_token()
-        if (
-            context.action_items[-1].asset and isinstance(context.action_items[-1].asset, EvmToken) is False and  # noqa: E501
-            not ((
-                context.action_items[-1].asset.evm_address != context.tx_log.address and  # type: ignore[attr-defined]  # mypy fails to understand that due the previous statement in the or this check won't be evaluated if the asset isn't a token
-                context.action_items[-1].amount != context.event.amount
-            ) or (
-                context.action_items[-1].extra_data['from_token'] != context.tx_log.address and
-                context.action_items[-1].extra_data['amount_in'] != context.event.amount
-            ))
-        ):
-            return FAILED_ENRICHMENT_OUTPUT
+            if (
+                (event_token_amount := (
+                    self.wrapped_native_token if event.asset == self.evm_inquirer.native_token else event.asset,  # noqa: E501
+                    event.amount,
+                )) in token_amounts_spent and
+                event.event_type == HistoryEventType.SPEND
+            ):
+                event.event_type = HistoryEventType.TRADE
+                event.event_subtype = HistoryEventSubType.SPEND
+                event.notes = f'Swap {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} via Balancer v2'  # noqa: E501
+                event.counterparty = CPT_BALANCER_V2
+                spend_event = event
+            elif (
+                event_token_amount in token_amounts_received and
+                event.event_type == HistoryEventType.RECEIVE
+            ):
+                event.event_type = HistoryEventType.TRADE
+                event.event_subtype = HistoryEventSubType.RECEIVE
+                event.notes = f'Receive {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} as the result of a swap via Balancer v2'  # noqa: E501
+                event.counterparty = CPT_BALANCER_V2
+                receive_event = event
 
-        context.event.counterparty = CPT_BALANCER_V2
-        if context.event.event_type == HistoryEventType.RECEIVE:
-            context.event.event_subtype = HistoryEventSubType.RECEIVE
-            context.event.notes = f'Receive {context.event.amount} {asset.symbol} as the result of a swap via Balancer v2'  # noqa: E501
+        if spend_event is None or receive_event is None:
+            log.error(f'Failed to find both in and out events for a Balancer v2 swap in {transaction}')  # noqa: E501
         else:
-            context.event.event_subtype = HistoryEventSubType.SPEND
-            context.event.notes = f'Swap {context.event.amount} {asset.symbol} via Balancer v2'
+            maybe_reshuffle_events(
+                ordered_events=[spend_event, receive_event],
+                events_list=decoded_events,
+            )
 
-        context.event.event_type = HistoryEventType.TRADE
-
-        return TransferEnrichmentOutput(matched_counterparty=CPT_BALANCER_V2, process_swaps=True)
+        return decoded_events
 
     # -- DecoderInterface methods
 
@@ -247,10 +207,8 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
             VAULT_ADDRESS: (self.decode_vault_events,),
         }
 
-    def enricher_rules(self) -> list[Callable]:
-        return [
-            self._maybe_enrich_balancer_v2_transfers,
-        ]
+    def post_decoding_rules(self) -> dict[str, list[tuple[int, Callable]]]:
+        return {CPT_BALANCER_V2: [(0, self._handle_post_decoding)]}
 
     @staticmethod
     def counterparties() -> tuple[CounterpartyDetails, ...]:


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=126990247

Changes the balancer v2 decoding logic to use a post decoding function instead of a combination of action items and transfer enrichment. This allows both native and token transfers to simply be processed from the decoded events list and reordered via `maybe_reshuffle_events`.
