### PR TITLE
Improve velodrome balances logic

### DIFF
--- a/rotkehlchen/chain/evm/decoding/velodrome/balances.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/balances.py
@@ -60,13 +60,15 @@ class VelodromeLikeBalances(ProtocolWithGauges):
 
     def query_balances(self) -> BalancesSheetType:
         balances = super().query_balances()
-        if len(addresses_with_deposits := self.addresses_with_deposits()) == 0:
+        if (
+            len(addresses_with_deposits := self.addresses_with_deposits()) == 0 or
+            len(addresses_to_token_ids := {
+                address: list(token_ids_set) for address, events in addresses_with_deposits.items()
+                if len(token_ids_set := {event.extra_data['token_id'] for event in events if event.extra_data is not None}) != 0  # noqa: E501
+            }) == 0
+        ):  # Skip voting escrow balances if there are no deposits with token ids in the extra data
             return balances
 
-        addresses_to_token_ids = {
-            address: [event.extra_data['token_id'] for event in events if event.extra_data is not None]  # noqa: E501
-            for address, events in addresses_with_deposits.items()
-        }
         voting_escrow_contract = EvmContract(
             address=self.voting_escrow_address,
             abi=VOTING_ESCROW_ABI,

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -369,7 +369,10 @@ class VelodromeLikeDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderM
             ):  # increase amount locked
                 token_id = event.extra_data['token_id']  # type: ignore[index]  # it is always available
                 event.notes = f'Increase locked amount in veNFT-{token_id} by {event.amount} {self.token_symbol}'  # noqa: E501
-                event.extra_data = None
+                # The lock time on amount increases is zero, so remove it from the extra data.
+                # But keep the token_id for balance detection if the original deposit was from a
+                # different address or wasn't decoded for some reason.
+                event.extra_data.pop('lock_time', None)  # type: ignore[union-attr]  # extra_data is not None
                 return DEFAULT_EVM_DECODING_OUTPUT
 
         for tx_log in context.all_logs:  # Handle increase unlock time case

--- a/rotkehlchen/tests/data_migrations/test_migration_22.py
+++ b/rotkehlchen/tests/data_migrations/test_migration_22.py
@@ -10,7 +10,8 @@ from rotkehlchen.types import Location
 @pytest.mark.parametrize('data_migration_version', [21])
 def test_migration_22_remove_coinbase_legacy_keys(database: DBHandler) -> None:
     """Test that migration 22 removes Coinbase legacy keys but doesn't touch ECDSA or ED25519 keys.
-    Uses a uuid to simulate a valid ED25519 key.
+    Generates uuids to simulate valid keys in the proper formats. Doesn't include api secrets
+    since they are not referenced in the migration.
     """
     with database.user_write() as write_cursor:
         write_cursor.executemany(

--- a/rotkehlchen/tests/unit/decoders/test_aerodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_aerodrome.py
@@ -448,6 +448,7 @@ def test_increase_locked_amount(base_accounts, base_transaction_decoder):
             counterparty=CPT_AERODROME,
             address=string_to_evm_address('0xeBf418Fe2512e7E6bd9b87a8F0f294aCDC67e6B4'),
             notes=f'Increase locked amount in veNFT-3334 by {lock_amount} AERO',
+            extra_data={'token_id': 3334},
         ),
     ]
     assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_velodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_velodrome.py
@@ -1059,6 +1059,7 @@ def test_increase_locked_amount(optimism_accounts, optimism_transaction_decoder)
             counterparty=CPT_VELODROME,
             address=string_to_evm_address('0xFAf8FD17D9840595845582fCB047DF13f006787d'),
             notes=f'Increase locked amount in veNFT-20820 by {lock_amount} VELO',
+            extra_data={'token_id': 20820},
         ),
     ]
     assert events == expected_events


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=143423154

improves a couple things:
* The `Failed to query velodrome locked balances for address` error was showing for accounts where there were velodrome deposits that didn't include the token ids (guage deposits and lock amount increases). Changed this so it won't attempt the query if there are no token ids found from the history for a given address.
* Changes the lock amount increase events to include the token ids as well. I observed on one account I was testing that the original lock event was from one address and the nft was then transfered to a different address where there were several amount increase events. Tracking only the second address would miss those token ids otherwise. A bit of an edge case probably but good to handle better.
* also adds to the docstring of the migration 22 test to mention why it doesn't include the api secret as discussed in [discord](https://discord.com/channels/657906918408585217/1080783409640648765/1449151567197503558)