### PR TITLE
Avoid race condition on monerium refresh logic

### DIFF
--- a/rotkehlchen/externalapis/monerium.py
+++ b/rotkehlchen/externalapis/monerium.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 from urllib.parse import urljoin
 
 import requests
+from gevent.lock import Semaphore
 from oauthlib.oauth2 import WebApplicationClient
 
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
@@ -304,6 +305,7 @@ class MoneriumOAuthClient:
         self.session.headers.setdefault('Accept', MONERIUM_ACCEPT_HEADER)
         self._credentials: MoneriumOAuthCredentials | None = self._load_credentials()
         self._oauth_client: WebApplicationClient | None = None
+        self._refresh_lock: Semaphore = Semaphore()
         if self._credentials is not None:
             self._oauth_client = WebApplicationClient(AUTHORIZATION_CODE_FLOW_CLIENT_ID)
 
@@ -415,7 +417,12 @@ class MoneriumOAuthClient:
         if not self._credentials.is_expiring():  # type: ignore  # ._credentials is not None because it is checked above
             return
 
-        self._refresh_access_token()
+        with self._refresh_lock:
+            # ensure that no other greenlet refreshed already the token
+            if not self._credentials.is_expiring():  # type: ignore
+                return
+
+            self._refresh_access_token()
 
     def request(
             self,
@@ -498,7 +505,7 @@ class MoneriumOAuthClient:
         try:
             response = self.session.post(
                 url=urljoin(MONERIUM_API_BASE_URL, 'auth/token'),
-                params={
+                data={
                     'grant_type': 'refresh_token',
                     'client_id': AUTHORIZATION_CODE_FLOW_CLIENT_ID,
                     'refresh_token': self._credentials.refresh_token,


### PR DESCRIPTION
From my logs:

  ```
  [14/11/2025 10:37:26 CET] DEBUG rotkehlchen.externalapis.monerium Greenlet-9: Querying monerium API orders
  [14/11/2025 10:37:26 CET] DEBUG rotkehlchen.externalapis.monerium Greenlet-9: Preparing to refresh monerium oauth token
  [14/11/2025 10:38:02 CET] DEBUG rotkehlchen.externalapis.monerium Greenlet-11: Querying monerium API orders
  [14/11/2025 10:38:02 CET] DEBUG rotkehlchen.externalapis.monerium Greenlet-11: Preparing to refresh monerium oauth token
  [14/11/2025 10:38:02 CET] ERROR rotkehlchen.chain.evm.decoding.monerium.decoder Greenlet-11: Failed to process monerium events in 0x8682e8c980c9cd0f2edb7551caaeb6dc4a253f7ebf8b6f98ee03538f593df75e on arbitrum one due to Failed to
  refresh Monerium access token: 400 {"error":"invalid_grant","error_description":"Unable to load refresh token info: Access not found via code: XXX"}
  . Skipping monerium post processing.
  ```

after asking to the monerium team a race condition indeed could break the logic since they delete the token if that happens.

This commit:

- Adds a lock to ensure that two greenlets don't try to refresh the token at the same time.
- Adds a test that fails without the changes and works with them ensuring that token is refreshed once.

