### PR TITLE
fix: remove address filter from `ActionItem`

### DIFF
--- a/rotkehlchen/chain/base/modules/echo/decoder.py
+++ b/rotkehlchen/chain/base/modules/echo/decoder.py
@@ -76,7 +76,6 @@ class EchoDecoder(DecoderInterface):
                     amount=fee_amount,
                     location_label=user_address,
                     to_event_subtype=HistoryEventSubType.FEE,
-                    address=FUNDING_CONDUIT,
                     to_counterparty=CPT_ECHO,
                     to_notes=f'Paid {fee_amount} USDC as part of funding an Echo deal',
                 ))
@@ -123,7 +122,6 @@ class EchoDecoder(DecoderInterface):
                     asset=token,
                     amount=amount,
                     location_label=user_address,
-                    address=tx_log.address,
                     to_counterparty=CPT_ECHO,
                     to_notes=f'Refund {amount} USDC from {tx_log.address} on Echo',
                 ))

--- a/rotkehlchen/chain/base/modules/efp/decoder.py
+++ b/rotkehlchen/chain/base/modules/efp/decoder.py
@@ -2,7 +2,6 @@ import logging
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.efp.constants import CPT_EFP
 from rotkehlchen.chain.evm.decoding.efp.decoder import EfpCommonDecoder
@@ -93,7 +92,6 @@ class EfpDecoder(EfpCommonDecoder):
                 token_type=TokenKind.ERC721,
                 collectible_id=str(int.from_bytes(context.tx_log.topics[3])),
             )),
-            address=ZERO_ADDRESS,
             to_notes=f'Receive EFP list NFT for {user_address}',
             to_counterparty=CPT_EFP,
         )])

--- a/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
@@ -218,7 +218,6 @@ class CurvecrvusdDecoder(CurveBorrowRepayCommonDecoder, ReloadableDecoderMixin):
                     token_amount=reward_raw_amount,
                     token=reward_token,
                 )),
-                address=context.tx_log.address,
                 to_counterparty=CPT_CURVE,
                 to_notes=f'Receive {reward_amount} {reward_token.symbol} from Curve peg keeper update',  # noqa: E501
             ),

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -104,7 +104,7 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
         if context.tx_log.topics[0] != b'K\xec\xcb\x90\xf9\x94\xc3\x1a\xce\xd7\xa2;V\x11\x02\x07(\xa2=\x8e\xc5\xcd\xdd\x1a>\x9d\x97\xb9o\xda\x86f':  # TokenTransferred # noqa: E501
             return DEFAULT_DECODING_OUTPUT
 
-        if self.v3_migration_helper and (to_address := bytes_to_address(context.tx_log.topics[2])) == self.v3_migration_helper and self.base.is_tracked(from_address := bytes_to_address(context.tx_log.topics[1])):  # noqa: E501
+        if self.v3_migration_helper and (bytes_to_address(context.tx_log.topics[2])) == self.v3_migration_helper and self.base.is_tracked(from_address := bytes_to_address(context.tx_log.topics[1])):  # noqa: E501
             token = self.base.get_evm_token(address=context.tx_log.address)
             assert token, 'token should be in the DB. Decoding rule reads it from the DB'
             amount = token_normalized_value(token_amount=int.from_bytes(context.tx_log.data[:32]), token=token)  # noqa: E501
@@ -115,7 +115,6 @@ class Aavev2CommonDecoder(Commonv2v3LikeDecoder):
                 asset=token,
                 amount=amount,
                 location_label=from_address,
-                address=to_address,
                 to_event_type=HistoryEventType.MIGRATE,
                 to_event_subtype=HistoryEventSubType.SPEND,
                 to_notes=f'Migrate {amount} {token.symbol} from AAVE v2',

--- a/rotkehlchen/chain/evm/decoding/aura_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aura_finance/decoder.py
@@ -272,7 +272,6 @@ class AuraFinanceCommonDecoder(DecoderInterface):
                     amount=withdrawn_amount,
                     location_label=user_address,
                     to_event_subtype=HistoryEventSubType.RETURN_WRAPPED,
-                    address=ZERO_ADDRESS,
                     to_counterparty=CPT_AURA_FINANCE,
                     to_notes=f'Return {withdrawn_amount} {aura_token.symbol_or_name()} to Aura',
                     paired_events_data=((event,), False),

--- a/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
@@ -199,7 +199,6 @@ class Dripsv1CommonDecoder(DecoderInterface, CustomizableDateMixin):
             from_event_subtype=HistoryEventSubType.NONE,
             location_label=user,
             asset=A_DAI,
-            address=self.drips_hub,
             to_event_subtype=HistoryEventSubType.DONATE,
             to_location_label=user,
             to_address=context.tx_log.address,

--- a/rotkehlchen/chain/evm/decoding/structures.py
+++ b/rotkehlchen/chain/evm/decoding/structures.py
@@ -22,7 +22,6 @@ class ActionItem:
     asset: Optional['Asset'] = None
     amount: Optional['FVal'] = None
     location_label: str | None = None
-    address: ChecksumEvmAddress | None = None
     to_event_type: Optional['HistoryEventType'] = None
     to_event_subtype: Optional['HistoryEventSubType'] = None
     to_notes: str | None = None

--- a/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
-from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
+from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.constants import STAKED, WITHDRAWN
 from rotkehlchen.chain.evm.decoding.giveth.constants import (
     CPT_GIVETH,
@@ -98,7 +98,6 @@ class GivethDecoder(GivethDecoderBase):
             amount=amount,
             location_label=user,
             asset=Asset(self.pow_token_id),
-            address=ZERO_ADDRESS,
             to_event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             to_location_label=user,
             to_address=context.tx_log.address,
@@ -112,7 +111,6 @@ class GivethDecoder(GivethDecoderBase):
             amount=amount,
             location_label=user,
             asset=Asset(GGIV_TOKEN_ID),
-            address=ZERO_ADDRESS,
         )]
         return DecodingOutput(action_items=action_items)
 
@@ -131,7 +129,6 @@ class GivethDecoder(GivethDecoderBase):
             amount=amount,
             location_label=user,
             asset=Asset(self.pow_token_id),
-            address=ZERO_ADDRESS,
             to_event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             to_address=context.tx_log.address,
             to_notes='Return {amount} POW to Giveth staking',  # to be filled by the action item
@@ -144,7 +141,6 @@ class GivethDecoder(GivethDecoderBase):
              amount=amount,
              location_label=user,
              asset=Asset(self.giv_token_id),
-             address=GNOSIS_GIVPOWERSTAKING_WRAPPER,
              to_event_type=HistoryEventType.WITHDRAWAL,
              to_event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
              to_notes='Withdraw {amount} GIV from staking',  # to be filled by the action item
@@ -156,6 +152,5 @@ class GivethDecoder(GivethDecoderBase):
              amount=amount,
              location_label=user,
              asset=Asset(GGIV_TOKEN_ID),
-             address=ZERO_ADDRESS,
          )]
         return DecodingOutput(action_items=action_items)


### PR DESCRIPTION
I noticed that `action_item.address` doesn't apply a filter to the `ActionItem` as you would expect. This PR adds this handling so that if `action_item.address` doesn't match that of the transfer then the `ActionItem` will not be applied.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
