### PR TITLE
Use all indexers for rpc method calls

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/node_inquirer.py
+++ b/rotkehlchen/chain/arbitrum_one/node_inquirer.py
@@ -6,7 +6,7 @@ from web3.types import BlockIdentifier
 
 from rotkehlchen.chain.constants import DEFAULT_RPC_TIMEOUT
 from rotkehlchen.chain.ethereum.constants import (
-    ETHEREUM_ETHERSCAN_NODE,
+    EVM_INDEXERS_NODE,
 )
 from rotkehlchen.chain.ethereum.utils import MULTICALL_CHUNKS
 from rotkehlchen.chain.evm.constants import BALANCE_SCANNER_ADDRESS
@@ -94,7 +94,7 @@ class ArbitrumOneInquirer(EvmNodeInquirer):
             return super().multicall(
                 calls=calls,
                 require_success=require_success,
-                call_order=[node for node in call_order if node != ETHEREUM_ETHERSCAN_NODE],
+                call_order=[node for node in call_order if node != EVM_INDEXERS_NODE],
                 block_identifier=block_identifier,
                 calls_chunk_size=calls_chunk_size,
             )
@@ -102,7 +102,7 @@ class ArbitrumOneInquirer(EvmNodeInquirer):
             return super().multicall(
                 calls=calls,
                 require_success=require_success,
-                call_order=[ETHEREUM_ETHERSCAN_NODE],
+                call_order=[EVM_INDEXERS_NODE],
                 block_identifier=block_identifier,
                 calls_chunk_size=3,
             )

--- a/rotkehlchen/chain/ethereum/constants.py
+++ b/rotkehlchen/chain/ethereum/constants.py
@@ -5,7 +5,7 @@ from rotkehlchen.constants import ONE
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import SupportedBlockchain, Timestamp, deserialize_evm_tx_hash
 
-ETHEREUM_ETHERSCAN_NODE_NAME: Final = 'etherscan'
+EVM_INDEXERS_NODE_NAME: Final = 'indexers'
 
 ETH2_DEPOSIT_ADDRESS: Final = string_to_evm_address('0x00000000219ab540356cBB839Cbe05303d7705Fa')
 ETHEREUM_GENESIS: Final = Timestamp(1438269973)
@@ -14,9 +14,9 @@ CPT_KRAKEN: Final = 'kraken'
 CPT_POLONIEX: Final = 'poloniex'
 CPT_UPHOLD: Final = 'uphold'
 
