### PR TITLE
Fix poloniex withdrawal fees

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` rotki will no longer count fee in the withdrawn amount in poloniex
 * :bug:`10894` rotki will now properly decode more Aave V3 transactions involving native tokens.
 * :bug:`-` ERC20 transfers will no longer be missed when transaction querying fails due to network problems.
 * :bug:`-` rotki will now decode more kinds of Jupiter swaps.

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -371,7 +371,7 @@ def test_poloniex_deposits_withdrawal_unknown_asset(poloniex: 'Poloniex') -> Non
         event_type=HistoryEventType.WITHDRAWAL,
         timestamp=TimestampMS(1458994442000),
         asset=A_BTC,
-        amount=FVal('5.0'),
+        amount=FVal('4.5'),
         unique_id='withdrawal_1',
         extra_data={
             'address': '131rdg5Rzn6BFufnnQaHhVa5ZtRU1J2EZR',
@@ -392,7 +392,7 @@ def test_poloniex_deposits_withdrawal_unknown_asset(poloniex: 'Poloniex') -> Non
         event_type=HistoryEventType.WITHDRAWAL,
         timestamp=TimestampMS(1468994442000),
         asset=A_ETH,
-        amount=FVal('10.0'),
+        amount=FVal('9.9'),
         unique_id='withdrawal_2',
         extra_data={
             'address': '0xB7E033598Cb94EF5A35349316D3A2e4f95f308Da',


### PR DESCRIPTION
As reported by antipro in our discord rotki takes the full amount as withdrawal amount while the `amount` field according to https://api-docs.poloniex.com/spot/api/private/wallet should have been amount - fee.

