### PR TITLE
refactor: remove redundant length check in pylint log checker

### DIFF
--- a/tools/pylint/log_checker.py
+++ b/tools/pylint/log_checker.py
@@ -54,5 +54,5 @@ class LogNokwargsChecker(BaseChecker):
             >>> log.debug('foo', a=1)
         """
         for inferred_func in node.func.infer():
-            if is_normal_logging_call(inferred_func) and node.keywords and len(node.keywords) != 0:
+            if is_normal_logging_call(inferred_func) and node.keywords:
                 self.add_message(LOGNOKWARGS_SYMBOL, node=node)


### PR DESCRIPTION
Remove redundant `len(node.keywords) != 0` check in log_checker.py since 
`node.keywords` already evaluates to False for empty containers.

This follows Python best practices (PEP 8) for checking container emptiness
and makes the code more concise and readable.

The original condition:
`if is_normal_logging_call(inferred_func) and node.keywords and len(node.keywords) != 0:`

Is logically equivalent to:
`if is_normal_logging_call(inferred_func) and node.keywords:`
