### PR TITLE
Fix nightly tests

### DIFF
--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - tests
+  workflow_dispatch:
 
 permissions: { }
 

--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -24,7 +24,7 @@ jobs:
       SOURCE_BRANCH: ${{ github.head_ref }}
     runs-on: ${{ inputs.os }}
     name: 'Backend tests'
-    timeout-minutes: 50
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          cd "$HOME/work/rotki/rotki/test-caching" || exit
+          cd "test-caching" || exit
           git fetch origin
           if [[ $(git branch --all | grep "remotes/origin/$SOURCE_BRANCH") ]]; then
             echo "Branch $SOURCE_BRANCH exists on origin. Checking it out..."
@@ -86,7 +86,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -140,7 +139,7 @@ jobs:
             COVERAGE_ARGS='--cov=./'
           fi
 
-          export CASSETTES_DIR="$HOME/work/rotki/rotki/test-caching"
+          export CASSETTES_DIR="$(pwd)/test-caching"
 
           if [ "${{ matrix.test-group }}" == 'api' ]
           then

--- a/rotkehlchen/tests/api/test_data_import.py
+++ b/rotkehlchen/tests/api/test_data_import.py
@@ -493,7 +493,7 @@ def test_data_import_custom_format(rotkehlchen_api_server: 'APIServer', file_upl
 
 
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 def test_data_import_binance_history(
         rotkehlchen_api_server: 'APIServer',
         websocket_connection: 'WebsocketReader',

--- a/rotkehlchen/tests/api/test_historical_assets_price.py
+++ b/rotkehlchen/tests/api/test_historical_assets_price.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from rotkehlchen.tests.fixtures.websockets import WebsocketReader
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])
 def test_get_historical_assets_price(
         rotkehlchen_api_server: APIServer,

--- a/rotkehlchen/tests/api/test_historical_balances.py
+++ b/rotkehlchen/tests/api/test_historical_balances.py
@@ -103,7 +103,7 @@ def fixture_setup_historical_data(rotkehlchen_api_server: 'APIServer') -> None:
         )
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_balance(
@@ -146,7 +146,7 @@ def test_get_historical_balance(
     assert outcome['result']['ETH']['amount'] == '10'
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_asset_balance(
@@ -670,7 +670,7 @@ def test_get_historical_netvalue_with_negative_amount(
     ))
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.freeze_time('2025-03-06 00:00:00 GMT')
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_prices_per_asset(

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -169,7 +169,7 @@ def test_history_export_download_csv(
     assert_csv_export_response(response, temp_csv_file, is_download=True)
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('db_settings', [{'csv_export_delimiter': ';'}])
 @pytest.mark.freeze_time('2025-04-30')
 def test_history_export_csv_custom_delimiter(

--- a/rotkehlchen/tests/external_apis/test_cryptocompare.py
+++ b/rotkehlchen/tests/external_apis/test_cryptocompare.py
@@ -82,7 +82,7 @@ def check_cc_result(result: list, forward: bool):
             raise AssertionError(f'Unexpected time entry {entry.time}')
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_cryptocompare_histohour_data_going_forward(database, freezer):
     """Test that the cryptocompare histohour data retrieval works properly
@@ -135,7 +135,7 @@ def test_cryptocompare_histohour_data_going_forward(database, freezer):
     assert data_range[1] == 1289174400  # that's the closest ts to now_ts cc returns
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_cryptocompare_histohour_data_going_backward(database, freezer):
     """Test that the cryptocompare histohour data retrieval works properly
@@ -317,7 +317,7 @@ def test_cryptocompare_query_with_api_key(cryptocompare):
     assert price is not None
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_starknet_historical_price_after_ticker_change(cryptocompare: 'Cryptocompare') -> None:
     """Check that Starknet token price query after Cryptocompare ticker change is accurate.
@@ -333,7 +333,7 @@ def test_starknet_historical_price_after_ticker_change(cryptocompare: 'Cryptocom
     assert price == Price(FVal('1.75404934188528'))
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 def test_special_cases(cryptocompare: 'Cryptocompare') -> None:
     a_eur, a_dpi = A_EUR.resolve_to_asset_with_oracles(), A_DPI.resolve_to_asset_with_oracles()
     current_price = cryptocompare._special_case_handling(
@@ -360,7 +360,7 @@ def test_special_cases(cryptocompare: 'Cryptocompare') -> None:
     assert historical_data[0]['TIMESTAMP'] == 1732694400
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 def test_query_multiple_current_prices(cryptocompare: 'Cryptocompare'):
     assert cryptocompare.query_multiple_current_prices(
         from_assets=[
@@ -372,7 +372,7 @@ def test_query_multiple_current_prices(cryptocompare: 'Cryptocompare'):
     ) == {A_BTC: FVal(40.48), A_DAI: FVal(0.0004486), A_BSC_BNB: FVal(0.2673)}
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 def test_query_multiple_current_prices_handles_exceptions(cryptocompare: 'Cryptocompare'):
     """
     Regression test for query_multiple_current_prices to ensure it properly handles
@@ -409,7 +409,7 @@ def test_query_multiple_current_prices_handles_exceptions(cryptocompare: 'Crypto
         )) == 3
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 def test_query_multiple_current_prices_handles_special_case_exceptions(cryptocompare: 'Cryptocompare'):  # noqa: E501
     """Regression test for special case handling in query_multiple_current_prices."""
     # Include a special case asset that might fail

--- a/rotkehlchen/tests/fixtures/db.py
+++ b/rotkehlchen/tests/fixtures/db.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from collections.abc import Generator
 from contextlib import ExitStack
 from pathlib import Path
@@ -52,8 +50,8 @@ def fixture_user_data_dir(data_dir, username) -> Path:
 
 @pytest.fixture(name='include_cryptocompare_key')
 def fixture_include_cryptocompare_key() -> bool:
-    """By default use a cryptocompare API key only in the OSX CI"""
-    return 'CI' in os.environ and sys.platform == 'darwin'
+    """By default use a cryptocompare API key in all tests."""
+    return True
 
 
 @pytest.fixture(name='include_etherscan_key')

--- a/rotkehlchen/tests/fixtures/variables.py
+++ b/rotkehlchen/tests/fixtures/variables.py
@@ -44,4 +44,4 @@ def network_mocking(request):
     Once the --no-network-mocking argument is passed all tests that use this fixture
     switch to using the network instead.
     """
-    return request.config.option.no_network_mocking is False
+    return not request.config.getoption('--no-network-mocking', default=False)

--- a/rotkehlchen/tests/integration/test_backend.py
+++ b/rotkehlchen/tests/integration/test_backend.py
@@ -12,14 +12,14 @@ def test_backend():
         # Only works with --logtarget stdout. Figure out why it does not work
         # without it. The message should be printed and logged, so it should not
         # make a difference: https://github.com/rotki/rotki/blob/8830172fe3f46c0ec56f1e32a1c24be67018c1bf/rotkehlchen/api/server.py#L280-L282  # noqa: E501
-        ['python', '-m', 'rotkehlchen', '--logtarget', 'stdout'],
+        ['uv', 'run', 'python', '-m', 'rotkehlchen', '--logtarget', 'stdout'],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
     timeout = 10
     if sys.platform == 'darwin':
-        timeout = 30  # in macos the backend may take a long time to start
+        timeout = 45  # in macos the backend may take a long time to start
     with gevent.Timeout(timeout):
         try:
             while True:

--- a/rotkehlchen/tests/unit/accounting/test_basic.py
+++ b/rotkehlchen/tests/unit/accounting/test_basic.py
@@ -324,7 +324,7 @@ def test_other_currency_fiat_trades(accountant, google_service):
     check_pnls_and_csv(accountant, expected_pnls, google_service)
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey', 'api_key'])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 @pytest.mark.parametrize('accounting_initialize_parameters', [True])
 def test_asset_and_price_not_found_in_history_processing(accountant):

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -364,7 +364,7 @@ def test_price_priority_order():
     assert priority_value == HistoricalPriceOracle.MANUAL.serialize_for_db()
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey', 'api_key'])
 @pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
 def test_uniswap_v2_position_price_query(price_historian: PriceHistorian):
@@ -384,7 +384,7 @@ def test_uniswap_v2_position_price_query(price_historian: PriceHistorian):
     assert price.is_close('3591639.375183')
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey', 'api_key'])
 @pytest.mark.parametrize('mocked_price_queries', [mocked_prices])
 @pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE,)])
 def test_uniswap_v3_position_price_query(price_historian: PriceHistorian):
@@ -404,7 +404,7 @@ def test_uniswap_v3_position_price_query(price_historian: PriceHistorian):
     assert price.is_close('91.707127')
 
 
-@pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_matic_pol_hardforked_price(price_historian: PriceHistorian) -> None:
     """Test that pol/matic tokens all get proper prices before/after the hardfork."""

--- a/rotkehlchen/tests/unit/test_search.py
+++ b/rotkehlchen/tests/unit/test_search.py
@@ -61,6 +61,8 @@ def test_db_persistence_after_search(messages_aggregator):
     - Check that the manual price is still in the global database"""
     rotki_process = subprocess.Popen(
         [  # noqa: S607  # is only used to execute rotki code here
+            'uv',
+            'run',
             'python',
             '-m'
             'rotkehlchen.tests.utils.crash_test',

--- a/rotkehlchen/tests/utils/database.py
+++ b/rotkehlchen/tests/utils/database.py
@@ -70,7 +70,6 @@ def maybe_include_cryptocompare_key(db: DBHandler, include_cryptocompare_key: bo
         '5159ca00f2579ef634b7f210ad725550572afbfb44e409460dd8a908d1c6416a',
         '6781b638eca6c3ca51a87efcdf0b9032397379a0810c5f8198a25493161c318d',
     ]
-    # Add the tests only etherscan API key
     with db.user_write() as write_cursor:
         db.add_external_service_credentials(
             write_cursor=write_cursor,

--- a/rotkehlchen/tests/websocketsapi/test_misc.py
+++ b/rotkehlchen/tests/websocketsapi/test_misc.py
@@ -27,7 +27,7 @@ def test_websockets_concurrent_use(rotkehlchen_api_server, websocket_connection)
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     string_len = 27000 if platform.system() == 'Darwin' else 100000
-    with gevent.Timeout(10):
+    with gevent.Timeout(20):  # This runs a bit slowly on Windows and needs a generous timeout.
         g1 = gevent.spawn(_send_stuff, rotki.msg_aggregator, websocket_connection, string_len)
         _send_stuff(rotki.msg_aggregator, websocket_connection, string_len)
         g2 = gevent.spawn(_send_stuff, rotki.msg_aggregator, websocket_connection, string_len)


### PR DESCRIPTION
There were a number of things off in the nightly tests. This PR changes the following:

* Adds `workflow_dispatch` to the nightly job definition to allow manually triggering it for easier debugging when it breaks
* Increases the backend tests timeout from 50 to 60 minutes. On windows the tests seem to run slower (no individual test taking a long time that I could tell, just all of them running slower) and was hitting the timeout on the `Backend tests (others)` step. Also increases a couple timeouts in other tests where they caused trouble on various platforms.
* Fixes the path for the vcr cassettes directory where it was using the `$HOME` variable that only works in linux.
* Removes a pip cache thing that doesn't seem to be used anymore since we use `uv` and was causing an error during the post python setup where it couldn't find a pip cache directory to clean up.
* Changes the `include_cryptocompare_key` fixture to be True for all patforms and adds `filter_query_parameters=['api_key']` to the tests using it like is done for etherscan's api key.
* Changes the network_mocking fixture to use `getoption` to avoid a bug on mac where it was causing attribute errors.
* Adds `uv run` to several tests where it launches a separate python process for something.

A successful workflow run using this branch is here: https://github.com/nicholasyoder/rotki/actions/runs/20036682673/job/57463222818