### PR TITLE
use default cowswap `order_type` when missing `fullAppData`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`10652` Cowswap swaps with a missing `fullAppData` field will now be properly decoded.
 * :bug:`-` Monerium aave v3 events will now always have the earn event at the end.
 
 * :release:`1.40.1 <2025-09-15>`

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -93,12 +93,12 @@ class CowswapAPI:
                 order_type = data['class']
             else:
                 raw_fee_amount = int(data.get('executedSurplusFee', data.get('executedFee', 0)))
-                
+
                 try:
                     # Cowswap API sometimes returns nullish `fullAppData` so this may fail
                     metadata = json.loads(data['fullAppData'])['metadata']
                     order_type = metadata['orderClass']['orderClass'] if 'orderClass' in metadata else 'limit'  # noqa: E501
-                except:
+                except TypeError:
                     order_type = 'limit'
         except (KeyError, json.decoder.JSONDecodeError, ValueError, DeserializationError) as e:
             log.error(f'Could not process Cowswap API response: {data} due to {e!s}')

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -93,8 +93,13 @@ class CowswapAPI:
                 order_type = data['class']
             else:
                 raw_fee_amount = int(data.get('executedSurplusFee', data.get('executedFee', 0)))
-                metadata = json.loads(data['fullAppData'])['metadata']
-                order_type = metadata['orderClass']['orderClass'] if 'orderClass' in metadata else 'limit'  # noqa: E501
+                
+                try:
+                    # Cowswap API sometimes returns nullish `fullAppData` so this may fail
+                    metadata = json.loads(data['fullAppData'])['metadata']
+                    order_type = metadata['orderClass']['orderClass'] if 'orderClass' in metadata else 'limit'  # noqa: E501
+                except:
+                    order_type = 'limit'
         except (KeyError, json.decoder.JSONDecodeError, ValueError, DeserializationError) as e:
             log.error(f'Could not process Cowswap API response: {data} due to {e!s}')
             raise RemoteError('Invalid data from Cowswap API response') from e

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -94,11 +94,10 @@ class CowswapAPI:
             else:
                 raw_fee_amount = int(data.get('executedSurplusFee', data.get('executedFee', 0)))
 
-                try:
-                    # Cowswap API sometimes returns nullish `fullAppData` so this may fail
-                    metadata = json.loads(data['fullAppData'])['metadata']
+                if (full_app_data := data.get('fullAppData')) is not None:
+                    metadata = json.loads(full_app_data)['metadata']
                     order_type = metadata['orderClass']['orderClass'] if 'orderClass' in metadata else 'limit'  # noqa: E501
-                except TypeError:
+                else:
                     order_type = 'limit'
         except (KeyError, json.decoder.JSONDecodeError, ValueError, DeserializationError) as e:
             log.error(f'Could not process Cowswap API response: {data} due to {e!s}')

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -96,7 +96,8 @@ class CowswapAPI:
             )
 
         return raw_fee_amount, order_type
