### PR TITLE
fix: add confirmation to open external link from event notes

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventNote.vue
+++ b/frontend/app/src/components/history/events/HistoryEventNote.vue
@@ -114,6 +114,7 @@ function isLinkTypeWithoutImage(t: any, chain: string): t is keyof ExplorerUrls 
         :text="note.word"
         color="primary"
         custom
+        confirm
       />
       <template v-else>
         {{ ` ${note.word} ` }}

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1669,6 +1669,10 @@
     "details": "Details",
     "entry_type": "Entry Type",
     "events": "Events",
+    "external_link_confirmation": {
+      "message": "You are about to open an external link. Please verify the URL carefully and be cautious of phishing attempts.",
+      "title": "Open External Link?"
+    },
     "fee": "Fee",
     "filter": {
       "date_hint": "format {format} HH:mm:ss (time/seconds are optional)",
@@ -1707,6 +1711,7 @@
     "type": "Type",
     "unclaimed": "Unclaimed",
     "unknown": "Unknown",
+    "url": "URL",
     "validator_index": "Validator Index",
     "value_in_symbol": "{symbol} Value",
     "xpub": "XPUB"


### PR DESCRIPTION
<img width="1570" height="765" alt="Screenshot at Oct 21 21-36-02" src="https://github.com/user-attachments/assets/4fc0a4dd-6b03-4a5b-acbe-eaf9b490ba84" />