### PR TITLE
fix coverage upload

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -169,3 +169,4 @@ jobs:
         with:
           name: coverage-${{ inputs.os }}-${{ matrix.test-group }}
           path: .coverage.${{ matrix.test-group }}
+          include-hidden-files: true


### PR DESCRIPTION
`upload-artifact@v4` excludes hidden files by default so they were silently skipped. see https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs

workflow is being run: https://github.com/prettyirrelevant/rotki/actions/runs/20431127586