### PR TITLE
Bump version: 1.41.1 → 1.41.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.41.1
+current_version = 1.41.2
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.41.2 <2025-12-05>`
 * :feature:`11063` rotki has now improved the date/time range selector in the PnL report generation menu.
 * :bug:`-` Fix the issue that prevented pressing Enter from submitting most forms.
 * :feature:`-` Users will now see an indicator at the top if page-specific notes exist for that page.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,9 @@ project_copyright = '2018-2020, Eleftherios Karapetsas. 2020-2025, Rotki Solutio
 author = 'The rotki team'
 
 # The short X.Y version
-version = '1.41.1'
+version = '1.41.2'
 # The full version, including alpha/beta/rc tags
-release = '1.41.1'
+release = '1.41.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "type": "module",
   "license": "AGPL-3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ rotkehlchen_mock = "rotkehlchen_mock.__main__:main"
 # dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools_scm]
-fallback_version = "1.41.1"
+fallback_version = "1.41.2"
 
 [tool.setuptools.package-data]
 "rotkehlchen.data" = ["*"]


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
