### PR TITLE
Refactor DecoderInterface and add SolanaDecodingRules

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.chain.arbitrum_one.transactions import ArbitrumOneTransactions
     from rotkehlchen.chain.arbitrum_one.types import ArbitrumOneTransaction
-    from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+    from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.premium.premium import Premium
 
@@ -59,7 +59,7 @@ class ArbitrumOneTransactionDecoder(EVMTransactionDecoder):
 
     def _chain_specific_decoder_initialization(
             self,
-            decoder: 'DecoderInterface',
+            decoder: 'EvmDecoderInterface',
     ) -> None:
         """Initialize the transaction type mappings"""
         if not isinstance(decoder, ArbitrumDecoderInterface):

--- a/rotkehlchen/chain/arbitrum_one/decoding/interfaces.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/interfaces.py
@@ -1,10 +1,10 @@
 from abc import ABC
 from collections.abc import Callable
 
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 
 
-class ArbitrumDecoderInterface(DecoderInterface, ABC):
+class ArbitrumDecoderInterface(EvmDecoderInterface, ABC):
 
     def decoding_by_tx_type(self) -> dict[int, list[tuple[int, Callable]]]:
         """Subclasses may implement this Arbitrum specific decoder rule to state

--- a/rotkehlchen/chain/arbitrum_one/modules/hyperliquid/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/hyperliquid/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.arbitrum_one.modules.hyperliquid.constants import (
 )
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class HyperliquidDecoder(DecoderInterface):
+class HyperliquidDecoder(EvmDecoderInterface):
     """Hyperliquid deposit/withdrawals work only with USDC"""
 
     def _process_deposit(

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
@@ -269,7 +269,7 @@ class UmamiDecoder(ArbitrumDecoderInterface):
         return {
             token.evm_address: (self._decode_umami_vault_events,)
             for token in GlobalDBHandler.get_evm_tokens(
-                    chain_id=self.evm_inquirer.chain_id,
+                    chain_id=self.node_inquirer.chain_id,
                     protocol=CPT_UMAMI,
             )
         } | {UMAMI_STAKING_CONTRACT: (self._decode_umami_staking_events,)}

--- a/rotkehlchen/chain/base/modules/basenames/decoder.py
+++ b/rotkehlchen/chain/base/modules/basenames/decoder.py
@@ -91,8 +91,8 @@ class BasenamesDecoder(EnsCommonDecoder):
 
         # Call the L2 Resolver contract's name method.
         try:
-            if not (name_to_show := self.evm_inquirer.contracts.contract(BASENAMES_L2_RESOLVER).call(  # noqa: E501
-                node_inquirer=self.evm_inquirer,
+            if not (name_to_show := self.node_inquirer.contracts.contract(BASENAMES_L2_RESOLVER).call(  # noqa: E501
+                node_inquirer=self.node_inquirer,
                 method_name='name',
                 arguments=[node],
             )):

--- a/rotkehlchen/chain/base/modules/efp/decoder.py
+++ b/rotkehlchen/chain/base/modules/efp/decoder.py
@@ -89,7 +89,7 @@ class EfpDecoder(EfpCommonDecoder):
             location_label=(user_address := bytes_to_address(context.tx_log.topics[2])),
             asset=Asset(evm_address_to_identifier(  # EFP List NFT
                 address=EFP_LIST_REGISTRY,
-                chain_id=self.evm_inquirer.chain_id,
+                chain_id=self.node_inquirer.chain_id,
                 token_type=TokenKind.ERC721,
                 collectible_id=str(int.from_bytes(context.tx_log.topics[3])),
             )),

--- a/rotkehlchen/chain/base/modules/runmoney/decoder.py
+++ b/rotkehlchen/chain/base/modules/runmoney/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.constants import STAKED
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -30,13 +30,13 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class RunmoneyDecoder(DecoderInterface):
+class RunmoneyDecoder(EvmDecoderInterface):
     def _decode_join_event(self, context: DecoderContext) -> DecodingOutput:
         for event in context.decoded_events:
             if (
                     event.event_type == HistoryEventType.SPEND and
                     event.event_subtype == HistoryEventSubType.NONE and
-                    event.asset == self.evm_inquirer.native_token
+                    event.asset == self.node_inquirer.native_token
             ):
                 event.counterparty = CPT_RUNMONEY
                 event.event_type = HistoryEventType.TRADE

--- a/rotkehlchen/chain/decoding/interfaces.py
+++ b/rotkehlchen/chain/decoding/interfaces.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from .tools import BaseDecoderTools
+
+if TYPE_CHECKING:
+    from .types import CounterpartyDetails
+
+T_Address = TypeVar('T_Address')
+T_NodeInquirer = TypeVar('T_NodeInquirer')
+T_DecoderTools = TypeVar('T_DecoderTools', bound=BaseDecoderTools)
+
+
+class DecoderInterface(ABC, Generic[T_Address, T_NodeInquirer, T_DecoderTools]):
+
+    def __init__(self, node_inquirer: 'T_NodeInquirer', base_tools: 'T_DecoderTools') -> None:
+        self.base = base_tools
+        self.node_inquirer = node_inquirer
+
+    def addresses_to_decoders(self) -> dict[T_Address, tuple[Any, ...]]:
+        """Subclasses may implement this to return the mappings of contract/program addresses
+        to corresponding decoder functions.
+        """
+        return {}
+
+    @staticmethod
+    @abstractmethod
+    def counterparties() -> tuple['CounterpartyDetails', ...]:
+        """Subclasses implement this to specify which counterparties they introduce."""

--- a/rotkehlchen/chain/ethereum/modules/aave/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, STAKED_TOPIC
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class AaveDecoder(DecoderInterface):
+class AaveDecoder(EvmDecoderInterface):
     """Aave decoder for staking and unstaking events"""
     def _decode_staking_events(self, context: DecoderContext) -> DecodingOutput:
         """Decode aave staking unstaking events"""

--- a/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.ethereum.modules.aave.common import asset_to_atoken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V1
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -22,7 +22,7 @@ REDEEM_UNDERLYING = b'\x9cN\xd5\x99\xcd\x85U\xb9\xc1\xe8\xcdvC$\r}q\xebv\xb7\x92
 LIQUIDATION_CALL = b'V\x86GW\xfd[\x1f\xc9\xf3\x8f_:\x98\x1c\xd8\xaeQ,\xe4\x1b\x90,\xf7?\xc5\x06\xee6\x9ck\xc27'  # noqa: E501
 
 
-class Aavev1Decoder(DecoderInterface):
+class Aavev1Decoder(EvmDecoderInterface):
 
     def _decode_pool_event(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] == DEPOSIT:

--- a/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Final
 from rotkehlchen.chain.arbitrum_one.constants import ARBITRUM_ONE_CPT_DETAILS, CPT_ARBITRUM_ONE
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -42,7 +42,7 @@ INBOX_MESSAGE_DELIVERED: Final = b'\xffd\x90_s\xa6\x7f\xb5\x94\xe0\xf9@\xa8\x07Z
 BRIDGE_CALL_TRIGGERED: Final = b'-\x9d\x11^\xf3\xe4\xa6\x06\xd6\x98\x91;\x1e\xae\x83\x1a<\xdf\xe2\r\x9a\x83\xd4\x80\x07\xb0RgI\xc3\xd4f'  # noqa: E501
 
 
-class ArbitrumOneBridgeDecoder(DecoderInterface):
+class ArbitrumOneBridgeDecoder(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',

--- a/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Final
 from rotkehlchen.assets.asset import AssetWithSymbol
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.constants import BASE_CPT_DETAILS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -26,7 +26,7 @@ TRANSACTION_DEPOSITED: Final = b'\xb3\x815h\xd9\x99\x1f\xc9Q\x96\x1f\xcbLxH\x93W
 WITHDRAWAL_FINALIZED: Final = b"\xdb\\vR\x85z\xa1c\xda\xad\xd6p\xe1\x16b\x8f\xb4.\x86\x9d\x8a\xc4%\x1e\xf8\x97\x1d\x9eW'\xdf\x1b"  # noqa: E501
 
 
-class BaseBridgeDecoder(DecoderInterface):
+class BaseBridgeDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/blur/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/blur/decoder.py
@@ -10,7 +10,7 @@ from rotkehlchen.chain.evm.constants import (
     DEPOSIT_TOPIC_V2,
     WITHDRAW_TOPIC_V2,
 )
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class BlurDecoder(DecoderInterface):
+class BlurDecoder(EvmDecoderInterface):
 
     def _decode_staking_events(self, context: DecoderContext) -> DecodingOutput:
         """Decode staking events in the Blur protocol"""

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.ethereum.modules.compound.constants import (
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.constants import MINT_TOPIC
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -49,7 +49,7 @@ DISTRIBUTED_SUPPLIER_COMP = b',\xae\xcd\x17\xd0/V\xfa\x89w\x05\xdc\xc7@\xda-#|7?
 DISTRIBUTED_BORROWER_COMP = b'\x1f\xc3\xec\xc0\x87\xd8\xd2\xd1^#\xd0\x03*\xf5\xa4pY\xc3\x89-\x00=\x8e\x13\x9f\xdc\xb6\xbb2|\x99\xa6'  # noqa: E501
 
 
-class Compoundv2Decoder(DecoderInterface):
+class Compoundv2Decoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -26,7 +26,10 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER, STAKED
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface, ReloadableCacheDecoderMixin
+from rotkehlchen.chain.evm.decoding.interfaces import (
+    EvmDecoderInterface,
+    ReloadableCacheDecoderMixin,
+)
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     FAILED_ENRICHMENT_OUTPUT,
@@ -55,7 +58,7 @@ log = RotkehlchenLogsAdapter(logger)
 REWARD_ADDED = b'\xde\x88\xa9"\xe0\xd3\xb8\x8b$\xe9b>\xfe\xb4d\x91\x9ck\xf9\xf6hW\xa6^+\xfc\xf2\xce\x87\xa9C='  # noqa: E501
 
 
-class ConvexDecoder(DecoderInterface, ReloadableCacheDecoderMixin):
+class ConvexDecoder(EvmDecoderInterface, ReloadableCacheDecoderMixin):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',

--- a/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
@@ -63,7 +63,7 @@ class CurvecrvusdDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMixin):
                 userdb=self.base.database,
                 cache_key=CacheType.CURVE_CRVUSD_CONTROLLERS,
         ) is True:
-            query_crvusd_controllers(evm_inquirer=self.evm_inquirer)
+            query_crvusd_controllers(evm_inquirer=self.node_inquirer)
         elif len(self.controllers) != 0:
             return None  # we didn't update the globaldb cache, and we have the data already
 
@@ -72,7 +72,7 @@ class CurvecrvusdDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMixin):
                 cursor=cursor,
                 key_parts=(
                     CacheType.CURVE_CRVUSD_CONTROLLERS,
-                    str(self.evm_inquirer.chain_id.serialize_for_db()),
+                    str(self.node_inquirer.chain_id.serialize_for_db()),
                 ),
             ))
 

--- a/rotkehlchen/chain/ethereum/modules/defisaver/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/defisaver/decoder.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class DefisaverDecoder(DecoderInterface):
+class DefisaverDecoder(EvmDecoderInterface):
 
     def _decode_subscribe(self, context: DecoderContext) -> DecodingOutput:
         sub_id = int.from_bytes(context.tx_log.topics[1])

--- a/rotkehlchen/chain/ethereum/modules/digixdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/digixdao/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.modules.digixdao.constants import (
     DIGIX_DGD_ETH_REFUND_CONTRACT,
 )
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -22,7 +22,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 REFUND_TOPIC: Final = b's\xf0J\xf9\xdc\xc5\x82\xa9#\xec\x15\xd3\xee\xa9\x90\xfe4\xad\xab\xff\xf2\x87\x9e(\xd4Er\xe0\x1aT\xab\xb6'  # noqa: E501
 
 
-class DigixdaoDecoder(DecoderInterface):
+class DigixdaoDecoder(EvmDecoderInterface):
 
     def _decode_dgd_eth_refund(self, context: DecoderContext) -> DecodingOutput:
         """Decode ETH refund for DGD tokens."""

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import WITHDRAW_TOPIC
 from rotkehlchen.chain.evm.contracts import EvmContract
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -29,7 +29,7 @@ ORDER_PLACEMENT = b'\xde\xcfo\xde\x82C\x98\x12\x99\xf7\xb7\xa7v\xf2\x9a\x9f\xc6z
 WITHDRAW_REQUEST = b',bE\xafPo\x0f\xc1\x08\x99\x18\xc0,\x1d\x01\xbd\xe9\xcc\x80v\t\xb34\xb3\xe7dMm\xfbZl^'  # noqa: E501
 
 
-class DxdaomesaDecoder(DecoderInterface):
+class DxdaomesaDecoder(EvmDecoderInterface):
 
     def __init__(  # pylint: disable=super-init-not-called
             self,
@@ -141,7 +141,7 @@ class DxdaomesaDecoder(DecoderInterface):
         if not self.base.is_tracked(owner):
             return DEFAULT_DECODING_OUTPUT
 
-        result = self.evm_inquirer.multicall_specific(
+        result = self.node_inquirer.multicall_specific(
             contract=self.contract,
             method_name='tokenIdToAddressMap',
             arguments=[[topic_data[1]], [topic_data[2]]],

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
@@ -324,7 +324,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
         """
         db_filter = EvmEventFilterQuery.make(
             counterparties=[CPT_EIGENLAYER],
-            location=Location.from_chain_id(self.evm_inquirer.chain_id),
+            location=Location.from_chain_id(self.node_inquirer.chain_id),
             to_ts=context.transaction.timestamp,
             event_types=[HistoryEventType.INFORMATIONAL],
             event_subtypes=[HistoryEventSubType.REMOVE_ASSET],
@@ -398,7 +398,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
 
     def _decode_withdrawal_queued(self, context: DecoderContext) -> DecodingOutput:
         """Creates and adds a queued withdrawal for each withdrawal in the event"""
-        contract = self.evm_inquirer.contracts.contract(EIGENLAYER_DELEGATION)
+        contract = self.node_inquirer.contracts.contract(EIGENLAYER_DELEGATION)
         _, log_data = contract.decode_event(tx_log=context.tx_log, event_name='WithdrawalQueued', argument_names=('withdrawalRoot', 'withdrawal'))  # noqa: E501
         if not self.base.any_tracked([staker := log_data[1][0], withdrawer := log_data[1][2]]):
             return DEFAULT_DECODING_OUTPUT
@@ -472,7 +472,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
 
             ])
 
