### PR TITLE
feat: Support querying for Kraken Futures balances

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2469,6 +2469,7 @@
       "experimental": "The integration for this exchange is experimental, and you may find some imperfections. Please let us know if you encounter any issues.",
       "id": "ID",
       "kraken_account": "Select the type of your Kraken account",
+      "kraken_futures_keys": "Futures Keys",
       "passphrase": "Passphrase",
       "private_key": "Private Key",
       "secret": "Secret",

--- a/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
@@ -176,11 +176,13 @@ export function useExchanges(): UseExchangesReturn {
   };
 
   const setupExchange = async (exchange: ExchangeFormData): Promise<boolean> => {
-    const { krakenAccountType, location, mode, newName, okxLocation } = exchange;
+    const { krakenAccountType, krakenFuturesApiKey, krakenFuturesApiSecret, location, mode, newName, okxLocation } = exchange;
 
     const filteredPayload: ExchangeFormData = {
       ...exchange,
       krakenAccountType: location === 'kraken' ? krakenAccountType : undefined,
+      krakenFuturesApiKey: location === 'kraken' ? krakenFuturesApiKey : undefined,
+      krakenFuturesApiSecret: location === 'kraken' ? krakenFuturesApiSecret : undefined,
       okxLocation: location === 'okx' ? okxLocation : undefined,
     };
 

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -66,6 +66,8 @@ function createNewExchange(): ExchangeFormData {
     apiSecret: '',
     binanceMarkets: undefined,
     krakenAccountType: 'starter',
+    krakenFuturesApiKey: '',
+    krakenFuturesApiSecret: '',
     location: get(exchangesWithKey)[0],
     mode: 'add',
     name: '',

--- a/frontend/app/src/types/exchanges.ts
+++ b/frontend/app/src/types/exchanges.ts
@@ -66,6 +66,8 @@ interface ExchangePayload {
   readonly apiSecret: string;
   readonly passphrase: string;
   readonly krakenAccountType?: KrakenAccountType;
+  readonly krakenFuturesApiKey?: string;
+  readonly krakenFuturesApiSecret?: string;
   readonly binanceMarkets?: string[];
   readonly okxLocation?: OkxLocation;
 }

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -718,6 +718,8 @@ class RestAPI:
             api_secret: ApiSecret | None,
             passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
+            kraken_futures_api_key: ApiKey | None,
+            kraken_futures_api_secret: ApiSecret | None,
             binance_markets: list[str] | None,
             okx_location: Optional['OkxLocation'],
     ) -> Response:
@@ -731,6 +733,8 @@ class RestAPI:
             api_secret=api_secret,
             passphrase=passphrase,
             kraken_account_type=kraken_account_type,
+            kraken_futures_api_key=kraken_futures_api_key,
+            kraken_futures_api_secret=kraken_futures_api_secret,
             binance_selected_trade_pairs=binance_markets,
             okx_location=okx_location,
         )
@@ -749,6 +753,8 @@ class RestAPI:
             api_secret: ApiSecret | None,
             passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
+            kraken_futures_api_key: ApiKey | None,
+            kraken_futures_api_secret: ApiSecret | None,
             binance_markets: list[str] | None,
             okx_location: Optional['OkxLocation'],
     ) -> Response:
@@ -760,6 +766,8 @@ class RestAPI:
             api_secret=api_secret,
             passphrase=passphrase,
             kraken_account_type=kraken_account_type,
+            kraken_futures_api_key=kraken_futures_api_key,
+            kraken_futures_api_secret=kraken_futures_api_secret,
             binance_selected_trade_pairs=binance_markets,
             okx_location=okx_location,
         )

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -558,6 +558,8 @@ class ExchangesResource(BaseMethodView):
             api_secret: ApiSecret | None,
             passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
+            kraken_futures_api_key: ApiKey | None,
+            kraken_futures_api_secret: ApiSecret | None,
             binance_markets: list[str] | None,
             okx_location: Optional['OkxLocation'],
     ) -> Response:
@@ -568,6 +570,8 @@ class ExchangesResource(BaseMethodView):
             api_secret=api_secret,
             passphrase=passphrase,
             kraken_account_type=kraken_account_type,
+            kraken_futures_api_key=kraken_futures_api_key,
+            kraken_futures_api_secret=kraken_futures_api_secret,
             binance_markets=binance_markets,
             okx_location=okx_location,
         )
@@ -583,6 +587,8 @@ class ExchangesResource(BaseMethodView):
             api_secret: ApiSecret | None,
             passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
+            kraken_futures_api_key: ApiKey | None,
+            kraken_futures_api_secret: ApiSecret | None,
             binance_markets: list[str] | None,
             okx_location: Optional['OkxLocation'],
     ) -> Response:
