### PR TITLE
add support for Coinbase ED25519 API key format

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`11039` rotki will now support Coinbase's new ED25519 API key format.
 * :bug:`11032` Deleted or missed Binance, Bitstamp, and Coinbase events are now properly restored when re-pulling exchange history data.
 * :feature:`` Users will now be able to change the order of used indexers for EVM chains.
 * :bug:`-` Curve pool native asset withdrawals will now include the pool in the event notes like withdrawals of other tokens.

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -1,11 +1,11 @@
-import hashlib
-import hmac
+import base64
 import logging
 import re
 import secrets
 import time
 from collections import defaultdict
 from collections.abc import Sequence
+from enum import Enum
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
@@ -14,6 +14,7 @@ import gevent
 import jwt
 import requests
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_coinbase
@@ -23,9 +24,8 @@ from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.api import AuthenticationError
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
-from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
@@ -77,15 +77,51 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 CB_EVENTS_PREFIX = 'CBE_'
-CB_VERSION = '2019-08-25'  # the latest api version we know rotki works fine for: https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/versioning  # noqa: E501
-LEGACY_RE: re.Pattern = re.compile(r'^[\w]+$')
-NEW_RE: re.Pattern = re.compile(r'^organizations/[\w-]+/apiKeys/[\w-]+$')
-PRIVATE_KEY_RE: re.Pattern = re.compile(
+ECDSA_KEY_RE: re.Pattern = re.compile(r'^organizations/[\w-]+/apiKeys/[\w-]+$')
+ECDSA_PRIVATE_KEY_RE: re.Pattern = re.compile(
     r'^-----BEGIN EC PRIVATE KEY-----\n'
     r'[\w+/=\n]+'
     r'-----END EC PRIVATE KEY-----\n?$',
     re.MULTILINE,
 )
+
+
+class CoinbaseKeyType(Enum):
+    """Coinbase API key types with their corresponding authentication algorithms"""
+    ECDSA = 'ES256'
+    ED25519 = 'EdDSA'
+
+    @classmethod
+    def detect_type(cls, api_key: str) -> 'CoinbaseKeyType':
+        """Detect API key type from format
+
+        May raise:
+        - InputError: if api_key format is invalid
+        """
+        if ECDSA_KEY_RE.match(api_key):
+            return cls.ECDSA
+
+        if len(api_key) == 36 and api_key.count('-') == 4:  # for ED25519, check uuid format
+            return cls.ED25519
+
+        raise InputError(f'Invalid API key format: {api_key}')
+
+    def validate_secret(self, secret: bytes) -> tuple[bool, str]:
+        """Validate secret format for this key type.
+
+        Returns a tuple indicating validation success and error message if any.
+        """
+        try:
+            if self == CoinbaseKeyType.ECDSA:
+                if ECDSA_PRIVATE_KEY_RE.match(secret.decode('utf-8', 'strict')):
+                    return True, ''
+                return False, 'Invalid ECDSA private key format'
+            else:  # can only be ED25519
+                if len(base64.b64decode(secret)) in (32, 64):
+                    return True, ''
+                return False, 'Invalid ED25519 key length (must be 32 or 64 bytes)'
+        except (UnicodeDecodeError, ValueError):
+            return False, f'Invalid {self.name} private key format'
 
 
 class CoinbasePermissionError(Exception):
@@ -102,6 +138,10 @@ class Coinbase(ExchangeInterface):
             database: 'DBHandler',
             msg_aggregator: MessagesAggregator,
     ):
+        """
+        May raise:
+        - InputError: if api_key format is invalid
+        """
         super().__init__(
             name=name,
             location=Location.COINBASE,
@@ -110,15 +150,7 @@ class Coinbase(ExchangeInterface):
             database=database,
             msg_aggregator=msg_aggregator,
         )
