### PR TITLE
Correctly query CRV balances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :feature:`11086` rotki will now properly handle Kraken margin profit, loss, fee, and any other so far unsupported event.
 * :bug:`11084` Indexer related backend query task will no longer randomly die.
 * :bug:`11094` rotki should now process correctly all the RPCs responses from Binance SC nodes.
+* :bug:`11148` Locked Curve CRV balances in the vote escrow contract will now show up correctly.
 
 * :release:`1.41.2 <2025-12-05>`
 * :feature:`11063` rotki has now improved the date/time range selector in the PnL report generation menu.

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -74,12 +74,14 @@ class ProtocolWithBalance(abc.ABC):
             tx_decoder: 'EVMTransactionDecoder',
             counterparty: PROTOCOLS_WITH_BALANCES,
             deposit_event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
+            excluded_addresses: list[ChecksumEvmAddress] | None = None,
     ):
         self.counterparty = counterparty
         self.event_db = DBHistoryEvents(evm_inquirer.database)
         self.evm_inquirer = evm_inquirer
         self.tx_decoder = tx_decoder
         self.deposit_event_types = deposit_event_types
+        self.excluded_addresses = excluded_addresses
 
     def addresses_with_activity(
             self,
@@ -96,6 +98,7 @@ class ProtocolWithBalance(abc.ABC):
             type_and_subtype_combinations=event_types,
             location=Location.from_chain_id(self.evm_inquirer.chain_id),
             entry_types=IncludeExcludeFilterData(values=[HistoryBaseEntryType.EVM_EVENT]),
+            excluded_addresses=self.excluded_addresses,
         )
         with self.event_db.db.conn.read_ctx() as cursor:
             events = self.event_db.get_history_events_internal(
@@ -134,8 +137,15 @@ class ProtocolWithGauges(ProtocolWithBalance):
             counterparty: PROTOCOLS_WITH_BALANCES,
             deposit_event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
             gauge_deposit_event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
+            excluded_addresses: list[ChecksumEvmAddress] | None = None,
     ):
-        super().__init__(evm_inquirer=evm_inquirer, tx_decoder=tx_decoder, counterparty=counterparty, deposit_event_types=deposit_event_types)  # noqa: E501
+        super().__init__(
+            evm_inquirer=evm_inquirer,
+            tx_decoder=tx_decoder,
+            counterparty=counterparty,
+            deposit_event_types=deposit_event_types,
+            excluded_addresses=excluded_addresses,
+        )
         self.gauge_deposit_event_types = gauge_deposit_event_types
 
     def addresses_with_gauge_deposits(self) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
@@ -230,9 +240,12 @@ class ProtocolWithGauges(ProtocolWithBalance):
         for address, events in self.addresses_with_gauge_deposits().items():
             # Create a mapping of a gauge to its token
             for event in events:
-                gauge_address = self.get_gauge_address(event)
-                if gauge_address is None:
+                if (
+                    (gauge_address := self.get_gauge_address(event)) is None or
+                    gauge_address in gauges_to_token  # avoid the call to resolve_to_evm_token by checking if we already processed the gauge  # noqa: E501
+                ):
                     continue
