### PR TITLE
Add native sol transfer decoding

### DIFF
--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -42,6 +42,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
     deserialize_hex_color_code,
     deserialize_timestamp,
+    deserialize_tx_signature,
 )
 from rotkehlchen.types import (
     SUPPORTED_CHAIN_IDS,
@@ -792,7 +793,7 @@ class SolanaSignatureField(fields.Field):
         if not isinstance(value, str):
             raise ValidationError('Transaction signature should be a string')
 
-        return Signature.from_string(value)
+        return deserialize_tx_signature(value)
 
 
 class AssetTypeField(fields.Field):

--- a/rotkehlchen/chain/decoding/structures.py
+++ b/rotkehlchen/chain/decoding/structures.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T_Event = TypeVar('T_Event')
+
+
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
+class CommonDecodingOutput(Generic[T_Event]):
+    """Output of decoding functions
+
+    - events can be returned if the decoding method has generated new events and they need to be
+    added to the list of other decoded events.
+    - refresh_balances may be set to True if the user's on-chain balances in some protocols has
+    changed (for example if the user has deposited / withdrawn funds from a curve gauge).
+    - reload_decoders can be None in which case nothing happens. Or a set of decoders names
+    for which to reload data. The decoder's name is the class name without the Decoder suffix.
+    For example Eigenlayer for EigenlayerDecoder
+    """
+    events: list[T_Event] | None = None
+    refresh_balances: bool = False
+    reload_decoders: set[str] | None = None

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple, Optional
 
+from rotkehlchen.chain.decoding.structures import CommonDecodingOutput
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
@@ -68,29 +69,20 @@ class EnricherContext(DecoderBasicContext):
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
-class DecodingOutput:
-    """
-    Output of decoding functions
+class DecodingOutput(CommonDecodingOutput['EvmEvent']):
+    """Output of EVM decoding functions
 
-    - events can be returned if the decoding method has generated new events and they needs to be
-    added to the list of other decoded events.
     - action_items is a list of actions to be performed later automatically or to be passed
     in further decoding methods.
     - matched_counterparty is optionally set if needed for decoder rules that matched
     and is used in post-decoding rules like in the case of balancer
-    - refresh_balances may be set to True if the user's on-chain balances in some protocols has
-    changed (for example if the user has deposited / withdrawn funds from a curve gauge).
-    - reload_decoders can be None in which case nothing happens. Or a set of decoders names for which to reload data. The decoder's name is the class name without the Decoder suffix. For example Eigenlayer for EigenlayerDecoder
     - process_swaps indicates whether there are swaps that need to be converted into EvmSwapEvents.
     - stop_processing if true will stop processing log events for the transaction and clear
         any processed events. Used when we want to stop iterating over certain transactions
         because we have determined it's full of unnecessary log events and should all be skipped.
-    """  # noqa: E501
-    events: list['EvmEvent'] | None = None
+    """
     action_items: list[ActionItem] = field(default_factory=list)
     matched_counterparty: str | None = None
-    refresh_balances: bool = False
-    reload_decoders: set[str] | None = None
     process_swaps: bool = False
     stop_processing: bool = False
 

--- a/rotkehlchen/chain/solana/decoding/constants.py
+++ b/rotkehlchen/chain/solana/decoding/constants.py
@@ -1,0 +1,6 @@
+from typing import Final
+
+from rotkehlchen.types import SolanaAddress
+
+SYSTEM_PROGRAM: Final = SolanaAddress('11111111111111111111111111111111')
+NATIVE_TRANSFER_DELIMITER: Final = b'\x02\x00\x00\x00'

--- a/rotkehlchen/chain/solana/decoding/decoder.py
+++ b/rotkehlchen/chain/solana/decoding/decoder.py
@@ -1,20 +1,36 @@
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from solders.solders import Signature
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.decoder import TransactionDecoder
+from rotkehlchen.chain.decoding.utils import decode_safely
+from rotkehlchen.chain.evm.decoding.constants import OUTGOING_EVENT_TYPES
+from rotkehlchen.chain.solana.decoding.constants import NATIVE_TRANSFER_DELIMITER, SYSTEM_PROGRAM
 from rotkehlchen.chain.solana.decoding.interfaces import SolanaDecoderInterface
+from rotkehlchen.chain.solana.decoding.structures import (
+    SolanaDecoderContext,
+    SolanaDecodingOutput,
+)
 from rotkehlchen.chain.solana.decoding.tools import SolanaDecoderTools
-from rotkehlchen.chain.solana.types import SolanaTransaction
+from rotkehlchen.chain.solana.types import SolanaInstruction, SolanaTransaction
 from rotkehlchen.chain.solana.utils import lamports_to_sol
 from rotkehlchen.constants.assets import A_SOL
-from rotkehlchen.db.filtering import SolanaTransactionsNotDecodedFilterQuery
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.db.filtering import (
+    SolanaEventFilterQuery,
+    SolanaTransactionsNotDecodedFilterQuery,
+)
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.solanatx import DBSolanaTx
+from rotkehlchen.errors.misc import ModuleLoadingError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.solana_event import SolanaEvent
-from rotkehlchen.types import SolanaAddress, SupportedBlockchain
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.types import Location, SolanaAddress, SupportedBlockchain
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
@@ -22,6 +38,9 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
     from rotkehlchen.premium.premium import Premium
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
@@ -39,7 +58,7 @@ class SolanaDecodingRules:
         )
 
 
