### PR TITLE
Fix more nightly tests problems

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -143,12 +143,12 @@ jobs:
 
           if [ "${{ matrix.test-group }}" == 'api' ]
           then
-            uv run pytestgeventwrapper.py "$PYTEST_ARGS" "$COVERAGE_ARGS" rotkehlchen/tests/api
+            uv run pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS rotkehlchen/tests/api
           elif [ "${{ matrix.test-group }}" == 'decoders' ]
           then
-            uv run pytestgeventwrapper.py "$PYTEST_ARGS" "$COVERAGE_ARGS" -n 6 rotkehlchen/tests/unit/decoders rotkehlchen/tests/unit/solana_decoders -v
+            uv run pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS -n 6 rotkehlchen/tests/unit/decoders rotkehlchen/tests/unit/solana_decoders -v
           else
-            uv run pytestgeventwrapper.py "$PYTEST_ARGS" "$COVERAGE_ARGS" --ignore=rotkehlchen/tests/api --ignore=rotkehlchen/tests/unit/decoders --ignore=rotkehlchen/tests/unit/solana_decoders rotkehlchen/tests/
+            uv run pytestgeventwrapper.py $PYTEST_ARGS $COVERAGE_ARGS --ignore=rotkehlchen/tests/api --ignore=rotkehlchen/tests/unit/decoders --ignore=rotkehlchen/tests/unit/solana_decoders rotkehlchen/tests/
           fi
 
           uv run pytestgeventwrapper.py --dead-fixtures

--- a/rotkehlchen/globaldb/asset_updates/manager.py
+++ b/rotkehlchen/globaldb/asset_updates/manager.py
@@ -194,9 +194,12 @@ class AssetsUpdater:
         self.asset_parser = AssetParser()
         self.asset_collection_parser = AssetCollectionParser()
         self.multiasset_mappings_parser = MultiAssetMappingsParser()
-        self.branch = os.getenv('GITHUB_BASE_REF', 'develop')
         if is_production():
             self.branch = 'master'
+        elif (base_ref := os.getenv('GITHUB_BASE_REF', 'develop')) != '':
+            self.branch = base_ref
+        else:  # In the CI when it's not triggered by a PR the base ref is ''
+            self.branch = 'develop'
 
     def _get_remote_info_json(self) -> dict[str, Any]:
         url = f'https://raw.githubusercontent.com/rotki/assets/{self.branch}/updates/info.json'


### PR DESCRIPTION
Fixes two things:

* The `GITHUB_BASE_REF` is `''` in the CI when NOT running from a PR. This was causing the url in the asset updater to be `https://raw.githubusercontent.com/rotki/assets//updates/info.json` (missing the branch). Apparently until recently github was resolving this to the default branch, but that now returns 404. So changed it to default to develop in this case. We already do something similar here: https://github.com/rotki/rotki/blob/develop/rotkehlchen/tests/conftest.py#L401
* The `COVERAGE_ARGS` variable is set to `''` on macos. It was surrounded by quotes in the command and `pytestgeventwrapper.py` interpreted it as an empty path, which caused the actual path that is specified to be ignored and all tests were being run for each test group. Removed the quotes around the variable in the command to fix.

A successful nightlies workflow run using these changes is here: https://github.com/nicholasyoder/rotki/actions/runs/20245793829/job/58128696083