@@ -594,6 +600,8 @@ class ExchangesResource(BaseMethodView):
             api_secret=api_secret,
             passphrase=passphrase,
             kraken_account_type=kraken_account_type,
+            kraken_futures_api_key=kraken_futures_api_key,
+            kraken_futures_api_secret=kraken_futures_api_secret,
             binance_markets=binance_markets,
             okx_location=okx_location,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1877,9 +1877,30 @@ class BinanceMarketsSchemaMixin(Schema):
                 'Please choose the trading pairs you want to monitor before adding the API key.',
                 field_name='binance_markets',
             )
+        if hasattr(super(), 'validate_schema'):
+            super().validate_schema(data, **_kwargs)  # type: ignore[misc]
 
 
-class ExchangesResourceEditSchema(BinanceMarketsSchemaMixin):
+class KrakenFutureKeysSchemaMixin(Schema):
+    """Additional logic for adding/editing Kraken Futures credentials"""
+    kraken_futures_api_key = ApiKeyField(load_default=None)
+    kraken_futures_api_secret = ApiSecretField(load_default=None)
+
+    @validates_schema
+    def validate_schema(
+            self,
+            data: dict[str, Any],
+            **_kwargs: Any,
+    ) -> None:
+        kraken_futures_api_key = data['kraken_futures_api_key']
+        kraken_futures_api_secret = data['kraken_futures_api_secret']
+        if (kraken_futures_api_key is None) ^ (kraken_futures_api_secret is None):
+            raise ValidationError(
+                'Both the Kraken Futures API Key and Secret must be provided.',
+            )
+
+
+class ExchangesResourceEditSchema(BinanceMarketsSchemaMixin, KrakenFutureKeysSchemaMixin):
     name = NonEmptyStringField(required=True)
     new_name = EmptyAsNoneStringField(load_default=None)
     api_key = ApiKeyField(load_default=None)
@@ -1889,7 +1910,7 @@ class ExchangesResourceEditSchema(BinanceMarketsSchemaMixin):
     okx_location = SerializableEnumField(enum_class=OkxLocation, load_default=None)
 
 
-class ExchangesResourceAddSchema(BinanceMarketsSchemaMixin):
+class ExchangesResourceAddSchema(BinanceMarketsSchemaMixin, KrakenFutureKeysSchemaMixin):
     name = NonEmptyStringField(required=True)
     api_key = ApiKeyField(required=True)
     api_secret = ApiSecretField(load_default=None)

--- a/rotkehlchen/constants/misc.py
+++ b/rotkehlchen/constants/misc.py
@@ -19,6 +19,8 @@ NFT_DIRECTIVE: Final = '_nft_'
 # API URLS
 KRAKEN_BASE_URL: Final = 'https://api.kraken.com'
 KRAKEN_API_VERSION: Final = '0'
+KRAKEN_FUTURES_BASE_URL: Final = 'https://futures.kraken.com'
+KRAKEN_FUTURES_API_VERSION: Final = 'v3'
 
 DEFAULT_MAX_LOG_SIZE_IN_MB: Final = 300
 DEFAULT_MAX_LOG_BACKUP_FILES: Final = 3

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -6,9 +6,11 @@ from rotkehlchen.errors.serialization import DeserializationError
 KDF_ITER: Final = 64000
 
 KRAKEN_ACCOUNT_TYPE_KEY: Final = 'kraken_account_type'
+KRAKEN_FUTURES_API_KEY_KEY: Final = 'kraken_futures_api_key'
+KRAKEN_FUTURES_API_SECRET_KEY: Final = 'kraken_futures_api_secret'
 OKX_LOCATION_KEY: Final = 'okx_location'
 BINANCE_MARKETS_KEY: Final = 'binance_selected_trade_pairs'
-USER_CREDENTIAL_MAPPING_KEYS: Final = (KRAKEN_ACCOUNT_TYPE_KEY, BINANCE_MARKETS_KEY, OKX_LOCATION_KEY)  # noqa: E501
+USER_CREDENTIAL_MAPPING_KEYS: Final = (KRAKEN_ACCOUNT_TYPE_KEY, KRAKEN_FUTURES_API_KEY_KEY, KRAKEN_FUTURES_API_SECRET_KEY, BINANCE_MARKETS_KEY, OKX_LOCATION_KEY)  # noqa: E501
 
 
 # -- EVM transactions attributes values -- used in evm_tx_mappings

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -54,6 +54,8 @@ from rotkehlchen.db.constants import (
     EXTRAINTERNALTXPREFIX,
     KDF_ITER,
     KRAKEN_ACCOUNT_TYPE_KEY,
+    KRAKEN_FUTURES_API_KEY_KEY,
+    KRAKEN_FUTURES_API_SECRET_KEY,
     OKX_LOCATION_KEY,
     USER_CREDENTIAL_MAPPING_KEYS,
 )
