### PR TITLE
Use get_raw_accounts_info for sol balances

### DIFF
--- a/rotkehlchen/chain/solana/manager.py
+++ b/rotkehlchen/chain/solana/manager.py
@@ -68,14 +68,10 @@ class SolanaManager(ChainManagerWithTransactions[SolanaAddress]):
         May raise:
         - RemoteError if an external service is queried and there is a problem with its query.
         """
-        response = self.node_inquirer.query(
-            method=lambda client: client.get_multiple_accounts(
-                pubkeys=[Pubkey.from_string(addr) for addr in accounts],
-            ),
-        )
-
         result = {}
-        for account, entry in zip(accounts, response.value, strict=False):
+        for account, entry in self.node_inquirer.get_raw_accounts_info(
+            pubkeys=[Pubkey.from_string(addr) for addr in accounts],
+        ).items():
             if entry is None or entry.lamports == 0:
                 log.debug(f'Found no account entry in balances for solana account {account}. Skipping')  # noqa: E501
                 result[account] = ZERO


### PR DESCRIPTION
Changes `get_multi_balance` to use `get_raw_accounts_info` instead of directly calling `get_multiple_accounts`. This ensures proper chunking will be done if a user has > 100 solana accounts.
