### PR TITLE
skip certain tests in nightlies due to github api ratelimits

### DIFF
--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
@@ -21,6 +21,7 @@ from rotkehlchen.db.constants import UpdateType
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.asset_updates.manager import AssetsUpdater
 from rotkehlchen.globaldb.migrations.manager import LAST_GLOBALDB_DATA_MIGRATION
+from rotkehlchen.tests.conftest import TestEnvironment, requires_env
 from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 from rotkehlchen.types import (
     SPAM_PROTOCOL,
@@ -84,6 +85,7 @@ class DBToken:
         }
 
 
+@requires_env([TestEnvironment.STANDARD])  # skip in nightlies due to github api rate limits
 def test_asset_updates_consistency_with_packaged_db(
         tmpdir_factory: 'pytest.TempdirFactory',
         messages_aggregator: 'MessagesAggregator',
@@ -452,6 +454,7 @@ def test_oracle_ids_in_asset_collections(globaldb: 'GlobalDBHandler'):
         pytest.fail('oracle IDs do not match:\n' + '\n'.join(mismatches))
 
 
+@requires_env([TestEnvironment.STANDARD])  # skip in nightlies due to github api rate limits
 @pytest.mark.parametrize('our_version', ['1.40.0'])  # set latest version so data can be updated
 def test_remote_updates_consistency_with_packaged_db(
         tmpdir_factory: 'pytest.TempdirFactory',

--- a/rotkehlchen/tests/unit/globaldb/test_upgrades.py
+++ b/rotkehlchen/tests/unit/globaldb/test_upgrades.py
@@ -40,6 +40,7 @@ from rotkehlchen.globaldb.upgrades.v3_v4 import (
 )
 from rotkehlchen.globaldb.upgrades.v5_v6 import V5_V6_UPGRADE_UNIQUE_CACHE_KEYS
 from rotkehlchen.globaldb.utils import GLOBAL_DB_VERSION
+from rotkehlchen.tests.conftest import TestEnvironment, requires_env
 from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 from rotkehlchen.tests.utils.database import column_exists, index_exists
 from rotkehlchen.tests.utils.globaldb import patch_for_globaldb_upgrade_to
@@ -1477,6 +1478,7 @@ def test_applying_all_upgrade(globaldb: GlobalDBHandler, messages_aggregator):
 
 @pytest.mark.parametrize('globaldb_upgrades', [[]])
 @pytest.mark.parametrize('custom_globaldb', ['v4_global.db'])
+@requires_env([TestEnvironment.STANDARD])  # skip in nightlies due to github api rate limits
 @pytest.mark.parametrize('target_globaldb_version', [4])
 @pytest.mark.parametrize('reload_user_assets', [False])
 def test_assets_updates_applied_before_v10_change(globaldb, messages_aggregator):


### PR DESCRIPTION
<img width="2426" height="904" alt="CleanShot 2025-11-10 at 16 19 45@2x" src="https://github.com/user-attachments/assets/f852afc0-21eb-4248-9d1d-8db9c59bf379" />

all ci failures for linux in the nightlies are caused by github api rate limits. skipping them makes sense since they already run during PRs anyway.

- `rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py::test_remote_updates_consistency_with_packaged_db`
- `rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py::test_asset_updates_consistency_with_packaged_db`
- `rotkehlchen/tests/unit/globaldb/test_upgrades.py::test_assets_updates_applied_before_v10_change`