@@ -1896,6 +1898,8 @@ class DBHandler:
             api_secret: ApiSecret | None,
             passphrase: str | None = None,
             kraken_account_type: KrakenAccountType | None = None,
+            kraken_futures_api_key: ApiKey | None = None,
+            kraken_futures_api_secret: ApiSecret | None = None,
             binance_selected_trade_pairs: list[str] | None = None,
             okx_location: OkxLocation | None = None,
     ) -> None:
@@ -1909,20 +1913,33 @@ class DBHandler:
                 (name, location.serialize_for_db(), api_key, api_secret.decode() if api_secret is not None else None, passphrase),  # noqa: E501
             )
 
-            if location == Location.KRAKEN and kraken_account_type is not None:
-                cursor.execute(
-                    'INSERT INTO user_credentials_mappings '
-                    '(credential_name, credential_location, setting_name, setting_value) '
-                    'VALUES (?, ?, ?, ?)',
-                    (name, location.serialize_for_db(), KRAKEN_ACCOUNT_TYPE_KEY, kraken_account_type.serialize()),  # noqa: E501
-                )
+            if location == Location.KRAKEN:
+                if kraken_account_type is not None:
+                    self._insert_into_credentials_mappings(
+                        cursor=cursor,
+                        name=name,
+                        location=location.serialize_for_db(),
+                        settings={KRAKEN_ACCOUNT_TYPE_KEY: kraken_account_type.serialize()},
+                    )
+
+                if kraken_futures_api_key is not None and kraken_futures_api_secret is not None:
+                    try:
+                        self._insert_into_credentials_mappings(
+                            cursor=cursor,
+                            location=location.serialize_for_db(),
+                            name=name,
+                            settings={KRAKEN_FUTURES_API_KEY_KEY: kraken_futures_api_key,
+                                      KRAKEN_FUTURES_API_SECRET_KEY: kraken_futures_api_secret},
+                        )
+                    except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
+                        raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501
 
             if location == Location.OKX and okx_location is not None:
-                cursor.execute(
-                    'INSERT INTO user_credentials_mappings '
-                    '(credential_name, credential_location, setting_name, setting_value) '
-                    'VALUES (?, ?, ?, ?)',
-                    (name, location.serialize_for_db(), OKX_LOCATION_KEY, okx_location.serialize()),  # noqa: E501
+                self._insert_into_credentials_mappings(
+                    cursor=cursor,
+                    name=name,
+                    location=location.serialize_for_db(),
+                    settings={OKX_LOCATION_KEY: okx_location.serialize()},
                 )
 
             if location in (Location.BINANCE, Location.BINANCEUS) and binance_selected_trade_pairs is not None:  # noqa: E501
@@ -1938,6 +1955,8 @@ class DBHandler:
             api_secret: ApiSecret | None,
             passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
+            kraken_futures_api_key: ApiKey | None,
+            kraken_futures_api_secret: ApiSecret | None,
             binance_selected_trade_pairs: list[str] | None,
             okx_location: Optional['OkxLocation'],
     ) -> None:
@@ -1972,34 +1991,37 @@ class DBHandler:
             except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
                 raise InputError(f'Could not update DB user_credentials due to {e!s}') from e
 
