### PR TITLE
fix(colibri): correct misleading comments

### DIFF
--- a/colibri/src/api/database.rs
+++ b/colibri/src/api/database.rs
@@ -94,7 +94,6 @@ pub async fn logout_user(State(state): State<Arc<AppState>>) -> impl IntoRespons
 
     // Explicitly close the SQLite connection if available, then drop the handle
     if let Some(client) = &db.client {
-        // If the client exposes a close method (rusqlite-backed), call it
         std::mem::drop(client.close());
     }
     db.client = None;

--- a/colibri/src/main.rs
+++ b/colibri/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .collect();
 
-    // configure cors to allow only requests from the localhost
+    // configure cors to allow only requests matching the configured glob patterns
     let cors_layer = CorsLayer::new()
         .allow_origin(AllowOrigin::predicate(
             move |origin: &HeaderValue, _request_parts: &RequestParts| {


### PR DESCRIPTION
 Fix CORS comment that incorrectly stated "only localhost" when it actually uses configurable glob patterns
 Remove misleading conditional comment in logout_user that implied optional behavior for unconditional code