### PR TITLE
fix: correct binance range tracking

### DIFF
--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -878,7 +878,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 ranges.update_used_query_range(
                     write_cursor=write_cursor,
                     location_string=range_query_name,
-                    queried_ranges=[(start_ts, end_ts)],
+                    queried_ranges=[(query_start_ts, query_end_ts)],
                 )
 
         return False


### PR DESCRIPTION
Ensure Binance Simple Earn history only marks the specific queried sub-range as processed so later intervals are not skipped.