### PR TITLE
fix: Use correct default_factory in combine_nested_dicts_inplace

### DIFF
--- a/rotkehlchen/utils/misc.py
+++ b/rotkehlchen/utils/misc.py
@@ -196,7 +196,7 @@ def combine_nested_dicts_inplace(
             if inner_key in inner_dict_a:
                 inner_dict_a[inner_key] = op(inner_dict_a[inner_key], value_b)
             elif op is operator.sub:
-                inner_dict_a[inner_key] = op(inner_dict_a.default_factory(), value_b)  # type: ignore[misc]
+                inner_dict_a[inner_key] = op(inner_dict_b.default_factory(), value_b)  # type: ignore[misc]
             else:
                 inner_dict_a[inner_key] = value_b
     return a


### PR DESCRIPTION
Fixed copy-paste error in combine_nested_dicts_inplace where inner_dict_a.default_factory was incorrectly used instead of 
inner_dict_b.default_factory when handling subtraction of new keys.

This ensures consistency with line 192 which correctly uses inner_dict_b.default_factory when creating new outer keys, and 
matches the function's semantics of combining data FROM b INTO a.