### PR TITLE
docs: clarify logging redaction comment

### DIFF
--- a/rotkehlchen/logging.py
+++ b/rotkehlchen/logging.py
@@ -92,7 +92,7 @@ class RotkehlchenLogsAdapter(logging.LoggerAdapter):
         This is the main post-processing function for rotki logs
 
         This function:
-        - appends all kwargs to the final message, redacting any sensitive information
+        - appends all kwargs to the final message, redacting sensitive keys inside a ``json_data`` payload
         - appends the greenlet id in the log message
         """
         msg, greenlet = str(given_msg), gevent.getcurrent()


### PR DESCRIPTION
  Sync the RotkehlchenLogsAdapter.process docstring with what the code actually does: we only scrub sensitive keys inside json_data before appending kwargs.
  