### PR TITLE
Fix an error where getBlockByNumber didn't work for BSC nodes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`11084` Indexer related backend query task will no longer randomly die.
+* :bug:`11094` rotki should now process correctly all the RPCs responses from Binance SC nodes.
 
 * :release:`1.41.2 <2025-12-05>`
 * :feature:`11063` rotki has now improved the date/time range selector in the PnL report generation menu.

--- a/rotkehlchen/chain/mixins/rpc_nodes.py
+++ b/rotkehlchen/chain/mixins/rpc_nodes.py
@@ -243,7 +243,7 @@ class EVMRPCMixin(RPCManagerMixin['Web3']):
             with suppress(ValueError):  # If not existing raises ValueError, so ignore
                 web3.middleware_onion.remove(middleware)
 
-        if self.chain_id in (ChainID.OPTIMISM, ChainID.POLYGON_POS, ChainID.ARBITRUM_ONE, ChainID.BASE):  # noqa: E501
+        if self.chain_id in (ChainID.OPTIMISM, ChainID.POLYGON_POS, ChainID.ARBITRUM_ONE, ChainID.BASE, ChainID.BINANCE_SC):  # noqa: E501
             # TODO: Is it needed for all non-mainet EVM chains?
             # https://web3py.readthedocs.io/en/stable/middleware.html#why-is-geth-poa-middleware-necessary
             web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)


### PR DESCRIPTION
We were missing a middleware required by Web3 since Binance uses a different length for the extraData field in the response

https://web3py.readthedocs.io/en/v7.14.0/middleware.html#proof-of-authority
