### PR TITLE
Send ws messages when decoding txs via periodic task

### DIFF
--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -457,6 +457,7 @@ class TaskManager:
                 exception_is_error=True,
                 method=evm_inquirer.transactions_decoder.get_and_decode_undecoded_transactions,
                 limit=TX_DECODING_LIMIT,
+                send_ws_notifications=True,
             )]
         return None
 


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=135490139

The periodic task for decoding evm txs starts decoding for a chain before the user opens the history view and triggers decoding for all chains that way. So there was a chain that was already getting decoded, but wasn't sending any ws messages, so it would appear in the frontend as still having undecoded txs when the decoding for all the other chains finished.
