### PR TITLE
fix: correct coingecko query_asset_image doc comment

### DIFF
--- a/colibri/src/coingecko.rs
+++ b/colibri/src/coingecko.rs
@@ -23,8 +23,7 @@ impl Coingecko {
     }
 
     /// Queries the asset image of the given asset id from coingecko
-    /// and if it finds it then it saves it in the proper directory
-    /// and returns its contents
+    /// and returns its contents if found
     pub async fn query_asset_image(&self, asset_id: &str) -> Option<Bytes> {
         let coingecko_id = match self.globaldb.get_coingecko_id(asset_id).await {
             Err(e) => {


### PR DESCRIPTION
The doc comment claimed the function saves the image to disk, but it only fetches and returns the bytes. The actual file writing happens in the caller (query_icon_remotely in icons.rs) which calls write_icon_to_file separately.