### PR TITLE
feat(11198): show mcc icons for gnosis pay transactions

### DIFF
--- a/frontend/app/src/components/common/MerchantIcon.vue
+++ b/frontend/app/src/components/common/MerchantIcon.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { RuiIcons } from '@rotki/ui-library';
+
+const props = defineProps<{
+  code: string;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const mccIconMap: Record<string, RuiIcons> = {
+  4121: 'lu-car', // Taxicabs and Rideshares
+  5200: 'lu-hammer', // Home Supply Warehouse Stores
+  5310: 'lu-percent', // Discount Stores
+  5311: 'lu-store', // Department Stores
+  5331: 'lu-coins', // Variety Stores (Dollar Stores)
+  5411: 'lu-shopping-cart', // Grocery Stores, Supermarkets
+  5462: 'lu-croissant', // Bakeries
+  5541: 'lu-fuel', // Service Stations (Gas Stations)
+  5621: 'lu-shopping-bag', // Women's Ready-to-Wear Stores
+  5651: 'lu-users', // Family Clothing Stores
+  5691: 'lu-shirt', // Clothing Stores
+  5732: 'lu-smartphone', // Electronics Stores
+  5812: 'lu-utensils', // Eating Places, Restaurants
+  5813: 'lu-wine', // Bars, Cocktail Lounges, Taverns
+  5814: 'lu-hamburger', // Fast Food Restaurants
+  5912: 'lu-pill', // Drug Stores, Pharmacies
+  5942: 'lu-book-open', // Book Stores
+  5977: 'lu-sparkles', // Cosmetic Stores
+  5999: 'lu-shopping-bag', // Miscellaneous Retail Stores
+  7011: 'lu-bed', // Hotels, Motels, Resorts
+};
+
+const DEFAULT_ICON = 'lu-store';
+
+const iconName = computed<string>(() => mccIconMap[props.code] ?? DEFAULT_ICON);
+</script>
+
+<template>
+  <RuiTooltip
+    :popper="{ placement: 'top' }"
+    :open-delay="400"
+  >
+    <template #activator>
+      <span class="size-5 inline-flex items-center justify-center rounded-full bg-rui-primary text-white transform translate-y-0.5">
+        <RuiIcon
+          v-if="code"
+          :name="iconName"
+          size="14"
+          class="inline"
+        />
+      </span>
+    </template>
+    {{ t('transactions.events.note.merchant_code', { code }) }}
+  </RuiTooltip>
+</template>

--- a/frontend/app/src/components/history/events/HistoryEventNote.vue
+++ b/frontend/app/src/components/history/events/HistoryEventNote.vue
@@ -2,6 +2,7 @@
 import type { ExplorerUrls } from '@/types/asset/asset-urls';
 import { type BigNumber, Blockchain } from '@rotki/common';
 import Flag from '@/components/common/Flag.vue';
+import MerchantIcon from '@/components/common/MerchantIcon.vue';
 import AmountDisplay from '@/components/display/amount/AmountDisplay.vue';
 import ExternalLink from '@/components/helper/ExternalLink.vue';
 import { type NoteFormat, NoteType, useHistoryEventNote } from '@/composables/history/events/notes';
@@ -71,6 +72,12 @@ function isLinkTypeWithoutImage(t: any, chain: string): t is keyof ExplorerUrls 
         <Flag
           :iso="note.countryCode"
           class="mx-1"
+        />
+      </template>
+      <template v-else-if="note.type === NoteType.MERCHANT_CODE && note.merchantCode">
+        <MerchantIcon
+          :code="note.merchantCode"
+          class="mx-0.5"
         />
       </template>
       <template v-else-if="note.type === NoteType.WORD && note.word">

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5190,6 +5190,9 @@
       },
       "loading": "Loading events...",
       "no_data": "Events are hidden because they contain ignored assets",
