### PR TITLE
rotki will now query DOT and KSM balances properly again

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`10914` rotki will now query polkadot and kusama balances correctly again after their migration to asset hub.
 * :bug:`-` rotki will no longer count fee in the withdrawn amount in poloniex
 * :bug:`10894` rotki will now properly decode more Aave V3 transactions involving native tokens.
 * :bug:`-` ERC20 transfers will no longer be missed when transaction querying fails due to network problems.

--- a/rotkehlchen/chain/substrate/types.py
+++ b/rotkehlchen/chain/substrate/types.py
@@ -5,8 +5,6 @@ from substrateinterface import SubstrateInterface
 
 SubstrateAddress = NewType('SubstrateAddress', str)
 SubstratePublicKey = NewType('SubstratePublicKey', str)
-
-SubstrateChainId = NewType('SubstrateChainId', str)
 BlockNumber = NewType('BlockNumber', int)
 
 
@@ -15,22 +13,22 @@ BlockNumber = NewType('BlockNumber', int)
 class KusamaNodeName(Enum):
     """Public nodes for Kusama.
 
-    Taken from: https://github.com/polkadot-js/apps/blob/master/packages/apps-config/src/endpoints/production.ts#L34
+    Taken from: https://www.comparenodes.com/library/public-endpoints/assethub/
     """
     OWN = 0  # make sure it's always 0 to match PolkadotNodeName
-    PARITY = 1
+    DWELLIR = 1
     ONFINALITY = 2
-    ELARA = 3
+    STAKEWORLD = 3
 
     def __str__(self) -> str:
         if self == KusamaNodeName.OWN:
             return 'own node'
-        if self == KusamaNodeName.PARITY:
-            return 'parity'
+        if self == KusamaNodeName.DWELLIR:
+            return 'dwellir'
         if self == KusamaNodeName.ONFINALITY:
             return 'onfinality'
-        if self == KusamaNodeName.ELARA:
-            return 'elara'
+        if self == KusamaNodeName.STAKEWORLD:
+            return 'stakeworld'
 
         raise AssertionError(f'Unexpected KusamaNodeName: {self}')
 
@@ -40,12 +38,12 @@ class KusamaNodeName(Enum):
                 'The endpoint url for a substrate own node must be got either '
                 'via "own_rpc_endpoint" or the specific db setting',
             )
-        if self == KusamaNodeName.PARITY:
-            return 'https://kusama-rpc.polkadot.io/'
+        if self == KusamaNodeName.DWELLIR:
+            return 'https://asset-hub-kusama-rpc.n.dwellir.com/'
         if self == KusamaNodeName.ONFINALITY:
-            return 'https://kusama.api.onfinality.io/public-https'
-        if self == KusamaNodeName.ELARA:
-            return 'https://kusama.elara.patract.io'
+            return 'https://assethub-kusama.api.onfinality.io/public'
+        if self == KusamaNodeName.STAKEWORLD:
+            return 'https://ksm-rpc.stakeworld.io/assethub'
         raise AssertionError(f'Unexpected KusamaNodeName: {self}')
 
     def is_owned(self) -> bool:
@@ -55,22 +53,22 @@ class KusamaNodeName(Enum):
 class PolkadotNodeName(Enum):
     """Public nodes for Polkadot.
 
-    Taken from: https://github.com/polkadot-js/apps/blob/master/packages/apps-config/src/endpoints/production.ts#L34
+    Taken from: https://www.comparenodes.com/library/public-endpoints/assethub/
     """
     OWN = 0  # make sure it's always 0 to match KusamaNodeName
-    PARITY = 1
+    DWELLIR = 1
     ONFINALITY = 2
-    ELARA = 3
+    STAKEWORLD = 3
 
     def __str__(self) -> str:
         if self == PolkadotNodeName.OWN:
             return 'own node'
-        if self == PolkadotNodeName.PARITY:
-            return 'parity'
+        if self == PolkadotNodeName.DWELLIR:
+            return 'dwellir'
         if self == PolkadotNodeName.ONFINALITY:
             return 'onfinality'
-        if self == PolkadotNodeName.ELARA:
-            return 'elara'
+        if self == PolkadotNodeName.STAKEWORLD:
+            return 'stakeworld'
 
         raise AssertionError(f'Unexpected PolkadotNodeName: {self}')
 
@@ -80,12 +78,12 @@ class PolkadotNodeName(Enum):
                 'The endpoint url for a substrate own node must be got either '
                 'via "own_rpc_endpoint" or the specific db setting',
             )
