### PR TITLE
Fix issue where misc counterparties were missing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`11149` rotki will now properly pull all new Coinbase events.
 * :bug:`-` Asset selection fields will now properly display ignored assets if they are already selected as the value.
 * :bug:`11113` An invalid Coinbase API key in the DB will no longer prevent logging into the app.
+* :bug:`-` Gas events will be editable again.
 * :bug:`11108` rotki will now correctly count the number of events allowed for the tier during the PnL report
 * :feature:`10832` rotki will now query and store Binance Convert trades.
 * :feature:`11086` rotki will now properly handle Kraken margin profit, loss, fee, and any other so far unsupported event.

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1299,12 +1299,12 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     def get_all_counterparties(self) -> set['CounterpartyDetails']:
         """
         Obtain the set of unique counterparties from the decoders across
-        all EVM chains and Solana.
+        all EVM chains and Solana, including misc entries defined per decoder.
         """
         return reduce(
             operator.or_,
             [
-                self.get_chain_manager(chain).transactions_decoder.rules.all_counterparties  # type: ignore[attr-defined]
+                self.get_chain_manager(chain).transactions_decoder.get_all_counterparties()  # type: ignore[attr-defined]
                 for chain in CHAINS_WITH_TRANSACTION_DECODERS
             ],
         )

--- a/rotkehlchen/chain/decoding/types.py
+++ b/rotkehlchen/chain/decoding/types.py
@@ -1,11 +1,16 @@
-from typing import NamedTuple, Protocol, Self
+from abc import ABC, abstractmethod
+from typing import NamedTuple, Self
 
 
-class SupportsAddition(Protocol):
-    """Protocol for types that support addition with the + operator.
+class DecodingRulesBase(ABC):
+    """Abstract base class for decoding rules that have counterparties and support addition.
     Decoding rules must implement this to allow merging during recursive discovery.
     """
-    def __add__(self, other: Self) -> Self: ...
+    all_counterparties: set['CounterpartyDetails']
+
+    @abstractmethod
+    def __add__(self, other: Self) -> Self:
+        """Merge two decoding rules instances."""
 
 
 def get_versioned_counterparty_label(counterparty: str) -> str:

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_evm_token, get_or_create_evm_token
 from rotkehlchen.chain.decoding.constants import CPT_GAS, MIN_LOGS_PROCESSED_TO_SLEEP
 from rotkehlchen.chain.decoding.decoder import TransactionDecoder
-from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.decoding.types import DecodingRulesBase
 from rotkehlchen.chain.decoding.utils import decode_safely
 from rotkehlchen.chain.ethereum.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
@@ -94,6 +94,7 @@ from .utils import maybe_reshuffle_events
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles, EvmToken
+    from rotkehlchen.chain.decoding.types import CounterpartyDetails
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer, EvmNodeInquirerWithProxies
     from rotkehlchen.chain.evm.transactions import EvmTransactions
     from rotkehlchen.db.dbhandler import DBHandler
@@ -123,7 +124,7 @@ class EventDecoderFunction(Protocol):
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
-class EvmDecodingRules:
+class EvmDecodingRules(DecodingRulesBase):
     address_mappings: dict[ChecksumEvmAddress, tuple[Any, ...]]
     event_rules: list[EventDecoderFunction]
     input_data_rules: dict[bytes, dict[bytes, Callable]]
@@ -173,7 +174,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             transactions: 'EvmTransactions',
             value_asset: 'AssetWithOracles',
             event_rules: list[EventDecoderFunction],
-            misc_counterparties: list[CounterpartyDetails],
+            misc_counterparties: list['CounterpartyDetails'],
             base_tools: 'BaseEvmDecoderTools',
             premium: 'Premium | None' = None,
             dbevmtx_class: type[DBEvmTx] = DBEvmTx,
@@ -1322,7 +1323,7 @@ class EVMTransactionDecoderWithDSProxy(EVMTransactionDecoder, ABC):
             transactions: 'EvmTransactions',
             value_asset: 'AssetWithOracles',
             event_rules: list[EventDecoderFunction],
-            misc_counterparties: list[CounterpartyDetails],
+            misc_counterparties: list['CounterpartyDetails'],
             base_tools: 'BaseEvmDecoderToolsWithProxy',
             beacon_chain: 'BeaconChain | None' = None,
             premium: 'Premium | None' = None,

--- a/rotkehlchen/chain/solana/decoding/decoder.py
+++ b/rotkehlchen/chain/solana/decoding/decoder.py
@@ -7,6 +7,7 @@ from solders.solders import Signature
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_solana_token
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.decoder import TransactionDecoder
+from rotkehlchen.chain.decoding.types import DecodingRulesBase
 from rotkehlchen.chain.decoding.utils import decode_safely
 from rotkehlchen.chain.ethereum.utils import (
     token_normalized_value,
@@ -67,7 +68,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 @dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=True)
-class SolanaDecodingRules:
+class SolanaDecodingRules(DecodingRulesBase):
     address_mappings: dict[SolanaAddress, tuple[Any, ...]]
     all_counterparties: set['CounterpartyDetails']
 

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.constants import ETHEREUM_ETHERSCAN_NODE_NAME
 from rotkehlchen.chain.evm.types import NodeName
 from rotkehlchen.constants.misc import DEFAULT_MAX_LOG_BACKUP_FILES, DEFAULT_SQL_VM_INSTRUCTIONS_CB
@@ -491,11 +492,12 @@ def test_counterparties(rotkehlchen_api_server_with_exchanges: 'APIServer') -> N
         ),
     )
     result = assert_proper_sync_response_with_result(response)
+    assert any(counterparty_details['identifier'] == CPT_GAS for counterparty_details in result)
     for counterparty_details in result:
         assert 'identifier' in counterparty_details
         assert 'label' in counterparty_details
         assert 'icon' in counterparty_details or 'image' in counterparty_details
-        if counterparty_details['identifier'] == 'gas':
+        if counterparty_details['identifier'] == CPT_GAS:
             assert counterparty_details['icon'] == 'lu-flame'
         elif counterparty_details['identifier'] == 'jupiter':
             assert counterparty_details['label'] == 'Jupiter'


### PR DESCRIPTION
The CPT_GAS is present in the misc counterparties for the evm decoders and it wasn't being propagated to the frontend. The side effect is that gas events couldn't be edited

## How to test

Editing a gas event should be possible 


