### PR TITLE
fix: remove manual Content-Type header for FormData

### DIFF
--- a/frontend/app/src/composables/api/assets/icon.ts
+++ b/frontend/app/src/composables/api/assets/icon.ts
@@ -38,11 +38,7 @@ export function useAssetIconApi(): UseAssetIconApiReturn {
     const data = new FormData();
     data.append('file', file);
     data.append('asset', identifier);
-    return api.post<boolean>(`/assets/icon/modify`, data, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    return api.post<boolean>(`/assets/icon/modify`, data);
   };
 
   const setIcon = async (asset: string, file: string): Promise<boolean> => api.put<boolean>(`/assets/icon/modify`, {

--- a/frontend/app/src/composables/api/assets/index.ts
+++ b/frontend/app/src/composables/api/assets/index.ts
@@ -61,9 +61,6 @@ export function useAssetsApi(): UseAssetApiReturn {
       data.append('async_query', 'true');
 
       const response = await api.post<PendingTask>('/assets/user', data, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
         validStatuses: VALID_FILE_OPERATION_STATUS,
       });
       return PendingTaskSchema.parse(response);

--- a/frontend/app/src/composables/api/import/index.ts
+++ b/frontend/app/src/composables/api/import/index.ts
@@ -22,11 +22,7 @@ export function useImportDataApi(): UseImportDataApiReturn {
   };
 
   const importFile = async (data: FormData): Promise<PendingTask> => {
-    const response = await api.post<PendingTask>('/import', data, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    const response = await api.post<PendingTask>('/import', data);
 
     return PendingTaskSchema.parse(response);
   };

--- a/frontend/app/src/composables/api/reports/index.ts
+++ b/frontend/app/src/composables/api/reports/index.ts
@@ -87,11 +87,7 @@ export function useReportsApi(): UseReportsApi {
     const data = new FormData();
     data.append('filepath', filepath);
     data.append('async_query', 'true');
-    const response = await api.patch<PendingTask>('/history/debug', data, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    const response = await api.patch<PendingTask>('/history/debug', data);
 
     return PendingTaskSchema.parse(response);
   };


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
