### PR TITLE
Add SolanaTransactionDecoder class

### DIFF
--- a/rotkehlchen/chain/solana/decoding/decoder.py
+++ b/rotkehlchen/chain/solana/decoding/decoder.py
@@ -1,7 +1,27 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.types import SolanaAddress
+from solders.solders import Signature
+
+from rotkehlchen.chain.decoding.decoder import TransactionDecoder
+from rotkehlchen.chain.solana.decoding.interfaces import SolanaDecoderInterface
+from rotkehlchen.chain.solana.decoding.tools import SolanaDecoderTools
+from rotkehlchen.chain.solana.types import SolanaTransaction
+from rotkehlchen.chain.solana.utils import lamports_to_sol
+from rotkehlchen.constants.assets import A_SOL
+from rotkehlchen.db.filtering import SolanaTransactionsNotDecodedFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.solanatx import DBSolanaTx
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+from rotkehlchen.types import SolanaAddress, SupportedBlockchain
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
+    from rotkehlchen.chain.solana.transactions import SolanaTransactions
+    from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.drivers.gevent import DBCursor
+    from rotkehlchen.premium.premium import Premium
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
@@ -17,3 +37,66 @@ class SolanaDecodingRules:
         return SolanaDecodingRules(
             address_mappings=self.address_mappings | other.address_mappings,
         )
+
+
+class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecodingRules, SolanaDecoderInterface, Signature, SolanaEvent, SolanaTransaction, SolanaDecoderTools, DBSolanaTx, SolanaTransactionsNotDecodedFilterQuery]):  # noqa: E501
+
+    def __init__(
+            self,
+            database: 'DBHandler',
+            node_inquirer: 'SolanaInquirer',
+            transactions: 'SolanaTransactions',
+            base_tools: 'SolanaDecoderTools',
+            premium: 'Premium | None' = None,
+    ):
+        self.node_inquirer = node_inquirer
+        self.transactions = transactions
+        self.dbevents = DBHistoryEvents(database)
+        super().__init__(
+            database=database,
+            dbtx=DBSolanaTx(database),
+            tx_not_decoded_filter_query_class=SolanaTransactionsNotDecodedFilterQuery,
+            chain_name=SupportedBlockchain.SOLANA.name.lower(),
+            value_asset=A_SOL.resolve_to_asset_with_oracles(),
+            rules=SolanaDecodingRules(address_mappings={}),
+            premium=premium,
+            base_tools=base_tools,
+            misc_counterparties=[],
+            possible_decoding_exceptions=(),
+        )
+
+    def _add_builtin_decoders(self, rules: SolanaDecodingRules) -> None:
+        # TODO: add native/token transfer decoders here
+        ...
+
+    def _add_single_decoder(
+            self,
+            class_name: str,
+            decoder_class: type[SolanaDecoderInterface],
+            rules: SolanaDecodingRules,
+    ) -> None:
+        # TODO: initialize a single decoder here
+        ...
+
+    @staticmethod
+    def _load_default_decoding_rules() -> SolanaDecodingRules:
+        return SolanaDecodingRules(address_mappings={})
+
+    def _load_transaction_context(
+            self,
+            cursor: 'DBCursor',
+            tx_hash: Signature,
+    ) -> SolanaTransaction:
+        return self.transactions.get_or_create_transaction(signature=tx_hash)
+
+    def _decode_transaction_from_context(
+            self,
+            context: SolanaTransaction,
+            ignore_cache: bool,
+            delete_customized: bool,
+    ) -> tuple[list[SolanaEvent], bool, set[str] | None]:
+        # TODO: load existing events from the db or do decoding here
+        return [], False, None
+
+    def _calculate_fees(self, tx: SolanaTransaction) -> FVal:
+        return lamports_to_sol(tx.fee)