-class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecodingRules, SolanaDecoderInterface, Signature, SolanaEvent, SolanaTransaction, SolanaDecoderTools, DBSolanaTx, SolanaTransactionsNotDecodedFilterQuery]):  # noqa: E501
+class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecodingRules, SolanaDecoderInterface, Signature, SolanaEvent, SolanaTransaction, SolanaDecoderTools, DBSolanaTx, SolanaEventFilterQuery, SolanaTransactionsNotDecodedFilterQuery]):  # noqa: E501
 
     def __init__(
             self,
@@ -56,6 +75,7 @@ class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecod
             database=database,
             dbtx=DBSolanaTx(database),
             tx_not_decoded_filter_query_class=SolanaTransactionsNotDecodedFilterQuery,
+            tx_mappings_table='solana_tx_mappings',
             chain_name=SupportedBlockchain.SOLANA.name.lower(),
             value_asset=A_SOL.resolve_to_asset_with_oracles(),
             rules=SolanaDecodingRules(address_mappings={}),
@@ -66,8 +86,7 @@ class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecod
         )
 
     def _add_builtin_decoders(self, rules: SolanaDecodingRules) -> None:
-        # TODO: add native/token transfer decoders here
-        ...
+        """No-op for solana. All decoders are loaded dynamically."""
 
     def _add_single_decoder(
             self,
@@ -75,8 +94,28 @@ class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecod
             decoder_class: type[SolanaDecoderInterface],
             rules: SolanaDecodingRules,
     ) -> None:
-        # TODO: initialize a single decoder here
-        ...
+        """Initialize a single decoder, add it to the set of decoders to use
+        and append its rules to the passed rules
+        """
+        if class_name in self.decoders:
+            raise ModuleLoadingError(f'{self.chain_name} decoder with name {class_name} already loaded')  # noqa: E501
+
+        self.decoders[class_name] = (decoder := decoder_class(
+            node_inquirer=self.node_inquirer,
+            base_tools=self.base,
+            msg_aggregator=self.msg_aggregator,
+        ))
+        new_address_to_decoders = decoder.addresses_to_decoders()
+
+        if __debug__:  # sanity checks for now only in debug as decoders are constant
+            self.assert_keys_are_unique(
+                new_struct=new_address_to_decoders,
+                main_struct=rules.address_mappings,
+                class_name=class_name,
+                type_name='address_mappings',
+            )
+
+        rules.address_mappings.update(new_address_to_decoders)
 
     @staticmethod
     def _load_default_decoding_rules() -> SolanaDecodingRules:
@@ -95,8 +134,166 @@ class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecod
             ignore_cache: bool,
             delete_customized: bool,
     ) -> tuple[list[SolanaEvent], bool, set[str] | None]:
-        # TODO: load existing events from the db or do decoding here
-        return [], False, None
+        if (events := self._maybe_load_or_purge_events_from_db(
+            transaction=context,
+            tx_ref=context.signature,
+            location=Location.SOLANA,
+            ignore_cache=ignore_cache,
+            delete_customized=delete_customized,
+        )) is not None:
+            return events, False, None
+
+        # else we should decode now
+        return self._decode_transaction(transaction=context)
+
+    def _make_event_filter_query(self, tx_ref: Signature) -> SolanaEventFilterQuery:
+        return SolanaEventFilterQuery.make(signatures=[tx_ref])
 
     def _calculate_fees(self, tx: SolanaTransaction) -> FVal:
         return lamports_to_sol(tx.fee)