-        if self == PolkadotNodeName.PARITY:
-            return 'https://rpc.polkadot.io/'
+        if self == PolkadotNodeName.DWELLIR:
+            return 'https://asset-hub-polkadot-rpc.n.dwellir.com/'
         if self == PolkadotNodeName.ONFINALITY:
-            return 'https://polkadot.api.onfinality.io/public-ws'
-        if self == PolkadotNodeName.ELARA:
-            return 'https://polkadot.elara.patract.io'
+            return 'https://statemint.api.onfinality.io/public'
+        if self == PolkadotNodeName.STAKEWORLD:
+            return 'https://dot-rpc.stakeworld.io/assethub'
         raise AssertionError(f'Unexpected PolkadotNodeName: {self}')
 
     def is_owned(self) -> bool:

--- a/rotkehlchen/chain/substrate/utils.py
+++ b/rotkehlchen/chain/substrate/utils.py
@@ -9,15 +9,15 @@ from .types import KusamaNodeName, PolkadotNodeName, SubstrateAddress, Substrate
 
 KUSAMA_NODES_TO_CONNECT_AT_START = (
     KusamaNodeName.OWN,
-    KusamaNodeName.PARITY,
-    KusamaNodeName.ELARA,
+    KusamaNodeName.DWELLIR,
+    KusamaNodeName.STAKEWORLD,
     KusamaNodeName.ONFINALITY,
 )
 
 POLKADOT_NODES_TO_CONNECT_AT_START = (
     PolkadotNodeName.OWN,
-    PolkadotNodeName.PARITY,
-    PolkadotNodeName.ELARA,
+    PolkadotNodeName.DWELLIR,
+    PolkadotNodeName.STAKEWORLD,
     PolkadotNodeName.ONFINALITY,
 )
 

--- a/rotkehlchen/tests/api/blockchain/test_substrate.py
+++ b/rotkehlchen/tests/api/blockchain/test_substrate.py
@@ -53,7 +53,7 @@ def test_add_ksm_blockchain_account_invalid(rotkehlchen_api_server: 'APIServer')
     )
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('kusama_manager_connect_at_start', [(KusamaNodeName.OWN,)])
 @pytest.mark.parametrize('ksm_rpc_endpoint', [KUSAMA_TEST_RPC_ENDPOINT], ids=['KUSAMA_TEST_RPC_ENDPOINT'])  # setting ids to rename the argument to be processed by vcr since its value can contain characters that are illegal in windows. Affects all other similar fixtures in this file # noqa: E501
