### PR TITLE
Skip events from same exchange in match list

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -6436,5 +6436,8 @@ class RestAPI:
 
         return api_response(_wrap_in_ok_result(result={
             'close_matches': close_match_identifiers,
-            'other_events': [x.identifier for x in other_events],
+            'other_events': [x.identifier for x in other_events if not (
+                x.location == asset_movement.location and
+                x.location_label == asset_movement.location_label
+            )],  # Skip any events that are for the same exchange as the asset movement.
         }))


### PR DESCRIPTION
Related #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

Changes the possible match list to not include events from the same exchange since an asset movement's corresponding event will never be in the same exchange.