### PR TITLE
Fix txs not decoded query

### DIFF
--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -206,7 +206,6 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             self=self,
             database=database,
             dbtx=dbevmtx_class(database),
-            tx_not_decoded_filter_query_class=EvmTransactionsNotDecodedFilterQuery,
             tx_mappings_table='evm_tx_mappings',
             chain_name=evm_inquirer.chain_name,
             value_asset=value_asset,
@@ -357,6 +356,15 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             post_processing_rules={},
             all_counterparties=set(),
             addresses_to_counterparties={},
+        )
+
+    def _get_tx_not_decoded_filter_query(
+            self,
+            limit: int | None,
+    ) -> EvmTransactionsNotDecodedFilterQuery:
+        return EvmTransactionsNotDecodedFilterQuery.make(
+            limit=limit,
+            chain_id=self.evm_inquirer.chain_id,
         )
 
     def get_decoders_products(self) -> dict[str, list[EvmProduct]]:

--- a/rotkehlchen/chain/solana/decoding/decoder.py
+++ b/rotkehlchen/chain/solana/decoding/decoder.py
@@ -89,7 +89,6 @@ class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecod
         super().__init__(
             database=database,
             dbtx=DBSolanaTx(database),
-            tx_not_decoded_filter_query_class=SolanaTransactionsNotDecodedFilterQuery,
             tx_mappings_table='solana_tx_mappings',
             chain_name=SupportedBlockchain.SOLANA.name.lower(),
             value_asset=A_SOL.resolve_to_asset_with_oracles(),
@@ -135,6 +134,12 @@ class SolanaTransactionDecoder(TransactionDecoder[SolanaTransaction, SolanaDecod
     @staticmethod
     def _load_default_decoding_rules() -> SolanaDecodingRules:
         return SolanaDecodingRules(address_mappings={})
+
+    def _get_tx_not_decoded_filter_query(
+            self,
+            limit: int | None,
+    ) -> SolanaTransactionsNotDecodedFilterQuery:
+        return SolanaTransactionsNotDecodedFilterQuery.make(limit=limit)
 
     def _load_transaction_context(
             self,


### PR DESCRIPTION
Fixes a bug that was introduced in https://github.com/rotki/rotki/pull/10667 where the query for undecoded evm transactions was no longer filtered by chain id and so if there were multiple evm chains with undecoded transactions the first one to try to do decoding would end up with `hash xxxx does not correspond to a transaction.` errors since it would try to pull tx info for txs from another chain.