-ETHEREUM_ETHERSCAN_NODE: Final = WeightedNode(
+EVM_INDEXERS_NODE: Final = WeightedNode(
     node_info=NodeName(
-        name=ETHEREUM_ETHERSCAN_NODE_NAME,
+        name=EVM_INDEXERS_NODE_NAME,
         endpoint='',
         owned=False,
         blockchain=SupportedBlockchain.ETHEREUM,

--- a/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/utils.py
@@ -39,7 +39,7 @@ def uniswap_lp_token_balances(
         call_order = [WeightedNode(node_info=own_node_info, weight=ONE, active=True)]
     else:
         chunks = list(get_chunks(lp_addresses, n=700))
-        call_order = ethereum.default_call_order(skip_etherscan=True)
+        call_order = ethereum.default_call_order(skip_indexers=True)
 
     balances = []
     for chunk in chunks:

--- a/rotkehlchen/chain/evm/active_management/manager.py
+++ b/rotkehlchen/chain/evm/active_management/manager.py
@@ -63,7 +63,7 @@ class ActiveManager:
         """
         return self.node_inquirer._query(
             method=self._create_token_transfer,
-            call_order=self.node_inquirer.default_call_order(skip_etherscan=True),
+            call_order=self.node_inquirer.default_call_order(skip_indexers=True),
             from_address=from_address,
             to_address=to_address,
             token=token,
@@ -99,7 +99,7 @@ class ActiveManager:
         """
         return self.node_inquirer._query(
             method=self._transfer_native_token,
-            call_order=self.node_inquirer.default_call_order(skip_etherscan=True),
+            call_order=self.node_inquirer.default_call_order(skip_indexers=True),
             from_address=from_address,
             to_address=to_address,
             amount=amount,

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -138,10 +138,10 @@ def get_chunk_size_call_order(
     """
     if evm_inquirer.connected_to_any_node():
         chunk_size = web3_node_chunk_size
-        call_order = evm_inquirer.default_call_order(skip_etherscan=True)
+        call_order = evm_inquirer.default_call_order(skip_indexers=True)
     else:
         chunk_size = etherscan_chunk_size if evm_inquirer.chain_id != ChainID.ARBITRUM_ONE else arbiscan_chunksize  # noqa: E501
-        call_order = [evm_inquirer.etherscan_node]
+        call_order = [evm_inquirer.indexers_node]
 
     return chunk_size, call_order
 

--- a/rotkehlchen/chain/mixins/rpc_nodes.py
+++ b/rotkehlchen/chain/mixins/rpc_nodes.py
@@ -18,7 +18,7 @@ from web3 import HTTPProvider, Web3
 from web3.exceptions import Web3Exception
 from web3.middleware import ExtraDataToPOAMiddleware
 
-from rotkehlchen.chain.ethereum.constants import ETHEREUM_ETHERSCAN_NODE
+from rotkehlchen.chain.ethereum.constants import EVM_INDEXERS_NODE
 from rotkehlchen.chain.evm.types import NodeName, WeightedNode
 from rotkehlchen.chain.solana.constants import SOLANA_GENESIS_BLOCK_HASH
 from rotkehlchen.constants.misc import ONE
@@ -191,7 +191,7 @@ class EVMRPCMixin(RPCManagerMixin['Web3']):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.etherscan_node = ETHEREUM_ETHERSCAN_NODE
+        self.indexers_node = EVM_INDEXERS_NODE
 
     def determine_capabilities(self, web3: Web3) -> tuple[bool, bool]:
         """This method checks for the capabilities of an rpc node. This includes:
@@ -336,18 +336,18 @@ class EVMRPCMixin(RPCManagerMixin['Web3']):
         log.warning(message)
         return False, message
 
-    def default_call_order(self, skip_etherscan: bool = False) -> list['WeightedNode']:
+    def default_call_order(self, skip_indexers: bool = False) -> list['WeightedNode']:
         """Default call order for evm nodes
 
         Own node always has preference. Then all other node types are randomly queried
         in sequence depending on a weighted probability.
 
-        If skip_etherscan is set to True then etherscan is not included in the list of
+        If skip_indexers is set to True then the indexers are not included in the list of
         nodes to query.
         """
         ordered_list = super().default_call_order()
-        if not skip_etherscan:  # explicitly adding at the end to minimize etherscan API queries
-            ordered_list.append(self.etherscan_node)
+        if not skip_indexers:  # explicitly adding at the end to minimize indexer API queries
+            ordered_list.append(self.indexers_node)
 
         return ordered_list
 

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -27,7 +27,7 @@ from rotkehlchen.types import (
     ExternalService,
     Timestamp,
 )
-from rotkehlchen.utils.misc import from_gwei, hexstr_to_int, ts_sec_to_ms
+from rotkehlchen.utils.misc import from_gwei, ts_sec_to_ms
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -139,114 +139,6 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
 
         # else
         raise RemoteError(f'{chain_id} {self.name} returned error response: {json_ret}')
-
-    def get_latest_block_number(self, chain_id: SUPPORTED_CHAIN_IDS) -> int:
-        """Gets the latest block number
-
-        May raise:
-        - RemoteError due to self._query().
-        """
-        result = self._query(
-            chain_id=chain_id,
-            module='proxy',
-            action='eth_blockNumber',
-        )
-        return int(result, 16)
-
-    def get_block_by_number(
-            self,
-            chain_id: SUPPORTED_CHAIN_IDS,
-            block_number: int,
-    ) -> dict[str, Any]:
-        """
-        Gets a block object by block number
-
-        May raise:
-        - RemoteError due to self._query().
-        """
-        options = {'tag': hex(block_number), 'boolean': 'true'}
-        block_data = self._query(
-            chain_id=chain_id,
-            module='proxy',
-            action='eth_getBlockByNumber',
-            options=options,
-        )
-        # We need to convert some data from hex here
-        # https://github.com/PyCQA/pylint/issues/4739
-        block_data['timestamp'] = hexstr_to_int(block_data['timestamp'])
-        block_data['number'] = hexstr_to_int(block_data['number'])
-
-        return block_data
-
-    def get_transaction_by_hash(
-            self,
-            chain_id: SUPPORTED_CHAIN_IDS,
-            tx_hash: EVMTxHash,
-    ) -> dict[str, Any] | None:
-        """
-        Gets a transaction object by hash
-
-        May raise:
-        - RemoteError due to self._query().
-        """
-        options = {'txhash': str(tx_hash)}
-        return self._query(
-            chain_id=chain_id,
-            module='proxy',
-            action='eth_getTransactionByHash',
-            options=options,
-        )
-
-    def get_code(self, chain_id: SUPPORTED_CHAIN_IDS, account: ChecksumEvmAddress) -> str:
-        """Gets the deployment bytecode at the given address
-
-        May raise:
-        - RemoteError if there are any problems with reaching Etherscan or if
-        an unexpected response is returned
-        """
-        return self._query(
-            chain_id=chain_id,
-            module='proxy',
-            action='eth_getCode',
-            options={'address': account},
-        )
-
-    def get_transaction_receipt(
-            self,
-            chain_id: SUPPORTED_CHAIN_IDS,
-            tx_hash: EVMTxHash,
-    ) -> dict[str, Any] | None:
-        """Gets the receipt for the given transaction hash
-
-        May raise:
-        - RemoteError due to self._query().
-        """
-        return self._query(
-            chain_id=chain_id,
-            module='proxy',
-            action='eth_getTransactionReceipt',
-            options={'txhash': str(tx_hash)},
-        )
-
-    def eth_call(
-            self,
-            chain_id: SUPPORTED_CHAIN_IDS,
-            to_address: ChecksumEvmAddress,
-            input_data: str,
-    ) -> str:
-        """Performs an eth_call on the given address and the given input data.
-
-        May raise:
-        - RemoteError if there are any problems with reaching Etherscan or if
-        an unexpected response is returned
-        """
-        options = {'to': to_address, 'data': input_data}
-        return self._query(
-            chain_id=chain_id,
-            module='proxy',
-            action='eth_call',
-            options=options,
-        )
 
     def get_logs(
             self,

--- a/rotkehlchen/tests/api/blockchain/test_evm.py
+++ b/rotkehlchen/tests/api/blockchain/test_evm.py
@@ -13,7 +13,7 @@ from eth_utils import to_checksum_address
 from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.chain.evm.structures import EvmTxReceipt
 from rotkehlchen.chain.evm.transactions import EvmTransaction
-from rotkehlchen.chain.evm.types import EvmIndexer, string_to_evm_address
+from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ZERO
 from rotkehlchen.constants.assets import A_AVAX, A_ETH
 from rotkehlchen.db.addressbook import DBAddressbook
@@ -400,7 +400,6 @@ def test_add_multievm_accounts(rotkehlchen_api_server: 'APIServer') -> None:
 @pytest.mark.vcr(filter_query_parameters=['apikey'], allow_playback_repeats=True)
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
-@pytest.mark.parametrize('db_settings', [{'default_evm_indexer_order': [EvmIndexer.BLOCKSCOUT]}])
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])
 def test_detect_evm_accounts(
         rotkehlchen_api_server: 'APIServer',
@@ -411,7 +410,8 @@ def test_detect_evm_accounts(
     Test that the endpoint to detect new evm addresses works properly
     and sends the ws messages
 
-    The given account is everywhere.
+    The given account is everywhere. Note that it's not detected in BSC since none of the indexers
+    support that chain with a free API key as of 2025-12-22.
     """
     response = requests.post(api_url_for(
         rotkehlchen_api_server,
@@ -429,7 +429,6 @@ def test_detect_evm_accounts(
         {'chain': SupportedBlockchain.BASE.serialize(), 'address': ethereum_accounts[0]},
         {'chain': SupportedBlockchain.GNOSIS.serialize(), 'address': ethereum_accounts[0]},
         {'chain': SupportedBlockchain.SCROLL.serialize(), 'address': ethereum_accounts[0]},
-        {'chain': SupportedBlockchain.BINANCE_SC.serialize(), 'address': ethereum_accounts[0]},
         {'chain': SupportedBlockchain.ZKSYNC_LITE.serialize(), 'address': ethereum_accounts[0]},
         {'chain': SupportedBlockchain.AVALANCHE.serialize(), 'address': ethereum_accounts[0]},
     ], key=operator.itemgetter('chain', 'address'))
@@ -444,7 +443,6 @@ def test_detect_evm_accounts(
     assert ethereum_accounts[0] in blockchain_accounts.base
     assert ethereum_accounts[0] in blockchain_accounts.gnosis
     assert ethereum_accounts[0] in blockchain_accounts.scroll
-    assert ethereum_accounts[0] in blockchain_accounts.binance_sc
     assert ethereum_accounts[0] in blockchain_accounts.zksync_lite
     assert ethereum_accounts[0] in blockchain_accounts.avax
 

--- a/rotkehlchen/tests/api/blockchain/test_optimism.py
+++ b/rotkehlchen/tests/api/blockchain/test_optimism.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 TEST_ADDY = '0x9531C059098e3d194fF87FebB587aB07B30B1306'
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'], match_on=['uri', 'method', 'raw_body'], allow_playback_repeats=True)  # noqa: E501
+@pytest.mark.vcr(filter_query_parameters=['apikey'], allow_playback_repeats=True)
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('network_mocking', [False])
 def test_add_optimism_blockchain_account(rotkehlchen_api_server: 'APIServer') -> None:
@@ -67,6 +67,8 @@ def test_add_optimism_blockchain_account(rotkehlchen_api_server: 'APIServer') ->
     # now check that detecting tokens works
     optimism_tokens = (
         Asset('eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),
+        Asset('eip155:10/erc20:0x4F604735c1cF31399C6E711D5962b2B3E0225AD3'),
+        Asset('eip155:10/erc20:0x94b008aA00579c1307B0EF2c499aD98a8ce58e58'),
     )
     # patch get_evm_tokens return value to just a few tokens
     # to prevent issues when the asset database changes

--- a/rotkehlchen/tests/api/test_blockchain_transactions.py
+++ b/rotkehlchen/tests/api/test_blockchain_transactions.py
@@ -102,7 +102,7 @@ def test_decode_given_transactions_custom_indexer(rotkehlchen_api_server: 'APISe
     )
     assert outcome is True
     assert CachedSettings().get_evm_indexers_order_for_chain(ChainID.ETHEREUM) == default_order
-    assert call_order == [custom_indexer]
+    assert all(indexer == custom_indexer for indexer in call_order)
 
     result = requests.put(  # test validation of indexers
         api_url_for(

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -10,7 +10,7 @@ import requests
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.chain.decoding.constants import CPT_GAS
-from rotkehlchen.chain.ethereum.constants import ETHEREUM_ETHERSCAN_NODE_NAME
+from rotkehlchen.chain.ethereum.constants import EVM_INDEXERS_NODE_NAME
 from rotkehlchen.chain.evm.types import NodeName
 from rotkehlchen.constants.misc import DEFAULT_MAX_LOG_BACKUP_FILES, DEFAULT_SQL_VM_INSTRUCTIONS_CB
 from rotkehlchen.fval import FVal
@@ -174,7 +174,7 @@ def test_manage_nodes(rotkehlchen_api_server: 'APIServer') -> None:
     result = assert_proper_sync_response_with_result(response)
     assert len(result) == 7
     for node in result:
-        if node['name'] != ETHEREUM_ETHERSCAN_NODE_NAME:
+        if node['name'] != EVM_INDEXERS_NODE_NAME:
             assert node['endpoint'] != ''
         else:
             assert node['identifier'] == 1

--- a/rotkehlchen/tests/external_apis/test_blockscout.py
+++ b/rotkehlchen/tests/external_apis/test_blockscout.py
@@ -120,7 +120,7 @@ def test_missing_data_error(blockscout: Blockscout) -> None:
     """
     with (
         pytest.raises(RemoteError, match='Blockscout is missing data'),
-        patch.object(blockscout.session, 'get', return_value=MockResponse(
+        patch.object(blockscout.session, 'request', return_value=MockResponse(
             status_code=HTTPStatus.OK,
             text='{"message": "Internal transactions for this transaction have not been processed yet","result": [],"status": "2"}',  # noqa: E501
         )),

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -190,7 +190,7 @@ def test_native_token_balance(
     address = polygon_pos_accounts[0]
     sorted_call_order = sorted(blockchain.polygon_pos.node_inquirer.default_call_order())  # type: ignore
 
-    def mock_default_call_order(skip_etherscan: bool = False):  # pylint: disable=unused-argument
+    def mock_default_call_order(skip_indexers: bool = False):  # pylint: disable=unused-argument
         # return sorted_call_order to remove randomness, and thus make it vcr'able
         return sorted_call_order
 

--- a/rotkehlchen/tests/unit/test_ethereum_inquirer.py
+++ b/rotkehlchen/tests/unit/test_ethereum_inquirer.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 
 from rotkehlchen.chain.accounts import BlockchainAccountData
-from rotkehlchen.chain.ethereum.constants import ETHEREUM_ETHERSCAN_NODE
+from rotkehlchen.chain.ethereum.constants import EVM_INDEXERS_NODE, EVM_INDEXERS_NODE_NAME
 from rotkehlchen.chain.ethereum.modules.thegraph.constants import CONTRACT_STAKING
 from rotkehlchen.chain.evm.constants import SWAPPED_TOPIC, ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
@@ -209,7 +209,7 @@ def test_call_contract(ethereum_inquirer, ethereum_manager_connect_at_start):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE, ETHEREUM_ETHERSCAN_NODE)])  # noqa: E501
+@pytest.mark.parametrize('ethereum_manager_connect_at_start', [(INFURA_ETH_NODE, EVM_INDEXERS_NODE)])  # noqa: E501
 def test_rpc_request_timeout(
         ethereum_inquirer: 'EthereumInquirer',
         ethereum_manager_connect_at_start: list[WeightedNode],
@@ -453,7 +453,7 @@ def test_ethereum_nodes_prune_and_archive_status(
             assert not web3_node.is_pruned
             assert web3_node.is_archive
 
-    if ethereum_manager_connect_at_start[0].node_info.name == 'etherscan':
+    if ethereum_manager_connect_at_start[0].node_info.name == EVM_INDEXERS_NODE_NAME:
         assert len(ethereum_inquirer.rpc_mapping) == 0  # excluding etherscan
     else:
         assert len(ethereum_inquirer.rpc_mapping) == 1
@@ -526,7 +526,7 @@ def test_get_pruned_nodes_behaviour_in_txn_queries(
         side_effect=mock_etherscan_get_tx,
         autospec=True,
     )
-    call_order = pruned_node + [ETHEREUM_ETHERSCAN_NODE]
+    call_order = pruned_node + [EVM_INDEXERS_NODE]
     with etherscan_get_tx_patch, etherscan_get_tx_receipt_patch:
         ethereum_inquirer.maybe_get_transaction_by_hash(txn_hash, call_order)
         ethereum_inquirer.maybe_get_transaction_receipt(txn_hash, call_order)

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -464,17 +464,17 @@ def test_find_quickswap_algrebra_lp_token_price(database: 'DBHandler', inquirer_
         evm_address=string_to_evm_address('0x8eF88E4c7CfbbaC1C163f7eddd4B578792201de6'),
         chain_id=ChainID.POLYGON_POS,
         token_kind=TokenKind.ERC721,
-        collectible_id='170952',
+        collectible_id='181062',
         protocol=CPT_QUICKSWAP_V3,
-    )).is_close('2150.137434')
+    )).is_close('1993.637500')
     assert inquirer_defi.find_usd_price(asset=get_or_create_evm_token(
         userdb=database,
         evm_address=string_to_evm_address('0x84715977598247125C3D6E2e85370d1F6fDA1eaF'),
         chain_id=ChainID.BASE,
         token_kind=TokenKind.ERC721,
-        collectible_id='584',
+        collectible_id='2782',
         protocol=CPT_QUICKSWAP_V4,
-    )).is_close('10953.387601')
+    )).is_close('1540.218529')
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -511,23 +511,23 @@ def test_find_aerodrome_lp_token_price(inquirer, base_manager):
     )
     inquirer.inject_evm_managers([(ChainID.BASE, base_manager)])
     price = inquirer.find_usd_price(asset=token)
-    assert price.is_close(FVal('64887262.569622'))
+    assert price.is_close(FVal('65026635.229284'))
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey'], match_on=['uri', 'method', 'body'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_curve_lp_token_price(inquirer: 'Inquirer', blockchain: 'ChainsAggregator'):
     tested_tokens: dict[ChainID, tuple[str, FVal]] = {
         ChainID.ETHEREUM: ('0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c', FVal('2577.551783')),
         # 3CRV-OP-gauge
-        ChainID.OPTIMISM: ('0x4456d13Fc6736e8e8330394c0C622103E06ea419', FVal('1737.730901')),
+        ChainID.OPTIMISM: ('0x4456d13Fc6736e8e8330394c0C622103E06ea419', FVal('1782.773383')),
         # Curve.fi amDAI/amUSDC/amUSDT (am3CRV)
         ChainID.POLYGON_POS: ('0xE7a24EF0C5e95Ffb0f6684b813A78F2a3AD7D171', FVal('1.139380')),
         # crvUSDT-gauge
         ChainID.ARBITRUM_ONE: ('0xB08FEf57bFcc5f7bF0EF69C0c090849d497C8F8A', FVal('1.726938')),
         # tricrypto
-        ChainID.BASE: ('0x63Eb7846642630456707C3efBb50A03c79B89D81', FVal('1.032154')),
+        ChainID.BASE: ('0x63Eb7846642630456707C3efBb50A03c79B89D81', FVal('1.039377')),
         # crvusdusdt-gauge
         ChainID.GNOSIS: ('0xC2EfDbC1a21D82A677380380eB282a963A6A6ada', FVal('1.000344')),
         # crvUSD/USDT gauge
@@ -1194,7 +1194,7 @@ def test_find_savings_crvusd_price(inquirer_defi: 'Inquirer') -> None:
     assert price == FVal('1.041968030723485250')
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey'], match_on=['uri', 'method', 'body'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_pendle_yield_tokens_prices(database: 'DBHandler', inquirer_defi: 'Inquirer') -> None:
@@ -1393,7 +1393,7 @@ def test_find_beefy_finance_boost_vault_price(
             weight=ONE,
         )],
     )
-    assert inquirer_defi.find_usd_price(rmoo_token) == FVal('247.80721536927881284627513063683570519048')  # noqa: E501
+    assert inquirer_defi.find_usd_price(rmoo_token) == FVal('199.06067619344672271996351206958275405755224768387246')  # noqa: E501
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1434,7 +1434,7 @@ def test_find_beefy_finance_clm_vaults_price(
     )
     cow_price = inquirer_defi.find_usd_price(cow_token)
     rcow_price = inquirer_defi.find_usd_price(rcow_token)
-    assert cow_price == rcow_price == FVal('3280.3835424538426781759')
+    assert cow_price == rcow_price == FVal('2867.90676977741868831673')
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1469,7 +1469,7 @@ def test_find_beefy_finance_reward_pool_vault_price(ethereum_inquirer: 'Ethereum
     assert inquirer_defi.find_usd_price(vault_token) == FVal('185.4')
 
 
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey'], match_on=['uri', 'method', 'body'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_uniswap_v3_position_price(database: 'DBHandler', inquirer_defi: 'Inquirer') -> None:
@@ -1505,9 +1505,9 @@ def test_find_uniswap_v3_position_price(database: 'DBHandler', inquirer_defi: 'I
 
     assert get_position_price(
         token_address=string_to_evm_address('0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1'),
-        token_id='1815027',
+        token_id='4318421',
         chain_id=ChainID.BASE,
-    ).is_close(FVal('93.54660'), max_diff='1e-5')
+    ).is_close(FVal('498.01916'), max_diff='1e-5')
 
     assert get_position_price(
         token_address=string_to_evm_address('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
@@ -1519,8 +1519,7 @@ def test_find_uniswap_v3_position_price(database: 'DBHandler', inquirer_defi: 'I
         token_address=string_to_evm_address('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
         token_id='929877',
         chain_id=ChainID.OPTIMISM,
-    ).is_close(FVal('1010.96583'), max_diff='1e-5')
-
+    ).is_close(FVal('1010.99591'), max_diff='1e-5')
     assert get_position_price(
         token_address=string_to_evm_address('0x7b8A01B39D58278b5DE7e48c8449c9f4F5170613'),
         token_id='188693',

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -1004,7 +1004,7 @@ def test_extrafi_farm_balances(
 
 
 @pytest.mark.freeze_time
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey'], match_on=['uri', 'method', 'body'])
 def test_extrafi_cache(optimism_inquirer: 'OptimismInquirer', freezer):
     """Check that the cache gets populated and timestamp updated if
     we requery again"""

--- a/rotkehlchen/tests/utils/ethereum.py
+++ b/rotkehlchen/tests/utils/ethereum.py
@@ -13,7 +13,7 @@ from rotkehlchen.chain.base.transactions import BaseTransactions
 from rotkehlchen.chain.binance_sc.decoding.decoder import BinanceSCTransactionDecoder
 from rotkehlchen.chain.binance_sc.transactions import BinanceSCTransactions
 from rotkehlchen.chain.ethereum.constants import (
-    ETHEREUM_ETHERSCAN_NODE,
+    EVM_INDEXERS_NODE,
 )
 from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
@@ -78,7 +78,7 @@ PRUNED_AND_NOT_ARCHIVED_NODE = WeightedNode(
     weight=ONE,
 )
 ETHERSCAN_AND_INFURA_PARAMS: tuple[str, list[tuple]] = ('ethereum_manager_connect_at_start, call_order', [  # noqa: E501
-    ((), (ETHEREUM_ETHERSCAN_NODE,)),
+    ((), (EVM_INDEXERS_NODE,)),
     (
         (WeightedNode(node_info=NodeName(name='own', endpoint=INFURA_TEST, owned=True, blockchain=SupportedBlockchain.ETHEREUM), weight=ONE, active=True),),  # noqa: E501
         (WeightedNode(node_info=NodeName(name='own', endpoint=INFURA_TEST, owned=True, blockchain=SupportedBlockchain.ETHEREUM), weight=ONE, active=True),),  # noqa: E501
@@ -88,7 +88,7 @@ ETHERSCAN_AND_INFURA_PARAMS: tuple[str, list[tuple]] = ('ethereum_manager_connec
 
 ETHERSCAN_AND_INFURA_AND_ALCHEMY: tuple[str, list[tuple]] = ('ethereum_manager_connect_at_start, call_order', [  # noqa: E501
     # Query etherscan only
-    ((), (ETHEREUM_ETHERSCAN_NODE,)),
+    ((), (EVM_INDEXERS_NODE,)),
     # For "our own" node querying use infura
     (
         (WeightedNode(node_info=NodeName(name='own', endpoint=INFURA_TEST, owned=True, blockchain=SupportedBlockchain.ETHEREUM), weight=ONE, active=True),),  # noqa: E501
@@ -118,7 +118,7 @@ ETHEREUM_WEB3_AND_ETHERSCAN_TEST_PARAMETERS = (
     'ethereum_manager_connect_at_start',
     [
         (INFURA_ETH_NODE,),
-        (ETHEREUM_ETHERSCAN_NODE,),
+        (EVM_INDEXERS_NODE,),
     ],
 )
 
@@ -128,7 +128,7 @@ ETHEREUM_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED = (
     [
         (PRUNED_AND_NOT_ARCHIVED_NODE,),
         (INFURA_ETH_NODE,),
-        (ETHEREUM_ETHERSCAN_NODE,),
+        (EVM_INDEXERS_NODE,),
         (ETHERSCAN_AND_INFURA_AND_ALCHEMY[1][2][0][0],),
     ],
 )
@@ -149,7 +149,7 @@ if 'GITHUB_WORKFLOW' in os.environ:  # TODO: Undo this if once all tests where i
     # from Github actions hangs and times out
     ETHEREUM_TEST_PARAMETERS = ('ethereum_manager_connect_at_start, call_order', [
         # Query etherscan only
-        ((), (ETHEREUM_ETHERSCAN_NODE,)),
+        ((), (EVM_INDEXERS_NODE,)),
     ])
 else:
     # For Travis and local tests also use Infura, works fine

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -723,6 +723,7 @@ def mock_history_processing(
 def mock_etherscan_like_transaction_response(
         etherscan_like_api: 'EtherscanLikeApi',
         remote_errors: bool,
+        session_mock_attribute: str = 'get',
 ) -> _patch:
     def mocked_request_dict(url, params, *_args, **_kwargs):
         if remote_errors:
@@ -776,7 +777,11 @@ def mock_etherscan_like_transaction_response(
 
         return MockResponse(200, payload)
 
-    return patch.object(etherscan_like_api.session, 'get', wraps=mocked_request_dict)
+    return patch.object(
+        target=etherscan_like_api.session,
+        attribute=session_mock_attribute,
+        wraps=mocked_request_dict,
+    )
 
 
 class TradesTestSetup(NamedTuple):
@@ -828,6 +833,7 @@ def mock_history_processing_and_exchanges(
         blockscout_patch=mock_etherscan_like_transaction_response(
             etherscan_like_api=rotki.chains_aggregator.ethereum.node_inquirer.blockscout,
             remote_errors=remote_errors,
+            session_mock_attribute='request',  # blockscout uses both post and get via session.request()  # noqa: E501
         ),
         routescan_patch=mock_etherscan_like_transaction_response(
             etherscan_like_api=rotki.chains_aggregator.ethereum.node_inquirer.routescan,


### PR DESCRIPTION
Related: #11078 - the thing the issue actually talks about more (getLogs) is not an RPC method but simply the `logs` module of etherscan. Will add support for that on the other indexers in another pr.