-        if location == Location.KRAKEN and kraken_account_type is not None:
-            try:
-                write_cursor.execute(
-                    'INSERT OR REPLACE INTO user_credentials_mappings '
-                    '(credential_name, credential_location, setting_name, setting_value) '
-                    'VALUES (?, ?, ?, ?)',
-                    (
-                        new_name if new_name is not None else name,
-                        location.serialize_for_db(),
-                        KRAKEN_ACCOUNT_TYPE_KEY,
-                        kraken_account_type.serialize(),
-                    ),
+        if location == Location.KRAKEN:
+            if kraken_account_type is not None:
+                try:
+                    self._insert_into_credentials_mappings(
+                        cursor=write_cursor,
+                        name=new_name if new_name is not None else name,
+                        location=location.serialize_for_db(),
+                        settings={KRAKEN_ACCOUNT_TYPE_KEY: kraken_account_type.serialize()},
                 )
-            except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
-                raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501
+                except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
+                    raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501
+
+            if kraken_futures_api_key is not None and kraken_futures_api_secret is not None:
+                try:
+                    self._insert_into_credentials_mappings(
+                        cursor=write_cursor,
+                        name=new_name if new_name is not None else name,
+                        location=location.serialize_for_db(),
+                        settings={KRAKEN_FUTURES_API_KEY_KEY: kraken_futures_api_key,
+                                  KRAKEN_FUTURES_API_SECRET_KEY: kraken_futures_api_secret},
+                    )
+                except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
+                    raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501
 
         if location == Location.OKX and okx_location is not None:
             try:
-                write_cursor.execute(
-                    'INSERT OR REPLACE INTO user_credentials_mappings '
-                    '(credential_name, credential_location, setting_name, setting_value) '
-                    'VALUES (?, ?, ?, ?)',
-                    (
-                        new_name if new_name is not None else name,
-                        location.serialize_for_db(),
-                        OKX_LOCATION_KEY,
-                        okx_location.serialize(),
-                    ),
+                self._insert_into_credentials_mappings(
+                    cursor=write_cursor,
+                    name=new_name if new_name is not None else name,
+                    location=location.serialize_for_db(),
+                    settings={OKX_LOCATION_KEY: okx_location.serialize()},
                 )
             except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
                 raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501
@@ -2144,6 +2166,8 @@ class DBHandler:
                         extras[key] = KrakenAccountType.deserialize(entry[1])
                     except DeserializationError as e:
                         log.error(f'Couldnt deserialize kraken account type from DB. {e!s}')
+                elif key in (KRAKEN_FUTURES_API_KEY_KEY, KRAKEN_FUTURES_API_SECRET_KEY):
+                    extras[key] = entry[1]
                 elif key == OKX_LOCATION_KEY:
                     try:  # type is checked above
                         extras[key] = OkxLocation.deserialize(entry[1])  # type: ignore
@@ -3853,3 +3877,25 @@ class DBHandler:
         with self.conn.read_ctx() as cursor:
             excluded_chains = self.get_settings(cursor).evmchains_to_skip_detection
         return list(set(SUPPORTED_EVM_EVMLIKE_CHAINS) - set(excluded_chains))
+
+    def _insert_into_credentials_mappings(
+            self,
+            cursor: DBCursor,
+            name: str,
+            location: str,
+            settings: dict,
+    ) -> None:
+        """
+        Inserts the provided key-value pairs into the user_credentials_mappings table in the DB
+        """
+        cursor.executemany(
+            'INSERT OR REPLACE INTO user_credentials_mappings '
+            '(credential_name, credential_location, setting_name, setting_value) '
+            'VALUES (?, ?, ?, ?)',
+            [(
+                name,
+                location,
+                settings_name,
+                settings_value,
+            ) for settings_name, settings_value in settings.items()
+        ])

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -6,7 +6,6 @@ import itertools
 import json
 import logging
 import operator
-import time
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal
@@ -18,9 +17,19 @@ from requests import Response
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_kraken
-from rotkehlchen.constants import KRAKEN_API_VERSION, KRAKEN_BASE_URL, ZERO
+from rotkehlchen.constants import (
+    KRAKEN_API_VERSION,
+    KRAKEN_BASE_URL,
+    KRAKEN_FUTURES_API_VERSION,
+    KRAKEN_FUTURES_BASE_URL,
+    ZERO,
+)
 from rotkehlchen.constants.assets import A_ETH2, A_KFEE, A_USD
-from rotkehlchen.db.constants import KRAKEN_ACCOUNT_TYPE_KEY
+from rotkehlchen.db.constants import (
+    KRAKEN_ACCOUNT_TYPE_KEY,
+    KRAKEN_FUTURES_API_KEY_KEY,
+    KRAKEN_FUTURES_API_SECRET_KEY,
+)
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.asset import UnknownAsset
@@ -61,7 +70,14 @@ from rotkehlchen.types import (
     Timestamp,
     TimestampMS,
 )
-from rotkehlchen.utils.misc import pairwise, timestamp_to_date, ts_ms_to_sec, ts_now
+from rotkehlchen.utils.misc import (
+    combine_dicts,
+    pairwise,
+    timestamp_to_date,
+    ts_ms_to_sec,
+    ts_now,
+    ts_now_in_ms,
+)
 from rotkehlchen.utils.mixins.cacheable import cache_response_timewise
 from rotkehlchen.utils.mixins.enums import SerializableEnumNameMixin
 from rotkehlchen.utils.mixins.lockable import protect_with_lock
@@ -123,7 +139,10 @@ def kraken_ledger_entry_type_to_ours(value: str) -> tuple[HistoryEventType, Hist
     return event_type, event_subtype
 
 
-def _check_and_get_response(response: Response, method: str) -> str | dict:
+def _check_and_get_response(
+        response: Response,
+        method: Literal['Balance', 'TradesHistory', 'Ledgers', 'Assets', 'AssetPairs', 'accounts'],
+) -> str | dict:
     """Checks the kraken response and if it's successful returns the result.
 
     If there is recoverable error a string is returned explaining the error
@@ -155,14 +174,7 @@ def _check_and_get_response(response: Response, method: str) -> str | dict:
         # else
         raise RemoteError(error)
 
-    result = decoded_json.get('result', None)
-    if result is None:
-        if method == 'Balance':
-            return {}
-
-        raise RemoteError(f'Missing result in kraken response for {method}')
-
-    return result
+    return decoded_json
 
 
 class KrakenAccountType(SerializableEnumNameMixin):
@@ -183,6 +195,8 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             database: 'DBHandler',
             msg_aggregator: 'MessagesAggregator',
             kraken_account_type: KrakenAccountType | None = None,
+            kraken_futures_api_key: ApiKey | None = None,
+            kraken_futures_api_secret: ApiSecret | None = None,
     ):
         super().__init__(
             name=name,
@@ -199,6 +213,12 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
         self.call_counter = 0
         self.last_query_ts = 0
         self.history_events_db = DBHistoryEvents(self.db)
+        self.futures_api_key = kraken_futures_api_key
+        self.futures_api_secret = ApiSecret(base64.b64decode(kraken_futures_api_secret)) if kraken_futures_api_secret is not None else None  # noqa: E501
+
+    def set_futures_api_key(self, api_key: ApiKey, api_secret: ApiSecret) -> None:
+        self.futures_api_key = api_key
+        self.futures_api_secret = ApiSecret(base64.b64decode(api_secret))
 
     def set_account_type(self, account_type: KrakenAccountType | None) -> None:
         if account_type is None:
@@ -227,11 +247,13 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
     def edit_exchange_extras(self, extras: dict) -> tuple[bool, str]:
         account_type = extras.get(KRAKEN_ACCOUNT_TYPE_KEY)
-        if account_type is None:
-            return False, 'No account type provided'
+        if account_type is not None:
+            self.set_account_type(account_type)
 
-        # now we can update the account type
-        self.set_account_type(account_type)
+        if ((futures_api_key := extras.get(KRAKEN_FUTURES_API_KEY_KEY)) is not None
+             and (futures_api_secret := extras.get(KRAKEN_FUTURES_API_SECRET_KEY)) is not None):
+            self.set_futures_api_key(futures_api_key, futures_api_secret)
+
         return True, ''
 
     def validate_api_key(self) -> tuple[bool, str]:
@@ -257,11 +279,17 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
         )
         if not valid:
             return False, msg
+
+        if self._has_futures_keys():
+            valid, msg = self._validate_single_api_key_action('accounts')
+            if not valid:
+                return False, msg
+
         return True, ''
 
     def _validate_single_api_key_action(
             self,
-            method_str: Literal['Balance', 'TradesHistory', 'Ledgers'],
+            method_str: Literal['Balance', 'TradesHistory', 'Ledgers', 'accounts'],
             req: dict[str, Any] | None = None,
     ) -> tuple[bool, str]:
         try:
@@ -283,8 +311,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             # else
             log.error(f'Kraken API key validation error: {e!s}')
             msg = (
-                'Unknown error at Kraken API key validation. Perhaps API '
-                'Key/Secret combination invalid?'
+                'Unknown error at Kraken API key validation. Perhaps API Key/Secret combination invalid?'  # noqa: E501
             )
             return False, msg
         return True, ''
@@ -292,14 +319,21 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
     def first_connection(self) -> None:
         self.first_connection_made = True
 
-    def _manage_call_counter(self, method: str) -> None:
+    def _manage_call_counter(
+            self,
+            method: Literal['Balance', 'TradesHistory', 'Ledgers', 'Assets', 'AssetPairs', 'accounts'],  # noqa: E501
+    ) -> None:
         self.last_query_ts = ts_now()
         if method in {'Ledgers', 'TradesHistory'}:
             self.call_counter += 2
         else:
             self.call_counter += 1
 
-    def api_query(self, method: str, req: dict | None = None) -> dict:
+    def api_query(
+            self,
+            method: Literal['Balance', 'TradesHistory', 'Ledgers', 'Assets', 'AssetPairs', 'accounts'],  # noqa: E501
+            req: dict | None = None,
+    ) -> dict:
         tries = KRAKEN_QUERY_TRIES
         while tries > 0:
             if self.call_counter + MAX_CALL_COUNTER_INCREASE > self.call_limit:
@@ -328,7 +362,11 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 data=req,
                 call_counter=self.call_counter,
             )
-            result = self._query_private(method, req)
+
+            if method == 'accounts':
+                result = self._query_futures_api_method(method)
+            else:
+                result = self._query_private(method, req)
             if isinstance(result, str):
                 # Got a recoverable error
                 backoff_in_seconds = int(KRAKEN_BACKOFF_DIVIDEND / tries)
@@ -347,7 +385,11 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             f'After {KRAKEN_QUERY_TRIES} kraken queries for {method} could still not be completed',
         )
 
-    def _query_private(self, method: str, req: dict | None = None) -> dict | str:
+    def _query_private(
+            self,
+            method: Literal['Balance', 'TradesHistory', 'Ledgers', 'Assets', 'AssetPairs', 'accounts'],  # noqa: E501
+            req: dict | None = None,
+    ) -> dict | str:
         """API queries that require a valid key/secret pair.
 
         Arguments:
@@ -359,7 +401,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             req = {}
 
         urlpath = '/' + KRAKEN_API_VERSION + '/private/' + method
-        req['nonce'] = int(1000 * time.time())
+        req['nonce'] = ts_now_in_ms()
         post_data = urlencode(req)
         # any unicode strings must be turned to bytes
         hashable = (str(req['nonce']) + post_data).encode()
@@ -368,27 +410,58 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             message=message,
             digest_algorithm=hashlib.sha512,
         )
-        self.session.headers.update({
-            'API-Sign': signature,
-        })
         try:
             response = self.session.post(
                 KRAKEN_BASE_URL + urlpath,
                 data=post_data.encode(),
                 timeout=CachedSettings().get_timeout_tuple(),
+                headers={'APIKey': self.api_key, 'API-Sign': signature},
             )
         except requests.exceptions.RequestException as e:
             raise RemoteError(f'Kraken API request failed due to {e!s}') from e
         self._manage_call_counter(method)
 
-        return _check_and_get_response(response, method)
+        decoded_json = _check_and_get_response(response, method)
+
+        if isinstance(decoded_json, str):
+            return decoded_json
+
+        result = decoded_json.get('result', None)
+        if result is None:
+            if method == 'Balance':
+                return {}
+
+            raise RemoteError(f'Missing result in kraken response for {method}')
+
+        return result
 
     # ---- General exchanges interface ----
     @protect_with_lock()
     @cache_response_timewise()
     def query_balances(self) -> ExchangeQueryBalances:
+        returned_balances: dict | None
+        spot_balances, spot_msg = self.query_balances_method('Balance')
+        if spot_balances is not None:
+            spot_balances, spot_msg = self.deserialize_kraken_balance(spot_balances)
+
+        if not self._has_futures_keys():
+            log.debug('Kraken Futures keys are not set, returning only spot balances')
+            return spot_balances, spot_msg
+
+        futures_balances, futures_msg = self.query_futures_balances()
+        if spot_balances is not None and futures_balances is not None:
+            returned_balances = combine_dicts(futures_balances, spot_balances)
+        else:
+            returned_balances = spot_balances or futures_balances
+
+        return returned_balances, spot_msg + futures_msg
+
+    def query_balances_method(
+            self,
+            method: Literal['Balance', 'TradesHistory', 'Ledgers', 'accounts'],
+    ) -> tuple[dict | None, str]:
         try:
-            kraken_balances = self.api_query('Balance', req={})
+            kraken_balances = self.api_query(method, req={})
         except RemoteError as e:
             if "Missing key: 'result'" in str(e):
                 # handle https://github.com/rotki/rotki/issues/946
@@ -401,8 +474,13 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 log.error(msg)
                 return None, msg
 
+        return kraken_balances, ''
+
+    def deserialize_kraken_balance(self, kraken_balances: dict) -> tuple[dict, str]:
         assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
         for kraken_name, amount_ in kraken_balances.items():
+            log.debug(
+                f'deserializing kraken balance for {kraken_name} with amount: {amount_}')
             try:
                 amount = deserialize_fval(amount_)
                 if amount == ZERO:
@@ -1062,3 +1140,102 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             returned_events.append(event)
 
         return returned_events, skipped, found_unknown_event
+
+    def _query_futures_api_method(
+            self,
+            method: Literal['accounts'],
+    ) -> dict | str:
+        """API queries that require a valid key/secret pair.
+
+        Arguments:
+        method -- API method name (string, no default)
+        """
+        urlpath: str = '/derivatives/api/' + KRAKEN_FUTURES_API_VERSION + '/' + method
+        urlpath_without_prefix = urlpath.removeprefix('/derivatives')
+        nonce = str(ts_now_in_ms())
+
+        # any unicode strings must be turned to bytes
+        hashable = (nonce + urlpath_without_prefix).encode()
+        message = hashlib.sha256(hashable).digest()
+        signature = self.generate_hmac_b64_signature(
+            secret=self.futures_api_secret,
+            message=message,
+            digest_algorithm=hashlib.sha512,
+        )
+        full_url = KRAKEN_FUTURES_BASE_URL + urlpath
+        log.debug(f'Querying Kraken for {method} with {nonce} at URL: {full_url}')
+        try:
+            response = self.session.get(
+                full_url,
+                timeout=CachedSettings().get_timeout_tuple(),
+                headers={
+                    'APIKey': self.futures_api_key,
+                    'Nonce': nonce,
+                    'Authent': signature,
+                },
+            )
+            log.debug(f'raw response from kraken for API method {method} = {response}')
+        except requests.exceptions.RequestException as e:
+            raise RemoteError(f'Kraken API request failed due to {e!s}') from e
+
+        self._manage_call_counter(method)
+        return _check_and_get_response(response, method)
+
+    def query_futures_balances(self, **kwargs: Any) -> tuple[dict | None, str]:
+        log.debug(f'querying futures balances for {self.location} with kwargs {kwargs}...')
+        raw_balances, msg = self.query_balances_method('accounts')
+        log.debug(f'got Kraken Futures raw balances = {raw_balances}')
+        if raw_balances is None:
+            return raw_balances, msg
+
+        try:
+            accounts: dict = raw_balances['accounts']
+            cash: dict = accounts['cash']
+            cash_balances: dict = cash['balances']
+            flex: dict = accounts['flex']
+            flex_currencies: dict = flex['currencies']
+        except KeyError as e:
+            return None, f'Error parsing Kraken Futures response: {e!s}'
+
+        cash_balances_deserialized, msg = self.deserialize_kraken_balance(
+            {k.upper(): v for k, v in cash_balances.items()},
+        )
+        single_collateral_balances = self._parse_single_collateral_futures_margin(accounts)
+        single_collateral_deserialized, msg = self.deserialize_kraken_balance(
+            {k.upper(): v for k, v in single_collateral_balances.items()},
+        )
+        flex_balances: defaultdict = defaultdict(float)
+        for currency, flex_collateral in flex_currencies.items():
+            flex_balances[currency] += flex_collateral.get('quantity', ZERO)
+        flex_deserialized, msg = self.deserialize_kraken_balance(flex_balances)
+
+        total_futures_balances = {
+            currency: cash_balances_deserialized.get(currency, Balance())
+                    + single_collateral_deserialized.get(currency, Balance())
+                    + flex_deserialized.get(currency, Balance())
+            for currency in cash_balances_deserialized |
+                            single_collateral_deserialized | flex_deserialized
+        }
+
+        log.debug(f'done querying futures balances for {self.location}')
+        log.debug(f'total Kraken Futures balances = {total_futures_balances}')
+        return total_futures_balances, ''
+
+    @staticmethod
+    def _parse_single_collateral_futures_margin(
+            accounts: dict[str, dict],
+    ) -> defaultdict[str, float]:
+        parsed_balances: defaultdict[str, float] = defaultdict(float)
+        for account, collateral in accounts.items():
+            if not account.startswith('fi_'):
+                continue
+            if (
+                    (currency := collateral.get('currency'))
+                    and (balances := collateral.get('balances'))
+                    and (amount := balances.get(currency))
+            ):
+                parsed_balances[currency] += amount
+        return parsed_balances
+
+    def _has_futures_keys(self) -> ApiKey | ApiSecret | None:
+        return self.futures_api_key and self.futures_api_secret

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -6,7 +6,13 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Optional
 
 from rotkehlchen.api.websockets.typedefs import HistoryEventsStep
-from rotkehlchen.db.constants import BINANCE_MARKETS_KEY, KRAKEN_ACCOUNT_TYPE_KEY, OKX_LOCATION_KEY
+from rotkehlchen.db.constants import (
+    BINANCE_MARKETS_KEY,
+    KRAKEN_ACCOUNT_TYPE_KEY,
+    KRAKEN_FUTURES_API_KEY_KEY,
+    KRAKEN_FUTURES_API_SECRET_KEY,
+    OKX_LOCATION_KEY,
+)
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.exchanges.binance import BINANCE_BASE_URL, BINANCEUS_BASE_URL
@@ -83,6 +89,8 @@ class ExchangeManager:
             api_secret: ApiSecret | None,
             passphrase: str | None,
             kraken_account_type: Optional['KrakenAccountType'],
+            kraken_futures_api_key: ApiKey | None,
+            kraken_futures_api_secret: ApiSecret | None,
             binance_selected_trade_pairs: list[str] | None,
             okx_location: Optional['OkxLocation'],
     ) -> tuple[bool, str]:
@@ -115,6 +123,8 @@ class ExchangeManager:
         if isinstance(exchangeobj, ExchangeWithExtras):
             success, msg = exchangeobj.edit_exchange_extras({
                 KRAKEN_ACCOUNT_TYPE_KEY: kraken_account_type,
+                KRAKEN_FUTURES_API_KEY_KEY: kraken_futures_api_key,
+                KRAKEN_FUTURES_API_SECRET_KEY: kraken_futures_api_secret,
                 BINANCE_MARKETS_KEY: binance_selected_trade_pairs,
                 OKX_LOCATION_KEY: okx_location,
             })
@@ -133,6 +143,8 @@ class ExchangeManager:
                     api_secret=api_secret,
                     passphrase=passphrase,
                     kraken_account_type=kraken_account_type,
+                    kraken_futures_api_key=kraken_futures_api_key,
+                    kraken_futures_api_secret=kraken_futures_api_secret,
                     binance_selected_trade_pairs=binance_selected_trade_pairs,
                     okx_location=okx_location,
                 )
