### PR TITLE
Rename evm decoding output

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.chain.arbitrum_one.decoding.interfaces import ArbitrumDecoderIn
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ARB
@@ -40,9 +40,9 @@ class AirdropsDecoder(ArbitrumDecoderInterface):
         )
         self.arb_token = A_ARB.resolve_to_evm_token()
 
-    def _decode_arbitrum_airdrop_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_arbitrum_airdrop_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != ARB_CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.topics[1])
         raw_amount = int.from_bytes(context.tx_log.data[0:32])
@@ -56,7 +56,7 @@ class AirdropsDecoder(ArbitrumDecoderInterface):
                 event.notes = f'Claimed {amount} ARB from arbitrum airdrop'
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {

--- a/rotkehlchen/chain/arbitrum_one/modules/gitcoin/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gitcoin/decoder.py
@@ -3,7 +3,10 @@ from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.chain.evm.decoding.constants import CPT_GITCOIN
 from rotkehlchen.chain.evm.decoding.gitcoinv2.decoder import GitcoinV2CommonDecoder
-from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_EVM_DECODING_OUTPUT,
+    EvmDecodingOutput,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -61,12 +64,12 @@ class GitcoinDecoder(GitcoinV2CommonDecoder):
             direct_allocation_strategy_addresses=[string_to_evm_address('0x91AD709FE04E214eF53218572D8d8690a8b4FdD0')],
         )
 
-    def _decode_donation_impact_minting(self, context: 'DecoderContext') -> DecodingOutput:
+    def _decode_donation_impact_minting(self, context: 'DecoderContext') -> EvmDecodingOutput:
         if context.tx_log.topics[0] != ON_ATTESTED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if not self.base.is_tracked(recipient := bytes_to_address(context.tx_log.topics[2])):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = from_wei(int.from_bytes(context.tx_log.data[:32]))
         for event in context.decoded_events:
@@ -80,7 +83,7 @@ class GitcoinDecoder(GitcoinV2CommonDecoder):
         else:
             log.error(f'In minting donation impact could not find the ETH fee transfer in {context.transaction}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/arbitrum_one/modules/open_ocean/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/open_ocean/decoder.py
@@ -7,9 +7,9 @@ from rotkehlchen.chain.evm.decoding.open_ocean.decoder import (
     OpenOceanDecoder as OpenOceanBaseDecoder,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -29,13 +29,13 @@ log = RotkehlchenLogsAdapter(logger)
 
 class OpenOceanDecoder(OpenOceanBaseDecoder):
 
-    def _process_arb_airdrop(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def _process_arb_airdrop(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         """This logic processes an airdrop made from the OpenOcean team as part of the
         swaps incentive program using the ARB granted by the Arbitrum DAO
         https://forum.arbitrum.foundation/t/openocean-final-stip-round-1/17564/1
         """
         if context.tx_log.topics[0] != CLAIMED_REWARDS:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value(
             token_amount=int.from_bytes(context.tx_log.data[64:96]),
@@ -59,7 +59,7 @@ class OpenOceanDecoder(OpenOceanBaseDecoder):
         else:
             log.error(f'Failed to match distributor reward in {context.transaction}')
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict['ChecksumEvmAddress', tuple[Any, ...]]:
         return super().addresses_to_decoders() | {DISTRIBUTOR_ADDR: (self._process_arb_airdrop,)}

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
@@ -16,10 +16,10 @@ from rotkehlchen.chain.evm.constants import (
 )
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.fval import FVal
@@ -132,7 +132,7 @@ class UmamiDecoder(ArbitrumDecoderInterface):
             fee_event_type=HistoryEventType.WITHDRAWAL,
         )
 
-    def _decode_umami_vault_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_umami_vault_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode umami vault deposit/withdraw events.
 
         A deposit/withdraw consists of two transactions, a request tx and an execution tx.
@@ -208,7 +208,7 @@ class UmamiDecoder(ArbitrumDecoderInterface):
                 ordered_events=ordered_events,
                 events_list=context.decoded_events,
             )
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if (
             context.tx_log.topics[0] == ERC20_OR_ERC721_TRANSFER and
@@ -219,7 +219,7 @@ class UmamiDecoder(ArbitrumDecoderInterface):
                 amount=int.from_bytes(context.tx_log.data[0:32]),
                 asset=vault_asset,
             )
-            return DecodingOutput(action_items=[ActionItem(
+            return EvmDecodingOutput(action_items=[ActionItem(
                 action='transform',
                 from_event_type=HistoryEventType.RECEIVE,
                 from_event_subtype=HistoryEventSubType.NONE,
@@ -231,9 +231,9 @@ class UmamiDecoder(ArbitrumDecoderInterface):
                 to_notes=f'Receive {receive_amount} {vault_asset.symbol} after a deposit in Umami',
             )])
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_umami_staking_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_umami_staking_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode stake/unstake/reward events."""
         for event in context.decoded_events:
             asset_symbol = event.asset.resolve_to_asset_with_symbol().symbol
@@ -261,7 +261,7 @@ class UmamiDecoder(ArbitrumDecoderInterface):
                     event.counterparty = CPT_UMAMI
                     event.notes = f'Unstake {event.amount} {asset_symbol} from Umami'
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/arbitrum_one/modules/weth/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/weth/decoder.py
@@ -2,17 +2,17 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
-from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
+from rotkehlchen.chain.evm.decoding.structures import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.chain.evm.decoding.weth.decoder import WethDecoder as EthBaseWethDecoder
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
-    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
 
 
 class WethDecoder(EthBaseWethDecoder):
 
-    def _decode_wrapper(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def _decode_wrapper(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         """WETH on Arbitrum is deployed as proxy, check for transfers to/from ZERO_ADDRESS."""
         if context.tx_log.topics[0] == ERC20_OR_ERC721_TRANSFER:
             from_address = bytes_to_address(context.tx_log.topics[1])
@@ -22,4 +22,4 @@ class WethDecoder(EthBaseWethDecoder):
             elif to_address == ZERO_ADDRESS and self.base.is_tracked(from_address):
                 return self._decode_withdrawal_event(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT

--- a/rotkehlchen/chain/base/modules/basenames/decoder.py
+++ b/rotkehlchen/chain/base/modules/basenames/decoder.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
 from rotkehlchen.chain.evm.decoding.ens.decoder import EnsCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.constants.assets import A_ETH
@@ -163,9 +163,9 @@ class BasenamesDecoder(EnsCommonDecoder):
 
         return name
 
-    def _decode_registrar_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_registrar_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != NAME_REGISTERED_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         try:
             _, decoded_data = decode_event_data_abi_str(
@@ -174,7 +174,7 @@ class BasenamesDecoder(EnsCommonDecoder):
             )
         except DeserializationError as e:
             log.error(f'Failed to decode Basenames registered event due to {e!s}')
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         fullname = f'{decoded_data[0]}.base.eth'
         expires = decoded_data[1]
@@ -220,7 +220,7 @@ class BasenamesDecoder(EnsCommonDecoder):
                 events_list=context.decoded_events,
             )
 
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/base/modules/efp/decoder.py
+++ b/rotkehlchen/chain/base/modules/efp/decoder.py
@@ -7,10 +7,10 @@ from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.efp.constants import CPT_EFP
 from rotkehlchen.chain.evm.decoding.efp.decoder import EfpCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
@@ -50,17 +50,17 @@ class EfpDecoder(EfpCommonDecoder):
             list_records_contract=string_to_evm_address('0x41Aa48Ef3c0446b46a5b1cc6337FF3d3716E2A33'),
         )
 
-    def _decode_account_metadata_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_account_metadata_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode events from the EFPAccountMetadata contract, currently only deployed on Base.
         See https://docs.ethfollow.xyz/production/deployments
         """
         if context.tx_log.topics[0] != UPDATE_ACCOUNT_METADATA:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if (context.tx_log.data[96:128].rstrip(b'\x00').decode()) != 'primary-list':
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
-        return DecodingOutput(events=[self.base.make_event_from_transaction(
+        return EvmDecodingOutput(events=[self.base.make_event_from_transaction(
             transaction=context.transaction,
             tx_log=context.tx_log,
             event_type=HistoryEventType.INFORMATIONAL,
@@ -72,7 +72,7 @@ class EfpDecoder(EfpCommonDecoder):
             counterparty=CPT_EFP,
         )])
 
-    def _decode_list_registry_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_list_registry_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode events from the EFPListRegistry contract, currently only deployed on Base.
         See https://docs.ethfollow.xyz/production/deployments
         """
@@ -80,9 +80,9 @@ class EfpDecoder(EfpCommonDecoder):
             context.tx_log.topics[0] != ERC20_OR_ERC721_TRANSFER or
             len(context.tx_log.topics) != 4  # erc721 should have 4
         ):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
-        return DecodingOutput(action_items=[ActionItem(
+        return EvmDecodingOutput(action_items=[ActionItem(
             action='transform',
             from_event_type=HistoryEventType.RECEIVE,
             from_event_subtype=HistoryEventSubType.NONE,

--- a/rotkehlchen/chain/base/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/base/modules/odos/v2/decoder.py
@@ -5,7 +5,7 @@ from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.odos.v2.constants import CPT_ODOS_V2
 from rotkehlchen.chain.evm.decoding.odos.v2.decoder import Odosv2DecoderBase
-from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
+from rotkehlchen.chain.evm.decoding.structures import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.utils.misc import bytes_to_address
@@ -20,7 +20,7 @@ from .constants import (
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
-    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -39,15 +39,15 @@ class Odosv2Decoder(Odosv2DecoderBase):
             router_address=ODOS_V2_ROUTER,
         )
 
-    def decode_claim(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def decode_claim(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         if (
             context.tx_log.topics[0] != REWARD_CLAIMED_TOPIC or
             context.tx_log.address != ODOS_AIRDROP_DISTRIBUTOR
         ):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if self.base.is_tracked(recipient := bytes_to_address(context.tx_log.topics[2])) is False:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[0:32]),
@@ -67,7 +67,7 @@ class Odosv2Decoder(Odosv2DecoderBase):
                 event.notes = f'Claim {amount} ODOS from Odos airdrop'
                 event.extra_data = {AIRDROP_IDENTIFIER_KEY: 'odos'}
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict['ChecksumEvmAddress', tuple[Any, ...]]:
         return super().addresses_to_decoders() | {

--- a/rotkehlchen/chain/base/modules/runmoney/decoder.py
+++ b/rotkehlchen/chain/base/modules/runmoney/decoder.py
@@ -7,9 +7,9 @@ from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.constants import STAKED
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.resolver import tokenid_belongs_to_collection, tokenid_to_collectible_id
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -31,7 +31,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class RunmoneyDecoder(EvmDecoderInterface):
-    def _decode_join_event(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_join_event(self, context: DecoderContext) -> EvmDecodingOutput:
         for event in context.decoded_events:
             if (
                     event.event_type == HistoryEventType.SPEND and
@@ -52,7 +52,7 @@ class RunmoneyDecoder(EvmDecoderInterface):
                 event.event_subtype = HistoryEventSubType.RECEIVE
                 event.notes = f'Receive Runmoney membership NFT with id {tokenid_to_collectible_id(event.asset.identifier)} for joining the club'  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     @staticmethod
     def _decode_stake_unstake_event(
@@ -62,7 +62,7 @@ class RunmoneyDecoder(EvmDecoderInterface):
             to_event_subtype: Literal[HistoryEventSubType.DEPOSIT_ASSET, HistoryEventSubType.REMOVE_ASSET],  # noqa: E501
             action: Literal['deposit', 'withdraw'],
             preposition: Literal['into', 'from'],
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
             token_decimals=6,  # usdc token has decimal=6
@@ -81,10 +81,10 @@ class RunmoneyDecoder(EvmDecoderInterface):
         else:
             log.error(f'Failed to find runmoney {action} event for transaction {context.transaction}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     @staticmethod
-    def _decode_claim_event(context: DecoderContext) -> DecodingOutput:
+    def _decode_claim_event(context: DecoderContext) -> EvmDecodingOutput:
         user_address = bytes_to_address(context.tx_log.topics[1])
         usdc_amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
@@ -105,9 +105,9 @@ class RunmoneyDecoder(EvmDecoderInterface):
                 event.event_subtype = HistoryEventSubType.REWARD
                 event.notes = f'Claim {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} as interest earned from Runmoney'  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_runmoney_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_runmoney_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """This decodes the following runmoney.app events:
             - Joined: club membership events (eth fee payment + nft receipt)
             - Staked: usdc deposits into the protocol
@@ -140,7 +140,7 @@ class RunmoneyDecoder(EvmDecoderInterface):
         if context.tx_log.topics[0] == CLAIM_TOPIC:
             return self._decode_claim_event(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {RUNMONEY_CONTRACT_ADDRESS: (self._decode_runmoney_events,)}

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -11,9 +11,9 @@ from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderToolsWithProxy
 from rotkehlchen.chain.evm.decoding.constants import CPT_ACCOUNT_DELEGATION
 from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoderWithDSProxy
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -99,14 +99,14 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if tx_log.topics[0] == AIRDROP_CLAIM and tx_log.address == '0xDE3e5a990bCE7fC60a6f017e7c4a95fc4939299E':  # noqa: E501
             for event in decoded_events:
                 if event.asset == A_GTC and event.event_type == HistoryEventType.RECEIVE:
                     event.event_subtype = HistoryEventSubType.AIRDROP
                     event.notes = f'Claim {event.amount} GTC from the GTC airdrop'
                     event.extra_data = {AIRDROP_IDENTIFIER_KEY: 'gitcoin'}
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if tx_log.topics[0] == MERKLE_CLAIM and tx_log.address == '0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe':  # noqa: E501
             for event in decoded_events:
@@ -114,9 +114,9 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
                     event.event_subtype = HistoryEventSubType.AIRDROP
                     event.notes = f'Claim {event.amount} 1INCH from the 1INCH airdrop'
                     event.extra_data = {AIRDROP_IDENTIFIER_KEY: '1inch'}
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- methods that need to be implemented by child classes --
 

--- a/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
@@ -13,10 +13,10 @@ from rotkehlchen.chain.evm.decoding.cowswap.constants import COWSWAP_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.interfaces import MerkleClaimDecoderInterface
 from rotkehlchen.chain.evm.decoding.oneinch.constants import ONEINCH_ICON, ONEINCH_LABEL
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.constants import UNISWAP_ICON, UNISWAP_LABEL
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -104,9 +104,9 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             msg_aggregator=msg_aggregator,
         )
 
-    def _decode_fox_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_fox_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != FOX_CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         raw_amount = int.from_bytes(context.tx_log.data[64:96])
         amount = token_normalized_value_decimals(
@@ -125,11 +125,11 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             ):
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_badger_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_badger_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != BADGER_HUNT_EVENT:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         raw_amount = int.from_bytes(context.tx_log.data[32:64])
         amount = token_normalized_value_decimals(
@@ -148,15 +148,15 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             ):
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def _decode_fpis_claim(
             self,
             context: DecoderContext,
             airdrop: Literal['convex', 'fpis'],
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != SIMPLE_CLAIM:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.data[0:32])
         raw_amount = int.from_bytes(context.tx_log.data[32:64])
@@ -196,14 +196,14 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             ):
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_elfi_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_elfi_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         """Example:
         https://etherscan.io/tx/0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b
         """
         if context.tx_log.topics[0] != ELFI_VOTE_CHANGE:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.topics[1])
         delegate_address = bytes_to_address(context.tx_log.topics[2])
@@ -241,13 +241,13 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
                     address=context.transaction.to_address,
                     extra_data={AIRDROP_IDENTIFIER_KEY: 'elfi'},
                 )
-                return DecodingOutput(events=[event])
+                return EvmDecodingOutput(events=[event])
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_ens_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_ens_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != SIMPLE_CLAIM:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         raw_amount = int.from_bytes(context.tx_log.data[:32])
         amount = token_normalized_value_decimals(
@@ -255,7 +255,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             token_decimals=DEFAULT_TOKEN_DECIMALS,  # ens 18 decimals
         )
         user_address = bytes_to_address(context.tx_log.topics[1])
-        return DecodingOutput(
+        return EvmDecodingOutput(
             action_items=[
                 ActionItem(
                     action='transform',

--- a/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/base_bridge/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.constants import BASE_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -83,11 +83,11 @@ class BaseBridgeDecoder(EvmDecoderInterface):
                     counterparty=BASE_CPT_DETAILS,
                 )
 
-    def _decode_bridge_eth(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_bridge_eth(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a bridging event for ETH. Either a deposit or a withdrawal."""
         if context.tx_log.topics[0] not in {TRANSACTION_DEPOSITED, WITHDRAWAL_FINALIZED}:
             # Make sure that we are decoding a supported event.
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         # Read information from event's topics & data
         if context.tx_log.topics[0] == TRANSACTION_DEPOSITED:
@@ -105,7 +105,7 @@ class BaseBridgeDecoder(EvmDecoderInterface):
             from_address=from_address,
             to_address=to_address,
         )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/defisaver/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/defisaver/decoder.py
@@ -4,9 +4,9 @@ from typing import Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
@@ -23,7 +23,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 class DefisaverDecoder(EvmDecoderInterface):
 
-    def _decode_subscribe(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_subscribe(self, context: DecoderContext) -> EvmDecodingOutput:
         sub_id = int.from_bytes(context.tx_log.topics[1])
         proxy = bytes_to_address(context.tx_log.topics[2])
         event = self.base.make_event_from_transaction(
@@ -38,9 +38,9 @@ class DefisaverDecoder(EvmDecoderInterface):
             address=context.tx_log.address,
             counterparty=CPT_DEFISAVER,
         )
-        return DecodingOutput(events=[event])
+        return EvmDecodingOutput(events=[event])
 
-    def _decode_deactivate_sub(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_deactivate_sub(self, context: DecoderContext) -> EvmDecodingOutput:
         sub_id = int.from_bytes(context.tx_log.topics[1])
         event = self.base.make_event_from_transaction(
             transaction=context.transaction,
@@ -54,15 +54,15 @@ class DefisaverDecoder(EvmDecoderInterface):
             address=context.tx_log.address,
             counterparty=CPT_DEFISAVER,
         )
-        return DecodingOutput(events=[event])
+        return EvmDecodingOutput(events=[event])
 
-    def _decode_substorage_action(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_substorage_action(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == DEACTIVATE_SUB:
             return self._decode_deactivate_sub(context)
         if context.tx_log.topics[0] == SUBSCRIBE:
             return self._decode_subscribe(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/digixdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/digixdao/decoder.py
@@ -9,9 +9,9 @@ from rotkehlchen.chain.ethereum.modules.digixdao.constants import (
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.constants.assets import A_ETH
@@ -24,10 +24,10 @@ REFUND_TOPIC: Final = b's\xf0J\xf9\xdc\xc5\x82\xa9#\xec\x15\xd3\xee\xa9\x90\xfe4
 
 class DigixdaoDecoder(EvmDecoderInterface):
 
-    def _decode_dgd_eth_refund(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_dgd_eth_refund(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode ETH refund for DGD tokens."""
         if context.tx_log.topics[0] != REFUND_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.topics[1])
         dgd_amount = token_normalized_value_decimals(
@@ -67,7 +67,7 @@ class DigixdaoDecoder(EvmDecoderInterface):
             ordered_events=[out_event, in_event],
             events_list=context.decoded_events,
         )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {DIGIX_DGD_ETH_REFUND_CONTRACT: (self._decode_dgd_eth_refund,)}

--- a/rotkehlchen/chain/ethereum/modules/diva/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/diva/decoder.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.evm.decoding.interfaces import (
     MerkleClaimDecoderInterface,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_DIVA
@@ -50,10 +50,10 @@ class DivaDecoder(GovernableDecoderInterface, MerkleClaimDecoderInterface):
         )
         self.diva = A_DIVA.resolve_to_evm_token()
 
-    def _decode_delegation_change(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_delegation_change(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode a change in the delegated address"""
         if context.tx_log.topics[0] != DELEGATE_CHANGED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         delegator = bytes_to_address(context.tx_log.topics[1])
         delegate = bytes_to_address(context.tx_log.topics[3])
@@ -74,7 +74,7 @@ class DivaDecoder(GovernableDecoderInterface, MerkleClaimDecoderInterface):
             notes=f'Change DIVA Delegate from {delegator} to {delegate}',
             counterparty=CPT_DIVA,
         )
-        return DecodingOutput(events=[event], refresh_balances=False)
+        return EvmDecodingOutput(events=[event], refresh_balances=False)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/hop/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hop/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP, HOP_CPT_DETAIL
 from rotkehlchen.chain.evm.decoding.hop.decoder import HopCommonDecoder
 from rotkehlchen.chain.evm.decoding.interfaces import GovernableDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -48,15 +48,15 @@ class HopDecoder(HopCommonDecoder, GovernableDecoderInterface):
             proposals_url='https://www.tally.xyz/gov/hop/proposal',
         )
 
-    def _decode_send_to_l2(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_send_to_l2(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != TRANSFER_TO_L2:
             return super()._decode_events(context=context)
 
         if self.base.is_tracked(recipient := bytes_to_address(context.tx_log.topics[2])) is None:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if (bridge := self.bridges.get(context.tx_log.address)) is None:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount_raw = int.from_bytes(context.tx_log.data[:32])
         amount = self._get_bridge_asset_amount(amount_raw=amount_raw, identifier=bridge.identifier)
@@ -75,7 +75,7 @@ class HopDecoder(HopCommonDecoder, GovernableDecoderInterface):
                 )
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/juicebox/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/juicebox/decoder.py
@@ -19,9 +19,9 @@ from rotkehlchen.chain.ethereum.modules.juicebox.constants import (
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.settings import CachedSettings
@@ -63,10 +63,10 @@ class JuiceboxDecoder(EvmDecoderInterface):
 
         return metadata.get('name'), metadata.get('tags', [])
 
-    def _decode_pay(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_pay(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode pay with rewards in juicebox"""
         if context.tx_log.topics[0] != PAY_SIGNATURE:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         try:
             topic_data, decoded_data = decode_event_data_abi_str(context.tx_log, PAY_ABI)
@@ -75,7 +75,7 @@ class JuiceboxDecoder(EvmDecoderInterface):
                 f'Failed to deserialize Juicebox event at '
                 f'{context.transaction.tx_hash.hex()} due to {e}',
             )
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=decoded_data[2],
@@ -112,7 +112,7 @@ class JuiceboxDecoder(EvmDecoderInterface):
                 action_verb = 'donating' if is_donation else 'contributing'
                 event.notes = f'Receive an NFT for {action_verb} via Juicebox'
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -9,9 +9,9 @@ from rotkehlchen.chain.evm.decoding.kyber.decoder import (
     KyberCommonDecoder,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -63,9 +63,9 @@ class KyberDecoder(KyberCommonDecoder):
         destination_token = self.base.get_or_create_evm_asset(destination_token_address)
         return sender, source_token, destination_token
 
-    def _decode_legacy_trade(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_legacy_trade(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != KYBER_TRADE:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         sender, source_asset, destination_asset = self._legacy_contracts_basic_info(context.tx_log)
         spent_amount_raw = int.from_bytes(context.tx_log.data[64:96])
@@ -82,11 +82,11 @@ class KyberDecoder(KyberCommonDecoder):
             counterparty=CPT_KYBER_LEGACY,
         )
 
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
-    def _decode_legacy_upgraded_trade(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_legacy_upgraded_trade(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != KYBER_TRADE_LEGACY:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         sender, source_asset, destination_asset = self._legacy_contracts_basic_info(context.tx_log)
         spent_amount_raw = int.from_bytes(context.tx_log.data[96:128])
@@ -103,7 +103,7 @@ class KyberDecoder(KyberCommonDecoder):
             counterparty=CPT_KYBER_LEGACY,
         )
 
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/lido/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lido/decoder.py
@@ -5,10 +5,10 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_ETH, A_STETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -42,7 +42,7 @@ class LidoDecoder(EvmDecoderInterface):
         )
         self.steth_evm_address = A_STETH.resolve_to_evm_token().evm_address
 
-    def _decode_lido_staking_in_steth(self, context: DecoderContext, sender: ChecksumEvmAddress) -> DecodingOutput:  # noqa: E501
+    def _decode_lido_staking_in_steth(self, context: DecoderContext, sender: ChecksumEvmAddress) -> EvmDecodingOutput:  # noqa: E501
         """Decode the submit of eth to lido contract for obtaining steth in return"""
         amount_raw = int.from_bytes(context.tx_log.data[:32])
         collateral_amount = token_normalized_value_decimals(
@@ -78,7 +78,7 @@ class LidoDecoder(EvmDecoderInterface):
                 f'At lido steth submit decoding of tx {context.transaction.tx_hash.hex()}'
                 f' did not find the related ETH transfer',
             )
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         action_items = []  # also create an action item for the reception of the stETH tokens
         if paired_event is not None and action_from_event_type is not None:
@@ -96,9 +96,9 @@ class LidoDecoder(EvmDecoderInterface):
                 extra_data={'staked_eth': str(collateral_amount)},
             ))
 
-        return DecodingOutput(action_items=action_items, matched_counterparty=CPT_LIDO)
+        return EvmDecodingOutput(action_items=action_items, matched_counterparty=CPT_LIDO)
 
-    def _decode_lido_eth_staking_contract(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_lido_eth_staking_contract(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode interactions with stETH ans wstETH contracts"""
         if (
             context.tx_log.topics[0] == LIDO_STETH_SUBMITTED and
@@ -106,7 +106,7 @@ class LidoDecoder(EvmDecoderInterface):
         ):
             return self._decode_lido_staking_in_steth(context=context, sender=sender)
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/lockedgno/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lockedgno/decoder.py
@@ -5,10 +5,10 @@ from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -52,7 +52,7 @@ class LockedgnoDecoder(EvmDecoderInterface):
             evm_inquirer=ethereum_inquirer,
         )
 
-    def _decode_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_events(self, context: DecoderContext) -> EvmDecodingOutput:
         for event in context.decoded_events:
             if (
                     event.event_type == HistoryEventType.SPEND and
@@ -78,7 +78,7 @@ class LockedgnoDecoder(EvmDecoderInterface):
                     to_notes=f'Receive {event.amount} locked GNO from the locking contract',
                     to_counterparty=CPT_LOCKEDGNO,
                 )
-                return DecodingOutput(action_items=[action_item])
+                return EvmDecodingOutput(action_items=[action_item])
 
             if (
                     event.event_type == HistoryEventType.RECEIVE and
@@ -104,9 +104,9 @@ class LockedgnoDecoder(EvmDecoderInterface):
                     to_notes=f'Return {event.amount} locked GNO to the locking contract',
                     to_counterparty=CPT_LOCKEDGNO,
                 )
-                return DecodingOutput(action_items=[action_item])
+                return EvmDecodingOutput(action_items=[action_item])
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v2/decoder.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.oneinch.decoder import OneinchCommonDecoder
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
 from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class Oneinchv2Decoder(OneinchCommonDecoder):
             counterparty=CPT_ONEINCH_V2,
         )
 
-    def _decode_swapped(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_swapped(self, context: DecoderContext) -> EvmDecodingOutput:
         return self._create_swapped_events(
             context=context,
             sender=bytes_to_address(context.tx_log.topics[1]),

--- a/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.history.events.structures.evm_event import EvmProduct
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -24,12 +24,12 @@ log = RotkehlchenLogsAdapter(logger)
 
 class PaladinDecoder(EvmDecoderInterface):
 
-    def _decode_claim_quest(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_claim_quest(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[3])):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = int.from_bytes(context.tx_log.data[32:64])
         reward_token_address = bytes_to_address(context.tx_log.data[64:96])
@@ -50,7 +50,7 @@ class PaladinDecoder(EvmDecoderInterface):
                 break
         else:  # not found
             log.error(f'Paladin bribe transfer was not found for {context.transaction.tx_hash.hex()}')  # noqa: E501
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/pendle/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.pendle.constants import CPT_PENDLE
 from rotkehlchen.chain.evm.decoding.pendle.decoder import PendleCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -53,7 +53,7 @@ class PendleDecoder(PendleCommonDecoder, CustomizableDateMixin):
         )
         CustomizableDateMixin.__init__(self, base_tools.database)
 
-    def _decode_ve_pendle_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_ve_pendle_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == NEW_LOCK_POSITION_TOPIC:
             refund_event = None
             for event in context.decoded_events:
@@ -119,7 +119,7 @@ class PendleDecoder(PendleCommonDecoder, CustomizableDateMixin):
             else:
                 log.error(f'Could not find pendle unlock transfer for transaction {context.transaction}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return super().addresses_to_decoders() | {

--- a/rotkehlchen/chain/ethereum/modules/spark/lend/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/spark/lend/decoder.py
@@ -12,10 +12,10 @@ from rotkehlchen.chain.evm.decoding.interfaces import MerkleClaimDecoderInterfac
 from rotkehlchen.chain.evm.decoding.spark.constants import CPT_SPARK
 from rotkehlchen.chain.evm.decoding.spark.lend.decoder import SparklendCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -49,10 +49,10 @@ class SparklendDecoder(SparklendCommonDecoder, MerkleClaimDecoderInterface):
             incentives=string_to_evm_address('0x4370D3b6C9588E02ce9D22e684387859c7Ff5b34'),
         )
 
-    def _decode_spark_airdrop_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_spark_airdrop_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode Spark airdrop claims using the ClaimReward event"""
         if context.tx_log.topics[0] != SPARK_CLAIM_SIGNATURE:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         raw_amount = int.from_bytes(context.tx_log.data[0:32])
         amount = token_normalized_value_decimals(
@@ -77,12 +77,12 @@ class SparklendDecoder(SparklendCommonDecoder, MerkleClaimDecoderInterface):
                 event.extra_data = {AIRDROP_IDENTIFIER_KEY: 'spark'}
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_spark_staking(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_spark_staking(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode Spark token staking into the staking contract"""
         if context.tx_log.topics[0] != DEPOSIT_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.topics[1])
         raw_amount = int.from_bytes(context.tx_log.data[0:32])
@@ -120,7 +120,7 @@ class SparklendDecoder(SparklendCommonDecoder, MerkleClaimDecoderInterface):
             to_counterparty=CPT_SPARK,
         ))
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict['ChecksumEvmAddress', tuple[Any, ...]]:
         """Map contract addresses to their respective decoder methods"""

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -7,9 +7,9 @@ from rotkehlchen.chain.ethereum.modules.sushiswap.constants import CPT_SUSHISWAP
 from rotkehlchen.chain.evm.constants import BURN_TOPIC, MINT_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.v2.constants import UNISWAP_V2_SWAP_SIGNATURE
 from rotkehlchen.chain.evm.decoding.uniswap.v2.utils import (
@@ -38,7 +38,7 @@ class SushiswapDecoder(EvmDecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if tx_log.topics[0] == UNISWAP_V2_SWAP_SIGNATURE and transaction.to_address == SUSHISWAP_ROUTER:  # noqa: E501
             return decode_uniswap_v2_like_swap(
                 tx_log=tx_log,
@@ -50,7 +50,7 @@ class SushiswapDecoder(EvmDecoderInterface):
                 evm_inquirer=self.node_inquirer,
                 notify_user=self.notify_user,
             )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def _maybe_decode_v2_liquidity_addition_and_removal(
             self,
@@ -60,7 +60,7 @@ class SushiswapDecoder(EvmDecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if tx_log.topics[0] == MINT_TOPIC:
             return decode_uniswap_like_deposit_and_withdrawals(
                 tx_log=tx_log,
@@ -87,7 +87,7 @@ class SushiswapDecoder(EvmDecoderInterface):
                 init_code_hash=SUSHISWAP_V2_INIT_CODE_HASH,
                 tx_hash=transaction.tx_hash,
             )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.modules.aave.v1.decoder import DEFAULT_DECODING_OUTPUT
+from rotkehlchen.chain.ethereum.modules.aave.v1.decoder import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, EvmDecodingOutput
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V1, UNISWAP_ICON
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -39,7 +39,7 @@ class Uniswapv1Decoder(EvmDecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         """Search for both events. Since the order is not guaranteed try reshuffle in both cases"""
         out_event = in_event = None
         if tx_log.topics[0] == TOKEN_PURCHASE:
@@ -79,7 +79,7 @@ class Uniswapv1Decoder(EvmDecoderInterface):
                     out_event = event
 
         maybe_reshuffle_events(ordered_events=[out_event, in_event], events_list=decoded_events)
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.history.events.structures.evm_event import EvmProduct
@@ -24,9 +24,9 @@ log = RotkehlchenLogsAdapter(logger)
 
 class VotiumDecoder(EvmDecoderInterface):
 
-    def _decode_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         claimed_token_address = bytes_to_address(context.tx_log.topics[1])
         claimed_token = self.base.get_or_create_evm_token(claimed_token_address)
@@ -50,7 +50,7 @@ class VotiumDecoder(EvmDecoderInterface):
         else:  # not found
             log.error(f'Votium bribe transfer was not found for {context.transaction.tx_hash.hex()}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import REWARD_PAID_TOPIC_V2
 from rotkehlchen.chain.evm.decoding.constants import STAKED, WITHDRAWN
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
+from rotkehlchen.chain.evm.decoding.structures import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.constants.assets import A_CRVP_DAIUSDCTTUSD, A_YFI
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -16,7 +16,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
-    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
     from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
 
@@ -97,7 +97,7 @@ class YearnygovDecoder(EvmDecoderInterface):
                 event.notes = f'Deposit {event.amount} yDAI+yUSDC+yUSDT+yTUSD in ygov.finance'
                 break
 
-    def decode_gov_events(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def decode_gov_events(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         if context.tx_log.topics[0] == REWARD_PAID_TOPIC_V2:
             self._decode_reward_token(context)
         elif context.tx_log.topics[0] == WITHDRAWN:
@@ -105,7 +105,7 @@ class YearnygovDecoder(EvmDecoderInterface):
         elif context.tx_log.topics[0] == STAKED:
             self._decode_stake(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict['ChecksumEvmAddress', tuple[Any, ...]]:
         return {YGOV_ADDRESS: (self.decode_gov_events,)}

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -4,9 +4,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_raw_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import ChecksumEvmAddress
@@ -22,7 +22,7 @@ PENDING_WITHDRAWALS_COMPLETE: Final = b'\x9bTx\xc9\x9b\\\xa4\x1b\xee\xc4\xf6\xf6
 
 class ZksyncDecoder(EvmDecoderInterface):
 
-    def _decode_event(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_event(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == ONCHAIN_DEPOSIT:
             user_address = bytes_to_address(context.tx_log.topics[1])
             return self._decode_deposit(context, user_address)
@@ -37,9 +37,9 @@ class ZksyncDecoder(EvmDecoderInterface):
         elif context.tx_log.topics[0] == PENDING_WITHDRAWALS_COMPLETE:
             return self._decode_withdrawal(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_deposit(self, context: DecoderContext, user_address: ChecksumEvmAddress) -> DecodingOutput:  # noqa: E501
+    def _decode_deposit(self, context: DecoderContext, user_address: ChecksumEvmAddress) -> EvmDecodingOutput:  # noqa: E501
         """Match a zksync lite deposit with the transfer to decode it
 
         TODO: This is now quite bad. We don't use the token id of zksync as we should.
@@ -68,9 +68,9 @@ class ZksyncDecoder(EvmDecoderInterface):
                 event.notes = f'Deposit {event.amount} {crypto_asset.symbol} to zksync'
                 break
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_withdrawal(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_withdrawal(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode zksync lite withdrawal event.
         The log event doesn't contain information about the withdrawn
         amount or token since there are multiple withdrawals bundled together
@@ -82,7 +82,7 @@ class ZksyncDecoder(EvmDecoderInterface):
                 event.counterparty = CPT_ZKSYNC
                 event.notes = f'Withdraw {event.amount} {event.asset.symbol_or_name()} from zksync'
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.decoding.aave.common import Commonv2v3LikeDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -88,9 +88,9 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
                 event.address = context.tx_log.address
                 event.extra_data = {'is_liquidation': True}  # adding this field to the decoded event to differentiate paybacks happening in liquidations.  # noqa: E501
 
-    def _decode_incentives(self, context: 'DecoderContext') -> DecodingOutput:
+    def _decode_incentives(self, context: 'DecoderContext') -> EvmDecodingOutput:
         if context.tx_log.topics[0] != b'V7\xd7\xf9b$\x8a\x7f\x05\xa7\xabi\xee\xc6Dn1\xf3\xd0\xa2\x99\xd9\x97\xf15\xa6\\b\x80nx\x91':  # RewardsClaimed  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         return self._decode_incentives_common(
             context=context,
@@ -100,9 +100,9 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
             amount_raw=context.tx_log.data[0:32],
         )
 
-    def _decode_migration(self, context: 'DecoderContext') -> DecodingOutput:
+    def _decode_migration(self, context: 'DecoderContext') -> EvmDecodingOutput:
         if context.tx_log.topics[0] != b'K\xec\xcb\x90\xf9\x94\xc3\x1a\xce\xd7\xa2;V\x11\x02\x07(\xa2=\x8e\xc5\xcd\xdd\x1a>\x9d\x97\xb9o\xda\x86f':  # TokenTransferred # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if self.v3_migration_helper and (to_address := bytes_to_address(context.tx_log.topics[2])) == self.v3_migration_helper and self.base.is_tracked(from_address := bytes_to_address(context.tx_log.topics[1])):  # noqa: E501
             token = self.base.get_evm_token(address=context.tx_log.address)
@@ -121,9 +121,9 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
                 to_notes=f'Migrate {amount} {token.symbol} from AAVE v2',
                 to_counterparty=CPT_AAVE_V2,
             )
-            return DecodingOutput(action_items=[action_item])
+            return EvmDecodingOutput(action_items=[action_item])
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # --- DecoderInterface methods
     @staticmethod

--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -9,8 +9,8 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.common import Commonv2v3LikeDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
-    DecodingOutput,
+    DEFAULT_EVM_DECODING_OUTPUT,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.constants.resolver import evm_address_to_identifier
@@ -119,9 +119,9 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
                 event.notes = f'Spend {event.amount} {asset.symbol} as an {self.label} fee'
                 event.counterparty = self.counterparty
 
-    def _decode_incentives(self, context: 'DecoderContext') -> DecodingOutput:
+    def _decode_incentives(self, context: 'DecoderContext') -> EvmDecodingOutput:
         if context.tx_log.topics[0] != REWARDS_CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         return self._decode_incentives_common(
             context=context,
@@ -388,7 +388,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
                 )
                 matched_asset_symbols = set()
 
-    def _collateral_swap(self, context: 'DecoderContext') -> DecodingOutput:
+    def _collateral_swap(self, context: 'DecoderContext') -> EvmDecodingOutput:
         """Decode a collateral swap event from aave.
 
         This swapped event logs the underlying token swapped. At this point we have decoded
@@ -398,7 +398,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
         in the post decoding.
         """
         if context.tx_log.topics[0] != SWAPPED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         swapped_addr = bytes_to_address(context.tx_log.topics[1])
         for event in context.decoded_events:
@@ -419,7 +419,7 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
         else:
             log.error(f'Failed to find aave v3 collateral swap in {context.transaction}')
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/balancer/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/decoder.py
@@ -16,10 +16,10 @@ from rotkehlchen.chain.evm.decoding.interfaces import (
     ReloadablePoolsAndGaugesDecoderMixin,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -69,9 +69,9 @@ class BalancerCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoder
         assert isinstance(self.cache_data[0], set), f'{self.counterparty} Decoder cache_data[0] is not a set'  # noqa: E501
         return self.cache_data[0]
 
-    def _decode_gauge_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_gauge_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] not in (DEPOSIT_TOPIC_V2, WITHDRAW_TOPIC_V2):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         gauge_asset = self.base.get_or_create_evm_token(context.tx_log.address)
         amount = asset_normalized_value(
@@ -112,7 +112,7 @@ class BalancerCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoder
                 event.event_subtype = HistoryEventSubType.REDEEM_WRAPPED
                 event.notes = f'Withdraw {amount} {evm_asset.symbol} from {self.counterparty} gauge'  # noqa: E501
 
-        return DecodingOutput(action_items=[] if paired_events_data is None else [
+        return EvmDecodingOutput(action_items=[] if paired_events_data is None else [
             ActionItem(
                 action='transform',
                 from_event_type=from_event_type,  # type: ignore[arg-type]  # it cannot be none if paired_events_data is present

--- a/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
@@ -12,12 +12,12 @@ from rotkehlchen.chain.evm.decoding.balancer.decoder import BalancerCommonDecode
 from rotkehlchen.chain.evm.decoding.balancer.types import BalancerV1EventTypes
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     FAILED_ENRICHMENT_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
     EnricherContext,
+    EvmDecodingOutput,
     TransferEnrichmentOutput,
 )
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -149,10 +149,10 @@ class Balancerv1CommonDecoder(BalancerCommonDecoder):
 
         return FAILED_ENRICHMENT_OUTPUT
 
-    def _decode_pool_events(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_pool_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """Not all balancer v1 pools are created via the UI. This method decodes the events of such pools."""  # noqa: E501
         if context.tx_log.topics[0] not in (JOIN_V1, EXIT_V1, ERC20_OR_ERC721_TRANSFER):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         from_event_subtype, to_event_type, to_event_subtype, location_label = HistoryEventSubType.NONE, None, None, None  # noqa: E501
         if context.tx_log.topics[0] == JOIN_V1:
@@ -183,7 +183,7 @@ class Balancerv1CommonDecoder(BalancerCommonDecoder):
                 else f'Return {amount} {token.symbol} to a Balancer v1 pool'
             )
 
-        return DecodingOutput(action_items=[ActionItem(
+        return EvmDecodingOutput(action_items=[ActionItem(
             action='transform',
             from_event_type=from_event_type,
             from_event_subtype=from_event_subtype,

--- a/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
@@ -15,9 +15,9 @@ from rotkehlchen.chain.evm.decoding.balancer.constants import CPT_BALANCER_V2
 from rotkehlchen.chain.evm.decoding.balancer.decoder import BalancerCommonDecoder
 from rotkehlchen.chain.evm.decoding.balancer.v2.constants import V2_SWAP, VAULT_ADDRESS
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -60,15 +60,15 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
         )
         self.wrapped_native_token = CHAIN_TO_WRAPPED_TOKEN[self.node_inquirer.blockchain].resolve_to_evm_token()  # noqa: E501
 
-    def decode_vault_events(self, context: DecoderContext) -> DecodingOutput:
+    def decode_vault_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == V2_SWAP:
-            return DecodingOutput(matched_counterparty=CPT_BALANCER_V2)
+            return EvmDecodingOutput(matched_counterparty=CPT_BALANCER_V2)
         if context.tx_log.topics[0] == POOL_BALANCE_CHANGED_TOPIC:
             return self._decode_join_or_exit(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_join_or_exit(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_join_or_exit(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes and processes Balancer v2 pool join/exit events"""
         send_events, receive_events = [], []
         for event in context.decoded_events:
@@ -128,10 +128,10 @@ class Balancerv2CommonDecoder(BalancerCommonDecoder):
             transaction=context.transaction,
             decoded_events=context.decoded_events,
         )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_pool_events(self, context: DecoderContext) -> DecodingOutput:
-        return DEFAULT_DECODING_OUTPUT  # no-op
+    def _decode_pool_events(self, context: DecoderContext) -> EvmDecodingOutput:
+        return DEFAULT_EVM_DECODING_OUTPUT  # no-op
 
     def _handle_post_decoding(
             self,

--- a/rotkehlchen/chain/evm/decoding/beefy_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/beefy_finance/decoder.py
@@ -9,9 +9,9 @@ from rotkehlchen.chain.ethereum.utils import (
 )
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
@@ -190,14 +190,14 @@ class BeefyFinanceCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
             transaction=transaction,
         )
 
-    def _decode_zap_deposits_and_withdrawals(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_zap_deposits_and_withdrawals(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes zap contract transactions that bundle token swaps with vault operations.
 
         Zap contracts allow users to deposit any token into a vault by automatically
         swapping it for the required LP tokens, or withdraw vault tokens as any desired token.
         """
         if context.tx_log.topics[0] != FULFILLED_ORDER_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amounts_and_assets = []
         for tx_log in context.all_logs:
@@ -221,7 +221,7 @@ class BeefyFinanceCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
             expected_amounts_and_assets=amounts_and_assets,
         )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def reload_data(self) -> Mapping['ChecksumEvmAddress', tuple[Any, ...]] | None:
         if (is_cache_updated := should_update_protocol_cache(

--- a/rotkehlchen/chain/evm/decoding/eas/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/eas/decoder.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO
@@ -52,9 +52,9 @@ class EASCommonDecoder(EvmDecoderInterface, ABC):
         )
         self.attestation_service_address = attestation_service_address
 
-    def _decode_attestation_action(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_attestation_action(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != ATTESTED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         attester = bytes_to_address(context.tx_log.topics[2])
         recipient = bytes_to_address(context.tx_log.topics[1])
@@ -63,7 +63,7 @@ class EASCommonDecoder(EvmDecoderInterface, ABC):
         elif self.base.is_tracked(recipient):
             location_label = recipient
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         uid = context.tx_log.data.hex()
         prefix = f'{self.node_inquirer.chain_name}.'
@@ -84,7 +84,7 @@ class EASCommonDecoder(EvmDecoderInterface, ABC):
             counterparty=CPT_EAS,
             address=context.tx_log.address,
         )
-        return DecodingOutput(events=[event])
+        return EvmDecodingOutput(events=[event])
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
@@ -11,10 +11,10 @@ from rotkehlchen.chain.evm.decoding.constants import (
 )
 from rotkehlchen.chain.evm.decoding.interfaces import CommonGrantsDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -61,9 +61,9 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
         self.payout_claimed_matching_contracts1 = payout_claimed_matching_contracts1
         self.payout_claimed_matching_contracts2 = payout_claimed_matching_contracts2
 
-    def _decode_bulkcheckout(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_bulkcheckout(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != DONATION_SENT:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         donor_tracked, dst_tracked = False, False
         if self.base.is_tracked(donor := bytes_to_address(context.tx_log.topics[3])):
@@ -73,7 +73,7 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
             dst_tracked = True
 
         if donor_tracked is False and dst_tracked is False:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         asset = self.base.get_or_create_evm_asset(bytes_to_address(context.tx_log.topics[1]))  # this checks for ETH special address inside # noqa: E501
         amount = asset_normalized_value(
@@ -124,11 +124,11 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
                 to_notes=notes,
                 to_counterparty=CPT_GITCOIN,
             )
-            return DecodingOutput(action_items=[action_item])
+            return EvmDecodingOutput(action_items=[action_item])
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_funds_claimed_matching(self, context: DecoderContext, name: str, asset: Asset) -> DecodingOutput:  # noqa: E501
+    def _decode_funds_claimed_matching(self, context: DecoderContext, name: str, asset: Asset) -> EvmDecodingOutput:  # noqa: E501
         """The > GR13 case seen in mainnet. Example transaction:
         https://etherscan.io/tx/0xc7ba01598f7fee42bb3923af95355d676ad38ec0aebdcdf49eaf7cb74d2150b2
         """
@@ -142,9 +142,9 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
                 counterparty=CPT_GITCOIN,
             )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_payout_claimed_matching_amount_in_data(self, context: DecoderContext, name: str, asset: Asset) -> DecodingOutput:  # noqa: E501
+    def _decode_payout_claimed_matching_amount_in_data(self, context: DecoderContext, name: str, asset: Asset) -> EvmDecodingOutput:  # noqa: E501
         """The GR12 case seen in mainnet. Example transaction:
         https://etherscan.io/tx/0x5acb6ddac6b72fc6ff45e6a387cf8316c1478dfbaff513918c4cc8731858b362
         """
@@ -158,9 +158,9 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
                 counterparty=CPT_GITCOIN,
             )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_payout_claimed_matching_recipient_in_data(self, context: DecoderContext, name: str, asset: Asset) -> DecodingOutput:  # noqa: E501
+    def _decode_payout_claimed_matching_recipient_in_data(self, context: DecoderContext, name: str, asset: Asset) -> EvmDecodingOutput:  # noqa: E501
         """The GR10-11 case seen in mainnet. Recipient also in data. Example transaction:
         https://etherscan.io/tx/0x3a069b8cef0d25068fbd2ae4e46ddd552451ed1bbe3737fbaaca05eeb87d9425
         """
@@ -174,7 +174,7 @@ class GitcoinOldCommonDecoder(CommonGrantsDecoderMixin):
                 counterparty=CPT_GITCOIN,
             )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/giveth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/giveth/decoder.py
@@ -9,9 +9,9 @@ from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, SIMPLE_CLAIM
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_DETAILS_GIVETH, CPT_GIVETH
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -52,9 +52,9 @@ class GivethDecoderBase(EvmDecoderInterface, ABC):
         self.distro_address = distro_address
         self.givpower_staking_address = givpower_staking_address
 
-    def _decode_token_locked(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_token_locked(self, context: DecoderContext) -> EvmDecodingOutput:
         if not self.base.is_tracked(user := bytes_to_address(context.tx_log.topics[1])):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
@@ -94,11 +94,11 @@ class GivethDecoderBase(EvmDecoderInterface, ABC):
             ordered_events=[lock_event, receive_event],
             events_list=context.decoded_events,
         )
-        return DecodingOutput(events=[lock_event])
+        return EvmDecodingOutput(events=[lock_event])
 
-    def decode_claim(self, context: DecoderContext) -> DecodingOutput:
+    def decode_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != SIMPLE_CLAIM or not self.base.is_tracked(user := bytes_to_address(context.tx_log.topics[1])):  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
@@ -118,10 +118,10 @@ class GivethDecoderBase(EvmDecoderInterface, ABC):
         else:
             log.error(f'Could not find the Giv token transfer after reward claiming for {context.transaction}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     @abstractmethod
-    def decode_staking_events(self, context: DecoderContext) -> DecodingOutput:
+    def decode_staking_events(self, context: DecoderContext) -> EvmDecodingOutput:
         """The staking events are slightly different in gnosis and optimism so let
         each decoder implement them"""
 

--- a/rotkehlchen/chain/evm/decoding/kyber/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/kyber/decoder.py
@@ -7,9 +7,9 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import SWAPPED_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.fval import FVal
@@ -67,16 +67,16 @@ class KyberCommonDecoder(EvmDecoderInterface):
             if out_event is not None and in_event is not None:
                 maybe_reshuffle_events(ordered_events=[out_event, in_event], events_list=decoded_events)  # noqa: E501
 
-    def _decode_aggregator_trade(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_aggregator_trade(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a kyber aggregator swap, updating the events with proper metadata"""
         if context.tx_log.topics[0] != SWAPPED_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         sender = bytes_to_address(context.tx_log.data[:32])
         receiver = bytes_to_address(context.tx_log.data[96:128])
 
         if self.base.any_tracked([sender, receiver]) is False:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         source_token_address = bytes_to_address(context.tx_log.data[32:64])
         destination_token_address = bytes_to_address(context.tx_log.data[64:96])
@@ -97,7 +97,7 @@ class KyberCommonDecoder(EvmDecoderInterface):
             counterparty=CPT_KYBER,
         )
 
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/merkl/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/merkl/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import REWARD_CLAIMED
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -41,10 +41,10 @@ class MerklDecoder(EvmDecoderInterface):
             msg_aggregator=msg_aggregator,
         )
 
-    def _decode_reward_claim(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_reward_claim(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode a Merkl reward claim event."""
         if context.tx_log.topics[0] != REWARD_CLAIMED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         claimed_asset = self.base.get_or_create_evm_asset(
             address=(claimed_asset_addr := bytes_to_address(context.tx_log.topics[2])),
@@ -75,7 +75,7 @@ class MerklDecoder(EvmDecoderInterface):
         else:
             log.error(f'Failed to find Merkl reward claim event in {context.transaction}')
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.externalapis.monerium import init_monerium
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -60,14 +60,14 @@ class MoneriumCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
         """
         return set()
 
-    def _decode_mint_and_burn(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_mint_and_burn(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode mint and burn events for monerium"""
         if context.transaction.tx_hash.hex() in self._v1_to_v2_migration_hashes():
             # stop processing the transaction if it is a migration from v1 to v2
-            return DecodingOutput(stop_processing=True)
+            return EvmDecodingOutput(stop_processing=True)
 
         if context.tx_log.topics[0] != ERC20_OR_ERC721_TRANSFER:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         from_address = bytes_to_address(value=context.tx_log.topics[1])
         to_address = bytes_to_address(value=context.tx_log.topics[2])
@@ -116,7 +116,7 @@ class MoneriumCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
                 counterparty=CPT_MONERIUM,
             )
 
-        return DecodingOutput(
+        return EvmDecodingOutput(
             events=[event] if event is not None else None,
             refresh_balances=False,
             matched_counterparty=CPT_MONERIUM,

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -6,7 +6,7 @@ from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.transactions import EvmTransactions
 from rotkehlchen.constants.misc import ZERO
@@ -129,7 +129,7 @@ class OdosCommonDecoderBase(EvmDecoderInterface):
             sender: 'ChecksumEvmAddress',
             input_tokens: dict[str, FVal],
             output_tokens: dict[str, FVal],
-    ) -> 'DecodingOutput':
+    ) -> 'EvmDecodingOutput':
         """Decodes swaps done using an Odos v1/v2 router"""
         in_events, out_events = [], []
         for event in context.decoded_events:
@@ -177,4 +177,4 @@ class OdosCommonDecoderBase(EvmDecoderInterface):
             ordered_events=out_events + in_events + fee_events,
             events_list=context.decoded_events,
         )
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)

--- a/rotkehlchen/chain/evm/decoding/odos/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/odos/v1/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
 from rotkehlchen.chain.evm.decoding.odos.common import OdosCommonDecoderBase
 from rotkehlchen.chain.evm.decoding.odos.v1.constants import CPT_ODOS_V1, SWAPPED_EVENT_ABI
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -38,10 +38,10 @@ class Odosv1DecoderBase(OdosCommonDecoderBase):
             router_address=router_address,
         )
 
-    def _decode_v1_swap(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def _decode_v1_swap(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         """Decodes swaps done using an Odos v1 router"""
         if context.tx_log.topics[0] != b'\xe8uh\xfeY4\xcbu$\xb9n\x16\xb2%\xee.~s\x8c\xcb\xb7\x06\xc7\xbe\xe5,\xe0{\xf06\x0ei':  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         try:
             # decode the swap event structure
@@ -52,10 +52,10 @@ class Odosv1DecoderBase(OdosCommonDecoderBase):
                 f'Failed to deserialize Odos event {context.tx_log=} at '
                 f'{context.transaction} due to {e}',
             )
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if not self.base.is_tracked(decoded_data[0]):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         input_tokens = self.base.resolve_tokens_data(token_amounts=decoded_data[1], token_addresses=decoded_data[2])  # noqa: E501
         output_tokens = self.base.resolve_tokens_data(token_amounts=decoded_data[3], token_addresses=[data[0] for data in decoded_data[4]])  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/odos/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/odos/v2/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
 from rotkehlchen.chain.evm.decoding.odos.common import OdosCommonDecoderBase
 from rotkehlchen.chain.evm.decoding.odos.v2.constants import CPT_ODOS_V2, SWAPMULTI_EVENT_ABI
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -39,7 +39,7 @@ class Odosv2DecoderBase(OdosCommonDecoderBase):
             router_address=router_address,
         )
 
-    def _decode_v2_swap(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def _decode_v2_swap(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         """Decodes swaps done using an Odos v2 router"""
         if context.tx_log.topics[0] == b'\x82>\xaf\x01\x00-sS\xfb\xca\xdb.\xa30\\\xc4o\xa3]y\x9c\xb0\x91HF\xd1\x85\xac\x06\xf8\xad\x05':  # swapCompact()  # noqa: E501
             # decode the single swap event structure
@@ -61,12 +61,12 @@ class Odosv2DecoderBase(OdosCommonDecoderBase):
                     f'Failed to deserialize Odos event {context.tx_log=} at '
                     f'{context.transaction} due to {e}',
                 )
-                return DEFAULT_DECODING_OUTPUT
+                return DEFAULT_EVM_DECODING_OUTPUT
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if not self.base.is_tracked(decoded_data[0]):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         input_tokens = self.base.resolve_tokens_data(token_amounts=decoded_data[1], token_addresses=decoded_data[2])  # noqa: E501
         output_tokens = self.base.resolve_tokens_data(token_amounts=decoded_data[3], token_addresses=decoded_data[4])  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
@@ -9,9 +9,9 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
 from rotkehlchen.constants.assets import A_ETH, A_WETH
@@ -52,7 +52,7 @@ class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
         self.source_chain = source_chain
         self.target_chain = target_chain
 
-    def _decode_bridge_tokens(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_bridge_tokens(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a bridging event for tokens. Either a deposit or a withdrawal."""
         if context.tx_log.topics[0] == TOKENS_BRIDGING_INITIATED:
             from_address = context.transaction.from_address
@@ -61,7 +61,7 @@ class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
             to_address = bytes_to_address(context.tx_log.topics[2])
             from_address = to_address  # We have no from_address information
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         bridged_asset = get_or_create_evm_token(
             userdb=self.node_inquirer.database,
@@ -118,7 +118,7 @@ class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
         else:
             log.error(f'Could not find the transfer event for bridging to {to_address} in {context.transaction}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -46,11 +46,11 @@ class OneinchCommonDecoder(EvmDecoderInterface, ABC):
             destination_token_address: ChecksumEvmAddress,
             spent_amount_raw: int,
             return_amount_raw: int,
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         """Function to abstract the functionality of oneinch decoding where Once
         the data has been pulled from the log we create the decoded events"""
         if not self.base.any_tracked([sender, receiver]):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         source_token = self.base.get_or_create_evm_asset(source_token_address)
         destination_token = self.base.get_or_create_evm_asset(destination_token_address)
@@ -79,7 +79,7 @@ class OneinchCommonDecoder(EvmDecoderInterface, ABC):
             ordered_events=[out_event, in_event],
             events_list=context.decoded_events,
         )
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     @staticmethod
     def generate_counterparty_details(counterparty: str) -> tuple[CounterpartyDetails, ...]:
@@ -90,14 +90,14 @@ class OneinchCommonDecoder(EvmDecoderInterface, ABC):
         ),)
 
     @abstractmethod
-    def _decode_swapped(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_swapped(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode the swapped log for the particular 1inch version"""
 
-    def decode_action(self, context: DecoderContext) -> DecodingOutput:
+    def decode_action(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] in self.swapped_signatures:
             return self._decode_swapped(context=context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import (
     ORDERFILLED_RFQ,
     PANCAKE_SWAP_TOPIC,
 )
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
 from rotkehlchen.chain.evm.decoding.uniswap.v2.constants import UNISWAP_V2_SWAP_SIGNATURE
 from rotkehlchen.chain.evm.decoding.uniswap.v3.constants import (
     SWAP_SIGNATURE as UNISWAP_V3_SWAP_SIGNATURE,
@@ -117,7 +117,7 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
     def addresses_to_counterparties(self) -> dict[ChecksumEvmAddress, str]:
         return {self.router_address: self.counterparty}
 
-    def _decode_swapped(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_swapped(self, context: DecoderContext) -> EvmDecodingOutput:
         sender = context.transaction.from_address
         decoded_events = context.decoded_events
         out_event = in_event = None
@@ -151,7 +151,7 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
             ordered_events=[out_event, in_event],
             events_list=decoded_events,
         )
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/open_ocean/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/open_ocean/decoder.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.constants import (
     UNISWAP_V2_SWAP_SIGNATURE,
@@ -53,10 +53,10 @@ class OpenOceanDecoder(EvmDecoderInterface, ABC):
         )
         return asset, amount
 
-    def _decode_swapped(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_swapped(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode OpenOcean swaps that include a SWAPPED_TOPIC tx_log event."""
         if context.tx_log.topics[0] != SWAPPED_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         spend_asset, spend_amount = self._get_asset_and_amount(
             asset_address=bytes_to_address(context.tx_log.topics[2]),
@@ -74,7 +74,7 @@ class OpenOceanDecoder(EvmDecoderInterface, ABC):
             receive_asset=receive_asset,
             receive_amount=receive_amount,
         )
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     @staticmethod
     def _decode_swap(

--- a/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.transactions import EvmTransactions
@@ -52,13 +52,13 @@ class ParaswapCommonDecoder(EvmDecoderInterface, ABC):
             context: DecoderContext,
             sender: ChecksumEvmAddress,
             receiver: ChecksumEvmAddress | None = None,
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         """This function is used to decode the swap done by paraswap.
         In v6 swaps, receiver is unavailable and is ignored,
         since sender should always be a tracked address.
         """
         if not self.base.any_tracked((sender,) if receiver is None else (sender, receiver)):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         out_event: EvmEvent | None = None
         in_event: EvmEvent | None = None
@@ -92,7 +92,7 @@ class ParaswapCommonDecoder(EvmDecoderInterface, ABC):
 
         if in_event is None or out_event is None:
             log.error(f'Could not find the corresponding events when decoding {self.node_inquirer.chain_name} paraswap swap {context.transaction.tx_hash.hex()}')  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if partial_refund_event is not None:  # if some in_asset is returned back.
             # it's assumed in the above for loop, that the second in_event is the partial refund
@@ -161,7 +161,7 @@ class ParaswapCommonDecoder(EvmDecoderInterface, ABC):
             ordered_events=[out_event, in_event, fee_event],
             events_list=context.decoded_events,
         )
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/paraswap/v5/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/v5/decoder.py
@@ -4,9 +4,9 @@ from typing import Any
 
 from rotkehlchen.chain.evm.decoding.paraswap.decoder import ParaswapCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.v2.constants import UNISWAP_V2_SWAP_SIGNATURE
 from rotkehlchen.chain.evm.decoding.uniswap.v3.constants import DIRECT_SWAP_SIGNATURE
@@ -25,7 +25,7 @@ from .constants import (
 
 class Paraswapv5CommonDecoder(ParaswapCommonDecoder, ABC):
 
-    def _decode_paraswap_swap(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_paraswap_swap(self, context: DecoderContext) -> EvmDecodingOutput:
         """This decodes the following types of trades:
         - Simple Buy
         - Simple Swap
@@ -36,7 +36,7 @@ class Paraswapv5CommonDecoder(ParaswapCommonDecoder, ABC):
         - Direct Swap on Balancer V2
         """
         if context.tx_log.topics[0] not in {PARASWAP_SWAP_SIGNATURE, BUY_SIGNATURE, DIRECT_SWAP_SIGNATURE}:  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         return self._decode_swap(
             context=context,
@@ -44,7 +44,7 @@ class Paraswapv5CommonDecoder(ParaswapCommonDecoder, ABC):
             sender=bytes_to_address(context.tx_log.data[96:128]),
         )
 
-    def _decode_uniswap_v2_swap(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_uniswap_v2_swap(self, context: DecoderContext) -> EvmDecodingOutput:
         """This decodes swaps done directly on Uniswap V2 pools"""
         return self._decode_swap(
             context=context,

--- a/rotkehlchen/chain/evm/decoding/quickswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/quickswap/v3/decoder.py
@@ -16,9 +16,9 @@ from rotkehlchen.chain.evm.decoding.quickswap.v3.constants import (
     QUICKSWAP_V3_NFT_MANAGER_ABI,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.utils import (
     decode_uniswap_v3_like_position_create_or_exit,
@@ -68,7 +68,7 @@ class Quickswapv3LikeLPDecoder(EvmDecoderInterface):
         self.version_string = version_string
         self.wrapped_native_currency = CHAIN_TO_WRAPPED_TOKEN[evm_inquirer.blockchain]
 
-    def _decode_deposits_and_withdrawals(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_deposits_and_withdrawals(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == QUICKSWAP_INCREASE_LIQUIDITY_TOPIC:
             is_deposit = True
             amount0_raw = int.from_bytes(context.tx_log.data[64:96])
@@ -78,7 +78,7 @@ class Quickswapv3LikeLPDecoder(EvmDecoderInterface):
             amount0_raw = int.from_bytes(context.tx_log.data[32:64])
             amount1_raw = int.from_bytes(context.tx_log.data[64:96])
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         position_id = int.from_bytes(context.tx_log.topics[1])
         try:
@@ -98,7 +98,7 @@ class Quickswapv3LikeLPDecoder(EvmDecoderInterface):
                 f'Failed to query {self.counterparty} nft contract for '
                 f'position {position_id} due to {e!s}',
             )
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         return decode_uniswap_v3_like_deposit_or_withdrawal(
             context=context,

--- a/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
@@ -12,9 +12,9 @@ from rotkehlchen.chain.evm.decoding.socket_bridge.constants import (
     GATEWAY_ADDRESS,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.errors.serialization import DeserializationError
@@ -49,9 +49,9 @@ class SocketBridgeDecoder(EvmDecoderInterface):
         )
         self.eth = A_ETH.resolve_to_crypto_asset()
 
-    def _decode_bridged_asset(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_bridged_asset(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != BRIDGE_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount_raw = int.from_bytes(context.tx_log.data[0:32])
         token_address = bytes_to_address(context.tx_log.data[32:64])
@@ -93,7 +93,7 @@ class SocketBridgeDecoder(EvmDecoderInterface):
                     f'Bridge {amount} {bridged_asset.symbol} to {receiver} at {target_chain} using Socket'  # noqa: E501
                 )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -69,7 +69,7 @@ class EnricherContext(DecoderBasicContext):
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
-class DecodingOutput(CommonDecodingOutput['EvmEvent']):
+class EvmDecodingOutput(CommonDecodingOutput['EvmEvent']):
     """Output of EVM decoding functions
 
     - action_items is a list of actions to be performed later automatically or to be passed
@@ -102,5 +102,5 @@ class TransferEnrichmentOutput(NamedTuple):
     process_swaps: bool = False
 
 
-DEFAULT_DECODING_OUTPUT: Final = DecodingOutput()
+DEFAULT_EVM_DECODING_OUTPUT: Final = EvmDecodingOutput()
 FAILED_ENRICHMENT_OUTPUT: Final = TransferEnrichmentOutput()

--- a/rotkehlchen/chain/evm/decoding/summer_fi/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/summer_fi/decoder.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.summer_fi.constants import ACCOUNT_CREATED_TOPIC, CPT_SUMMER_FI
 from rotkehlchen.constants import ZERO
@@ -35,17 +35,17 @@ class SummerFiCommonDecoder(EvmDecoderInterface):
         )
         self.account_factory = account_factory
 
-    def _decode_account_creation(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_account_creation(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode smart account creation events."""
         if (
             context.tx_log.topics[0] != ACCOUNT_CREATED_TOPIC or
             not self.base.is_tracked(user_address := bytes_to_address(context.tx_log.topics[2]))
         ):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         proxy_address = bytes_to_address(context.tx_log.topics[1])
         vault_id = int.from_bytes(context.tx_log.topics[3])
-        return DecodingOutput(events=[self.base.make_event_from_transaction(
+        return EvmDecodingOutput(events=[self.base.make_event_from_transaction(
             transaction=context.transaction,
             tx_log=context.tx_log,
             event_type=HistoryEventType.INFORMATIONAL,

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
@@ -5,9 +5,9 @@ from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
 from rotkehlchen.constants.assets import A_ETH
@@ -50,7 +50,7 @@ class SuperchainL1SideCommonBridgeDecoder(EvmDecoderInterface, ABC):
         self.counterparty = counterparty
         self.l2_chain = l2_chain
 
-    def _decode_bridge(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_bridge(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a bridging(deposit or withdrawal) event for superchain chains.
 
         Note:
@@ -67,7 +67,7 @@ class SuperchainL1SideCommonBridgeDecoder(EvmDecoderInterface, ABC):
             ERC20_WITHDRAWAL_FINALIZED,
         }:
             # Make sure that we are decoding a supported event.
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         # Read information from event's topics & data
         if context.tx_log.topics[0] in {ETH_DEPOSIT_INITIATED, ETH_WITHDRAWAL_FINALIZED}:
@@ -119,12 +119,12 @@ class SuperchainL1SideCommonBridgeDecoder(EvmDecoderInterface, ABC):
                     counterparty=self.counterparty,
                 )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_prove_withdrawal(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_prove_withdrawal(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a proving withdrawal event."""
         if context.tx_log.topics[0] != WITHDRAWAL_PROVEN:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         withdrawal_hash = context.tx_log.topics[1].hex()
         event = self.base.make_event_from_transaction(
@@ -139,7 +139,7 @@ class SuperchainL1SideCommonBridgeDecoder(EvmDecoderInterface, ABC):
             counterparty=self.counterparty.identifier,
             address=context.tx_log.address,
         )
-        return DecodingOutput(events=[event])
+        return EvmDecodingOutput(events=[event])
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return dict.fromkeys(self.bride_addresses, (self._decode_bridge,))

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
@@ -8,9 +8,9 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
 from rotkehlchen.constants.resolver import evm_address_to_identifier
@@ -55,7 +55,7 @@ class SuperchainL2SideBridgeCommonDecoder(EvmDecoderInterface, ABC):
         self.native_assets = native_assets
         self.counterparty = counterparty
 
-    def _decode_receive_or_deposit(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_receive_or_deposit(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a bridging event.
 
         Note:
@@ -66,7 +66,7 @@ class SuperchainL2SideBridgeCommonDecoder(EvmDecoderInterface, ABC):
              https://docs.optimism.io/app-developers/bridging/custom-bridge
         """
         if context.tx_log.topics[0] not in {DEPOSIT_FINALIZED, WITHDRAWAL_INITIATED}:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         # Read information from event's topics & data
         l1_token_address = bytes_to_address(context.tx_log.topics[1])
@@ -91,7 +91,7 @@ class SuperchainL2SideBridgeCommonDecoder(EvmDecoderInterface, ABC):
             except (UnknownAsset, WrongAssetType):
                 # can't call `notify_user`` since we don't have any particular event here.
                 log.error(f'Failed to resolve asset with address {l2_token_address} to an {self.node_inquirer.chain_name} token')  # noqa: E501
-                return DEFAULT_DECODING_OUTPUT
+                return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = asset_normalized_value(asset=asset, amount=raw_amount)
 
@@ -126,7 +126,7 @@ class SuperchainL2SideBridgeCommonDecoder(EvmDecoderInterface, ABC):
                     counterparty=self.counterparty,
                 )
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/uniswap/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/utils.py
@@ -7,7 +7,10 @@ from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import get_versioned_counterparty_label
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, get_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_EVM_DECODING_OUTPUT,
+    EvmDecodingOutput,
+)
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 from rotkehlchen.chain.evm.decoding.uniswap.v4.constants import V4_SWAP_TOPIC
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
@@ -45,7 +48,7 @@ def decode_basic_uniswap_info(
         counterparty: str,
         notify_user: Callable[['EvmEvent', str], None],
         native_currency: 'CryptoAsset',
-) -> DecodingOutput:
+) -> EvmDecodingOutput:
     """
     Check last three events and if they are related to the swap, label them as such.
     We check three events because potential events are: spend, (optionally) approval, receive.
@@ -58,7 +61,7 @@ def decode_basic_uniswap_info(
             crypto_asset = event.asset.resolve_to_crypto_asset()
         except (UnknownAsset, WrongAssetType):
             notify_user(event, counterparty)
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if (
             event.event_type == HistoryEventType.INFORMATIONAL and
@@ -120,7 +123,7 @@ def decode_basic_uniswap_info(
         ordered_events=[approval_event, spend_event, receive_event],
         events_list=decoded_events,
     )
-    return DecodingOutput(process_swaps=True)
+    return EvmDecodingOutput(process_swaps=True)
 
 
 def get_uniswap_swap_amounts(tx_log: 'EvmTxReceiptLog') -> tuple[int, int]:

--- a/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import BURN_TOPIC, MINT_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V2, UNISWAP_ICON
 from rotkehlchen.chain.evm.decoding.uniswap.utils import decode_basic_uniswap_info
@@ -54,7 +54,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
             self,
             tx_log: EvmTxReceiptLog,
             decoded_events: list['EvmEvent'],
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         """
         Decodes only basic swap info. Basic swap info includes trying to find approval, spend and
         receive events for this particular swap but doesn't include ensuring order of events if the
@@ -87,7 +87,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if tx_log.topics[0] == UNISWAP_V2_SWAP_SIGNATURE:
             if transaction.to_address == self.router_address:
                 # If uniswap v2 router is used, then we can decode an entire swap.
@@ -108,7 +108,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
             # and other properties should be decoded by the aggregator decoding methods later.
             return self._decode_basic_swap_info(tx_log=tx_log, decoded_events=decoded_events)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def _maybe_decode_v2_liquidity_addition_and_removal(
             self,
@@ -118,7 +118,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if tx_log.topics[0] == MINT_TOPIC:
             return decode_uniswap_like_deposit_and_withdrawals(
                 tx_log=tx_log,
@@ -145,7 +145,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
                 init_code_hash=UNISWAP_V2_INIT_CODE_HASH,
                 tx_hash=transaction.tx_hash,
             )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
@@ -12,10 +12,10 @@ from rotkehlchen.chain.decoding.types import (
 )
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.constants import (
     CPT_UNISWAP_V2,
@@ -139,13 +139,13 @@ class Uniswapv3CommonDecoder(EvmDecoderInterface):
             return None
         return to_asset, to_amount
 
-    def _decode_deposits_and_withdrawals(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_deposits_and_withdrawals(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == INCREASE_LIQUIDITY_SIGNATURE:
             is_deposit = True
         elif context.tx_log.topics[0] == COLLECT_LIQUIDITY_SIGNATURE:
             is_deposit = False
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         position_id = int.from_bytes(context.tx_log.topics[1])
         try:
@@ -173,7 +173,7 @@ class Uniswapv3CommonDecoder(EvmDecoderInterface):
                 'Failed to query uniswap v3 nft contract for '
                 f'position {position_id} due to {e!s}',
             )
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         return decode_uniswap_v3_like_deposit_or_withdrawal(
             context=context,
@@ -196,14 +196,14 @@ class Uniswapv3CommonDecoder(EvmDecoderInterface):
             decoded_events: list['EvmEvent'],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         """
         Detect some basic uniswap v3 events. This method doesn't ensure the order of the events
         and other things, but just labels some of the events as uniswap v3 events.
         The order should be ensured by the post-decoding rules.
         """
         if tx_log.topics[0] != SWAP_SIGNATURE:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount_received, amount_sent = get_uniswap_swap_amounts(tx_log=tx_log)
 

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/utils.py
@@ -12,7 +12,7 @@ from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import get_versioned_counterparty_label
 from rotkehlchen.chain.ethereum.oracles.constants import UNISWAP_FACTORY_ADDRESSES
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value, generate_address_via_create2
-from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecoderContext, DecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecoderContext, EvmDecodingOutput
 from rotkehlchen.chain.evm.decoding.uniswap.utils import get_position_price_from_underlying
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.constants.resolver import tokenid_to_collectible_id
@@ -152,7 +152,7 @@ def decode_uniswap_v3_like_deposit_or_withdrawal(
         position_id: int,
         evm_inquirer: 'EvmNodeInquirer',
         wrapped_native_currency: Asset,
-) -> DecodingOutput:
+) -> EvmDecodingOutput:
     """This method decodes a Uniswap V3 like LP liquidity increase or decrease.
 
     Examples of such transactions are:
@@ -256,7 +256,7 @@ def decode_uniswap_v3_like_deposit_or_withdrawal(
             ),
         )
 
-    return DecodingOutput(
+    return EvmDecodingOutput(
         action_items=new_action_items,
         matched_counterparty=counterparty,
     )

--- a/rotkehlchen/chain/evm/decoding/uniswap/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v4/decoder.py
@@ -8,10 +8,10 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V4, UNISWAP_ICON
 from rotkehlchen.chain.evm.decoding.uniswap.utils import (
@@ -62,9 +62,9 @@ class Uniswapv4CommonDecoder(EvmDecoderInterface):
         self.position_manager = position_manager
         self.universal_router = universal_router
 
-    def _decode_modify_liquidity(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def _decode_modify_liquidity(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         if context.tx_log.topics[0] != MODIFY_LIQUIDITY:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if len(pool_info := self.node_inquirer.call_contract(
             contract_address=self.position_manager,
@@ -73,7 +73,7 @@ class Uniswapv4CommonDecoder(EvmDecoderInterface):
             arguments=[context.tx_log.topics[1][:25]],
         )) != 5:
             log.error(f'Unexpected response from Uniswap V4 Position Manager poolKeys call: {pool_info}')  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         lp_assets, has_native = [], False
         for raw_address in pool_info[:2]:
@@ -129,7 +129,7 @@ class Uniswapv4CommonDecoder(EvmDecoderInterface):
                     amount=deposit_withdraw_event.amount,
                 )
 
-        return DecodingOutput(
+        return EvmDecodingOutput(
             matched_counterparty=CPT_UNISWAP_V4_LP,  # Trigger _lp_post_decoding
             action_items=[ActionItem(
                 action='transform',

--- a/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
@@ -7,9 +7,9 @@ from rotkehlchen.chain.ethereum.decoding.constants import GNOSIS_CPT_DETAILS
 from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -64,7 +64,7 @@ class XdaiBridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
         self.target_chain = target_chain
         self.peripheral_addresses = peripheral_addresses or ()
 
-    def _decode_bridged_asset(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_bridged_asset(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a bridging event for the `bridged_asset`, either a deposit or a withdrawal."""
         create_event = False
         if context.tx_log.topics[0] in self.deposit_topics:
@@ -77,7 +77,7 @@ class XdaiBridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
                 create_event = True
 
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = asset_normalized_value(
             amount=int.from_bytes(context.tx_log.data[32:64]),
@@ -117,7 +117,7 @@ class XdaiBridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
                 new_event_type=new_event_type,
                 counterparty=GNOSIS_CPT_DETAILS,
             )
-            return DecodingOutput(events=[event])
+            return EvmDecodingOutput(events=[event])
 
         for event in context.decoded_events:
             if (
@@ -145,7 +145,7 @@ class XdaiBridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
                 f'Could not find the transfer event for bridging to {to_address}'
                 f' in {self.node_inquirer.chain_name} transaction {context.transaction.tx_hash.hex()}',  # noqa: E501
             )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/evm/decoding/zerox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/zerox/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.uniswap.constants import UNISWAP_SIGNATURES
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
@@ -239,10 +239,10 @@ class ZeroxCommonDecoder(EvmDecoderInterface):
 
         return decoded_events
 
-    def _decode_meta_tx_swap(self, context: 'DecoderContext') -> DecodingOutput:
+    def _decode_meta_tx_swap(self, context: 'DecoderContext') -> EvmDecodingOutput:
         """Decodes the swap event from the 0x router contract via executeMetaTransactionV2."""
         if context.tx_log.topics[0] != METATX_ZEROX or context.tx_log.address != self.router_address:  # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         # using [] for cases with multiple dexes, where multiple send/receive events exist
         send_events, receive_events, fee_event = [], [], None
@@ -282,7 +282,7 @@ class ZeroxCommonDecoder(EvmDecoderInterface):
             fee_event=fee_event,
         )
 
-        return DecodingOutput(process_swaps=True)
+        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
@@ -11,10 +11,10 @@ from rotkehlchen.chain.evm.decoding.giveth.constants import (
 )
 from rotkehlchen.chain.evm.decoding.giveth.decoder import GivethDecoderBase
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.gnosis.modules.giveth.constants import (
@@ -54,7 +54,7 @@ class GivethDecoder(GivethDecoderBase):
             pow_token_id='eip155:100/erc20:0xD93d3bDBa18ebcB3317a57119ea44ed2Cf41C2F2',
         )
 
-    def decode_staking_events(self, context: DecoderContext) -> DecodingOutput:
+    def decode_staking_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == STAKED:
             return self._decode_deposit(context=context)
         elif context.tx_log.topics[0] == WITHDRAWN:
@@ -62,11 +62,11 @@ class GivethDecoder(GivethDecoderBase):
         elif context.tx_log.topics[0] == TOKEN_LOCKED:
             return self._decode_token_locked(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_deposit(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_deposit(self, context: DecoderContext) -> EvmDecodingOutput:
         if not self.base.is_tracked(user := bytes_to_address(context.tx_log.topics[1])):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
@@ -88,7 +88,7 @@ class GivethDecoder(GivethDecoderBase):
                 break
         else:
             log.error(f'Could not find the GIV/PoW token transfers for {context.transaction}')
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         # Since the receive transaction comes after we need an action item
         action_items = [ActionItem(
@@ -114,11 +114,11 @@ class GivethDecoder(GivethDecoderBase):
             asset=Asset(GGIV_TOKEN_ID),
             address=ZERO_ADDRESS,
         )]
-        return DecodingOutput(action_items=action_items)
+        return EvmDecodingOutput(action_items=action_items)
 
-    def _decode_withdraw(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_withdraw(self, context: DecoderContext) -> EvmDecodingOutput:
         if not self.base.is_tracked(user := bytes_to_address(context.tx_log.topics[1])):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
@@ -158,4 +158,4 @@ class GivethDecoder(GivethDecoderBase):
              asset=Asset(GGIV_TOKEN_ID),
              address=ZERO_ADDRESS,
          )]
-        return DecodingOutput(action_items=action_items)
+        return EvmDecodingOutput(action_items=action_items)

--- a/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
@@ -7,10 +7,10 @@ from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER, OPTIMISM_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.interfaces import MerkleClaimDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
@@ -46,7 +46,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
         )
         self.op_token = A_OP.resolve_to_evm_token()
 
-    def _decode_distributed_airdrop(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_distributed_airdrop(self, context: DecoderContext) -> EvmDecodingOutput:
         """This decodes airdrops sent directly to users by the OP Foundation:
         - Airdrop 1: For users who did not claim their allocation.
         - Airdrop 2 & 3: Automatically distributed, no claim required.
@@ -55,7 +55,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             bytes_to_address(context.tx_log.topics[1]) != OPTIMISM_FOUNDATION_ADDRESS and
             not self.base.is_tracked(bytes_to_address(context.tx_log.topics[2]))
         ):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         if context.transaction.to_address == string_to_evm_address('0xbE9a9B1B07f027130e56d8569d1aeA5dd5a86013'):  # noqa: E501
             airdrop_identifier, note_suffix = 'optimism_2', '2'
@@ -64,7 +64,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
         elif context.transaction.to_address == string_to_evm_address('0x4bd927E14f828e5862F166919Fd5091dA6ae44c0'):  # noqa: E501
             airdrop_identifier, note_suffix = 'optimism_3', '3'
         else:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         context.action_items.append(ActionItem(
             action='transform',
@@ -81,7 +81,7 @@ class AirdropsDecoder(MerkleClaimDecoderInterface):
             to_notes=f'Receive {amount} OP from the optimism airdrop {note_suffix}',
             extra_data={AIRDROP_IDENTIFIER_KEY: airdrop_identifier},
         ))
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {

--- a/rotkehlchen/chain/optimism/modules/extrafi/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/extrafi/decoder.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.chain.evm.decoding.extrafi.constants import CPT_EXTRAFI
 from rotkehlchen.chain.evm.decoding.extrafi.decoder import ExtrafiCommonDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.constants.assets import A_OP
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -35,11 +35,11 @@ class ExtrafiDecoder(ExtrafiCommonDecoder):
             extra_token_identifier='eip155:10/erc20:0x2dAD3a13ef0C6366220f989157009e501e7938F8',
         )
 
-    def _handle_op_rewards(self, context: DecoderContext) -> DecodingOutput:
+    def _handle_op_rewards(self, context: DecoderContext) -> EvmDecodingOutput:
         """For a period of time extrafi gave/gives extra incentives for pool depositors by
         sending them directly to user addresses from their community fund"""
         if context.tx_log.topics[0] != b'fu<\xd25ei\xee\x08\x122\xe3\xbe\x89\t\xb9P\xe0\xa7l\x1f\x84`\xc3\xa5\xe3\xc2\xbe2\xb1\x1b\xed':  # SafeMultiSigTransaction # noqa: E501
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         # If this transaction appears in your history you most probably received an Optimism
         # incentive reward, so create an action item to find it and mark it appropriately
@@ -52,7 +52,7 @@ class ExtrafiDecoder(ExtrafiCommonDecoder):
             to_notes='Receive {amount} OP as a reward incentive for participating in an Extrafi pool',  # noqa: E501
             to_counterparty=CPT_EXTRAFI,
         )
-        return DecodingOutput(action_items=[action_item])
+        return EvmDecodingOutput(action_items=[action_item])
 
     def addresses_to_decoders(self) -> dict['ChecksumEvmAddress', tuple[Any, ...]]:
         return super().addresses_to_decoders() | {

--- a/rotkehlchen/chain/optimism/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/giveth/decoder.py
@@ -6,9 +6,9 @@ from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_GIVETH, TOKEN_LOCKED
 from rotkehlchen.chain.evm.decoding.giveth.decoder import GivethDecoderBase
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -48,7 +48,7 @@ class GivethDecoder(GivethDecoderBase):
             pow_token_id='eip155:10/erc20:0x301C739CF6bfb6B47A74878BdEB13f92F13Ae5E7',
         )
 
-    def decode_staking_events(self, context: DecoderContext) -> DecodingOutput:
+    def decode_staking_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] == TOKEN_DEPOSITED:
             return self._decode_token_movement(
                 context=context,
@@ -78,7 +78,7 @@ class GivethDecoder(GivethDecoderBase):
         elif context.tx_log.topics[0] == TOKEN_LOCKED:
             return self._decode_token_locked(context)
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def _decode_token_movement(
             self,
@@ -92,9 +92,9 @@ class GivethDecoder(GivethDecoderBase):
             receive_type: HistoryEventType,
             receive_subtype: HistoryEventSubType,
             receive_notes: str,
-    ) -> DecodingOutput:
+    ) -> EvmDecodingOutput:
         if not self.base.is_tracked(user := bytes_to_address(context.tx_log.topics[1])):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         amount = token_normalized_value_decimals(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
@@ -126,10 +126,10 @@ class GivethDecoder(GivethDecoderBase):
 
         if in_event is None or out_event is None:
             log.error(f'Could not find the GIV/PoW token transfers for {context.transaction}')
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         maybe_reshuffle_events(
             ordered_events=[out_event, in_event],
             events_list=context.decoded_events,
         )
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT

--- a/rotkehlchen/chain/optimism/modules/optimism/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/optimism/decoder.py
@@ -4,9 +4,9 @@ from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.decoding.constants import DELEGATE_CHANGED, OPTIMISM_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import CPT_OPTIMISM
@@ -21,13 +21,13 @@ OPTIMISM_TOKEN = string_to_evm_address('0x42000000000000000000000000000000000000
 
 class OptimismDecoder(EvmDecoderInterface):
 
-    def _decode_delegate_changed(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_delegate_changed(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] != DELEGATE_CHANGED:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         delegator = bytes_to_address(context.tx_log.topics[1])
         if not self.base.is_tracked(delegator):
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         delegator_note = ''
         if delegator != context.transaction.from_address:
@@ -46,7 +46,7 @@ class OptimismDecoder(EvmDecoderInterface):
             counterparty=CPT_OPTIMISM,
             address=context.transaction.to_address,
         )
-        return DecodingOutput(events=[event])
+        return EvmDecodingOutput(events=[event])
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/polygon_pos/modules/polygon_pos_bridge/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/polygon_pos_bridge/decoder.py
@@ -9,10 +9,10 @@ from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON, CPT_POLYGON_DETAILS
 from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_DECODING_OUTPUT,
+    DEFAULT_EVM_DECODING_OUTPUT,
     ActionItem,
     DecoderContext,
-    DecodingOutput,
+    EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -36,7 +36,7 @@ POL_TOKEN_ADDRESS = string_to_evm_address('0x00000000000000000000000000000000000
 
 class PolygonPosBridgeDecoder(EvmDecoderInterface):
 
-    def _decode_withdraw(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_withdraw(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes bridge withdraw events.
 
         Ethereum to Polygon bridging uses a state sync mechanism to transfer data from ethereum
@@ -46,7 +46,7 @@ class PolygonPosBridgeDecoder(EvmDecoderInterface):
         withdrawal has been initiated and the corresponding receive event needs to be modified.
         """
         if context.tx_log.topics[0] != STATE_COMMITTED_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         for event in context.decoded_events:
             if (
@@ -71,9 +71,9 @@ class PolygonPosBridgeDecoder(EvmDecoderInterface):
         else:
             log.error(f'Failed to find Polygon bridge withdraw event for {context.transaction}')
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_plasma_withdraw(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_plasma_withdraw(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes withdrawals from plasma bridge.
         No transfer event is decoded automatically, so the withdrawal event must be created here.
         """
@@ -86,7 +86,7 @@ class PolygonPosBridgeDecoder(EvmDecoderInterface):
                 amount=int.from_bytes(context.tx_log.data[0:32]),
                 asset=asset,
             )
-            return DecodingOutput(events=[self.base.make_event_from_transaction(
+            return EvmDecodingOutput(events=[self.base.make_event_from_transaction(
                 transaction=context.transaction,
                 tx_log=context.tx_log,
                 event_type=HistoryEventType.WITHDRAWAL,
@@ -99,9 +99,9 @@ class PolygonPosBridgeDecoder(EvmDecoderInterface):
                 address=context.tx_log.address,
             )])
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_deposit(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_deposit(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes bridge deposit events.
         The transfer event has not been decoded yet and must be transformed via an action item.
 
@@ -138,9 +138,9 @@ class PolygonPosBridgeDecoder(EvmDecoderInterface):
                 to_counterparty=CPT_POLYGON,
             ))
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
-    def _decode_plasma_deposit(self, context: DecoderContext) -> DecodingOutput:
+    def _decode_plasma_deposit(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes deposits to plasma bridge."""
         for event in context.decoded_events:
             if (
@@ -165,7 +165,7 @@ class PolygonPosBridgeDecoder(EvmDecoderInterface):
         else:
             log.error(f'Failed to find Polygon bridge plasma deposit event for {context.transaction}')  # noqa: E501
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/chain/scroll/modules/scroll_airdrop/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_airdrop/decoder.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import CLAIMED_TOPIC
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
-from rotkehlchen.chain.evm.decoding.structures import DEFAULT_DECODING_OUTPUT
+from rotkehlchen.chain.evm.decoding.structures import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.chain.scroll.constants import CPT_SCROLL, SCROLL_CPT_DETAILS
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -16,7 +16,7 @@ from .constants import A_SCR, SCROLL_OFFCHAIN_TOKEN_DISTRIBUTOR, SCROLL_TOKEN_DI
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
-    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, DecodingOutput
+    from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
     from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
@@ -27,10 +27,10 @@ EXECUTION_SUCCESS_TOPIC: Final = b"D.q_bcF\xe8\xc5C\x81\x00-\xa6\x14\xf6+\xee\x8
 
 class ScrollAirdropDecoder(EvmDecoderInterface):
 
-    def _decode_airdop_claim(self, context: 'DecoderContext') -> 'DecodingOutput':
+    def _decode_airdop_claim(self, context: 'DecoderContext') -> 'EvmDecodingOutput':
         """Decodes scroll SCR airdrop claim event."""
         if context.tx_log.topics[0] != CLAIMED_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         user_address = bytes_to_address(context.tx_log.topics[1])
         amount = asset_normalized_value(
@@ -50,12 +50,12 @@ class ScrollAirdropDecoder(EvmDecoderInterface):
         else:
             log.error(f'Failed to find scroll airdrop claim event for {context.transaction}')
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     def _decode_scroll_batch_airdrop(
             self,
             context: 'DecoderContext',
-    ) -> 'DecodingOutput':
+    ) -> 'EvmDecodingOutput':
         """Decodes SCR token airdrop claims from Scroll's offchain distributor.
 
         Handles batch distributions for GitHub/email-based claims that are processed
@@ -64,7 +64,7 @@ class ScrollAirdropDecoder(EvmDecoderInterface):
         See https://scroll-faqs.gitbook.io/faq#23-when-will-i-receive-my-scr-tokens-after-claiming
         """
         if context.tx_log.topics[0] != EXECUTION_SUCCESS_TOPIC:
-            return DEFAULT_DECODING_OUTPUT
+            return DEFAULT_EVM_DECODING_OUTPUT
 
         for event in context.decoded_events:
             if (
@@ -78,7 +78,7 @@ class ScrollAirdropDecoder(EvmDecoderInterface):
                 event.extra_data = {AIRDROP_IDENTIFIER_KEY: 'scroll'}
                 event.notes = f'Receive {event.amount} SCR from scroll airdrop'
 
-        return DEFAULT_DECODING_OUTPUT
+        return DEFAULT_EVM_DECODING_OUTPUT
 
     # -- DecoderInterface methods
 


### PR DESCRIPTION
Renames `DecodingOutput` to `EvmDecodingOutput` and `DEFAULT_DECODING_OUTPUT` to `DEFAULT_EVM_DECODING_OUTPUT`  throughout the codebase as suggested here: https://github.com/rotki/rotki/pull/10675#discussion_r2405527305

Its a simple search and replace, with a few tweaks here and there to fix linting after the rename (import order & line length)