### PR TITLE
Fix vePendle balances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11007` rotki will now show the proper balance of locked Pendle for vePendle positions.
 * :bug:`-` rotki will now properly decode Gearbox pool transactions for pools with no farming token or lp tokens beyond the pool token and underlying asset.
 * :feature:`-` rotki will now support blockscout and routescan as fallback indexers for retrieving transactions when etherscan fails or does not support a given chain.
 * :bug:`-` Users can now click a location in the manual balance summary on the dashboard to filter by that location.

--- a/rotkehlchen/chain/ethereum/modules/pendle/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/balances.py
@@ -14,7 +14,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
-from .constants import PENDLE_TOKEN, VE_PENDLE_CONTRACT_ADDRESS
+from .constants import PENDLE_TOKEN, VE_PENDLE_ABI, VE_PENDLE_CONTRACT_ADDRESS
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding import EthereumTransactionDecoder
@@ -40,7 +40,7 @@ class PendleBalances(ProtocolWithBalance):
         )
         self.ve_pendle_contract = EvmContract(
             address=VE_PENDLE_CONTRACT_ADDRESS,
-            abi=self.evm_inquirer.contracts.erc20_abi,
+            abi=VE_PENDLE_ABI,
             deployed_block=16032087,
         )
 
@@ -57,7 +57,7 @@ class PendleBalances(ProtocolWithBalance):
                     (
                         self.ve_pendle_contract.address,
                         self.ve_pendle_contract.encode(
-                            method_name='balanceOf',
+                            method_name='positionData',
                             arguments=[addy],
                         ),
                     ) for addy in addresses_with_deposits
@@ -76,7 +76,7 @@ class PendleBalances(ProtocolWithBalance):
         for user_address, result in zip(addresses_with_deposits, results, strict=False):
             if (balance := self.ve_pendle_contract.decode(
                 result=result,
-                method_name='balanceOf',
+                method_name='positionData',
                 arguments=[user_address],
             )[0]) == 0:
                 continue

--- a/rotkehlchen/chain/ethereum/modules/pendle/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/constants.py
@@ -1,9 +1,12 @@
 from typing import Final
 
+from eth_typing.abi import ABI
+
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.evm.types import string_to_evm_address
 
 VE_PENDLE_CONTRACT_ADDRESS: Final = string_to_evm_address('0x4f30A9D41B80ecC5B94306AB4364951AE3170210')  # noqa: E501
+VE_PENDLE_ABI: Final[ABI] = [{'inputs': [{'name': '', 'type': 'address'}], 'name': 'positionData', 'outputs': [{'name': 'amount', 'type': 'uint128'}, {'name': 'expiry', 'type': 'uint128'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501
 PENDLE_TOKEN: Final = Asset('eip155:1/erc20:0x808507121B80c02388fAd14726482e061B8da827')
 NEW_LOCK_POSITION_TOPIC: Final = b'\xb1\xa37\x19V\xc5M\xc1\xd86\x95\xb4\xa0\x06\xb0Q\xc81>\xe9\x86\xe53\xb6\xb9d\xe7|\x90f\xfc,'  # noqa: E501
 WITHDRAW_TOPIC: Final = b'\x0e\x1b\xb0T\\\x1e\xbb\x9f\xb6\x80\xbd\xe75\x14\xe5r\x83\x1d\xe9;G\x9c\x08~\xc1\xefl5\xc3\xa1\x9f\xd6'  # noqa: E501

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -1387,7 +1387,7 @@ def test_hyperliquid(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
-@pytest.mark.parametrize('ethereum_accounts', [['0xFd83CCCecef02a334e6A86e7eA8D0aa0F61f1Faf']])
+@pytest.mark.parametrize('ethereum_accounts', [['0x94F567bf71A4A7a88114aB679336522120EE3788']])
 def test_pendle_locked_balances(
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_accounts: list[ChecksumEvmAddress],
@@ -1395,7 +1395,7 @@ def test_pendle_locked_balances(
 ) -> None:
     _, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=deserialize_evm_tx_hash('0xc8b252de1a62daa57d4fe294f371e67550e087fdeffe972261e1acc890d84bd5'),
+        tx_hash=deserialize_evm_tx_hash('0x2f133fe4ecabcfb1279198d70e4a1fbaf593a9e72ee5c6a03179147eb97311d5'),
     )
     protocol_balances_inquirer = PendleBalances(
         evm_inquirer=ethereum_inquirer,
@@ -1404,8 +1404,8 @@ def test_pendle_locked_balances(
     protocol_balances = protocol_balances_inquirer.query_balances()
     user_balance = protocol_balances[ethereum_accounts[0]]
     assert user_balance.assets[PENDLE_TOKEN][CPT_PENDLE] == Balance(
-        amount=FVal('135.60210839446895642'),
-        usd_value=FVal('329.5131233985595641006'),
+        amount=FVal('367.772672118320474345'),
+        usd_value=FVal('901.04304668988516214525'),
     )
 
 


### PR DESCRIPTION
Closes #11007 

Note that the address used in the old test no longer has locked pendle, so had to use a different address. The results now align with what is shown in debank.
