### PR TITLE
Temporary fix for liquity v2 proxy detection

### DIFF
--- a/rotkehlchen/tests/unit/decoders/test_liquity_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity_v2.py
@@ -2,11 +2,13 @@ import pytest
 
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
+from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH, A_LQTY
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import LIQUITY_STAKING_DETAILS, EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
+from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 
 
@@ -42,7 +44,7 @@ def test_lqty_v2_staking_deposit_with_rewards(ethereum_inquirer, ethereum_accoun
             location_label=ethereum_accounts[0],
             notes='Revoke LQTY spending approval of 0xD77Eb80F38fEC10D87A192d07329415173307E93 by 0x3Dd5BbB839f8AE9B64c73780e89Fdd1181Bf5205',  # noqa: E501
             counterparty=None,
-            address='0x3Dd5BbB839f8AE9B64c73780e89Fdd1181Bf5205',
+            address=(proxy_address := string_to_evm_address('0x3Dd5BbB839f8AE9B64c73780e89Fdd1181Bf5205')),  # noqa: E501
         ), EvmEvent(
             tx_ref=tx_hash,
             sequence_index=280,
@@ -55,7 +57,7 @@ def test_lqty_v2_staking_deposit_with_rewards(ethereum_inquirer, ethereum_accoun
             location_label=ethereum_accounts[0],
             notes='Stake 1742.012204302870975901 LQTY in the Liquity V2 protocol',
             counterparty=CPT_LIQUITY,
-            address='0x3Dd5BbB839f8AE9B64c73780e89Fdd1181Bf5205',
+            address=proxy_address,
             extra_data={
                 LIQUITY_STAKING_DETAILS: {
                     'staked_amount': '52907.46069202884604981',
@@ -91,6 +93,14 @@ def test_lqty_v2_staking_deposit_with_rewards(ethereum_inquirer, ethereum_accoun
         ),
     ]
     assert events == expected_events
+
+    # TODO: Remove this after we merge bugfixes->develop and proxy detection uses the contract deployment event instead.  # noqa: E501
+    # Also check that the proxy detection works correctly (relies on the tx decoded above).
+    proxies = ethereum_inquirer.proxies_inquirer.get_or_query_liquity_proxy(
+        addresses=[(user_address := ethereum_accounts[0]), (other_address := make_evm_address())],
+    )
+    assert proxies[user_address] == {proxy_address}
+    assert other_address not in proxies
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=143220362

Implements some of the same stuff as https://github.com/rotki/rotki/pull/11038, except that it relies on the already decoded staking/deposit events so that it can work in bugfixes without needing redecoding.