--- a/rotkehlchen/chain/solana/transactions.py
+++ b/rotkehlchen/chain/solana/transactions.py
@@ -1,0 +1,146 @@
+import logging
+from typing import TYPE_CHECKING, Final
+
+from solders.solders import Signature
+
+from rotkehlchen.api.websockets.typedefs import (
+    TransactionStatusStep,
+    TransactionStatusSubType,
+    WSMessageType,
+)
+from rotkehlchen.chain.solana.types import SolanaTransaction
+from rotkehlchen.db.filtering import SolanaTransactionsFilterQuery
+from rotkehlchen.db.solanatx import DBSolanaTx
+from rotkehlchen.errors.misc import MissingAPIKey, RemoteError
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.externalapis.helius import Helius
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.types import SolanaAddress, SupportedBlockchain, Timestamp
+from rotkehlchen.utils.misc import get_chunks, ts_now
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
+    from rotkehlchen.db.dbhandler import DBHandler
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+# The number of txs to query from RPCs before saving progress in the DB.
+# Using the api.mainnet-beta.solana.com RPC 10 txs took ~1 minute.
+RPC_TX_BATCH_SIZE: Final = 10
+
+
+class SolanaTransactions:
+
+    def __init__(
+            self,
+            node_inquirer: 'SolanaInquirer',
+            database: 'DBHandler',
+    ) -> None:
+        self.node_inquirer = node_inquirer
+        self.database = database
+        self.dbtx = DBSolanaTx(database=database)
+        self.helius = Helius(database=database)
+
+    def get_or_create_transaction(
+            self,
+            signature: Signature,
+            relevant_address: SolanaAddress | None = None,
+    ) -> SolanaTransaction:
+        """Gets a transaction from the DB or from onchain. If it must be queried from onchain, it
+        is also saved to the DB.
+        May raise:
+        - RemoteError if there is a problem with querying the external service.
+        - DeserializationError if there is a problem deserializing the transaction data.
+        """
+        with self.database.conn.read_ctx() as cursor:
+            if len(txs := self.dbtx.get_transactions(
+                cursor=cursor,
+                filter_=SolanaTransactionsFilterQuery.make(signature=signature),
+            )) == 1:
+                return txs[0]
+
+        tx = self.node_inquirer.get_transaction_for_signature(signature=signature)
+        with self.database.conn.write_ctx() as write_cursor:
+            self.dbtx.add_transactions(
+                write_cursor=write_cursor,
+                solana_transactions=[tx],
+                relevant_address=relevant_address,
+            )
+
+        return tx
+
+    def query_transactions_for_address(self, address: SolanaAddress) -> None:
+        """Query the transactions for the given address and save them to the DB.
+        Only queries new transactions if there are already transactions in the DB.
+        May raise RemoteError if there is a problem with querying the external service.
+        """
+        last_existing_sig, start_ts, end_ts = None, Timestamp(0), ts_now()
+        with self.database.conn.read_ctx() as cursor:
+            cursor.execute(
+                'SELECT st.signature, max(st.block_time) FROM solana_transactions st '
+                'JOIN solanatx_address_mappings sam ON st.identifier == sam.tx_id '
+                'WHERE sam.address = ?',
+                (address,),
+            )
+            if (max_result := cursor.fetchone()) is not None and None not in max_result:
+                last_existing_sig = Signature.from_bytes(max_result[0])
+                start_ts = Timestamp(max_result[1])
+
+        self.database.msg_aggregator.add_message(
+            message_type=WSMessageType.TRANSACTION_STATUS,
+            data={
+                'address': address,
+                'chain': SupportedBlockchain.SOLANA.value,
+                'subtype': str(TransactionStatusSubType.SOLANA),
+                'period': [start_ts, end_ts],
+                'status': str(TransactionStatusStep.QUERYING_TRANSACTIONS_STARTED),
+            },
+        )
+
+        # Get the list of signatures from the RPCs
+        signatures = self.node_inquirer.query_tx_signatures_for_address(
+            address=address,
+            until=last_existing_sig,
+        )
+
+        try:  # Query the tx data for each signature from either Helius or the RPCs and save it.
+            self.helius.get_transactions(
+                signatures=[str(x) for x in signatures],
+                relevant_address=address,
+            )
+        except (RemoteError, MissingAPIKey) as e:
+            log.debug(
+                f'Unable to query solana transactions from Helius due to {e!s} '
+                f'Falling back to querying from the RPCs for address {address}.',
+            )
+            solana_tx_db = DBSolanaTx(database=self.database)
+            for chunk in get_chunks(signatures, RPC_TX_BATCH_SIZE):
+                transactions = []
+                for signature in chunk:
+                    try:
+                        transactions.append(self.node_inquirer.get_transaction_for_signature(signature))
+                    except (RemoteError, DeserializationError) as e_:
+                        log.error(
+                            f'Failed to query solana transaction with signature {signature} '
+                            f'from the RPCs due to {e_!s}. Skipping.',
+                        )
+                        continue
+
+                with self.database.conn.write_ctx() as write_cursor:
+                    solana_tx_db.add_transactions(
+                        write_cursor=write_cursor,
+                        solana_transactions=transactions,
+                        relevant_address=address,
+                    )
+
+        self.database.msg_aggregator.add_message(
+            message_type=WSMessageType.TRANSACTION_STATUS,
+            data={
+                'address': address,
+                'chain': SupportedBlockchain.SOLANA.value,
+                'subtype': str(TransactionStatusSubType.SOLANA),
+                'period': [start_ts, end_ts],
+                'status': str(TransactionStatusStep.QUERYING_TRANSACTIONS_FINISHED),
+            },
+        )

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -48,6 +48,7 @@ from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
 from rotkehlchen.chain.scroll.manager import ScrollManager
 from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
 from rotkehlchen.chain.solana.manager import SolanaManager