@@ -231,7 +243,7 @@ class ExchangeManager:
             api_secret=api_secret,
             passphrase=passphrase,
         )
-        exchange = self.initialize_exchange(
+        exchange: ExchangeInterface = self.initialize_exchange(
             module=self._get_exchange_module(location),
             credentials=api_credentials,
             database=database,

--- a/rotkehlchen/exchanges/utils.py
+++ b/rotkehlchen/exchanges/utils.py
@@ -69,6 +69,7 @@ class SignatureGeneratorMixin:
     def generate_hmac_b64_signature(
             self,
             message: str | bytes,
+            secret: bytes | None = None,
             digest_algorithm: Any = hashlib.sha256,
             encoding: str = 'utf-8',
     ) -> str:
@@ -86,9 +87,11 @@ class SignatureGeneratorMixin:
         if isinstance(message, str):
             message = message.encode(encoding)
 
+        if secret is None:
+            secret = self.secret
         return base64.b64encode(
             hmac.new(
-                self.secret,
+                secret,
                 message,
                 digest_algorithm,
             ).digest(),

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -1405,6 +1405,8 @@ class Rotkehlchen:
             api_secret: ApiSecret | None,
             passphrase: str | None = None,
             kraken_account_type: Optional['KrakenAccountType'] = None,
+            kraken_futures_api_key: ApiKey | None = None,
+            kraken_futures_api_secret: ApiSecret | None = None,
             binance_selected_trade_pairs: list[str] | None = None,
             okx_location: Optional['OkxLocation'] = None,
     ) -> tuple[bool, str]:
@@ -1416,6 +1418,8 @@ class Rotkehlchen:
             location=location,
             api_key=api_key,
             api_secret=api_secret,
+            kraken_futures_api_key=kraken_futures_api_key,
+            kraken_futures_api_secret=kraken_futures_api_secret,
             database=self.data.db,
             passphrase=passphrase,
             binance_selected_trade_pairs=binance_selected_trade_pairs,
@@ -1430,6 +1434,8 @@ class Rotkehlchen:
                 api_secret=api_secret,
                 passphrase=passphrase,
                 kraken_account_type=kraken_account_type,
+                kraken_futures_api_key=kraken_futures_api_key,
+                kraken_futures_api_secret=kraken_futures_api_secret,
                 binance_selected_trade_pairs=binance_selected_trade_pairs,
                 okx_location=okx_location,
             )

--- a/rotkehlchen/tests/unit/test_exchanges.py
+++ b/rotkehlchen/tests/unit/test_exchanges.py
@@ -135,6 +135,8 @@ def test_change_credentials(rotkehlchen_api_server: APIServer) -> None:
             api_secret=TEST_CREDENTIALS_2.api_secret,
             passphrase=TEST_CREDENTIALS_2.passphrase,
             kraken_account_type=None,
+            kraken_futures_api_key=None,
+            kraken_futures_api_secret=None,
             binance_selected_trade_pairs=None,
             okx_location=None,
         )
