### PR TITLE
improve stakedao withdrawal decoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` More StakeDAO withdrawals are now decoded properly.
+* :bug:`-` Transaction decoding will no longer crash when a remote error occurs.
 * :bug:`-` Proper status notifications will be shown while the StakeDAO decoder cache is being queried.
 * :feature:`11039` rotki will now support Coinbase's new ED25519 API key format.
 * :bug:`11032` Deleted or missed Binance, Bitstamp, and Coinbase events are now properly restored when re-pulling exchange history data.

--- a/rotkehlchen/chain/decoding/decoder.py
+++ b/rotkehlchen/chain/decoding/decoder.py
@@ -13,7 +13,7 @@ from rotkehlchen.db.constants import TX_DECODED, TX_SPAM
 from rotkehlchen.db.dbtx import DBCommonTx, T_Transaction, T_TxHash, T_TxNotDecodedFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
-from rotkehlchen.errors.misc import InputError
+from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.errors.serialization import ConversionError, DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -91,6 +91,7 @@ class TransactionDecoder(ABC, Generic[T_Transaction, T_DecodingRules, T_DecoderI
             IndexError,
             ValueError,
             ConversionError,
+            RemoteError,
         )
         if possible_decoding_exceptions is not None:
             self.possible_decoding_exceptions += possible_decoding_exceptions

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -227,7 +227,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             premium=premium,
             base_tools=base_tools,
             misc_counterparties=misc_counterparties,
-            possible_decoding_exceptions=(NotERC721Conformant, NotERC20Conformant, Web3Exception, RemoteError),
+            possible_decoding_exceptions=(NotERC721Conformant, NotERC20Conformant, Web3Exception),
         )
 
     def _add_builtin_decoders(self, rules: EvmDecodingRules) -> None:

--- a/rotkehlchen/chain/evm/decoding/stakedao/constants.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/constants.py
@@ -10,7 +10,7 @@ CLAIMED_WITH_BOUNTY: Final = b'o\x9c\x98&\xbeYv\xf3\xf8*4\x90\xc5*\x832\x8c\xe2\
 REWARDS_CLAIMED_TOPIC: Final = b'j\xa3w*l6\x03\x99\xa9J=\xa6$\x8e~\x99\xe0)\xbc\xe1\xa1\xf5|{\x90\xb2\xbf\xa3\xc1\xaa\x7f5'  # noqa: E501
 CLAIMED_WITH_BRIBE: Final = b'\xd7\x95\x91St\x02K\xe1\xf02\x04\xe0R\xbdXK3\xbb\x85\xc9\x12\x8e\xde\x9cT\xad\xbe\x0b\xbd\xc2 \x95'  # noqa: E501
 
-STAKEDAO_GAUGE_ABI: Final[ABI] = [{'stateMutability': 'view', 'type': 'function', 'name': 'vault', 'inputs': [], 'outputs': [{'name': '', 'type': 'address'}]}]  # noqa: E501
+STAKEDAO_GAUGE_ABI: Final[ABI] = [{'stateMutability': 'view', 'type': 'function', 'name': 'staking_token', 'inputs': [], 'outputs': [{'name': '', 'type': 'address'}]}]  # noqa: E501
 STAKEDAO_VAULT_ABI: Final[ABI] = [{'inputs': [], 'name': 'token', 'outputs': [{'name': '_token', 'type': 'address'}], 'stateMutability': 'pure', 'type': 'function'}]  # noqa: E501
 
 STAKEDAO_SUPPORTED_CHAINS_WITHOUT_CLAIMS = (ChainID.BASE, ChainID.BINANCE_SC, ChainID.POLYGON_POS)


### PR DESCRIPTION
Fixes
```log
[04/12/2025 16:24:16 WAT] ERROR rotkehlchen.greenlets.manager Greenlet with id 4604310976: decode 500 ethereum transactions died with exception: Error querying information from ethereum. Checks logs to obtain more information.
Exception Name: <class 'rotkehlchen.errors.misc.RemoteError'>
Exception Info: Error querying information from ethereum. Checks logs to obtain more information
Traceback:
   File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/decoding/decoder.py", line 214, in get_and_decode_undecoded_transactions
    self.decode_transaction_hashes(
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/decoding/decoder.py", line 263, in decode_transaction_hashes
    self._decode_transaction_hashes(
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/decoder.py", line 737, in _decode_transaction_hashes
    refresh_balances, new_events = super()._decode_transaction_hashes(
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/decoding/decoder.py", line 391, in _decode_transaction_hashes
    fresh_events, new_refresh_balances, reload_decoders = self._decode_transaction_from_context(  # noqa: E501
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/decoder.py", line 1225, in _decode_transaction_from_context
    return self._get_or_decode_transaction_events(
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/decoder.py", line 775, in _get_or_decode_transaction_events
    return self._decode_transaction(transaction=transaction, tx_receipt=tx_receipt)
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/decoder.py", line 597, in _decode_transaction
    decoding_output = self.decode_by_address_rules(context)
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/decoder.py", line 454, in decode_by_address_rules
    result, err = decode_safely(  # can't used named arguments with *args
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/decoding/utils.py", line 93, in decode_safely
    return func(*args, **kwargs), False
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/stakedao/decoder.py", line 301, in _decode_deposit_withdrawal_events
    return self._decode_withdraw(context)
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/decoding/stakedao/decoder.py", line 228, in _decode_withdraw
    vault_address = deserialize_evm_address(self.node_inquirer.call_contract(
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/node_inquirer.py", line 527, in call_contract
    return self._query(
    ^^^^^^^^^^^^^^^^^
  File "/Users/prettyirrelevant/Developer/work/rotki/rotkehlchen/chain/evm/node_inquirer.py", line 409, in _query
    raise RemoteError(f'Error querying information from {self.blockchain!s}. Checks logs to obtain more information')  # noqa: E501
    ^^^^^^^^^^^^^^^^^
```