### PR TITLE
Fix process_result() tuple serialization

### DIFF
--- a/rotkehlchen/serialization/serialize.py
+++ b/rotkehlchen/serialization/serialize.py
@@ -145,7 +145,7 @@ def _process_entry(entry: Any) -> str | (list[Any] | (dict[str, Any] | Any)):
     )):
         return process_result(entry._asdict())
     if isinstance(entry, tuple):
-        return list(entry)
+        return [_process_entry(x) for x in entry]
     if isinstance(entry, Asset):
         return entry.identifier
     if isinstance(entry, (

--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -12,6 +12,7 @@ from eth_utils import to_checksum_address
 from hexbytes import HexBytes
 from packaging.version import Version
 
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.ethereum.utils import generate_address_via_create2
 from rotkehlchen.constants.assets import A_USDC
 from rotkehlchen.constants.resolver import identifier_to_evm_address
@@ -56,6 +57,34 @@ def test_process_result():
         json.dumps(d)
 
     json.dumps(process_result(d))
+
+
+def test_process_result_recursively_processes_tuples():
+    nested_tuple = {
+        'tuple': (
+            FVal('1.5'),
+            {
+                'nested': (
+                    FVal('3.2'),
+                    Asset('ETH'),
+                ),
+            },
+        ),
+    }
+
+    processed = process_result(nested_tuple)
+    assert processed == {
+        'tuple': [
+            '1.5',
+            {
+                'nested': [
+                    '3.2',
+                    'ETH',
+                ],
+            },
+        ],
+    }
+    json.dumps(processed)
 
 
 def test_hexbytes_in_process_result():


### PR DESCRIPTION
The tuple serialization at process_result just turned them into a list. Which would explode in our faces with type errors if any non primitive type was in there and we tried to export via API.

This never hit us so far since in all the places where tuples are exported we convert them manually.

But that's a footgun we should fix.

(Both claude and codex warn about this)

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
