### PR TITLE
Reload exchanges after removing keys in migration

### DIFF
--- a/rotkehlchen/tests/data_migrations/test_migration_22.py
+++ b/rotkehlchen/tests/data_migrations/test_migration_22.py
@@ -1,8 +1,12 @@
 import uuid
+from unittest.mock import patch
 
 import pytest
 
 from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.tests.data_migrations.test_migrations import (
+    MockRotkiForMigrationsWithExchangeManager,
+)
 from rotkehlchen.tests.utils.data_migrations import run_single_migration
 from rotkehlchen.types import Location
 
@@ -16,12 +20,18 @@ def test_migration_22_remove_coinbase_legacy_keys(database: DBHandler) -> None:
     with database.user_write() as write_cursor:
         write_cursor.executemany(
             'INSERT INTO user_credentials (name, location, api_key, api_secret, passphrase) VALUES (?, ?, ?, ?, ?)',  # noqa: E501
-            [('Coinbase 1', Location.COINBASE.serialize_for_db(), 'BADKEY', None, None),
-            ('Coinbase 2', Location.COINBASE.serialize_for_db(), str(uuid.uuid4()), None, None),
-            ('Coinbase 3', Location.COINBASE.serialize_for_db(), f'organizations/{uuid.uuid4()!s}/apiKeys/{uuid.uuid4()!s}', None, None)],  # noqa: E501
+            [('Coinbase 1', Location.COINBASE.serialize_for_db(), 'BADKEY', '', None),
+            ('Coinbase 2', Location.COINBASE.serialize_for_db(), str(uuid.uuid4()), '', None),
+            ('Coinbase 3', Location.COINBASE.serialize_for_db(), f'organizations/{uuid.uuid4()!s}/apiKeys/{uuid.uuid4()!s}', '', None)],  # noqa: E501
         )
 
-    run_single_migration(database=database, migration=22)
+    with (patch(
+        target='rotkehlchen.tests.utils.data_migrations.MockRotkiForMigrations',
+        new=MockRotkiForMigrationsWithExchangeManager,
+    )):
+        rotki = run_single_migration(database=database, migration=22)
+
+    assert [x.name for x in rotki.exchange_manager.connected_exchanges[Location.COINBASE]] == ['Coinbase 2', 'Coinbase 3']  # noqa: E501
     with database.conn.read_ctx() as cursor:
         result = cursor.execute('SELECT name FROM user_credentials').fetchall()
         assert result == [('Coinbase 2',), ('Coinbase 3',)]

--- a/rotkehlchen/tests/utils/data_migrations.py
+++ b/rotkehlchen/tests/utils/data_migrations.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-def run_single_migration(database: 'DBHandler', migration: int) -> None:
+def run_single_migration(database: 'DBHandler', migration: int) -> MockRotkiForMigrations:
     """Helper function to run a single migration in the migration tests."""
     migration_record = None
     for record in MIGRATION_LIST:
@@ -21,4 +21,6 @@ def run_single_migration(database: 'DBHandler', migration: int) -> None:
         target='rotkehlchen.data_migrations.manager.MIGRATION_LIST',
         new=[migration_record],
     ):
-        DataMigrationManager(MockRotkiForMigrations(database)).maybe_migrate_data()
+        DataMigrationManager(rotki := MockRotkiForMigrations(database)).maybe_migrate_data()
+
+    return rotki


### PR DESCRIPTION
Fixes something I noticed where a coinbase exchange with legacy keys was still present (in the app not actually in the DB) after the migration until logging in a second time.

Also fixes the nitpicks from https://github.com/rotki/rotki/pull/11165