### PR TITLE
Prevent paths in usernames

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`10578` rotki now has improved checks on usernames.
 * :bug:`10570` Adding/editing an EVM event with a transaction hash not present in the DB will now pull the transaction from onchain.
 * :bug:`-` Balancer V2 swaps that swap multiple times before reaching the desired token or that swap to the chain's native token will now be properly decoded.
 * :bug:`10556` Editing ZKSync lite history events will be possible again.

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -71,6 +71,12 @@ class DataHandler:
         """
         user_data_dir = self.data_directory / USERSDIR_NAME / username
         if create_new:
+            if user_data_dir.parent != self.data_directory / USERSDIR_NAME:
+                raise SystemPermissionError(
+                    f'Data dir for user {username} is not in the users directory. '
+                    'Usernames may not contain path separators.',
+                )
+
             try:
                 if (user_data_dir / USERDB_NAME).exists():
                     raise AuthenticationError(

--- a/rotkehlchen/tests/api/test_users.py
+++ b/rotkehlchen/tests/api/test_users.py
@@ -394,6 +394,19 @@ def test_user_creation_errors(
             contained_in_msg='Not a valid string',
         )
 
+        # name containing slashes (gets interpreted as a path)
+        assert_error_response(
+            response=requests.put(
+                url=api_url_for(rotkehlchen_api_server, 'usersresource'),
+                json={'name': 'john/doe', 'password': '1234'},
+            ),
+            contained_in_msg=(
+                'Data dir for user john/doe is not in the users directory. '
+                'Usernames may not contain path separators.',
+            ),
+            status_code=HTTPStatus.CONFLICT,
+        )
+
         # Invalid type for password
         data = {
             'name': username,


### PR DESCRIPTION
Closes #10578 

Adds validation to prevent including paths in usernames.

The issue also mentions:
> add an additional check in database/backups to ensure that the downloaded file is withing the rotki folder.

But this is already present here: https://github.com/rotki/rotki/blob/bugfixes/rotkehlchen/api/rest.py#L3572