### PR TITLE
Allow to customize order of indexers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -782,6 +782,11 @@ Getting or modifying settings
               "active_modules": ["makerdao_dsr", "makerdao_vaults", "aave"],
               "current_price_oracles": ["coingecko"],
               "historical_price_oracles": ["cryptocompare", "coingecko"],
+              "evm_indexers_order": {
+                  "ethereum": ["etherscan", "blockscout", "routescan"],
+                  "optimism": ["blockscout", "etherscan", "routescan"]
+              },
+              "default_evm_indexer_order": ["etherscan", "blockscout", "routescan"],
               "ssf_graph_multiplier": 2,
               "non_sync_exchanges": [{"location": "binance", "name": "binance1"}],
               "cost_basis_method": "fifo",
@@ -816,6 +821,8 @@ Getting or modifying settings
    :resjson list active_module: A list of strings denoting the active modules with which rotki is running.
    :resjson list current_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting current prices.
    :resjson list historical_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting historical prices.
+   :resjson object evm_indexers_order: Mapping of EVM chain names to the ordered list of indexers to query per chain. Example: ``{"ethereum": ["etherscan", "blockscout", "routescan"]}``.
+   :resjson list default_evm_indexer_order: Default order to use with EVM indexers.
    :resjson int ssf_graph_multiplier: A multiplier to the snapshot saving frequency for zero amount graphs. Originally 0 by default. If set it denotes the multiplier of the snapshot saving frequency at which to insert 0 save balances for a graph between two saved values.
    :resjson string cost_basis_method: Defines which method to use during the cost basis calculation. Currently supported: fifo, lifo.
    :resjson string address_name_priority: Defines the priority to search for address names. From first to last location in this array, the first name found will be displayed.
@@ -866,6 +873,8 @@ Getting or modifying settings
    :reqjson list active_module: A list of strings denoting the active modules with which rotki should run.
    :reqjson list current_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting current prices.
    :reqjson list historical_price_oracles: A list of strings denoting the price oracles rotki should query in specific order for requesting historical prices.
+   :reqjson object[optional] evm_indexers_order: Mapping of EVM chain names to the ordered list of indexers to query per chain. Each list must contain the available indexers without duplicates.
+   :resjson list[optional] default_evm_indexer_order: Default order to use with EVM indexers.
    :reqjson list non_syncing_exchanges: A list of objects with the keys ``name`` and ``location`` of the exchange. These exchanges will be ignored when querying the trades. Example: ``[{"name": "my_exchange", "location": "binance"}]``.
    :resjson int ssf_graph_multiplier: A multiplier to the snapshot saving frequency for zero amount graphs. Originally 0 by default. If set it denotes the multiplier of the snapshot saving frequency at which to insert 0 save balances for a graph between two saved values.
    :resjson bool infer_zero_timed_balances: A boolean denoting whether to infer zero timed balances for assets that have no balance at a specific time. This is useful for showing zero balance periods in graphs.