-        try:
-            self.is_legacy_api_key = self.is_legacy_key(api_key)
-        except AuthenticationError as e:
-            self.is_legacy_api_key = True
-            log.error(f'Error determining API key format: {e}. Defaulting to legacy key.')
-
-        if self.is_legacy_api_key:  # set headers for legacy
-            self.session.headers.update({'CB-ACCESS-KEY': self.api_key, 'CB-VERSION': CB_VERSION})
-
+        self.key_type = CoinbaseKeyType.detect_type(api_key)
         self.apiversion = 'v2'
         self.base_uri = 'https://api.coinbase.com'
         self.host = 'api.coinbase.com'
@@ -126,16 +158,6 @@ class Coinbase(ExchangeInterface):
         # skipped when both the debit and credit part of the trade is present.
         self.advanced_orders_to_currency: dict[str, str] = {}
         self.staking_events: set[tuple[TimestampMS, Asset, FVal]] = set()
-
-    def is_legacy_key(self, api_key: str) -> bool:
-        if LEGACY_RE.match(api_key):
-            log.debug('Legacy Key format!')
-            return True
-        elif NEW_RE.match(api_key):
-            log.debug('New Key format!')
-            return False
-        else:
-            raise AuthenticationError(f'Invalid API key format: {api_key}')
 
     def first_connection(self) -> None:
         self.first_connection_made = True
@@ -150,7 +172,8 @@ class Coinbase(ExchangeInterface):
         - 'exp': The expiration timestamp, set to 2 minutes from the current time.
         - 'uri': The provided URI.
 
-        The token is signed using the ES256 algorithm and includes a unique 'nonce' in the headers.
+        The token is signed using the appropriate algorithm (ES256 or EdDSA)
+        and includes a unique 'nonce' in the headers.
 
         Args:
             uri (str): The URI for which the JWT token is being generated.
@@ -162,7 +185,11 @@ class Coinbase(ExchangeInterface):
             RemoteError: If there is an error during the JWT token generation process.
         """
         try:
-            private_key = serialization.load_pem_private_key(self.secret, password=None)
+            if self.key_type == CoinbaseKeyType.ECDSA:
+                private_key = serialization.load_pem_private_key(self.secret, password=None)
+            else:  # can only be ED25519
+                private_key = ed25519.Ed25519PrivateKey.from_private_bytes(base64.b64decode(self.secret)[:32])  # noqa: E501
+
             current_time = int(time.time())
             jwt_payload = {
                 'sub': self.api_key,
@@ -174,7 +201,7 @@ class Coinbase(ExchangeInterface):
             jwt_token = jwt.encode(
                 jwt_payload,
                 private_key,
-                algorithm='ES256',
+                algorithm=self.key_type.value,
                 headers={'kid': self.api_key, 'nonce': secrets.token_hex()},
             )
         except (jwt.PyJWTError, ValueError) as e:
@@ -184,99 +211,30 @@ class Coinbase(ExchangeInterface):
 
     def validate_api_key(self) -> tuple[bool, str]:
         """Validates that the Coinbase API key is good for usage in rotki.
