### PR TITLE
adding erc721 tokens via api improvements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3539,6 +3539,17 @@ Querying all supported assets
                   "cryptocompare":"VET",
                   "coingecko":"vet",
                   "protocol":"None"
+              },
+              {
+                  "identifier": "eip155:1/erc721:0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1234",
+                  "evm_address": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+                  "evm_chain":"ethereum",
+                  "token_kind":"erc721",
+                  "name": "Bored Ape Yacht Club #1234",
+                  "symbol": "BAYC",
+                  "asset_type": "evm token",
+                  "collectible_id": "1234",
+                  "protocol":"None"
               }
           ],
           "message": ""
@@ -3558,6 +3569,7 @@ Querying all supported assets
    :resjson string cryptocompare: The cryptocompare identifier for the asset. can be missing if not known. If missing a query by symbol is attempted.
    :resjson string coingecko: The coingecko identifier for the asset. can be missing if not known.
    :resjson string protocol: An optional string for evm tokens denoting the protocol they belong to. For example uniswap, for uniswap LP tokens.
+   :resjson string collectible_id: Only present for ERC721 tokens. The token ID of the NFT.
    :resjson object underlying_tokens: Optional. If the token is an LP token or a token set or something similar which represents a pool of multiple other tokens, then this is a list of the underlying token addresses and a percentage(value in the range of 0 to 100) that each token contributes to the pool.
    :resjson string notes: If the type is ``custom_asset`` this is a string field with notes added by the user.
    :resjson string custom_asset_type: If the type is ``custom_asset`` this field contains the custom type set by the user for the asset.

--- a/rotkehlchen/serialization/schemas.py
+++ b/rotkehlchen/serialization/schemas.py
@@ -251,10 +251,10 @@ class EvmTokenSchema(TokenWithDecimalAndProtocolSchema):
                     f'is {weight_sum * 100} and does not add up to 100%',
                 )
 
-        if (collectible_id := data['collectible_id']) is not None:
-            if data['token_kind'] != TokenKind.ERC721:
+        if data['token_kind'] == TokenKind.ERC721:
+            if (collectible_id := data['collectible_id']) is None:
                 raise ValidationError(
-                    message='collectible_id can only be specified for ERC721 tokens',
+                    message='collectible_id is required for ERC721 tokens',
                     field_name='collectible_id',
                 )
             if not collectible_id.isdigit():
@@ -262,6 +262,11 @@ class EvmTokenSchema(TokenWithDecimalAndProtocolSchema):
                     message='collectible_id must be a valid positive integer',
                     field_name='collectible_id',
                 )
+        elif data['collectible_id'] is not None:
+            raise ValidationError(
+                message='collectible_id can only be specified for ERC721 tokens',
+                field_name='collectible_id',
+            )
 
     @post_load
     def transform_data(

--- a/rotkehlchen/tests/api/test_user_assets.py
+++ b/rotkehlchen/tests/api/test_user_assets.py
@@ -1138,6 +1138,18 @@ def test_add_edit_erc721_token(rotkehlchen_api_server: APIServer) -> None:
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
+    # ERC721 token without collectible_id should be rejected
+    erc721_without_collectible_id = valid_erc721_token_data.copy()
+    del erc721_without_collectible_id['collectible_id']
+    assert_error_response(
+        response=requests.put(
+            api_url_for(rotkehlchen_api_server, 'allassetsresource'),
+            json=erc721_without_collectible_id,
+        ),
+        contained_in_msg='collectible_id is required for ERC721 tokens',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+
     # Test adding ERC721 token with collectible ID
     result = assert_proper_sync_response_with_result(requests.put(
         api_url_for(rotkehlchen_api_server, 'allassetsresource'),


### PR DESCRIPTION
- return `collectible_id` for erc721 in `assets/all` endpoint.
- ensure that `collectible_id` is added when creating an erc721 token via the API