+
                 gauges_to_token[gauge_address] = event.asset.resolve_to_evm_token()
 
             balances[address] = self._query_gauges_balances(

--- a/rotkehlchen/chain/ethereum/modules/curve/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/balances.py
@@ -1,14 +1,33 @@
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Final
 
-from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithGauges
+from eth_typing import ABI
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithGauges
+from rotkehlchen.chain.ethereum.modules.curve.constants import VOTING_ESCROW
+from rotkehlchen.chain.ethereum.utils import normalized_fval_value_decimals
+from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
+from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_CRV
+from rotkehlchen.db.filtering import EvmEventFilterQuery
+from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.types import ChecksumEvmAddress
+from rotkehlchen.inquirer import Inquirer
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.types import ChecksumEvmAddress, Location
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
+
+VOTE_ESCROW_ABI: Final[ABI] = [{'inputs': [{'name': 'arg0', 'type': 'address'}], 'name': 'locked', 'outputs': [{'name': 'amount', 'type': 'int128'}, {'name': 'end', 'type': 'uint256'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class CurveBalances(ProtocolWithGauges):
@@ -30,7 +49,90 @@ class CurveBalances(ProtocolWithGauges):
             counterparty=CPT_CURVE,
             deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
             gauge_deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},  # noqa: E501
+            excluded_addresses=[VOTING_ESCROW],  # exclude the veCRV from the list of interacted contracts  # noqa: E501
         )
 
     def get_gauge_address(self, event: 'EvmEvent') -> ChecksumEvmAddress | None:
         return event.address
+
+    def query_balances(self) -> 'BalancesSheetType':
+        """Query gauge balances and CRV deposited in the veCRV contract"""
+        balances = super().query_balances()  # gauge balances
+        db_filter = EvmEventFilterQuery.make(
+            assets=(A_CRV,),
+            counterparties=[self.counterparty],
+            type_and_subtype_combinations=self.deposit_event_types,
+            location=Location.from_chain_id(self.evm_inquirer.chain_id),
+            addresses=[VOTING_ESCROW],
+        )
+        with self.event_db.db.conn.read_ctx() as cursor:
+            events = self.event_db.get_history_events_internal(
+                cursor=cursor,
+                filter_query=db_filter,
+            )
+
+        if len(events) == 0:
+            return balances
+
+        unique_depositors: set[ChecksumEvmAddress] = set()
+        unique_depositors.update(
+            string_to_evm_address(event.location_label) for event in events
+            if event.location_label is not None
+        )
+        self._query_and_save_vecrv_balances(
+            addresses=list(unique_depositors),
+            balances=balances,
+        )
+        return balances
+
+    def _query_and_save_vecrv_balances(
+            self,
+            addresses: list[ChecksumEvmAddress],
+            balances: 'BalancesSheetType',
+    ) -> None:
+        """
+        This logic handles CRV deposits into the escrow contract among
+        the decoded events. It queries `locked` instead of `balanceOf` to get the
+        deposited CRV via multicall.
+        """
+        if len(addresses) == 0:
+            return
+
+        voting_escrow_contract = EvmContract(
+            address=VOTING_ESCROW,
+            abi=VOTE_ESCROW_ABI,
+            deployed_block=0,
+        )
+        try:
+            results = self.evm_inquirer.multicall(
+                calls=[(
+                    voting_escrow_contract.address,
+                    voting_escrow_contract.encode(method_name='locked', arguments=[address]),
+                ) for address in addresses],
+            )
+        except RemoteError as e:
+            log.error(f'Failed to query locked CRV balances via multicall due to {e!s}')
+            return
+
+        price = Inquirer.find_usd_price(A_CRV)
+        for idx, result in enumerate(results):
+            address = addresses[idx]
+            locked_raw = voting_escrow_contract.decode(
+                result=result,
+                method_name='locked',
+                arguments=[address],
+            )[0]
+            try:
+                if (locked_amount := normalized_fval_value_decimals(
+                    amount=locked_raw,
+                    decimals=DEFAULT_TOKEN_DECIMALS,
+                )) == 0:
+                    continue
+            except DeserializationError as e:
+                log.error(f'Failed to decode locked CRV balances via multicall due to {e!s}')
+                return
+
+            balances[address].assets[A_CRV][self.counterparty] += Balance(
+                amount=locked_amount,
+                usd_value=price * locked_amount,
+            )

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -1285,6 +1285,7 @@ class EvmEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
             tx_hashes: list[EVMTxHash] | None = None,
             counterparties: list[str] | None = None,
             addresses: list[ChecksumEvmAddress] | None = None,
+            excluded_addresses: list[ChecksumEvmAddress] | None = None,
     ) -> Self:
         if entry_types is None:
             entry_types = IncludeExcludeFilterData(values=[HistoryBaseEntryType.EVM_EVENT, HistoryBaseEntryType.EVM_SWAP_EVENT])  # noqa: E501
@@ -1329,6 +1330,14 @@ class EvmEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
                 column='address',
                 values=addresses,
                 operator='IN',
+            ))
+
+        if excluded_addresses is not None:
+            filter_query.filters.append(DBMultiStringFilter(
+                and_op=True,
+                column='address',
+                values=excluded_addresses,
+                operator='NOT IN',
             ))
 
         return filter_query


### PR DESCRIPTION
What was happening is that the lock event was being detected along the gauge deposit events and the veCRV token was treated as a gauge. As such we were calling balanceOf in the veCRV and it returns the voting power instead of the total CRV locked.

The new logic excludes the CRV token query from the gauges logic and calls `locked` instead to get the actual CRV in the protocol

## Test intructions

You need an address that locked in the vote escrow contract (`0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2`) and that it didn't do it recently. The bug happened because the votes decrease over time and they don't match balanceOf

Closes #11148
