### PR TITLE
Send WS message with unmatched asset movement count

### DIFF
--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -673,3 +673,18 @@ Sent when the premium subscription status changes, such as activation, deactivat
 - ``expired``: Whether the premium subscription has expired
 - ``reason``: Only included when device limit is exceeded. Contains the device limit error message.
 
+
+Unmatched Asset Movements
+=================================
+
+Sent when the periodic event processing task is unable to find corresponding events for some asset movements.
+
+::
+
+    {
+        "type": "unmatched_asset_movements",
+        "data": {"count": 2}
+    }
+
+
+- ``count``: Total number of asset movements that could not be matched.

--- a/rotkehlchen/api/websockets/typedefs.py
+++ b/rotkehlchen/api/websockets/typedefs.py
@@ -31,6 +31,7 @@ class WSMessageType(StrEnum):
     SOLANA_TOKENS_MIGRATION = auto()
     DATABASE_UPLOAD_PROGRESS = auto()
     BINANCE_PAIRS_MISSING = auto()
+    UNMATCHED_ASSET_MOVEMENTS = auto()
 
 
 class ProgressUpdateSubType(StrEnum):


### PR DESCRIPTION
Related #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

Adds a ws message to notify the frontend when some asset movements can't be automatically matched as discussed in [discord](https://discord.com/channels/657906918408585217/1448435340615618622/1448435346818732032)