### PR TITLE
ci: switch runners to macos-15(-intel)

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -84,11 +84,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - runner: macos-14
+          - runner: macos-15
             arch: 'arm64'
             target: 11
             platform: macosx-11.0-arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             arch: 'x86_64'
             target: 10.9
             platform: macosx-10.9-x86_64

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -188,11 +188,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - runner: macos-14
+          - runner: macos-15
             arch: 'arm64'
             target: 11
             platform: macosx-11.0-arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             arch: 'x86_64'
             target: 10.9
             platform: macosx-10.9-x86_64


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