--- a/rotkehlchen/api/v1/fields.py
+++ b/rotkehlchen/api/v1/fields.py
@@ -27,6 +27,7 @@ from rotkehlchen.assets.asset import (
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.chain.bitcoin.hdkey import HDKey
 from rotkehlchen.chain.bitcoin.utils import is_valid_derivation_path
+from rotkehlchen.chain.evm.types import EvmIndexer
 from rotkehlchen.chain.solana.validation import is_valid_solana_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.misc import NFT_DIRECTIVE
@@ -1069,6 +1070,21 @@ class HistoricalPriceOracleField(fields.Field):
             raise ValidationError(f'Invalid historical price oracle: {value}') from e
 
         return historical_price_oracle
+
+
+class EvmIndexerField(fields.Field):
+
+    def _deserialize(
+            self,
+            value: str,
+            attr: str | None,  # pylint: disable=unused-argument
+            data: Mapping[str, Any] | None,
+            **_kwargs: Any,
+    ) -> EvmIndexer:
+        try:
+            return EvmIndexer.deserialize(value)
+        except DeserializationError as e:
+            raise ValidationError(f'Invalid EVM indexer: {value}') from e
 
 
 class NonEmptyList(fields.List):

--- a/rotkehlchen/tests/data/pnl_debug.json
+++ b/rotkehlchen/tests/data/pnl_debug.json
@@ -197,7 +197,9 @@
     "auto_create_calendar_reminders": true,
     "ask_user_upon_size_discrepancy": true,
     "auto_detect_tokens": true,
-    "csv_export_delimiter": ","
+    "csv_export_delimiter": ",",
+    "default_evm_indexer_order": ["etherscan", "blockscout", "routescan"],
+    "evm_indexers_order": {"ethereum": ["etherscan", "blockscout", "routescan"], "optimism": ["etherscan", "blockscout", "routescan"], "polygon_pos": ["etherscan", "blockscout", "routescan"], "arbitrum_one": ["etherscan", "blockscout", "routescan"], "base": ["etherscan", "blockscout", "routescan"], "gnosis": ["etherscan", "blockscout", "routescan"], "scroll": ["etherscan", "blockscout", "routescan"], "binance_sc": ["etherscan", "blockscout", "routescan"]}
   },
   "ignored_events_ids": ["100x0xca0a482213c17ccb0471b02ffab40b92279ae7f25da53e426fda5e73e915509f"],
   "pnl_settings": {

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -13,7 +13,11 @@ from rotkehlchen.accounting.structures.balance import BalanceType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccountData, BlockchainAccounts
-from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.chain.evm.types import (
+    DEFAULT_EVM_INDEXER_ORDER,
+    DEFAULT_INDEXERS_ORDER,
+    string_to_evm_address,
+)
 from rotkehlchen.constants import ONE, YEAR_IN_SECONDS, ZERO
 from rotkehlchen.constants.assets import (
     A_1INCH,
@@ -506,6 +510,8 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         'display_date_in_localtime': DEFAULT_DISPLAY_DATE_IN_LOCALTIME,
         'current_price_oracles': DEFAULT_CURRENT_PRICE_ORACLES,
         'historical_price_oracles': DEFAULT_HISTORICAL_PRICE_ORACLES,
+        'evm_indexers_order': DEFAULT_INDEXERS_ORDER,
+        'default_evm_indexer_order': DEFAULT_EVM_INDEXER_ORDER,
         'pnl_csv_with_formulas': DEFAULT_PNL_CSV_WITH_FORMULAS,
         'pnl_csv_have_summary': DEFAULT_PNL_CSV_HAVE_SUMMARY,
         'ssf_graph_multiplier': DEFAULT_SSF_GRAPH_MULTIPLIER,

--- a/rotkehlchen/tests/integration/test_eth2.py
+++ b/rotkehlchen/tests/integration/test_eth2.py
@@ -61,11 +61,11 @@ def test_withdrawals(eth2: 'Eth2', database, ethereum_accounts, query_method):
         eth2.query_services_for_validator_withdrawals(addresses=ethereum_accounts, to_ts=to_ts)
     dbevents = DBHistoryEvents(database)
     with database.conn.read_ctx() as cursor:
-        events = dbevents.get_history_events_internal(
+        events = [event for event in dbevents.get_history_events_internal(
             cursor=cursor,
             filter_query=EthWithdrawalFilterQuery.make(),
             group_by_event_ids=False,
-        )
+        ) if event.get_timestamp() <= ts_now()]  # blockscout returns all the events since it doesn't filter by time range  # noqa: E501
 
     assert len(events) == 94
     account0_events, account1_events = 0, 0

--- a/rotkehlchen/tests/integration/test_gnosischain.py
+++ b/rotkehlchen/tests/integration/test_gnosischain.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-@pytest.mark.freeze_time('2024-11-28 10:44:55 GMT')
+@pytest.mark.freeze_time('2025-12-01 15:17:30 GMT')
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65', '0x2449fE0bEA58e027f374e90b296e72Dfd7bCcBaE']])  # noqa: E501
 def test_gnosischain_specific_chain_data(

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 from unittest.mock import patch
 
 import pytest
@@ -14,8 +14,9 @@ from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.thegraph.constants import GRAPH_DELEGATION_TRANSFER_ABI
 from rotkehlchen.chain.evm.node_inquirer import _query_web3_get_logs
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
-from rotkehlchen.chain.evm.types import WeightedNode, string_to_evm_address
+from rotkehlchen.chain.evm.types import EvmIndexer, WeightedNode, string_to_evm_address
 from rotkehlchen.db.evmtx import DBEvmTx
+from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import EventNotInABI, RemoteError
 from rotkehlchen.tests.utils.checks import assert_serialized_dicts_equal
 from rotkehlchen.tests.utils.ethereum import (
@@ -356,26 +357,81 @@ def test_get_log_and_receipt_etherscan_bad_tx_index(
         )
 
 
+BLOCKNUMBER_BY_TS: Final = 1577836800
+BLOCKNUMBER_BY_TS_BLOCK: Final = 9193265
+
+
 def _test_get_blocknumber_by_time(ethereum_inquirer):
-    result = ethereum_inquirer.get_blocknumber_by_time(1577836800)
-    assert result == 9193265
+    result = ethereum_inquirer.get_blocknumber_by_time(BLOCKNUMBER_BY_TS)
+    assert result == BLOCKNUMBER_BY_TS_BLOCK
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-def test_get_blocknumber_by_time_blockscout(ethereum_inquirer):
-    """Queries blockscout api for known block times"""
-    _test_get_blocknumber_by_time(ethereum_inquirer)
+@pytest.mark.parametrize(
+    ('order', 'effects', 'expected_calls'),
+    [
+        (
+            (EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN, EvmIndexer.BLOCKSCOUT),
+            {
+                'etherscan': BLOCKNUMBER_BY_TS_BLOCK,
+                'routescan': RemoteError('Routescan should not be queried'),
+                'blockscout': RemoteError('Blockscout should not be queried'),
+            },
+            ['etherscan'],
+        ),
+        (
+            (EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN, EvmIndexer.BLOCKSCOUT),
+            {
+                'etherscan': RemoteError('Intentional etherscan error'),
+                'routescan': BLOCKNUMBER_BY_TS_BLOCK,
+                'blockscout': RemoteError('Blockscout should not be queried'),
+            },
+            ['etherscan', 'routescan'],
+        ),
+        (
+            (EvmIndexer.ROUTESCAN, EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN),
+            {
+                'etherscan': RemoteError('Etherscan should not be queried'),
+                'routescan': RemoteError('Intentional routescan error'),
+                'blockscout': BLOCKNUMBER_BY_TS_BLOCK,
+            },
+            ['routescan', 'blockscout'],
+        ),
+    ],
+)
+def test_get_blocknumber_by_time(
+        ethereum_inquirer,
+        order,
+        effects,
+        expected_calls,
+):
+    cached_settings = CachedSettings()
+    previous_order = cached_settings.get_entry('evm_indexers_order')
+    cached_settings.update_entry('evm_indexers_order', {ChainID.ETHEREUM: order})
+    calls: list[str] = []
 
+    def _side_effect(indexer_name: str) -> Callable[..., int]:
+        def _effect(*args, **kwargs) -> int:
+            calls.append(indexer_name)
+            response = effects[indexer_name]
+            if isinstance(response, Exception):
+                raise response
+            return response
+        return _effect
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
-def test_get_blocknumber_by_time_etherscan(ethereum_inquirer):
-    """Queries etherscan for known block times"""
-    with patch.object(
-        ethereum_inquirer.blockscout,
-        'get_blocknumber_by_time',
-        side_effect=RemoteError('Intentional blockscout remote error to test etherscan'),
-    ):
-        _test_get_blocknumber_by_time(ethereum_inquirer)
+    try:
+        ethereum_inquirer.timestamp_to_block_cache[ChainID.ETHEREUM].remove(BLOCKNUMBER_BY_TS)
+        with (
+                patch.object(ethereum_inquirer.etherscan, 'get_blocknumber_by_time', side_effect=_side_effect('etherscan')),  # noqa: E501
+                patch.object(ethereum_inquirer.routescan, 'get_blocknumber_by_time', side_effect=_side_effect('routescan')),  # noqa: E501
+                patch.object(ethereum_inquirer.blockscout, 'get_blocknumber_by_time', side_effect=_side_effect('blockscout')),  # noqa: E501
+        ):
+            _test_get_blocknumber_by_time(ethereum_inquirer)
+    finally:
+        cached_settings.update_entry('evm_indexers_order', previous_order)
+        ethereum_inquirer.timestamp_to_block_cache[ChainID.ETHEREUM].remove(BLOCKNUMBER_BY_TS)
+
+    assert calls == expected_calls
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/test_evm_indexer_order.py
+++ b/rotkehlchen/tests/unit/test_evm_indexer_order.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
+from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+from rotkehlchen.chain.evm.types import EvmIndexer
+from rotkehlchen.constants import ZERO
+from rotkehlchen.db.settings import CachedSettings
+from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.types import ChainID
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass
+class DummyIndexer:
+    name: str
+
+
+class DummyEvmNodeInquirer(EvmNodeInquirer):
+    def __init__(self) -> None:  # pylint: disable=super-init-not-called
+        # skip parent init to avoid heavy wiring; set only attributes needed for _try_indexers
+        self.chain_id = ChainID.ETHEREUM
+        self.etherscan = cast('Any', DummyIndexer('Etherscan'))
+        self.blockscout = cast('Any', DummyIndexer('Blockscout'))
+        self.routescan = cast('Any', DummyIndexer('Routescan'))
+        self.available_indexers = {
+            EvmIndexer.ETHERSCAN: self.etherscan,
+            EvmIndexer.BLOCKSCOUT: self.blockscout,
+            EvmIndexer.ROUTESCAN: self.routescan,
+        }
+
+    def _get_archive_check_data(self):
+        return (ZERO_ADDRESS, 0, ZERO)
+
+    def _get_pruned_check_tx_hash(self):
+        return GENESIS_HASH
+
+    def _is_pruned(self, web3: Any):
+        return False
+
+
+def test_try_indexers_respects_settings_order() -> None:
+    cached_settings = CachedSettings()
+    previous_order = cached_settings.get_entry('evm_indexers_order')
+    inquirer = DummyEvmNodeInquirer()
+
+    calls: list[str] = []
+
+    def query(indexer: DummyIndexer) -> str:
+        calls.append(indexer.name)
+        if indexer.name != 'Blockscout':
+            raise RemoteError('boom')
+        return 'ok'
+
+    cached_settings.update_entry(
+        'evm_indexers_order',
+        {ChainID.ETHEREUM: (EvmIndexer.ROUTESCAN, EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT)},
+    )
+    try:
+        result = inquirer._try_indexers(func=cast('Callable[[Any], str]', query))
+    finally:
+        cached_settings.update_entry('evm_indexers_order', previous_order)
+
+    assert result == 'ok'
+    assert calls == ['Routescan', 'Etherscan', 'Blockscout']

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -364,7 +364,7 @@ def test_price_priority_order():
     assert priority_value == HistoricalPriceOracle.MANUAL.serialize_for_db()
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
 def test_uniswap_v2_position_price_query(price_historian: PriceHistorian):
@@ -384,7 +384,7 @@ def test_uniswap_v2_position_price_query(price_historian: PriceHistorian):
     assert price.is_close('3591639.375183')
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
 def test_uniswap_v3_position_price_query(price_historian: PriceHistorian):


### PR DESCRIPTION
This PR:

1. Introduces a setting to configure which indexer to use per evm chain
2. Allows to configure it via API
3. Adjusts the tests that need a change due to recording them again or that aren't relevant anymore
4. Leaves pending to change the order for base & optimism. Work in progress in https://github.com/rotki/rotki/pull/11031
