### PR TITLE
Group matched movement events into sublists

### DIFF
--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -151,6 +151,14 @@ EVENT_GROUPING_ORDER = {  # Determines how to group events when serializing for 
         HistoryEventSubType.FEE: 2,
     }),
     HistoryEventType.MULTI_TRADE: spend_receive_fee,
+    HistoryEventType.DEPOSIT: {
+        HistoryEventSubType.DEPOSIT_ASSET: 0,
+        HistoryEventSubType.FEE: 1,
+    },
+    HistoryEventType.WITHDRAWAL: {
+        HistoryEventSubType.REMOVE_ASSET: 0,
+        HistoryEventSubType.FEE: 1,
+    },
 }
 
 # possible color values

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4097,6 +4097,7 @@ class RestAPI:
     @staticmethod
     def _serialize_and_group_history_events(
             events: list['HistoryBaseEntry'],
+            aggregate_by_group_ids: bool,
             event_accounting_rule_statuses: list[EventAccountingRuleStatus],
             grouped_events_nums: list[int | None],
             customized_event_ids: list[int],
@@ -4105,11 +4106,15 @@ class RestAPI:
             joined_group_ids: dict[str, str],
     ) -> list[dict[str, Any] | list[dict[str, Any]]]:
         """Serialize and group history events for the api.
-        Groups evm & solana swap and multi trade events into sub-lists. Uses the order defined in
-        EVENT_GROUPING_ORDER to decide which events belong in which group.
+        Groups onchain swaps, multi trades, and matched asset movement events into sub-lists.
+        Uses the order defined in EVENT_GROUPING_ORDER as well as some custom logic for matched
+        asset movements to decide which events belong in which group.
 
         Args:
         - events: list of events to serialize and group
+        - aggregate_by_group_ids: flag indicating whether the current request is aggregating
+           by group ids. When this is true, no sublist grouping is needed since there is
+           only a single event per group id.
         - event_accounting_rule_statuses and grouped_events_nums: lists with each element
            corresponding to an event.
         - customized_event_ids, ignored_ids, and hidden_event_ids: arguments applying to all events
@@ -4122,7 +4127,9 @@ class RestAPI:
         """
         entries: list[dict[str, Any] | list[dict[str, Any]]] = []
         current_group: list[dict[str, Any]] = []
+        current_asset_movement_group_id: str | None = None
         last_subtype_index: int | None = None
+        already_grouped_event_count = 0
         for event, event_accounting_rule_status, grouped_events_num in zip(
             events,
             event_accounting_rule_statuses,
@@ -4136,11 +4143,45 @@ class RestAPI:
                 event_accounting_rule_status=event_accounting_rule_status,
                 grouped_events_num=grouped_events_num,
             )
+            if aggregate_by_group_ids:
+                # no need to group into lists when aggregating by group_identifier since only
+                # a single event is returned for each group_identifier
+                entries.append(serialized)
+                continue
+
             if (replacement_group_id := joined_group_ids.get(event.group_identifier)) is not None:
                 serialized['entry']['group_identifier'] = replacement_group_id
                 serialized['entry']['actual_group_identifier'] = event.group_identifier
 
