### PR TITLE
Show missing helius api key msg earlier

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3659,16 +3659,16 @@
     "missing_api_key": {
       "action": "Enter key",
       "etherscan": {
-        "message": "Rotki queries for {location} chain are working slower because you dont have {location} {service} API key configured. Press @.quote:notification_messages.missing_api_key.get_key to make one or @.quote:notification_messages.missing_api_key.action to add it in the app.",
+        "message": "rotki queries for {location} chain are working slower because you don't have {location} {service} API key configured. Press @.quote:notification_messages.missing_api_key.get_key to make one or @.quote:notification_messages.missing_api_key.action to add it in the app.",
         "title": "{location} {service} API key"
       },
       "get_key": "Get API key",
       "helius": {
-        "message": "Rotki queries for Solana chain are working slower because you dont have Helius API key configured. Press @.quote:notification_messages.missing_api_key.get_key to make one or @.quote:notification_messages.missing_api_key.action to add it in the app.",
+        "message": "Transaction queries for Solana will be slow because you don't have a Helius API key configured. Press @.quote:notification_messages.missing_api_key.get_key to make one or @.quote:notification_messages.missing_api_key.action to add it in the app.",
         "title": "{service} API key for Solana"
       },
       "thegraph": {
-        "message": "Rotki cannot query {location} data because you don't have {service} API key configured, or the API key you are using isn't authorized for {location}. Press @.quote:notification_messages.missing_api_key.get_key to make one or @.quote:notification_messages.missing_api_key.action to add it in the app. Read the docs {docs} for more information.",
+        "message": "rotki cannot query {location} data because you don't have {service} API key configured, or the API key you are using isn't authorized for {location}. Press @.quote:notification_messages.missing_api_key.get_key to make one or @.quote:notification_messages.missing_api_key.action to add it in the app. Read the docs {docs} for more information.",
         "title": "{service} API key for {location}"
       }
     },


### PR DESCRIPTION
Creates a new ExternalServiceWithRecommendedApiKey class that both helius and etherscan inherit from that maybe sends the warning whenever the api key is retreived.

In helius this makes  `maybe_get_rpc_node` also trigger the warning message, which is called when loading the default_call_order for normal rpc queries, resulting in the helius warning message being shown as soon as balances are queried instead of waiting until txs are queried.

Also updates the warning message for helius to explicitly mention that its the transaction queries that will be slow without the key.