+
+    def _maybe_decode_fee_event(self, transaction: SolanaTransaction) -> SolanaEvent | None:
+        """Decode the fee event for the given transaction.
+        Returns the fee event or None if the fee is zero or the fee payer is not tracked.
+        """
+        if transaction.fee == ZERO or not self.base.is_tracked(fee_payer := transaction.account_keys[0]):  # noqa: E501
+            return None
+
+        return self.base.make_event_next_index(
+            tx_hash=transaction.signature,
+            timestamp=transaction.block_time,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_SOL,
+            amount=(amount := lamports_to_sol(transaction.fee)),
+            location_label=fee_payer,
+            notes=f'Spend {amount} SOL as transaction fee',
+            counterparty=CPT_GAS,
+        )
+
+    def _maybe_decode_native_transfer(
+            self,
+            transaction: SolanaTransaction,
+            instruction: SolanaInstruction,
+    ) -> SolanaEvent | None:
+        """Decode native SOL transfers."""
+        if instruction.program_id != SYSTEM_PROGRAM or instruction.data[:4] != NATIVE_TRANSFER_DELIMITER:  # noqa: E501
+            return None
+
+        if (account_len := len(instruction.accounts)) < 2:
+            log.error(
+                f'Encountered a native transfer instruction in {transaction} '
+                f'with {account_len} accounts. Expected 2. Skipping.',
+            )
+            return None
+
+        if (
+            (direction_result := self.base.decode_direction(
+                from_address=instruction.accounts[0],
+                to_address=instruction.accounts[1],
+            )) is None or
+            (raw_amount := int.from_bytes(instruction.data[4:12], byteorder='little')) == 0
+        ):
+            return None
+
+        amount = lamports_to_sol(raw_amount)
+        event_type, event_subtype, location_label, address, counterparty, verb = direction_result
+        counterparty_or_address = counterparty or address
+        preposition = 'to' if event_type in OUTGOING_EVENT_TYPES else 'from'
+        return self.base.make_event_next_index(
+            tx_hash=transaction.signature,
+            timestamp=transaction.block_time,
+            event_type=event_type,
+            event_subtype=event_subtype,
+            asset=A_SOL,
+            amount=amount,
+            location_label=location_label,
+            notes=f'{verb} {amount} SOL {preposition} {counterparty_or_address}',
+            counterparty=counterparty,
+            address=address,
+        )
+
+    def _decode_basic_events(
+            self,
+            transaction: SolanaTransaction,
+    ) -> tuple[list[SolanaEvent], list[SolanaInstruction]]:
+        """Decode the basic events (fee, transfers, etc.) for the given transaction.
+        Returns a tuple containing the list of decoded events and the list of instructions that
+        have not been decoded yet.
+        """
+        events: list[SolanaEvent] = []
+        if (fee_event := self._maybe_decode_fee_event(transaction=transaction)) is not None:
+            events.append(fee_event)
+
+        # Decode basic transfer instructions so that the more complex decoding that runs later
+        # can simply modify the already decoded transfer events.
+        undecoded_instructions = []
+        for instruction in transaction.instructions:
+            if (native_transfer_event := self._maybe_decode_native_transfer(
+                transaction=transaction,
+                instruction=instruction,
+            )) is not None:
+                events.append(native_transfer_event)
+                continue
+
+            # TODO: also decode token transfers here
+
+            undecoded_instructions.append(instruction)
+
+        return events, undecoded_instructions
+
+    def _decode_transaction(
+            self,
+            transaction: SolanaTransaction,
+    ) -> tuple[list[SolanaEvent], bool, set[str] | None]:
+        """Decodes a solana transaction and saves the result in the DB.
+        Returns
+        - the list of decoded events
+        - a flag which is True if balances refresh is needed
+        - A list of decoders to reload or None if no need
+        """
+        log.debug(f'Starting decoding of solana transaction {transaction.signature!s}')
+
+        if len(transaction.account_keys) == 0 or len(transaction.instructions) == 0:
+            log.warning(
+                f'Solana transaction {transaction.signature!s} '
+                f'has empty instructions or accounts. Skipping.',
+            )
+            return [], False, None
+
+        self.base.reset_sequence_counter(tx_data=transaction)
+        events, undecoded_instructions = self._decode_basic_events(transaction=transaction)
+        refresh_balances, reload_decoders = False, set()
+        for instruction in undecoded_instructions:
+            if (mapping_result := self.rules.address_mappings.get(instruction.program_id)) is None:
+                continue
+
+            context = SolanaDecoderContext(
+                transaction=transaction,
+                instruction=instruction,
+                decoded_events=events,
+            )
+            method, *args = mapping_result
+            decoding_output: SolanaDecodingOutput
+            decoding_output, err = decode_safely(  # can't used named arguments with *args
+                self.possible_decoding_exceptions,
+                self.msg_aggregator,
+                SupportedBlockchain.SOLANA,
+                method,
+                str(context.transaction.signature),
+                *(context, *args),
+            )
+            if err:
+                continue
+
+            if decoding_output.refresh_balances:
+                refresh_balances = True
+            if decoding_output.reload_decoders is not None:
+                reload_decoders.update(decoding_output.reload_decoders)
+            if decoding_output.events is not None:
+                events.extend(decoding_output.events)
+
+        if len(reload_decoders) == 0:
+            return events, refresh_balances, None
+
+        return events, refresh_balances, reload_decoders

