### PR TITLE
Properly handle routescan per minute/day rate limits

### DIFF
--- a/rotkehlchen/externalapis/routescan.py
+++ b/rotkehlchen/externalapis/routescan.py
@@ -1,7 +1,10 @@
 import logging
 from typing import TYPE_CHECKING, Final
 
-from rotkehlchen.errors.misc import ChainNotSupported
+import gevent
+from requests import Response
+
+from rotkehlchen.errors.misc import ChainNotSupported, RemoteError
 from rotkehlchen.externalapis.etherscan_like import EtherscanLikeApi
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ApiKey, ChainID, ExternalService
@@ -52,3 +55,45 @@ class Routescan(EtherscanLikeApi):
     ) -> dict[str, str]:
         """Routescan doesn't need chainid in params since it's in the URL."""
         return {'module': module, 'action': action, 'apikey': api_key}
+
+    def _handle_rate_limit(
+            self,
+            response: Response,
+            current_backoff: int,
+            backoff_limit: int,
+            chain_id: ChainID,
+    ) -> int:
+        """Handles rate limit responses from routescan. Returns the new backoff time.
+        May raise RemoteError if the time until reset for the rate-limited time period is greater
+        than the backoff limit, or if the response is not as expected.
+        """
+        for remaining_key, reset_key, display_name in (
+            ('x-ratelimit-rpd-remaining', 'x-ratelimit-rpd-reset', 'Daily'),  # day
+            ('x-ratelimit-rpm-remaining', 'x-ratelimit-rpm-reset', 'Per minute'),  # minute
+        ):
+            try:
+                if int(response.headers[remaining_key]) > 0:
+                    continue  # there are still requests remaining for this time period.
+
+                time_until_reset = int(response.headers[reset_key])
+            except (KeyError, ValueError, TypeError):
+                continue
+
+            if time_until_reset >= backoff_limit:
+                raise RemoteError(
+                    f'{display_name} rate limit reached for {self.name} on '
+                    f'{chain_id.name.capitalize()} with {time_until_reset} seconds until reset '
+                    f'while max backoff is {backoff_limit} seconds.',
+                )
+            else:
+                gevent.sleep(time_until_reset)
+                return time_until_reset
+
+        # If the ratelimit headers are missing or still have requests remaining (shouldn't happen),
+        # log the response info and fail with a RemoteError.
+        msg = f'Unexpected rate limit response from {self.name} on {chain_id.name.capitalize()}.'
+        log.error(
+            f'{msg} Expected rate limit headers with no remaining requests but got: '
+            f'{response.headers}. Response body: {response.text}.',
+        )
+        raise RemoteError(f'{msg} Check logs for details.')

--- a/rotkehlchen/tests/external_apis/test_routescan.py
+++ b/rotkehlchen/tests/external_apis/test_routescan.py
@@ -1,9 +1,15 @@
+from http import HTTPStatus
+from unittest.mock import _patch, patch
+
 import pytest
 
 from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants import DAY_IN_SECONDS
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.etherscan_like import HasChainActivity
 from rotkehlchen.externalapis.routescan import ROUTESCAN_SUPPORTED_CHAINS, Routescan
-from rotkehlchen.types import ChainID
+from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.types import ChainID, Timestamp
 
 
 @pytest.fixture(name='routescan')
@@ -33,3 +39,42 @@ def test_routescan_has_activity(routescan: Routescan) -> None:
             chain_id=chain,
             account=string_to_evm_address('0x84e8EE8911c147755bD70084b6b4D1a5A8351476'),
         ) == HasChainActivity.NONE  # random address with no activity
+
+
+def test_routescan_rate_limits(routescan: Routescan) -> None:
+    """Test that we properly handle rate limits from routescan."""
+
+    def _make_rate_limit_patch(
+            minute_remaining: int = 300,
+            minute_reset: int = 60,
+            day_remaining: int = 10000,
+            day_reset: int = DAY_IN_SECONDS,
+    ) -> _patch:
+        return patch.object(routescan.session, 'get', return_value=MockResponse(
+            status_code=HTTPStatus.TOO_MANY_REQUESTS,
+            text='',
+            headers={
+                'x-ratelimit-rpm-limit': '300',
+                'x-ratelimit-rpm-remaining': str(minute_remaining),
+                'x-ratelimit-rpm-reset': str(minute_reset),
+                'x-ratelimit-rpd-limit': '100000',
+                'x-ratelimit-rpd-remaining': str(day_remaining),
+                'x-ratelimit-rpd-reset': str(day_reset),
+            },
+        ))
+
+    for request_patch, expected_msg in ((
+        _make_rate_limit_patch(minute_remaining=0, minute_reset=30),
+        'Per minute rate limit reached for Routescan on Ethereum with 30 seconds until reset',
+    ), (
+        _make_rate_limit_patch(day_remaining=0, day_reset=4500),
+        'Daily rate limit reached for Routescan on Ethereum with 4500 seconds until reset',
+    ), (
+        _make_rate_limit_patch(),
+        'Unexpected rate limit response from Routescan on Ethereum. Check logs for details.',
+    )):
+        with (
+            request_patch,
+            pytest.raises(RemoteError, match=expected_msg),
+        ):
+            routescan.get_blocknumber_by_time(chain_id=ChainID.ETHEREUM, ts=Timestamp(1700000000))


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=142073143

Got the info regarding routescan's rate limited responses in their [discord](https://discord.com/channels/1152479750422540408/1445765439232933999/1445790900084150445). Rate limited responses from routescan will always have a status code of 429 and with info in the headers regarding the per minute / per day limits.