### PR TITLE
chore(ci): upgrade custom GitHub actions to latest versions

### DIFF
--- a/.github/workflows/rotki_cassette_merge.yml
+++ b/.github/workflows/rotki_cassette_merge.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'rotki/rotki' }}
     environment: cassette-merge
     steps:
-      - uses: rotki/action-cassette-deck@v2
+      - uses: rotki/action-cassette-deck@v3
         with:
           token: ${{ secrets.MERGE_TOKEN }}
           cassette_repo: test-caching

--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Run check action
-        uses: rotki/action-job-checker@v3
+        uses: rotki/action-job-checker@v4
         id: checker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -166,7 +166,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -262,7 +262,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -113,7 +113,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -195,7 +195,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -219,7 +219,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -350,7 +350,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/rotki_sqldiff.yml
+++ b/.github/workflows/rotki_sqldiff.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: SQLDiff action
         id: sql-diff
-        uses: rotki/action-sqldiff@v1
+        uses: rotki/action-sqldiff@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           files: '*.db'

--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -78,7 +78,7 @@ jobs:
           echo "VCR setup: $SOURCE_BRANCH not fully rebased on $TARGET_BRANCH" && exit 1
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 
@@ -116,7 +116,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_fe_external_links_verification.yml
+++ b/.github/workflows/task_fe_external_links_verification.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_fe_unit_tests.yml
+++ b/.github/workflows/task_fe_unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v3
         with:
           env_file: .github/.env.ci
 


### PR DESCRIPTION
All our internal actions have been updated and upgraded to use node24 now that it's supported

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