-    
+
+
 def parse_order_data(data: dict[str, Any]) -> tuple[int, str]:
     """Parses offchain order data from an api response.
     Returns raw_fee_amount and order_type as a tuple.

--- a/rotkehlchen/tests/external_apis/test_cowswap.py
+++ b/rotkehlchen/tests/external_apis/test_cowswap.py
@@ -13,41 +13,41 @@ def test_get_data_from_database(database):
 
 
 def test_handles_missing_fullappdata():
-    # Data taken from https://api.cow.fi/xdai/api/v1/orders/0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4  noqa: E501
+    # Data taken from https://api.cow.fi/xdai/api/v1/orders/0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4  # noqa: E501
     order_data = {
-        "creationDate":"2025-09-28T15:51:30Z",
-        "owner":"0x5089007dec8e93f891dcb908c9e2af8d9dedb72e",
-        "uid":"0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4",
-        "availableBalance": None,
-        "executedBuyAmount":"55114502215468646",
-        "executedSellAmount":"223917127089608233961",
-        "executedSellAmountBeforeFees":"223917127089608233961",
-        "executedFeeAmount":"0",
-        "executedFee":"589857233861541",
-        "executedFeeToken":"0xaf204776c7245bf4147c2612bf6e5972ee483701",
-        "invalidated": False,
-        "status":"fulfilled",
-        "class":"liquidity",
-        "settlementContract":"0x9008d19f58aabd9ed0d60971565aa8510560ab41",
-        "isLiquidityOrder": True,
-        "fullAppData": None,
-        "sellToken":"0xaf204776c7245bf4147c2612bf6e5972ee483701",
-        "buyToken":"0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
-        "receiver":"0x0000000000000000000000000000000000000000",
-        "sellAmount":"223917127089608233961",
-        "buyAmount":"55103055357127186",
-        "validTo":1759074980,
-        "appData":"0x362e5182440b52aa8fffe70a251550fbbcbca424740fe5a14f59bf0c1b06fe1d",
-        "feeAmount":"0",
-        "kind":"sell",
-        "partiallyFillable": False,
-        "sellTokenBalance":"erc20",
-        "buyTokenBalance":"erc20",
-        "signingScheme":"eip1271",
-        "signature":"0x5089007dec8e93f891dcb908c9e2af8d9dedb72e000000000000000000000000af204776c7245bf4147c2612bf6e5972ee4837010000000000000000000000006c76971f98945ae98dd7d4dfca8711ebea946ea6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c237970b9661893e900000000000000000000000000000000000000000000000000c3c3efd899aa120000000000000000000000000000000000000000000000000000000068d95aa4362e5182440b52aa8fffe70a251550fbbcbca424740fe5a14f59bf0c1b06fe1d0000000000000000000000000000000000000000000000000000000000000000f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee34677500000000000000000000000000000000000000000000000000000000000000005a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc95a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9",
-        "interactions": {
-            "pre":[],
-            "post":[]
-        }
+        'creationDate': '2025-09-28T15:51:30Z',
+        'owner': '0x5089007dec8e93f891dcb908c9e2af8d9dedb72e',
+        'uid': '0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4',  # noqa: E501
+        'availableBalance': None,
+        'executedBuyAmount': '55114502215468646',
+        'executedSellAmount': '223917127089608233961',
+        'executedSellAmountBeforeFees': '223917127089608233961',
+        'executedFeeAmount': '0',
+        'executedFee': '589857233861541',
+        'executedFeeToken': '0xaf204776c7245bf4147c2612bf6e5972ee483701',
+        'invalidated': False,
+        'status': 'fulfilled',
+        'class': 'liquidity',
+        'settlementContract': '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
+        'isLiquidityOrder': True,
+        'fullAppData': None,
+        'sellToken': '0xaf204776c7245bf4147c2612bf6e5972ee483701',
+        'buyToken': '0x6c76971f98945ae98dd7d4dfca8711ebea946ea6',
+        'receiver': '0x0000000000000000000000000000000000000000',
+        'sellAmount': '223917127089608233961',
+        'buyAmount': '55103055357127186',
+        'validTo': 1759074980,
+        'appData': '0x362e5182440b52aa8fffe70a251550fbbcbca424740fe5a14f59bf0c1b06fe1d',
+        'feeAmount': '0',
+        'kind': 'sell',
+        'partiallyFillable': False,
+        'sellTokenBalance': 'erc20',
+        'buyTokenBalance': 'erc20',
+        'signingScheme': 'eip1271',
+        'signature': '0x5089007dec8e93f891dcb908c9e2af8d9dedb72e000000000000000000000000af204776c7245bf4147c2612bf6e5972ee4837010000000000000000000000006c76971f98945ae98dd7d4dfca8711ebea946ea6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c237970b9661893e900000000000000000000000000000000000000000000000000c3c3efd899aa120000000000000000000000000000000000000000000000000000000068d95aa4362e5182440b52aa8fffe70a251550fbbcbca424740fe5a14f59bf0c1b06fe1d0000000000000000000000000000000000000000000000000000000000000000f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee34677500000000000000000000000000000000000000000000000000000000000000005a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc95a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9',  # noqa: E501
+        'interactions': {
+            'pre': [],
+            'post': [],
+        },
     }
     assert parse_order_data(order_data) == (589857233861541, 'limit')

--- a/rotkehlchen/tests/external_apis/test_cowswap.py
+++ b/rotkehlchen/tests/external_apis/test_cowswap.py
@@ -1,3 +1,5 @@
+import pytest
+
 from rotkehlchen.externalapis.cowswap import CowswapAPI
 from rotkehlchen.types import SupportedBlockchain
 
@@ -10,3 +12,11 @@ def test_get_data_from_database(database):
         database=database,
         chain=SupportedBlockchain.ETHEREUM,
     ).get_order_data('TEST_ORDER') == (12345678, 'market')
+
+@pytest.mark.vcr
+def test_handles_missing_fullappdata(database):
+    order_id = '0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4'
+    assert CowswapAPI(
+        database=database,
+        chain=SupportedBlockchain.GNOSIS,
+    ).get_order_data(order_id) == (589857233861541, 'limit')

--- a/rotkehlchen/tests/external_apis/test_cowswap.py
+++ b/rotkehlchen/tests/external_apis/test_cowswap.py
@@ -13,9 +13,10 @@ def test_get_data_from_database(database):
         chain=SupportedBlockchain.ETHEREUM,
     ).get_order_data('TEST_ORDER') == (12345678, 'market')
 
+
 @pytest.mark.vcr
 def test_handles_missing_fullappdata(database):
-    order_id = '0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4'
+    order_id = '0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4'  # noqa: E501
     assert CowswapAPI(
         database=database,
         chain=SupportedBlockchain.GNOSIS,

--- a/rotkehlchen/tests/external_apis/test_cowswap.py
+++ b/rotkehlchen/tests/external_apis/test_cowswap.py
@@ -1,6 +1,4 @@
-import pytest
-
-from rotkehlchen.externalapis.cowswap import CowswapAPI
+from rotkehlchen.externalapis.cowswap import CowswapAPI, parse_order_data
 from rotkehlchen.types import SupportedBlockchain
 
 
@@ -14,10 +12,42 @@ def test_get_data_from_database(database):
     ).get_order_data('TEST_ORDER') == (12345678, 'market')
 
 
-@pytest.mark.vcr
-def test_handles_missing_fullappdata(database):
-    order_id = '0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4'  # noqa: E501
-    assert CowswapAPI(
-        database=database,
-        chain=SupportedBlockchain.GNOSIS,
-    ).get_order_data(order_id) == (589857233861541, 'limit')
+def test_handles_missing_fullappdata():
+    # Data taken from https://api.cow.fi/xdai/api/v1/orders/0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4  noqa: E501
+    order_data = {
+        "creationDate":"2025-09-28T15:51:30Z",
+        "owner":"0x5089007dec8e93f891dcb908c9e2af8d9dedb72e",
+        "uid":"0x246d4707213a3d4bab8e7cae568cb458b81b3a9f05c014c1b6f7b537c788b5205089007dec8e93f891dcb908c9e2af8d9dedb72e68d95aa4",
+        "availableBalance": None,
+        "executedBuyAmount":"55114502215468646",
+        "executedSellAmount":"223917127089608233961",
+        "executedSellAmountBeforeFees":"223917127089608233961",
+        "executedFeeAmount":"0",
+        "executedFee":"589857233861541",
+        "executedFeeToken":"0xaf204776c7245bf4147c2612bf6e5972ee483701",
+        "invalidated": False,
+        "status":"fulfilled",
+        "class":"liquidity",
+        "settlementContract":"0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+        "isLiquidityOrder": True,
+        "fullAppData": None,
+        "sellToken":"0xaf204776c7245bf4147c2612bf6e5972ee483701",
+        "buyToken":"0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+        "receiver":"0x0000000000000000000000000000000000000000",
+        "sellAmount":"223917127089608233961",
+        "buyAmount":"55103055357127186",
+        "validTo":1759074980,
+        "appData":"0x362e5182440b52aa8fffe70a251550fbbcbca424740fe5a14f59bf0c1b06fe1d",
+        "feeAmount":"0",
+        "kind":"sell",
+        "partiallyFillable": False,
+        "sellTokenBalance":"erc20",
+        "buyTokenBalance":"erc20",
+        "signingScheme":"eip1271",
+        "signature":"0x5089007dec8e93f891dcb908c9e2af8d9dedb72e000000000000000000000000af204776c7245bf4147c2612bf6e5972ee4837010000000000000000000000006c76971f98945ae98dd7d4dfca8711ebea946ea6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c237970b9661893e900000000000000000000000000000000000000000000000000c3c3efd899aa120000000000000000000000000000000000000000000000000000000068d95aa4362e5182440b52aa8fffe70a251550fbbcbca424740fe5a14f59bf0c1b06fe1d0000000000000000000000000000000000000000000000000000000000000000f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee34677500000000000000000000000000000000000000000000000000000000000000005a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc95a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9",
+        "interactions": {
+            "pre":[],
+            "post":[]
+        }
+    }
+    assert parse_order_data(order_data) == (589857233861541, 'limit')


### PR DESCRIPTION
Closes #10652

I've wrapped the reading of `fullAppData` in try-except here to stop missing appdata from preventing the decoding of the remainder of the swap.

I've also added a vcr test which asserts that we can continue to pull fee data from one of these orders. It's maybe a little overkill as we could mock the data internally but I wanted to do a runthrough of the cassette system. 

https://github.com/rotki/test-caching/pull/265

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