-        output = self.evm_inquirer.multicall(calls=calls)
+        output = self.node_inquirer.multicall(calls=calls)
         for raw_address, raw_amount in pairwise(output):
             underlying_tokens.append(underlying_token := self.base.get_or_create_evm_token(
                 address=bytes_to_address(raw_address),

--- a/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.constants import ETH2_DEPOSIT_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class Eth2Decoder(DecoderInterface):
+class Eth2Decoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.ethereum.decoding.constants import AIRDROP_CLAIM
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class FluenceDecoder(DecoderInterface):
+class FluenceDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/golem/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/golem/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.constants import MIGRATED
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class GolemDecoder(DecoderInterface):
+class GolemDecoder(EvmDecoderInterface):
 
     def _decode_migration(self, context: DecoderContext) -> DecodingOutput:
         """Decode GNT -> GLM migration"""

--- a/rotkehlchen/chain/ethereum/modules/hedgey/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hedgey/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.constants import DELEGATE_CHANGED
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class HedgeyDecoder(DecoderInterface):
+class HedgeyDecoder(EvmDecoderInterface):
 
     def _decode_delegate_changed(
             self,
@@ -62,7 +62,7 @@ class HedgeyDecoder(DecoderInterface):
     def _decode_vault_creation(self, context: DecoderContext) -> DecodingOutput:
         vault_address = bytes_to_address(context.tx_log.data[:32])
         plan_id = int.from_bytes(context.tx_log.topics[1])
-        owner_address = deserialize_evm_address(self.evm_inquirer.call_contract(
+        owner_address = deserialize_evm_address(self.node_inquirer.call_contract(
             contract_address=VOTING_TOKEN_LOCKUPS,
             abi=VOTING_TOKEN_LOCKUPS_ABI,
             method_name='ownerOf',
@@ -111,7 +111,7 @@ class HedgeyDecoder(DecoderInterface):
             (contract.address, contract.encode(method_name='plans', arguments=[plan_id])),
             (contract.address, contract.encode(method_name='ownerOf', arguments=[plan_id])),
         ]
-        output = self.evm_inquirer.multicall(calls=calls)
+        output = self.node_inquirer.multicall(calls=calls)
         token_address = deserialize_evm_address(
             contract.decode(result=output[0], method_name='plans', arguments=[plan_id])[0],
         )

--- a/rotkehlchen/chain/ethereum/modules/juicebox/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/juicebox/decoder.py
@@ -17,7 +17,7 @@ from rotkehlchen.chain.ethereum.modules.juicebox.constants import (
     TERMINAL_3_1_2,
 )
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -35,12 +35,12 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class JuiceboxDecoder(DecoderInterface):
+class JuiceboxDecoder(EvmDecoderInterface):
 
     def _query_project_name(self, project_id: int) -> tuple[str | None, list[str]]:
         """Query metadata for project id in ipfs"""
         try:
-            ipfs_hash = self.evm_inquirer.call_contract(
+            ipfs_hash = self.node_inquirer.call_contract(
                 contract_address=JUICEBOX_PROJECTS,
                 abi=METADATA_CONTENT_OF_ABI,
                 method_name='metadataContentOf',

--- a/rotkehlchen/chain/ethereum/modules/lido/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lido/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class LidoDecoder(DecoderInterface):
+class LidoDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class LiquityDecoder(DecoderInterface):
+class LiquityDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/lockedgno/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lockedgno/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class LockedgnoDecoder(DecoderInterface):
+class LockedgnoDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.ethereum.modules.makerdao.constants import (
 from rotkehlchen.chain.ethereum.modules.makerdao.sai.constants import CPT_SAI
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     FAILED_ENRICHMENT_OUTPUT,
@@ -45,7 +45,7 @@ MAKERDAO_SAITAP_CONTRACT = string_to_evm_address('0xBda109309f9FafA6Dd6A9CB9f1Df
 MAKERDAO_SAI_PROXY_CONTRACT = string_to_evm_address('0x526af336D614adE5cc252A407062B8861aF998F5')
 
 
-class MakerdaosaiDecoder(DecoderInterface):
+class MakerdaosaiDecoder(EvmDecoderInterface):
     """
     Information relating to event topics and contracts came from:
     https://github.com/makerdao/sai/blob/d28fe5074af7c661fb3aa7f117ad419fb6414b91/DEVELOPING.md

--- a/rotkehlchen/chain/ethereum/modules/octant/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.utils import (
     token_normalized_value_decimals,
 )
 from rotkehlchen.chain.evm.constants import WITHDRAWN_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class OctantDecoder(DecoderInterface):
+class OctantDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
@@ -3,7 +3,7 @@ from typing import Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.constants import AMM_POSSIBLE_COUNTERPARTIES
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.oneinch.constants import ONEINCH_ICON, ONEINCH_LABEL
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
@@ -22,7 +22,7 @@ HISTORY = b'\x89M\xbf\x12b\x19\x9c$\xe1u\x02\x98\xa3\x84\xc7\t\x16\x0fI\xd1cB,\x
 SWAPPED = b'\xe2\xce\xe3\xf6\x83`Y\x82\x0bg9C\x85:\xfe\xbd\x9b0&\x12]\xab\rwB\x84\xe6\xf2\x8aHU\xbe'  # noqa: E501
 
 
-class Oneinchv1Decoder(DecoderInterface):
+class Oneinchv1Decoder(EvmDecoderInterface):
 
     def _decode_history(self, context: DecoderContext) -> DecodingOutput:
         sender = bytes_to_address(context.tx_log.topics[1])

--- a/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
@@ -4,7 +4,7 @@ from typing import Any
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class PaladinDecoder(DecoderInterface):
+class PaladinDecoder(EvmDecoderInterface):
 
     def _decode_claim_quest(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != CLAIMED:
@@ -38,7 +38,7 @@ class PaladinDecoder(DecoderInterface):
             userdb=self.base.database,
             evm_address=reward_token_address,
             chain_id=ChainID.ETHEREUM,
-            evm_inquirer=self.evm_inquirer,
+            evm_inquirer=self.node_inquirer,
         )
         normalized_amount = token_normalized_value(amount, claimed_token)
         for event in context.decoded_events:

--- a/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON, CPT_POLYGON_DETAILS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
@@ -31,7 +31,7 @@ log = RotkehlchenLogsAdapter(logger)
 MIGRATED = b'\x8b\x80\xbd\x19\xae\xa7\xb75\xbcmu\xdb\x8dj\xdb\xe1\x8b(\xc3\rb\xb3URE\xebg\xb24\x0c\xae\xdc'  # noqa: E501
 
 
-class PolygonDecoder(DecoderInterface):
+class PolygonDecoder(EvmDecoderInterface):
     """General polygon related decoder for ethereum mainnet. For now matic->pol migration"""
 
     def _decode_migration(self, context: DecoderContext) -> DecodingOutput:

--- a/rotkehlchen/chain/ethereum/modules/polygon_pos_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/polygon_pos_bridge/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON, CPT_POLYGON_DETAILS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
@@ -35,7 +35,7 @@ START_EXIT_TOPIC: Final = b'\xaaS\x03\xfd\xad\x12:\xb5\xec\xae\xfa\xf6\x917\xbf\
 PROCESS_EXIT_TOPIC: Final = b'\xfe\xb2\x00\r\xca>a|\xd6\xf3\xa8\xbb\xb60\x14\xbbT\xa1$\xaa\xc6\xcc\xbfs\xeer)\xb4\xcd\x01\xf1 '  # noqa: E501
 
 
-class PolygonPosBridgeDecoder(DecoderInterface):
+class PolygonPosBridgeDecoder(EvmDecoderInterface):
 
     def _decode_deposit(self, context: DecoderContext) -> DecodingOutput:
         """Decodes ETH and ERC20 bridge deposit events.

--- a/rotkehlchen/chain/ethereum/modules/puffer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/puffer/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.chain.ethereum.modules.puffer.constants import (
 )
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class PufferDecoder(DecoderInterface):
+class PufferDecoder(EvmDecoderInterface):
 
     def _decode_unlockedtokens_claimed(self, context: DecoderContext) -> DecodingOutput:
         """Decode claiming unlocked tokens (airdrop) from puffer"""

--- a/rotkehlchen/chain/ethereum/modules/safe/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class SafeDecoder(DecoderInterface):
+class SafeDecoder(EvmDecoderInterface):
     """Decoder for ethereum mainnet safe (mostly token) related activities"""
 
     def __init__(  # pylint: disable=super-init-not-called

--- a/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
@@ -5,7 +5,7 @@ from eth_abi import decode as decode_abi
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -50,7 +50,7 @@ DEPOSIT_ERC20: Final = b'1\xcd;\x97nMe@"\xbf\x95\xc6\x8a,\xe5?\x1d]\x94\xaf\xab\
 FINALIZE_WITHDRAW_ERC20: Final = b'\xc6\xf9\x85\x87;7\x80W\x05\xf6\xbc\xe7V\xdc\xe3\xd1\xffK`>)\x8dPb\x88\xcc\xe4\x99\x92hF\xa7'  # noqa: E501
 
 
-class ScrollBridgeDecoder(DecoderInterface):
+class ScrollBridgeDecoder(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EthereumInquirer',

--- a/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.diva.decoder import DELEGATE_CHANGED
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class ShutterDecoder(DecoderInterface):
+class ShutterDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/sky/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sky/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.ethereum.utils import (
     token_normalized_value_decimals,
 )
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class SkyDecoder(DecoderInterface):
+class SkyDecoder(EvmDecoderInterface):
     """Decoder for Sky ecosystem migration events.
 
     This decoder handles the migration of MakerDAO assets to the Sky ecosystem:

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP_V2
 from rotkehlchen.chain.evm.constants import BURN_TOPIC, MINT_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -28,7 +28,7 @@ SUSHISWAP_V2_FACTORY: Final = string_to_evm_address('0xC0AEe478e3658e2610c5F7A4A
 SUSHISWAP_V2_INIT_CODE_HASH: Final = '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303'  # noqa: E501
 
 
-class SushiswapDecoder(DecoderInterface):
+class SushiswapDecoder(EvmDecoderInterface):
 
     def _maybe_decode_v2_swap(
             self,
@@ -46,8 +46,8 @@ class SushiswapDecoder(DecoderInterface):
                 transaction=transaction,
                 counterparty=CPT_SUSHISWAP_V2,
                 router_address=SUSHISWAP_ROUTER,
-                database=self.evm_inquirer.database,
-                evm_inquirer=self.evm_inquirer,
+                database=self.node_inquirer.database,
+                evm_inquirer=self.node_inquirer,
                 notify_user=self.notify_user,
             )
         return DEFAULT_DECODING_OUTPUT
@@ -68,8 +68,8 @@ class SushiswapDecoder(DecoderInterface):
                 all_logs=all_logs,
                 is_deposit=True,
                 counterparty=CPT_SUSHISWAP_V2,
-                database=self.evm_inquirer.database,
-                evm_inquirer=self.evm_inquirer,
+                database=self.node_inquirer.database,
+                evm_inquirer=self.node_inquirer,
                 factory_address=SUSHISWAP_V2_FACTORY,
                 init_code_hash=SUSHISWAP_V2_INIT_CODE_HASH,
                 tx_hash=transaction.tx_hash,
@@ -81,8 +81,8 @@ class SushiswapDecoder(DecoderInterface):
                 all_logs=all_logs,
                 is_deposit=False,
                 counterparty=CPT_SUSHISWAP_V2,
-                database=self.evm_inquirer.database,
-                evm_inquirer=self.evm_inquirer,
+                database=self.node_inquirer.database,
+                evm_inquirer=self.node_inquirer,
                 factory_address=SUSHISWAP_V2_FACTORY,
                 init_code_hash=SUSHISWAP_V2_INIT_CODE_HASH,
                 tx_hash=transaction.tx_hash,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.aave.v1.decoder import DEFAULT_DECODING_OUTPUT
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V1, UNISWAP_ICON
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
@@ -29,7 +29,7 @@ TOKEN_PURCHASE = b'\xcd`\xaau\xde\xa3\x07/\xbc\x07\xaem}\x85k]\xc5\xf4\xee\xe8\x
 ETH_PURCHASE = b'\x7f@\x91\xb4l3\xe9\x18\xa0\xf3\xaaB0vA\xd1{\xb6p)BzSi\xe5K59\x84#\x87\x05'
 
 
-class Uniswapv1Decoder(DecoderInterface):
+class Uniswapv1Decoder(EvmDecoderInterface):
 
     def _maybe_decode_swap(
             self,

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class VotiumDecoder(DecoderInterface):
+class VotiumDecoder(EvmDecoderInterface):
 
     def _decode_claim(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != CLAIMED:

--- a/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
@@ -24,7 +24,7 @@ from rotkehlchen.chain.evm.constants import (
 )
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface, ReloadableDecoderMixin
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -68,7 +68,7 @@ def _get_vault_token_name(vault_address: 'ChecksumEvmAddress') -> str:
     return vault_token_name
 
 
-class YearnDecoder(DecoderInterface, ReloadableDecoderMixin):
+class YearnDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
     def __init__(
             self,
             ethereum_inquirer: 'EthereumInquirer',
@@ -92,8 +92,8 @@ class YearnDecoder(DecoderInterface, ReloadableDecoderMixin):
         """
         if should_update_protocol_cache(self.base.database, CacheType.YEARN_VAULTS) is True:
             query_yearn_vaults(
-                db=self.evm_inquirer.database,
-                ethereum_inquirer=cast('EthereumInquirer', self.evm_inquirer),
+                db=self.node_inquirer.database,
+                ethereum_inquirer=cast('EthereumInquirer', self.node_inquirer),
             )
         elif len(self.vaults[CPT_YEARN_V2]) != 0:
             return None  # we didn't update the globaldb cache and we have the data already

--- a/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.modules.yearn.ygov.constants import YGOV_ADDRESS
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import REWARD_PAID_TOPIC_V2
 from rotkehlchen.chain.evm.decoding.constants import STAKED, WITHDRAWN
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
 from rotkehlchen.constants.assets import A_CRVP_DAIUSDCTTUSD, A_YFI
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class YearnygovDecoder(DecoderInterface):
+class YearnygovDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -2,7 +2,7 @@ from typing import Any, Final
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_raw_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -20,7 +20,7 @@ NEW_PRIORITY_REQUEST: Final = b'\xd0\x943r\xc0\x8bC\x8a\x88\xd4\xb3\x9dw!i\x01\x
 PENDING_WITHDRAWALS_COMPLETE: Final = b'\x9bTx\xc9\x9b\\\xa4\x1b\xee\xc4\xf6\xf6\x08A&\xd6\xf9\xe2c\x82\xd0\x17\xb4\xbbg\xc3|\x9e\x84S\xa3\x13'  # noqa: E501
 
 
-class ZksyncDecoder(DecoderInterface):
+class ZksyncDecoder(EvmDecoderInterface):
 
     def _decode_event(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] == ONCHAIN_DEPOSIT:

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -135,7 +135,7 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
 
     def addresses_to_counterparties(self) -> dict['ChecksumEvmAddress', str]:
         return dict.fromkeys(GlobalDBHandler.get_addresses_by_protocol(
-            chain_id=self.evm_inquirer.chain_id,
+            chain_id=self.node_inquirer.chain_id,
             protocol=CPT_AAVE_V2,
         ), CPT_AAVE_V2) | dict.fromkeys(self.pool_addresses, CPT_AAVE_V2)
 
@@ -143,6 +143,6 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
         return super().addresses_to_decoders() | {
             self.incentives: (self._decode_incentives,),
         } | dict.fromkeys(GlobalDBHandler.get_addresses_by_protocol(
-            chain_id=self.evm_inquirer.chain_id,
+            chain_id=self.node_inquirer.chain_id,
             protocol=CPT_AAVE_V2,
         ), (self._decode_migration,))

--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -82,7 +82,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
                 asset=EvmToken(evm_address_to_identifier(
                     address=tx_log.address,
                     token_type=TokenKind.ERC20,
-                    chain_id=self.evm_inquirer.chain_id,
+                    chain_id=self.node_inquirer.chain_id,
                 )),
             ) for tx_log in context.all_logs
             if tx_log.topics[0] == BURN and tx_log.topics[1] == context.tx_log.topics[3]
@@ -339,7 +339,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
                 earned_event=earned_event,
                 match_fn=lambda primary, secondary: (
                     (underlying_token := get_single_underlying_token(secondary.asset.resolve_to_evm_token())) is not None and  # noqa: E501
-                    (underlying_token == primary.asset or (underlying_token == self.wrapped_native_token and primary.asset == self.evm_inquirer.native_token))  # noqa: E501
+                    (underlying_token == primary.asset or (underlying_token == self.wrapped_native_token and primary.asset == self.node_inquirer.native_token))  # noqa: E501
                 ),
             )
 
@@ -352,7 +352,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
                 earned_event=earned_event,
                 match_fn=lambda primary, secondary: (  # use symbols due to Monerium and its different versions  # noqa: E501
                     (underlying_token := get_single_underlying_token(primary.asset.resolve_to_evm_token())) is not None and  # noqa: E501
-                    (underlying_token.symbol == secondary.asset.resolve_to_crypto_asset().symbol or (underlying_token == self.wrapped_native_token and secondary.asset == self.evm_inquirer.native_token))  # noqa: E501
+                    (underlying_token.symbol == secondary.asset.resolve_to_crypto_asset().symbol or (underlying_token == self.wrapped_native_token and secondary.asset == self.node_inquirer.native_token))  # noqa: E501
                 ),
             )
 
@@ -442,7 +442,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
 
     def addresses_to_counterparties(self) -> dict[ChecksumEvmAddress, str]:
         return dict.fromkeys(GlobalDBHandler.get_addresses_by_protocol(  # type: ignore[return-value]  # they are inherently strings
-            chain_id=self.evm_inquirer.chain_id,
+            chain_id=self.node_inquirer.chain_id,
             protocol=self.counterparty,
         ), self.counterparty) | dict.fromkeys(self.pool_addresses, self.counterparty)
 

--- a/rotkehlchen/chain/evm/decoding/balancer/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.evm.decoding.balancer.constants import (
     CPT_BALANCER_V2,
 )
 from rotkehlchen.chain.evm.decoding.interfaces import (
-    DecoderInterface,
+    EvmDecoderInterface,
     ReloadablePoolsAndGaugesDecoderMixin,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 
-class BalancerCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin, ABC):
+class BalancerCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMixin, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',

--- a/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
@@ -252,7 +252,7 @@ class Balancerv1CommonDecoder(BalancerCommonDecoder):
                         cursor=cursor,
                         key_parts=(
                             CacheType.BALANCER_V1_POOLS,
-                            str(self.evm_inquirer.chain_id.value),
+                            str(self.node_inquirer.chain_id.value),
                         ),
                     )
                 ],

--- a/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
@@ -58,7 +58,7 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
                 cache_type=CacheType.BALANCER_V2_POOLS,
             ),
         )
-        self.wrapped_native_token = CHAIN_TO_WRAPPED_TOKEN[self.evm_inquirer.blockchain].resolve_to_evm_token()  # noqa: E501
+        self.wrapped_native_token = CHAIN_TO_WRAPPED_TOKEN[self.node_inquirer.blockchain].resolve_to_evm_token()  # noqa: E501
 
     def decode_vault_events(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] == V2_SWAP:
@@ -169,7 +169,7 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
 
             if (
                 (event_token_amount := (
-                    self.wrapped_native_token if event.asset == self.evm_inquirer.native_token else event.asset,  # noqa: E501
+                    self.wrapped_native_token if event.asset == self.node_inquirer.native_token else event.asset,  # noqa: E501
                     event.amount,
                 )) in token_amounts_spent and
                 event.event_type == HistoryEventType.SPEND

--- a/rotkehlchen/chain/evm/decoding/balancer/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v3/decoder.py
@@ -99,14 +99,14 @@ class Balancerv3CommonDecoder(BalancerCommonDecoder):
             to_event_subtype = HistoryEventSubType.REDEEM_WRAPPED
             to_notes_template = 'Withdraw {amount} {symbol} from a Balancer v3 pool'
 
-        pool_tokens = self.evm_inquirer.call_contract(
+        pool_tokens = self.node_inquirer.call_contract(
             contract_address=(lp_token_address := bytes_to_address(context.tx_log.topics[1])),
             method_name='getTokens',
             abi=BALANCER_V3_POOL_ABI,
         )
         lp_token_identifier = evm_address_to_identifier(
             address=lp_token_address,
-            chain_id=self.evm_inquirer.chain_id,
+            chain_id=self.node_inquirer.chain_id,
         )
         pool_token_event = None
         for event in context.decoded_events:
@@ -148,7 +148,7 @@ class Balancerv3CommonDecoder(BalancerCommonDecoder):
                     if (
                             event.event_type == from_event_type and
                             event.event_subtype == HistoryEventSubType.NONE and
-                            event.asset == self.evm_inquirer.native_token and
+                            event.asset == self.node_inquirer.native_token and
                             event.amount == amount
                     ):
                         event.event_type = to_event_type
@@ -156,7 +156,7 @@ class Balancerv3CommonDecoder(BalancerCommonDecoder):
                         event.event_subtype = to_event_subtype
                         event.notes = to_notes_template.format(
                             amount=event.amount,
-                            symbol=self.evm_inquirer.native_token.symbol,
+                            symbol=self.node_inquirer.native_token.symbol,
                         )
                         break
 
@@ -229,9 +229,9 @@ class Balancerv3CommonDecoder(BalancerCommonDecoder):
             # swap log amounts would miss wrapped token portions and only capture direct
             # swap amounts, leading to incomplete event matching across the full transaction flow
             if (token_out := self.base.get_or_create_evm_asset(bytes_to_address(tx_log.topics[2]))) == self.wrapped_native_token:  # noqa: E501
-                out_assets.add(self.evm_inquirer.native_token)
+                out_assets.add(self.node_inquirer.native_token)
             if (token_in := self.base.get_or_create_evm_asset(bytes_to_address(tx_log.topics[3]))) == self.wrapped_native_token:  # noqa: E501
-                in_assets.add(self.evm_inquirer.native_token)
+                in_assets.add(self.node_inquirer.native_token)
 
             in_assets.add(token_in)
             out_assets.add(token_out)

--- a/rotkehlchen/chain/evm/decoding/cctp/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cctp/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.evm.decoding.cctp.constants import (
     MINT_AND_WITHDRAW,
     USDC_DECIMALS,
 )
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class CctpCommonDecoder(DecoderInterface):
+class CctpCommonDecoder(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
@@ -69,9 +69,9 @@ class CctpCommonDecoder(DecoderInterface):
                 event.location_label == user_address
             ):
                 try:
-                    chain_info = f' from {self.evm_inquirer.chain_id.label()} to {CCTP_DOMAIN_MAPPING[to_chain].label()}'  # noqa: E501
+                    chain_info = f' from {self.node_inquirer.chain_id.label()} to {CCTP_DOMAIN_MAPPING[to_chain].label()}'  # noqa: E501
                 except KeyError:
-                    log.error(f'Could not find chain ID {to_chain} for CCTP transfer from {self.evm_inquirer.chain_name}')  # noqa: E501
+                    log.error(f'Could not find chain ID {to_chain} for CCTP transfer from {self.node_inquirer.chain_name}')  # noqa: E501
                     chain_info = ''
                 event.event_type = HistoryEventType.DEPOSIT
                 event.event_subtype = HistoryEventSubType.BRIDGE
@@ -79,7 +79,7 @@ class CctpCommonDecoder(DecoderInterface):
                 event.counterparty = CPT_CCTP
                 break
         else:
-            log.error(f'Could not find matching spend event for {self.evm_inquirer.chain_name} CCTP bridge deposit {context.transaction.tx_hash.hex()}')  # noqa: E501
+            log.error(f'Could not find matching spend event for {self.node_inquirer.chain_name} CCTP bridge deposit {context.transaction.tx_hash.hex()}')  # noqa: E501
 
         return DEFAULT_DECODING_OUTPUT
 
@@ -105,7 +105,7 @@ class CctpCommonDecoder(DecoderInterface):
                 event.counterparty = CPT_CCTP
                 break
         else:
-            log.error(f'Could not find matching receive event for {self.evm_inquirer.chain_name} CCTP bridge withdrawal {context.transaction.tx_hash.hex()}')  # noqa: E501
+            log.error(f'Could not find matching receive event for {self.node_inquirer.chain_name} CCTP bridge withdrawal {context.transaction.tx_hash.hex()}')  # noqa: E501
 
         return DEFAULT_DECODING_OUTPUT
 
@@ -122,13 +122,13 @@ class CctpCommonDecoder(DecoderInterface):
             ):
                 from_chain = int.from_bytes(context.tx_log.data[:32])
                 try:
-                    chain_info = f' from {CCTP_DOMAIN_MAPPING[from_chain].label()} to {self.evm_inquirer.chain_id.label()}'  # noqa: E501
+                    chain_info = f' from {CCTP_DOMAIN_MAPPING[from_chain].label()} to {self.node_inquirer.chain_id.label()}'  # noqa: E501
                     event.notes = f'Bridge {event.amount} USDC{chain_info} via CCTP'
                 except KeyError:
-                    log.error(f'Could not find chain ID {from_chain} for CCTP transfer to {self.evm_inquirer.chain_name}')  # noqa: E501
+                    log.error(f'Could not find chain ID {from_chain} for CCTP transfer to {self.node_inquirer.chain_name}')  # noqa: E501
                 break
         else:
-            log.error(f'Could not find matching withdrawal event for {self.evm_inquirer.chain_name} CCTP bridge chain information {context.transaction.tx_hash.hex()}')  # noqa: E501
+            log.error(f'Could not find matching withdrawal event for {self.node_inquirer.chain_name} CCTP bridge chain information {context.transaction.tx_hash.hex()}')  # noqa: E501
 
         return DEFAULT_DECODING_OUTPUT
 

--- a/rotkehlchen/chain/evm/decoding/clique/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clique/decoder.py
@@ -2,14 +2,14 @@ from abc import ABC
 
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import CLAIMED_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DecoderContext
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import ChecksumEvmAddress
 from rotkehlchen.utils.misc import bytes_to_address
 
 
-class CliqueAirdropDecoderInterface(DecoderInterface, ABC):
+class CliqueAirdropDecoderInterface(EvmDecoderInterface, ABC):
     """Decoders of protocols using clique airdrop claim"""
 
     def _decode_claim(self, context: DecoderContext) -> tuple[ChecksumEvmAddress, FVal] | None:

--- a/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
@@ -121,7 +121,7 @@ class ClrfundCommonDecoder(CommonGrantsDecoderMixin):
                 break
 
         else:  # not found
-            log.error(f'Failed to find clrfund donation event for {self.evm_inquirer.chain_name} {context.transaction.tx_hash.hex()}')  # noqa: E501
+            log.error(f'Failed to find clrfund donation event for {self.node_inquirer.chain_name} {context.transaction.tx_hash.hex()}')  # noqa: E501
 
         return DEFAULT_DECODING_OUTPUT
 
@@ -135,7 +135,7 @@ class ClrfundCommonDecoder(CommonGrantsDecoderMixin):
         try:  # using decode_event_data_abi_str since data contains a string
             _, decoded_data = decode_event_data_abi_str(context.tx_log, REQUEST_SUBMITTED_ABI)
         except DeserializationError as e:
-            log.error(f'Failed to decode clrfund request submitted event due to {e!s} for {self.evm_inquirer.chain_name} {context.transaction.tx_hash.hex()}')  # noqa: E501
+            log.error(f'Failed to decode clrfund request submitted event due to {e!s} for {self.node_inquirer.chain_name} {context.transaction.tx_hash.hex()}')  # noqa: E501
             return DEFAULT_DECODING_OUTPUT
 
         jsondata, new_event = {}, None
@@ -149,7 +149,7 @@ class ClrfundCommonDecoder(CommonGrantsDecoderMixin):
             if (
                     event.event_type == HistoryEventType.SPEND and
                     event.event_subtype == HistoryEventSubType.NONE and
-                    event.asset == self.evm_inquirer.native_token and
+                    event.asset == self.node_inquirer.native_token and
                     event.address == context.tx_log.address
             ):
                 event.event_subtype = HistoryEventSubType.FEE

--- a/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_norma
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
 from rotkehlchen.chain.evm.decoding.cowswap.constants import COWSWAP_CPT_DETAILS, CPT_COWSWAP
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -70,7 +70,7 @@ class CowswapSwapData:
     order_type: str = 'market'
 
 
-class CowswapCommonDecoder(DecoderInterface, abc.ABC):
+class CowswapCommonDecoder(EvmDecoderInterface, abc.ABC):
 
     def __init__(
             self,
@@ -90,8 +90,8 @@ class CowswapCommonDecoder(DecoderInterface, abc.ABC):
         self.settlement_address = GPV2_SETTLEMENT_ADDRESS
         self.native_asset_flow_address = NATIVE_ASSET_FLOW_ADDRESS
         self.cowswap_api = CowswapAPI(
-            database=self.evm_inquirer.database,
-            chain=cast('SUPPORTED_COWSWAP_BLOCKCHAIN', self.evm_inquirer.blockchain),
+            database=self.node_inquirer.database,
+            chain=cast('SUPPORTED_COWSWAP_BLOCKCHAIN', self.node_inquirer.blockchain),
         )
 
     def _decode_native_asset_orders(self, context: DecoderContext) -> DecodingOutput:
@@ -99,7 +99,7 @@ class CowswapCommonDecoder(DecoderInterface, abc.ABC):
             target_token_address = bytes_to_address(context.tx_log.data[32:64])
             target_token = EvmToken(evm_address_to_identifier(
                 address=target_token_address,
-                chain_id=self.evm_inquirer.chain_id,
+                chain_id=self.node_inquirer.chain_id,
                 token_type=TokenKind.ERC20,
             ))
             for event in context.decoded_events:
@@ -234,7 +234,7 @@ class CowswapCommonDecoder(DecoderInterface, abc.ABC):
                 if spend_event is None:
                     log.error(
                         f'Could not find a spend event of {swap_data.from_amount} '
-                        f'{swap_data.from_asset} in a {self.evm_inquirer.chain_name} cowswap transaction {transaction.tx_hash.hex()}')  # noqa: E501
+                        f'{swap_data.from_asset} in a {self.node_inquirer.chain_name} cowswap transaction {transaction.tx_hash.hex()}')  # noqa: E501
                     continue
             else:
                 # If native asset is spent, then there will not be a decoded transfer. Thus we create it.  # noqa: E501
@@ -406,7 +406,7 @@ class CowswapCommonDecoderWithVCOW(CowswapCommonDecoder):
     def _decode_normal_claim(self, context: DecoderContext) -> DecodingOutput:
         raw_amount = int.from_bytes(context.tx_log.data[128:160])
         amount = asset_normalized_value(amount=raw_amount, asset=self.vcow_token)
-        airdrop_identifier: Literal['cow_mainnet', 'cow_gnosis'] = 'cow_mainnet' if self.evm_inquirer.chain_id == ChainID.ETHEREUM else 'cow_gnosis'  # noqa: E501
+        airdrop_identifier: Literal['cow_mainnet', 'cow_gnosis'] = 'cow_mainnet' if self.node_inquirer.chain_id == ChainID.ETHEREUM else 'cow_gnosis'  # noqa: E501
         # claimTypes with payment: 1=GnoOption, 2=UserOption, 3=Investor
         claim_supports_payment = int.from_bytes(context.tx_log.data[32:64]) in (1, 2, 3)
         claimant_address = bytes_to_address(context.tx_log.data[64:96])
@@ -421,7 +421,7 @@ class CowswapCommonDecoderWithVCOW(CowswapCommonDecoder):
                 event.location_label == claimant_address and
                 event.event_type == HistoryEventType.SPEND and
                 event.event_subtype == HistoryEventSubType.NONE and
-                event.asset in (self.evm_inquirer.native_token, self.gno_token)
+                event.asset in (self.node_inquirer.native_token, self.gno_token)
             ):
                 event.event_type = HistoryEventType.TRADE
                 event.event_subtype = HistoryEventSubType.SPEND
@@ -445,7 +445,7 @@ class CowswapCommonDecoderWithVCOW(CowswapCommonDecoder):
                 break
 
         else:
-            log.error(f'Could not find the normal COW token claim for {self.evm_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}')  # noqa: E501
+            log.error(f'Could not find the normal COW token claim for {self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}')  # noqa: E501
 
         if claim_has_payment:
             if in_event is not None:
@@ -454,7 +454,7 @@ class CowswapCommonDecoderWithVCOW(CowswapCommonDecoder):
                     events_list=context.decoded_events,
                 )
             else:
-                log.error(f'Could not find the COW token claim corresponding to detected payment for {self.evm_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}')  # noqa: E501
+                log.error(f'Could not find the COW token claim corresponding to detected payment for {self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}')  # noqa: E501
 
         return DecodingOutput(process_swaps=True)
 
@@ -465,7 +465,7 @@ class CowswapCommonDecoderWithVCOW(CowswapCommonDecoder):
 
         # in gnosis chain the Vested log event has no amount in data. So we don't
         # match on amount for action items and in post decoding fix notes instead of here
-        amount = token_normalized_value(int.from_bytes(context.tx_log.data), self.vcow_token) if self.evm_inquirer.chain_id != ChainID.GNOSIS else None  # noqa: E501
+        amount = token_normalized_value(int.from_bytes(context.tx_log.data), self.vcow_token) if self.node_inquirer.chain_id != ChainID.GNOSIS else None  # noqa: E501
         return DecodingOutput(
             action_items=[
                 ActionItem(

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -37,7 +37,7 @@ from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     read_curve_pools_and_gauges,
 )
 from rotkehlchen.chain.evm.decoding.interfaces import (
-    DecoderInterface,
+    EvmDecoderInterface,
     ReloadablePoolsAndGaugesDecoderMixin,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
+class CurveCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
 
     def __init__(
             self,
@@ -410,7 +410,7 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
                 if _log.topics[0] in ADD_LIQUIDITY_EVENTS:
                     lp_and_gauge_token_addresses = get_lp_and_gauge_token_addresses(
                         pool_address=_log.address,
-                        chain_id=self.evm_inquirer.chain_id,
+                        chain_id=self.node_inquirer.chain_id,
                     )
 
             if lp_and_gauge_token_addresses is not None:
@@ -617,7 +617,7 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
         """
         if (pool_addresses := self.pools.get(context.tx_log.address)) is None:
             log.error(
-                f'Curve pool for {self.evm_inquirer.chain_name} {context.tx_log.address} '
+                f'Curve pool for {self.node_inquirer.chain_name} {context.tx_log.address} '
                 f'not present in cache at {context.transaction.tx_hash.hex()}. Skipping',
             )
             return DEFAULT_DECODING_OUTPUT
@@ -631,7 +631,7 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
         pool_assets = [
             Asset(evm_address_to_identifier(
                 address=address,
-                chain_id=self.evm_inquirer.chain_id,
+                chain_id=self.node_inquirer.chain_id,
                 token_type=TokenKind.ERC20,
             )) if address != ETH_SPECIAL_ADDRESS else A_ETH for address in pool_addresses
         ]
@@ -723,7 +723,7 @@ class CurveCommonDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin)
         # get pool tokens for this gauge
         lp_and_gauge_token_addresses = get_lp_and_gauge_token_addresses(
             pool_address=context.tx_log.address,
-            chain_id=self.evm_inquirer.chain_id,
+            chain_id=self.node_inquirer.chain_id,
         )
         pool_tokens = []
         for address in lp_and_gauge_token_addresses:

--- a/rotkehlchen/chain/evm/decoding/curve/lend/common.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/common.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.evm.decoding.curve.constants import (
     CPT_CURVE,
     CURVE_COUNTERPARTY_DETAILS,
 )
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class CurveBorrowRepayCommonDecoder(DecoderInterface, ABC):
+class CurveBorrowRepayCommonDecoder(EvmDecoderInterface, ABC):
     """Common borrow/repay event decoder for both crvUSD markets and llamalend vaults."""
 
     def __init__(
@@ -92,7 +92,7 @@ class CurveBorrowRepayCommonDecoder(DecoderInterface, ABC):
                 return string_to_evm_address(value)
 
         try:
-            value = deserialize_evm_address(self.evm_inquirer.call_contract(
+            value = deserialize_evm_address(self.node_inquirer.call_contract(
                 contract_address=contract_address,
                 abi=contract_abi,
                 method_name=contract_method,
@@ -100,7 +100,7 @@ class CurveBorrowRepayCommonDecoder(DecoderInterface, ABC):
         except (RemoteError, DeserializationError) as e:
             log.error(
                 f'Failed to retrieve an evm address from the {contract_method} method on the '
-                f'{self.evm_inquirer.chain_name} Curve contract {contract_address} due to {e!s}',
+                f'{self.node_inquirer.chain_name} Curve contract {contract_address} due to {e!s}',
             )
             return None
 
@@ -145,7 +145,7 @@ class CurveBorrowRepayCommonDecoder(DecoderInterface, ABC):
         except (NotERC20Conformant, NotERC721Conformant) as e:
             log.error(
                 f'Failed to get or create token {token_address} associated with Curve contract '
-                f'{contract_address} on {self.evm_inquirer.chain_name} due to {e}',
+                f'{contract_address} on {self.node_inquirer.chain_name} due to {e}',
             )
             return None
 

--- a/rotkehlchen/chain/evm/decoding/curve/lend/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/decoder.py
@@ -91,8 +91,8 @@ class CurveLendCommonDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMix
                 cache_key=CacheType.CURVE_LENDING_VAULTS,
         ) is True:
             query_curve_lending_vaults(
-                database=self.evm_inquirer.database,
-                chain_id=self.evm_inquirer.chain_id,
+                database=self.node_inquirer.database,
+                chain_id=self.node_inquirer.chain_id,
             )
         elif len(self.vaults) != 0:
             return None  # we didn't update the globaldb cache, and we have the data already
@@ -103,7 +103,7 @@ class CurveLendCommonDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMix
                 'ON evm_tokens.identifier = common_asset_details.identifier '
                 'WHERE protocol=? AND symbol=? AND chain=?'
             )
-            bindings = (CPT_CURVE, CURVE_LEND_VAULT_SYMBOL, self.evm_inquirer.chain_id.serialize_for_db())  # noqa: E501
+            bindings = (CPT_CURVE, CURVE_LEND_VAULT_SYMBOL, self.node_inquirer.chain_id.serialize_for_db())  # noqa: E501
 
             cursor.execute(f'SELECT COUNT(*) {query_body}', bindings)
             if cursor.fetchone()[0] == len(self.vaults):
@@ -282,7 +282,7 @@ class CurveLendCommonDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMix
             ).fetchone()) is None:
                 log.error(
                     'Failed to find Curve lending vault address for controller '
-                    f'{controller_address} on {self.evm_inquirer.chain_name}',
+                    f'{controller_address} on {self.node_inquirer.chain_name}',
                 )
                 return None
 
@@ -310,7 +310,7 @@ class CurveLendCommonDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMix
         )) is None:
             log.error(
                 'Failed to get borrowed token for Curve lending vault '
-                f'{vault_address} on {self.evm_inquirer.chain_name}',
+                f'{vault_address} on {self.node_inquirer.chain_name}',
             )
             return None
 

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -103,7 +103,7 @@ if TYPE_CHECKING:
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
     from .base import BaseEvmDecoderTools, BaseEvmDecoderToolsWithProxy
-    from .interfaces import DecoderInterface
+    from .interfaces import EvmDecoderInterface
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -165,7 +165,7 @@ class EvmTransactionContext(NamedTuple):
     receipt: 'EvmTxReceipt'
 
 
-class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRules, 'DecoderInterface', 'EVMTxHash', 'EvmEvent', EvmTransactionContext, 'BaseEvmDecoderTools'], ABC):  # noqa: E501
+class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRules, 'EvmDecoderInterface', 'EVMTxHash', 'EvmEvent', EvmTransactionContext, 'BaseEvmDecoderTools'], ABC):  # noqa: E501
 
     def __init__(
             self,
@@ -291,7 +291,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
     def _add_single_decoder(
             self,
             class_name: str,
-            decoder_class: type['DecoderInterface'],
+            decoder_class: type['EvmDecoderInterface'],
             rules: EvmDecodingRules,
     ) -> None:
         """Initialize a single decoder, add it to the set of decoders to use
@@ -367,7 +367,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
 
         return possible_products
 
-    def _reload_single_decoder(self, cursor: 'DBCursor', decoder: 'DecoderInterface') -> None:
+    def _reload_single_decoder(self, cursor: 'DBCursor', decoder: 'EvmDecoderInterface') -> None:
         """Reload data for a single decoder"""
         super()._reload_single_decoder(cursor=cursor, decoder=decoder)
         if isinstance(decoder, ReloadableDecoderMixin):
@@ -1331,7 +1331,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
 
     def _chain_specific_decoder_initialization(
             self,
-            decoder: 'DecoderInterface',  # pylint: disable=unused-argument
+            decoder: 'EvmDecoderInterface',  # pylint: disable=unused-argument
     ) -> None:
         """Custom initialization for each decoder, based on the type of EVM chain.
 

--- a/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
@@ -12,7 +12,7 @@ from rotkehlchen.chain.evm.decoding.drips.v1.constants import (
     SPLIT,
     SPLITS_UPDATED,
 )
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
+class Dripsv1CommonDecoder(EvmDecoderInterface, CustomizableDateMixin):
 
     def __init__(
             self,
@@ -94,7 +94,7 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
             notes += f' and forward {split_amount} DAI to dependencies for splitting'
             split_events = [x for x in context.decoded_events if x.event_type == HistoryEventType.INFORMATIONAL and x.counterparty == CPT_DRIPS]  # noqa: E501
             if len(split_events) == 0:
-                log.error(f'Could not find split events for {self.evm_inquirer.chain_name} {context.transaction.tx_hash.hex()}')  # noqa: E501
+                log.error(f'Could not find split events for {self.node_inquirer.chain_name} {context.transaction.tx_hash.hex()}')  # noqa: E501
             else:  # count them as an in event pairing so they come after the action item transfer
                 paired_events_data = (split_events, False)
 
@@ -114,7 +114,7 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
         return DecodingOutput(action_items=[action_item])
 
     def _decode_splits_updated(self, context: DecoderContext) -> DecodingOutput:
-        contract = self.evm_inquirer.contracts.contract(self.drips_hub)
+        contract = self.node_inquirer.contracts.contract(self.drips_hub)
         topic_data, log_data = contract.decode_event(tx_log=context.tx_log, event_name='SplitsUpdated', argument_names=('user', 'receivers'))  # noqa: E501
 
         if not self.base.is_tracked(user := topic_data[0]):

--- a/rotkehlchen/chain/evm/decoding/eas/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/eas/decoder.py
@@ -3,7 +3,7 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -31,7 +31,7 @@ log = RotkehlchenLogsAdapter(logger)
 ATTESTED = b'\x8b\xf4k\xf4\xcf\xd6t\xfasZ=c\xec\x1c\x9a\xd4\x15?\x03<)\x03A\xf3\xa5\x88\xb7V\x85\x14\x1b5'  # noqa: E501
 
 
-class EASCommonDecoder(DecoderInterface, ABC):
+class EASCommonDecoder(EvmDecoderInterface, ABC):
     """This is the Ethereum Attestation Service common decoder
 
     https://attest.sh/
@@ -66,10 +66,10 @@ class EASCommonDecoder(DecoderInterface, ABC):
             return DEFAULT_DECODING_OUTPUT
 
         uid = context.tx_log.data.hex()
-        prefix = f'{self.evm_inquirer.chain_name}.'
-        if self.evm_inquirer.chain_id == ChainID.ETHEREUM:
+        prefix = f'{self.node_inquirer.chain_name}.'
+        if self.node_inquirer.chain_id == ChainID.ETHEREUM:
             prefix = ''
-        elif self.evm_inquirer.chain_id == ChainID.ARBITRUM_ONE:
+        elif self.node_inquirer.chain_id == ChainID.ARBITRUM_ONE:
             prefix = 'arbitrum.'
 
         event = self.base.make_event_from_transaction(

--- a/rotkehlchen/chain/evm/decoding/efp/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/efp/decoder.py
@@ -6,7 +6,7 @@ from eth_utils import to_checksum_address
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -39,7 +39,7 @@ log = RotkehlchenLogsAdapter(logger)
 LIST_OP_TOPIC: Final = b"\xb0gc\x0e9\x08\xf1f\x06\x9cwvbP\xc5SAN'E\xe7B\xa5b\xd53\xf2\x97D\xa9\x1as"  # noqa: E501
 
 
-class EfpCommonDecoder(DecoderInterface, ABC):
+class EfpCommonDecoder(EvmDecoderInterface, ABC):
 
     def __init__(
             self,
@@ -61,13 +61,13 @@ class EfpCommonDecoder(DecoderInterface, ABC):
         with GlobalDBHandler().conn.read_ctx() as cursor:
             if (address := globaldb_get_unique_cache_value(
                     cursor=cursor,
-                    key_parts=(CacheType.EFP_SLOT_ADDRESS, (chain := str(self.evm_inquirer.chain_id)), str(slot)),  # noqa: E501
+                    key_parts=(CacheType.EFP_SLOT_ADDRESS, (chain := str(self.node_inquirer.chain_id)), str(slot)),  # noqa: E501
             )) is not None:
                 return string_to_evm_address(address)
 
         try:
-            if (address := to_checksum_address(self.evm_inquirer.contracts.contract(self.list_records_contract).call(  # noqa: E501
-                node_inquirer=self.evm_inquirer,
+            if (address := to_checksum_address(self.node_inquirer.contracts.contract(self.list_records_contract).call(  # noqa: E501
+                node_inquirer=self.node_inquirer,
                 method_name='getListUser',
                 arguments=[slot],
             ))) == ZERO_ADDRESS:

--- a/rotkehlchen/chain/evm/decoding/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/firebird_finance/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import SWAPPED_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class FirebirdFinanceCommonDecoder(DecoderInterface):
+class FirebirdFinanceCommonDecoder(EvmDecoderInterface):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
@@ -26,7 +26,7 @@ from rotkehlchen.chain.evm.decoding.gitcoinv2.constants import (
     VOTED_WITH_ORIGIN,
     VOTED_WITHOUT_APPLICATION_IDX,
 )
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class GitcoinV2CommonDecoder(DecoderInterface, ABC):
+class GitcoinV2CommonDecoder(EvmDecoderInterface, ABC):
     """This is the gitcoin v2 (allo protocol) common decoder
 
     Not the same as gitcoin v1, or v1.5 (they have changed contracts many times).
@@ -113,7 +113,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
         if (recipient_address := self.recipient_id_to_addr.get(recipient_id)) is not None:
             return recipient_address
 
-        result = self.evm_inquirer.call_contract(
+        result = self.node_inquirer.call_contract(
             contract_address=contract_address,
             abi=GET_RECIPIENT_ABI,
             method_name='getRecipient',
@@ -263,7 +263,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
         token_address = bytes_to_address(context.tx_log.data[32:64])
         amount_raw = int.from_bytes(context.tx_log.data[:32])
         if token_address == ETH_SPECIAL_ADDRESS:
-            asset = self.evm_inquirer.native_token
+            asset = self.node_inquirer.native_token
         else:
             asset = self.base.get_or_create_evm_token(token_address)
 
@@ -346,7 +346,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
         paying_contract_address = bytes_to_address(context.tx_log.topics[paying_contract_idx])
         token_address = bytes_to_address(context.tx_log.data[:32])
         if token_address == ZERO_ADDRESS:
-            asset = self.evm_inquirer.native_token
+            asset = self.node_inquirer.native_token
         else:
             asset = self.base.get_or_create_evm_token(token_address)
         amount_raw = int.from_bytes(context.tx_log.data[32:64])
@@ -374,7 +374,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
         else:
             log.error(
                 f'Could not find a corresponding event for donation to {receiver}'
-                f' in {self.evm_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
+                f' in {self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
             )
 
         return DEFAULT_DECODING_OUTPUT
@@ -509,7 +509,7 @@ class GitcoinV2CommonDecoder(DecoderInterface, ABC):
         else:
             log.error(
                 f'Could not find a corresponding event for round payout to {grantee}'
-                f' in {self.evm_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
+                f' in {self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
             )
 
         return DEFAULT_DECODING_OUTPUT

--- a/rotkehlchen/chain/evm/decoding/giveth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/giveth/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, SIMPLE_CLAIM
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_DETAILS_GIVETH, CPT_GIVETH
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class GivethDecoderBase(DecoderInterface, ABC):
+class GivethDecoderBase(EvmDecoderInterface, ABC):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/evm/decoding/hop/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/hop/decoder.py
@@ -16,7 +16,7 @@ from rotkehlchen.chain.evm.constants import (
 from rotkehlchen.chain.evm.decoding.constants import STAKED, WITHDRAWN
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP, HOP_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.hop.structures import HopBridgeEventData
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class HopCommonDecoder(DecoderInterface):
+class HopCommonDecoder(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
@@ -70,7 +70,7 @@ class HopCommonDecoder(DecoderInterface):
             bridges: dict[ChecksumEvmAddress, HopBridgeEventData],
             reward_contracts: set[ChecksumEvmAddress],
     ) -> None:
-        DecoderInterface.__init__(  # forced to use this instead of super
+        EvmDecoderInterface.__init__(  # forced to use this instead of super
             self,  # in ordere to "address" the diamond inheritance problem
             evm_inquirer=evm_inquirer,
             base_tools=base_tools,
@@ -380,7 +380,7 @@ class HopCommonDecoder(DecoderInterface):
                         pool_address=context.tx_log.address,
                     )
                 except (WrongAssetType, UnknownAsset) as e:
-                    log.error(f'Could not resolve {event.asset!s} in {self.evm_inquirer.chain_name} while decoding AddLiquidity in Hop: {e!s}')  # noqa: E501
+                    log.error(f'Could not resolve {event.asset!s} in {self.node_inquirer.chain_name} while decoding AddLiquidity in Hop: {e!s}')  # noqa: E501
 
         maybe_reshuffle_events(
             ordered_events=[out_event1, out_event2, in_event],
@@ -423,7 +423,7 @@ class HopCommonDecoder(DecoderInterface):
         if (swap_asset_id := self.swaps_to_asset.get(context.tx_log.address)) is None:
             log.error(
                 f'Could not find asset for the saddle swap address while decoding '
-                f'{self.evm_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',
+                f'{self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',
             )
             return None
 

--- a/rotkehlchen/chain/evm/decoding/kyber/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/kyber/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.assets.asset import CryptoAsset
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import SWAPPED_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class KyberCommonDecoder(DecoderInterface):
+class KyberCommonDecoder(EvmDecoderInterface):
 
     def _maybe_update_events(
             self,

--- a/rotkehlchen/chain/evm/decoding/llamazip/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/llamazip/decoder.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.llamazip.constants import CPT_LLAMAZIP, LLAMAZIP_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class LlamazipCommonDecoder(DecoderInterface, abc.ABC):
+class LlamazipCommonDecoder(EvmDecoderInterface, abc.ABC):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/evm/decoding/magpie/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/magpie/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import RABBY_WALLET_FEE_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class MagpieCommonDecoder(DecoderInterface):
+class MagpieCommonDecoder(EvmDecoderInterface):
     """Decoder for Magpie protocol swaps"""
 
     def __init__(
@@ -69,12 +69,12 @@ class MagpieCommonDecoder(DecoderInterface):
 
         # Get tokens - handle ETH represented as zero address
         if source_token_address == ZERO_ADDRESS:
-            source_token = self.evm_inquirer.native_token
+            source_token = self.node_inquirer.native_token
         else:
             source_token = self.base.get_or_create_evm_asset(source_token_address)
 
         if destination_token_address == ZERO_ADDRESS:
-            destination_token = self.evm_inquirer.native_token
+            destination_token = self.node_inquirer.native_token
         else:
             destination_token = self.base.get_or_create_evm_asset(destination_token_address)
 

--- a/rotkehlchen/chain/evm/decoding/merkl/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/merkl/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import REWARD_CLAIMED
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class MerklDecoder(DecoderInterface):
+class MerklDecoder(EvmDecoderInterface):
 
     def __init__(
             self,
@@ -67,7 +67,7 @@ class MerklDecoder(DecoderInterface):
                 protocol = get_merkl_protocol_for_token(
                     account=user_address,
                     token=claimed_asset_addr,
-                    chain_id=self.evm_inquirer.chain_id,
+                    chain_id=self.node_inquirer.chain_id,
                 )
                 from_str = f'{protocol} via Merkl' if protocol else 'Merkl'
                 event.notes = f'Claim {event.amount} {claimed_asset.symbol} from {from_str}'

--- a/rotkehlchen/chain/evm/decoding/metamask/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/metamask/decoder.py
@@ -4,7 +4,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.constants import AMM_POSSIBLE_COUNTERPARTIES
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 
-class MetamaskCommonDecoder(DecoderInterface):
+class MetamaskCommonDecoder(EvmDecoderInterface):
 
     def __init__(
             self,
@@ -57,7 +57,7 @@ class MetamaskCommonDecoder(DecoderInterface):
         for log in context.all_logs:
             if log.topics[0] == METAMASK_FEE_TOPIC:
                 fee_raw = int.from_bytes(log.data)
-                fee_asset = self.evm_inquirer.native_token
+                fee_asset = self.node_inquirer.native_token
                 fee_asset_address = log.address
                 break
             if (

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface, ReloadableDecoderMixin
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 
-class MoneriumCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
+class MoneriumCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
 
     def __init__(
             self,
@@ -73,10 +73,10 @@ class MoneriumCommonDecoder(DecoderInterface, ReloadableDecoderMixin):
         to_address = bytes_to_address(value=context.tx_log.topics[2])
 
         token = get_or_create_evm_token(
-            userdb=self.evm_inquirer.database,
+            userdb=self.node_inquirer.database,
             evm_address=context.tx_log.address,
-            chain_id=self.evm_inquirer.chain_id,
-            evm_inquirer=self.evm_inquirer,
+            chain_id=self.node_inquirer.chain_id,
+            evm_inquirer=self.node_inquirer,
         )
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data),

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.transactions import EvmTransactions
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class OdosCommonDecoderBase(DecoderInterface):
+class OdosCommonDecoderBase(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
@@ -41,9 +41,9 @@ class OdosCommonDecoderBase(DecoderInterface):
             base_tools=base_tools,
             msg_aggregator=msg_aggregator,
         )
-        self.evm_txns = EvmTransactions(self.evm_inquirer, self.base.database)
+        self.evm_txns = EvmTransactions(self.node_inquirer, self.base.database)
         self.router_address = router_address
-        self.native_currency = self.evm_inquirer.native_token
+        self.native_currency = self.node_inquirer.native_token
         self.label = self.counterparties()[0].label
 
     def _calculate_router_fee(
@@ -63,7 +63,7 @@ class OdosCommonDecoderBase(DecoderInterface):
                 tx_log.topics[0] != ERC20_OR_ERC721_TRANSFER or
                 ((identifier := evm_address_to_identifier(
                     address=tx_log.address,
-                    chain_id=self.evm_inquirer.chain_id,
+                    chain_id=self.node_inquirer.chain_id,
                     token_type=TokenKind.ERC20,
                 )) not in output_tokens)
             ):

--- a/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.decoding.constants import GNOSIS_CPT_DETAILS
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -32,7 +32,7 @@ TOKENS_BRIDGING_INITIATED: Final = b'Y\xa9\xa8\x02{\x9c\x87\xb9a\xe2T\x89\x98!\x
 TOKENS_BRIDGED: Final = b'\x9a\xfdG\x90~%\x02\x8c\xda\xca\x89\xd1\x93Q\x8c0+\xbb\x12\x86\x17\xd5\xa9\x92\xc5\xab\xd4X\x15Re\x93'  # noqa: E501
 
 
-class OmnibridgeCommonDecoder(DecoderInterface, abc.ABC):
+class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
 
     def __init__(
             self,
@@ -64,10 +64,10 @@ class OmnibridgeCommonDecoder(DecoderInterface, abc.ABC):
             return DEFAULT_DECODING_OUTPUT
 
         bridged_asset = get_or_create_evm_token(
-            userdb=self.evm_inquirer.database,
+            userdb=self.node_inquirer.database,
             evm_address=bytes_to_address(context.tx_log.topics[1]),
-            chain_id=self.evm_inquirer.chain_id,
-            evm_inquirer=self.evm_inquirer,
+            chain_id=self.node_inquirer.chain_id,
+            evm_inquirer=self.node_inquirer,
         )
         amount = asset_normalized_value(
             amount=int.from_bytes(context.tx_log.data[0:32]),

--- a/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 from .constants import CPT_ONEINCH, ONEINCH_ICON
 
 
-class OneinchCommonDecoder(DecoderInterface, ABC):
+class OneinchCommonDecoder(EvmDecoderInterface, ABC):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/evm/decoding/open_ocean/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/open_ocean/decoder.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class OpenOceanDecoder(DecoderInterface, ABC):
+class OpenOceanDecoder(EvmDecoderInterface, ABC):
 
     def _get_asset_and_amount(
             self,
@@ -46,10 +46,10 @@ class OpenOceanDecoder(DecoderInterface, ABC):
         Uses native token if address is ZERO_ADDRESS:
         https://github.com/openocean-finance/OpenOceanExchangeV2/blob/5e83cc1cf0a29a3ab23e405f9528b876ff8b1478/contracts/libraries/UniversalERC20.sol#L62
         """
-        asset = self.base.get_or_create_evm_asset(address=asset_address) if asset_address != ZERO_ADDRESS else self.evm_inquirer.native_token  # noqa: E501
+        asset = self.base.get_or_create_evm_asset(address=asset_address) if asset_address != ZERO_ADDRESS else self.node_inquirer.native_token  # noqa: E501
         amount = token_normalized_value_decimals(
             token_amount=raw_amount,
-            token_decimals=DEFAULT_TOKEN_DECIMALS if asset == self.evm_inquirer.native_token else asset.resolve_to_evm_token().decimals,  # noqa: E501
+            token_decimals=DEFAULT_TOKEN_DECIMALS if asset == self.node_inquirer.native_token else asset.resolve_to_evm_token().decimals,  # noqa: E501
         )
         return asset, amount
 

--- a/rotkehlchen/chain/evm/decoding/quickswap/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/quickswap/v2/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import BURN_TOPIC, MINT_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.quickswap.constants import CPT_QUICKSWAP_V2
 from rotkehlchen.chain.evm.decoding.quickswap.utils import decode_quickswap_swap
 from rotkehlchen.chain.evm.decoding.uniswap.v2.constants import UNISWAP_V2_SWAP_SIGNATURE
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 
-class Quickswapv2CommonDecoder(DecoderInterface):
+class Quickswapv2CommonDecoder(EvmDecoderInterface):
 
     def __init__(
             self,
@@ -64,8 +64,8 @@ class Quickswapv2CommonDecoder(DecoderInterface):
             all_logs=all_logs,
             is_deposit=is_deposit,
             counterparty=CPT_QUICKSWAP_V2,
-            database=self.evm_inquirer.database,
-            evm_inquirer=self.evm_inquirer,
+            database=self.node_inquirer.database,
+            evm_inquirer=self.node_inquirer,
             factory_address=self.factory_address,
             init_code_hash=UNISWAP_V2_INIT_CODE_HASH,
             tx_hash=transaction.tx_hash,

--- a/rotkehlchen/chain/evm/decoding/quickswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/quickswap/v3/decoder.py
@@ -6,7 +6,7 @@ from eth_typing.abi import ABI
 
 from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.quickswap.constants import CPT_QUICKSWAP_V3
 from rotkehlchen.chain.evm.decoding.quickswap.utils import decode_quickswap_swap
 from rotkehlchen.chain.evm.decoding.quickswap.v3.constants import (
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class Quickswapv3LikeLPDecoder(DecoderInterface):
+class Quickswapv3LikeLPDecoder(EvmDecoderInterface):
     """Common decoder for Quickswap v3 and v4 LP deposits and withdrawals."""
 
     def __init__(
@@ -87,7 +87,7 @@ class Quickswapv3LikeLPDecoder(DecoderInterface):
             # The other values differ depending on the version (we only use token0 & token1).
             # V3: https://docs.quickswap.exchange/technical-reference/smart-contracts/v3/position-manager#positions  # noqa: E501
             # V4: see QUICKSWAP_V4_NFT_MANAGER_ABI (the quickswap docs do not yet include V4 technical reference)  # noqa: E501
-            lp_position_info = self.evm_inquirer.call_contract(
+            lp_position_info = self.node_inquirer.call_contract(
                 contract_address=self.nft_manager,
                 abi=self.nft_manager_abi,
                 method_name='positions',
@@ -109,7 +109,7 @@ class Quickswapv3LikeLPDecoder(DecoderInterface):
             amount0_raw=amount0_raw,
             amount1_raw=amount1_raw,
             position_id=position_id,
-            evm_inquirer=self.evm_inquirer,
+            evm_inquirer=self.node_inquirer,
             wrapped_native_currency=self.wrapped_native_currency,
         )
 
@@ -126,7 +126,7 @@ class Quickswapv3LikeLPDecoder(DecoderInterface):
         """  # noqa: E501
         return decode_uniswap_v3_like_position_create_or_exit(
             decoded_events=decoded_events,
-            evm_inquirer=self.evm_inquirer,
+            evm_inquirer=self.node_inquirer,
             nft_manager=self.nft_manager,
             counterparty=self.counterparty,
             token_symbol=f'QKSWP-{self.version_string}-ALGB-POS',

--- a/rotkehlchen/chain/evm/decoding/safe/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/safe/decoder.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Callable
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -38,7 +38,7 @@ def _get_maybe_indexed_address(context: DecoderContext, details: str) -> Checksu
     return address
 
 
-class SafemultisigDecoder(DecoderInterface):
+class SafemultisigDecoder(EvmDecoderInterface):
     def _decode_added_owner(self, context: DecoderContext) -> DecodingOutput:
         if (address := _get_maybe_indexed_address(context, details='safe owner addition')) is None:
             return DEFAULT_DECODING_OUTPUT

--- a/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.socket_bridge.constants import (
     BRIDGE_TOPIC,
     CPT_SOCKET,
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class SocketBridgeDecoder(DecoderInterface):
+class SocketBridgeDecoder(EvmDecoderInterface):
     """The gateway contract is deployed in all the chains with the same address"""
 
     def __init__(
@@ -60,10 +60,10 @@ class SocketBridgeDecoder(DecoderInterface):
             bridged_asset: CryptoAsset = self.eth
         else:
             bridged_asset = get_or_create_evm_token(
-                userdb=self.evm_inquirer.database,
+                userdb=self.node_inquirer.database,
                 evm_address=token_address,
-                chain_id=self.evm_inquirer.chain_id,
-                evm_inquirer=self.evm_inquirer,
+                chain_id=self.node_inquirer.chain_id,
+                evm_inquirer=self.node_inquirer,
             )
         amount = asset_normalized_value(amount=amount_raw, asset=bridged_asset)
         sender = bytes_to_address(context.tx_log.data[128:160])

--- a/rotkehlchen/chain/evm/decoding/spark/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/decoder.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 
 from .constants import SPARK_COUNTERPARTY_DETAILS
 
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
 
 
-class SparkCommonDecoder(DecoderInterface):
+class SparkCommonDecoder(EvmDecoderInterface):
 
     @staticmethod
     def counterparties() -> tuple['CounterpartyDetails', ...]:

--- a/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
@@ -127,7 +127,7 @@ class SparksavingsCommonDecoder(SparkCommonDecoder):
             encounter=(encounter := TokenEncounterInfo(should_notify=False)),
         )
         underlying_token = self.base.get_or_create_evm_token(
-            address=deserialize_evm_address(self.evm_inquirer.call_contract(
+            address=deserialize_evm_address(self.node_inquirer.call_contract(
                 contract_address=vault_token.evm_address,
                 abi=ERC4626_ABI,
                 method_name='asset',
@@ -151,7 +151,7 @@ class SparksavingsCommonDecoder(SparkCommonDecoder):
                     event.event_subtype == HistoryEventSubType.NONE and
                     event.amount == underlying_amount and
                     # the native token check is for gnosis since xDAI can be deposited
-                    event.asset in (underlying_token, self.evm_inquirer.native_token)
+                    event.asset in (underlying_token, self.node_inquirer.native_token)
                 ):
                     event.counterparty = CPT_SPARK
                     event.event_type = HistoryEventType.DEPOSIT
@@ -184,7 +184,7 @@ class SparksavingsCommonDecoder(SparkCommonDecoder):
                 event.event_subtype == HistoryEventSubType.NONE and
                 event.amount == underlying_amount and
                 # the native token check is for gnosis since xDAI can be deposited
-                event.asset in (underlying_token, self.evm_inquirer.native_token)
+                event.asset in (underlying_token, self.node_inquirer.native_token)
             ):
                 event.counterparty = CPT_SPARK
                 event.event_type = HistoryEventType.WITHDRAWAL

--- a/rotkehlchen/chain/evm/decoding/summer_fi/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/summer_fi/decoder.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 
-class SummerFiCommonDecoder(DecoderInterface):
+class SummerFiCommonDecoder(EvmDecoderInterface):
 
     def __init__(
             self,
@@ -50,7 +50,7 @@ class SummerFiCommonDecoder(DecoderInterface):
             tx_log=context.tx_log,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.CREATE,
-            asset=self.evm_inquirer.native_token,
+            asset=self.node_inquirer.native_token,
             amount=ZERO,
             location_label=user_address,
             notes=f'Create Summer.fi smart account {proxy_address} with id {vault_id}',

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -31,7 +31,7 @@ ETH_WITHDRAWAL_FINALIZED: Final = b'*\xc6\x9e\xe8\x04\xd9\xa7\xa0\x98BI\xf5\x08\
 WITHDRAWAL_PROVEN: Final = b'g\xa6 \x8c\xfc\xc0\x80\x1dP\xf6\xcb\xe7ds?O\xdd\xf6j\xc0\xb0DB\x06\x1a\x8a\x8c\x0c\xb6\xb6?b'  # noqa: E501
 
 
-class SuperchainL1SideCommonBridgeDecoder(DecoderInterface, ABC):
+class SuperchainL1SideCommonBridgeDecoder(EvmDecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',

--- a/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Final
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import BURN_TOPIC, MINT_TOPIC
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 UNISWAP_V2_INIT_CODE_HASH: Final = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f'  # noqa: E501
 
 
-class Uniswapv2CommonDecoder(DecoderInterface):
+class Uniswapv2CommonDecoder(EvmDecoderInterface):
 
     def __init__(
             self,
@@ -76,7 +76,7 @@ class Uniswapv2CommonDecoder(DecoderInterface):
             decoded_events=decoded_events,
             counterparty=CPT_UNISWAP_V2,
             notify_user=self.notify_user,
-            native_currency=self.evm_inquirer.native_token,
+            native_currency=self.node_inquirer.native_token,
         )
 
     def _maybe_decode_v2_swap(
@@ -99,8 +99,8 @@ class Uniswapv2CommonDecoder(DecoderInterface):
                     transaction=transaction,
                     counterparty=CPT_UNISWAP_V2,
                     router_address=self.router_address,
-                    database=self.evm_inquirer.database,
-                    evm_inquirer=self.evm_inquirer,
+                    database=self.node_inquirer.database,
+                    evm_inquirer=self.node_inquirer,
                     notify_user=self.notify_user,
                 )
 
@@ -126,8 +126,8 @@ class Uniswapv2CommonDecoder(DecoderInterface):
                 all_logs=all_logs,
                 is_deposit=True,
                 counterparty=CPT_UNISWAP_V2,
-                evm_inquirer=self.evm_inquirer,
-                database=self.evm_inquirer.database,
+                evm_inquirer=self.node_inquirer,
+                database=self.node_inquirer.database,
                 factory_address=self.factory_address,
                 init_code_hash=UNISWAP_V2_INIT_CODE_HASH,
                 tx_hash=transaction.tx_hash,
@@ -139,8 +139,8 @@ class Uniswapv2CommonDecoder(DecoderInterface):
                 all_logs=all_logs,
                 is_deposit=False,
                 counterparty=CPT_UNISWAP_V2,
-                evm_inquirer=self.evm_inquirer,
-                database=self.evm_inquirer.database,
+                evm_inquirer=self.node_inquirer,
+                database=self.node_inquirer.database,
                 factory_address=self.factory_address,
                 init_code_hash=UNISWAP_V2_INIT_CODE_HASH,
                 tx_hash=transaction.tx_hash,

--- a/rotkehlchen/chain/evm/decoding/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v4/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     ActionItem,
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class Uniswapv4CommonDecoder(DecoderInterface):
+class Uniswapv4CommonDecoder(EvmDecoderInterface):
 
     def __init__(
             self,
@@ -66,7 +66,7 @@ class Uniswapv4CommonDecoder(DecoderInterface):
         if context.tx_log.topics[0] != MODIFY_LIQUIDITY:
             return DEFAULT_DECODING_OUTPUT
 
-        if len(pool_info := self.evm_inquirer.call_contract(
+        if len(pool_info := self.node_inquirer.call_contract(
             contract_address=self.position_manager,
             abi=POSITION_MANAGER_ABI,
             method_name='poolKeys',
@@ -173,7 +173,7 @@ class Uniswapv4CommonDecoder(DecoderInterface):
         """
         return decode_uniswap_v3_like_position_create_or_exit(
             decoded_events=decoded_events,
-            evm_inquirer=self.evm_inquirer,
+            evm_inquirer=self.node_inquirer,
             nft_manager=self.position_manager,
             counterparty=CPT_UNISWAP_V4,
             token_symbol='UNI-V4-POS',

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.evm.constants import (
     ZERO_ADDRESS,
 )
 from rotkehlchen.chain.evm.decoding.interfaces import (
-    DecoderInterface,
+    EvmDecoderInterface,
     ReloadablePoolsAndGaugesDecoderMixin,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class VelodromeLikeDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
+class VelodromeLikeDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMixin):
     """A decoder class for velodrome-like related events."""
 
     def __init__(
@@ -403,7 +403,7 @@ class VelodromeLikeDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixi
                 asset=get_or_create_evm_token(
                     userdb=self.base.database,
                     evm_address=self.voting_escrow_address,
-                    chain_id=self.evm_inquirer.chain_id,
+                    chain_id=self.node_inquirer.chain_id,
                     token_kind=TokenKind.ERC721,
                     collectible_id=str(token_id),
                 ),
@@ -453,7 +453,7 @@ class VelodromeLikeDecoder(DecoderInterface, ReloadablePoolsAndGaugesDecoderMixi
             asset=get_or_create_evm_token(
                 userdb=self.base.database,
                 evm_address=self.voting_escrow_address,
-                chain_id=self.evm_inquirer.chain_id,
+                chain_id=self.node_inquirer.chain_id,
                 token_kind=TokenKind.ERC721,
                 collectible_id=str(int.from_bytes(context.tx_log.topics[3])),
             ),

--- a/rotkehlchen/chain/evm/decoding/weth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/weth/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.assets.asset import CryptoAsset, EvmToken
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC_V2
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class WethDecoderBase(DecoderInterface, ABC):
+class WethDecoderBase(EvmDecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',

--- a/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.decoding.constants import GNOSIS_CPT_DETAILS
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class XdaiBridgeCommonDecoder(DecoderInterface, abc.ABC):
+class XdaiBridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
 
     def __init__(
             self,
@@ -143,7 +143,7 @@ class XdaiBridgeCommonDecoder(DecoderInterface, abc.ABC):
         else:
             log.error(
                 f'Could not find the transfer event for bridging to {to_address}'
-                f' in {self.evm_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
+                f' in {self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
             )
         return DEFAULT_DECODING_OUTPUT
 

--- a/rotkehlchen/chain/evm/decoding/zerox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/zerox/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class ZeroxCommonDecoder(DecoderInterface):
+class ZeroxCommonDecoder(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'EvmNodeInquirer',
@@ -47,7 +47,7 @@ class ZeroxCommonDecoder(DecoderInterface):
         flash_wallet_address is a contract that can execute arbitrary calls from 0x router_address.
         Docs: https://0x.org/docs/introduction/0x-cheat-sheet#exchange-proxy-addresses"""
         super().__init__(evm_inquirer, base_tools, msg_aggregator)
-        self.evm_txns = EvmTransactions(self.evm_inquirer, self.base.database)
+        self.evm_txns = EvmTransactions(self.node_inquirer, self.base.database)
         self.router_address = router_address
         self.settler_routers_addresses = settler_routers_addresses
         self.flash_wallet_address = flash_wallet_address

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface, ReloadableDecoderMixin
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class GnosisPayDecoder(DecoderInterface, ReloadableDecoderMixin):
+class GnosisPayDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/optimism/modules/optimism/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/optimism/decoder.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.constants import DELEGATE_CHANGED, OPTIMISM_CPT_DETAILS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -19,7 +19,7 @@ from rotkehlchen.utils.misc import bytes_to_address
 OPTIMISM_TOKEN = string_to_evm_address('0x4200000000000000000000000000000000000042')
 
 
-class OptimismDecoder(DecoderInterface):
+class OptimismDecoder(EvmDecoderInterface):
 
     def _decode_delegate_changed(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != DELEGATE_CHANGED:

--- a/rotkehlchen/chain/optimism/modules/walletconnect/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/walletconnect/decoder.py
@@ -7,7 +7,7 @@ from rotkehlchen.chain.ethereum.utils import (
 )
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, STAKING_DEPOSIT
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT, DecodingOutput
 from rotkehlchen.chain.optimism.modules.walletconnect.constants import WALLETCONECT_STAKE_WEIGHT
 from rotkehlchen.constants.misc import ZERO
@@ -39,7 +39,7 @@ TOKENS_CLAIMED: Final = b'\x89n\x03If\xea\xaf\x1a\xdcT\xac\xc0\xf2W\x05o\xeb\xbd
 STAKING_WITHDRAW: Final = b"\x02\xf2Rp\xa4\xd8{\xeau\xdbT\x1c\xdf\xe5Y3J'[J#5 \xedl\n$)f|\xca\x94"
 
 
-class WalletconnectDecoder(DecoderInterface, CustomizableDateMixin):
+class WalletconnectDecoder(EvmDecoderInterface, CustomizableDateMixin):
 
     def __init__(
             self,

--- a/rotkehlchen/chain/polygon_pos/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/giveth/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_DETAILS_GIVETH, CPT_GIVETH
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class GivethDecoder(DecoderInterface):
+class GivethDecoder(EvmDecoderInterface):
 
     def _decode_donation_events(self, context: DecoderContext) -> DecodingOutput:
         if context.tx_log.topics[0] != DONATION_MADE_TOPIC:

--- a/rotkehlchen/chain/polygon_pos/modules/polygon_pos_bridge/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/polygon_pos_bridge/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON, CPT_POLYGON_DETAILS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
@@ -34,7 +34,7 @@ PLASMA_BRIDGE_CHILD_CHAIN: Final = string_to_evm_address('0xD9c7C4ED4B66858301D0
 POL_TOKEN_ADDRESS = string_to_evm_address('0x0000000000000000000000000000000000001010')
 
 
-class PolygonPosBridgeDecoder(DecoderInterface):
+class PolygonPosBridgeDecoder(EvmDecoderInterface):
 
     def _decode_withdraw(self, context: DecoderContext) -> DecodingOutput:
         """Decodes bridge withdraw events.

--- a/rotkehlchen/chain/scroll/modules/scroll_airdrop/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_airdrop/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import CLAIMED_TOPIC
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
 from rotkehlchen.chain.scroll.constants import CPT_SCROLL, SCROLL_CPT_DETAILS
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -25,7 +25,7 @@ log = RotkehlchenLogsAdapter(logger)
 EXECUTION_SUCCESS_TOPIC: Final = b"D.q_bcF\xe8\xc5C\x81\x00-\xa6\x14\xf6+\xee\x8d'8e5\xb2R\x1e\xc8T\x08\x98Un"  # noqa: E501
 
 
-class ScrollAirdropDecoder(DecoderInterface):
+class ScrollAirdropDecoder(EvmDecoderInterface):
 
     def _decode_airdop_claim(self, context: 'DecoderContext') -> 'DecodingOutput':
         """Decodes scroll SCR airdrop claim event."""

--- a/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
@@ -7,7 +7,7 @@ from eth_abi import decode as decode_abi
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_DECODING_OUTPUT,
     DecoderContext,
@@ -48,7 +48,7 @@ RELAYED_MESSAGE: Final = b"FA\xdfJ\x96 q\xe1'\x19\xd8\xc8\xc8\xe5\xac\x7f\xc4\xd
 RELAY_MESSAGE: Final = b'\x8e\xf13.'
 
 
-class ScrollBridgeDecoder(DecoderInterface):
+class ScrollBridgeDecoder(EvmDecoderInterface):
     def __init__(
             self,
             evm_inquirer: 'ScrollInquirer',

--- a/rotkehlchen/chain/solana/decoding/decoder.py
+++ b/rotkehlchen/chain/solana/decoding/decoder.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import Any
+
+from rotkehlchen.types import SolanaAddress
+
+
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
+class SolanaDecodingRules:
+    address_mappings: dict[SolanaAddress, tuple[Any, ...]]
+
+    def __add__(self, other: 'SolanaDecodingRules') -> 'SolanaDecodingRules':
+        if not isinstance(other, SolanaDecodingRules):
+            raise TypeError(
+                f'Can only add SolanaDecodingRules to SolanaDecodingRules. Got {type(other)}',
+            )
+
+        return SolanaDecodingRules(
+            address_mappings=self.address_mappings | other.address_mappings,
+        )


### PR DESCRIPTION
* Refactors the existing evm only `DecoderInterface` into a generic base `DecoderInterface` and an `EvmDecoderInterface`. Doesn't actually add a `SolanaDecoderInterface` since we don't have a `SolanaDecoderTools` yet.
* Adds a `SolanaDecodingRules` dataclass with just address_mappings as this should work for most instruction decoding I think.

The majority of the changes are simply renaming `DecoderInterface` to `EvmDecoderInterface` throughout and changing `self.evm_inquirer` to `self.node_inquirer` in the decoders.