### PR TITLE
feat(frontend): support Filipina Peso (PHP) as main currency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`10604` Add support for Philippine Peso (PHP) as a fiat currency.
 * :feature:`9396` rotki will now properly decode onchain messages sent in EVM transactions.
 * :feature:`10544` rotki will now properly decode transactions for rotki sponsorship contract.
 * :feature:`10681` rotki will now provide an option in history events to persist filters when navigating between pages.

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetForm.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetForm.vue
@@ -150,6 +150,7 @@ async function saveAsset() {
     coingecko: get(coingecko),
     cryptocompare: get(cryptocompare),
     evmChain: get(evmChain) || null,
+    forked: get(forked) || undefined,
     protocol: onlyIfTruthy(get(protocol)),
     swappedFor: onlyIfTruthy(get(swappedFor)),
     tokenKind: get(tokenKind) || null,

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1865,6 +1865,7 @@
     "ngn": "Nigerian naira",
     "nok": "Norwegian krone",
     "nzd": "New Zealand Dollar",
+    "php": "Philippine Peso",
     "pln": "Polish zloty",
     "rub": "Russian Ruble",
     "sek": "Swedish Krona",

--- a/frontend/app/src/types/currencies.ts
+++ b/frontend/app/src/types/currencies.ts
@@ -35,6 +35,7 @@ const CURRENCY_AED = 'AED';
 const CURRENCY_CZK = 'CZK';
 const CURRENCY_ILS = 'ILS';
 const CURRENCY_MXN = 'MXN';
+const CURRENCY_PHP = 'PHP';
 
 // eslint-disable-next-line unused-imports/no-unused-vars
 const SUPPORTED_CURRENCIES = [
@@ -66,6 +67,7 @@ const SUPPORTED_CURRENCIES = [
   CURRENCY_CZK,
   CURRENCY_ILS,
   CURRENCY_MXN,
+  CURRENCY_PHP,
 ] as const;
 
 export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
@@ -99,6 +101,7 @@ export const useCurrencies = createSharedComposable(() => {
     new Currency(t('currencies.czk'), CURRENCY_CZK, 'Kč'),
     new Currency(t('currencies.ils'), CURRENCY_ILS, '₪'),
     new Currency(t('currencies.mxn'), CURRENCY_MXN, 'Mex$'),
+    new Currency(t('currencies.php'), CURRENCY_PHP, '₱'),
     new Currency('Bitcoin', CURRENCY_BTC, '₿', true),
     new Currency('Ether', CURRENCY_ETH, 'Ξ', true),
   ]);


### PR DESCRIPTION
Closes #10604

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
