### PR TITLE
Allow marking asset movements as having no match

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6274,7 +6274,7 @@ Match exchange asset movements with onchain events
 
 .. http:put:: /api/(version)/history/events/match/asset_movements
 
-   Matches exchange asset movement events with corresponding onchain events.
+   Matches exchange asset movement events with corresponding events, or mark the asset movement as having no corresponding event.
 
    **Example Request**:
 
@@ -6290,7 +6290,7 @@ Match exchange asset movements with onchain events
       }
 
    :reqjson int asset_movement: DB identifier of the asset movement to match
-   :reqjson int matched_event: DB identifier of the corresponding onchain event to match with the asset movement.
+   :reqjson int[optional] matched_event: DB identifier of the corresponding event to match with the asset movement. The asset movement is marked as having no match if this parameter is omitted or set to null.
 
    **Example Response**:
 

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -12,15 +12,24 @@ Matching Asset Movements With Onchain Events
 
 Exchange asset movement events may now be manually matched with specific onchain events via the API.
 
+* **New Endpoint**: ``PUT /api/(version)/history/events/match/asset_movements``
+
+  - Match asset movements with corresponding events or mark asset movements as having no match.
+  - Required ``asset_movement`` parameter specifying the DB identifier of the asset movement.
+  - Optional ``matched_event`` parameter specifying the DB identifier of the event to match with the asset movement. If this parameter is omitted or set to null, the asset movement is marked as having no match.
+  - Example: ``{"asset_movement": 123, "matched_event": 124}``
+
 * **New Endpoint**: ``POST /api/(version)/history/events/match/asset_movements``
 
-  - Two required parameters (``asset_movement`` and ``matched_event``) specifying the DB identifiers of the events to match.
-  - Example: ``{"asset_movement": 123, "matched_event": 124}``
+  - Finds possible matches for a given asset movement within the specified time range.
+  - Required ``asset_movement`` parameter specifying the group identifier to find matches for.
+  - Optional ``time_range`` parameter specifying the time range in seconds to include. Defaults to 7200 (2 hours).
+  - Example: ``{"asset_movement": "ef2...69f", "time_range": 7200}``
 
 * **New Endpoint**: ``GET /api/(version)/history/events/match/asset_movements``
 
   - Takes no parameters.
-  - Returns a list of group identifiers of any unmatched asset movements in the DB.
+  - Returns a list of group identifiers of any unmatched asset movements in the DB that are not marked as having no match.
 
 * **Modified Endpoint**: ``POST /api/(version)/history/events``
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -3643,7 +3643,7 @@ class MatchAssetMovementsResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(put_schema, location='json')
-    def put(self, asset_movement: int, matched_event: int) -> Response:
+    def put(self, asset_movement: int, matched_event: int | None) -> Response:
         return self.rest_api.match_asset_movements(
             asset_movement_identifier=asset_movement,
             matched_event_identifier=matched_event,

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -4560,7 +4560,7 @@ class ConfigurationUpdateSchema(Schema):
 
 class MatchAssetMovementsSchema(Schema):
     asset_movement = fields.Integer(required=True)
-    matched_event = fields.Integer(required=True)
+    matched_event = fields.Integer(required=False, load_default=None)
 
 
 class FindPossibleMatchesSchema(Schema):

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -549,7 +549,7 @@ class CommonGrantsDecoderMixin(EvmDecoderInterface, ABC):
         coded per contract and we have a hard coded list it's best to not ask the chain
         and do an extra network query since this is immutable.
 
-        The caller should confirm that the topic[0] matces the required topic hash.
+        The caller should confirm that the topic[0] matches the required topic hash.
         """
         if not self.base.any_tracked([claimee := bytes_to_address(claimee_raw), context.transaction.from_address]):  # noqa: E501
             return DEFAULT_EVM_DECODING_OUTPUT

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -6,6 +6,8 @@ from rotkehlchen.db.constants import EXTRAINTERNALTXPREFIX
 from rotkehlchen.types import BTCAddress, ChecksumEvmAddress, SolanaAddress, Timestamp
 from rotkehlchen.utils.mixins.enums import Enum
 
+ASSET_MOVEMENT_NO_MATCH_CACHE_VALUE: Final = -1
+
 
 class DBCacheStatic(Enum):
     """It contains all the keys that don't depend on a variable

--- a/rotkehlchen/tests/unit/events/test_match_asset_movements.py
+++ b/rotkehlchen/tests/unit/events/test_match_asset_movements.py
@@ -256,11 +256,11 @@ def test_match_asset_movements(database: 'DBHandler') -> None:
             'SELECT * FROM key_value_cache WHERE name LIKE ?',
             ('matched_asset_movement_%',),
         ).fetchall() == [
-            (f'matched_asset_movement_{withdrawal4_identifier}', str(withdrawal4_matched_event.identifier)),  # noqa: E501
             (f'matched_asset_movement_{withdrawal4_matched_event.identifier}', str(withdrawal4_identifier)),  # noqa: E501
-            (f'matched_asset_movement_{deposit3_matched_event.identifier}', str(deposit_3_identifier)),  # noqa: E501
-            (f'matched_asset_movement_{withdrawal1_matched_event.identifier}', str(withdrawal_1_identifier)),  # noqa: E501
-            (f'matched_asset_movement_{deposit2_matched_event.identifier}', str(deposit_2_identifier)),  # noqa: E501
+            (f'matched_asset_movement_{withdrawal4_identifier}', str(withdrawal4_matched_event.identifier)),  # noqa: E501
+            (f'matched_asset_movement_{deposit_3_identifier}', str(deposit3_matched_event.identifier)),  # noqa: E501
+            (f'matched_asset_movement_{withdrawal_1_identifier}', str(withdrawal1_matched_event.identifier)),  # noqa: E501
+            (f'matched_asset_movement_{deposit_2_identifier}', str(deposit2_matched_event.identifier)),  # noqa: E501
         ]
         matched_asset_movements = events_db.get_history_events_internal(
             cursor=cursor,


### PR DESCRIPTION
Related: #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

previously the MATCHED_ASSET_MOVEMENT cache had the matched event id as part of the name and the asset movement id as the value. Now this is reversed so the asset movement id is in the name, and for movements with no match the value can be set to `-1`

also note that the endpoint added in #11229 is added to the dev changelog since that was missed in that pr.