### PR TITLE
Remove unneeded pol price special logic

### DIFF
--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -11,15 +11,12 @@ from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 from rotkehlchen.chain.evm.decoding.uniswap.v3.utils import get_uniswap_v3_position_price
 from rotkehlchen.chain.evm.utils import lp_price_from_uniswaplike_pool_contract
-from rotkehlchen.chain.polygon_pos.constants import POLYGON_POS_POL_HARDFORK
 from rotkehlchen.constants import HOUR_IN_SECONDS, ONE
 from rotkehlchen.constants.assets import (
     A_ETH,
     A_ETH2,
-    A_ETH_POL,
     A_EUR,
     A_KFEE,
-    A_POL,
     A_USD,
 )
 from rotkehlchen.constants.prices import ZERO_PRICE
@@ -195,14 +192,6 @@ class PriceHistorian:
                 max_seconds_distance=max_seconds_distance,
             )
             return Price(usd_price * usd_to_target_price) if usd_to_target_price is not None else None  # noqa: E501
-
-        if from_asset == A_POL and timestamp > POLYGON_POS_POL_HARDFORK:
-            return PriceHistorian._get_cached_price_or_query(
-                from_asset=A_ETH_POL,
-                to_asset=to_asset,
-                timestamp=timestamp,
-                max_seconds_distance=max_seconds_distance,
-            )
 
         if GlobalDBHandler.asset_in_collection(collection_id=240, asset_id=from_asset.identifier):  # part of the EURe collection # noqa: E501  # todo: Super hacky. Figure out a way to generalize
             return PriceHistorian._get_cached_price_or_query(

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -67,7 +67,6 @@ from rotkehlchen.chain.evm.protocol_constants import (
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.evm.utils import lp_price_from_uniswaplike_pool_contract
-from rotkehlchen.chain.polygon_pos.constants import POLYGON_POS_POL_HARDFORK
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import (
     A_3CRV,
@@ -708,16 +707,13 @@ class Inquirer:
     @staticmethod
     def _maybe_replace_asset(asset: Asset) -> Asset:
         """Get the asset to actually use when finding the price of the specified asset.
-        Uses the main asset for collection assets and also handles special cases like ETH2 and POL.
+        Uses the main asset for collection assets and also handles the ETH2 special case.
         Returns either a replacement asset, or the original asset.
         """
         if asset == A_ETH2:
             return A_ETH
-        elif (
-            (collection_main_asset_id := GlobalDBHandler.get_collection_main_asset(asset.identifier)) is not None and  # noqa: E501
-            (collection_main_asset_id != 'eip155:1/erc20:0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6' or ts_now() > POLYGON_POS_POL_HARDFORK)  # only use the pol token after the hardfork.  # noqa: E501
-        ):
-            return Asset(collection_main_asset_id)
+        elif (main_asset_id := GlobalDBHandler.get_collection_main_asset(asset.identifier)) is not None:  # noqa: E501
+            return Asset(main_asset_id)
 
         return asset
 

--- a/rotkehlchen/tests/fixtures/history.py
+++ b/rotkehlchen/tests/fixtures/history.py
@@ -26,6 +26,11 @@ def fixture_session_coingecko():
     return Coingecko(database=None)
 
 
+@pytest.fixture(name='coingecko')
+def fixture_coingecko():
+    return Coingecko(database=None)
+
+
 @pytest.fixture(name='alchemy')
 def fixture_alchemy(database: 'DBHandler'):
     with database.user_write() as write_cursor:
@@ -40,6 +45,11 @@ def fixture_alchemy(database: 'DBHandler'):
 
 
 @pytest.fixture(scope='session', name='session_defillama')
+def fixture_session_defillama():
+    return Defillama(database=None)
+
+
+@pytest.fixture(name='defillama')
 def fixture_defillama():
     return Defillama(database=None)
 
@@ -76,9 +86,9 @@ def price_historian(
         should_mock_price_queries,
         mocked_price_queries,
         cryptocompare,
-        session_coingecko,
+        coingecko,
         alchemy,
-        session_defillama,
+        defillama,
         uniswapv2_inquirer,
         uniswapv3_inquirer,
         default_mock_price_value,
@@ -92,9 +102,9 @@ def price_historian(
     historian = PriceHistorian(
         data_directory=data_dir,
         cryptocompare=cryptocompare,
-        coingecko=session_coingecko,
+        coingecko=coingecko,
         alchemy=alchemy,
-        defillama=session_defillama,
+        defillama=defillama,
         uniswapv2=uniswapv2_inquirer,
         uniswapv3=uniswapv3_inquirer,
     )

--- a/rotkehlchen/tests/unit/globaldb/test_prices.py
+++ b/rotkehlchen/tests/unit/globaldb/test_prices.py
@@ -1,18 +1,5 @@
-import pytest
-
-from rotkehlchen.chain.polygon_pos.constants import POLYGON_POS_POL_HARDFORK
-from rotkehlchen.constants.assets import (
-    A_BAL,
-    A_BTC,
-    A_ETH,
-    A_ETH_POL,
-    A_POL,
-    A_USD,
-)
-from rotkehlchen.constants.misc import ONE, ZERO
+from rotkehlchen.constants.assets import A_BAL, A_BTC, A_ETH, A_USD
 from rotkehlchen.fval import FVal
-from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
 from rotkehlchen.tests.utils.constants import A_EUR
 from rotkehlchen.types import Price, Timestamp
@@ -144,35 +131,3 @@ def test_get_historical_price(globaldb, historical_price_test_data):  # pylint: 
         max_seconds_distance=3600,
     )
     assert price_entry is None
-
-
-@pytest.mark.parametrize('should_mock_price_queries', [False])
-def test_matic_pol_hardforked_price(price_historian: PriceHistorian):
-    """Test that we return price of POL for MATIC after hardfork"""
-    before_hardfork = Timestamp(POLYGON_POS_POL_HARDFORK - 1)
-    after_hardfork = Timestamp(POLYGON_POS_POL_HARDFORK + 1)
-    assert GlobalDBHandler.add_single_historical_price(HistoricalPrice(  # set MATIC price ZERO
-        from_asset=A_POL,
-        to_asset=A_USD,
-        source=HistoricalPriceOracle.MANUAL,
-        timestamp=before_hardfork,
-        price=Price(ZERO),
-    ))
-    assert GlobalDBHandler.add_single_historical_price(HistoricalPrice(  # set POL price ONE
-        from_asset=A_ETH_POL,
-        to_asset=A_USD,
-        source=HistoricalPriceOracle.MANUAL,
-        timestamp=after_hardfork,
-        price=Price(ONE),
-    ))
-
-    assert price_historian.query_historical_price(
-        from_asset=A_POL,
-        to_asset=A_USD,
-        timestamp=before_hardfork,
-    ) == Price(ZERO)  # MATIC price is ZERO
-    assert price_historian.query_historical_price(
-        from_asset=A_POL,  # query MATIC after hardfork
-        to_asset=A_USD,
-        timestamp=after_hardfork,
-    ) == Price(ONE)  # POL price is ONE


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=137286231

The special price logic we added when the matic/pol fork happened is no longer needed since the oracles now get proper historic prices for all the tokens involved.
