### PR TITLE
Skip querying Binance US convert events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Changelog
 * :bug:`11113` An invalid Coinbase API key in the DB will no longer prevent logging into the app.
 * :bug:`-` Gas events will be editable again.
 * :bug:`11108` rotki will now correctly count the number of events allowed for the tier during the PnL report
-* :feature:`10832` rotki will now query and store Binance Convert trades.
+* :feature:`10832` rotki will now query and store Binance Convert trades (not supported for Binance US).
 * :feature:`11086` rotki will now properly handle Kraken margin profit, loss, fee, and any other so far unsupported event.
 * :bug:`11084` Indexer related backend query task will no longer randomly die.
 * :bug:`11094` rotki should now process correctly all the RPCs responses from Binance SC nodes.

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -1328,6 +1328,9 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
         """Query Binance Convert trades using the convert/tradeFlow endpoint.
         Docs: https://developers.binance.com/docs/convert/trade/Get-Convert-Trade-History
         """
+        if self.location == Location.BINANCEUS:
+            return []  # Binance US does not support the convert API endpoint as of 2025-12-17
+
         convert_trades = self._api_query_list_within_time_delta(
             start_ts=start_ts,
             end_ts=end_ts,


### PR DESCRIPTION
Skips trying to query convert history for binance US since it was failing with a 404. I checked the binance US docs and there is no mention of the `convert/tradeFlow` endpoint. I also spoke with binance support and they confirmed that this is unavailable in the Binance US api, despite the Binance US app having this feature. There simply is no way to query it via the API currently, and they didn't make it sound like its going to get added any time soon either unfortunately.
