### PR TITLE
fix(aave-v3): correct error logging for missing underlying token

### DIFF
--- a/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/aave/v3/decoder.py
@@ -284,9 +284,12 @@ class Aavev3LikeCommonDecoder(Commonv2v3LikeDecoder):
                     )
                 ) > 0
             ):  # parse the mint amount and balance_increase
-                if _log.topics[0] == BURN and (earned_token := get_single_underlying_token(earned_token)) is None:  # type: ignore[assignment]  # we ignore if None  # noqa: E501
-                    log.error(f'Failed to find underlying token for Aave v3 token {earned_token}. Skipping')  # noqa: E501
-                    continue
+                if _log.topics[0] == BURN:
+                    if (underlying_token := get_single_underlying_token(earned_token)) is None:
+                        log.error(f'Failed to find underlying token for Aave v3 token {earned_token}. Skipping')  # noqa: E501
+                        continue
+
+                    earned_token = underlying_token
 
                 if (  # check if we need to create the earned event
                         maybe_earned_event is None or


### PR DESCRIPTION
Fixed a bug where the error log message would always show "None" instead of the actual token name when failing to find an underlying token. The walrus operator was overwriting the earned_token variable before it was used in the log message, making debugging impossible. Now the original token is preserved for the error message before reassignment.