### PR TITLE
Fix loading solana tokens from the db

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/modules/umami/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/balances.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
-from rotkehlchen.assets.utils import get_token
+from rotkehlchen.assets.utils import get_evm_token
 from rotkehlchen.chain.arbitrum_one.modules.umami.constants import (
     CPT_UMAMI,
     UMAMI_MASTERCHEF_ABI,
@@ -104,7 +104,7 @@ class UmamiBalances(ProtocolWithBalance):
                     if balance == 0:
                         continue
 
-                    if (gm_vault_token := get_token(
+                    if (gm_vault_token := get_evm_token(
                             evm_address=(gm_vault_token_address := gm_vault_addresses[idx]),
                             chain_id=self.evm_inquirer.chain_id,
                     )) is None:

--- a/rotkehlchen/chain/evm/decoding/base.py
+++ b/rotkehlchen/chain/evm/decoding/base.py
@@ -3,7 +3,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token, get_token
+from rotkehlchen.assets.utils import get_evm_token, get_or_create_evm_token
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import OUTGOING_EVENT_TYPES
 from rotkehlchen.chain.evm.structures import EvmTxReceipt
@@ -308,7 +308,7 @@ class BaseDecoderTools:
 
     def get_evm_token(self, address: ChecksumEvmAddress) -> EvmToken | None:
         """Query a token from the DB or cache. If it does not exist there return None"""
-        return get_token(evm_address=address, chain_id=self.evm_inquirer.chain_id)
+        return get_evm_token(evm_address=address, chain_id=self.evm_inquirer.chain_id)
 
     def get_or_create_evm_token(
             self,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -17,7 +17,7 @@ from more_itertools import peekable
 from web3.exceptions import Web3Exception
 
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token, get_token
+from rotkehlchen.assets.utils import TokenEncounterInfo, get_evm_token, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.v3.constants import BALANCER_V3_SUPPORTED_CHAINS
@@ -788,7 +788,10 @@ class EVMTransactionDecoder(ABC):
                 continue
 
             rules_decoding_output = self.try_all_rules(
-                token=get_token(evm_address=tx_log.address, chain_id=self.evm_inquirer.chain_id),
+                token=get_evm_token(
+                    evm_address=tx_log.address,
+                    chain_id=self.evm_inquirer.chain_id,
+                ),
                 tx_log=tx_log,
                 transaction=transaction,
                 decoded_events=events,

--- a/rotkehlchen/chain/evm/decoding/pendle/utils.py
+++ b/rotkehlchen/chain/evm/decoding/pendle/utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import requests
 
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token, get_token
+from rotkehlchen.assets.utils import TokenEncounterInfo, get_evm_token, get_or_create_evm_token
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.errors.misc import NotERC20Conformant, RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.errors.serialization import DeserializationError
@@ -93,7 +93,7 @@ def query_pendle_yield_tokens(evm_inquirer: 'EvmNodeInquirer') -> None:
     encounter = TokenEncounterInfo(should_notify=False, description='Querying Pendle yield tokens')
     for token in all_tokens:
         try:
-            if (cached_token := get_token(evm_address=token, chain_id=evm_inquirer.chain_id)) is not None:  # noqa: E501
+            if (cached_token := get_evm_token(evm_address=token, chain_id=evm_inquirer.chain_id)) is not None:  # noqa: E501
                 get_or_create_evm_token(
                     name=cached_token.name,
                     symbol=cached_token.symbol,

--- a/rotkehlchen/chain/evm/decoding/utils.py
+++ b/rotkehlchen/chain/evm/decoding/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 from eth_typing import ABI
 
 from rotkehlchen.assets.asset import AssetWithSymbol
-from rotkehlchen.assets.utils import get_token
+from rotkehlchen.assets.utils import get_evm_token
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.utils import maybe_notify_cache_query_status
@@ -246,7 +246,7 @@ def get_vault_price(
     if (
         vault_token.underlying_tokens is None or
         len(vault_token.underlying_tokens) == 0 or
-        (underlying_token := get_token(
+        (underlying_token := get_evm_token(
             evm_address=vault_token.underlying_tokens[0].address,
             chain_id=evm_inquirer.chain_id,
         )) is None

--- a/rotkehlchen/tests/unit/decoders/test_ens.py
+++ b/rotkehlchen/tests/unit/decoders/test_ens.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.utils import get_token
+from rotkehlchen.assets.utils import get_evm_token
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.airdrops.decoder import ENS_ADDRESS
 from rotkehlchen.chain.ethereum.modules.ens.constants import (
@@ -152,7 +152,7 @@ def test_mint_ens_name(ethereum_inquirer, add_subgraph_api_key):  # pylint: disa
             address=ENS_REGISTRAR_CONTROLLER_1,
         ),
     ]
-    ens_nft = get_token(
+    ens_nft = get_evm_token(
         evm_address=string_to_evm_address('0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85'),
         chain_id=ChainID.ETHEREUM,
         token_kind=TokenKind.ERC721,

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.assets.utils import get_token
+from rotkehlchen.assets.utils import get_evm_token
 from rotkehlchen.chain.base.modules.uniswap.v3.constants import UNISWAP_UNIVERSAL_ROUTER
 from rotkehlchen.chain.binance_sc.modules.uniswap.v3.constants import (
     UNISWAP_UNIVERSAL_ROUTER as UNISWAP_UNIVERSAL_ROUTER_BINANCE_SC,
@@ -573,7 +573,7 @@ def test_uniswap_v3_add_liquidity(ethereum_inquirer):
     assert events == expected_events
 
     # Ensure the position token's name and symbol are set correctly
-    position_token = get_token(
+    position_token = get_evm_token(
         evm_address=string_to_evm_address('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
         chain_id=ChainID.ETHEREUM,
         token_kind=TokenKind.ERC721,


### PR DESCRIPTION
Fixes a problem I noticed where solana nfts wouldn't get loaded from the db right because it was just using `solana_address_to_identifier(token_address)` to get the identifier which defaults to the token identifier.

Adds a new `get_solana_token` function similar to the `get_token` that we have for evm tokens, and renames the old `get_token` to `get_evm_token`.