@@ -107,7 +107,7 @@ def test_add_ksm_blockchain_account(
     assert FVal(total_ksm['usd_value']) >= ZERO
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('ksm_accounts', [[SUBSTRATE_ACC1_KSM_ADDR, SUBSTRATE_ACC2_KSM_ADDR]])
 @pytest.mark.parametrize('kusama_manager_connect_at_start', [(KusamaNodeName.OWN,)])

--- a/rotkehlchen/tests/api/test_substrate_manager.py
+++ b/rotkehlchen/tests/api/test_substrate_manager.py
@@ -10,8 +10,8 @@ from rotkehlchen.tests.utils.api import (
 from rotkehlchen.tests.utils.substrate import KUSAMA_TEST_RPC_ENDPOINT
 
 
-@pytest.mark.vcr
-@pytest.mark.freeze_time('2023-10-12 09:00:00 GMT')
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.freeze_time('2025-11-09 17:00:00 GMT')
 def test_set_unset_own_rpc_endpoint(rotkehlchen_api_server: APIServer) -> None:
     """Test that successfully setting/unsetting an own node (via `ksm_rpc_endpoint` setting)
     updates the `available_node_attributes_map`, sorts `available_nodes_call_order`,

--- a/rotkehlchen/tests/unit/test_substrate_manager.py
+++ b/rotkehlchen/tests/unit/test_substrate_manager.py
@@ -55,13 +55,13 @@ def test_get_accounts_balance(kusama_manager):
         SUBSTRATE_ACC1_KSM_ADDR,
         SUBSTRATE_ACC2_KSM_ADDR,
     ])
-    assert account_balance[SUBSTRATE_ACC1_KSM_ADDR] >= ZERO
-    assert account_balance[SUBSTRATE_ACC2_KSM_ADDR] >= ZERO
+    assert account_balance[SUBSTRATE_ACC1_KSM_ADDR] > ZERO
+    assert account_balance[SUBSTRATE_ACC2_KSM_ADDR] > ZERO
 
 
 def test_get_chain_id(kusama_manager):
     chain_id = kusama_manager.get_chain_id()
-    assert chain_id == 'Kusama'
+    assert chain_id == 'Kusama Asset Hub'
 
 
 def test_get_chain_properties(kusama_manager):
@@ -123,7 +123,7 @@ def test_set_available_nodes_call_order(kusama_manager):
         ),
     )
     node_attrs_item_3 = (
-        KusamaNodeName.PARITY,
+        KusamaNodeName.DWELLIR,
         NodeNameAttributes(
             node_interface=object(),
             weight_block=1000,
@@ -151,15 +151,15 @@ def test_format_own_rpc_endpoint(endpoint, formatted_endpoint):
 
 
 def test_connect_to_own_node(polkadot_manager: 'SubstrateManager'):
-    polkadot_manager.connect_at_start = [PolkadotNodeName.OWN, PolkadotNodeName.PARITY]
+    polkadot_manager.connect_at_start = [PolkadotNodeName.OWN, PolkadotNodeName.DWELLIR]
     polkadot_manager.own_rpc_endpoint = ''
     polkadot_manager.attempt_connections()
-    assert [task.task_name for task in polkadot_manager.greenlet_manager.greenlets] == ['polkadot manager connection to parity node']  # noqa: E501
+    assert [task.task_name for task in polkadot_manager.greenlet_manager.greenlets] == ['polkadot manager connection to dwellir node']  # noqa: E501
     polkadot_manager.greenlet_manager.clear()
     polkadot_manager.greenlet_manager.greenlets = []
     polkadot_manager.own_rpc_endpoint = 'http://localhost:1234'
     polkadot_manager.attempt_connections()
     assert [task.task_name for task in polkadot_manager.greenlet_manager.greenlets] == [
         'polkadot manager connection to own node node',
-        'polkadot manager connection to parity node',
+        'polkadot manager connection to dwellir node',
     ]

--- a/rotkehlchen/tests/utils/substrate.py
+++ b/rotkehlchen/tests/utils/substrate.py
@@ -28,13 +28,13 @@ log = RotkehlchenLogsAdapter(logger)
 SUBSTRATE_ACC1_PUBLIC_KEY = '0xa6659e4c3f22c2aa97d54a36e31ab57a617af62bd43ec62ed570771492069270'
 SUBSTRATE_ACC1_DOT_ADDR = '14mB8stSf1vdP7WzbVr82YPgGGF7cBK9N7KxiVEac9UQgYj7'
 SUBSTRATE_ACC1_KSM_ADDR = 'GLVeryFRbg5hEKvQZcAnLvXZEXhiYaBjzSDwrXBXrfPF7wj'
-SUBSTRATE_ACC2_PUBLIC_KEY = '0x7e0bd3a5719525e3a4778010994c71be04eb6b7cd2e90931a76a3c89fa412b12'
+SUBSTRATE_ACC2_PUBLIC_KEY = '0x203066b0a657bdbdbe9974c20a2644881f384f9b206c7c394054c0d411d7bc6e'
 SUBSTRATE_ACC2_DOT_ADDR = '13rGYiGMwLkHbt5Q5rcdyS4Tq7kmJgdE4d4tLex6Pwa7cVZA'
-SUBSTRATE_ACC2_KSM_ADDR = 'FRb4hMAhvVjuztKtvNgjEbK863MR3tGSWB9a2EhKem6AygK'
+SUBSTRATE_ACC2_KSM_ADDR = 'DJXRnqb3aTRpQfZtfZKFB3rXrDcdKjyS7C3BrrB5oWMDrxJ'
 
 # Use 2 nodes for tests
 KUSAMA_TEST_NODES = (
-    KusamaNodeName.PARITY,
+    KusamaNodeName.DWELLIR,
     KusamaNodeName.ONFINALITY,
 )
 
@@ -42,7 +42,7 @@ KUSAMA_SS58_FORMAT = 2
 POLKADOT_SS58_FORMAT = 2
 KUSAMA_MAIN_ASSET_DECIMALS = FVal(12)
 KUSAMA_DEFAULT_OWN_RPC_ENDPOINT = 'http://localhost:9933'
-KUSAMA_TEST_RPC_ENDPOINT = 'https://ksm.getblock.io/ae78eb1d-2643-4e22-b691-0ecb9d9c5e08/mainnet/'  # made by lef for testing # noqa: E501
+KUSAMA_TEST_RPC_ENDPOINT = 'https://assethub-kusama.api.onfinality.io/rpc?apikey=4f8b5736-9951-4a54-b789-0a384c50c4ed'  # made byq lef for testing # noqa: E501
 
 
 def attempt_connect_test_nodes(


### PR DESCRIPTION
Fix #10914, by changing our integration to query the assethub nodes and no longer querying the relay nodes as per
https://support.polkadot.network/support/solutions/articles/65000190561

---

Now I can go for a long run https://x.com/LefterisJP/status/1987472486196207673