### PR TITLE
Properly pull all new coinbase events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11149` rotki will now properly pull all new Coinbase events.
 * :bug:`-` Asset selection fields will now properly display ignored assets if they are already selected as the value.
 * :bug:`11113` An invalid Coinbase API key in the DB will no longer prevent logging into the app.
 * :bug:`11108` rotki will now correctly count the number of events allowed for the tier during the PnL report


### PR DESCRIPTION
Closes #11149 

We were skipping the query if the `updated_at` timestamp from coinbase was before the last query ts, but this `updated_at` timestamp doesn't actually get updated for all events. I'm not completely sure when coinbase does update it. The docs don't seem to say. But mine is showing a ts in June and I have several events since then, so it can't be used to check if there are events needing pulled. Changed it to ignore that `updated_at` ts.