### PR TITLE
fix: use events with ignored asset for consistency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`10602` Users will be able to edit EVM swap events, even if the asset is ignored.
 * :bug:`-` Users will now be able to add EVM and EVM swap events from the "Add new event" button on top.
 * :feature:`-` Users will now be able to see the balance in these currencies: AED (United Arab Emirates Dirham), CZK (Czech koruna), ILS (Israeli new shekel), and MXN (Mexican Peso)
 * :bug:`-` Blockchain queries will no longer fail when certain nodes return empty responses.

--- a/frontend/app/src/components/history/events/HistoryEventFormDialog.vue
+++ b/frontend/app/src/components/history/events/HistoryEventFormDialog.vue
@@ -27,11 +27,13 @@ const stateUpdated = ref<boolean>(false);
 const loading = ref<boolean>(false);
 const form = useTemplateRef<InstanceType<typeof HistoryEventForm>>('form');
 
-const title = computed<string>(() =>
-  get(modelValue) !== undefined
-    ? t('transactions.events.dialog.edit.title')
-    : t('transactions.events.dialog.add.title'),
-);
+const title = computed<string>(() => {
+  const value = get(modelValue);
+  if (value === undefined || value.type === 'add' || value.type === 'group-add') {
+    return t('transactions.events.dialog.add.title');
+  }
+  return t('transactions.events.dialog.edit.title');
+});
 
 async function save() {
   set(loading, true);

--- a/frontend/app/src/components/history/events/HistoryEventTypeCombination.vue
+++ b/frontend/app/src/components/history/events/HistoryEventTypeCombination.vue
@@ -43,7 +43,7 @@ const { t } = useI18n({ useScope: 'global' });
       <RuiIcon
         size="20"
         :name="icon || type.icon"
-        :color="type.color"
+        :color="highlight ? undefined : type.color"
       />
       <RuiIcon
         v-if="showInfo"

--- a/frontend/app/src/components/history/events/HistoryEventsListItem.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsListItem.vue
@@ -11,6 +11,8 @@ import HistoryEventNote from '@/components/history/events/HistoryEventNote.vue';
 import HistoryEventsListItemAction from '@/components/history/events/HistoryEventsListItemAction.vue';
 import HistoryEventType from '@/components/history/events/HistoryEventType.vue';
 import { useSupportedChains } from '@/composables/info/chains';
+import { useRefMap } from '@/composables/utils/useRefMap';
+import { useIgnoredAssetsStore } from '@/store/assets/ignored';
 
 const props = defineProps<{
   item: HistoryEventEntry;
@@ -28,6 +30,8 @@ const emit = defineEmits<{
   'show:missing-rule-action': [data: HistoryEventEditData];
   'refresh': [];
 }>();
+
+const { item } = toRefs(props);
 
 const { getChain } = useSupportedChains();
 
@@ -77,6 +81,11 @@ function getEventNoteAttrs(event: HistoryEventEntry) {
     ...data,
   };
 }
+
+const eventAsset = useRefMap(item, ({ asset }) => asset);
+
+const { useIsAssetIgnored } = useIgnoredAssetsStore();
+const isIgnoredAsset = useIsAssetIgnored(eventAsset);
 </script>
 
 <template>
@@ -86,6 +95,7 @@ function getEventNoteAttrs(event: HistoryEventEntry) {
     :class="{
       'bg-rui-error/[0.05]': isHighlighted,
       'border-b': !isLast && !compact,
+      '!opacity-50': isIgnoredAsset,
     }"
   >
     <div

--- a/frontend/app/src/components/history/events/HistoryEventsListSwap.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsListSwap.vue
@@ -12,6 +12,7 @@ import { useSupportedChains } from '@/composables/info/chains';
 
 const props = defineProps<{
   events: HistoryEventEntry[];
+  allEvents: HistoryEventEntry[];
   highlightedIdentifiers?: string[];
 }>();
 
@@ -56,6 +57,10 @@ const usedEvents = computed(() => {
   // Add remaining spend events if any
   if (spendEvents.length > receiveEvents.length) {
     const remainingSpend = spendEvents.slice(receiveEvents.length);
+    alternating.push(...remainingSpend);
+  }
+  else if (receiveEvents.length > spendEvents.length) {
+    const remainingSpend = receiveEvents.slice(spendEvents.length);
     alternating.push(...remainingSpend);
   }
 
@@ -202,7 +207,7 @@ watch(expanded, () => {
         />
 
         <LazyLoader
-          v-if="!expanded && eventIndex === 0 && usedEvents.length > 0"
+          v-if="!expanded && eventIndex === 0 && usedEvents.length > 1"
           key="swap-arrow"
           class="flex items-center px-2 @md:pl-0 h-14 col-start-5"
         >
@@ -216,12 +221,13 @@ watch(expanded, () => {
     </div>
 
     <LazyLoader
-      v-if="!expanded && getCompactNotes(events)"
+      v-if="!expanded"
       key="history-event-notes"
       class="py-2 pt-4 md:pl-0 @5xl:!pl-0 @5xl:pt-4 col-span-10 @md:col-span-7 @5xl:!col-span-4"
       min-height="80"
     >
       <HistoryEventNote
+        v-if="getCompactNotes(events)"
         :notes="getCompactNotes(events)"
         :amount="events.map(item => item.amount)"
       />
@@ -236,7 +242,7 @@ watch(expanded, () => {
       <HistoryEventsListItemAction
         :item="events[0]"
         :index="0"
-        :events="events"
+        :events="allEvents"
         @edit-event="emit('edit-event', $event)"
         @delete-event="emit('delete-event', $event)"
         @show:missing-rule-action="emit('show:missing-rule-action', $event)"

--- a/frontend/app/src/components/history/events/HistoryEventsListTable.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsListTable.vue
@@ -7,6 +7,7 @@ import HistoryEventsListItem from '@/components/history/events/HistoryEventsList
 import HistoryEventsListSwap from '@/components/history/events/HistoryEventsListSwap.vue';
 
 interface HistoryEventsListTableProps {
+  allEvents: HistoryEventRow[];
   events: HistoryEventRow[];
   eventGroup: HistoryEventEntry;
   loading: boolean;
@@ -14,7 +15,7 @@ interface HistoryEventsListTableProps {
   highlightedIdentifiers?: string[];
 }
 
-defineProps<HistoryEventsListTableProps>();
+const props = defineProps<HistoryEventsListTableProps>();
 
 const emit = defineEmits<{
   'edit-event': [data: HistoryEventEditData];
@@ -24,6 +25,16 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+function findAllEventsFromArrayItem(items: HistoryEventEntry[]): HistoryEventEntry[] | undefined {
+  if (items.length === 0)
+    return undefined;
+
+  const firstId = items[0].identifier;
+
+  const arrayOnly: HistoryEventEntry[][] = props.allEvents.filter(event => Array.isArray(event));
+  return arrayOnly.find(event => event.map(item => item.identifier).includes(firstId));
+}
 </script>
 
 <template>
@@ -34,6 +45,7 @@ const { t } = useI18n({ useScope: 'global' });
           v-if="Array.isArray(item)"
           :key="`swap-${index}`"
           :events="item"
+          :all-events="findAllEventsFromArrayItem(item) || item"
           :highlighted-identifiers="highlightedIdentifiers"
           @edit-event="emit('edit-event', $event)"
           @delete-event="emit('delete-event', $event)"
@@ -46,7 +58,7 @@ const { t } = useI18n({ useScope: 'global' });
           class="flex-1"
           :item="item"
           :index="index"
-          :events="flatten(events)"
+          :events="flatten(allEvents)"
           :event-group="eventGroup"
           :is-last="index === events.length - 1"
           :is-highlighted="highlightedIdentifiers?.includes(item.identifier.toString())"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsTable.vue
@@ -44,9 +44,10 @@ const { groupLoading, groups: rawGroups, pageParams } = toRefs(props);
 
 // Event data management
 const {
+  allEventsMapped,
+  displayedEventsMapped,
   entriesFoundTotal,
   events,
-  eventsGroupedByEventIdentifier,
   eventsLoading,
   found,
   groups,
@@ -76,7 +77,7 @@ const {
   suggestNextSequenceId,
   toggle,
 } = useHistoryEventsOperations({
-  eventsGroupedByEventIdentifier,
+  allEventsMapped,
   flattenedEvents: events,
 }, emit);
 
@@ -185,7 +186,8 @@ useRememberTableSorting<HistoryEventEntry>(TableId.HISTORY, sort, cols);
       <HistoryEventsList
         class="-my-4"
         :class="{ 'opacity-50': row.ignoredInAccounting }"
-        :all-events="eventsGroupedByEventIdentifier[row.eventIdentifier] || []"
+        :all-events="allEventsMapped[row.eventIdentifier] || []"
+        :displayed-events="displayedEventsMapped[row.eventIdentifier] || []"
         :event-group="row"
         :loading="sectionLoading || eventsLoading"
         :has-ignored-event="hasIgnoredEvent"

--- a/frontend/app/src/modules/history/events/composables/use-history-events-operations.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-events-operations.ts
@@ -19,7 +19,7 @@ import { useNotificationsStore } from '@/store/notifications';
 import { isTaskCancelled } from '@/utils';
 
 interface UseHistoryEventsOperationsOptions {
-  eventsGroupedByEventIdentifier: ComputedRef<Record<string, HistoryEventRow[]>>;
+  allEventsMapped: ComputedRef<Record<string, HistoryEventRow[]>>;
   flattenedEvents: ComputedRef<HistoryEventEntry[]>;
 }
 
@@ -42,7 +42,7 @@ export function useHistoryEventsOperations(
   options: UseHistoryEventsOperationsOptions,
   emit: HistoryEventsTableEmitFn,
 ): UseHistoryEventsOperationsReturn {
-  const { eventsGroupedByEventIdentifier, flattenedEvents } = options;
+  const { allEventsMapped, flattenedEvents } = options;
 
   const selected = ref<HistoryEventEntry[]>([]);
   const showRedecodeConfirmation = ref<boolean>(false);
@@ -144,7 +144,7 @@ export function useHistoryEventsOperations(
       return;
     }
 
-    const groupedEvents = get(eventsGroupedByEventIdentifier)[eventIdentifier] || [];
+    const groupedEvents = get(allEventsMapped)[eventIdentifier] || [];
     const childEvents = flatten(groupedEvents);
     const isAnyCustom = childEvents.some(item => item.customized);
 

--- a/frontend/app/src/modules/history/management/forms/HistoryEventAssetPriceForm.vue
+++ b/frontend/app/src/modules/history/management/forms/HistoryEventAssetPriceForm.vue
@@ -180,6 +180,7 @@ defineExpose({
         <AssetSelect
           v-model="asset"
           outlined
+          show-ignored
           :disabled="disabled || disableAsset"
           :data-cy="type ? `${type}-asset` : 'asset'"
           :label="type && t('transactions.events.form.asset_price.asset_label', { type: toSentenceCase((type)) })"


### PR DESCRIPTION
Fix https://github.com/rotki/rotki/issues/10602#issuecomment-3291067367
It's because the spend asset / receive asset is ignored and is not returned in the response. 
This causes the swap logic to error.
The solution from this PR is to provide those events with ignored assets as well.