### PR TITLE
fix: guard calendar timestamp type

### DIFF
--- a/rotkehlchen/externalapis/google_calendar.py
+++ b/rotkehlchen/externalapis/google_calendar.py
@@ -280,7 +280,7 @@ class GoogleCalendarAPI:
             # Convert timestamp to datetime
             try:
                 # Check if timestamp is in milliseconds (common issue)
-                if isinstance(entry.timestamp, int | float) and entry.timestamp > 1e10:
+                if isinstance(entry.timestamp, (int, float)) and entry.timestamp > 1e10:
                     # Timestamp is likely in milliseconds, convert to seconds
                     timestamp_seconds = entry.timestamp / 1000
                     log.debug(


### PR DESCRIPTION
Rework the timestamp check in the Google Calendar sync so Python 3.11 doesn’t blow up on the union type and we keep detecting millisecond inputs correctly.