### PR TITLE
Avoid storing every stakedao token in db

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :feature:`4609` rotki will now properly handle Superfluid stream transactions and balances.
 * :feature:`10980` Users will now be able to report unsupported events through the history event page.
 * :feature:`6642` Users will now be able to provide feedback directly though the applications help & support sidebar.
+* :feature:`10854` rotki will now be faster to load assets.
 * :bug:`11099` rotki will now allow to create events manually with location Avalanche.
 * :bug:`11002` Liquity V2 proxy detection will now work correctly and proxy deployment transactions will be decoded properly.
 * :feature:`-` StakeDAO V2 Curve strategy transactions will be correctly decoded with vault balances properly detected.

--- a/rotkehlchen/chain/evm/decoding/stakedao/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/decoder.py
@@ -15,6 +15,7 @@ from rotkehlchen.chain.evm.constants import DEPOSIT_TOPIC_V2, WITHDRAW_TOPIC_V2,
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface, ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.stakedao.utils import (
+    ensure_gauge_token,
     query_stakedao_gauges,
 )
 from rotkehlchen.chain.evm.decoding.structures import (
@@ -316,6 +317,12 @@ class StakedaoCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
         return EvmDecodingOutput(action_items=action_items)
 
     def _decode_deposit_withdrawal_events(self, context: DecoderContext) -> EvmDecodingOutput:
+        ensure_gauge_token(
+            gauge_address=context.tx_log.address,
+            evm_inquirer=self.node_inquirer,
+            tx_hash=context.transaction.tx_hash,
+        )
+
         if context.tx_log.topics[0] == DEPOSIT_TOPIC_V2:
             return self._decode_deposit(context)
         elif context.tx_log.topics[0] == WITHDRAW_TOPIC_V2:

--- a/rotkehlchen/chain/evm/decoding/stakedao/utils.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/utils.py
@@ -6,16 +6,18 @@ from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
 from rotkehlchen.chain.evm.decoding.stakedao.constants import CPT_STAKEDAO
 from rotkehlchen.chain.evm.utils import maybe_notify_cache_query_status
 from rotkehlchen.constants import ONE
-from rotkehlchen.errors.misc import NotERC20Conformant, RemoteError, UnableToDecryptRemoteData
+from rotkehlchen.errors.misc import RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.globaldb.cache import globaldb_set_general_cache_values
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
-from rotkehlchen.types import CacheType, ChecksumEvmAddress, Timestamp, TokenKind
+from rotkehlchen.types import CacheType, ChecksumEvmAddress, EVMTxHash, Timestamp, TokenKind
 from rotkehlchen.utils.network import request_get_dict
 
 if TYPE_CHECKING:
+    from eth_typing.abi import ABI
+
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 
 logger = logging.getLogger(__name__)
@@ -25,6 +27,8 @@ STAKEDAO_API: Final = 'https://api.stakedao.org/api'
 # This is gotten from:
 # https://github.com/stake-dao/api?tab=readme-ov-file#strategies-data
 SUPPORTED_STAKEDAO_STRATEGIES: Final = {'curve', 'balancer', 'pendle', 'pancakeswap', 'angle'}
+GAUGE_COMPACT_ABI: Final['ABI'] = [{'stateMutability': 'view', 'type': 'function', 'name': 'staking_token', 'inputs': [], 'outputs': [{'name': '', 'type': 'address'}]}]  # noqa: E501
+LIQUITY_GAUGE_ABI: Final['ABI'] = [{'inputs': [], 'name': 'token', 'outputs': [{'name': '', 'type': 'address'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501
 
 
 def query_stakedao_gauges(evm_inquirer: 'EvmNodeInquirer') -> None:
@@ -45,7 +49,7 @@ def query_stakedao_gauges(evm_inquirer: 'EvmNodeInquirer') -> None:
             total=total,
         )
 
-    all_gauges: set[tuple[ChecksumEvmAddress, ChecksumEvmAddress]] = set()
+    all_gauges: set[ChecksumEvmAddress] = set()
     chain_id = evm_inquirer.chain_id.serialize()
     last_notified_ts, total_count = Timestamp(0), 0
     try:  # Query lockers
@@ -55,10 +59,7 @@ def query_stakedao_gauges(evm_inquirer: 'EvmNodeInquirer') -> None:
                 if item['chainId'] != chain_id:
                     continue
 
-                all_gauges.add((
-                    deserialize_evm_address(item['modules']['gauge']),
-                    deserialize_evm_address(item['token']['address']),
-                ))
+                all_gauges.add(deserialize_evm_address(item['modules']['gauge']))
                 total_count += 1
                 last_notified_ts = _notify_status(last_ts=last_notified_ts, total=total_count)
             except (KeyError, DeserializationError) as e:
@@ -73,10 +74,7 @@ def query_stakedao_gauges(evm_inquirer: 'EvmNodeInquirer') -> None:
                     if item['chainId'] != chain_id:
                         continue
 
-                    all_gauges.add((
-                        deserialize_evm_address(item['sdGauge']['address']),
-                        deserialize_evm_address(item['lpToken']['address']),
-                    ))
+                    all_gauges.add(deserialize_evm_address(item['sdGauge']['address']))
                     total_count += 1
                     last_notified_ts = _notify_status(last_ts=last_notified_ts, total=total_count)
                 except (KeyError, DeserializationError) as e:
@@ -87,37 +85,76 @@ def query_stakedao_gauges(evm_inquirer: 'EvmNodeInquirer') -> None:
     except (RemoteError, UnableToDecryptRemoteData) as e:
         log.error(f'Failed to retrieve StakeDAO gauges for {chain_id} lockers and strategies from API due to {e!s}')  # noqa: E501
 
-    only_gauges, encounter = set(), TokenEncounterInfo(description=f'Querying stakedao gauges for {evm_inquirer.chain_name}', should_notify=False)  # noqa: E501
-    for idx, (gauge_token_addr, underlying_addr) in enumerate(all_gauges, start=1):
-        try:
-            get_or_create_evm_token(
-                chain_id=evm_inquirer.chain_id,
-                protocol=CPT_STAKEDAO,
-                userdb=evm_inquirer.database,
-                evm_address=gauge_token_addr,
-                evm_inquirer=evm_inquirer,
-                encounter=encounter,
-                underlying_tokens=[UnderlyingToken(
-                    address=get_or_create_evm_token(
-                        chain_id=evm_inquirer.chain_id,
-                        evm_inquirer=evm_inquirer,
-                        userdb=evm_inquirer.database,
-                        evm_address=underlying_addr,
-                        encounter=encounter,
-                    ).evm_address,
-                    weight=ONE,
-                    token_kind=TokenKind.ERC20,
-                )],
-            )
-            only_gauges.add(gauge_token_addr)
-            last_notified_ts = _notify_status(last_ts=last_notified_ts, total=total_count, processed=idx)  # noqa: E501
-        except NotERC20Conformant as e:
-            log.error(f'Failed to add stake dao gauge {gauge_token_addr} for {evm_inquirer.chain_id} due to {e!s}')  # noqa: E501
-            continue
-
     with GlobalDBHandler().conn.write_ctx() as write_cursor:
         globaldb_set_general_cache_values(
             write_cursor=write_cursor,
             key_parts=(CacheType.STAKEDAO_GAUGES, str(chain_id)),
-            values=only_gauges,
+            values=all_gauges,
         )
+
+    last_notified_ts = _notify_status(last_ts=last_notified_ts, total=total_count, processed=total_count)  # noqa: E501
+
+
+def ensure_gauge_token(
+        gauge_address: ChecksumEvmAddress,
+        evm_inquirer: 'EvmNodeInquirer',
+        tx_hash: 'EVMTxHash',
+) -> None:
+    """Ensure that StakeDao tokens are present in the database
+
+    Since we don't store all the tokens in the database this logic checks if
+    we already have the token in the db with the right information and if that
+    is not the case then it queries the chain to get the underlying token and
+    create/update the token locally.
+
+    May raise:
+        - RemoteError
+    """
+    with GlobalDBHandler().conn.read_ctx() as cursor:
+        if (row := cursor.execute(
+            'SELECT parent.protocol FROM evm_tokens AS parent '
+            'JOIN underlying_tokens_list AS ut ON parent.identifier=ut.parent_token_entry '
+            'JOIN evm_tokens AS underlying ON underlying.identifier=ut.identifier '
+            'WHERE parent.address=? AND parent.chain=?',
+            (gauge_address, evm_inquirer.chain_id.serialize_for_db()),
+        ).fetchone()) is not None and row[0] == CPT_STAKEDAO:
+            return  # nothing to do, token exists with correct protocol and underlying token
+
+    try:
+        staking_token = evm_inquirer.call_contract(
+            contract_address=gauge_address,
+            abi=GAUGE_COMPACT_ABI,
+            method_name='staking_token',
+        )
+        underlying_addr = evm_inquirer.call_contract(
+            contract_address=staking_token,
+            abi=LIQUITY_GAUGE_ABI,
+            method_name='token',
+        )
+    except RemoteError as e:
+        log.error(
+            f'Failed to pull stakedao token information for {gauge_address} at '
+            f'{evm_inquirer.chain_id} due to {e}',
+        )
+        return
+
+    encounter = TokenEncounterInfo(tx_ref=tx_hash, should_notify=False)
+    get_or_create_evm_token(  # ensure that the token is edited and correct
+        chain_id=evm_inquirer.chain_id,
+        protocol=CPT_STAKEDAO,
+        userdb=evm_inquirer.database,
+        evm_address=gauge_address,
+        evm_inquirer=evm_inquirer,
+        encounter=encounter,
+        underlying_tokens=[UnderlyingToken(
+            address=get_or_create_evm_token(
+                chain_id=evm_inquirer.chain_id,
+                evm_inquirer=evm_inquirer,
+                userdb=evm_inquirer.database,
+                evm_address=underlying_addr,
+                encounter=encounter,
+            ).evm_address,
+            token_kind=TokenKind.ERC20,
+            weight=ONE,
+        )],
+    )

--- a/rotkehlchen/tests/utils/binance_sc.py
+++ b/rotkehlchen/tests/utils/binance_sc.py
@@ -32,6 +32,14 @@ ANKR_BINANCE_SC_NODE: Final = NodeName(
     blockchain=SupportedBlockchain.BINANCE_SC,
 )
 
+
+ZAN_BINANCE_SC_NODE: Final = NodeName(
+    name='zan.top',
+    endpoint='https://api.zan.top/bsc-mainnet',
+    owned=False,
+    blockchain=SupportedBlockchain.BINANCE_SC,
+)
+
 BINANCE_SC_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED: tuple[str, list[tuple]] = (
     'binance_sc_manager_connect_at_start',
     [(WeightedNode(


### PR DESCRIPTION
It does so by checking in the cache the gauge tokens and querying on chain the underlying token when it is required. Does a check to see if we need to actually perform the calls or not