--- a/rotkehlchen/chain/solana/decoding/structures.py
+++ b/rotkehlchen/chain/solana/decoding/structures.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Final
+
+from rotkehlchen.chain.decoding.structures import CommonDecodingOutput
+from rotkehlchen.chain.solana.types import SolanaInstruction, SolanaTransaction
+from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+
+
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
+class SolanaDecoderContext:
+    """Arguments context for decoding rules"""
+    instruction: SolanaInstruction
+    transaction: SolanaTransaction
+    decoded_events: list[SolanaEvent]
+
+
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
+class SolanaDecodingOutput(CommonDecodingOutput[SolanaEvent]):
+    ...
+
+
+DEFAULT_SOLANA_DECODING_OUTPUT: Final = SolanaDecodingOutput()

--- a/rotkehlchen/db/dbtx.py
+++ b/rotkehlchen/db/dbtx.py
@@ -7,13 +7,16 @@ from rotkehlchen.db.filtering import (
 )
 
 if TYPE_CHECKING:
+    from solders.solders import Signature
+
+    from rotkehlchen.chain.solana.types import SolanaTransaction
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
-
+    from rotkehlchen.types import EvmTransaction, EVMTxHash
 
 T_Address = TypeVar('T_Address')
-T_Transaction = TypeVar('T_Transaction')
-T_TxHash = TypeVar('T_TxHash')
+T_Transaction = TypeVar('T_Transaction', bound='SolanaTransaction | EvmTransaction')
+T_TxHash = TypeVar('T_TxHash', bound='EVMTxHash | Signature')
 T_TxFilterQuery = TypeVar('T_TxFilterQuery')
 T_TxNotDecodedFilterQuery = TypeVar(
     'T_TxNotDecodedFilterQuery',

--- a/rotkehlchen/externalapis/helius.py
+++ b/rotkehlchen/externalapis/helius.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 import gevent
 import requests
 from base58 import b58decode
-from solders.solders import Signature
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.solana.types import SolanaInstruction, SolanaTransaction
@@ -20,6 +19,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_int,
     deserialize_solana_address,
     deserialize_timestamp,
+    deserialize_tx_signature,
 )
 from rotkehlchen.utils.misc import get_chunks
 from rotkehlchen.utils.serialization import jsonloads_list
@@ -182,7 +182,7 @@ class Helius(ExternalServiceWithApiKey):
                 fee=deserialize_int(value=raw_tx['fee'], location='solana tx fee from helius'),
                 slot=deserialize_int(value=raw_tx['slot'], location='solana tx slot from helius'),
                 success=raw_tx.get('transactionError') is None,
-                signature=Signature.from_string(raw_tx['signature']),
+                signature=deserialize_tx_signature(raw_tx['signature']),
                 block_time=deserialize_timestamp(raw_tx['timestamp']),
                 account_keys=[deserialize_solana_address(x['account']) for x in raw_tx['accountData']],  # noqa: E501
                 instructions=instructions,

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, overload
 
 from eth_utils import to_checksum_address
