### PR TITLE
fix: remove outdated docstring for on_account_addition

### DIFF
--- a/rotkehlchen/utils/interfaces.py
+++ b/rotkehlchen/utils/interfaces.py
@@ -32,10 +32,7 @@ class EthereumModule(ABC):
 
     @abstractmethod
     def on_account_addition(self, address: ChecksumEvmAddress) -> None:
-        """Actions to run on new ethereum account additions
-
-        Can optionally return a list of asset balances determined by the module
-        """
+        """Actions to run on new ethereum account additions"""
 
     @abstractmethod
     def on_account_removal(self, address: ChecksumEvmAddress) -> None:


### PR DESCRIPTION
The docstring for EthereumModule.on_account_addition claimed the method could "optionally return a list of asset balances" but the signature was changed to return None back in commit 485077eef (Aug 2022). The comment was simply forgotten during that refactor. Removed the stale part of the docstring to match the actual method signature.