### PR TITLE
Use only archive nodes for historical solana data

### DIFF
--- a/rotkehlchen/chain/solana/constants.py
+++ b/rotkehlchen/chain/solana/constants.py
@@ -13,7 +13,10 @@ from construct import (
     Struct,
     this,
 )
+from solders.hash import Hash
 from solders.pubkey import Pubkey
+
+SOLANA_GENESIS_BLOCK_HASH: Final = Hash.from_string('4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZAMdL4VZHirAn')
 
 # Used to derive the metadata PDA (Program Derived Address) for tokens in get_metadata_account
 METADATA_PROGRAM_IDS: Final = (

--- a/rotkehlchen/chain/solana/manager.py
+++ b/rotkehlchen/chain/solana/manager.py
@@ -49,6 +49,7 @@ class SolanaManager(ChainManagerWithTransactions[SolanaAddress]):
         self.transactions = SolanaTransactions(
             node_inquirer=self.node_inquirer,
             database=node_inquirer.database,
+            helius=node_inquirer.helius,
         )
         self.transactions_decoder = SolanaTransactionDecoder(
             database=node_inquirer.database,

--- a/rotkehlchen/chain/solana/transactions.py
+++ b/rotkehlchen/chain/solana/transactions.py
@@ -36,11 +36,12 @@ class SolanaTransactions:
             self,
             node_inquirer: 'SolanaInquirer',
             database: 'DBHandler',
+            helius: Helius,
     ) -> None:
         self.node_inquirer = node_inquirer
         self.database = database
         self.dbtx = DBSolanaTx(database=database)
-        self.helius = Helius(database=database)
+        self.helius = helius
 
     def get_or_create_transaction(
             self,

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -82,6 +82,7 @@ from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.externalapis.cryptocompare import Cryptocompare
 from rotkehlchen.externalapis.defillama import Defillama
 from rotkehlchen.externalapis.etherscan import Etherscan
+from rotkehlchen.externalapis.helius import Helius
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.asset_updates.manager import AssetsUpdater
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -476,6 +477,7 @@ class Rotkehlchen:
                 node_inquirer=SolanaInquirer(
                     greenlet_manager=self.greenlet_manager,
                     database=self.data.db,
+                    helius=Helius(database=self.data.db),
                 ),
                 premium=self.premium,
             ),

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -48,6 +48,7 @@ from rotkehlchen.tests.utils.factories import make_random_b64bytes
 from rotkehlchen.tests.utils.history import maybe_mock_historical_price_queries
 from rotkehlchen.tests.utils.inquirer import inquirer_inject_evm_managers_set_order
 from rotkehlchen.tests.utils.mock import mock_proxies, patch_etherscan_request
+from rotkehlchen.tests.utils.solana import patch_solana_inquirer_nodes
 from rotkehlchen.tests.utils.substrate import wait_until_all_substrate_nodes_connected
 from rotkehlchen.types import (
     AVAILABLE_MODULES_MAP,
@@ -549,6 +550,7 @@ def fixture_rotkehlchen_api_server(
         scroll_manager_connect_at_start,
         binance_sc_manager_connect_at_start,
         kusama_manager_connect_at_start,
+        solana_nodes_connect_at_start,
         ksm_rpc_endpoint,
         max_tasks_num,
         legacy_messages_via_websockets,
@@ -644,6 +646,12 @@ def fixture_rotkehlchen_api_server(
                         manager_connect_at_start=connect_at_start,
                         mock_data=mock_data,
                     )
+
+                patch_solana_inquirer_nodes(
+                    stack=stack,
+                    solana_inquirer=api_server.rest_api.rotkehlchen.chains_aggregator.solana.node_inquirer,
+                    solana_nodes_connect_at_start=solana_nodes_connect_at_start,
+                )
 
             if mocked_proxies is not None:
                 mock_proxies(stack, mocked_proxies)

--- a/rotkehlchen/tests/utils/solana.py
+++ b/rotkehlchen/tests/utils/solana.py
@@ -1,10 +1,54 @@
+from collections.abc import Sequence
+from contextlib import ExitStack
+from typing import Final
+from unittest.mock import patch
+
 from solders.solders import Signature
 
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode
 from rotkehlchen.chain.solana.decoding.decoder import SolanaTransactionDecoder
 from rotkehlchen.chain.solana.decoding.tools import SolanaDecoderTools
 from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
 from rotkehlchen.chain.solana.transactions import SolanaTransactions
+from rotkehlchen.constants.misc import ONE
 from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+from rotkehlchen.types import SupportedBlockchain
+
+MAINNET_BETA_SOLANA_NODE: Final = WeightedNode(
+    node_info=NodeName(
+        name='solana.com',
+        endpoint='https://api.mainnet-beta.solana.com',
+        blockchain=SupportedBlockchain.SOLANA,
+        owned=False,
+    ),
+    weight=ONE,
+    active=True,
+)
+
+
+def patch_solana_inquirer_nodes(
+        stack: ExitStack,
+        solana_inquirer: SolanaInquirer,
+        solana_nodes_connect_at_start: Sequence[WeightedNode] | str = 'DEFAULT',
+) -> None:
+    """Patch the solana inquirer node connection behavior for tests."""
+    if solana_nodes_connect_at_start == 'DEFAULT':
+        # Use only the mainnet-beta.solana.com node by default in the tests.
+        stack.enter_context(patch.object(
+            target=solana_inquirer,
+            attribute='default_call_order',
+            side_effect=lambda: [MAINNET_BETA_SOLANA_NODE],
+        ))
+        stack.enter_context(patch(
+            target='rotkehlchen.chain.mixins.rpc_nodes.SolanaRPCMixin._is_archive',
+            return_value=True,  # we know this node is an archive node.
+        ))
+    else:
+        stack.enter_context(patch.object(
+            target=solana_inquirer,
+            attribute='default_call_order',
+            side_effect=lambda: solana_nodes_connect_at_start,
+        ))
 
 
 def get_decoded_events_of_solana_tx(
@@ -18,6 +62,7 @@ def get_decoded_events_of_solana_tx(
         transactions=SolanaTransactions(
             node_inquirer=solana_inquirer,
             database=solana_inquirer.database,
+            helius=solana_inquirer.helius,
         ),
         base_tools=SolanaDecoderTools(
             database=solana_inquirer.database,


### PR DESCRIPTION
Closes: https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=132564255

* Adds a is_archive check for solana rpcs
* Ensures only archive nodes are used when querying txs
* Adds a helius rpc as a fallback archive node if the user has a helius api key