### PR TITLE
Fix BTC and OMG mappings in independent reserve

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :bug:`-` Users will now be able to see the transaction hash of the deposit/withdrawal for the exchange asset movement event.
 * :bug:`10585` Token balances on mainnet Summer.fi proxy accounts will now be detected properly.
 * :bug:`-` Manual current prices are now properly saved as historical prices for use in balance graphs and charts.
+* :bug:`10602` rotki will now track BTC (Xbt) and OmiseGO (Omg) trades in Independent Reserve correctly.
 * :bug:`10578` rotki now has improved checks on usernames.
 * :bug:`-` rotki will now properly decode Paraswap swaps made using smart wallets.
 * :bug:`10570` Adding/editing an EVM event with a transaction hash not present in the DB will now pull the transaction from onchain.

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -13,7 +13,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
 from rotkehlchen.constants import ZERO
-from rotkehlchen.constants.assets import A_BTC
+from rotkehlchen.constants.assets import A_BTC, A_OMG
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
@@ -64,6 +64,11 @@ def independentreserve_asset(symbol: str) -> AssetWithOracles:
     - UnsupportedAsset
     - UnknownAsset
     """
+    if symbol == 'Xbt':  # TODO: @yabirgb In develop move those to assets mappings https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=128888662  # noqa: E501
+        return A_BTC.resolve_to_crypto_asset()
+    elif symbol == 'Omg':
+        return A_OMG.resolve_to_crypto_asset()
+
     return symbol_to_asset_or_token(GlobalDBHandler.get_assetid_from_exchange_name(
         exchange=Location.INDEPENDENTRESERVE,
         symbol=symbol,

--- a/rotkehlchen/tests/exchanges/test_independentreserve.py
+++ b/rotkehlchen/tests/exchanges/test_independentreserve.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
-from rotkehlchen.constants.assets import A_ETC, A_ETH
+from rotkehlchen.constants.assets import A_BTC, A_ETC, A_ETH, A_OMG
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.data_structures import Location
 from rotkehlchen.exchanges.independentreserve import (
@@ -48,6 +48,14 @@ def test_assets_are_known():
                 f'Found unknown secondary asset {currency} in IndependentReserve. '
                 f'Support for it has to be added',
             ))
+
+
+def test_missing_mapping_assets():
+    """Regression test for #10602. TODO: @yabirgb remove in develop
+    https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=128888662
+    """
+    assert independentreserve_asset('Xbt') == A_BTC
+    assert independentreserve_asset('Omg') == A_OMG
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])


### PR DESCRIPTION
Part for #10602. We are missing in develop to move them to proper mappings instead of having them harcoded.