-from solders.solders import Pubkey
+from solders.solders import Pubkey, Signature
 
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import (
     L2_CHAINIDS_WITH_L1_FEES,
@@ -356,6 +356,16 @@ def deserialize_solana_address(value: str) -> SolanaAddress:
         return SolanaAddress(str(Pubkey.from_string(value)))
     except ValueError as e:
         raise DeserializationError(f'Invalid solana address: {value}') from e
+
+
+def deserialize_tx_signature(value: str) -> Signature:
+    """Deserialize a solana transaction signature from a string.
+    May raise DeserializationError if the data is invalid.
+    """
+    try:
+        return Signature.from_string(value)
+    except ValueError as e:
+        raise DeserializationError(f'Failed to deserialize solana tx signature due to {e!s}') from e  # noqa: E501
 
 
 def deserialize_int_from_str(symbol: str, location: str) -> int:

--- a/rotkehlchen/tests/api/test_solana_transactions.py
+++ b/rotkehlchen/tests/api/test_solana_transactions.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 
 import pytest
 import requests
-from solders.solders import Signature
 
 from rotkehlchen.chain.solana.types import SolanaTransaction
 from rotkehlchen.db.filtering import SolanaTransactionsFilterQuery
 from rotkehlchen.db.solanatx import DBSolanaTx
+from rotkehlchen.serialization.deserialize import deserialize_tx_signature
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
 from rotkehlchen.tests.utils.factories import make_solana_address, make_solana_signature
 from rotkehlchen.types import SolanaAddress
@@ -49,12 +49,12 @@ def test_query_solana_transactions(
 
     tx_count = 1
     for signatures_list, until_sig in ((
-        (Signature.from_string('5vBFfTGrcdkE7ZdsUDSU2kRkhoFp4EgKtLLB6h2m1uQoG5wCddCkFGnNjXaHrV2r1kZ8CpJfh7UcWJ9tFXAyKc8Q'),
-        Signature.from_string('2ZYFMzQMpDFcAmXo2UMhGErSitNpuZ4zeu548QvMU8k37cgetF91wTYnGmN1oZq6EG7zXaZyNPCzWtakDnSJEtgF')),
+        (deserialize_tx_signature('5vBFfTGrcdkE7ZdsUDSU2kRkhoFp4EgKtLLB6h2m1uQoG5wCddCkFGnNjXaHrV2r1kZ8CpJfh7UcWJ9tFXAyKc8Q'),
+        deserialize_tx_signature('2ZYFMzQMpDFcAmXo2UMhGErSitNpuZ4zeu548QvMU8k37cgetF91wTYnGmN1oZq6EG7zXaZyNPCzWtakDnSJEtgF')),
         None,  # First query ignores the tx already in the DB because it's for a different address.
     ), (
-        (Signature.from_string('LLco7QQYo9HVc8w6YZeabxrdhZAjQxGRvrk1hNCJPrHGYAELjh3HwQKvTA1n8bWmkcLyKkFivieooK8C9LvYZuy'),),
-        Signature.from_string('5vBFfTGrcdkE7ZdsUDSU2kRkhoFp4EgKtLLB6h2m1uQoG5wCddCkFGnNjXaHrV2r1kZ8CpJfh7UcWJ9tFXAyKc8Q'),
+        (deserialize_tx_signature('LLco7QQYo9HVc8w6YZeabxrdhZAjQxGRvrk1hNCJPrHGYAELjh3HwQKvTA1n8bWmkcLyKkFivieooK8C9LvYZuy'),),
+        deserialize_tx_signature('5vBFfTGrcdkE7ZdsUDSU2kRkhoFp4EgKtLLB6h2m1uQoG5wCddCkFGnNjXaHrV2r1kZ8CpJfh7UcWJ9tFXAyKc8Q'),
     )):
         with (
             patch.object(

--- a/rotkehlchen/tests/external_apis/test_helius.py
+++ b/rotkehlchen/tests/external_apis/test_helius.py
@@ -2,12 +2,11 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final
 from unittest.mock import call, patch
 
-from solders.solders import Signature
-
 from rotkehlchen.db.filtering import SolanaTransactionsFilterQuery
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.db.solanatx import DBSolanaTx
 from rotkehlchen.externalapis.helius import HELIUS_API_URL, Helius
+from rotkehlchen.serialization.deserialize import deserialize_tx_signature
 from rotkehlchen.tests.utils.factories import make_solana_address
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import ApiKey, ExternalService, ExternalServiceApiCredentials
@@ -74,7 +73,7 @@ def test_get_transactions(database: 'DBHandler'):
 
     assert len(txs) == 1  # the mocked response only includes tx data for the jupiter swap tx
     tx = txs[0]  # Check some properties of the deserialized transaction
-    assert tx.signature == Signature.from_string(swap_tx_signature)
+    assert tx.signature == deserialize_tx_signature(swap_tx_signature)
     assert tx.fee == 10195
     assert tx.slot == 367689024
     assert tx.block_time == 1758217531

--- a/rotkehlchen/tests/unit/solana_decoders/test_system.py
+++ b/rotkehlchen/tests/unit/solana_decoders/test_system.py
@@ -1,0 +1,87 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.constants.assets import A_SOL
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.serialization.deserialize import deserialize_tx_signature
+from rotkehlchen.tests.utils.solana import get_decoded_events_of_solana_tx
+from rotkehlchen.types import SolanaAddress, TimestampMS
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [
+    ['4DrfzUpTdNtfr7D1RBVw2WhPshasifw97mH3aj27Skp9'],
+    ['3AmPaYAe6xWFxci4iCe8m2TkrQFZJPaj5AeBPTDoeFkR'],
+    ['4DrfzUpTdNtfr7D1RBVw2WhPshasifw97mH3aj27Skp9', '3AmPaYAe6xWFxci4iCe8m2TkrQFZJPaj5AeBPTDoeFkR'],  # noqa: E501
+])
+def test_native_transfer(
+        solana_inquirer: 'SolanaInquirer',
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    """Check that native transfers are decoded correctly.
+    Tests three scenarios:
+    * Both addresses tracked, decoded as fee event, transfer event.
+    * Only sender tracked, decoded as fee event, spend event.
+    * Only receiver tracked, decoded as a receive event only.
+    """
+    signature = deserialize_tx_signature('2RrXcP3MMgjjt46SJ34wT4pXKhCV94psPJnZgVyVRkPZpk5JSmCMgFyd1rwKuz3LMTAi3hhay11N41YPtodav81z')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    transfer_amount, spend_address, receive_address = '0.718759267', SolanaAddress('4DrfzUpTdNtfr7D1RBVw2WhPshasifw97mH3aj27Skp9'), SolanaAddress('3AmPaYAe6xWFxci4iCe8m2TkrQFZJPaj5AeBPTDoeFkR')  # noqa: E501
+    fee_event = SolanaEvent(
+        signature=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1759436023000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.000005'),
+        location_label=spend_address,
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    )
+    if len(solana_accounts) == 2:
+        assert events == [fee_event, SolanaEvent(
+            signature=signature,
+            sequence_index=1,
+            timestamp=timestamp,
+            event_type=HistoryEventType.TRANSFER,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_SOL,
+            amount=FVal(transfer_amount),
+            location_label=spend_address,
+            notes=f'Transfer {transfer_amount} SOL to {receive_address}',
+            address=receive_address,
+        )]
+    elif solana_accounts == [spend_address]:
+        assert events == [fee_event, SolanaEvent(
+            signature=signature,
+            sequence_index=1,
+            timestamp=timestamp,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_SOL,
+            amount=FVal(transfer_amount),
+            location_label=spend_address,
+            notes=f'Send {transfer_amount} SOL to {receive_address}',
+            address=receive_address,
+        )]
+    elif solana_accounts == [receive_address]:
+        assert events == [SolanaEvent(
+            signature=signature,
+            sequence_index=0,
+            timestamp=timestamp,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_SOL,
+            amount=FVal(transfer_amount),
+            location_label=receive_address,
+            notes=f'Receive {transfer_amount} SOL from {spend_address}',
+            address=spend_address,
+        )]

--- a/rotkehlchen/tests/unit/test_solana.py
+++ b/rotkehlchen/tests/unit/test_solana.py
@@ -2,13 +2,13 @@ from contextlib import suppress
 from typing import TYPE_CHECKING
 
 import pytest
-from solders.solders import Signature
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import get_or_create_solana_token, get_solana_token
 from rotkehlchen.chain.solana.utils import MetadataInfo, MintInfo, is_solana_token_nft
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.errors.misc import InputError
+from rotkehlchen.serialization.deserialize import deserialize_tx_signature
 from rotkehlchen.tests.utils.makerdao import FVal
 from rotkehlchen.types import SolanaAddress, Timestamp, TokenKind
 
@@ -136,7 +136,7 @@ def test_is_nft_via_offchain_metadata() -> None:
 @pytest.mark.vcr
 def test_query_tx_from_rpc(solana_inquirer: 'SolanaInquirer') -> None:
     tx = solana_inquirer.get_transaction_for_signature(
-        signature=(signature := Signature.from_string('58F9fNP78FiBCbVc2Gdy6on2d6pZiJcTbqib4MsTfNcgAXqS7UGp3a3eeEy7fRWnLiXaJjncUHdqtpCnEFuVsVEM')),  # noqa: E501
+        signature=(signature := deserialize_tx_signature('58F9fNP78FiBCbVc2Gdy6on2d6pZiJcTbqib4MsTfNcgAXqS7UGp3a3eeEy7fRWnLiXaJjncUHdqtpCnEFuVsVEM')),  # noqa: E501
     )
     assert tx is not None
     assert tx.signature == signature
@@ -173,5 +173,5 @@ def test_query_signatures_for_address(solana_inquirer: 'SolanaInquirer') -> None
         address=SolanaAddress('7T8ckKtdc5DH7ACS5AnCny7rVXYJPEsaAbdBri1FhPxY'),
     )
     assert len(signatures) == 64
-    assert signatures[0] == Signature.from_string('4awgHCjCD2Da2UbaKitSfUWExW2eVSA1x5PBrdHBi61NdCpWWxG1JbCDRbKUsQYSPZfPzMKLGrJw2XhajUUvz2Tc')  # noqa: E501
-    assert signatures[63] == Signature.from_string('Ars2bdNxYNVRDmWsGCwr9j8jHgRkb6gq7giaritpLw9yj6kiefwEUZpqz4Hr6SxRnJLTLtNnQaVNjuX6jjMAL7T')  # noqa: E501
+    assert signatures[0] == deserialize_tx_signature('4awgHCjCD2Da2UbaKitSfUWExW2eVSA1x5PBrdHBi61NdCpWWxG1JbCDRbKUsQYSPZfPzMKLGrJw2XhajUUvz2Tc')  # noqa: E501
+    assert signatures[63] == deserialize_tx_signature('Ars2bdNxYNVRDmWsGCwr9j8jHgRkb6gq7giaritpLw9yj6kiefwEUZpqz4Hr6SxRnJLTLtNnQaVNjuX6jjMAL7T')  # noqa: E501

--- a/rotkehlchen/tests/utils/solana.py
+++ b/rotkehlchen/tests/utils/solana.py
@@ -1,0 +1,29 @@
+from solders.solders import Signature
+
+from rotkehlchen.chain.solana.decoding.decoder import SolanaTransactionDecoder
+from rotkehlchen.chain.solana.decoding.tools import SolanaDecoderTools
+from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
+from rotkehlchen.chain.solana.transactions import SolanaTransactions
+from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+
+
+def get_decoded_events_of_solana_tx(
+        solana_inquirer: SolanaInquirer,
+        signature: Signature,
+) -> list[SolanaEvent]:
+    """Convenience function to decode a single solana transaction and return the events."""
+    return SolanaTransactionDecoder(
+        database=solana_inquirer.database,
+        node_inquirer=solana_inquirer,
+        transactions=SolanaTransactions(
+            node_inquirer=solana_inquirer,
+            database=solana_inquirer.database,
+        ),
+        base_tools=SolanaDecoderTools(
+            database=solana_inquirer.database,
+            node_inquirer=solana_inquirer,
+        ),
+    ).decode_and_get_transaction_hashes(
+        ignore_cache=True,
+        tx_hashes=[signature],
+    )


### PR DESCRIPTION
* Adds more logic to SolanaTransactionDecoder, implementing the full decoding flow with decoding of fee events and native solana transfers.
* Adds a small `get_decoded_events_of_solana_tx` helper function for in the tests similar to what we have for evm.