### PR TITLE
VCR tests using beaconcha.in api

### DIFF
--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -643,6 +643,7 @@ def test_add_get_edit_delete_eth2_validators(
     assert result == {'entries': [validator.serialize() for validator in custom_percentage_validators], 'entries_limit': -1, 'entries_found': 2}  # noqa: E501
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_modules', [['eth2']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('method', ['PUT', 'DELETE'])

--- a/rotkehlchen/tests/external_apis/test_beaconchain.py
+++ b/rotkehlchen/tests/external_apis/test_beaconchain.py
@@ -18,6 +18,7 @@ def test_query_chunks_empty_list():
     assert calculate_query_chunks([]) == []
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_get_eth1_validator_indices_single(beaconchain):
     address = '0x2bCF6fE9F95Fe5eCec37f69dFE00Bfb4668ac35D'
     validators = beaconchain.get_eth1_address_validators(address=address)
@@ -32,6 +33,7 @@ def test_get_eth1_validator_indices_single(beaconchain):
     assert validators[0].public_key == '0xadefb3de3c892823aa8d389a4b9582f56f64463db2b72b4d77c515d268cf695f9047604371eb73d2a514c8f711ae7eba'  # noqa: E501
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_get_eth1_validator_indices_multiple(beaconchain):
     address = '0x3266F3546a1e5Dc6A15588f3324741A0E20a3B6c'
     validators = beaconchain.get_eth1_address_validators(address=address)

--- a/rotkehlchen/tests/integration/test_eth2.py
+++ b/rotkehlchen/tests/integration/test_eth2.py
@@ -151,7 +151,7 @@ def test_withdrawals(eth2: 'Eth2', database, ethereum_accounts, query_method):
     assert account1_events == 47
 
 
-# @pytest.mark.vcr
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2023-04-24 21:00:00 GMT')
 @pytest.mark.parametrize('ethereum_accounts', [[

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -416,6 +416,7 @@ def test_eth_validators_performance(eth2, database, ethereum_accounts):
     assert performance['validators'] == {}
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
 @pytest.mark.parametrize('start_with_valid_premium', [True])


### PR DESCRIPTION
Should fix the beaconcha.in rate limit errors we have been seeing in the CI.