-            if event.entry_type in (HistoryBaseEntryType.EVM_SWAP_EVENT, HistoryBaseEntryType.SOLANA_SWAP_EVENT):  # noqa: E501
+            if (
+                replacement_group_id is not None and
+                event.group_identifier != current_asset_movement_group_id and
+                ((  # this is the matched event
+                    event.extra_data is not None and
+                    (current_asset_movement_group_id := event.extra_data.get('matched_asset_movement', {}).get('group_identifier')) is not None  # noqa: E501
+                ) or (  # or the matched event was an asset movement and this is its fee event
+                    event.entry_type == HistoryBaseEntryType.ASSET_MOVEMENT_EVENT and
+                    event.event_subtype == HistoryEventSubType.FEE
+                ))
+            ):  # This event is part of the matched event for an asset movement.
+                if len(current_group) != already_grouped_event_count:
+                    # This is the beginning of an asset movement group coming immediately after
+                    # another asset movement group. Add the current group to entries and reset
+                    # to begin a new group.
+                    entries.append(current_group)
+                    current_group, already_grouped_event_count, last_subtype_index = [], 0, None
+
+                # Append to current_group and increment already_grouped_event_count so the logic
+                # below using the EVENT_GROUPING_ORDER works correctly for the asset movement.
+                current_group.append(serialized)
+                already_grouped_event_count += 1
+            elif (event.entry_type in (
+                HistoryBaseEntryType.EVM_SWAP_EVENT,
+                HistoryBaseEntryType.SOLANA_SWAP_EVENT,
+            ) or (
+                event.group_identifier == current_asset_movement_group_id and
+                event.entry_type == HistoryBaseEntryType.ASSET_MOVEMENT_EVENT
+            )):
                 if (event_subtype_index := EVENT_GROUPING_ORDER[event.event_type].get(event.event_subtype)) is None:  # noqa: E501
                     log.error(
                         'Unable to determine group order for event type/subtype '
@@ -4149,7 +4190,7 @@ class RestAPI:
                     event_subtype_index = 0
 
                 if (
-                    len(current_group) == 0 or
+                    len(current_group) == already_grouped_event_count or
                     (last_subtype_index is not None and event_subtype_index >= last_subtype_index)
                 ):
                     current_group.append(serialized)
@@ -4157,12 +4198,15 @@ class RestAPI:
                     if len(current_group) > 0:
                         entries.append(current_group)
                     current_group = [serialized]
+                    already_grouped_event_count = 0
+                    current_asset_movement_group_id = None
 
                 last_subtype_index = event_subtype_index
             else:  # Non-groupable event
                 if len(current_group) > 0:
                     entries.append(current_group)
-                    current_group, last_subtype_index = [], None
+                    current_group, already_grouped_event_count = [], 0
+                    last_subtype_index = current_asset_movement_group_id = None
                 entries.append(serialized)
 
         if len(current_group) > 0:  # Append any remaining group
@@ -4225,6 +4269,7 @@ class RestAPI:
         result = {
             'entries': self._serialize_and_group_history_events(
                 events=events,
+                aggregate_by_group_ids=aggregate_by_group_ids,
                 event_accounting_rule_statuses=query_missing_accounting_rules(
                     db=self.rotkehlchen.data.db,
                     accounting_pot=accountant_pot,

--- a/rotkehlchen/tests/api/test_event_matching.py
+++ b/rotkehlchen/tests/api/test_event_matching.py
@@ -13,7 +13,10 @@ from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.tasks.events import get_unmatched_asset_movements
+from rotkehlchen.tasks.events import (
+    get_unmatched_asset_movements,
+    update_asset_movement_matched_event,
+)
 from rotkehlchen.tests.unit.test_eth2 import HOUR_IN_MILLISECONDS
 from rotkehlchen.tests.utils.api import (
     api_url_for,
@@ -281,14 +284,17 @@ def test_get_history_events_with_matched_asset_movements(
         rotkehlchen_api_server: 'APIServer',
 ) -> None:
     """Test that getting history events with matched asset movements works as expected with
-    asset movements grouped with their matched events.
+    asset movements grouped with their matched events. Checks both the case where a movement
+    is matched with an evm event and also where two movements are matched with each other.
+    The matched events (including any asset movement fee events) are grouped in a sublist to
+    make them easier to identify in the frontend.
     """
     rotki = rotkehlchen_api_server.rest_api.rotkehlchen
     dbevents = DBHistoryEvents(rotki.data.db)
     with rotki.data.db.conn.write_ctx() as write_cursor:
         dbevents.add_history_events(
             write_cursor=write_cursor,
-            history=[AssetMovement(
+            history=[(movement1 := AssetMovement(
                 identifier=1,
                 location=Location.KRAKEN,
                 event_type=HistoryEventType.WITHDRAWAL,
@@ -296,46 +302,71 @@ def test_get_history_events_with_matched_asset_movements(
                 asset=A_ETH,
                 amount=FVal('0.1'),
                 unique_id='1',
-            ), (matched_movement := AssetMovement(
+            )), AssetMovement(
                 identifier=2,
                 location=Location.KRAKEN,
                 event_type=HistoryEventType.WITHDRAWAL,
+                timestamp=movement1.timestamp,
+                asset=A_ETH,
+                amount=FVal('0.001'),
+                is_fee=True,
+                unique_id='1',
+            ), (movement2 := AssetMovement(
+                identifier=3,
+                location=Location.BINANCE,
+                event_type=HistoryEventType.DEPOSIT,
                 timestamp=TimestampMS(1500000000001),
                 asset=A_ETH,
-                amount=FVal('0.5'),
+                amount=FVal('0.1'),
                 unique_id='2',
-            )), (evm_event_1 := EvmEvent(
-                identifier=3,
-                tx_ref=(tx_ref := make_evm_tx_hash()),
-                sequence_index=0,
+            )), AssetMovement(
+                identifier=4,
+                location=Location.BINANCE,
+                event_type=HistoryEventType.DEPOSIT,
+                timestamp=movement2.timestamp,
+                asset=A_ETH,
+                amount=FVal('0.001'),
+                is_fee=True,
+                unique_id='2',
+            ), (movement3 := AssetMovement(
+                identifier=5,
+                location=Location.KRAKEN,
+                event_type=HistoryEventType.WITHDRAWAL,
                 timestamp=TimestampMS(1500000000002),
-                location=Location.ETHEREUM,
-                event_type=HistoryEventType.RECEIVE,
-                event_subtype=HistoryEventSubType.NONE,
                 asset=A_ETH,
                 amount=FVal('0.5'),
-                location_label=(user_address := make_evm_address()),
-            )), EvmEvent(
-                identifier=4,
-                tx_ref=tx_ref,
-                sequence_index=1,
+                unique_id='3',
+            )), EvmEvent(  # event in tx but unrelated to the movement. Could be gas fee, etc.
+                identifier=6,
+                tx_ref=(tx_ref := make_evm_tx_hash()),
+                sequence_index=0,
                 timestamp=TimestampMS(1500000000002),
                 location=Location.ETHEREUM,
                 event_type=HistoryEventType.SPEND,
                 event_subtype=HistoryEventSubType.NONE,
                 asset=A_ETH,
                 amount=FVal('0.01'),
+                location_label=(user_address := make_evm_address()),
+            ), (evm_event_1 := EvmEvent(
+                identifier=7,
+                tx_ref=tx_ref,
+                sequence_index=1,
+                timestamp=TimestampMS(1500000000002),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_ETH,
+                amount=FVal('0.5'),
                 location_label=user_address,
-            )],
+            ))],
         )
 
-        assert matched_movement.identifier is not None
-        assert evm_event_1.identifier is not None
-        rotki.data.db.set_dynamic_cache(
-            write_cursor=write_cursor,
-            name=DBCacheDynamic.MATCHED_ASSET_MOVEMENT,
-            identifier=matched_movement.identifier,
-            value=evm_event_1.identifier,
+    for asset_movement, matched_event in ((movement1, movement2), (movement3, evm_event_1)):
+        update_asset_movement_matched_event(
+            events_db=dbevents,
+            asset_movement=asset_movement,
+            matched_event=matched_event,
+            is_deposit=False,
         )
 
     # First query history aggregated by group
@@ -350,7 +381,8 @@ def test_get_history_events_with_matched_asset_movements(
     assert len(result['entries']) == 2
     assert result['entries'][0]['grouped_events_num'] == 3  # includes both evm events and the matched asset movement  # noqa: E501
     assert result['entries'][0]['entry']['group_identifier'] == evm_event_1.group_identifier
-    assert result['entries'][1]['grouped_events_num'] == 1  # the unmatched asset movement
+    assert result['entries'][1]['grouped_events_num'] == 4  # the two matched movements and their fees  # noqa: E501
+    assert result['entries'][1]['entry']['group_identifier'] == movement2.group_identifier
 
     # Then query the evm event group and the matched asset movement should be included
     result = assert_proper_response_with_result(
@@ -363,18 +395,52 @@ def test_get_history_events_with_matched_asset_movements(
         ),
         rotkehlchen_api_server=rotkehlchen_api_server,
     )['entries']
-
-    # The group returned should all have the group_identifier of the evm event, but should also
+    # The events returned should all have the group_identifier of the evm event, but should also
     # have the actual_group_identifier set to preserve the real group_identifier of each event.
     # The presence of this field also notifies frontend that this group is a combination of
     # several groups and may need special handling.
-    assert len(result) == 3  # receive and spend onchain events plus the asset movement
-    assert result[0]['entry']['event_type'] == 'receive'
-    assert result[0]['entry']['group_identifier'] == evm_event_1.group_identifier
-    assert result[0]['entry']['actual_group_identifier'] == evm_event_1.group_identifier
-    assert result[1]['entry']['event_type'] == 'spend'
-    assert result[1]['entry']['group_identifier'] == evm_event_1.group_identifier
-    assert result[1]['entry']['actual_group_identifier'] == evm_event_1.group_identifier
-    assert result[2]['entry']['event_type'] == 'withdrawal'
-    assert result[2]['entry']['group_identifier'] == evm_event_1.group_identifier
-    assert result[2]['entry']['actual_group_identifier'] == matched_movement.group_identifier
+    assert len(result) == 2
+    # The first event in the tx isn't related to the asset movement
+    assert (unrelated_event_entry := result[0])['entry']['event_type'] == 'spend'
+    assert unrelated_event_entry['entry']['group_identifier'] == evm_event_1.group_identifier
+    assert unrelated_event_entry['entry']['actual_group_identifier'] == evm_event_1.group_identifier  # noqa: E501
+    # matched events are in a sublist so frontend can easily group them
+    assert len(match1_sublist := result[1]) == 2
+    assert match1_sublist[0]['entry']['event_type'] == 'deposit'
+    assert match1_sublist[0]['entry']['group_identifier'] == evm_event_1.group_identifier
+    assert match1_sublist[0]['entry']['actual_group_identifier'] == evm_event_1.group_identifier
+    assert match1_sublist[1]['entry']['event_type'] == 'withdrawal'
+    assert match1_sublist[1]['entry']['group_identifier'] == evm_event_1.group_identifier
+    assert match1_sublist[1]['entry']['actual_group_identifier'] == movement3.group_identifier
+
+    # Then check the events for the second matched event (movement2)
+    result = assert_proper_response_with_result(
+        response=requests.post(api_url_for(rotkehlchen_api_server, 'historyeventresource'), json={
+            'aggregate_by_group_ids': False,
+            'group_identifiers': [movement2.group_identifier],
+        }),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+    )['entries']
+    assert len(result) == 1
+    assert len(match2_sublist := result[0]) == 4
+    assert all(x['entry']['group_identifier'] == movement2.group_identifier for x in match2_sublist)  # noqa: E501
+    assert match2_sublist[0]['entry']['event_type'] == 'deposit'
+    assert match2_sublist[0]['entry']['actual_group_identifier'] == movement2.group_identifier
+    assert match2_sublist[1]['entry']['event_subtype'] == 'fee'
+    assert match2_sublist[1]['entry']['actual_group_identifier'] == movement2.group_identifier
+    assert match2_sublist[2]['entry']['event_type'] == 'withdrawal'
+    assert match2_sublist[2]['entry']['actual_group_identifier'] == movement1.group_identifier
+    assert match2_sublist[3]['entry']['event_subtype'] == 'fee'
+    assert match2_sublist[3]['entry']['actual_group_identifier'] == movement1.group_identifier
+
+    # Check that querying both groups at once works correctly
+    assert assert_proper_response_with_result(
+        response=requests.post(
+            api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+            json={
+                'aggregate_by_group_ids': False,
+                'group_identifiers': [movement2.group_identifier, evm_event_1.group_identifier],
+            },
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+    )['entries'] == [unrelated_event_entry, match1_sublist, match2_sublist]


### PR DESCRIPTION
Related: #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

Groups asset movements and their matched events into a sublist in the history events response like we do for swaps etc as discussed in [discord](https://discord.com/channels/657906918408585217/1448435340615618622/1455925585590358028).