### PR TITLE
Limit possible movement matches to assets in same collection

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6358,11 +6358,13 @@ Match exchange asset movements with onchain events
 
       {
           "asset_movement": "ef2fcd9d69e358f184e5aae29f74b39e7613a13eaaae00717bde70a165cfd69f",
-          "time_range": 7200
+          "time_range": 7200,
+          "only_expected_assets": true
       }
 
    :reqjson string asset_movement: Group identifier of the asset movement to find matches for.
-   :reqjson int time_range: Optional. Time range in seconds to search for matches. Defaults to 7200 (2 hours).
+   :reqjson int[optional] time_range: Time range in seconds to search for matches. Defaults to 7200 (2 hours).
+   :reqjson bool[optional] only_expected_assets: Flag indicating whether to limit the possible matches to only events with assets in the same collection as the asset movement's asset. True by default.
 
    **Example Response**:
 

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -24,7 +24,8 @@ Exchange asset movement events may now be manually matched with specific onchain
   - Finds possible matches for a given asset movement within the specified time range.
   - Required ``asset_movement`` parameter specifying the group identifier to find matches for.
   - Optional ``time_range`` parameter specifying the time range in seconds to include. Defaults to 7200 (2 hours).
-  - Example: ``{"asset_movement": "ef2...69f", "time_range": 7200}``
+  - Optional ``only_expected_assets`` parameter indicating whether to limit the possible matches to only events with assets in the same collection as the asset movement's asset. True by default.
+  - Example: ``{"asset_movement": "ef2...69f", "time_range": 7200, "only_expected_assets": true}``
 
 * **New Endpoint**: ``GET /api/(version)/history/events/match/asset_movements``
 

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -3651,8 +3651,9 @@ class MatchAssetMovementsResource(BaseMethodView):
 
     @require_loggedin_user()
     @use_kwargs(post_schema, location='json')
-    def post(self, asset_movement: str, time_range: int) -> Response:
+    def post(self, asset_movement: str, time_range: int, only_expected_assets: bool) -> Response:
         return self.rest_api.get_matches_for_asset_movement(
             asset_movement_group_identifier=asset_movement,
             time_range=time_range,
+            only_expected_assets=only_expected_assets,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -4566,3 +4566,4 @@ class MatchAssetMovementsSchema(Schema):
 class FindPossibleMatchesSchema(Schema):
     asset_movement = fields.String(required=True)
     time_range = fields.Integer(required=False, load_default=ASSET_MOVEMENT_MATCH_WINDOW)
+    only_expected_assets = fields.Boolean(required=False, load_default=True)


### PR DESCRIPTION
Related: #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

* limits possible matches to only events with assets in the same collection as the movement's asset (optional, but on be default)
* orders the possible matches list by distance from the asset movement's timestamp