### PR TITLE
prevent ERC20 transfers from being marked as queried when API fails

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` ERC20 transfers will no longer be missed when transaction querying fails due to network problems.
 * :bug:`-` rotki will now decode more kinds of Jupiter swaps.
 * :bug:`-` Fix an issue where editing the latest price of an asset in the asset page shows the wrong initial price.
 * :bug:`-` Contract deployment events will now display the deployed contract address in the event notes.

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -437,6 +437,7 @@ class EvmTransactions(ABC):  # noqa: B024
                     f'from_ts: {query_start_ts} '
                     f'to_ts: {query_end_ts} ',
                 )
+                return
 
         log.debug(f'{self.evm_inquirer.chain_name} ERC20 Transfers done for address {address}. Update range {start_ts} - {end_ts}')  # noqa: E501
         with self.database.user_write() as write_cursor:


### PR DESCRIPTION
First part of https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=137511941