@@ -156,6 +158,8 @@ def test_change_credentials(rotkehlchen_api_server: APIServer) -> None:
             api_secret=TEST_CREDENTIALS_3.api_secret,
             passphrase=TEST_CREDENTIALS_3.passphrase,
             kraken_account_type=None,
+            kraken_futures_api_key=None,
+            kraken_futures_api_secret=None,
             binance_selected_trade_pairs=None,
             okx_location=None,
         )


### PR DESCRIPTION
## Summary of Changes

A section for Futures API keys was added to the Exchange Keys form when Kraken is selected. On submit, futures keys are stored in the `user_credentials_mappings` table to later be used in the `Kraken` class to query balances. Spot API keys are still required but Futures keys are optional.

## Known Issues

- Futures trades and funding changes are not pulled into the history. Only balances in the futures wallet are queried and displayed
- `******` shows for futures keys on the form when editing the exchange, even if they were not initially set.
- Futures keys are not validated in a query to Kraken on edit, only when they are supplied when initially adding the exchange.

## Testing

A [Kraken Futures demo account](https://support.kraken.com/articles/360024809011-api-testing-environment-derivatives) was created and used to test this new integration. The API keys are hardcoded here for the tests, similar to how it's done for `sandbox_gemini`. I also have the username and login password if you needed it, just let me know.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.