-
-        For Legacy keys, make sure that the following permissions are given to the key:
-        wallet:accounts:read, wallet:transactions:read,
-        wallet:withdrawals:read, wallet:deposits:read
-
-        For CDP keys, make sure they are formatted properly
+        Checks that the API key format is correct and the secret is properly formatted.
         """
-        self.is_legacy_api_key = self.is_legacy_key(self.api_key)
-        if self.is_legacy_api_key:
-            self.session.headers.update({'CB-ACCESS-KEY': self.api_key, 'CB-VERSION': CB_VERSION})
-            result, msg = self._validate_single_api_key_action('accounts')
-            if result is None:
-                return False, msg
+        try:
+            self.key_type = CoinbaseKeyType.detect_type(self.api_key)
+        except InputError as e:
+            return False, str(e)
 
-            # now get the account ids
-            account_info = self._get_active_account_info(result)
-            if len(account_info) != 0:
-                # and now try to get all transactions of an account to see if that's possible
-                method = f'accounts/{account_info[0][0]}/transactions'
-                result, msg = self._validate_single_api_key_action(method)
-                if result is None:
-                    return False, msg
-
-        else:  # Validate new API key format
-            if not NEW_RE.match(self.api_key):
-                return False, 'Invalid Coinbase API key name format'
-
-            if not PRIVATE_KEY_RE.match(self.secret.decode('utf-8', 'strict')):
-                return False, 'Invalid Coinbase private key format'
+        is_valid, error_msg = self.key_type.validate_secret(self.secret)
+        if not is_valid:
+            return False, error_msg
 
         return True, ''
 
-    def _validate_single_api_key_action(
-            self,
-            method_str: str,
-            ignore_pagination: bool = False,
-    ) -> tuple[list[Any] | None, str]:
-        try:
-            result = self._api_query(method_str, ignore_pagination=ignore_pagination)
-
-        except CoinbasePermissionError as e:
-            error = str(e)
-            if 'transactions' in method_str:
-                permission = 'wallet:transactions:read'
-            elif 'deposits' in method_str:
-                permission = 'wallet:deposits:read'
-            elif 'withdrawals' in method_str:
-                permission = 'wallet:withdrawals:read'
-            elif 'trades' in method_str:
-                permission = 'wallet:trades:read'
-            # the accounts elif should be at the end since the word appears
-            # in other endpoints
-            elif 'accounts' in method_str:
-                permission = 'wallet:accounts:read'
-            else:
-                raise AssertionError(
-                    f'Unexpected coinbase method {method_str} at API key validation',
-                ) from e
-            msg = (
-                f'Provided Coinbase API key needs to have {permission} permission activated. '
-                f'Please log into your coinbase account and set all required permissions: '
-                f'wallet:accounts:read, wallet:transactions:read, '
-                f'wallet:withdrawals:read, wallet:deposits:read, wallet:trades:read'
-            )
-
-            return None, msg
-        except RemoteError as e:
-            error = str(e)
-            if 'invalid signature' in error:
-                return None, 'Failed to authenticate with the Provided API key/secret'
-            if 'invalid api key' in error:
-                return None, 'Provided API Key is invalid'
-            # else any other remote error
-            return None, error
-
-        return result, ''
-
     def edit_exchange_credentials(self, credentials: ExchangeAuthCredentials) -> bool:
+        """
+        May raise:
+        - InputError: if credentials.api_key format is invalid
+        """
         changed = super().edit_exchange_credentials(credentials)
-        if credentials.api_key is not None:
-            try:
-                new_is_legacy = self.is_legacy_key(credentials.api_key)
-            except AuthenticationError as e:
-                log.error(f'Invalid coinbase API key format: {e}')
-                new_is_legacy = True
-
-            if new_is_legacy != self.is_legacy_api_key:  # Key type has changed
-                self.is_legacy_api_key = new_is_legacy
-
-            if self.is_legacy_api_key:
-                self.session.headers.update({'CB-ACCESS-KEY': credentials.api_key})
-            else:
-                self.api_key = credentials.api_key
+        if (
+                credentials.api_key is not None and
+                (new_key_type := CoinbaseKeyType.detect_type(credentials.api_key)) != self.key_type
+        ):
+            self.key_type = new_key_type
 
         return changed
 
@@ -336,25 +294,8 @@ class Coinbase(ExchangeInterface):
         if options:
             next_uri += f'?{urlencode(options)}'
         while True:
-            if self.is_legacy_api_key:
-                timestamp = str(int(time.time()))
-                message = timestamp + request_verb + next_uri
-                signature = hmac.new(
-                    self.secret,
-                    message.encode(),
-                    hashlib.sha256,
-                ).hexdigest()
-                self.session.headers.update({
-                    'CB-ACCESS-SIGN': signature,
-                    'CB-ACCESS-TIMESTAMP': timestamp,
-                })
-
-            else:
-                uri = f'{request_verb} {self.host}/{self.apiversion}/{endpoint}'
-                token = self.build_jwt(uri)
-                self.session.headers.update({
-                    'Authorization': f'Bearer {token}',
-                })
+            token = self.build_jwt(uri=f'{request_verb} {self.host}/{self.apiversion}/{endpoint}')
+            self.session.headers.update({'Authorization': f'Bearer {token}'})
 
             full_url = self.base_uri + next_uri
             log.debug('Coinbase API query', request_url=full_url)

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -1,3 +1,5 @@
+import base64
+import uuid
 import warnings as test_warnings
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -21,6 +23,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.history.events.utils import create_event_identifier_from_unique_id
 from rotkehlchen.tests.utils.constants import A_SOL, A_XTZ
 from rotkehlchen.tests.utils.exchanges import TRANSACTIONS_RESPONSE, mock_normal_coinbase_query
+from rotkehlchen.tests.utils.factories import make_random_bytes
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, TimestampMS
 
@@ -30,7 +33,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture(name='mock_coinbase')
 def fixture_mock_coinbase(messages_aggregator) -> Coinbase:
-    return Coinbase('coinbase1', 'a', b'a', object(), messages_aggregator)  # type: ignore
+    return Coinbase('coinbase1', str(uuid.uuid4()), base64.b64encode(make_random_bytes(32)), object(), messages_aggregator)  # type: ignore  # noqa: E501
 
 
 def test_name(mock_coinbase):

--- a/rotkehlchen/tests/unit/test_app.py
+++ b/rotkehlchen/tests/unit/test_app.py
@@ -1,3 +1,5 @@
+import base64
+import uuid
 from unittest import mock
 
 import pytest
@@ -8,7 +10,7 @@ from rotkehlchen.exchanges.constants import EXCHANGES_WITH_PASSPHRASE, SUPPORTED
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.fixtures.messages import MockRotkiNotifier
-from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
+from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret, make_random_bytes
 from rotkehlchen.types import Location
 
 
@@ -34,9 +36,14 @@ def test_initializing_exchanges(uninitialized_rotkehlchen):
         passphrase = None
         if location in EXCHANGES_WITH_PASSPHRASE:
             passphrase = 'supersecretpassphrase'
-        credentials.append(
-            (str(location), location.serialize_for_db(), make_api_key(), make_api_secret().decode(), passphrase),  # noqa: E501  # pylint: disable=no-member
-        )
+        if location == Location.COINBASE:
+            credentials.append(
+                (str(location), location.serialize_for_db(), str(uuid.uuid4()), base64.b64encode(make_random_bytes(32)).decode(), passphrase),  # noqa: E501
+            )
+        else:
+            credentials.append(
+                (str(location), location.serialize_for_db(), make_api_key(), make_api_secret().decode(), passphrase),  # noqa: E501  # pylint: disable=no-member
+            )
     credentials.append(
         ('rotkehlchen', Location.EXTERNAL.serialize_for_db(), make_api_key(), make_api_secret().decode(), None),  # noqa: E501  # pylint: disable=no-member
     )

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -1,5 +1,7 @@
+import base64
 import json
 import os
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, overload
 from unittest.mock import _patch, patch
@@ -37,6 +39,7 @@ from rotkehlchen.tests.utils.constants import A_XMR
 from rotkehlchen.tests.utils.factories import (
     make_api_key,
     make_api_secret,
+    make_random_bytes,
     make_random_uppercasenumeric_string,
 )
 from rotkehlchen.tests.utils.kraken import MockKraken
@@ -655,8 +658,8 @@ def create_test_coinbase(
 ) -> Coinbase:
     return Coinbase(
         name=name,
-        api_key=make_api_key(),
-        secret=make_api_secret(),
+        api_key=ApiKey(str(uuid.uuid4())),
+        secret=ApiSecret(base64.b64encode(make_random_bytes(32))),
         database=database,
         msg_aggregator=msg_aggregator,
     )


### PR DESCRIPTION
Closes #11039. 

It also removes support for legacy api keys https://docs.cdp.coinbase.com/coinbase-app/introduction/changelog#2025-jan-22