### PR TITLE
Fix reset assets API endpoint return

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -1649,7 +1649,7 @@ class RestAPI:
 
         if success:
             AssetResolver.clean_memory_cache()  # clean the cache after deleting any possible asset
-            return _wrap_in_ok_result(OK_RESULT)
+            return OK_RESULT
         return wrap_in_fail_result(msg, status_code=HTTPStatus.CONFLICT)
 
     def query_netvalue_data(self, include_nfts: bool) -> Response:

--- a/rotkehlchen/tests/api/test_assets_updates.py
+++ b/rotkehlchen/tests/api/test_assets_updates.py
@@ -944,7 +944,7 @@ def test_async_db_reset(rotkehlchen_api_server: 'APIServer') -> None:
         rotkehlchen_api_server,
         task_id,
     )
-    assert outcome['result']['result'] is True
+    assert outcome['result'] is True
     assert outcome['message'] == ''
 
     with pytest.raises(UnknownAsset):


### PR DESCRIPTION
We were doing a double wrapping of the OK_RESULT.

I am not sure if frontend will need adjustment but looking at its code
and asking codex seems to say it was in fact ignored:

```
frontend/app/src/composables/assets/index.ts:179-205 is the sole consumer of the rebuild endpoint. It calls restoreAssetsDatabaseCaller (which just launches the async task) and then awaits the task via awaitTask<boolean, TaskMeta>(…), but it never reads the returnedvalue—it only cares that the task completes without throwing. So even though the task result currently comes back as a nested {result: {…}}, that value is ignored in practice.
```