### PR TITLE
abstract evm transaction decoder

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -403,11 +403,11 @@ When the endpoint to start the task for decoding undecoded transactions is queri
 
     {
         "type": "progress_updates",
-        "data": {chain":"ethereum", "total":2, "processed":0, "subtype":"evm_undecoded_transactions"}
+        "data": {chain":"ethereum", "total":2, "processed":0, "subtype":"undecoded_transactions"}
     }
 
 
-- ``subtype``: Set to "evm_undecoded_transactions" to identify transaction decoding progress
+- ``subtype``: Set to "undecoded_transactions" to identify transaction decoding progress
 - ``chain``: Chain where the task is decoding transactions.
 - ``total``: Total number of transactions that will be decoded.
 - ``processed``: The total number of transactions that have already been decoded.

--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -1,7 +1,7 @@
 from typing import Final
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.history.events.structures.types import (
     EventCategory,
     EventCategoryDetails,

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -34,7 +34,7 @@ class WSMessageType(StrEnum):
 
 
 class ProgressUpdateSubType(StrEnum):
-    EVM_UNDECODED_TRANSACTIONS = auto()
+    UNDECODED_TRANSACTIONS = auto()
     PROTOCOL_CACHE_UPDATES = auto()
     CSV_IMPORT_RESULT = auto()
     HISTORICAL_PRICE_QUERY_STATUS = auto()

--- a/rotkehlchen/chain/decoding/constants.py
+++ b/rotkehlchen/chain/decoding/constants.py
@@ -1,0 +1,4 @@
+from typing import Final
+
+CPT_GAS: Final = 'gas'
+MIN_LOGS_PROCESSED_TO_SLEEP: Final[int] = 1000

--- a/rotkehlchen/chain/decoding/decoder.py
+++ b/rotkehlchen/chain/decoding/decoder.py
@@ -1,0 +1,364 @@
+import importlib
+import logging
+import pkgutil
+from abc import ABC, abstractmethod
+from contextlib import suppress
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from gevent.lock import Semaphore
+
+from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
+from rotkehlchen.errors.serialization import ConversionError, DeserializationError
+from rotkehlchen.fval import FVal
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
+
+from .constants import CPT_GAS
+from .tools import BaseDecoderTools
+from .types import CounterpartyDetails, SupportsAddition
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from rotkehlchen.assets.asset import AssetWithOracles
+    from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.drivers.gevent import DBCursor
+    from rotkehlchen.premium.premium import Premium
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+T_Event = TypeVar('T_Event')
+T_TxHash = TypeVar('T_TxHash')
+T_Transaction = TypeVar('T_Transaction')
+T_DecodingRules = TypeVar('T_DecodingRules', bound=SupportsAddition)
+T_DecoderInterface = TypeVar('T_DecoderInterface')
+T_DecoderTools = TypeVar('T_DecoderTools', bound=BaseDecoderTools)
+T_TransactionDecodingContext = TypeVar('T_TransactionDecodingContext')
+
+
+class TransactionDecoder(ABC, Generic[T_Transaction, T_DecodingRules, T_DecoderInterface, T_TxHash, T_Event, T_TransactionDecodingContext, T_DecoderTools]):  # noqa: E501
+    def __init__(
+            self,
+            database: 'DBHandler',
+            chain_name: str,
+            value_asset: 'AssetWithOracles',
+            rules: T_DecodingRules,
+            misc_counterparties: list[CounterpartyDetails],
+            base_tools: T_DecoderTools,
+            premium: 'Premium | None' = None,
+            possible_decoding_exceptions: tuple[type[Exception], ...] | None = None,
+    ) -> None:
+        """Initialize a transaction decoder module for a particular blockchain.
+
+        `value_asset` is the asset that is normally transferred at value transfers
+        and the one that is spent for gas in this chain
+
+        `misc_counterparties` is a list of counterparties not associated with any specific
+        decoder that should be included for this decoder modules.
+
+        `premium` is the Premium object for checking user limits
+        """
+        self.database = database
+        self.premium = premium
+        self.misc_counterparties = [CounterpartyDetails(identifier=CPT_GAS, label='gas', icon='lu-flame')] + misc_counterparties  # noqa: E501
+        self.msg_aggregator = database.msg_aggregator
+        self.chain_name = chain_name
+        self.chain_modules_root = f'rotkehlchen.chain.{self.chain_name}.modules'
+        self.chain_modules_prefix_length = len(self.chain_modules_root)
+        self.dbevents = DBHistoryEvents(self.database)
+        self.base = base_tools
+        self.value_asset = value_asset
+        self.rules = rules
+        self.decoders: dict[str, T_DecoderInterface] = {}
+        self.possible_decoding_exceptions: tuple[type[Exception], ...] = (
+            UnknownAsset,
+            WrongAssetType,
+            DeserializationError,
+            IndexError,
+            ValueError,
+            ConversionError,
+        )
+        if possible_decoding_exceptions is not None:
+            self.possible_decoding_exceptions += possible_decoding_exceptions
+
+        # Add the built-in decoders
+        self._add_builtin_decoders(self.rules)
+        # Recursively check all submodules to get all decoder address mappings and rules
+        self.rules += self._recursively_initialize_decoders(self.chain_modules_root)
+        self.undecoded_tx_query_lock = Semaphore()
+
+    @abstractmethod
+    def _add_builtin_decoders(self, rules: T_DecodingRules) -> None:
+        """Adds decoders that should be built-in for every decoding run
+
+        Think: Perhaps we can move them under a specific directory and use the
+        normal loading?
+        """
+
+    @abstractmethod
+    def _add_single_decoder(
+            self,
+            class_name: str,
+            decoder_class: type[T_DecoderInterface],
+            rules: T_DecodingRules,
+    ) -> None:
+        """Initialize a single decoder, add it to the set of decoders to use
+        and append its rules to the passed rules
+        """
+
+    @staticmethod
+    @abstractmethod
+    def _load_default_decoding_rules() -> T_DecodingRules:
+        """Return a fresh rules object with all chain-specific defaults."""
+
+    def _recursively_initialize_decoders(
+            self,
+            package: 'str | ModuleType',
+    ) -> T_DecodingRules:
+        """Discover decoder modules under `package` and merge their rules.
+        May raise:
+         - ModuleLoadingError if a decoder is registered more than once
+         - ImportError for unexpected import failures while loading submodules
+        """
+        if isinstance(package, str):
+            package = importlib.import_module(package)
+
+        rules = self._load_default_decoding_rules()
+        for _, name, is_pkg in pkgutil.walk_packages(package.__path__):
+            full_name = package.__name__ + '.' + name
+            if full_name == __name__ or is_pkg is False:
+                continue  # skip
+
+            submodule = None
+            with suppress(ModuleNotFoundError):
+                submodule = importlib.import_module(full_name + '.decoder')
+
+            if submodule is not None:
+                # take module name, transform it and find decoder if exists
+                class_name = full_name[self.chain_modules_prefix_length:].translate({ord('.'): None})  # noqa: E501
+                parts = class_name.split('_')
+                class_name = ''.join([x.capitalize() for x in parts])
+                submodule_decoder = getattr(submodule, f'{class_name}Decoder', None)
+
+                if submodule_decoder:
+                    self._add_single_decoder(class_name=class_name, decoder_class=submodule_decoder, rules=rules)  # noqa: E501
+
+            if is_pkg:
+                recursive_results = self._recursively_initialize_decoders(full_name)
+                rules += recursive_results
+
+        return rules
+
+    def _reload_single_decoder(self, cursor: 'DBCursor', decoder: T_DecoderInterface) -> None:
+        """Reload data for a single decoder"""
+        if isinstance(decoder, CustomizableDateMixin):
+            decoder.reload_settings(cursor)
+
+    def reload_data(self, cursor: 'DBCursor') -> None:
+        """Reload all related settings from DB and data that any decoder may require from the chain
+        so that decoding happens with latest data
+        """
+        self.base.refresh_tracked_accounts(cursor)
+        for decoder in self.decoders.values():
+            self._reload_single_decoder(cursor, decoder)
+
+    def reload_specific_decoders(self, cursor: 'DBCursor', decoders: set[str]) -> None:
+        """Reload DB data for the given decoders. Decoders are identified by the class name
+        (without the Decoder suffix)
+        """
+        self.base.refresh_tracked_accounts(cursor)
+        for decoder_name in decoders:
+            if (decoder := self.decoders.get(decoder_name)) is None:
+                log.error(f'Requested reloading of data for unknown {self.chain_name} decoder {decoder_name}')  # noqa: E501
+                continue
+
+            self._reload_single_decoder(cursor, decoder)
+
+    @abstractmethod
+    def _get_tx_hashes_not_decoded(self, limit: int | None) -> list[T_TxHash]:
+        """Return up to `limit` transaction hashes that still need decoding for this chain."""
+
+    def get_and_decode_undecoded_transactions(
+            self,
+            limit: int | None = None,
+            send_ws_notifications: bool = False,
+    ) -> list[T_TxHash]:
+        """Checks the DB for up to `limit` undecoded transactions and decodes them.
+        If a list of addresses is provided then only the transactions involving those
+        addresses are decoded.
+
+        This is protected by concurrent access from a lock"""
+        with self.undecoded_tx_query_lock:
+            log.debug(f'Starting task to process undecoded transactions for {self.chain_name} with {limit=}')  # noqa: E501
+            hashes = self._get_tx_hashes_not_decoded(limit=limit)
+            if len(hashes) != 0:
+                log.debug(f'Will decode {len(hashes)} transactions for {self.chain_name}')
+                self.decode_transaction_hashes(
+                    ignore_cache=False,
+                    tx_hashes=hashes,
+                    send_ws_notifications=send_ws_notifications,
+                )
+
+            log.debug(f'Finished task to process undecoded transactions for {self.chain_name} with {limit=}')  # noqa: E501
+            return hashes
+
+    def decode_and_get_transaction_hashes(
+            self,
+            ignore_cache: bool,
+            tx_hashes: list[T_TxHash],
+            send_ws_notifications: bool = False,
+            delete_customized: bool = False,
+    ) -> list[T_Event]:
+        """
+        Thin wrapper around _decode_transaction_hashes that returns the decoded events.
+
+        May raise:
+        - DeserializationError if there is a problem with contacting a remote to get receipts
+        - RemoteError if there is a problem with contacting a remote to get receipts
+        - InputError if the transaction hash is not found in the DB
+        """
+        events: list[T_Event] = []
+        self._decode_transaction_hashes(
+            ignore_cache=ignore_cache,
+            tx_hashes=tx_hashes,
+            events=events,
+            send_ws_notifications=send_ws_notifications,
+            delete_customized=delete_customized,
+        )
+        return events
+
+    def decode_transaction_hashes(
+            self,
+            ignore_cache: bool,
+            tx_hashes: list[T_TxHash],
+            send_ws_notifications: bool = False,
+            delete_customized: bool = False,
+    ) -> None:
+        """
+        Thin wrapper around _decode_transaction_hashes that ignores decoded events
+
+        May raise:
+        - DeserializationError if there is a problem with contacting a remote to get receipts
+        - RemoteError if there is a problem with contacting a remote to get receipts
+        - InputError if the transaction hash is not found in the DB
+        """
+        self._decode_transaction_hashes(
+            ignore_cache=ignore_cache,
+            tx_hashes=tx_hashes,
+            events=None,
+            send_ws_notifications=send_ws_notifications,
+            delete_customized=delete_customized,
+        )
+
+    @abstractmethod
+    def _load_transaction_context(
+            self,
+            cursor: 'DBCursor',
+            tx_hash: T_TxHash,
+    ) -> T_TransactionDecodingContext:
+        """Return the chain-specific decoding context for `tx_hash`.
+
+        The context can be any type (tuple, dataclass, etc.) that the subclass
+        understands and will later pass to `_decode_transaction_from_context`.
+        Implementations should raise `InputError` if the transaction cannot be
+        located or fetched.
+        """
+
+    @abstractmethod
+    def _decode_transaction_from_context(
+            self,
+            context: T_TransactionDecodingContext,
+            ignore_cache: bool,
+            delete_customized: bool,
+    ) -> tuple[list[T_Event], bool, set[str] | None]:
+        """Decode a transaction using the previously loaded `context`.
+
+        Returns `(events, refresh_balances, reload_decoders)` where:
+        - `events` is the list of decoded events for this transaction,
+        - `refresh_balances` signals whether balances must be refreshed,
+        - `reload_decoders` lists decoder names that should be reloaded (or `None`).
+        """
+
+    def _decode_transaction_hashes(
+            self,
+            ignore_cache: bool,
+            tx_hashes: list[T_TxHash],
+            events: list[T_Event] | None = None,
+            send_ws_notifications: bool = False,
+            delete_customized: bool = False,
+    ) -> tuple[bool, list[T_Event]]:
+        """Make sure that receipts are pulled + events decoded for the given transaction hashes.
+        If delete_customized is True then also customized events are deleted before redecoding.
+
+        The transaction hashes must exist in the DB at the time of the call.
+        This logic modifies the `events` argument if it isn't none.
+
+        May raise:
+        - DeserializationError if there is a problem with contacting a remote to get receipts
+        - RemoteError if there is a problem with contacting a remote to get receipts
+        - InputError if the transaction hash is not found in the DB
+        """
+        with self.database.conn.read_ctx() as cursor:
+            self.reload_data(cursor)
+
+        refresh_balances, new_events = False, []
+        total_transactions = len(tx_hashes)
+        log.debug(f'Started logic to decode {total_transactions} transactions from {self.chain_name}')  # noqa: E501
+        for tx_index, tx_hash in enumerate(tx_hashes):
+            log.debug(f'Decoding logic started for {tx_hash} ({self.chain_name})')
+            if send_ws_notifications and tx_index % 10 == 0:
+                log.debug(f'Processed {tx_index} out of {total_transactions} transactions from {self.chain_name}')  # noqa: E501
+                self.msg_aggregator.add_message(
+                    message_type=WSMessageType.PROGRESS_UPDATES,
+                    data={
+                        'chain': self.chain_name,
+                        'subtype': str(ProgressUpdateSubType.UNDECODED_TRANSACTIONS),
+                        'total': total_transactions,
+                        'processed': tx_index,
+                    },
+                )
+
+            # TODO: Change this if transaction filter query can accept multiple hashes
+            with self.database.conn.read_ctx() as cursor:
+                context = self._load_transaction_context(
+                    cursor=cursor,
+                    tx_hash=tx_hash,
+                )
+
+            fresh_events, new_refresh_balances, reload_decoders = self._decode_transaction_from_context(  # noqa: E501
+                context=context,
+                ignore_cache=ignore_cache,
+                delete_customized=delete_customized,
+            )
+
+            if events is not None:
+                events.extend(fresh_events)
+
+            new_events.extend(fresh_events)
+            if new_refresh_balances is True:
+                refresh_balances = True
+
+            if reload_decoders is not None:
+                with self.database.conn.read_ctx() as cursor:
+                    self.reload_specific_decoders(cursor, decoders=reload_decoders)
+
+        if send_ws_notifications:
+            self.msg_aggregator.add_message(
+                message_type=WSMessageType.PROGRESS_UPDATES,
+                data={
+                    'chain': self.chain_name,
+                    'subtype': str(ProgressUpdateSubType.UNDECODED_TRANSACTIONS),
+                    'total': total_transactions,
+                    'processed': total_transactions,
+                },
+            )
+
+        return refresh_balances, new_events
+
+    @abstractmethod
+    def _calculate_fees(self, tx: T_Transaction) -> FVal:
+        """Calculates the transaction fee using the chain's formula."""

--- a/rotkehlchen/chain/decoding/types.py
+++ b/rotkehlchen/chain/decoding/types.py
@@ -1,4 +1,11 @@
-from typing import NamedTuple
+from typing import NamedTuple, Protocol, Self
+
+
+class SupportsAddition(Protocol):
+    """Protocol for types that support addition with the + operator.
+    Decoding rules must implement this to allow merging during recursive discovery.
+    """
+    def __add__(self, other: Self) -> Self: ...
 
 
 def get_versioned_counterparty_label(counterparty: str) -> str:

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.makerdao.constants import (
     MAKER_BURN_TOPIC,
@@ -10,7 +11,7 @@ from rotkehlchen.chain.ethereum.modules.makerdao.constants import (
 )
 from rotkehlchen.chain.ethereum.modules.makerdao.sai.constants import CPT_SAI
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS, ERC20_OR_ERC721_TRANSFER
+from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/constants.py
+++ b/rotkehlchen/chain/evm/decoding/constants.py
@@ -7,7 +7,6 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
 from rotkehlchen.history.events.structures.types import HistoryEventType
 
-CPT_GAS: Final = 'gas'
 CPT_GITCOIN: Final = 'gitcoin'
 CPT_BASE: Final = 'base'
 CPT_ACCOUNT_DELEGATION: Final = 'account delegation'

--- a/rotkehlchen/chain/evm/decoding/extrafi/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/decoder.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import (
     asset_normalized_value,
@@ -11,7 +12,6 @@ from rotkehlchen.chain.ethereum.utils import (
     token_normalized_value_decimals,
 )
 from rotkehlchen.chain.evm.constants import REWARD_PAID_TOPIC
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.extrafi.cache import (
     get_existing_reward_pools,
     query_extrafi_data,

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING, Any, Optional
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.types import (
     CounterpartyDetails,
     get_versioned_counterparty_label,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/decoder.py
@@ -51,5 +51,5 @@ class L2WithL1FeesTransactionDecoder(EVMTransactionDecoder, ABC):
             dbevmtx_class=dbevmtx_class,
         )
 
-    def _calculate_gas_burned(self, tx: L2WithL1FeesTransaction) -> FVal:  # type: ignore[override]
+    def _calculate_fees(self, tx: L2WithL1FeesTransaction) -> FVal:  # type: ignore[override]
         return from_wei(FVal(tx.gas_used * tx.gas_price + tx.l1_fee))

--- a/rotkehlchen/chain/zksync_lite/manager.py
+++ b/rotkehlchen/chain/zksync_lite/manager.py
@@ -835,7 +835,7 @@ class ZksyncLiteManager:
                     message_type=WSMessageType.PROGRESS_UPDATES,
                     data={
                         'chain': EvmlikeChain.ZKSYNC_LITE,
-                        'subtype': str(ProgressUpdateSubType.EVM_UNDECODED_TRANSACTIONS),
+                        'subtype': str(ProgressUpdateSubType.UNDECODED_TRANSACTIONS),
                         'total': total_transactions,
                         'processed': tx_index,
                     },
@@ -846,7 +846,7 @@ class ZksyncLiteManager:
                 message_type=WSMessageType.PROGRESS_UPDATES,
                 data={
                     'chain': EvmlikeChain.ZKSYNC_LITE,
-                    'subtype': str(ProgressUpdateSubType.EVM_UNDECODED_TRANSACTIONS),
+                    'subtype': str(ProgressUpdateSubType.UNDECODED_TRANSACTIONS),
                     'total': total_transactions,
                     'processed': total_transactions,
                 },

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -7,12 +7,12 @@ from more_itertools import peekable
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.accounting.types import EventAccountingRuleStatus
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.accounting.structures import (
     BaseEventSettings,
     EventsAccountantCallback,
     TxAccountingTreatment,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.db.constants import (
     LINKABLE_ACCOUNTING_PROPERTIES,
     LINKABLE_ACCOUNTING_SETTINGS_NAME,

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -315,7 +315,7 @@ class DBHistoryEvents:
         if location.is_bitcoin():
             where_str = f'WHERE event_identifier IN ({placeholders})'
             id_prefix = BTC_EVENT_IDENTIFIER_PREFIX if location == Location.BITCOIN else BCH_EVENT_IDENTIFIER_PREFIX  # noqa: E501
-            bindings = [f'{id_prefix}{tx_hash}' for tx_hash in tx_hashes]  # type: ignore  # tx_hashes will be strings for bitcoin
+            bindings = [f'{id_prefix}{tx_hash}' for tx_hash in tx_hashes]
         else:
             where_str = (
                 f'WHERE identifier IN (SELECT identifier FROM evm_events_info '

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -11,8 +11,8 @@ import requests
 from requests import Response
 
 from rotkehlchen.accounting.types import EventAccountingRuleStatus
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
@@ -1329,10 +1329,10 @@ def test_decoding_missing_transactions(
     assert result['decoded_tx_number']['ethereum'] == len(transactions)
 
     websocket_connection.wait_until_messages_num(num=4, timeout=4)
-    assert websocket_connection.pop_message() == {'type': 'progress_updates', 'data': {'chain': 'ethereum', 'total': 2, 'processed': 0, 'subtype': 'evm_undecoded_transactions'}}  # noqa: E501
+    assert websocket_connection.pop_message() == {'type': 'progress_updates', 'data': {'chain': 'ethereum', 'total': 2, 'processed': 0, 'subtype': 'undecoded_transactions'}}  # noqa: E501
     assert websocket_connection.pop_message()
     assert websocket_connection.pop_message()
-    assert websocket_connection.pop_message() == {'type': 'progress_updates', 'data': {'chain': 'ethereum', 'total': 2, 'processed': 2, 'subtype': 'evm_undecoded_transactions'}}  # noqa: E501
+    assert websocket_connection.pop_message() == {'type': 'progress_updates', 'data': {'chain': 'ethereum', 'total': 2, 'processed': 2, 'subtype': 'undecoded_transactions'}}  # noqa: E501
 
     dbevents = DBHistoryEvents(rotki.data.db)
     with rotki.data.db.conn.read_ctx() as cursor:

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 import pytest
 import requests
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import (

--- a/rotkehlchen/tests/api/test_statistics.py
+++ b/rotkehlchen/tests/api/test_statistics.py
@@ -9,8 +9,8 @@ import requests
 
 from rotkehlchen.accounting.structures.balance import BalanceType
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.ens.constants import CPT_ENS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_ETH2, A_EUR, A_USDC
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.evmtx import DBEvmTx

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.oneinch.constants import CPT_ONEINCH_V6
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE

--- a/rotkehlchen/tests/unit/accounting/evm/test_transactions.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_transactions.py
@@ -4,7 +4,7 @@ import pytest
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/accounting/test_default_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_default_settings.py
@@ -12,7 +12,7 @@ from rotkehlchen.accounting.cost_basis.base import (
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL
 from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_DAI, A_ETH
 from rotkehlchen.db.settings import ModifiableDBSettings

--- a/rotkehlchen/tests/unit/accounting/test_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_settings.py
@@ -5,9 +5,9 @@ import pytest
 from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.eth2.structures import ValidatorDetails, ValidatorType
 from rotkehlchen.chain.evm.accounting.structures import BaseEventSettings
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR
 from rotkehlchen.db.accounting_rules import DBAccountingRules

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -1,6 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.oneinch.constants import (
     CPT_ONEINCH_V1,
     CPT_ONEINCH_V2,
@@ -10,7 +11,6 @@ from rotkehlchen.chain.ethereum.modules.oneinch.constants import (
 )
 from rotkehlchen.chain.ethereum.modules.oneinch.v2.constants import ONEINCH_V2_MAINNET_ROUTER
 from rotkehlchen.chain.ethereum.modules.oneinch.v3.constants import ONEINCH_V3_MAINNET_ROUTER
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.oneinch.constants import CPT_ONEINCH_V6, ONEINCH_V6_ROUTER
 from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import ONEINCH_V4_ROUTER
 from rotkehlchen.chain.evm.decoding.oneinch.v5.decoder import ONEINCH_V5_ROUTER

--- a/rotkehlchen/tests/unit/decoders/test_aave_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v2.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.aave.constants import (
     STK_AAVE_ADDR,
@@ -16,7 +17,6 @@ from rotkehlchen.chain.evm.decoding.aave.constants import (
     CPT_AAVE_V2,
     CPT_AAVE_V3,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_aave_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v3.py
@@ -4,11 +4,11 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V3
 from rotkehlchen.chain.evm.decoding.aave.v3.constants import OLD_POOL_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.safe.constants import CPT_SAFE_MULTISIG
 from rotkehlchen.chain.evm.decoding.weth.constants import CPT_WETH
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_aerodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_aerodrome.py
@@ -2,8 +2,8 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.base.modules.aerodrome.decoder import ROUTER
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.velodrome.constants import CPT_AERODROME
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE, ZERO

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.chain.arbitrum_one.constants import CPT_ARBITRUM_ONE
 from rotkehlchen.chain.arbitrum_one.modules.airdrops.decoder import ARBITRUM_ONE_AIRDROP
 from rotkehlchen.chain.arbitrum_one.modules.arbitrum_governor.constants import GOVERNOR_ADDRESSES
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ARB, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
@@ -3,12 +3,12 @@ import pytest
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.constants import CPT_ARBITRUM_ONE
 from rotkehlchen.chain.arbitrum_one.modules.arbitrum_one_bridge.decoder import BRIDGE_ADDRESS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.arbitrum_one_bridge.decoder import (
     BRIDGE_ADDRESS_MAINNET,
     L1_GATEWAY_ROUTER,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_aura_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_aura_finance.py
@@ -1,9 +1,9 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aura_finance.constants import CPT_AURA_FINANCE
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_balancer.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer.py
@@ -4,10 +4,10 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.constants import CPT_BALANCER_V1, CPT_BALANCER_V2
 from rotkehlchen.chain.evm.decoding.balancer.v2.constants import VAULT_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_BAL, A_DAI, A_ETH, A_USDC, A_WETH, A_XDAI
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_balancer_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer_v3.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.constants import CPT_BALANCER_V3
 from rotkehlchen.chain.evm.decoding.balancer.v3.constants import VAULT_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_XDAI

--- a/rotkehlchen/tests/unit/decoders/test_base_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_base_bridge.py
@@ -1,7 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_BASE, CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.evm.decoding.constants import CPT_BASE
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_basenames.py
+++ b/rotkehlchen/tests/unit/decoders/test_basenames.py
@@ -9,7 +9,7 @@ from rotkehlchen.chain.base.modules.basenames.constants import (
     BASENAMES_REGISTRY,
     CPT_BASENAMES,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE, ZERO

--- a/rotkehlchen/tests/unit/decoders/test_beefy_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_beefy_finance.py
@@ -4,9 +4,9 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.beefy_finance.constants import CPT_BEEFY_FINANCE
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.morpho.constants import CPT_MORPHO
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE

--- a/rotkehlchen/tests/unit/decoders/test_blur.py
+++ b/rotkehlchen/tests/unit/decoders/test_blur.py
@@ -3,12 +3,12 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.blur.constants import (
     BLUR_IDENTIFIER,
     BLUR_STAKING_CONTRACT,
     CPT_BLUR,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_cctp.py
+++ b/rotkehlchen/tests/unit/decoders/test_cctp.py
@@ -4,9 +4,9 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.modules.cctp.constants import USDC_IDENTIFIER_ARB
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.cctp.constants import CPT_CCTP
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.polygon_pos.modules.cctp.constants import USDC_IDENTIFIER_POLYGON
 from rotkehlchen.constants.assets import A_ETH, A_POLYGON_POS_MATIC, A_USDC

--- a/rotkehlchen/tests/unit/decoders/test_clrfund.py
+++ b/rotkehlchen/tests/unit/decoders/test_clrfund.py
@@ -2,7 +2,7 @@ import pytest
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.arbitrum_one.modules.clrfund.constants import CPT_CLRFUND
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_compound_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v2.py
@@ -2,11 +2,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.compound.constants import (
     COMPTROLLER_PROXY_ADDRESS,
     CPT_COMPOUND,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import (
     A_CBAT,

--- a/rotkehlchen/tests/unit/decoders/test_compound_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v3.py
@@ -6,10 +6,10 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.modules.compound.v3.constants import (
     COMPOUND_BULKER_ADDRESS as ARBITRUM_BULKER_ADDRESS,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.compound.v3.constants import COMPOUND_REWARDS_ADDRESS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.compound.v3.constants import CPT_COMPOUND_V3
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.modules.compound.v3.constants import (
     COMPOUND_BULKER_ADDRESS as OPTIMISM_BULKER_ADDRESS,

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -4,10 +4,10 @@ import pytest
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.convex.constants import CPT_CONVEX, CVX_LOCKER_V2
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE, ZERO

--- a/rotkehlchen/tests/unit/decoders/test_cowswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_cowswap.py
@@ -1,9 +1,9 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.chain.evm.decoding.cowswap.decoder import GPV2_SETTLEMENT_ADDRESS
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -8,6 +8,7 @@ from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.binance_sc.modules.curve.constants import (
     CURVE_SWAP_ROUTER_NG as CURVE_SWAP_ROUTER_NG_BSC,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.curve.constants import (
     CURVE_MINTER,
     FEE_DISTRIBUTOR_3CRV,
@@ -16,7 +17,6 @@ from rotkehlchen.chain.ethereum.modules.curve.constants import (
     VOTING_ESCROW,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import (
     CHILD_LIQUIDITY_GAUGE_FACTORY,
     CPT_CURVE,

--- a/rotkehlchen/tests/unit/decoders/test_curve_crvusd.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve_crvusd.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_curve_lend.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve_lend.py
@@ -4,8 +4,8 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.decoding.curve.lend.constants import CURVE_LEND_VAULT_SYMBOL
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_defisaver.py
+++ b/rotkehlchen/tests/unit/decoders/test_defisaver.py
@@ -1,7 +1,7 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.defisaver.constants import CPT_DEFISAVER, SUB_STORAGE
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_degen.py
+++ b/rotkehlchen/tests/unit/decoders/test_degen.py
@@ -10,8 +10,8 @@ from rotkehlchen.chain.base.modules.degen.constants import (
     CPT_DEGEN,
     DEGEN_TOKEN_ID,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_digixdao.py
+++ b/rotkehlchen/tests/unit/decoders/test_digixdao.py
@@ -2,13 +2,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.digixdao.constants import (
     A_DGD,
     CPT_DIGIXDAO,
     DIGIX_DGD_ETH_REFUND_CONTRACT,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_diva.py
+++ b/rotkehlchen/tests/unit/decoders/test_diva.py
@@ -1,9 +1,9 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.diva.constants import CPT_DIVA
 from rotkehlchen.chain.ethereum.modules.diva.decoder import DIVA_GOVERNOR
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DIVA, A_ETH
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_dripsv1.py
+++ b/rotkehlchen/tests/unit/decoders/test_dripsv1.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.drips.v1.constants import CPT_DRIPS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DAI, A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_eas.py
+++ b/rotkehlchen/tests/unit/decoders/test_eas.py
@@ -1,6 +1,7 @@
 import pytest
 
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS, CPT_GITCOIN
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.evm.decoding.constants import CPT_GITCOIN
 from rotkehlchen.chain.evm.decoding.eas.constants import CPT_EAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_efp.py
+++ b/rotkehlchen/tests/unit/decoders/test_efp.py
@@ -4,8 +4,8 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.base.modules.efp.constants import EFP_LIST_REGISTRY
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.efp.constants import CPT_EFP
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE, ZERO

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -2,6 +2,7 @@ import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.eigenlayer.balances import EigenlayerBalances
@@ -18,7 +19,6 @@ from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import (
     REWARDS_COORDINATOR,
 )
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.safe.constants import CPT_SAFE_MULTISIG
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_STETH, A_WETH

--- a/rotkehlchen/tests/unit/decoders/test_element_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_element_finance.py
@@ -1,8 +1,8 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.airdrops.constants import CPT_ELEMENT_FINANCE
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ELFI, A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_enriched.py
+++ b/rotkehlchen/tests/unit/decoders/test_enriched.py
@@ -1,10 +1,10 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.airdrops.constants import CPT_ONEINCH
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_ens.py
+++ b/rotkehlchen/tests/unit/decoders/test_ens.py
@@ -4,6 +4,7 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import get_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.airdrops.decoder import ENS_ADDRESS
 from rotkehlchen.chain.ethereum.modules.ens.constants import (
@@ -18,7 +19,6 @@ from rotkehlchen.chain.ethereum.modules.ens.decoder import (
     ENS_REGISTRAR_CONTROLLER_2,
     _save_hash_mappings_get_fullname,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_ENS, A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_eth2.py
+++ b/rotkehlchen/tests/unit/decoders/test_eth2.py
@@ -1,12 +1,12 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.eth2.constants import (
     CONSOLIDATION_REQUEST_CONTRACT,
     CPT_ETH2,
     WITHDRAWAL_REQUEST_CONTRACT,
 )
 from rotkehlchen.chain.ethereum.modules.eth2.structures import ValidatorDetails, ValidatorType
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.eth2 import DBEth2

--- a/rotkehlchen/tests/unit/decoders/test_extrafi.py
+++ b/rotkehlchen/tests/unit/decoders/test_extrafi.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.extrafi.decoder import (
     CPT_EXTRAFI,
     EXTRAFI_FARMING_CONTRACT,

--- a/rotkehlchen/tests/unit/decoders/test_firebird_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_firebird_finance.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.firebird_finance.constants import CPT_FIREBIRD_FINANCE
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_BSC_BNB, A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_fluence.py
+++ b/rotkehlchen/tests/unit/decoders/test_fluence.py
@@ -1,11 +1,11 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.fluence.constants import (
     CPT_FLUENCE,
     DEV_REWARD_DISTRIBUTOR,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_gearbox.py
+++ b/rotkehlchen/tests/unit/decoders/test_gearbox.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.gearbox.constants import GEAR_STAKING_CONTRACT
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.gearbox.constants import CPT_GEARBOX
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_USDC

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin.py
@@ -1,7 +1,8 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.gitcoin.constants import GITCOIN_GOVERNOR_ALPHA
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS, CPT_GITCOIN
+from rotkehlchen.chain.evm.decoding.constants import CPT_GITCOIN
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_POLYGON_POS_MATIC, A_SAI
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
@@ -1,7 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS, CPT_GITCOIN
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.evm.decoding.constants import CPT_GITCOIN
 from rotkehlchen.chain.evm.decoding.gitcoinv2.constants import PROFILE_REGISTRY
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ARB, A_DAI, A_ETH, A_POLYGON_POS_MATIC

--- a/rotkehlchen/tests/unit/decoders/test_giveth.py
+++ b/rotkehlchen/tests/unit/decoders/test_giveth.py
@@ -1,8 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_GIVETH
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.gnosis.modules.giveth.constants import GNOSIS_GIVPOWERSTAKING_WRAPPER

--- a/rotkehlchen/tests/unit/decoders/test_gmx.py
+++ b/rotkehlchen/tests/unit/decoders/test_gmx.py
@@ -7,8 +7,8 @@ from rotkehlchen.chain.arbitrum_one.modules.gmx.constants import (
     GMX_ROUTER_ADDRESS,
     GMX_VAULT_ADDRESS,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_GMX
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_golem.py
+++ b/rotkehlchen/tests/unit/decoders/test_golem.py
@@ -1,8 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.golem.constants import CPT_GOLEM, GNT_MIGRATION_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH, A_GLM
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_harvest_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_harvest_finance.py
@@ -1,13 +1,13 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.harvest_finance.constants import (
     CPT_HARVEST_FINANCE,
     GRAIN_TOKEN_ID,
     HARVEST_GRAIN_CLAIM,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_hedgey.py
+++ b/rotkehlchen/tests/unit/decoders/test_hedgey.py
@@ -2,9 +2,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.airdrops.decoder import ENS_ADDRESS
 from rotkehlchen.chain.ethereum.modules.hedgey.constants import CPT_HEDGEY, VOTING_TOKEN_LOCKUPS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ENS, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_hop.py
+++ b/rotkehlchen/tests/unit/decoders/test_hop.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.hop.constants import HOP_GOVERNOR
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import (

--- a/rotkehlchen/tests/unit/decoders/test_hyperliquid.py
+++ b/rotkehlchen/tests/unit/decoders/test_hyperliquid.py
@@ -3,7 +3,7 @@ import pytest
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.modules.hyperliquid.constants import BRIDGE_ADDRESS, CPT_HYPER
 from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_juicebox.py
+++ b/rotkehlchen/tests/unit/decoders/test_juicebox.py
@@ -1,9 +1,9 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.juicebox.constants import CPT_JUICEBOX, TERMINAL_3_1_2
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -1,8 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.kyber.constants import CPT_KYBER_LEGACY
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.kyber.constants import CPT_KYBER
 from rotkehlchen.chain.evm.decoding.kyber.decoder import KYBER_AGGREGATOR_CONTRACT
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_lido_eth.py
+++ b/rotkehlchen/tests/unit/decoders/test_lido_eth.py
@@ -1,8 +1,8 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.lido.constants import CPT_LIDO
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH, A_STETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -1,5 +1,6 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.liquity.constants import (
     ACTIVE_POOL,
     BORROWER_OPERATIONS,
@@ -8,7 +9,6 @@ from rotkehlchen.chain.ethereum.modules.liquity.constants import (
     STABILITY_POOL,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_LQTY, A_LUSD
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_liquity_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity_v2.py
@@ -1,7 +1,7 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH, A_LQTY
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import LIQUITY_STAKING_DETAILS, EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_llamazip.py
+++ b/rotkehlchen/tests/unit/decoders/test_llamazip.py
@@ -4,7 +4,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.modules.llamazip.decoder import (
     ROUTER_ADDRESSES as ARBITRUM_ROUTER_ADDRESSES,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.llamazip.constants import CPT_LLAMAZIP
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.modules.llamazip.decoder import (

--- a/rotkehlchen/tests/unit/decoders/test_lockedgno.py
+++ b/rotkehlchen/tests/unit/decoders/test_lockedgno.py
@@ -1,11 +1,11 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.lockedgno.constants import (
     CPT_LOCKEDGNO,
     LOCKED_GNO_ADDRESS,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_magpie.py
+++ b/rotkehlchen/tests/unit/decoders/test_magpie.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.magpie.constants import CPT_MAGPIE
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -2,11 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.constants import CPT_KRAKEN
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
@@ -154,7 +154,6 @@ def test_decoders_initialization(ethereum_transaction_decoder: EthereumTransacti
         'drips',
         'digixdao',
         'gnosis-chain',
-        'gas',
         'ens',
         'eas',
         'efp',

--- a/rotkehlchen/tests/unit/decoders/test_makerdao.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao.py
@@ -1,7 +1,7 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.makerdao.constants import CPT_VAULT
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_WBTC
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
@@ -1,13 +1,13 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.makerdao.constants import (
     CPT_MAKERDAO_MIGRATION,
     CPT_VAULT,
     MAKERDAO_MIGRATION_ADDRESS,
 )
 from rotkehlchen.chain.ethereum.modules.makerdao.sai.constants import CPT_SAI
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_SAI, A_WETH

--- a/rotkehlchen/tests/unit/decoders/test_merkl.py
+++ b/rotkehlchen/tests/unit/decoders/test_merkl.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.merkl.constants import CPT_MERKL, MERKL_DISTRIBUTOR_ADDRESS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_metamask.py
+++ b/rotkehlchen/tests/unit/decoders/test_metamask.py
@@ -9,10 +9,10 @@ from rotkehlchen.chain.arbitrum_one.modules.metamask.constants import (
 from rotkehlchen.chain.binance_sc.modules.metamask.constants import (
     METAMASK_ROUTER as METAMASK_ROUTER_BSC,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.metamask.constants import (
     METAMASK_ROUTER as METAMASK_ROUTER_ETH,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.metamask.constants import CPT_METAMASK_SWAPS
 from rotkehlchen.chain.optimism.modules.metamask.constants import (
     METAMASK_ROUTER as METAMASK_ROUTER_OPT,

--- a/rotkehlchen/tests/unit/decoders/test_morpho.py
+++ b/rotkehlchen/tests/unit/decoders/test_morpho.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.morpho.constants import CPT_MORPHO
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_USDC, A_USDT, A_WETH_BASE

--- a/rotkehlchen/tests/unit/decoders/test_octant.py
+++ b/rotkehlchen/tests/unit/decoders/test_octant.py
@@ -1,11 +1,11 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.octant.constants import (
     CPT_OCTANT,
     OCTANT_DEPOSITS,
     OCTANT_REWARDS,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH, A_GLM
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_odos_v1.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v1.py
@@ -5,8 +5,8 @@ import pytest
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.modules.odos.v1.constants import ODOS_V1_ROUTER as ARB_ROUTER
 from rotkehlchen.chain.binance_sc.modules.odos.v1.constants import ODOS_V1_ROUTER as BSC_ROUTER
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.odos.v1.constants import ODOS_V1_ROUTER as ETH_ROUTER
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.odos.v1.constants import CPT_ODOS_V1
 from rotkehlchen.chain.optimism.modules.odos.v1.constants import ODOS_V1_ROUTER as OPT_ROUTER
 from rotkehlchen.chain.polygon_pos.modules.odos.v1.constants import ODOS_V1_ROUTER as POL_ROUTER

--- a/rotkehlchen/tests/unit/decoders/test_odos_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v2.py
@@ -11,9 +11,9 @@ from rotkehlchen.chain.base.modules.odos.v2.constants import (
 )
 from rotkehlchen.chain.base.node_inquirer import BaseInquirer
 from rotkehlchen.chain.binance_sc.modules.odos.v2.constants import ODOS_V2_ROUTER as BSC_ROUTER
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.odos.v2.constants import ODOS_V2_ROUTER as ETH_ROUTER
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.odos.v2.constants import CPT_ODOS_V2
 from rotkehlchen.chain.optimism.modules.odos.v2.constants import ODOS_V2_ROUTER as OP_ROUTER
 from rotkehlchen.chain.polygon_pos.modules.odos.v2.constants import ODOS_V2_ROUTER as MATIC_ROUTER

--- a/rotkehlchen/tests/unit/decoders/test_omni.py
+++ b/rotkehlchen/tests/unit/decoders/test_omni.py
@@ -1,6 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.omni.constants import (
     CPT_OMNI,
@@ -8,7 +9,6 @@ from rotkehlchen.chain.ethereum.modules.omni.constants import (
     OMNI_STAKING_CONTRACT,
     OMNI_TOKEN_ID,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_omnibridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_omnibridge.py
@@ -1,11 +1,11 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.decoding.constants import CPT_GNOSIS_CHAIN
 from rotkehlchen.chain.ethereum.modules.omnibridge.decoder import (
     BRIDGE_ADDRESS as ETHEREUM_BRIDGE_ADDRESS,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.gnosis.modules.omnibridge.decoder import (
     BRIDGE_ADDRESS as GNOSIS_BRIDGE_ADDRESS,

--- a/rotkehlchen/tests/unit/decoders/test_openocean.py
+++ b/rotkehlchen/tests/unit/decoders/test_openocean.py
@@ -4,7 +4,7 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.arbitrum_one.modules.open_ocean.decoder import DISTRIBUTOR_ADDR
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.open_ocean.constants import (
     CPT_OPENOCEAN,
     OPENOCEAN_EXCHANGE_ADDRESS,

--- a/rotkehlchen/tests/unit/decoders/test_optimism.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism.py
@@ -1,8 +1,8 @@
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
 from rotkehlchen.chain.optimism.modules.airdrops.decoder import (

--- a/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
 from rotkehlchen.chain.optimism.modules.optimism_governor.decoder import GOVERNOR_ADDRESS
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_paladin.py
+++ b/rotkehlchen/tests/unit/decoders/test_paladin.py
@@ -1,11 +1,11 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.paladin.constants import (
     CPT_PALADIN,
     PALADIN_MERKLE_DISTRIBUTOR_V2,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct

--- a/rotkehlchen/tests/unit/decoders/test_paraswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap.py
@@ -6,8 +6,8 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.base.modules.paraswap.v5.constants import (
     PARASWAP_AUGUSTUS_ROUTER as PARASWAP_AUGUSTUS_ROUTER_BASE,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.paraswap.v5.constants import PARASWAP_AUGUSTUS_ROUTER
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.paraswap.constants import CPT_PARASWAP
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import (

--- a/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.decoding.paraswap.constants import CPT_PARASWAP
 from rotkehlchen.chain.evm.decoding.paraswap.v6.constants import PARASWAP_AUGUSTUS_V6_ROUTER

--- a/rotkehlchen/tests/unit/decoders/test_pendle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pendle.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V3
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.pendle.constants import CPT_PENDLE
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/tests/unit/decoders/test_pickle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pickle.py
@@ -1,13 +1,13 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.pickle_finance.constants import (
     CORN_TOKEN_ID,
     CORNICHON_CLAIM,
     CPT_PICKLE,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_polygon.py
+++ b/rotkehlchen/tests/unit/decoders/test_polygon.py
@@ -1,7 +1,7 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.polygon.constants import POLYGON_MIGRATION_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_ETH_MATIC, A_POL

--- a/rotkehlchen/tests/unit/decoders/test_polygon_pos_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_polygon_pos_bridge.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.polygon_pos_bridge.decoder import (
     BRIDGE_ADDRESS,
     ERC20_BRIDGE_ADDRESS,
@@ -9,7 +10,6 @@ from rotkehlchen.chain.ethereum.modules.polygon_pos_bridge.decoder import (
     PLASMA_BRIDGE_ADDRESS,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.polygon_pos.modules.polygon_pos_bridge.decoder import (

--- a/rotkehlchen/tests/unit/decoders/test_puffer.py
+++ b/rotkehlchen/tests/unit/decoders/test_puffer.py
@@ -1,6 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import (
     EIGEN_TOKEN_ID,
 )
@@ -9,7 +10,6 @@ from rotkehlchen.chain.ethereum.modules.puffer.constants import (
     HEDGEY_DELEGATEDCLAIMS_CAMPAIGN,
     PUFFER_TOKEN_ID,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_quickswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_quickswapv2.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.quickswap.constants import CPT_QUICKSWAP_V2
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_POLYGON_POS_MATIC

--- a/rotkehlchen/tests/unit/decoders/test_quickswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_quickswapv3.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.quickswap.constants import CPT_QUICKSWAP_V3
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE

--- a/rotkehlchen/tests/unit/decoders/test_quickswapv4.py
+++ b/rotkehlchen/tests/unit/decoders/test_quickswapv4.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.quickswap.constants import CPT_QUICKSWAP_V4
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_rainbow.py
+++ b/rotkehlchen/tests/unit/decoders/test_rainbow.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.rainbow.constants import (
     CPT_RAINBOW_SWAPS,
     RAINBOW_ROUTER_CONTRACT,

--- a/rotkehlchen/tests/unit/decoders/test_runmoney.py
+++ b/rotkehlchen/tests/unit/decoders/test_runmoney.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.base.modules.runmoney.constants import (
     CPT_RUNMONEY,
     RUNMONEY_CONTRACT_ADDRESS,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_safe.py
+++ b/rotkehlchen/tests/unit/decoders/test_safe.py
@@ -1,13 +1,13 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.safe.constants import (
     CPT_SAFE,
     SAFE_LOCKING,
     SAFE_VESTING,
     SAFEPASS_AIRDROP,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.safe.constants import CPT_SAFE_MULTISIG
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_XDAI

--- a/rotkehlchen/tests/unit/decoders/test_scroll_airdrop.py
+++ b/rotkehlchen/tests/unit/decoders/test_scroll_airdrop.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.scroll.constants import CPT_SCROLL
 from rotkehlchen.chain.scroll.modules.scroll_airdrop.constants import (
     A_SCR,

--- a/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
@@ -3,6 +3,7 @@ from typing import Final
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.scroll_bridge.decoder import (
     L1_ERC20_GATEWAY,
     L1_ETH_GATEWAY_PROXY,
@@ -11,7 +12,6 @@ from rotkehlchen.chain.ethereum.modules.scroll_bridge.decoder import (
     L1_USDC_GATEWAY,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.scroll.constants import CPT_SCROLL
 from rotkehlchen.chain.scroll.modules.scroll_bridge.decoder import (

--- a/rotkehlchen/tests/unit/decoders/test_shutter.py
+++ b/rotkehlchen/tests/unit/decoders/test_shutter.py
@@ -1,11 +1,11 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.shutter.constants import (
     CPT_SHUTTER,
     SHUTTER_AIDROP_CONTRACT,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH, A_SHU
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_sky.py
+++ b/rotkehlchen/tests/unit/decoders/test_sky.py
@@ -1,6 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.makerdao.constants import MKR_ADDRESS
 from rotkehlchen.chain.ethereum.modules.sky.constants import (
     CPT_SKY,
@@ -10,7 +11,6 @@ from rotkehlchen.chain.ethereum.modules.sky.constants import (
     USDS_ASSET,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_MKR, A_SDAI
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_socket.py
+++ b/rotkehlchen/tests/unit/decoders/test_socket.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.socket_bridge.constants import CPT_SOCKET, GATEWAY_ADDRESS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_spark.py
+++ b/rotkehlchen/tests/unit/decoders/test_spark.py
@@ -2,8 +2,8 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.spark.constants import CPT_SPARK
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_SDAI, A_WXDAI, A_XDAI

--- a/rotkehlchen/tests/unit/decoders/test_spark_airdrop.py
+++ b/rotkehlchen/tests/unit/decoders/test_spark_airdrop.py
@@ -3,7 +3,7 @@ from typing import Final
 import pytest
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.spark.constants import CPT_SPARK
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_stakedao.py
+++ b/rotkehlchen/tests/unit/decoders/test_stakedao.py
@@ -3,13 +3,13 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.stakedao.constants import (
     STAKEDAO_CLAIMER1,
     STAKEDAO_CLAIMER2,
     STAKEDAO_CLAIMER_OLD,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.stakedao.constants import CPT_STAKEDAO
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_BSC_BNB, A_CRV, A_CVX, A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_summer_fi.py
+++ b/rotkehlchen/tests/unit/decoders/test_summer_fi.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.summer_fi.constants import CPT_SUMMER_FI
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/decoders/test_superchain_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_superchain_bridge.py
@@ -2,9 +2,9 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.base.constants import CPT_BASE
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.superchain_bridge.op.decoder import OPTIMISM_PORTAL_ADDRESS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
 from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -1,8 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP_V2
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_USDT
 from rotkehlchen.constants.resolver import evm_address_to_identifier

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -3,11 +3,11 @@ import pytest
 from rotkehlchen.chain.arbitrum_one.modules.thegraph.constants import (
     CONTRACT_STAKING as CONTRACT_STAKING_ARB,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.thegraph.constants import (
     CONTRACT_STAKING,
     GRAPH_L1_LOCK_TRANSFER_TOOL,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.thegraph.constants import CPT_THEGRAPH
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_GRT, A_GRT_ARB

--- a/rotkehlchen/tests/unit/decoders/test_umami.py
+++ b/rotkehlchen/tests/unit/decoders/test_umami.py
@@ -6,8 +6,8 @@ from rotkehlchen.chain.arbitrum_one.modules.umami.constants import (
     CPT_UMAMI,
     UMAMI_STAKING_CONTRACT,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ARB, A_ETH, Asset
 from rotkehlchen.fval import FVal

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -3,12 +3,12 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.modules.airdrops.constants import CPT_UNISWAP
 from rotkehlchen.chain.ethereum.modules.airdrops.decoder import UNISWAP_DISTRIBUTOR
 from rotkehlchen.chain.ethereum.modules.uniswap.v2.decoder import UNISWAP_V2_ROUTER
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V2
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.base.modules.uniswap.v3.constants import UNISWAP_UNIVERSA
 from rotkehlchen.chain.binance_sc.modules.uniswap.v3.constants import (
     UNISWAP_UNIVERSAL_ROUTER as UNISWAP_UNIVERSAL_ROUTER_BINANCE_SC,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.uniswap.v3.constants import UNISWAP_UNIVERSAL_ROUTER_V2
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.chain.evm.decoding.safe.constants import CPT_SAFE_MULTISIG
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V3

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv4.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv4.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V4
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import (

--- a/rotkehlchen/tests/unit/decoders/test_velodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_velodrome.py
@@ -2,8 +2,8 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.velodrome.constants import CPT_VELODROME
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.modules.velodrome.decoder import ROUTER_V1, ROUTER_V2

--- a/rotkehlchen/tests/unit/decoders/test_votium.py
+++ b/rotkehlchen/tests/unit/decoders/test_votium.py
@@ -1,8 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.votium.constants import CPT_VOTIUM, VOTIUM_CONTRACTS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent, EvmProduct

--- a/rotkehlchen/tests/unit/decoders/test_walletconnect.py
+++ b/rotkehlchen/tests/unit/decoders/test_walletconnect.py
@@ -4,7 +4,7 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import get_or_create_evm_token
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.modules.walletconnect.constants import (
     CPT_WALLETCONNECT,

--- a/rotkehlchen/tests/unit/decoders/test_weth.py
+++ b/rotkehlchen/tests/unit/decoders/test_weth.py
@@ -1,8 +1,8 @@
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V3
 from rotkehlchen.chain.evm.decoding.weth.constants import CPT_WETH
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
@@ -2,12 +2,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.decoding.constants import CPT_GNOSIS_CHAIN
 from rotkehlchen.chain.ethereum.modules.xdai_bridge.decoder import (
     BRIDGE_ADDRESS,
     XDAI_BRIDGE_PERIPHERAL_PRE_USDS,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.gnosis.modules.xdai_bridge.decoder import (
     BRIDGE_ADDRESS as GNOSIS_BRIDGE_ADDRESS,
 )

--- a/rotkehlchen/tests/unit/decoders/test_yearn.py
+++ b/rotkehlchen/tests/unit/decoders/test_yearn.py
@@ -4,6 +4,7 @@ import pytest
 
 from rotkehlchen.assets.asset import Asset, UnderlyingToken
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.yearn.constants import (
     CPT_YEARN_V1,
     CPT_YEARN_V2,
@@ -11,7 +12,6 @@ from rotkehlchen.chain.ethereum.modules.yearn.constants import (
     YEARN_PARTNER_TRACKER,
 )
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE

--- a/rotkehlchen/tests/unit/decoders/test_ygov.py
+++ b/rotkehlchen/tests/unit/decoders/test_ygov.py
@@ -1,8 +1,8 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.yearn.constants import CPT_YGOV
 from rotkehlchen.chain.ethereum.modules.yearn.ygov.constants import YGOV_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_CRVP_DAIUSDCTTUSD, A_ETH, A_YFI
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/decoders/test_zerox.py
+++ b/rotkehlchen/tests/unit/decoders/test_zerox.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Final
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.zerox.constants import ZEROX_ROUTER
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.chain.evm.decoding.zerox.constants import CPT_ZEROX
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/tests/unit/decoders/test_zksync.py
+++ b/rotkehlchen/tests/unit/decoders/test_zksync.py
@@ -1,7 +1,7 @@
 import pytest
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.zksync.constants import CPT_ZKSYNC, ZKSYNC_BRIDGE
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_USDC, A_USDT, Asset
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -5,6 +5,7 @@ import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.chain.accounts import BlockchainAccountData
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.eth2.constants import (
     CONSOLIDATION_REQUEST_CONTRACT,
     CPT_ETH2,
@@ -18,7 +19,6 @@ from rotkehlchen.chain.ethereum.modules.eth2.structures import (
     ValidatorStatus,
     ValidatorType,
 )
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_ETH

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -4,9 +4,10 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.gitcoin.constants import GITCOIN_GRANTS_OLD1
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_ACCOUNT_DELEGATION, CPT_GAS
+from rotkehlchen.chain.evm.decoding.constants import CPT_ACCOUNT_DELEGATION
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
 from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, NamedTuple, cast
 from unittest.mock import _patch, patch
 
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_ETH2, A_USDC, A_USDT
 from rotkehlchen.constants.resolver import strethaddress_to_identifier

--- a/rotkehlchen/tests/utils/history_base_entry.py
+++ b/rotkehlchen/tests/utils/history_base_entry.py
@@ -3,8 +3,8 @@ from collections.abc import Sequence
 from itertools import groupby
 from typing import Any
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.gitcoin.constants import GITCOIN_GRANTS_OLD1
-from rotkehlchen.chain.evm.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_DAI, A_ETH, A_ETH2, A_USDT

--- a/rotkehlchen/utils/hexbytes.py
+++ b/rotkehlchen/utils/hexbytes.py
@@ -83,3 +83,9 @@ class HexBytes(bytes):
     def from_bytes(cls: type['HexBytes'], value: bytes) -> 'HexBytes':
         """Creates a new HexBytes instance directly from bytes, skipping deserialization"""
         return super().__new__(cls, value)
+
+    def __str__(self) -> str:
+        """TODO(@prettyirrelevant): Remove all the .hex() calls in the codebase.
+        https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=131451129
+        """
+        return self.hex()


### PR DESCRIPTION
### notes
- `CPT_GAS` moved from `chain/evm/decoding/constants.py` to `chain/decoding/constants.py`
- `ProgressUpdateSubType.EVM_UNDECODED_TRANSACTIONS` is now `ProgressUpdateSubType.UNDECODED_TRANSACTIONS` to support more chains.
- `_calculate_gas_burned`, `decode_transaction_hashes`, `decode_and_get_transaction_hashes`, `get_and_decode_undecoded_transactions`, `reload_specific_decoders`, `reload_data`, `_recursively_initialize_decoders`, `_add_single_decoder`, `_add_builtin_decoders`, `_reload_single_decoder` are now moved to the base class(`TransactionDecoder`)
- new methods
  - `_load_transaction_context` to fetch chain-specific transaction data needed for decoding.
  - `_decode_transaction_from_context` to decode transaction for a blockchain.
  - `_get_tx_hashes_not_decoded` retrieve hashes of transactions that haven't been decoded.
  -  `_make_blank_rules` returns decoding rules for the specific blockchain.