### PR TITLE
Fix liquity v2 proxy detection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11002` Liquity V2 proxy detection will now work correctly and proxy deployment transactions will be decoded properly.
 * :feature:`-` StakeDAO V2 Curve strategy transactions will be correctly decoded with vault balances properly detected.
 * :feature:`-` Morpho support is now extended to all chains rotki supports in which it is deployed including Arbitrum One, Polygon PoS, Optimism, etc.
 * :feature:`-` Jito tip payment events on Solana will now be properly decoded.

--- a/rotkehlchen/chain/ethereum/modules/liquity/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/liquity/constants.py
@@ -25,3 +25,4 @@ STAKING_REWARDS_ASSETS: Final = {A_ETH, A_LUSD}
 LIQUITY_V2_WRAPPER: Final = string_to_evm_address('0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1')
 DEPOSIT_LQTY_V2: Final = b'\\\xd3x\x95\xbb\x92\x87\xe5B\xa4&\xd6\xab\xbc\x93\xd7\xda\xca\ty\xbdC&M2\rO\xd2$\xa5\xfc^'  # noqa: E501
 WITHDRAW_LQTY_V2: Final = b"(p\xfe\x17uR\x97k\r\xbc1f\xde\xd2\x16\x9d]s'_\xc5e\xdf0\x89C \xfd6\x08\xf39"  # noqa: E501
+DEPLOY_USER_PROXY_LQTY_V2: Final = b'\xdaf\xba#/O\xb8\xc1"\xb7\x02oU\xee\xff\x1d\x0b\x9c\xf2V\x0bxs\xb2\xbb\xa6\xea\xabL=Y\x89'  # noqa: E501

--- a/rotkehlchen/chain/evm/proxies_inquirer.py
+++ b/rotkehlchen/chain/evm/proxies_inquirer.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from enum import StrEnum
 from typing import TYPE_CHECKING, overload
 
+from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY, LIQUITY_V2_WRAPPER
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.summer_fi.constants import CPT_SUMMER_FI
@@ -111,30 +112,18 @@ class EvmProxiesInquirer:
             self,
             addresses: Sequence[ChecksumEvmAddress],
     ) -> dict[ChecksumEvmAddress, set[ChecksumEvmAddress]]:
-        """Return liquity v2 proxies if they exist for the list of addresses
-        This should only be called if the chain is ethereum and lqtyv2_router is set.
+        """Return liquity v2 proxies if they exist for the list of addresses.
+        Finds proxy addresses by inspecting the decoded history events.
         """
-        assert self.lqtyv2_router, 'get_liquity_proxy should only be called for ethereum'
-        calls = [(
-            self.lqtyv2_router.address,
-            self.lqtyv2_router.encode(method_name='deriveUserProxyAddress', arguments=[address]),
-        ) for address in addresses]
-        output = self.node_inquirer.multicall(calls=calls)
-        mapping = {}
-        for idx, result_encoded in enumerate(output):
-            address = addresses[idx]
-            result = self.lqtyv2_router.decode(
-                result_encoded,
-                'deriveUserProxyAddress',
-                arguments=[address],
-            )[0]
-            try:
-                if (proxy_address := deserialize_evm_address(result)) != ZERO_ADDRESS:
-                    mapping[address] = {proxy_address}
-            except DeserializationError as e:
-                msg = f'Failed to deserialize {result} liquity proxy for address {address}. {e!s}'
-                log.error(msg)
-        return mapping
+        return self._get_proxy_addresses_from_history(
+            filter_query=EvmEventFilterQuery.make(
+                event_types=[HistoryEventType.INFORMATIONAL],
+                event_subtypes=[HistoryEventSubType.CREATE],
+                addresses=[LIQUITY_V2_WRAPPER],
+                counterparties=[CPT_LIQUITY],
+                location_labels=list(addresses),
+            ),
+        )
 
     def get_or_query_summer_fi_proxy(
             self,
@@ -143,15 +132,27 @@ class EvmProxiesInquirer:
         """Return summer.fi proxies if they exist for the list of addresses.
         Finds proxy addresses by inspecting the decoded history events.
         """
+        return self._get_proxy_addresses_from_history(
+            filter_query=EvmEventFilterQuery.make(
+                event_types=[HistoryEventType.INFORMATIONAL],
+                event_subtypes=[HistoryEventSubType.CREATE],
+                counterparties=[CPT_SUMMER_FI],
+                location_labels=list(addresses),
+            ),
+        )
+
+    def _get_proxy_addresses_from_history(
+            self,
+            filter_query: EvmEventFilterQuery,
+    ) -> dict[ChecksumEvmAddress, set[ChecksumEvmAddress]]:
+        """Find proxy addresses by inspecting the extra_data of the history events
+        returned by the given filter query.
+        Returns a mapping of addresses to the set of proxy addresses they have.
+        """
         with self.node_inquirer.database.conn.read_ctx() as cursor:
             events = DBHistoryEvents(self.node_inquirer.database).get_history_events_internal(
                 cursor=cursor,
-                filter_query=EvmEventFilterQuery.make(
-                    event_types=[HistoryEventType.INFORMATIONAL],
-                    event_subtypes=[HistoryEventSubType.CREATE],
-                    counterparties=[CPT_SUMMER_FI],
-                    location_labels=list(addresses),
-                ),
+                filter_query=filter_query,
             )
 
         mapping: defaultdict[ChecksumEvmAddress, set[ChecksumEvmAddress]] = defaultdict(set)


### PR DESCRIPTION
Closes #11002 

* Adds decoding of the proxy deployments
* Uses those decoded events to find the proxy addresses instead of the remote call that always returned an address
* Adds a check to the summer.fi test since its proxy logic was also touched.