### PR TITLE
Add a developer changelog

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     'releases',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
+    'sphinx.ext.extlinks',
     'sphinxcontrib.httpdomain',
     'sphinxcontrib.httpexample',
     'sphinx_inline_tabs',
@@ -50,6 +51,11 @@ extensions = [
 # 'releases' (changelog) settings
 releases_issue_uri = 'https://github.com/rotki/rotki/issues/%s'
 releases_release_uri = 'https://github.com/rotki/rotki/releases/tag/v%s'
+
+# 'extlinks' settings for custom link roles
+extlinks = {
+    'releasetag': ('https://github.com/rotki/rotki/releases/tag/v%s', '%s'),
+}
 # Enables 0.x.y releases to not be grouped into feature and bugfix releases
 # see: http://releases.readthedocs.io/en/latest/concepts.html#unstable-prehistory-mode
 # This needs to be kept enabled even once 1.0 has been reached!

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -1,0 +1,57 @@
+===================
+Developer Changelog
+===================
+
+This changelog documents API changes, schema modifications, and other developer-relevant changes that may affect integrations with rotki.
+
+Unreleased
+==========
+
+Event/Group Identifier Renaming
+-------------------------------
+
+The common identifier for groups of events (i.e. all events from a given EVM tx) is renamed from ``event_identifier`` to ``group_identifier``.
+
+* **Modified Endpoints**:
+
+  - ``POST``, ``PUT``, and ``PATCH`` on ``/api/(version)/history/events`` - Renamed ``event_identifier`` to ``group_identifier``.
+  - ``PUT /api/(version)/history/events/export`` - Renamed ``event_identifiers`` to ``group_identifiers``.
+  - ``POST /api/(version)/history/debug`` - Renamed ``event_identifier`` to ``group_identifier``.
+  - ``POST /api/(version)/balances/historical/asset`` - Renamed ``last_event_identifier`` to ``last_group_identifier``.
+  - ``POST /api/(version)/balances/historical/netvalue`` - Renamed ``last_event_identifier`` to ``last_group_identifier``.
+
+
+:releasetag:`1.41.1`
+====================
+
+Runtime Log Level Modification
+------------------------------
+
+The backend log level may now be modified at runtime without restarting.
+
+* **Modified Endpoint**: ``GET /api/(version)/settings/configuration``
+
+  - Now includes a ``loglevel`` field in response
+  - Example: ``{"loglevel": {"value": "DEBUG", "is_default": true}, ...}``
+
+* **New Endpoint**: ``PUT /api/(version)/settings/configuration``
+
+  - Currently only supports the ``loglevel`` parameter
+  - Accepted values: ``TRACE``, ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``
+  - Returns the same format as the GET endpoint.
+
+ERC-721 (NFT) Token IDs
+----------------------------------------
+
+ERC-721 token IDs may now be set when adding/editing assets.
+
+* **Modified Endpoint**: ``PUT /api/(version)/assets/all``
+
+  - Supports a new ``collectible_id`` field. Only valid when token_kind is ``"erc721"``.
+
+* **Modified Endpoint**: ``GET /api/(version)/assets/all``
+
+  - Now includes a ``collectible_id`` field in the response when token_kind is ``"erc721"``.
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ Contents
    api
    websockets
    changelog
+   dev_changelog


### PR DESCRIPTION
Adds a new developer changelog as discussed in [discord](https://discord.com/channels/657906918408585217/1080783409640648765/1441079116961939506)

I went with a new `dev_changelog.rst` file to avoid cluttering up the exiting changelog since these changes will often need more than single lines to describe.

I included the a couple things already released in the bugfixes release (under a 1.41.1 header ofc) as well as the group_identifier change that is in develop.

The `releases` sphinx extension only seems to work in a flat list, so I had to use `extlinks` to get the same functionality for the link to the release tag.