### PR TITLE
Move normalized value etc functions

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -56,6 +56,7 @@ from rotkehlchen.assets.asset import (
 )
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.assets.types import ASSET_TYPES_EXCLUDED_FOR_USERS, AssetType
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.balances.historical import HistoricalBalancesManager
 from rotkehlchen.balances.manual import (
     ManuallyTrackedBalance,
@@ -79,10 +80,7 @@ from rotkehlchen.chain.ethereum.modules.makerdao.cache import (
 )
 from rotkehlchen.chain.ethereum.modules.nft.structures import NftLpHandling
 from rotkehlchen.chain.ethereum.modules.yearn.utils import query_yearn_vaults
-from rotkehlchen.chain.ethereum.utils import (
-    token_normalized_value,
-    try_download_ens_avatar,
-)
+from rotkehlchen.chain.ethereum.utils import try_download_ens_avatar
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
 from rotkehlchen.chain.evm.decoding.balancer.balancer_cache import (
     query_balancer_data,

--- a/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/airdrops/decoder.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.arbitrum_one.constants import ARBITRUM_ONE_CPT_DETAILS, CPT_ARBITRUM_ONE
 from rotkehlchen.chain.arbitrum_one.decoding.interfaces import ArbitrumDecoderInterface
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,

--- a/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/arbitrum_one_bridge/decoder.py
@@ -5,12 +5,11 @@ from typing import TYPE_CHECKING, Any, Final
 from eth_typing.abi import ABI
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.arbitrum_one.constants import ARBITRUM_ONE_CPT_DETAILS, CPT_ARBITRUM_ONE
 from rotkehlchen.chain.arbitrum_one.decoding.interfaces import ArbitrumDecoderInterface
 from rotkehlchen.chain.arbitrum_one.types import ArbitrumOneTransaction
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/arbitrum_one/modules/gmx/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gmx/balances.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_GMX

--- a/rotkehlchen/chain/arbitrum_one/modules/gmx/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gmx/decoder.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.assets.asset import Asset, CryptoAsset
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.arbitrum_one.decoding.interfaces import ArbitrumDecoderInterface
 from rotkehlchen.chain.arbitrum_one.modules.gmx.constants import (
     CPT_GMX,
@@ -18,7 +19,6 @@ from rotkehlchen.chain.arbitrum_one.modules.gmx.constants import (
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,

--- a/rotkehlchen/chain/arbitrum_one/modules/hyperliquid/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/hyperliquid/decoder.py
@@ -3,13 +3,13 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.arbitrum_one.modules.hyperliquid.constants import (
     BRIDGE_ADDRESS,
     CPT_HYPER,
     FINALIZE_WITHDRAWAL,
 )
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/chain/arbitrum_one/modules/open_ocean/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/open_ocean/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Any, Final
 
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.open_ocean.constants import CPT_OPENOCEAN
 from rotkehlchen.chain.evm.decoding.open_ocean.decoder import (
     OpenOceanDecoder as OpenOceanBaseDecoder,

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/balances.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
-from rotkehlchen.assets.utils import get_evm_token
+from rotkehlchen.assets.utils import get_evm_token, token_normalized_value_decimals
 from rotkehlchen.chain.arbitrum_one.modules.umami.constants import (
     CPT_UMAMI,
     UMAMI_MASTERCHEF_ABI,
@@ -11,7 +11,6 @@ from rotkehlchen.chain.arbitrum_one.modules.umami.constants import (
 )
 from rotkehlchen.chain.arbitrum_one.modules.umami.utils import get_umami_vault_token_price
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.prices import ZERO_PRICE

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/decoder.py
@@ -1,6 +1,7 @@
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Final
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.arbitrum_one.decoding.interfaces import ArbitrumDecoderInterface
 from rotkehlchen.chain.arbitrum_one.modules.umami.constants import (
     CPT_UMAMI,
@@ -8,7 +9,6 @@ from rotkehlchen.chain.arbitrum_one.modules.umami.constants import (
 )
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import (
     DEPOSIT_TOPIC,
     STAKE_TOPIC,

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/utils.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/utils.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.constants import ERC4626_ABI
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.errors.misc import RemoteError

--- a/rotkehlchen/chain/base/modules/echo/decoder.py
+++ b/rotkehlchen/chain/base/modules/echo/decoder.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.base.modules.echo.constants import (
     CPT_ECHO,
     DEAL_ABI,
@@ -14,7 +15,6 @@ from rotkehlchen.chain.base.modules.echo.constants import (
     POOL_REFUNDED,
 )
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/base/modules/odos/v2/decoder.py
+++ b/rotkehlchen/chain/base/modules/odos/v2/decoder.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.odos.v2.constants import CPT_ODOS_V2
 from rotkehlchen.chain.evm.decoding.odos.v2.decoder import Odosv2DecoderBase

--- a/rotkehlchen/chain/base/modules/runmoney/balances.py
+++ b/rotkehlchen/chain/base/modules/runmoney/balances.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.base.modules.runmoney.constants import (
     CPT_RUNMONEY,
     RUNMONEY_CONTRACT_ABI,
     RUNMONEY_CONTRACT_ADDRESS,
 )
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/chain/base/modules/runmoney/decoder.py
+++ b/rotkehlchen/chain/base/modules/runmoney/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Any, Literal
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.constants import STAKED
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/airdrops.py
+++ b/rotkehlchen/chain/ethereum/airdrops.py
@@ -17,8 +17,12 @@ from web3.exceptions import Web3Exception
 
 from rotkehlchen.assets.asset import Asset, CryptoAsset, SolanaToken
 from rotkehlchen.assets.types import AssetType
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
-from rotkehlchen.chain.ethereum.utils import MULTICALL_CHUNKS, token_normalized_value_decimals
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    get_or_create_evm_token,
+    token_normalized_value_decimals,
+)
+from rotkehlchen.chain.ethereum.utils import MULTICALL_CHUNKS
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/chain/ethereum/interfaces/ammswap/utils.py
+++ b/rotkehlchen/chain/ethereum/interfaces/ammswap/utils.py
@@ -1,12 +1,11 @@
 from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import get_or_create_evm_token, token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.ammswap.types import (
     LiquidityPool,
     LiquidityPoolAsset,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import ChainID, ChecksumEvmAddress
 

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
 from rotkehlchen.chain.evm.types import WeightedNode, string_to_evm_address
 from rotkehlchen.db.filtering import EvmEventFilterQuery

--- a/rotkehlchen/chain/ethereum/modules/aave/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/balances.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.ethereum.modules.aave.constants import STK_AAVE_ADDR
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE
 from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order

--- a/rotkehlchen/chain/ethereum/modules/aave/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/decoder.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, STAKED_TOPIC
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/v1/decoder.py
@@ -1,9 +1,9 @@
 from typing import Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.aave.common import asset_to_atoken
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V1
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/airdrops/decoder.py
@@ -1,11 +1,11 @@
 import logging
 from typing import TYPE_CHECKING, Any, Final, Literal
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.convex.constants import CONVEX_CPT_DETAILS, CPT_CONVEX
 from rotkehlchen.chain.ethereum.modules.ens.constants import CPT_ENS, ENS_CPT_DETAILS
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, SIMPLE_CLAIM
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER

--- a/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/arbitrum_one_bridge/decoder.py
@@ -1,9 +1,9 @@
 import logging
 from typing import TYPE_CHECKING, Any, Final
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.arbitrum_one.constants import ARBITRUM_ONE_CPT_DETAILS, CPT_ARBITRUM_ONE
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/blur/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/blur/balances.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.ethereum.modules.blur.constants import (
     BLUR_IDENTIFIER,
     BLUR_STAKING_CONTRACT,
     CPT_BLUR,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/chain/ethereum/modules/blur/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/blur/decoder.py
@@ -2,8 +2,8 @@ import logging
 from typing import Any
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import (
     CLAIMED_TOPIC,
     DEFAULT_TOKEN_DECIMALS,

--- a/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/compound/v2/decoder.py
@@ -2,14 +2,17 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    asset_normalized_value,
+    get_or_create_evm_token,
+    token_normalized_value,
+)
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.compound.constants import (
     COMPTROLLER_PROXY_ADDRESS,
     CPT_COMPOUND,
 )
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.constants import MINT_TOPIC
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/modules/convex/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/balances.py
@@ -2,8 +2,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithGauges
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_CVX

--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.convex.constants import (
     BOOSTER,
@@ -21,7 +22,6 @@ from rotkehlchen.chain.ethereum.modules.convex.convex_cache import (
     query_convex_data,
     read_convex_data_from_cache,
 )
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER, STAKED
 from rotkehlchen.chain.evm.decoding.interfaces import (

--- a/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/crvusd/decoder.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.ethereum.modules.curve.crvusd.constants import (
     CRVUSD_PEG_KEEPERS_AND_POOLS,
     CURVE_CRVUSD_CONTROLLER_ABI,
@@ -10,7 +11,7 @@ from rotkehlchen.chain.ethereum.modules.curve.crvusd.constants import (
     PEG_KEEPER_WITHDRAW_TOPIC,
 )
 from rotkehlchen.chain.ethereum.modules.curve.crvusd.utils import query_crvusd_controllers
-from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache, token_normalized_value
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.decoding.curve.lend.common import CurveBorrowRepayCommonDecoder

--- a/rotkehlchen/chain/ethereum/modules/curve/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/decoder.py
@@ -2,7 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, UNSTAKE_TOPIC
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.curve.constants import (

--- a/rotkehlchen/chain/ethereum/modules/digixdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/digixdao/decoder.py
@@ -1,5 +1,6 @@
 from typing import Any, Final
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.digixdao.constants import (
@@ -7,7 +8,6 @@ from rotkehlchen.chain.ethereum.modules.digixdao.constants import (
     CPT_DIGIXDAO,
     DIGIX_DGD_ETH_REFUND_CONTRACT,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/dxdaomesa/decoder.py
@@ -3,8 +3,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import WITHDRAW_TOPIC
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
@@ -5,10 +5,9 @@ from typing import TYPE_CHECKING, Final
 from eth_typing.abi import ABI
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.ethereum.modules.eigenlayer.utils import get_eigenpods_to_owners_mapping
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ZERO

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import AssetWithSymbol
-from rotkehlchen.assets.utils import TokenEncounterInfo
+from rotkehlchen.assets.utils import TokenEncounterInfo, token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import (
@@ -38,7 +38,6 @@ from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import (
     WITHDRAWAL_QUEUED,
 )
 from rotkehlchen.chain.ethereum.modules.eigenlayer.utils import get_eigenpods_to_owners_mapping
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.clique.decoder import CliqueAirdropDecoderInterface
 from rotkehlchen.chain.evm.decoding.interfaces import ReloadableDecoderMixin

--- a/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/fluence/decoder.py
@@ -1,10 +1,10 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.decoding.constants import AIRDROP_CLAIM
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/modules/golem/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/golem/decoder.py
@@ -2,10 +2,10 @@ import logging
 from typing import Any
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.constants import MIGRATED
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/hedgey/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/hedgey/balances.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.inquirer import Inquirer

--- a/rotkehlchen/chain/ethereum/modules/hedgey/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/hedgey/decoder.py
@@ -2,8 +2,8 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.constants import DELEGATE_CHANGED

--- a/rotkehlchen/chain/ethereum/modules/juicebox/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/juicebox/decoder.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import requests
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
 from rotkehlchen.chain.ethereum.modules.juicebox.constants import (
@@ -16,7 +17,6 @@ from rotkehlchen.chain.ethereum.modules.juicebox.constants import (
     PAY_SIGNATURE,
     TERMINAL_3_1_2,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/kyber/decoder.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import CryptoAsset
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.kyber.constants import CPT_KYBER, KYBER_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.kyber.decoder import (
     KYBER_AGGREGATOR_CONTRACT,

--- a/rotkehlchen/chain/ethereum/modules/l2/loopring.py
+++ b/rotkehlchen/chain/ethereum/modules/l2/loopring.py
@@ -9,7 +9,7 @@ import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import CryptoAsset
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import (
     A_1INCH,

--- a/rotkehlchen/chain/ethereum/modules/lido/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/lido/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/decoder.py
@@ -2,9 +2,9 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/liquity/trove.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/trove.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from rotkehlchen.accounting.structures.balance import AssetBalance, Balance, BalanceSheet
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.proxies_inquirer import ProxyType
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py
@@ -1,17 +1,17 @@
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import CryptoAsset
+from rotkehlchen.assets.utils import (
+    asset_normalized_value,
+    token_normalized_value,
+    token_normalized_value_decimals,
+)
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.constants import RAY_DIGITS
 from rotkehlchen.chain.ethereum.modules.sky.constants import (
     CPT_SKY,
     MIGRATION_ACTIONS_CONTRACT,
     USDS_ASSET,
-)
-from rotkehlchen.chain.ethereum.utils import (
-    asset_normalized_value,
-    token_normalized_value,
-    token_normalized_value_decimals,
 )
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.constants import (

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
@@ -11,7 +12,6 @@ from rotkehlchen.chain.ethereum.modules.makerdao.constants import (
     MAKERDAO_LABEL,
 )
 from rotkehlchen.chain.ethereum.modules.makerdao.sai.constants import CPT_SAI
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/octant/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/balances.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_GLM
 from rotkehlchen.errors.misc import RemoteError

--- a/rotkehlchen/chain/ethereum/modules/octant/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/decoder.py
@@ -1,11 +1,11 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     token_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.evm.constants import WITHDRAWN_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/omni/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/omni/decoder.py
@@ -2,10 +2,10 @@ import logging
 from typing import Any
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.clique.decoder import CliqueAirdropDecoderInterface
 from rotkehlchen.chain.evm.decoding.constants import STAKED
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/v1/decoder.py
@@ -1,9 +1,9 @@
 from typing import Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.constants import AMM_POSSIBLE_COUNTERPARTIES
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.oneinch.constants import ONEINCH_ICON, ONEINCH_LABEL
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/paladin/decoder.py
@@ -1,9 +1,8 @@
 import logging
 from typing import Any
 
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import get_or_create_evm_token, token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/pendle/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/balances.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.pendle.constants import CPT_PENDLE

--- a/rotkehlchen/chain/ethereum/modules/pendle/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/decoder.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.pendle.constants import CPT_PENDLE
 from rotkehlchen.chain.evm.decoding.pendle.decoder import PendleCommonDecoder

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/decoder.py
@@ -3,8 +3,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import MerkleClaimDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
+++ b/rotkehlchen/chain/ethereum/modules/pickle_finance/main.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import AssetBalance, Balance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_PICKLE
 from rotkehlchen.errors.serialization import DeserializationError

--- a/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/polygon/decoder.py
@@ -2,9 +2,9 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.polygon.constants import CPT_POLYGON, CPT_POLYGON_DETAILS
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/puffer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/puffer/decoder.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import EIGEN_TOKEN_ID
 from rotkehlchen.chain.ethereum.modules.puffer.constants import (
@@ -14,7 +15,6 @@ from rotkehlchen.chain.ethereum.modules.puffer.constants import (
     PUFFERX_EIGEN_S2_AIRDROP2,
     UNLOCKED_TOKENS_CLAIMED,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/safe/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/balances.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/chain/ethereum/modules/safe/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/decoder.py
@@ -2,8 +2,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/scroll_bridge/decoder.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING, Any, Final
 
 from eth_abi import decode as decode_abi
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/shutter/decoder.py
@@ -1,10 +1,10 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.diva.decoder import DELEGATE_CHANGED
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/sky/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sky/decoder.py
@@ -1,11 +1,9 @@
 import logging
 from typing import Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
-    token_normalized_value_decimals,
-)
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/ethereum/modules/spark/lend/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/spark/lend/decoder.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.spark.constants import (
     SPARK_AIRDROP_DISTRIBUTOR,
     SPARK_STAKE_TOKEN,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, DEPOSIT_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import MerkleClaimDecoderInterface
 from rotkehlchen.chain.evm.decoding.spark.constants import CPT_SPARK

--- a/rotkehlchen/chain/ethereum/modules/spark/savings/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/spark/savings/decoder.py
@@ -1,16 +1,13 @@
 import logging
 from typing import TYPE_CHECKING
 
+from rotkehlchen.assets.utils import asset_normalized_value, token_normalized_value_decimals
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.sky.constants import (
     CPT_SKY,
     MIGRATION_ACTIONS_CONTRACT,
     SUSDS_ASSET,
     SUSDS_CONTRACT,
-)
-from rotkehlchen.chain.ethereum.utils import (
-    asset_normalized_value,
-    token_normalized_value_decimals,
 )
 from rotkehlchen.chain.evm.constants import (
     DEFAULT_TOKEN_DECIMALS,

--- a/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
@@ -1,11 +1,11 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.chain.ethereum.modules.thegraph.constants import CONTRACT_STAKING
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     token_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.ethereum.modules.thegraph.constants import CONTRACT_STAKING
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/votium/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/votium/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/decoder.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, cast
 
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.yearn.constants import (
@@ -16,7 +17,7 @@ from rotkehlchen.chain.ethereum.modules.yearn.constants import (
     YEARN_PARTNER_TRACKER,
 )
 from rotkehlchen.chain.ethereum.modules.yearn.utils import query_yearn_vaults
-from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache, token_normalized_value
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.constants import (
     DEPOSIT_TOPIC,
     STAKE_TOPIC,

--- a/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/ygov/decoder.py
@@ -1,10 +1,10 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.yearn.constants import CPT_YGOV, YEARN_ICON
 from rotkehlchen.chain.ethereum.modules.yearn.ygov.constants import YGOV_ADDRESS
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import REWARD_PAID_TOPIC_V2
 from rotkehlchen.chain.evm.decoding.constants import STAKED, WITHDRAWN
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/zksync/decoder.py
@@ -1,7 +1,7 @@
 from typing import Any, Final
 
+from rotkehlchen.assets.utils import asset_raw_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_raw_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -9,8 +9,7 @@ from eth_utils import to_checksum_address
 from web3.types import BlockIdentifier
 
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
+from rotkehlchen.assets.utils import get_or_create_evm_token, token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/chain/evm/active_management/manager.py
+++ b/rotkehlchen/chain/evm/active_management/manager.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.chain.ethereum.utils import asset_raw_value
+from rotkehlchen.assets.utils import asset_raw_value
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:

--- a/rotkehlchen/chain/evm/decoding/aave/common.py
+++ b/rotkehlchen/chain/evm/decoding/aave/common.py
@@ -4,10 +4,13 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN, get_single_underlying_token
+from rotkehlchen.assets.utils import (
+    CHAIN_TO_WRAPPED_TOKEN,
+    asset_normalized_value,
+    get_single_underlying_token,
+)
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.constants import RAY
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.constants import (
     CPT_AAVE_V3,

--- a/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v2/decoder.py
@@ -1,8 +1,8 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.decoding.aave.common import Commonv2v3LikeDecoder
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -3,10 +3,9 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_single_underlying_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_single_underlying_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.aave.common import Commonv2v3LikeDecoder
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/aura_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aura_finance/decoder.py
@@ -2,12 +2,12 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Final
 
-from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     asset_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.constants import (
     DEFAULT_TOKEN_DECIMALS,
     DEPOSIT_TOPIC,

--- a/rotkehlchen/chain/evm/decoding/balancer/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/decoder.py
@@ -2,8 +2,8 @@ from abc import ABC
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC_V2, WITHDRAW_TOPIC_V2
 from rotkehlchen.chain.evm.decoding.balancer.balancer_cache import query_balancer_data
 from rotkehlchen.chain.evm.decoding.balancer.constants import (

--- a/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v1/decoder.py
@@ -2,8 +2,8 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Final
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.balancer.balancer_cache import (
     read_balancer_pools_and_gauges_from_cache,
 )

--- a/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v2/decoder.py
@@ -2,12 +2,9 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN
+from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN, asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
-    asset_normalized_value,
-)
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.balancer_cache import (
     read_balancer_pools_and_gauges_from_cache,

--- a/rotkehlchen/chain/evm/decoding/balancer/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/v3/decoder.py
@@ -5,10 +5,9 @@ from typing import TYPE_CHECKING, Any
 
 from eth_abi import decode as decode_abi
 
-from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN
+from rotkehlchen.assets.utils import CHAIN_TO_WRAPPED_TOKEN, asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.balancer_cache import (
     read_balancer_pools_and_gauges_from_cache,

--- a/rotkehlchen/chain/evm/decoding/base.py
+++ b/rotkehlchen/chain/evm/decoding/base.py
@@ -3,9 +3,13 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
-from rotkehlchen.assets.utils import get_evm_token, get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    asset_normalized_value,
+    get_evm_token,
+    get_or_create_evm_token,
+    token_normalized_value,
+)
 from rotkehlchen.chain.decoding.tools import BaseDecoderTools
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import OUTGOING_EVENT_TYPES
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog

--- a/rotkehlchen/chain/evm/decoding/beefy_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/beefy_finance/decoder.py
@@ -2,12 +2,10 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
-    asset_normalized_value,
-    should_update_protocol_cache,
-)
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/beefy_finance/utils.py
+++ b/rotkehlchen/chain/evm/decoding/beefy_finance/utils.py
@@ -6,8 +6,9 @@ from rotkehlchen.assets.utils import (
     TokenEncounterInfo,
     get_or_create_evm_token,
     get_single_underlying_token,
+    token_normalized_value,
+    token_raw_value_decimals,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value, token_raw_value_decimals
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.utils import get_vault_price, update_cached_vaults
 from rotkehlchen.constants.misc import ONE, ZERO

--- a/rotkehlchen/chain/evm/decoding/cctp/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cctp/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.cctp.constants import (
     CCTP_CPT_DETAILS,
     CCTP_DOMAIN_MAPPING,

--- a/rotkehlchen/chain/evm/decoding/clique/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clique/decoder.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import CLAIMED_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DecoderContext

--- a/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/clrfund/decoder.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset, CryptoAsset
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.arbitrum_one.modules.clrfund.constants import (
     CLRFUND_CPT_DETAILS,
     CPT_CLRFUND,
@@ -10,7 +11,6 @@ from rotkehlchen.chain.arbitrum_one.modules.clrfund.constants import (
 )
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import FUNDS_CLAIMED
 from rotkehlchen.chain.evm.decoding.interfaces import CommonGrantsDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.constants import ZERO

--- a/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/decoder.py
@@ -3,10 +3,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import WITHDRAW_TOPIC, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/cowswap/decoder.py
@@ -5,10 +5,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
 
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.assets.utils import TokenEncounterInfo
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    asset_normalized_value,
+    token_normalized_value,
+)
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, token_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
 from rotkehlchen.chain.evm.decoding.cowswap.constants import COWSWAP_CPT_DETAILS, CPT_COWSWAP

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -3,10 +3,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.utils import TokenEncounterInfo
+from rotkehlchen.assets.utils import TokenEncounterInfo, asset_normalized_value, asset_raw_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, asset_raw_value
 from rotkehlchen.chain.evm.constants import (
     ADD_LIQUIDITY_DYNAMIC_ASSETS,
     DEPOSIT_TOPIC_V2,

--- a/rotkehlchen/chain/evm/decoding/curve/lend/balances.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/balances.py
@@ -4,9 +4,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import get_or_create_evm_token, token_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE

--- a/rotkehlchen/chain/evm/decoding/curve/lend/common.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/common.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from eth_typing import ABI
 
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.curve.crvusd.constants import CURVE_CRVUSD_CONTROLLER_ABI
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.curve.constants import (
     CPT_CURVE,
     CURVE_COUNTERPARTY_DETAILS,

--- a/rotkehlchen/chain/evm/decoding/curve/lend/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/decoder.py
@@ -2,12 +2,9 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value, token_normalized_value_decimals
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
-    should_update_protocol_cache,
-    token_normalized_value,
-    token_normalized_value_decimals,
-)
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.constants import (
     DEFAULT_TOKEN_DECIMALS,
     DEPOSIT_TOPIC,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -11,12 +11,16 @@ import gevent
 from web3.exceptions import Web3Exception
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_evm_token, get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    get_evm_token,
+    get_or_create_evm_token,
+    token_normalized_value,
+)
 from rotkehlchen.chain.decoding.constants import CPT_GAS, MIN_LOGS_PROCESSED_TO_SLEEP
 from rotkehlchen.chain.decoding.decoder import TransactionDecoder
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import decode_safely, maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.balancer.v3.constants import BALANCER_V3_SUPPORTED_CHAINS
 from rotkehlchen.chain.evm.decoding.balancer.v3.decoder import Balancerv3CommonDecoder

--- a/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/drips/v1/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.drips.v1.constants import (
     COLLECTED,

--- a/rotkehlchen/chain/evm/decoding/extrafi/balances.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/balances.py
@@ -6,12 +6,12 @@ from eth_utils import to_checksum_address
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
-from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
+    get_or_create_evm_token,
     token_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.extrafi.constants import (

--- a/rotkehlchen/chain/evm/decoding/extrafi/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/decoder.py
@@ -3,15 +3,15 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.assets.utils import get_or_create_evm_token
-from rotkehlchen.chain.decoding.constants import CPT_GAS
-from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     asset_normalized_value,
+    get_or_create_evm_token,
     token_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.constants import REWARD_PAID_TOPIC
 from rotkehlchen.chain.evm.decoding.extrafi.cache import (
     get_existing_reward_pools,

--- a/rotkehlchen/chain/evm/decoding/firebird_finance/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/firebird_finance/decoder.py
@@ -1,9 +1,9 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import SWAPPED_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/gearbox/balances.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/balances.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.gearbox.constants import CPT_GEARBOX

--- a/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
@@ -3,11 +3,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.assets.utils import token_normalized_value, token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import (
-    token_normalized_value,
-    token_normalized_value_decimals,
-)
 from rotkehlchen.chain.evm.constants import (
     DEFAULT_TOKEN_DECIMALS,
     DEPOSIT_TOPIC,

--- a/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoin/decoder.py
@@ -2,8 +2,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import (
     CPT_GITCOIN,
     FUNDS_CLAIMED,

--- a/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gitcoinv2/decoder.py
@@ -2,9 +2,9 @@ import logging
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Optional
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.abi import decode_event_data_abi
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import CPT_GITCOIN, GITCOIN_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.gitcoinv2.constants import (

--- a/rotkehlchen/chain/evm/decoding/giveth/balances.py
+++ b/rotkehlchen/chain/evm/decoding/giveth/balances.py
@@ -6,8 +6,8 @@ from eth_typing.abi import ABI
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_GIVETH

--- a/rotkehlchen/chain/evm/decoding/giveth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/giveth/decoder.py
@@ -3,9 +3,9 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, SIMPLE_CLAIM
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_DETAILS_GIVETH, CPT_GIVETH
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/evm/decoding/hop/balances.py
+++ b/rotkehlchen/chain/evm/decoding/hop/balances.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
 from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order

--- a/rotkehlchen/chain/evm/decoding/hop/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/hop/decoder.py
@@ -2,12 +2,9 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.assets.utils import token_normalized_value, token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
-    token_normalized_value,
-    token_normalized_value_decimals,
-)
 from rotkehlchen.chain.evm.constants import (
     ADD_LIQUIDITY_DYNAMIC_ASSETS,
     DEFAULT_TOKEN_DECIMALS,

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -5,13 +5,13 @@ from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, Final, Literal, overload
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.decoding.interfaces import DecoderInterface
-from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
-from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     asset_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.decoding.interfaces import DecoderInterface
+from rotkehlchen.chain.ethereum.abi import decode_event_data_abi_str
+from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.evm.constants import MERKLE_CLAIM
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/kyber/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/kyber/decoder.py
@@ -2,9 +2,9 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import CryptoAsset
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import SWAPPED_TOPIC
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/magpie/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/magpie/decoder.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import RABBY_WALLET_FEE_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/evm/decoding/merkl/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/merkl/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import REWARD_CLAIMED
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/metamask/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/metamask/decoder.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.constants import AMM_POSSIBLE_COUNTERPARTIES
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/monerium/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/monerium/decoder.py
@@ -2,9 +2,8 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import get_or_create_evm_token, token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin

--- a/rotkehlchen/chain/evm/decoding/morpho/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/morpho/decoder.py
@@ -2,9 +2,10 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache, token_normalized_value
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC, WITHDRAW_TOPIC_V3, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import REWARD_CLAIMED
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput

--- a/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
@@ -2,10 +2,9 @@ import abc
 import logging
 from typing import TYPE_CHECKING, Any, Final
 
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.decoding.constants import GNOSIS_CPT_DETAILS
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/open_ocean/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/open_ocean/decoder.py
@@ -3,9 +3,9 @@ from abc import ABC
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
@@ -3,9 +3,9 @@ from abc import ABC
 from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/pendle/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/pendle/decoder.py
@@ -2,14 +2,14 @@ import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     asset_normalized_value,
     asset_raw_value,
-    should_update_protocol_cache,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.constants import (
     DEFAULT_TOKEN_DECIMALS,
     SWAPPED_TOPIC,

--- a/rotkehlchen/chain/evm/decoding/rainbow/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/rainbow/decoder.py
@@ -3,9 +3,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional
 
 from rotkehlchen.assets.asset import CryptoAsset
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/socket_bridge/decoder.py
@@ -1,9 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.socket_bridge.constants import (

--- a/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/spark/savings/decoder.py
@@ -1,9 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.utils import TokenEncounterInfo
+from rotkehlchen.assets.utils import TokenEncounterInfo, token_normalized_value_decimals
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC, WITHDRAW_TOPIC_V3
 from rotkehlchen.chain.evm.decoding.constants import ERC4626_ABI
 from rotkehlchen.chain.evm.decoding.spark.constants import CPT_SPARK

--- a/rotkehlchen/chain/evm/decoding/stakedao/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/decoder.py
@@ -2,15 +2,15 @@ import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.utils import get_or_create_evm_token
-from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     asset_normalized_value,
     asset_raw_value,
-    should_update_protocol_cache,
+    get_or_create_evm_token,
     token_normalized_value,
 )
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
+from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
 from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC_V2, WITHDRAW_TOPIC_V2, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l1/decoder.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import EvmToken
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import Asset, EvmToken
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/thegraph/balances.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/balances.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.thegraph.constants import CPT_THEGRAPH
 from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
 from rotkehlchen.chain.evm.types import string_to_evm_address

--- a/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Any, Final
 from eth_typing.abi import ABI
 
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/uniswap/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/utils.py
@@ -3,10 +3,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Final, Literal
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_decimals, get_or_create_evm_token
 from rotkehlchen.chain.decoding.types import get_versioned_counterparty_label
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, get_decimals
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/decoding/uniswap/v2/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v2/utils.py
@@ -8,6 +8,7 @@ from web3 import Web3
 from rotkehlchen.assets.asset import Asset, CryptoAsset, EvmToken, UnderlyingToken
 from rotkehlchen.assets.utils import (
     TokenEncounterInfo,
+    asset_normalized_value,
     edit_token_and_clean_cache,
     get_or_create_evm_token,
 )
@@ -18,7 +19,7 @@ from rotkehlchen.chain.ethereum.modules.constants import (
     SUSHISWAP_LP_SYMBOL,
     UNISWAP_V2_LP_SYMBOL,
 )
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, generate_address_via_create2
+from rotkehlchen.chain.ethereum.utils import generate_address_via_create2
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/utils.py
@@ -8,10 +8,14 @@ from web3 import Web3
 from web3.types import BlockIdentifier
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    asset_normalized_value,
+    get_or_create_evm_token,
+)
 from rotkehlchen.chain.decoding.types import get_versioned_counterparty_label
 from rotkehlchen.chain.ethereum.oracles.constants import UNISWAP_FACTORY_ADDRESSES
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, generate_address_via_create2
+from rotkehlchen.chain.ethereum.utils import generate_address_via_create2
 from rotkehlchen.chain.evm.decoding.structures import ActionItem, DecoderContext, EvmDecodingOutput
 from rotkehlchen.chain.evm.decoding.uniswap.utils import get_position_price_from_underlying
 from rotkehlchen.constants.prices import ZERO_PRICE

--- a/rotkehlchen/chain/evm/decoding/uniswap/v4/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v4/utils.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING
 from eth_abi import encode as encode_abi
 from web3 import Web3
 
+from rotkehlchen.assets.utils import asset_normalized_value, asset_raw_value
 from rotkehlchen.chain.decoding.types import get_versioned_counterparty_label
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value, asset_raw_value
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.uniswap.utils import (

--- a/rotkehlchen/chain/evm/decoding/utils.py
+++ b/rotkehlchen/chain/evm/decoding/utils.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING, Any, Literal
 from eth_typing import ABI
 
 from rotkehlchen.assets.asset import AssetWithSymbol
-from rotkehlchen.assets.utils import get_evm_token
+from rotkehlchen.assets.utils import get_evm_token, token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.utils import maybe_notify_cache_query_status
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.errors.misc import (

--- a/rotkehlchen/chain/evm/decoding/velodrome/balances.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/balances.py
@@ -2,12 +2,12 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import (
     PROTOCOLS_WITH_BALANCES,
     BalancesSheetType,
     ProtocolWithGauges,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.velodrome.constants import VOTING_ESCROW_ABI

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -2,12 +2,12 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from rotkehlchen.assets.utils import get_or_create_evm_token
-from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     asset_normalized_value,
+    get_or_create_evm_token,
     token_normalized_value_decimals,
 )
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.constants import (
     BURN_TOPIC,
     DEFAULT_TOKEN_DECIMALS,

--- a/rotkehlchen/chain/evm/decoding/weth/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/weth/decoder.py
@@ -3,9 +3,9 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import CryptoAsset, EvmToken
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC_V2
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/xdai_bridge/decoder.py
@@ -2,9 +2,9 @@ import abc
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.decoding.constants import GNOSIS_CPT_DETAILS
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -5,11 +5,11 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from rotkehlchen.assets.asset import Asset, EvmToken, Nft
-from rotkehlchen.balances.historical import HistoricalBalancesManager
-from rotkehlchen.chain.ethereum.utils import (
+from rotkehlchen.assets.utils import (
     token_normalized_value,
     token_normalized_value_decimals,
 )
+from rotkehlchen.balances.historical import HistoricalBalancesManager
 from rotkehlchen.chain.evm.proxies_inquirer import ProxyType
 from rotkehlchen.chain.evm.types import WeightedNode, asset_id_is_evm_token
 from rotkehlchen.chain.structures import EvmTokenDetectionData

--- a/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/giveth/decoder.py
@@ -2,7 +2,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.constants import STAKED, WITHDRAWN
 from rotkehlchen.chain.evm.decoding.giveth.constants import (

--- a/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
+++ b/rotkehlchen/chain/gnosis/modules/gnosis_pay/decoder.py
@@ -2,8 +2,8 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,

--- a/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/airdrops/decoder.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Final
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER, OPTIMISM_CPT_DETAILS
 from rotkehlchen.chain.evm.decoding.interfaces import MerkleClaimDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/optimism/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/giveth/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Final
 
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_GIVETH, TOKEN_LOCKED
 from rotkehlchen.chain.evm.decoding.giveth.decoder import GivethDecoderBase

--- a/rotkehlchen/chain/optimism/modules/walletconnect/decoder.py
+++ b/rotkehlchen/chain/optimism/modules/walletconnect/decoder.py
@@ -2,9 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.chain.ethereum.utils import (
-    token_normalized_value_decimals,
-)
+from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS, STAKING_DEPOSIT
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/polygon_pos/modules/giveth/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/giveth/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.giveth.constants import CPT_DETAILS_GIVETH, CPT_GIVETH
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/polygon_pos/modules/polygon_pos_bridge/decoder.py
+++ b/rotkehlchen/chain/polygon_pos/modules/polygon_pos_bridge/decoder.py
@@ -2,8 +2,8 @@ import logging
 from collections.abc import Callable
 from typing import Any, Final
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/scroll/modules/scroll_airdrop/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_airdrop/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any, Final
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import CLAIMED_TOPIC
 from rotkehlchen.chain.evm.decoding.airdrops import match_airdrop_claim
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface

--- a/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/scroll_bridge/decoder.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Final
 
 from eth_abi import decode as decode_abi
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (

--- a/rotkehlchen/chain/scroll/modules/weth/decoder.py
+++ b/rotkehlchen/chain/scroll/modules/weth/decoder.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+from rotkehlchen.assets.utils import asset_normalized_value
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.chain.evm.decoding.structures import DEFAULT_EVM_DECODING_OUTPUT
 from rotkehlchen.chain.evm.decoding.weth.decoder import WethDecoder as EthBaseWethDecoder
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType

--- a/rotkehlchen/chain/solana/decoding/decoder.py
+++ b/rotkehlchen/chain/solana/decoding/decoder.py
@@ -4,13 +4,14 @@ from typing import TYPE_CHECKING, Any
 
 from solders.solders import Signature
 
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_solana_token
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    get_or_create_solana_token,
+    token_normalized_value,
+)
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.decoder import TransactionDecoder
 from rotkehlchen.chain.decoding.utils import decode_safely
-from rotkehlchen.chain.ethereum.utils import (
-    token_normalized_value,
-)
 from rotkehlchen.chain.evm.decoding.constants import OUTGOING_EVENT_TYPES
 from rotkehlchen.chain.solana.types import (
     SolanaInstruction,

--- a/rotkehlchen/chain/solana/manager.py
+++ b/rotkehlchen/chain/solana/manager.py
@@ -9,8 +9,11 @@ from spl.token.constants import TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_solana_token
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    get_or_create_solana_token,
+    token_normalized_value,
+)
 from rotkehlchen.chain.manager import ChainManagerWithNodesMixin, ChainManagerWithTransactions
 from rotkehlchen.chain.solana.utils import deserialize_token_account, lamports_to_sol
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL

--- a/rotkehlchen/chain/solana/modules/jupiter/decoder.py
+++ b/rotkehlchen/chain/solana/modules/jupiter/decoder.py
@@ -1,10 +1,9 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.assets.utils import get_or_create_solana_token
+from rotkehlchen.assets.utils import get_or_create_solana_token, token_normalized_value
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
-from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.solana.decoding.constants import ANCHOR_EVENT_DISCRIMINATOR
 from rotkehlchen.chain.solana.decoding.interfaces import SolanaDecoderInterface
 from rotkehlchen.chain.solana.decoding.structures import (

--- a/rotkehlchen/chain/zksync_lite/manager.py
+++ b/rotkehlchen/chain/zksync_lite/manager.py
@@ -13,8 +13,11 @@ from pysqlcipher3.dbapi2 import IntegrityError
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
 from rotkehlchen.assets.asset import Asset, CryptoAsset
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    asset_normalized_value,
+    get_or_create_evm_token,
+)
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.manager import ChainManagerWithTransactions, ChainWithEoA
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ZERO

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -9,10 +9,7 @@ import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
-from rotkehlchen.assets.utils import symbol_to_asset_or_token
-from rotkehlchen.chain.ethereum.utils import (
-    normalized_fval_value_decimals,
-)
+from rotkehlchen.assets.utils import normalized_fval_value_decimals, symbol_to_asset_or_token
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data

--- a/rotkehlchen/externalapis/opensea.py
+++ b/rotkehlchen/externalapis/opensea.py
@@ -9,9 +9,8 @@ import requests
 from eth_utils import to_checksum_address
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
-from rotkehlchen.chain.ethereum.utils import asset_normalized_value
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import NFT_DIRECTIVE

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -16,7 +16,11 @@ from typing import (
 )
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles, EvmToken, FiatAsset, UnderlyingToken
-from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
+from rotkehlchen.assets.utils import (
+    TokenEncounterInfo,
+    get_or_create_evm_token,
+    token_normalized_value_decimals,
+)
 from rotkehlchen.chain.arbitrum_one.modules.umami.constants import CPT_UMAMI
 from rotkehlchen.chain.arbitrum_one.modules.umami.utils import get_umami_vault_token_price
 from rotkehlchen.chain.ethereum.defi.price import handle_defi_price_query
@@ -25,7 +29,6 @@ from rotkehlchen.chain.ethereum.modules.yearn.constants import (
     CPT_YEARN_V2,
     CPT_YEARN_V3,
 )
-from rotkehlchen.chain.ethereum.utils import token_normalized_value_decimals
 from rotkehlchen.chain.evm.constants import ETH_SPECIAL_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.aura_finance.constants import CPT_AURA_FINANCE


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=127907198

Moves several functions for working with asset amounts from chain/ethereum/utils to assets/utils since they are not ethereum or even evm specific and are getting used with solana tokens etc.