+from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
 from rotkehlchen.chain.substrate.manager import SubstrateManager
 from rotkehlchen.chain.substrate.utils import (
     KUSAMA_NODES_TO_CONNECT_AT_START,
@@ -472,8 +473,11 @@ class Rotkehlchen:
             bitcoin_manager=BitcoinManager(database=self.data.db),
             bitcoin_cash_manager=BitcoinCashManager(database=self.data.db),
             solana_manager=SolanaManager(
-                greenlet_manager=self.greenlet_manager,
-                database=self.data.db,
+                node_inquirer=SolanaInquirer(
+                    greenlet_manager=self.greenlet_manager,
+                    database=self.data.db,
+                ),
+                premium=self.premium,
             ),
             msg_aggregator=self.msg_aggregator,
             database=self.data.db,

--- a/rotkehlchen/tests/api/test_solana_transactions.py
+++ b/rotkehlchen/tests/api/test_solana_transactions.py
@@ -58,19 +58,19 @@ def test_query_solana_transactions(
     )):
         with (
             patch.object(
-                target=rotki.chains_aggregator.solana,
+                target=rotki.chains_aggregator.solana.node_inquirer,
                 attribute='query_tx_signatures_for_address',
                 side_effect=lambda address, until, sigs=signatures_list: sigs,
             ) as mock_query_tx_signatures_for_address,
             patch.object(
-                target=rotki.chains_aggregator.solana.helius,
+                target=rotki.chains_aggregator.solana.transactions.helius,
                 attribute='get_transactions',
-                wraps=rotki.chains_aggregator.solana.helius.get_transactions,
+                wraps=rotki.chains_aggregator.solana.transactions.helius.get_transactions,
             ) as mock_helius_get_transactions,
             patch.object(
-                target=rotki.chains_aggregator.solana,
-                attribute='query_rpc_for_single_tx',
-                wraps=rotki.chains_aggregator.solana.query_rpc_for_single_tx,
+                target=rotki.chains_aggregator.solana.node_inquirer,
+                attribute='get_transaction_for_signature',
+                wraps=rotki.chains_aggregator.solana.node_inquirer.get_transaction_for_signature,
             ) as mock_rpc_get_transaction,
         ):
             response = requests.post(

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -38,6 +38,7 @@ from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
 from rotkehlchen.chain.scroll.manager import ScrollManager
 from rotkehlchen.chain.scroll.node_inquirer import ScrollInquirer
 from rotkehlchen.chain.solana.manager import SolanaManager
+from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
 from rotkehlchen.chain.substrate.manager import SubstrateChainProperties, SubstrateManager
 from rotkehlchen.chain.substrate.types import SubstrateAddress
 from rotkehlchen.chain.zksync_lite.manager import ZksyncLiteManager
@@ -858,12 +859,17 @@ def fixture_btc_derivation_gap_limit():
     return DEFAULT_BTC_DERIVATION_GAP_LIMIT
 
 
-@pytest.fixture(name='solana_manager')
-def fixture_solana_manager(greenlet_manager, database):
-    return SolanaManager(
+@pytest.fixture(name='solana_inquirer')
+def fixture_solana_inquirer(greenlet_manager, database):
+    return SolanaInquirer(
         greenlet_manager=greenlet_manager,
         database=database,
     )
+
+
+@pytest.fixture(name='solana_manager')
+def fixture_solana_manager(solana_inquirer):
+    return SolanaManager(node_inquirer=solana_inquirer)
 
 
 @pytest.fixture(name='blockchain')

--- a/rotkehlchen/tests/unit/test_solana.py
+++ b/rotkehlchen/tests/unit/test_solana.py
@@ -14,6 +14,7 @@ from rotkehlchen.types import SolanaAddress, Timestamp, TokenKind
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.solana.manager import SolanaManager
+    from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
     from rotkehlchen.globaldb.handler import GlobalDBHandler
 
 
@@ -68,7 +69,7 @@ def test_solana_token_balances(
 
 @pytest.mark.vcr
 def test_solana_query_token_metadata(
-        solana_manager: 'SolanaManager',
+        solana_inquirer: 'SolanaInquirer',
         globaldb: 'GlobalDBHandler',
 ) -> None:
     """Test that the solana token metadata is queried correctly for different types of tokens.
@@ -84,9 +85,9 @@ def test_solana_query_token_metadata(
             globaldb.delete_asset_by_identifier(identifier=asset.identifier)
 
         get_or_create_solana_token(
-            userdb=solana_manager.database,
+            userdb=solana_inquirer.database,
             address=SolanaAddress(asset.identifier.split(':')[1]),
-            solana_inquirer=solana_manager.node_inquirer,
+            solana_inquirer=solana_inquirer,
         )
 
     amep_token = get_solana_token(identifier_to_address(a_amep.identifier))
@@ -133,8 +134,8 @@ def test_is_nft_via_offchain_metadata() -> None:
 
 
 @pytest.mark.vcr
-def test_query_tx_from_rpc(solana_manager: 'SolanaManager') -> None:
-    tx = solana_manager.query_rpc_for_single_tx(
+def test_query_tx_from_rpc(solana_inquirer: 'SolanaInquirer') -> None:
+    tx = solana_inquirer.get_transaction_for_signature(
         signature=(signature := Signature.from_string('58F9fNP78FiBCbVc2Gdy6on2d6pZiJcTbqib4MsTfNcgAXqS7UGp3a3eeEy7fRWnLiXaJjncUHdqtpCnEFuVsVEM')),  # noqa: E501
     )
     assert tx is not None
@@ -167,8 +168,8 @@ def test_query_tx_from_rpc(solana_manager: 'SolanaManager') -> None:
 
 
 @pytest.mark.vcr
-def test_query_signatures_for_address(solana_manager: 'SolanaManager') -> None:
-    signatures = solana_manager.query_tx_signatures_for_address(
+def test_query_signatures_for_address(solana_inquirer: 'SolanaInquirer') -> None:
+    signatures = solana_inquirer.query_tx_signatures_for_address(
         address=SolanaAddress('7T8ckKtdc5DH7ACS5AnCny7rVXYJPEsaAbdBri1FhPxY'),
     )
     assert len(signatures) == 64


### PR DESCRIPTION
* Adds a basic SolanaTransactionDecoder class with todos for the functions that still need implemented (I am working on implementing these in another PR)
* Adds a new `SolanaTransactions` class similar to EvmTransactions - but not sharing a base class since it didn't look like that would really provide any benefit.
* Moves `query_tx_signatures_for_address`, `query_rpc_for_single_tx`, `_query_address_lookup_table`, and `deserialize_solana_tx_from_rpc` from the SolanaManger to the SolanaInquirer.
    - `query_rpc_for_single_tx` is also renamed to `get_transaction_for_signature` and changed to simply raise its errors instead of catching them and returning None.
    - the other functions are basically moved without change.
* Moves `query_transactions_for_address` from SolanaManager to SolanaTransactions