### PR TITLE
Add unit test for identifier to address conversion

### DIFF
--- a/rotkehlchen/constants/resolver.py
+++ b/rotkehlchen/constants/resolver.py
@@ -1,4 +1,5 @@
-from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import (
     EVM_TOKEN_KINDS_TYPE,
     SOLANA_TOKEN_KINDS_TYPE,
@@ -32,7 +33,10 @@ def identifier_to_evm_address(identifier: str) -> ChecksumEvmAddress | None:
     if len(parts := identifier.split(':')) < 3 or parts[0] != EVM_CHAIN_DIRECTIVE:
         return None
 
-    return string_to_evm_address(parts[2].split('/')[0])  # Don't include the token id for erc721
+    try:
+        return deserialize_evm_address(parts[2].split('/')[0])  # Don't include the token id for erc721  # noqa: E501
+    except DeserializationError:
+        return None
 
 
 def tokenid_to_collectible_id(identifier: str) -> str | None:


### PR DESCRIPTION
Adds a unit test for `identifier_to_evm_address` as requested here: https://github.com/rotki/rotki/pull/11012#discussion_r2577695259

Also changes it to use `deserialize_evm_address` to ensure its actually returning a valid address.
