### PR TITLE
exclude location labels of approval endpoints in `/locations/labels` endpoint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Filtering of events by accounts will now only include tracked accounts and exchange labels.
 * :feature:`-` Monerium users will be able to authenticate just by signing in with monerium via oauth.
 * :bug:`10652` Cowswap swaps with a missing `fullAppData` field will now be properly decoded.
 * :bug:`-` Monerium aave v3 events will now always have the earn event at the end.


### PR DESCRIPTION
Approval events can reference addresses the user doesn't control. we shouldn't show these as valid filters for location labels in the UI.