### PR TITLE
Refactor chain managers

### DIFF
--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -114,7 +114,7 @@ from rotkehlchen.types import (
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
     EVM_EVMLIKE_LOCATIONS,
     NON_EVM_CHAINS,
-    SUPPORTED_SUBSTRATE_CHAINS,
+    SUPPORTED_SUBSTRATE_CHAINS_TYPE,
     AddressbookEntry,
     AddressbookType,
     AssetAmount,
@@ -2135,7 +2135,7 @@ def _transform_evm_address(
 def _transform_substrate_address(
         ethereum_inquirer: EthereumInquirer,
         given_address: str,
-        chain: SUPPORTED_SUBSTRATE_CHAINS,
+        chain: SUPPORTED_SUBSTRATE_CHAINS_TYPE,
 ) -> SubstrateAddress:
     """Returns a DOT or KSM address (if exists) given an ENS domain. At this point any
     given address has been already validated either as an ENS name or as a

--- a/rotkehlchen/chain/balances.py
+++ b/rotkehlchen/chain/balances.py
@@ -13,7 +13,7 @@ from rotkehlchen.types import (
     SUPPORTED_BITCOIN_CHAINS_TYPE,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
     SUPPORTED_NON_BITCOIN_CHAINS,
-    SUPPORTED_SUBSTRATE_CHAINS,
+    SUPPORTED_SUBSTRATE_CHAINS_TYPE,
     BTCAddress,
     ChecksumEvmAddress,
     Eth2PubKey,
@@ -67,7 +67,7 @@ class BlockchainBalances:
         ...
 
     @overload
-    def get(self, chain: SUPPORTED_SUBSTRATE_CHAINS) -> dict[SubstrateAddress, BalanceSheet]:
+    def get(self, chain: SUPPORTED_SUBSTRATE_CHAINS_TYPE) -> dict[SubstrateAddress, BalanceSheet]:
         ...
 
     @overload
@@ -81,6 +81,34 @@ class BlockchainBalances:
     def get(self, chain: SupportedBlockchain) -> ALL_BALANCE_TYPES:
         """Get the appropriate balances dict corresponding to the given chain"""
         return getattr(self, chain.get_key())
+
+    @overload
+    def set(self, chain: SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE, balances: defaultdict[ChecksumEvmAddress, BalanceSheet]) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def set(self, chain: SUPPORTED_BITCOIN_CHAINS_TYPE, balances: dict[BTCAddress, Balance]) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def set(self, chain: Literal[SupportedBlockchain.ETHEREUM_BEACONCHAIN], balances: defaultdict[Eth2PubKey, BalanceSheet]) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def set(self, chain: SUPPORTED_SUBSTRATE_CHAINS_TYPE, balances: dict[SubstrateAddress, BalanceSheet]) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def set(self, chain: Literal[SupportedBlockchain.SOLANA], balances: dict[SolanaAddress, BalanceSheet]) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def set(self, chain: SupportedBlockchain, balances: ALL_BALANCE_TYPES) -> None:
+        ...
+
+    def set(self, chain: SupportedBlockchain, balances: ALL_BALANCE_TYPES) -> None:
+        """Set the balances dict for the given chain"""
+        return setattr(self, chain.get_key(), balances)
 
     def __iter__(self) -> Iterator[tuple[str, dict]]:
         """Easy way to iterate through all chains

--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -1,17 +1,29 @@
 import logging
-from typing import TYPE_CHECKING
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal
 
+from web3.exceptions import BadFunctionCallOutput
+
+from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.aggregator import CHAIN_TO_BALANCE_PROTOCOLS
 from rotkehlchen.chain.evm.active_management.manager import ActiveManager
 from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     query_curve_data,
 )
 from rotkehlchen.chain.evm.types import RemoteDataQueryStatus
-from rotkehlchen.errors.misc import InputError
+from rotkehlchen.chain.manager import ChainManagerWithTransactions
+from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ZERO
+from rotkehlchen.errors.misc import EthSyncError, InputError, RemoteError
 from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import CacheType, ChecksumEvmAddress
+from rotkehlchen.types import CacheType, ChecksumEvmAddress, Price, Timestamp
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithBalance
+
     from .accounting.aggregator import EVMAccountingAggregator
     from .decoding.decoder import EVMTransactionDecoder
     from .node_inquirer import EvmNodeInquirer
@@ -22,7 +34,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class EvmManager:
+class EvmManager(ChainManagerWithTransactions[ChecksumEvmAddress]):
     """EvmManager defines a basic implementation for EVM chains."""
 
     def __init__(
@@ -50,6 +62,153 @@ class EvmManager:
         If there is no node or the node can't query historical balance (not archive) then
         returns None"""
         return self.node_inquirer.get_historical_balance(address, block_number)
+
+    def query_balances(
+            self,
+            addresses: Sequence[ChecksumEvmAddress],
+    ) -> dict[ChecksumEvmAddress, BalanceSheet]:
+        """Queries all native, token, and protocol balances for the given addresses.
+
+        May raise:
+        - RemoteError if an external service such as Etherscan or cryptocompare
+        is queried and there is a problem with its query.
+        - EthSyncError if querying the token balances through a provided ethereum
+        client and the chain is not synced
+        """
+        return self.query_protocols_with_balance(
+            balances=self.query_evm_chain_balances(accounts=addresses),
+        )
+
+    def query_transactions(
+            self,
+            addresses: list[ChecksumEvmAddress],
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
+    ) -> None:
+        """Queries and saves the transactions for the given addresses in the specified time range.
+        May raise:
+        - RemoteError if there is a problem with an external query.
+        - pysqlcipher3.dbapi2.OperationalError if the SQL query fails due to
+        invalid filtering arguments.
+        """
+        self.transactions.query_chain(
+            addresses=addresses,
+            from_timestamp=from_timestamp,
+            to_timestamp=to_timestamp,
+        )
+
+    @staticmethod
+    def update_balances_after_token_query(
+            dsr_proxy_append: bool,
+            balance_result: dict[ChecksumEvmAddress, dict[EvmToken, FVal]],
+            token_usd_price: dict[EvmToken, Price],
+            balances: defaultdict[ChecksumEvmAddress, BalanceSheet],
+            balance_label: Literal['address', 'makerdao vault'] = DEFAULT_BALANCE_LABEL,
+    ) -> None:
+        """Updates the passed balances dict with the provided balances_result and token prices.
+        If dsr_proxy_append is True then the balances are appended to the existing ones, otherwise
+        existing balances are replaced.
+        """
+        # Update the per account token balance and usd value
+        for account, token_balances in balance_result.items():
+            for token, token_balance in token_balances.items():
+                balance = Balance(
+                    amount=token_balance,
+                    usd_value=token_balance * token_usd_price[token],
+                )
+                protocol = token.protocol or balance_label
+                assets_or_liabilities = balances[account].liabilities if token.is_liability() else balances[account].assets  # noqa: E501
+                if dsr_proxy_append:
+                    assets_or_liabilities[token][protocol] += balance
+                else:
+                    assets_or_liabilities[token][protocol] = balance
+
+    def query_evm_tokens(
+            self,
+            accounts: Sequence[ChecksumEvmAddress],
+            balances: defaultdict[ChecksumEvmAddress, BalanceSheet],
+    ) -> defaultdict[ChecksumEvmAddress, BalanceSheet]:
+        """Queries evm token balance via either etherscan or evm node
+
+        Should come here during addition of a new account or querying of all token
+        balances.
+
+        May raise:
+        - RemoteError if an external service such as Etherscan or cryptocompare
+        is queried and there is a problem with its query.
+        - EthSyncError if querying the token balances through a provided ethereum
+        client and the chain is not synced
+        """
+        try:
+            balance_result, token_usd_price = self.tokens.query_tokens_for_addresses(
+                addresses=accounts,
+            )
+        except BadFunctionCallOutput as e:
+            log.error(
+                f'Assuming unsynced chain. Got web3 BadFunctionCallOutput '
+                f'exception: {e!s}',
+            )
+            raise EthSyncError(
+                f'Tried to use the {self.node_inquirer.blockchain!s} chain of the provided '
+                'client to query token balances but the chain is not synced.',
+            ) from e
+
+        self.update_balances_after_token_query(
+            dsr_proxy_append=False,
+            balance_result=balance_result,
+            token_usd_price=token_usd_price,
+            balances=balances,
+        )
+        return balances
+
+    def query_evm_chain_balances(
+            self,
+            accounts: Sequence[ChecksumEvmAddress],
+    ) -> defaultdict[ChecksumEvmAddress, BalanceSheet]:
+        """Queries all the balances for an evm chain and populates the state
+
+        May raise:
+        - RemoteError if an external service such as Etherscan or cryptocompare
+        is queried and there is a problem with its query.
+        - EthSyncError if querying the token balances through a provided ethereum
+        client and the chain is not synced
+        """
+        chain_balances: defaultdict[ChecksumEvmAddress, BalanceSheet] = defaultdict(BalanceSheet)
+        native_token_usd_price = Inquirer.find_usd_price(self.node_inquirer.native_token)
+        for account, balance in self.node_inquirer.get_multi_balance(accounts).items():
+            if balance != ZERO:  # accounts (e.g. multisigs) can have zero balances
+                chain_balances[account].assets[self.node_inquirer.native_token][DEFAULT_BALANCE_LABEL] = Balance(  # noqa: E501
+                    amount=balance,
+                    usd_value=balance * native_token_usd_price,
+                )
+
+        return self.query_evm_tokens(accounts=accounts, balances=chain_balances)
+
+    def query_protocols_with_balance(
+            self,
+            balances: defaultdict[ChecksumEvmAddress, BalanceSheet],
+    ) -> defaultdict[ChecksumEvmAddress, BalanceSheet]:
+        """
+        Query for balances of protocols in which tokens can be locked without returning a liquid
+        version of the locked token. For example staking tokens in an old curve gauge. This balance
+        needs to be added to the total balance of the account. Examples of such protocols are
+        Legacy Curve gauges in ethereum, Convex and Velodrome.
+        """
+        for protocol in CHAIN_TO_BALANCE_PROTOCOLS[self.node_inquirer.chain_id]:
+            protocol_with_balance: ProtocolWithBalance = protocol(
+                evm_inquirer=self.node_inquirer,  # type: ignore  # mypy can't match all possibilities here
+                tx_decoder=self.transactions_decoder,  # type: ignore  # mypy can't match all possibilities here
+            )
+            try:
+                protocol_balances = protocol_with_balance.query_balances()
+            except RemoteError as e:
+                log.error(f'Failed to query balances for {protocol} due to {e}. Skipping')
+                continue
+
+            for address, asset_balances in protocol_balances.items():
+                balances[address] += asset_balances
+
+        return balances
 
 
 class CurveManagerMixin:

--- a/rotkehlchen/chain/evm/types.py
+++ b/rotkehlchen/chain/evm/types.py
@@ -1,14 +1,14 @@
 import re
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Literal, NamedTuple
+from typing import Any, NamedTuple
 
 from eth_typing import HexAddress, HexStr
 
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import (
-    EVM_CHAINS_WITH_CHAIN_MANAGER,
+    CHAINS_WITH_NODES,
     SUPPORTED_CHAIN_IDS,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
     ChainID,
@@ -34,7 +34,7 @@ class NodeName(NamedTuple):
     name: str
     endpoint: str
     owned: bool
-    blockchain: EVM_CHAINS_WITH_CHAIN_MANAGER | Literal[SupportedBlockchain.SOLANA]
+    blockchain: CHAINS_WITH_NODES
 
     def serialize(self) -> dict[str, Any]:
         return {

--- a/rotkehlchen/chain/manager.py
+++ b/rotkehlchen/chain/manager.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.types import Timestamp
+
+T_Address = TypeVar('T_Address')
+
+
+class ChainManager(ABC, Generic[T_Address]):
+
+    @abstractmethod
+    def query_balances(
+            self,
+            addresses: Sequence[T_Address],
+    ) -> dict[T_Address, BalanceSheet] | dict[T_Address, Balance]:
+        """Queries balances for the blockchain"""
+
+
+class ChainManagerWithTransactions(ChainManager[T_Address]):
+
+    @abstractmethod
+    def query_transactions(
+            self,
+            addresses: list[T_Address],
+            from_timestamp: Timestamp,
+            to_timestamp: Timestamp,
+    ) -> None:
+        """Query the blockchain for transactions and saves them in the DB.
+        The transactions for the given time range must be included. If the APIs used for a
+        particular blockchain require querying other transactions as well to reach the given
+        range, then those should also be saved to avoid requerying them later.
+        """

--- a/rotkehlchen/chain/substrate/utils.py
+++ b/rotkehlchen/chain/substrate/utils.py
@@ -3,7 +3,7 @@ from typing import get_args
 from substrateinterface import Keypair
 from substrateinterface.utils.ss58 import is_valid_ss58_address
 
-from rotkehlchen.types import SUPPORTED_SUBSTRATE_CHAINS, SupportedBlockchain
+from rotkehlchen.types import SUPPORTED_SUBSTRATE_CHAINS_TYPE, SupportedBlockchain
 
 from .types import KusamaNodeName, PolkadotNodeName, SubstrateAddress, SubstratePublicKey
 
@@ -27,7 +27,7 @@ POLKADOT_NODES_TO_CONNECT_AT_START = (
 SUBSTRATE_NODE_CONNECTION_TIMEOUT = 60
 
 
-def is_valid_substrate_address(chain: SUPPORTED_SUBSTRATE_CHAINS, value: str) -> bool:
+def is_valid_substrate_address(chain: SUPPORTED_SUBSTRATE_CHAINS_TYPE, value: str) -> bool:
     return is_valid_ss58_address(
         value=value,
         valid_ss58_format=2 if chain == SupportedBlockchain.KUSAMA else 0,
@@ -35,7 +35,7 @@ def is_valid_substrate_address(chain: SUPPORTED_SUBSTRATE_CHAINS, value: str) ->
 
 
 def get_substrate_address_from_public_key(
-        chain: SUPPORTED_SUBSTRATE_CHAINS,
+        chain: SUPPORTED_SUBSTRATE_CHAINS_TYPE,
         public_key: SubstratePublicKey,
 ) -> SubstrateAddress:
     """Return a valid address for the given Substrate chain and public key.
@@ -48,7 +48,7 @@ def get_substrate_address_from_public_key(
     - ValueError: if public key is not 32 bytes long or the ss58_format is not
     a valid int.
     """
-    assert chain in get_args(SUPPORTED_SUBSTRATE_CHAINS)
+    assert chain in get_args(SUPPORTED_SUBSTRATE_CHAINS_TYPE)
     if chain == SupportedBlockchain.KUSAMA:
         ss58_format = 2
     else:  # polkadot

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -127,7 +127,7 @@ from rotkehlchen.types import (
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
     SUPPORTED_EVMLIKE_CHAINS,
     SUPPORTED_EVMLIKE_CHAINS_TYPE,
-    SUPPORTED_SUBSTRATE_CHAINS,
+    SUPPORTED_SUBSTRATE_CHAINS_TYPE,
     AnyBlockchainAddress,
     ApiKey,
     ApiSecret,
@@ -1607,7 +1607,7 @@ class DBHandler:
     def get_single_blockchain_addresses(
             self,
             cursor: 'DBCursor',
-            blockchain: SUPPORTED_SUBSTRATE_CHAINS,
+            blockchain: SUPPORTED_SUBSTRATE_CHAINS_TYPE,
     ) -> list[SubstrateAddress]:
         ...
 

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -107,7 +107,7 @@ from rotkehlchen.types import (
     SUPPORTED_BITCOIN_CHAINS_TYPE,
     SUPPORTED_EVM_CHAINS_TYPE,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
-    SUPPORTED_SUBSTRATE_CHAINS,
+    SUPPORTED_SUBSTRATE_CHAINS_TYPE,
     AddressbookEntry,
     AddressbookType,
     ApiKey,
@@ -801,7 +801,7 @@ class Rotkehlchen:
     @overload
     def add_single_blockchain_accounts(
             self,
-            chain: SUPPORTED_SUBSTRATE_CHAINS,
+            chain: SUPPORTED_SUBSTRATE_CHAINS_TYPE,
             account_data: list[SingleBlockchainAccountData[SubstrateAddress]],
     ) -> None:
         ...

--- a/rotkehlchen/tests/api/blockchain/test_base.py
+++ b/rotkehlchen/tests/api/blockchain/test_base.py
@@ -244,9 +244,9 @@ def test_query_blockchain_balances_ignore_cache(
         wraps=rotki.chains_aggregator.query_eth_balances,
     )
     tokens_query = patch.object(
-        rotki.chains_aggregator,
+        rotki.chains_aggregator.ethereum,
         'query_evm_tokens',
-        wraps=rotki.chains_aggregator.query_evm_tokens,
+        wraps=rotki.chains_aggregator.ethereum.query_evm_tokens,
     )
 
     with ExitStack() as stack:

--- a/rotkehlchen/tests/integration/test_blockchain.py
+++ b/rotkehlchen/tests/integration/test_blockchain.py
@@ -13,7 +13,7 @@ from rotkehlchen.types import SupportedBlockchain
 
 
 def test_query_btc_balances(blockchain):
-    blockchain.query_btc_balances()
+    blockchain._query_chain_balances(blockchain=SupportedBlockchain.BITCOIN)
     assert 'BTC' not in blockchain.totals.assets
 
     account = '3BZU33iFcAiyVyu2M2GhEpLNuh81GymzJ7'
@@ -23,7 +23,7 @@ def test_query_btc_balances(blockchain):
         append_or_remove='append',
     )
 
-    blockchain.query_btc_balances()
+    blockchain._query_chain_balances(blockchain=SupportedBlockchain.BITCOIN)
     assert blockchain.totals.assets[A_BTC][DEFAULT_BALANCE_LABEL].usd_value is not None
     assert blockchain.totals.assets[A_BTC][DEFAULT_BALANCE_LABEL].amount is not None
 

--- a/rotkehlchen/tests/integration/test_zksynclite.py
+++ b/rotkehlchen/tests/integration/test_zksynclite.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.zksync_lite.constants import ZKL_IDENTIFIER
@@ -11,6 +11,7 @@ from rotkehlchen.chain.zksync_lite.structures import (
     ZKSyncLiteTransaction,
     ZKSyncLiteTXType,
 )
+from rotkehlchen.constants import DEFAULT_BALANCE_LABEL
 from rotkehlchen.constants.assets import (
     A_DAI,
     A_ETH,
@@ -145,29 +146,29 @@ def test_fetch_transactions(zksync_lite_manager):
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])
 def test_balances(zksync_lite_manager, inquirer):  # pylint: disable=unused-argument
     lefty, rotki, empty = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12', '0x9531C059098e3d194fF87FebB587aB07B30B1306', '0xB638e104563515a917025964ee874a484A489147'  # noqa: E501
-    balances = zksync_lite_manager.get_balances(addresses=[lefty, rotki, empty])
+    balances = zksync_lite_manager.query_balances(addresses=[lefty, rotki, empty])
     lefty_eth_amount = FVal('0.0004100008')
     eth, mana, uni, wbtc, link, dai, frax, usdc, storj, lrc, snx, pan, usdt = FVal('0.00002036000092'), FVal('16.38'), FVal('2.1409'), FVal('0.00012076'), FVal('0.47523'), FVal('53.83503876'), FVal('2.4306'), FVal('98.233404'), FVal('2.2064'), FVal('0.95'), FVal('0.95'), FVal('9202.65'), FVal('4.1')  # noqa: E501
     assert balances == {
-        lefty: {
-            A_ETH: Balance(lefty_eth_amount, lefty_eth_amount * CURRENT_PRICE_MOCK),
-        },
-        rotki: {
-            A_ETH: Balance(eth, eth * CURRENT_PRICE_MOCK),
-            A_MANA: Balance(mana, mana * CURRENT_PRICE_MOCK),
-            A_UNI: Balance(uni, uni * CURRENT_PRICE_MOCK),
-            A_WBTC: Balance(wbtc, wbtc * CURRENT_PRICE_MOCK),
-            A_LINK: Balance(link, link * CURRENT_PRICE_MOCK),
-            A_DAI: Balance(dai, dai * CURRENT_PRICE_MOCK),
-            EvmToken('eip155:1/erc20:0x853d955aCEf822Db058eb8505911ED77F175b99e'): Balance(frax, frax * CURRENT_PRICE_MOCK),  # noqa: E501  # FRAX
-            A_USDC: Balance(usdc, usdc * CURRENT_PRICE_MOCK),
-            EvmToken('eip155:1/erc20:0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC'): Balance(storj, storj * CURRENT_PRICE_MOCK),  # noqa: E501  # STORJ
-            A_LRC: Balance(lrc, lrc * CURRENT_PRICE_MOCK),
-            A_SNX: Balance(snx, snx * CURRENT_PRICE_MOCK),
-            A_PAN: Balance(pan, pan * CURRENT_PRICE_MOCK),
-            A_USDT: Balance(usdt, usdt * CURRENT_PRICE_MOCK),
-        },
-        empty: {},
+        lefty: BalanceSheet(assets={
+            A_ETH: {DEFAULT_BALANCE_LABEL: Balance(lefty_eth_amount, lefty_eth_amount * CURRENT_PRICE_MOCK)},  # noqa: E501
+        }),
+        rotki: BalanceSheet(assets={
+            A_ETH: {DEFAULT_BALANCE_LABEL: Balance(eth, eth * CURRENT_PRICE_MOCK)},
+            A_MANA: {DEFAULT_BALANCE_LABEL: Balance(mana, mana * CURRENT_PRICE_MOCK)},
+            A_UNI: {DEFAULT_BALANCE_LABEL: Balance(uni, uni * CURRENT_PRICE_MOCK)},
+            A_WBTC: {DEFAULT_BALANCE_LABEL: Balance(wbtc, wbtc * CURRENT_PRICE_MOCK)},
+            A_LINK: {DEFAULT_BALANCE_LABEL: Balance(link, link * CURRENT_PRICE_MOCK)},
+            A_DAI: {DEFAULT_BALANCE_LABEL: Balance(dai, dai * CURRENT_PRICE_MOCK)},
+            EvmToken('eip155:1/erc20:0x853d955aCEf822Db058eb8505911ED77F175b99e'): {DEFAULT_BALANCE_LABEL: Balance(frax, frax * CURRENT_PRICE_MOCK)},  # noqa: E501  # FRAX
+            A_USDC: {DEFAULT_BALANCE_LABEL: Balance(usdc, usdc * CURRENT_PRICE_MOCK)},
+            EvmToken('eip155:1/erc20:0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC'): {DEFAULT_BALANCE_LABEL: Balance(storj, storj * CURRENT_PRICE_MOCK)},  # noqa: E501  # STORJ
+            A_LRC: {DEFAULT_BALANCE_LABEL: Balance(lrc, lrc * CURRENT_PRICE_MOCK)},
+            A_SNX: {DEFAULT_BALANCE_LABEL: Balance(snx, snx * CURRENT_PRICE_MOCK)},
+            A_PAN: {DEFAULT_BALANCE_LABEL: Balance(pan, pan * CURRENT_PRICE_MOCK)},
+            A_USDT: {DEFAULT_BALANCE_LABEL: Balance(usdt, usdt * CURRENT_PRICE_MOCK)},
+        }),
+        empty: BalanceSheet(),
     }
 
 

--- a/rotkehlchen/tests/unit/test_bitcoin_cash.py
+++ b/rotkehlchen/tests/unit/test_bitcoin_cash.py
@@ -22,6 +22,7 @@ from rotkehlchen.utils.network import request_get
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.bitcoin.bch.manager import BitcoinCashManager
+    from rotkehlchen.inquirer import Inquirer
     from rotkehlchen.types import BTCAddress
 
 
@@ -92,6 +93,7 @@ def test_validate_bch_address_input():
 def test_query_bch_has_transactions_and_balances(
         bitcoin_cash_manager: 'BitcoinCashManager',
         bch_accounts: list['BTCAddress'],
+        inquirer: 'Inquirer',
 ) -> None:
     """Test that the bch have_transactions and get_balances work correctly from all apis."""
     user_address, expected_balance = bch_accounts[0], FVal('5.33798911')
@@ -117,9 +119,9 @@ def test_query_bch_has_transactions_and_balances(
             assert bitcoin_cash_manager.have_transactions(
                 accounts=bch_accounts,
             ) == {user_address: (True, expected_balance)}
-            assert bitcoin_cash_manager.get_balances(
-                accounts=bch_accounts,
-            ) == {user_address: expected_balance}
+            assert bitcoin_cash_manager.query_balances(
+                addresses=bch_accounts,
+            )[user_address].amount == expected_balance
 
         # reset health status so it tries to query health again in the next loop iteration
         bitcoin_cash_manager.last_haskoin_health = {}

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -226,7 +226,7 @@ def test_native_token_balance(
             only_cache=False,
             addresses=[address],
         )
-        blockchain.query_polygon_pos_balances()
+        blockchain._query_chain_balances(blockchain=SupportedBlockchain.POLYGON_POS)
         balances = blockchain.balances.polygon_pos[address].assets
         assert balances == {
             pol: {DEFAULT_BALANCE_LABEL: Balance(

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -120,6 +120,7 @@ from rotkehlchen.types import (
     ChainID,
     ChecksumEvmAddress,
     Price,
+    SupportedBlockchain,
     TokenKind,
     deserialize_evm_tx_hash,
 )
@@ -656,7 +657,10 @@ def test_aave_v3_balances(blockchain: 'ChainsAggregator') -> None:
         attribute='query_tokens_for_addresses',
         new=mock_new_balances,
     ):
-        blockchain.query_evm_tokens(manager=ethereum_manager, balances=balances)
+        balances = ethereum_manager.query_evm_tokens(
+            accounts=blockchain.accounts.eth,
+            balances=balances,
+        )
 
     # Check individual balances instead of full BalanceSheet comparison
     assert balances[blockchain.accounts.eth[0]].assets[a_eth_usdc][CPT_AAVE_V3] == Balance(
@@ -749,7 +753,7 @@ def test_compound_v3_token_balances_liabilities(
         target='rotkehlchen.chain.evm.tokens.EvmTokens.query_tokens_for_addresses',
         side_effect=mock_query_tokens,
     ):
-        blockchain.query_eth_balances()
+        blockchain._query_chain_balances(blockchain=SupportedBlockchain.ETHEREUM)
 
     def get_balance(amount: str):
         return Balance(

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -438,7 +438,7 @@ class ChainType(SerializableEnumNameMixin):
             return SUPPORTED_BITCOIN_CHAINS
 
         if self == ChainType.SUBSTRATE:
-            return get_args(SUPPORTED_SUBSTRATE_CHAINS)
+            return get_args(SUPPORTED_SUBSTRATE_CHAINS_TYPE)
 
         if self == ChainType.SOLANA:
             return [SupportedBlockchain.SOLANA]
@@ -494,7 +494,7 @@ class SupportedBlockchain(SerializableEnumValueMixin):
         return self in SUPPORTED_BITCOIN_CHAINS
 
     def is_substrate(self) -> bool:
-        return self in get_args(SUPPORTED_SUBSTRATE_CHAINS)
+        return self in get_args(SUPPORTED_SUBSTRATE_CHAINS_TYPE)
 
     def get_image_name(self) -> str:
         return SUPPORTED_BLOCKCHAIN_IMAGE_NAME_MAPPING[self]
@@ -709,10 +709,11 @@ SUPPORTED_BITCOIN_CHAINS_TYPE = Literal[
 ]
 SUPPORTED_BITCOIN_CHAINS: tuple[SUPPORTED_BITCOIN_CHAINS_TYPE, ...] = typing.get_args(SUPPORTED_BITCOIN_CHAINS_TYPE)  # noqa: E501
 
-SUPPORTED_SUBSTRATE_CHAINS = Literal[
+SUPPORTED_SUBSTRATE_CHAINS_TYPE = Literal[
     SupportedBlockchain.POLKADOT,
     SupportedBlockchain.KUSAMA,
 ]
+SUPPORTED_SUBSTRATE_CHAINS: tuple[SUPPORTED_SUBSTRATE_CHAINS_TYPE, ...] = typing.get_args(SUPPORTED_SUBSTRATE_CHAINS_TYPE)  # noqa: E501
 
 SUPPORTED_BLOCKCHAIN_TO_CHAINID = {
     SupportedBlockchain.ETHEREUM: ChainID.ETHEREUM,
@@ -731,25 +732,8 @@ CHAINID_TO_SUPPORTED_BLOCKCHAIN = {
 }
 NON_EVM_CHAINS = set(SupportedBlockchain) - set(SUPPORTED_BLOCKCHAIN_TO_CHAINID.keys())
 
-EVM_CHAINS_WITH_CHAIN_MANAGER = Literal[
-    SupportedBlockchain.ETHEREUM,
-    SupportedBlockchain.OPTIMISM,
-    SupportedBlockchain.POLYGON_POS,
-    SupportedBlockchain.ARBITRUM_ONE,
-    SupportedBlockchain.BASE,
-    SupportedBlockchain.AVALANCHE,
-    SupportedBlockchain.POLKADOT,
-    SupportedBlockchain.KUSAMA,
-    SupportedBlockchain.GNOSIS,
-    SupportedBlockchain.SCROLL,
-    SupportedBlockchain.ZKSYNC_LITE,
-    SupportedBlockchain.BINANCE_SC,
-]
-
-CHAINS_WITH_CHAIN_MANAGER = EVM_CHAINS_WITH_CHAIN_MANAGER | Literal[
-    SupportedBlockchain.BITCOIN,
-    SupportedBlockchain.BITCOIN_CASH,
-]
+CHAINS_WITH_NODES = SUPPORTED_EVM_CHAINS_TYPE | Literal[SupportedBlockchain.SOLANA]
+CHAINS_WITH_CHAIN_MANAGER = SUPPORTED_EVM_CHAINS_TYPE | SUPPORTED_EVMLIKE_CHAINS_TYPE | SUPPORTED_BITCOIN_CHAINS_TYPE | SUPPORTED_SUBSTRATE_CHAINS_TYPE | Literal[SupportedBlockchain.SOLANA]  # noqa: E501
 
 
 class Location(DBCharEnumMixIn):

--- a/rotkehlchen/utils/mixins/lockable.py
+++ b/rotkehlchen/utils/mixins/lockable.py
@@ -22,7 +22,7 @@ class LockableQueryMixIn:
         self.query_locks_map_lock = Semaphore()
 
 
-def protect_with_lock(arguments_matter: bool = False) -> Callable:
+def protect_with_lock(arguments_matter: bool = False, skip_ignore_cache: bool = False) -> Callable:
     """ This is a decorator for protecting a call of an object with a lock
     The objects must adhere to the interface of having:
         - A mapping of ids to query_lock objects
@@ -38,7 +38,7 @@ def protect_with_lock(arguments_matter: bool = False) -> Callable:
             lock_key = function_sig_key(
                 f.__name__,        # name
                 arguments_matter,  # arguments_matter
-                False,             # skip_ignore_cache
+                skip_ignore_cache,  # skip_ignore_cache
                 *args,
                 **kwargs,
             )


### PR DESCRIPTION
Refactors the chain managers to share a common base class.

* Adds new `ChainManager` and `ChainManagerWithTransactions` abstract base classes.
* Converts `BitcoinCommonManager`, `EvmManager`, `SolanaManager`, and `ZksyncLiteManager` to use `ChainManagerWithTransactions`
* Converts `AvalancheManager` and `SubstrateManager` to use `ChainManager`
* Moves a bunch of the balance querying logic from the ChainsAggregator into the relevant chain managers.
    - Removes most of the `query_xxxxx_balances` functions in the chains aggregator since they were duplicating code.
    - Moves some of the EVM specific functions from the ChainsAggregator into the EvmManager, such as `query_evm_chain_balances`, `query_evm_tokens`, and `_update_balances_after_token_query`