+      "note": {
+        "merchant_code": "Merchant Code: {code}"
+      },
       "selection_mode": {
         "create_rule": "Set custom accounting rule",
         "delete_selected": "Delete selected events",

--- a/frontend/app/tests/unit/specs/composables/history/notes.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/notes.spec.ts
@@ -527,4 +527,81 @@ describe('composables::history/notes', () => {
 
     expect(formatted).toMatchObject(expected);
   });
+
+  it('should handle country flag for gnosis pay event notes', () => {
+    const notes = 'Pay 8.5 EUR to Lidl in Berlin :country:DE:';
+
+    const formatted = get(formatNotes({ notes, counterparty: 'gnosis_pay' }));
+
+    const expected: NoteFormat[] = [
+      {
+        type: NoteType.WORD,
+        word: 'Pay',
+      },
+      {
+        type: NoteType.AMOUNT,
+        amount: bigNumberify(8.5),
+      },
+      {
+        type: NoteType.WORD,
+        word: 'EUR to Lidl in Berlin',
+      },
+      {
+        type: NoteType.FLAG,
+        countryCode: 'de',
+      },
+    ];
+
+    expect(formatted).toMatchObject(expected);
+  });
+
+  it('should handle merchant code for gnosis pay event notes', () => {
+    const notes = 'Pay 8.5 EUR to :merchant_code:5411: Lidl in Berlin :country:DE:';
+
+    const formatted = get(formatNotes({ notes, counterparty: 'gnosis_pay' }));
+
+    const expected: NoteFormat[] = [
+      {
+        type: NoteType.WORD,
+        word: 'Pay',
+      },
+      {
+        type: NoteType.AMOUNT,
+        amount: bigNumberify(8.5),
+      },
+      {
+        type: NoteType.WORD,
+        word: 'EUR to',
+      },
+      {
+        type: NoteType.MERCHANT_CODE,
+        merchantCode: '5411',
+      },
+      {
+        type: NoteType.WORD,
+        word: 'Lidl in Berlin',
+      },
+      {
+        type: NoteType.FLAG,
+        countryCode: 'de',
+      },
+    ];
+
+    expect(formatted).toMatchObject(expected);
+  });
+
+  it('should not handle country flag or merchant code for non-gnosis_pay counterparty', () => {
+    const notes = 'Pay 8.5 EUR to :merchant_code:5411: Lidl in Berlin :country:DE:';
+
+    const formatted = get(formatNotes({ notes, counterparty: 'other' }));
+
+    const expected: NoteFormat[] = [
+      {
+        type: NoteType.WORD,
+        word: 'Pay 8.5 EUR to :merchant_code:5411: Lidl in Berlin :country:DE:',
+      },
+    ];
+
+    expect(formatted).toMatchObject(expected);
+  });
 });

--- a/rotkehlchen/externalapis/gnosispay.py
+++ b/rotkehlchen/externalapis/gnosispay.py
@@ -447,7 +447,7 @@ class GnosisPay:
             if transaction.billing_symbol:
                 notes += f' ({transaction.billing_amount} {transaction.billing_symbol})'
 
-        notes += f' {preposition} {transaction.merchant_name}'
+        notes += f' {preposition} :merchant_code:{transaction.mcc}: {transaction.merchant_name}'
         if transaction.merchant_city:
             notes += f' in {transaction.merchant_city}'
 

--- a/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
+++ b/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
@@ -198,7 +198,7 @@ def test_gnosis_pay_spend(gnosis_inquirer, gnosis_accounts, rotki_premium_object
         )
 
         expected_events[0].identifier = 1
-        expected_events[0].notes = 'Pay 8.5 EUR to Lidl sagt Danke in Berlin :country:DE:'
+        expected_events[0].notes = 'Pay 8.5 EUR to :merchant_code:5411: Lidl sagt Danke in Berlin :country:DE:'  # noqa: E501
     assert refreshed_events == expected_events
 
 
@@ -259,7 +259,7 @@ def test_gnosis_pay_refund(gnosis_inquirer, gnosis_accounts):
     with patch.object(gnosis_txs_decoder, 'reload_data', lambda x: None):
         events = gnosis_txs_decoder.decode_and_get_transaction_hashes(ignore_cache=True, tx_hashes=[tx_hash])  # noqa: E501
 
-    expected_events[0].notes = 'Receive refund of 2.35 EUR from Acme Inc. in Sevilla :country:ES:'
+    expected_events[0].notes = 'Receive refund of 2.35 EUR from :merchant_code:6666: Acme Inc. in Sevilla :country:ES:'  # noqa: E501
     assert events == expected_events
 
 
@@ -269,7 +269,7 @@ def test_gnosis_pay_refund(gnosis_inquirer, gnosis_accounts):
 @pytest.mark.freeze_time('2023-11-14 22:30:00 GMT')
 def test_backfill_missing_gnosis_pay_events(gnosis_inquirer, gnosis_accounts):
     tx_hash, second_tx_hash = make_evm_tx_hash(), make_evm_tx_hash()
-    second_note = 'Pay 1.4 EUR to AUTOPISTA R4 SEITT -2 in MADRID :country:ES:'
+    second_note = 'Pay 1.4 EUR to :merchant_code:4784: AUTOPISTA R4 SEITT -2 in MADRID :country:ES:'  # noqa: E501
     gnosis_transactions = GnosisTransactions(
         gnosis_inquirer=gnosis_inquirer,
         database=gnosis_inquirer.database,


### PR DESCRIPTION
Closes #11198

<img width="755" height="177" alt="image" src="https://github.com/user-attachments/assets/e0810e80-6c9d-4280-9e19-d135a97621ff" />
