### PR TITLE
miscellanous fixes for cowswap swaps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Monerium aave v3 events will now always have the earn event at the end.
+* :bug:`-` Cowswap swaps that use the new ethflow contract or route through Spark Savings now decode correctly.
 
 * :release:`1.40.1 <2025-09-15>`
 * :bug:`10602` Users will be able to edit EVM swap events, even if the asset is ignored.

--- a/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
@@ -121,6 +121,11 @@ class SparksavingsCommonDecoder(SparkCommonDecoder):
         ):
             return DEFAULT_DECODING_OUTPUT
 
+        if not self.base.is_tracked(bytes_to_address(
+                value=context.tx_log.topics[2 if context.tx_log.topics[0] == DEPOSIT_TOPIC else 3],
+        )):
+            return DEFAULT_DECODING_OUTPUT
+
         vault_token = self.base.get_or_create_evm_token(
             address=context.tx_log.address,
             encounter=(encounter := TokenEncounterInfo(should_notify=False)),


### PR DESCRIPTION
- add new eth flow contract.
- restrict spark savings decoding to tracked owners so the sDAI leg in Cowswap swap steps remains untouched.