### PR TITLE
rename base decoder tools classes

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.arbitrum_one_tx import DBArbitrumOneTx
@@ -41,7 +41,7 @@ class ArbitrumOneTransactionDecoder(EVMTransactionDecoder):
             value_asset=A_ETH.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderTools(
+            base_tools=BaseEvmDecoderTools(
                 database=database,
                 evm_inquirer=arbitrum_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/arbitrum_one/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/aave/v3/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -30,7 +30,7 @@ class AirdropsDecoder(ArbitrumDecoderInterface):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/arbitrum_governor/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/arbitrum_governor/decoder.py
@@ -11,7 +11,7 @@ from .constants import GOVERNOR_ADDRESSES
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -24,7 +24,7 @@ class ArbitrumGovernorDecoder(GovernableDecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
@@ -31,7 +31,7 @@ from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -75,7 +75,7 @@ class ArbitrumOneBridgeDecoder(ArbitrumDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/aura_finance/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/aura_finance/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class AuraFinanceDecoder(AuraFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/cctp/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/cctp/decoder.py
@@ -6,7 +6,7 @@ from .constants import MESSAGE_TRANSMITTER, TOKEN_MESSENGER, USDC_IDENTIFIER_ARB
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class CctpDecoder(CctpCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/clrfund/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/clrfund/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -20,7 +20,7 @@ class ClrfundDecoder(ClrfundCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/compound/v3/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/compound/v3/decoder.py
@@ -6,7 +6,7 @@ from .constants import COMPOUND_BULKER_ADDRESS, COMPOUND_REWARDS_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Compoundv3Decoder(Compoundv3CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/cowswap/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/cowswap/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.constants.assets import A_ETH, A_WETH
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class CowswapDecoder(CowswapCommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/curve/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/curve/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.constants.assets import A_ETH
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -20,7 +20,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/curve/lend/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/curve/lend/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class CurvelendDecoder(CurveLendCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/eas/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/eas/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.eas.decoder import EASCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class EasDecoder(EASCommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/firebird_finance/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class FirebirdFinanceDecoder(FirebirdFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/gearbox/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gearbox/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.evm.decoding.gearbox.decoder import GearboxCommonDecoder
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class GearboxDecoder(GearboxCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gitcoin/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -29,7 +29,7 @@ class GitcoinDecoder(GitcoinV2CommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             optimism_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/gmx/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gmx/decoder.py
@@ -33,7 +33,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -52,7 +52,7 @@ class GmxDecoder(ArbitrumDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/hop/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/hop/decoder.py
@@ -6,7 +6,7 @@ from .constants import BRIDGES, REWARD_CONTRACTS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class HopDecoder(HopCommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/llamazip/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/llamazip/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 ROUTER_ADDRESSES: Final = (
@@ -19,7 +19,7 @@ class LlamazipDecoder(LlamazipCommonDecoder):
     def __init__(
             self,
             arbitrum_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/metamask/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/metamask/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.arbitrum_one.modules.metamask.constants import (
 from rotkehlchen.chain.evm.decoding.metamask.decoder import MetamaskCommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class MetamaskDecoder(MetamaskCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/monerium/decoder.py
@@ -6,7 +6,7 @@ from .constants import ARBITRUM_MONERIUM_ADDRESSES
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class MoneriumDecoder(MoneriumCommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/odos/v1/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/odos/v1/decoder.py
@@ -6,7 +6,7 @@ from .constants import ODOS_V1_ROUTER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Odosv1Decoder(Odosv1DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/odos/v2/decoder.py
@@ -6,7 +6,7 @@ from .constants import ODOS_V2_ROUTER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/oneinch/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import ONEINCH_V4_ROUTE
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Oneinchv4Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/paraswap/v5/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.ethereum.modules.paraswap.v5.constants import PARASWAP_AU
 from rotkehlchen.chain.evm.decoding.paraswap.v5.decoder import Paraswapv5CommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Paraswapv5Decoder(Paraswapv5CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/spark/savings/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/spark/savings/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.spark.savings.decoder import SparksavingsCom
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class SparksavingsDecoder(SparksavingsCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/stakedao/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/stakedao/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -13,7 +13,7 @@ class StakedaoDecoder(StakedaoCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ):
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/summer_fi/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/summer_fi/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class SummerFiDecoder(SummerFiCommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.constants.assets import A_GRT_ARB
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class ThegraphDecoder(ThegraphCommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
@@ -29,7 +29,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -48,7 +48,7 @@ class UmamiDecoder(ArbitrumDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/uniswap/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv2Decoder(Uniswapv2CommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/uniswap/v3/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v3.decoder import Uniswapv3CommonDec
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -17,7 +17,7 @@ class Uniswapv3Decoder(Uniswapv3CommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/uniswap/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv4Decoder(Uniswapv4CommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/arbitrum_one/modules/zerox/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/zerox/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.polygon_pos.modules.zerox.constants import ZEROX_FLASH_WA
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class ZeroxDecoder(ZeroxCommonDecoder):
     def __init__(
             self,
             arbitrum_one_inquirer: 'ArbitrumOneInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/decoding/decoder.py
+++ b/rotkehlchen/chain/base/decoding/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.decoder import L2WithL1FeesTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
@@ -34,7 +34,7 @@ class BaseTransactionDecoder(L2WithL1FeesTransactionDecoder):
             value_asset=A_ETH.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderTools(
+            base_tools=BaseEvmDecoderTools(
                 database=database,
                 evm_inquirer=base_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/base/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/base/modules/aave/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/aerodrome/decoder.py
+++ b/rotkehlchen/chain/base/modules/aerodrome/decoder.py
@@ -15,7 +15,7 @@ from .constants import ROUTER, VOTER_CONTRACT_ADDRESS, VOTING_ESCROW_CONTRACT_AD
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class AerodromeDecoder(VelodromeLikeDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/aura_finance/decoder.py
+++ b/rotkehlchen/chain/base/modules/aura_finance/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class AuraFinanceDecoder(AuraFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/basenames/decoder.py
+++ b/rotkehlchen/chain/base/modules/basenames/decoder.py
@@ -40,7 +40,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ class BasenamesDecoder(EnsCommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/cctp/decoder.py
+++ b/rotkehlchen/chain/base/modules/cctp/decoder.py
@@ -6,7 +6,7 @@ from .constants import MESSAGE_TRANSMITTER, TOKEN_MESSENGER, USDC_IDENTIFIER_BAS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class CctpDecoder(CctpCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/compound/v3/decoder.py
+++ b/rotkehlchen/chain/base/modules/compound/v3/decoder.py
@@ -6,7 +6,7 @@ from .constants import COMPOUND_BULKER_ADDRESS, COMPOUND_REWARDS_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Compoundv3Decoder(Compoundv3CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/cowswap/decoder.py
+++ b/rotkehlchen/chain/base/modules/cowswap/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.constants.assets import A_ETH, A_WETH
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class CowswapDecoder(CowswapCommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/curve/decoder.py
+++ b/rotkehlchen/chain/base/modules/curve/decoder.py
@@ -8,7 +8,7 @@ from .constants import CURVE_SWAP_ROUTERS_NG, DEPOSIT_AND_STAKE_ZAP
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -17,7 +17,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/eas/decoder.py
+++ b/rotkehlchen/chain/base/modules/eas/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.eas.decoder import EASCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class EasDecoder(EASCommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/efp/decoder.py
+++ b/rotkehlchen/chain/base/modules/efp/decoder.py
@@ -25,7 +25,7 @@ from .constants import EFP_LIST_REGISTRY
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -40,7 +40,7 @@ class EfpDecoder(EfpCommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/extrafi/decoder.py
+++ b/rotkehlchen/chain/base/modules/extrafi/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.extrafi.decoder import ExtrafiCommonDecoder
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -13,7 +13,7 @@ class ExtrafiDecoder(ExtrafiCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/hop/decoder.py
+++ b/rotkehlchen/chain/base/modules/hop/decoder.py
@@ -6,7 +6,7 @@ from .constants import BRIDGES, REWARD_CONTRACTS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class HopDecoder(HopCommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/morpho/decoder.py
+++ b/rotkehlchen/chain/base/modules/morpho/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.constants.assets import A_WETH_BASE
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class MorphoDecoder(MorphoCommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/base/modules/odos/v2/decoder.py
@@ -19,7 +19,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -29,7 +29,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/base/modules/paraswap/v5/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.base.modules.paraswap.v5.constants import (
 from rotkehlchen.chain.evm.decoding.paraswap.v5.decoder import Paraswapv5CommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class Paraswapv5Decoder(Paraswapv5CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/quickswap/v2/decoder.py
+++ b/rotkehlchen/chain/base/modules/quickswap/v2/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.quickswap.v2.decoder import Quickswapv2Commo
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Quickswapv2Decoder(Quickswapv2CommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/quickswap/v4/decoder.py
+++ b/rotkehlchen/chain/base/modules/quickswap/v4/decoder.py
@@ -7,7 +7,7 @@ from .constants import QUICKSWAP_V4_NFT_MANAGER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class Quickswapv4Decoder(Quickswapv4CommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/spark/savings/decoder.py
+++ b/rotkehlchen/chain/base/modules/spark/savings/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.spark.savings.decoder import SparksavingsCom
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class SparksavingsDecoder(SparksavingsCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/summer_fi/decoder.py
+++ b/rotkehlchen/chain/base/modules/summer_fi/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class SummerFiDecoder(SummerFiCommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/superchain_bridge/decoder.py
+++ b/rotkehlchen/chain/base/modules/superchain_bridge/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -24,7 +24,7 @@ class SuperchainBridgeDecoder(SuperchainL2SideBridgeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/base/modules/uniswap/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv2Decoder(Uniswapv2CommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/base/modules/uniswap/v3/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v3.decoder import Uniswapv3CommonDec
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 from .constants import UNISWAP_ROUTER_ADDRESSES, UNISWAP_V3_NFT_MANAGER
@@ -15,7 +15,7 @@ class Uniswapv3Decoder(Uniswapv3CommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/base/modules/uniswap/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv4Decoder(Uniswapv4CommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/base/modules/zerox/decoder.py
+++ b/rotkehlchen/chain/base/modules/zerox/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.polygon_pos.modules.zerox.constants import ZEROX_FLASH_WA
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class ZeroxDecoder(ZeroxCommonDecoder):
     def __init__(
             self,
             base_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/decoding/decoder.py
+++ b/rotkehlchen/chain/binance_sc/decoding/decoder.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.constants.assets import A_BSC_BNB
 from rotkehlchen.types import ChecksumEvmAddress
@@ -28,7 +28,7 @@ class BinanceSCTransactionDecoder(EVMTransactionDecoder):
             value_asset=A_BSC_BNB.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderTools(
+            base_tools=BaseEvmDecoderTools(
                 database=database,
                 evm_inquirer=binance_sc_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/binance_sc/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/aave/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/curve/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/curve/decoder.py
@@ -9,7 +9,7 @@ from rotkehlchen.constants.assets import A_BSC_BNB
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -18,7 +18,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/firebird_finance/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class FirebirdFinanceDecoder(FirebirdFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/magpie/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/magpie/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -13,7 +13,7 @@ class MagpieDecoder(MagpieCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/metamask/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/metamask/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.binance_sc.modules.metamask.constants import (
 from rotkehlchen.chain.evm.decoding.metamask.decoder import MetamaskCommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class MetamaskDecoder(MetamaskCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/odos/v1/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/odos/v1/decoder.py
@@ -6,7 +6,7 @@ from .constants import ODOS_V1_ROUTER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Odosv1Decoder(Odosv1DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/odos/v2/decoder.py
@@ -6,7 +6,7 @@ from .constants import ODOS_V2_ROUTER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/paraswap/v5/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.decoding.paraswap.v5.decoder import Paraswapv5CommonD
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Paraswapv5Decoder(Paraswapv5CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/uniswap/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv2Decoder(Uniswapv2CommonDecoder):
     def __init__(
             self,
             binance_sc_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/uniswap/v3/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v3.decoder import Uniswapv3CommonDec
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -17,7 +17,7 @@ class Uniswapv3Decoder(Uniswapv3CommonDecoder):
     def __init__(
             self,
             binance_sc_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/uniswap/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv4Decoder(Uniswapv4CommonDecoder):
     def __init__(
             self,
             binance_sc_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/binance_sc/modules/zerox/decoder.py
+++ b/rotkehlchen/chain/binance_sc/modules/zerox/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.polygon_pos.modules.zerox.constants import ZEROX_FLASH_WA
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.binance_sc.node_inquirer import BinanceSCInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class ZeroxDecoder(ZeroxCommonDecoder):
     def __init__(
             self,
             binance_sc_inquirer: 'BinanceSCInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.constants import CPT_KRAKEN, CPT_POLONIEX, CPT_UPHOLD
 from rotkehlchen.chain.ethereum.modules.monerium.constants import V1_TO_V2_MONERIUM_MAPPINGS
 from rotkehlchen.chain.evm.constants import MERKLE_CLAIM
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderToolsWithProxy
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderToolsWithProxy
 from rotkehlchen.chain.evm.decoding.constants import CPT_ACCOUNT_DELEGATION
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoderWithDSProxy
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -80,7 +80,7 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
                     image='account_delegation.svg',
                 ),
             ],
-            base_tools=BaseDecoderToolsWithProxy(
+            base_tools=BaseEvmDecoderToolsWithProxy(
                 database=database,
                 evm_inquirer=ethereum_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v2/decoder.py
@@ -8,7 +8,7 @@ from .constants import ETH_GATEWAYS, POOL_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -17,7 +17,7 @@ class Aavev2Decoder(Aavev2CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v3/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
@@ -46,7 +46,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -95,7 +95,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -46,7 +46,7 @@ class ArbitrumOneBridgeDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/aura_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aura_finance/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.constants.assets import A_BAL
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class AuraFinanceDecoder(AuraFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.types import ChainID, ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -31,7 +31,7 @@ class BaseBridgeDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/cctp/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/cctp/decoder.py
@@ -7,7 +7,7 @@ from .constants import MESSAGE_TRANSMITTER, TOKEN_MESSENGER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class CctpDecoder(CctpCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -32,7 +32,7 @@ from .utils import get_compound_underlying_token
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import CryptoAsset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -54,7 +54,7 @@ class Compoundv2Decoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/compound/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v3/decoder.py
@@ -6,7 +6,7 @@ from .constants import COMPOUND_BULKER_ADDRESS, COMPOUND_REWARDS_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Compoundv3Decoder(Compoundv3CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -45,7 +45,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -59,7 +59,7 @@ class ConvexDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/cowswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/cowswap/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class CowswapDecoder(CowswapCommonDecoderWithVCOW):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
@@ -30,7 +30,7 @@ from rotkehlchen.types import CacheType, ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.fval import FVal
     from rotkehlchen.user_messages import MessagesAggregator
@@ -45,7 +45,7 @@ class CurvecrvusdDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',  # pylint: disable=unused-argument
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -44,7 +44,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -57,7 +57,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/curve/lend/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/lend/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class CurvelendDecoder(CurveLendCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/diva/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/diva/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_DIVA, DIVA_ADDRESS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -38,7 +38,7 @@ class DivaDecoder(GovernableDecoderInterface, MerkleClaimDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/drips/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/drips/v1/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.drips.v1.decoder import Dripsv1CommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Dripsv1Decoder(Dripsv1CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -21,7 +21,7 @@ from .constants import CPT_DXDAO_MESA
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 DEPOSIT = b'\xc1\x1c\xc3N\x93\xc6z\x938+\x99\xf2I\x8e\x997\x19\x87\x98\xf3\xc1\xc2\x88\x80\x08\xff\xc0\xee\xb8/h\xc4'  # noqa: E501
@@ -34,7 +34,7 @@ class DxdaomesaDecoder(DecoderInterface):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/eas/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eas/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.eas.decoder import EASCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class EasDecoder(EASCommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/efp/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/efp/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class EfpDecoder(EfpCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
@@ -66,7 +66,7 @@ from rotkehlchen.utils.misc import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/ens/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/ens/decoder.py
@@ -51,7 +51,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -92,7 +92,7 @@ class EnsDecoder(GovernableDecoderInterface, EnsCommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
     ) -> None:
         EnsCommonDecoder.__init__(

--- a/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
@@ -30,7 +30,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.externalapis.beaconchain.service import BeaconChain
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -45,7 +45,7 @@ class Eth2Decoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             beacon_chain: 'BeaconChain',
     ) -> None:

--- a/rotkehlchen/chain/ethereum/modules/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/firebird_finance/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class FirebirdFinanceDecoder(FirebirdFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
@@ -22,7 +22,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_FLUENCE, DEV_REWARD_DISTRIBUTOR, FLUENCE_IDENTIFIER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -35,7 +35,7 @@ class FluenceDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/gearbox/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gearbox/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.evm.decoding.gearbox.decoder import GearboxCommonDecoder
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -16,7 +16,7 @@ class GearboxDecoder(GearboxCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoin/decoder.py
@@ -30,7 +30,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -43,7 +43,7 @@ class GitcoinDecoder(GovernableDecoderInterface, GitcoinOldCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         """Some sources for merkle payouts can be seen here:

--- a/rotkehlchen/chain/ethereum/modules/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/gitcoinv2/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.gitcoinv2.decoder import GitcoinV2CommonDeco
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Gitcoinv2Decoder(GitcoinV2CommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/hop/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hop/decoder.py
@@ -18,7 +18,7 @@ from .constants import BRIDGES, HOP_GOVERNOR
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 TRANSFER_TO_L2 = b'\n\x06\x07h\x8c\x86\xec\x17u\xab\xcd\xba\xb7\xb3::5\xa6\xc9\xcd\xe6w\xc9\xbe\x88\x01P\xc21\xcck\x0b'  # noqa: E501
@@ -28,7 +28,7 @@ class HopDecoder(HopCommonDecoder, GovernableDecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         HopCommonDecoder.__init__(  # using direct constructor calls due to

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -22,7 +22,7 @@ from .constants import CPT_KYBER_LEGACY
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 KYBER_TRADE_LEGACY = b'\xf7$\xb4\xdff\x17G6\x12\xb5=\x7f\x88\xec\xc6\xea\x980t\xb3\t`\xa0I\xfc\xd0e\x7f\xfe\x80\x80\x83'  # noqa: E501
@@ -37,7 +37,7 @@ class KyberDecoder(KyberCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/lido/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lido/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.utils.misc import bytes_to_address, from_wei
 from .constants import CPT_LIDO, LIDO_STETH_SUBMITTED, STETH_MAX_ROUND_ERROR_WEI
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -32,7 +32,7 @@ class LidoDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -43,7 +43,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -58,7 +58,7 @@ class LiquityDecoder(DecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/lockedgno/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lockedgno/decoder.py
@@ -19,7 +19,7 @@ from .constants import CPT_LOCKEDGNO, LOCKED_GNO_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ class LockedgnoDecoder(DecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/magpie/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/magpie/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -13,7 +13,7 @@ class MagpieDecoder(MagpieCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -74,7 +74,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -92,7 +92,7 @@ class MakerdaoDecoder(DecoderInterface):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         DecoderInterface.__init__(

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -32,7 +32,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -52,7 +52,7 @@ class MakerdaosaiDecoder(DecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/metamask/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/metamask/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.modules.metamask.constants import (
 from rotkehlchen.chain.evm.decoding.metamask.decoder import MetamaskCommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class MetamaskDecoder(MetamaskCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/monerium/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecode
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class MoneriumDecoder(MoneriumCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/morpho/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/morpho/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.constants.assets import A_WETH
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class MorphoDecoder(MorphoCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/octant/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/decoder.py
@@ -23,7 +23,7 @@ from .constants import CPT_OCTANT, LOCKED, OCTANT_DEPOSITS, OCTANT_REWARDS, UNLO
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class OctantDecoder(DecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/odos/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/odos/v1/decoder.py
@@ -6,7 +6,7 @@ from .constants import ODOS_V1_ROUTER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Odosv1Decoder(Odosv1DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/odos/v2/decoder.py
@@ -6,7 +6,7 @@ from .constants import ODOS_V2_ROUTER
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/omnibridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/omnibridge/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.types import ChainID
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 BRIDGE_ADDRESS: Final = string_to_evm_address('0x88ad09518695c6c3712AC10a214bE5109a655671')
@@ -17,7 +17,7 @@ class OmnibridgeDecoder(OmnibridgeCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOu
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -19,7 +19,7 @@ class Oneinchv2Decoder(OneinchCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.decoder import OneinchCommonDecoder
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -18,7 +18,7 @@ class Oneinchv3Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import ONEINCH_V4_ROUTE
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Oneinchv4Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/paraswap/v5/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.modules.paraswap.v5.constants import (
 from rotkehlchen.chain.evm.decoding.paraswap.v5.decoder import Paraswapv5CommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class Paraswapv5Decoder(Paraswapv5CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/pendle/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/decoder.py
@@ -26,7 +26,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class PendleDecoder(PendleCommonDecoder, CustomizableDateMixin):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
@@ -23,7 +23,7 @@ from .constants import CORN_TOKEN_ID, CORNICHON_CLAIM, CPT_PICKLE
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -36,7 +36,7 @@ class PickleFinanceDecoder(MerkleClaimDecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/safe/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/decoder.py
@@ -32,7 +32,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -46,7 +46,7 @@ class SafeDecoder(DecoderInterface):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
@@ -29,7 +29,7 @@ from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -54,7 +54,7 @@ class ScrollBridgeDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_SHUTTER, REDEEMED_VESTING, SHUTTER_AIDROP_CONTRACT
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -36,7 +36,7 @@ class ShutterDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/spark/lend/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/spark/lend/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -36,7 +36,7 @@ class SparklendDecoder(SparklendCommonDecoder, MerkleClaimDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/spark/savings/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/spark/savings/decoder.py
@@ -33,7 +33,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -45,7 +45,7 @@ class SparksavingsDecoder(SparksavingsCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/stakedao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/stakedao/decoder.py
@@ -10,7 +10,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -19,7 +19,7 @@ class StakedaoDecoder(StakedaoCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ):
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/summer_fi/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/summer_fi/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class SummerFiDecoder(SummerFiCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/superchain_bridge/base/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/superchain_bridge/base/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.types import ChainID
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 OPTIMISM_PORTAL_ADDRESS: Final = string_to_evm_address('0xbEb5Fc579115071764c7423A4f12eDde41f106Ed')  # noqa: E501
@@ -20,7 +20,7 @@ class SuperchainBridgebaseDecoder(SuperchainL1SideCommonBridgeDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/superchain_bridge/op/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/superchain_bridge/op/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.types import ChainID, ChecksumEvmAddress
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -21,7 +21,7 @@ class SuperchainBridgeopDecoder(SuperchainL1SideCommonBridgeDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
@@ -31,7 +31,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -40,7 +40,7 @@ class ThegraphDecoder(ThegraphCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 UNISWAP_V2_ROUTER: Final = string_to_evm_address('0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D')
@@ -16,7 +16,7 @@ class Uniswapv2Decoder(Uniswapv2CommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v3/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v3.decoder import Uniswapv3CommonDec
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 from .constants import UNISWAP_ROUTER_ADDRESSES, UNISWAP_V3_NFT_MANAGER
@@ -15,7 +15,7 @@ class Uniswapv3Decoder(Uniswapv3CommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class Uniswapv4Decoder(Uniswapv4CommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/xdai_bridge/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.types import ChainID
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 BRIDGE_ADDRESS: Final = string_to_evm_address('0x4aa42145Aa6Ebf72e164C9bBC74fbD3788045016')
@@ -33,7 +33,7 @@ class XdaiBridgeDecoder(XdaiBridgeCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
@@ -43,7 +43,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
@@ -72,7 +72,7 @@ class YearnDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -29,7 +29,7 @@ class YearnygovDecoder(DecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/ethereum/modules/zerox/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zerox/decoder.py
@@ -9,7 +9,7 @@ from rotkehlchen.chain.evm.decoding.zerox.decoder import ZeroxCommonDecoder
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -18,7 +18,7 @@ class ZeroxDecoder(ZeroxCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/aave/common.py
+++ b/rotkehlchen/chain/evm/decoding/aave/common.py
@@ -35,7 +35,7 @@ from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction, TokenKind
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -54,7 +54,7 @@ class Commonv2v3LikeDecoder(DecoderInterface):
             repay_signature: bytes,
             native_gateways: tuple['ChecksumEvmAddress', ...],
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ):
         self.counterparty = counterparty

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -17,7 +17,7 @@ from ..constants import CPT_AAVE_V2
 from .constants import BORROW, DEPOSIT, REPAY
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
@@ -28,7 +28,7 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             pool_addresses: Sequence['ChecksumEvmAddress'],
             native_gateways: 'tuple[ChecksumEvmAddress, ...]',

--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -25,7 +25,7 @@ from ..constants import CPT_AAVE_V3, MINT
 from .constants import BORROW, BURN, DEPOSIT, REPAY, REWARDS_CLAIMED, SWAPPED
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -40,7 +40,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             pool_addresses: Sequence['ChecksumEvmAddress'],
             native_gateways: 'tuple[ChecksumEvmAddress, ...]',

--- a/rotkehlchen/chain/evm/decoding/aura_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aura_finance/decoder.py
@@ -34,7 +34,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -63,7 +63,7 @@ class AuraFinanceCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             claim_zap_address: ChecksumEvmAddress,
             base_reward_tokens: tuple['Asset', 'Asset'],  # this is always the AURA and BAL tokens of the chain  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/balancer/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/decoder.py
@@ -27,7 +27,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTransaction
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -37,7 +37,7 @@ class BalancerCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMix
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             counterparty: Literal['balancer-v1', 'balancer-v2', 'balancer-v3'],
             read_fn: Callable[[ChainID], tuple[set[ChecksumEvmAddress], set[ChecksumEvmAddress]]],

--- a/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
@@ -30,7 +30,7 @@ from rotkehlchen.types import CacheType, ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -47,7 +47,7 @@ class Balancerv1CommonDecoder(BalancerCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
@@ -26,7 +26,7 @@ from rotkehlchen.types import CacheType, ChecksumEvmAddress, EvmTransaction
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -44,7 +44,7 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/balancer/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v3/decoder.py
@@ -40,7 +40,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.fval import FVal
@@ -56,7 +56,7 @@ class Balancerv3CommonDecoder(BalancerCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/base.py
+++ b/rotkehlchen/chain/evm/decoding/base.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
 from rotkehlchen.assets.utils import get_evm_token, get_or_create_evm_token
-from rotkehlchen.chain.decoding.tools import BaseDecoderTools as ChainBaseDecoderTools
+from rotkehlchen.chain.decoding.tools import BaseDecoderTools
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import OUTGOING_EVENT_TYPES
@@ -38,10 +38,8 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class BaseDecoderTools(ChainBaseDecoderTools[EvmTxReceipt, ChecksumEvmAddress, EVMTxHash, EvmEvent, EvmProduct]):  # noqa: E501
-    """A class that keeps a common state and offers some common decoding functionality
-    TODO: rename `BaseDecoderTools` to `BaseEvmDecoderTools` in a follow-up pr.
-    """
+class BaseEvmDecoderTools(BaseDecoderTools[EvmTxReceipt, ChecksumEvmAddress, EVMTxHash, EvmEvent, EvmProduct]):  # noqa: E501
+    """A class that keeps a common state and offers some common decoding functionality"""
 
     def __init__(
             self,
@@ -323,8 +321,8 @@ class BaseDecoderTools(ChainBaseDecoderTools[EvmTxReceipt, ChecksumEvmAddress, E
         )
 
 
-class BaseDecoderToolsWithProxy(BaseDecoderTools):
-    """Like BaseDecoderTools but with Proxy evm inquirers"""
+class BaseEvmDecoderToolsWithProxy(BaseEvmDecoderTools):
+    """Like BaseEvmDecoderTools but with Proxy evm inquirers"""
 
     def __init__(
             self,

--- a/rotkehlchen/chain/evm/decoding/beefy_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/beefy_finance/decoder.py
@@ -34,7 +34,7 @@ from .utils import query_beefy_vaults
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import CryptoAsset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.fval import FVal
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -54,7 +54,7 @@ class BeefyFinanceCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/cctp/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cctp/decoder.py
@@ -24,7 +24,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -36,7 +36,7 @@ class CctpCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             token_messenger: ChecksumEvmAddress,
             message_transmitter: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
@@ -27,7 +27,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -40,7 +40,7 @@ class ClrfundCommonDecoder(CommonGrantsDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
             rounds_data: list[tuple[ChecksumEvmAddress, ChecksumEvmAddress, str, Asset]],
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
@@ -35,7 +35,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -50,7 +50,7 @@ class Compoundv3CommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             rewards_address: 'ChecksumEvmAddress',
             bulker_address: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.fval import FVal
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -75,7 +75,7 @@ class CowswapCommonDecoder(DecoderInterface, abc.ABC):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer | ArbitrumOneInquirer | GnosisInquirer | BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             native_asset: Asset,
             wrapped_native_asset: Asset,
@@ -354,7 +354,7 @@ class CowswapCommonDecoderWithVCOW(CowswapCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer | ArbitrumOneInquirer | GnosisInquirer | BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             native_asset: Asset,
             wrapped_native_asset: Asset,

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -63,7 +63,7 @@ from rotkehlchen.types import CacheType, ChecksumEvmAddress, EvmTransaction, Tok
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -78,7 +78,7 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',  # pylint: disable=unused-argument
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             native_currency: 'Asset',
             aave_pools: set['ChecksumEvmAddress'],

--- a/rotkehlchen/chain/evm/decoding/curve/lend/common.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/common.py
@@ -37,7 +37,7 @@ from .constants import BORROW_TOPIC, CURVE_VAULT_ABI, REMOVE_COLLATERAL_TOPIC, R
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import EvmToken
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.fval import FVal
     from rotkehlchen.user_messages import MessagesAggregator
@@ -52,7 +52,7 @@ class CurveBorrowRepayCommonDecoder(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',  # pylint: disable=unused-argument
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             evm_product: Literal[EvmProduct.LENDING, EvmProduct.MINTING],
             leverage_zap: 'ChecksumEvmAddress | None' = None,

--- a/rotkehlchen/chain/evm/decoding/curve/lend/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/decoder.py
@@ -47,7 +47,7 @@ from .utils import query_curve_lending_vaults
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import EvmToken
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.fval import FVal
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -62,7 +62,7 @@ class CurveLendCommonDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMix
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',  # pylint: disable=unused-argument
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             leverage_zap: 'ChecksumEvmAddress | None',
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -79,7 +79,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import bytes_to_address, from_wei
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
-from .base import BaseDecoderTools, BaseDecoderToolsWithProxy
+from .base import BaseEvmDecoderTools, BaseEvmDecoderToolsWithProxy
 from .constants import (
     CPT_ACCOUNT_DELEGATION,
     CPT_GAS,
@@ -222,7 +222,7 @@ class EVMTransactionDecoder(ABC):
             value_asset: 'AssetWithOracles',
             event_rules: list[EventDecoderFunction],
             misc_counterparties: list[CounterpartyDetails],
-            base_tools: BaseDecoderTools,
+            base_tools: BaseEvmDecoderTools,
             premium: 'Premium | None' = None,
             dbevmtx_class: type[DBEvmTx] = DBEvmTx,
             addresses_exceptions: dict[ChecksumEvmAddress, int] | None = None,
@@ -1605,7 +1605,7 @@ class EVMTransactionDecoderWithDSProxy(EVMTransactionDecoder, ABC):
             value_asset: 'AssetWithOracles',
             event_rules: list[EventDecoderFunction],
             misc_counterparties: list[CounterpartyDetails],
-            base_tools: BaseDecoderToolsWithProxy,
+            base_tools: BaseEvmDecoderToolsWithProxy,
             beacon_chain: 'BeaconChain | None' = None,
             premium: 'Premium | None' = None,
     ):
@@ -1621,4 +1621,4 @@ class EVMTransactionDecoderWithDSProxy(EVMTransactionDecoder, ABC):
             beacon_chain=beacon_chain,
         )
         self.evm_inquirer: EvmNodeInquirerWithProxies  # Set explicit type
-        self.base: BaseDecoderToolsWithProxy  # Set explicit type
+        self.base: BaseEvmDecoderToolsWithProxy  # Set explicit type

--- a/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
@@ -28,7 +28,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -42,7 +42,7 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             drips_hub: ChecksumEvmAddress,
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/eas/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/eas/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_EAS, EAS_CPT_DETAILS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -41,7 +41,7 @@ class EASCommonDecoder(DecoderInterface, ABC):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             attestation_service_address: 'ChecksumEvmAddress',
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/efp/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/efp/decoder.py
@@ -29,7 +29,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_EFP
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -44,7 +44,7 @@ class EfpCommonDecoder(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             list_records_contract: 'ChecksumEvmAddress',
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/ens/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/ens/decoder.py
@@ -34,7 +34,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -47,7 +47,7 @@ class EnsCommonDecoder(DecoderInterface, CustomizableDateMixin, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             reverse_resolver: 'ChecksumEvmAddress',
             counterparty: str,

--- a/rotkehlchen/chain/evm/decoding/extrafi/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/decoder.py
@@ -52,7 +52,7 @@ from rotkehlchen.types import CacheType, TokenKind
 from rotkehlchen.utils.misc import bytes_to_address, timestamp_to_date
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -66,7 +66,7 @@ class ExtrafiCommonDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             extra_token_identifier: str,
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/firebird_finance/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_FIREBIRD_FINANCE, FIREBIRD_FINANCE_LABEL
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -33,7 +33,7 @@ class FirebirdFinanceCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
@@ -45,7 +45,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -58,7 +58,7 @@ class GearboxCommonDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             staking_contract: ChecksumEvmAddress,
             gear_token_identifier: 'str',

--- a/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
@@ -24,7 +24,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import DONATION_SENT, PAYOUT_CLAIMED
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -37,7 +37,7 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             bulkcheckout_address: ChecksumEvmAddress | None = None,
             funds_claimed_matching_contracts: list[tuple[ChecksumEvmAddress, str, Asset]] | None = None,  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
@@ -46,7 +46,7 @@ from rotkehlchen.utils.misc import bytes_to_address, bytes_to_hexstr
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import CryptoAsset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -76,7 +76,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             project_registry: Optional['ChecksumEvmAddress'],
             voting_impl_addresses: list['ChecksumEvmAddress'],

--- a/rotkehlchen/chain/evm/decoding/giveth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/giveth/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -34,7 +34,7 @@ class GivethDecoderBase(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             distro_address: 'ChecksumEvmAddress',
             givpower_staking_address: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/hop/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/hop/decoder.py
@@ -53,7 +53,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -65,7 +65,7 @@ class HopCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             bridges: dict[ChecksumEvmAddress, HopBridgeEventData],
             reward_contracts: set[ChecksumEvmAddress],

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
 
-    from .base import BaseDecoderTools
+    from .base import BaseEvmDecoderTools
 
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class DecoderInterface(ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         """This is the Decoder interface initialization signature"""
@@ -283,7 +283,7 @@ class GovernableDecoderInterface(DecoderInterface, ABC):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',  # pylint: disable=unused-argument
             protocol: str,
             proposals_url: str,

--- a/rotkehlchen/chain/evm/decoding/llamazip/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/llamazip/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -27,7 +27,7 @@ class LlamazipCommonDecoder(DecoderInterface, abc.ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_addresses: tuple['ChecksumEvmAddress', ...],
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/merkl/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/merkl/decoder.py
@@ -19,7 +19,7 @@ from .constants import CPT_MERKL, MERKL_DISTRIBUTOR_ADDRESS
 from .utils import get_merkl_protocol_for_token
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -32,7 +32,7 @@ class MerklDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/metamask/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/metamask/decoder.py
@@ -18,7 +18,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_METAMASK_SWAPS, METAMASK_FEE_TOPIC, SWAP_SIGNATURE
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -28,7 +28,7 @@ class MetamaskCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
             fee_receiver_address: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -25,7 +25,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -36,7 +36,7 @@ class MoneriumCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             monerium_token_addresses: set[ChecksumEvmAddress],
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/morpho/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/morpho/decoder.py
@@ -29,7 +29,7 @@ from .utils import query_morpho_reward_distributors, query_morpho_vaults
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset, EvmToken
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.fval import FVal
@@ -45,7 +45,7 @@ class MorphoCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             bundlers: set['ChecksumEvmAddress'],
             adapters: set['ChecksumEvmAddress'],

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -20,7 +20,7 @@ from rotkehlchen.types import ChecksumEvmAddress, TokenKind
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -32,7 +32,7 @@ class OdosCommonDecoderBase(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/odos/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/odos/v1/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -27,7 +27,7 @@ class Odosv1DecoderBase(OdosCommonDecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/odos/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/odos/v2/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -28,7 +28,7 @@ class Odosv2DecoderBase(OdosCommonDecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.types import ChainID, ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -37,7 +37,7 @@ class OmnibridgeCommonDecoder(DecoderInterface, abc.ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             bridge_address: ChecksumEvmAddress,
             source_chain: ChainID,

--- a/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -26,7 +26,7 @@ class OneinchCommonDecoder(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: 'ChecksumEvmAddress',
             swapped_signatures: list[bytes],

--- a/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
@@ -28,7 +28,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -40,7 +40,7 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             counterparty: str,
             router_address: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/oneinch/v5/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v5/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4Decoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -19,7 +19,7 @@ class Oneinchv5Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/oneinch/v6/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v6/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.decoder import OneinchCommonDecoder
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Oneinchv6Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_PARASWAP
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -37,7 +37,7 @@ class ParaswapCommonDecoder(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
             fee_receiver_address: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/paraswap/v6/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/v6/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 from .constants import PARASWAP_AUGUSTUS_V6_ROUTER, PARASWAP_METHODS, PARASWAP_V6_FEE_CLAIMER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -34,7 +34,7 @@ class Paraswapv6CommonDecoder(ParaswapCommonDecoder, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/pendle/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/pendle/decoder.py
@@ -52,7 +52,7 @@ from .constants import (
 from .utils import query_pendle_markets
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -64,7 +64,7 @@ class PendleCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/quickswap/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/quickswap/v2/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v2.utils import (
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -26,7 +26,7 @@ class Quickswapv2CommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: 'ChecksumEvmAddress',
             factory_address: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/quickswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/quickswap/v3/decoder.py
@@ -34,7 +34,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -50,7 +50,7 @@ class Quickswapv3LikeLPDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             nft_manager: 'ChecksumEvmAddress',
             nft_manager_abi: ABI,
@@ -145,7 +145,7 @@ class Quickswapv3CommonDecoder(Quickswapv3LikeLPDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: 'ChecksumEvmAddress',
             nft_manager: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/quickswap/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/quickswap/v4/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from .constants import CPT_QUICKSWAP_V4_ROUTER, QUICKSWAP_SWAP_TOPIC, QUICKSWAP_V4_NFT_MANAGER_ABI
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -34,7 +34,7 @@ class Quickswapv4CommonDecoder(Quickswapv3LikeLPDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             swap_router: 'ChecksumEvmAddress',
             nft_manager: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/rainbow/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/rainbow/decoder.py
@@ -24,7 +24,7 @@ from rotkehlchen.utils.misc import bytes_to_address, from_wei
 from .constants import CPT_RAINBOW_SWAPS, RAINBOW_ROUTER_CONTRACT
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -39,7 +39,7 @@ class RainbowDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
@@ -25,7 +25,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import CryptoAsset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -39,7 +39,7 @@ class SocketBridgeDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/spark/lend/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/lend/decoder.py
@@ -9,7 +9,7 @@ from rotkehlchen.chain.evm.decoding.spark.constants import (
 from rotkehlchen.chain.evm.decoding.spark.decoder import SparkCommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -19,7 +19,7 @@ class SparklendCommonDecoder(Aavev3LikeCommonDecoder, SparkCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             pool_addresses: Sequence['ChecksumEvmAddress'],
             native_gateways: 'tuple[ChecksumEvmAddress, ...]',

--- a/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import SWAP_TOPIC
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -42,7 +42,7 @@ class SparksavingsCommonDecoder(SparkCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             spark_savings_tokens: tuple['ChecksumEvmAddress', ...],
             psm_address: 'ChecksumEvmAddress | None' = None,

--- a/rotkehlchen/chain/evm/decoding/stakedao/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/decoder.py
@@ -45,7 +45,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -62,7 +62,7 @@ class StakedaoCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             claim_bribe_addresses: set['ChecksumEvmAddress'] | None = None,
             claim_bribe_protocolfee_addresses: set['ChecksumEvmAddress'] | None = None,

--- a/rotkehlchen/chain/evm/decoding/summer_fi/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/summer_fi/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -24,7 +24,7 @@ class SummerFiCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             account_factory: 'ChecksumEvmAddress',
     ) -> None:

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -35,7 +35,7 @@ class SuperchainL1SideCommonBridgeDecoder(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             bridge_addresses: tuple['ChecksumEvmAddress', ...],
             counterparty: 'CounterpartyDetails',

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -37,7 +37,7 @@ class SuperchainL2SideBridgeCommonDecoder(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             native_assets: Sequence['Asset'],
             bridge_addresses: tuple['ChecksumEvmAddress', ...],

--- a/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
@@ -27,7 +27,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_THEGRAPH, THEGRAPH_CPT_DETAILS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -53,7 +53,7 @@ class ThegraphCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             native_asset: Asset,
             staking_contract: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
@@ -23,7 +23,7 @@ from rotkehlchen.types import EvmTransaction
 from .constants import UNISWAP_V2_SWAP_SIGNATURE
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.types import ChecksumEvmAddress
@@ -37,7 +37,7 @@ class Uniswapv2CommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: 'ChecksumEvmAddress',
             factory_address: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
@@ -50,7 +50,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import ts_ms_to_sec
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -89,7 +89,7 @@ class Uniswapv3CommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             routers_addresses: set['ChecksumEvmAddress'],
             nft_manager: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v4/decoder.py
@@ -27,7 +27,7 @@ from .constants import CPT_UNISWAP_V4_LP, MODIFY_LIQUIDITY, POSITION_MANAGER_ABI
 from .utils import decode_uniswap_v4_like_swaps
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -43,7 +43,7 @@ class Uniswapv4CommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             pool_manager: 'ChecksumEvmAddress',
             position_manager: 'ChecksumEvmAddress',

--- a/rotkehlchen/chain/evm/decoding/uniswap/v4/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v4/utils.py
@@ -32,7 +32,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset, EvmToken
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -120,7 +120,7 @@ def decode_uniswap_v4_like_swaps(
         transaction: 'EvmTransaction',
         decoded_events: list['EvmEvent'],
         all_logs: list['EvmTxReceiptLog'],
-        base_tools: 'BaseDecoderTools',
+        base_tools: 'BaseEvmDecoderTools',
         swap_topics: tuple[bytes, ...],
         counterparty: str,
         router_address: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -54,7 +54,7 @@ from rotkehlchen.utils.misc import bytes_to_address, timestamp_to_date
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.chain.optimism.manager import OptimismInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -70,7 +70,7 @@ class VelodromeLikeDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixi
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer | BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             counterparty: Literal['velodrome', 'aerodrome'],
             voting_escrow_address: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/decoding/weth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/weth/decoder.py
@@ -21,7 +21,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -36,7 +36,7 @@ class WethDecoderBase(DecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             base_asset: CryptoAsset,
             wrapped_token: EvmToken,
@@ -164,7 +164,7 @@ class WethDecoder(WethDecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -32,7 +32,7 @@ class XdaiBridgeCommonDecoder(DecoderInterface, abc.ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             deposit_topics: tuple[bytes, ...],
             withdrawal_topic: bytes | None,  # withdrawal is currently unsupported on gnosis

--- a/rotkehlchen/chain/evm/decoding/zerox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/zerox/decoder.py
@@ -22,7 +22,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 from .constants import CPT_ZEROX, METATX_ZEROX
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.fval import FVal
@@ -37,7 +37,7 @@ class ZeroxCommonDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
             router_address: ChecksumEvmAddress,
             flash_wallet_address: ChecksumEvmAddress,

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EventDecoderFunction, EVMTransactionDecoder
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
@@ -35,7 +35,7 @@ class L2WithL1FeesTransactionDecoder(EVMTransactionDecoder, ABC):
             value_asset: AssetWithOracles,
             event_rules: list[EventDecoderFunction],
             misc_counterparties: list[CounterpartyDetails],
-            base_tools: BaseDecoderTools,
+            base_tools: BaseEvmDecoderTools,
             premium: 'Premium | None' = None,
             dbevmtx_class: type[DBL2WithL1FeesTx] = DBL2WithL1FeesTx,
     ):

--- a/rotkehlchen/chain/gnosis/decoding/decoder.py
+++ b/rotkehlchen/chain/gnosis/decoding/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Final
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.chain.gnosis.modules.monerium.constants import V1_TO_V2_MONERIUM_MAPPINGS
 from rotkehlchen.chain.gnosis.tokens import GNOSIS_MONERIUM_LEGACY_ADDRESSES
@@ -37,7 +37,7 @@ class GnosisTransactionDecoder(EVMTransactionDecoder):
             value_asset=A_XDAI.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderTools(
+            base_tools=BaseEvmDecoderTools(
                 database=database,
                 evm_inquirer=gnosis_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/gnosis/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/aave/v3/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3LikeCommonDecod
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/aura_finance/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/aura_finance/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.aura_finance.decoder import AuraFinanceCommo
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class AuraFinanceDecoder(AuraFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/cowswap/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/cowswap/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class CowswapDecoder(CowswapCommonDecoderWithVCOW):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/curve/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/curve/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_XDAI
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -20,7 +20,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
@@ -28,7 +28,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -41,7 +41,7 @@ class GivethDecoder(GivethDecoderBase):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
@@ -26,7 +26,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
@@ -40,7 +40,7 @@ class GnosisPayDecoder(DecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/hop/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/hop/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.hop.decoder import HopCommonDecoder
 from .constants import BRIDGES, REWARD_CONTRACTS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class HopDecoder(HopCommonDecoder):
     def __init__(
             self,
             gnosis_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/magpie/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/magpie/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.magpie.decoder import MagpieCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class MagpieDecoder(MagpieCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/monerium/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.gnosis.modules.monerium.constants import GNOSIS_MONERIUM_
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class MoneriumDecoder(MoneriumCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/omnibridge/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/omnibridge/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.types import ChainID
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 BRIDGE_ADDRESS: Final = string_to_evm_address('0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d')
@@ -17,7 +17,7 @@ class OmnibridgeDecoder(OmnibridgeCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/oneinch/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import ONEINCH_V4_ROUTE
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Oneinchv4Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/spark/lend/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/spark/lend/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.spark.lend.decoder import SparklendCommonDec
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class SparklendDecoder(SparklendCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/spark/savings/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/spark/savings/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.spark.savings.decoder import SparksavingsCom
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class SparksavingsDecoder(SparksavingsCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/wxdai/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/wxdai/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.gnosis.modules.wxdai.constants import CPT_WXDAI
 from rotkehlchen.constants.assets import A_WXDAI, A_XDAI
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class WxdaiDecoder(WethDecoderBase):
     def __init__(
             self,
             gnosis_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/gnosis/modules/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/xdai_bridge/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.types import ChainID
 from .constants import BRIDGE_ADDRESS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -21,7 +21,7 @@ class XdaiBridgeDecoder(XdaiBridgeCommonDecoder):
     def __init__(
             self,
             gnosis_inquirer: 'GnosisInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/decoding/decoder.py
+++ b/rotkehlchen/chain/optimism/decoding/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderToolsWithProxy
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderToolsWithProxy
 from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.decoder import L2WithL1FeesTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
@@ -34,7 +34,7 @@ class OptimismTransactionDecoder(L2WithL1FeesTransactionDecoder):
             value_asset=A_ETH.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderToolsWithProxy(
+            base_tools=BaseEvmDecoderToolsWithProxy(
                 database=database,
                 evm_inquirer=optimism_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/optimism/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/aave/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3LikeCommonDecod
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
@@ -20,7 +20,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -36,7 +36,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/aura_finance/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/aura_finance/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.aura_finance.decoder import AuraFinanceCommo
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class AuraFinanceDecoder(AuraFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/cctp/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/cctp/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.cctp.decoder import CctpCommonDecoder
 from .constants import MESSAGE_TRANSMITTER, TOKEN_MESSENGER, USDC_IDENTIFIER_OPT
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class CctpDecoder(CctpCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/compound/v3/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/compound/v3/decoder.py
@@ -6,7 +6,7 @@ from .constants import COMPOUND_BULKER_ADDRESS, COMPOUND_REWARDS_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -15,7 +15,7 @@ class Compoundv3Decoder(Compoundv3CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'BaseInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/curve/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/curve/decoder.py
@@ -9,7 +9,7 @@ from rotkehlchen.chain.evm.decoding.curve.decoder import CurveCommonDecoder
 from rotkehlchen.constants.assets import A_ETH
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -19,7 +19,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/curve/lend/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/curve/lend/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from rotkehlchen.chain.evm.decoding.curve.lend.decoder import CurveLendCommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class CurvelendDecoder(CurveLendCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/eas/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/eas/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.eas.decoder import EASCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class EasDecoder(EASCommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/efp/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/efp/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.efp.decoder import EfpCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class EfpDecoder(EfpCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/extrafi/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/extrafi/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from .constants import EXTRAFI_COMMUNITY_FUND
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
@@ -25,7 +25,7 @@ class ExtrafiDecoder(ExtrafiCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/firebird_finance/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.firebird_finance.decoder import FirebirdFina
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class FirebirdFinanceDecoder(FirebirdFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/gearbox/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/gearbox/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.optimism.modules.gearbox.constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -16,7 +16,7 @@ class GearboxDecoder(GearboxCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/gitcoin/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.gitcoinv2.decoder import GitcoinV2CommonDeco
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -18,7 +18,7 @@ class GitcoinDecoder(GitcoinV2CommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/giveth/decoder.py
@@ -19,7 +19,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -35,7 +35,7 @@ class GivethDecoder(GivethDecoderBase):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/hop/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/hop/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.hop.decoder import HopCommonDecoder
 from .constants import BRIDGES, REWARD_CONTRACTS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class HopDecoder(HopCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/llamazip/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/llamazip/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.llamazip.decoder import LlamazipCommonDecode
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -18,7 +18,7 @@ class LlamazipDecoder(LlamazipCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/magpie/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/magpie/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.magpie.decoder import MagpieCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class MagpieDecoder(MagpieCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/metamask/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/metamask/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.optimism.modules.metamask.constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class MetamaskDecoder(MetamaskCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/odos/v1/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/odos/v1/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.odos.v1.decoder import Odosv1DecoderBase
 from .constants import ODOS_V1_ROUTER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Odosv1Decoder(Odosv1DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/odos/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.odos.v2.decoder import Odosv2DecoderBase
 from .constants import ODOS_V2_ROUTER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/oneinch/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4Decoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -18,7 +18,7 @@ class Oneinchv4Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/optimism_governor/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/optimism_governor/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 GOVERNOR_ADDRESS = string_to_evm_address('0xcDF27F107725988f2261Ce2256bDfCdE8B382B10')
@@ -26,7 +26,7 @@ class OptimismGovernorDecoder(GovernableDecoderInterface):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/paraswap/v5/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.ethereum.modules.paraswap.v5.constants import PARASWAP_AU
 from rotkehlchen.chain.evm.decoding.paraswap.v5.decoder import Paraswapv5CommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Paraswapv5Decoder(Paraswapv5CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/spark/savings/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/spark/savings/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.spark.savings.decoder import SparksavingsCom
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class SparksavingsDecoder(SparksavingsCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/summer_fi/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/summer_fi/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.summer_fi.decoder import SummerFiCommonDecod
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class SummerFiDecoder(SummerFiCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/superchain_bridge/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/superchain_bridge/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.constants.assets import A_ETH, A_OPTIMISM_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -24,7 +24,7 @@ class SuperchainBridgeDecoder(SuperchainL2SideBridgeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/uniswap/v2/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v2.decoder import Uniswapv2CommonDec
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Uniswapv2Decoder(Uniswapv2CommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/uniswap/v3/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.modules.uniswap.v3.constants import (
 from rotkehlchen.chain.evm.decoding.uniswap.v3.decoder import Uniswapv3CommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class Uniswapv3Decoder(Uniswapv3CommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/uniswap/v4/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v4.decoder import Uniswapv4CommonDec
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Uniswapv4Decoder(Uniswapv4CommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/velodrome/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/velodrome/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.types import CacheType
 from .constants import ROUTER_V1, ROUTER_V2, VOTER_CONTRACT_ADDRESS, VOTING_ESCROW_CONTRACT_ADDRESS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.manager import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -27,7 +27,7 @@ class VelodromeDecoder(VelodromeLikeDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/walletconnect/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/walletconnect/decoder.py
@@ -26,7 +26,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.decoding.structures import DecoderContext
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
@@ -44,7 +44,7 @@ class WalletconnectDecoder(DecoderInterface, CustomizableDateMixin):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/optimism/modules/zerox/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/zerox/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.optimism.modules.zerox.constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -18,7 +18,7 @@ class ZeroxDecoder(ZeroxCommonDecoder):
     def __init__(
             self,
             optimism_inquirer: 'OptimismInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/decoding/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/decoding/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Final
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
 from rotkehlchen.chain.polygon_pos.modules.monerium.constants import V1_TO_V2_MONERIUM_MAPPINGS
 from rotkehlchen.chain.polygon_pos.tokens import POLYGON_MONERIUM_LEGACY_ADDRESSES
@@ -37,7 +37,7 @@ class PolygonPOSTransactionDecoder(EVMTransactionDecoder):
             value_asset=A_POLYGON_POS_MATIC.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderTools(
+            base_tools=BaseEvmDecoderTools(
                 database=database,
                 evm_inquirer=polygon_pos_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/polygon_pos/modules/aave/v2/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/aave/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.polygon_pos.modules.aave.constants import V3_MIGRATION_HELPER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Aavev2Decoder(Aavev2CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/aave/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3LikeCommonDecod
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/aura_finance/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/aura_finance/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.aura_finance.decoder import AuraFinanceCommo
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class AuraFinanceDecoder(AuraFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/cctp/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/cctp/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.cctp.decoder import CctpCommonDecoder
 from .constants import MESSAGE_TRANSMITTER, TOKEN_MESSENGER, USDC_IDENTIFIER_POLYGON
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class CctpDecoder(CctpCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/compound/v3/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/compound/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.compound.v3.decoder import Compoundv3CommonD
 from .constants import COMPOUND_BULKER_ADDRESS, COMPOUND_REWARDS_ADDRESS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Compoundv3Decoder(Compoundv3CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/curve/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/curve/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC
 from .constants import AAVE_POOLS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -22,7 +22,7 @@ class CurveDecoder(CurveCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/drips/v1/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/drips/v1/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.drips.v1.decoder import Dripsv1CommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Dripsv1Decoder(Dripsv1CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/firebird_finance/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.firebird_finance.decoder import FirebirdFina
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class FirebirdFinanceDecoder(FirebirdFinanceCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/gitcoin/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -19,7 +19,7 @@ class GitcoinDecoder(GitcoinOldCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         GitcoinOldCommonDecoder.__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/gitcoinv2/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.gitcoinv2.decoder import GitcoinV2CommonDeco
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Gitcoinv2Decoder(GitcoinV2CommonDecoder):
     def __init__(  # pylint: disable=super-init-not-called
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/hop/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/hop/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.hop.decoder import HopCommonDecoder
 from .constants import BRIDGES, REWARD_CONTRACTS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class HopDecoder(HopCommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/magpie/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/magpie/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.magpie.decoder import MagpieCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class MagpieDecoder(MagpieCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/metamask/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/metamask/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.polygon_pos.modules.metamask.constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class MetamaskDecoder(MetamaskCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/monerium/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.polygon_pos.modules.monerium.constants import POLYGON_MON
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -14,7 +14,7 @@ class MoneriumDecoder(MoneriumCommonDecoder):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/odos/v1/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/odos/v1/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.odos.v1.decoder import Odosv1DecoderBase
 from .constants import ODOS_V1_ROUTER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Odosv1Decoder(Odosv1DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/odos/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.odos.v2.decoder import Odosv2DecoderBase
 from .constants import ODOS_V2_ROUTER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/oneinch/v4/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import ONEINCH_V4_ROUTE
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Oneinchv4Decoder(Oneinchv3n4DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/paraswap/v5/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.paraswap.v5.decoder import Paraswapv5CommonD
 from rotkehlchen.chain.polygon_pos.modules.paraswap.v5.constants import PARASWAP_FEE_CLAIMER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Paraswapv5Decoder(Paraswapv5CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/quickswap/v2/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/quickswap/v2/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.quickswap.v2.decoder import Quickswapv2Commo
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Quickswapv2Decoder(Quickswapv2CommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/quickswap/v3/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/quickswap/v3/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from .constants import QUICKSWAP_V3_NFT_MANAGER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -16,7 +16,7 @@ class Quickswapv3Decoder(Quickswapv3CommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/uniswap/v2/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v2.decoder import Uniswapv2CommonDec
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Uniswapv2Decoder(Uniswapv2CommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/uniswap/v3/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.modules.uniswap.v3.constants import (
 from rotkehlchen.chain.evm.decoding.uniswap.v3.decoder import Uniswapv3CommonDecoder
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -17,7 +17,7 @@ class Uniswapv3Decoder(Uniswapv3CommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/uniswap/v4/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.uniswap.v4.decoder import Uniswapv4CommonDec
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Uniswapv4Decoder(Uniswapv4CommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/wmatic/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/wmatic/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.polygon_pos.modules.wmatic.constants import CPT_WMATIC
 from rotkehlchen.constants.assets import A_POLYGON_POS_MATIC, A_WMATIC
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class WmaticDecoder(WethDecoderBase):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/polygon_pos/modules/zerox/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/zerox/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.polygon_pos.modules.zerox.constants import (
 )
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -18,7 +18,7 @@ class ZeroxDecoder(ZeroxCommonDecoder):
     def __init__(
             self,
             polygon_pos_inquirer: 'PolygonPOSInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/scroll/decoding/decoder.py
+++ b/rotkehlchen/chain/scroll/decoding/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
 from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.decoder import L2WithL1FeesTransactionDecoder
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -33,7 +33,7 @@ class ScrollTransactionDecoder(L2WithL1FeesTransactionDecoder):
             value_asset=A_ETH.resolve_to_asset_with_oracles(),
             event_rules=[],
             misc_counterparties=[],
-            base_tools=BaseDecoderTools(
+            base_tools=BaseEvmDecoderTools(
                 database=database,
                 evm_inquirer=scroll_inquirer,
                 is_non_conformant_erc721_fn=self._is_non_conformant_erc721,

--- a/rotkehlchen/chain/scroll/modules/aave/v3/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/aave/v3/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.aave.v3.decoder import Aavev3LikeCommonDecod
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Aavev3Decoder(Aavev3LikeCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ScrollInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/scroll/modules/compound/v3/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/compound/v3/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.compound.v3.decoder import Compoundv3CommonD
 from .constants import COMPOUND_BULKER_ADDRESS, COMPOUND_REWARDS_ADDRESS
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class Compoundv3Decoder(Compoundv3CommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ScrollInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/scroll/modules/magpie/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/magpie/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.evm.decoding.magpie.decoder import MagpieCommonDecoder
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -13,7 +13,7 @@ class MagpieDecoder(MagpieCommonDecoder):
     def __init__(
             self,
             evm_inquirer: 'ScrollInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/scroll/modules/monerium/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/monerium/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecode
 from .constants import SCROLL_MONERIUM_ADDRESSES
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -15,7 +15,7 @@ class MoneriumDecoder(MoneriumCommonDecoder):
     def __init__(
             self,
             scroll_inquirer: 'ScrollInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/scroll/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/odos/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.evm.decoding.odos.v2.decoder import Odosv2DecoderBase
 from .constants import ODOS_V2_ROUTER
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -14,7 +14,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
     def __init__(
             self,
             evm_inquirer: 'ScrollInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(

--- a/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
@@ -25,7 +25,7 @@ from rotkehlchen.types import ChainID, ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.base import BaseDecoderTools
+    from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -52,7 +52,7 @@ class ScrollBridgeDecoder(DecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'ScrollInquirer',
-            base_tools: 'BaseDecoderTools',
+            base_tools: 'BaseEvmDecoderTools',
             msg_aggregator: 'MessagesAggregator',
     ) -> None:
         super().__init__(


### PR DESCRIPTION
Follow-up for https://github.com/rotki/rotki/pull/10636.
- renames `BaseDecoderTools` to `BaseEvmDecoderTools`
- renames `BaseDecoderToolsWithProxy` to `BaseEvmDecoderToolsWithProxy`