### PR TITLE
Allow unlinking matched asset movements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6391,6 +6391,43 @@ Match exchange asset movements with onchain events
    :statuscode 409: No user is logged in or failure
    :statuscode 500: Internal rotki error
 
+.. http:delete:: /api/(version)/history/events/match/asset_movements
+
+   Unlinks matched asset movements, or resets the asset movement to being simply unmatched if the asset movement is marked as having no corresponding event.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      DELETE /api/1/history/events/match/asset_movements HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {
+          "asset_movement": 123
+      }
+
+   :reqjson int asset_movement: DB identifier of the asset movement to unlink
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "result": true,
+          "message": ""
+      }
+
+   :resjson bool result: A boolean for success or failure
+   :resjson str message: Error message if any errors occurred.
+   :statuscode 200: Events unlinked successfully
+   :statuscode 400: Provided JSON is in some way malformed
+   :statuscode 409: No user is logged in or failure.
+   :statuscode 500: Internal rotki error
+
 Querying messages to show to the user
 =====================================
 

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -31,6 +31,11 @@ Exchange asset movement events may now be manually matched with specific onchain
 
   - Optional ``only_ignored`` flag indicating whether to return a list of the movements that are marked as having no match, or the list of all movements that have not been matched or ignored yet.
 
+* **New Endpoint**: ``DELETE /api/(version)/history/events/match/asset_movements``
+
+  - Required ``asset_movement`` parameter specifying the DB identifier of the asset movement to unlink from its corresponding matched event.
+  - Unlinks the asset movement from its matched event. This asset movement will now appear in the list of unmatched movements again.
+
 * **Modified Endpoint**: ``POST /api/(version)/history/events``
 
   - New optional ``actual_group_identifier`` field in the response, containing the actual group identifier of the event as stored in the DB.

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -180,6 +180,7 @@ from rotkehlchen.api.v1.schemas import (
     TransactionDecodingSchema,
     TransactionQuerySchema,
     TransactionReferenceAdditionSchema,
+    UnlinkMatchedAssetMovementSchema,
     UpdateCalendarReminderSchema,
     UpdateCalendarSchema,
     UserActionLoginSchema,
@@ -3648,6 +3649,7 @@ class MatchAssetMovementsResource(BaseMethodView):
     get_schema = GetUnmatchedAssetMovementsSchema()
     put_schema = MatchAssetMovementsSchema()
     post_schema = FindPossibleMatchesSchema()
+    delete_schema = UnlinkMatchedAssetMovementSchema()
 
     @require_loggedin_user()
     @use_kwargs(get_schema, location='json_and_query')
@@ -3669,4 +3671,11 @@ class MatchAssetMovementsResource(BaseMethodView):
             asset_movement_group_identifier=asset_movement,
             time_range=time_range,
             only_expected_assets=only_expected_assets,
+        )
+
+    @require_loggedin_user()
+    @use_kwargs(delete_schema, location='json')
+    def delete(self, asset_movement: int) -> Response:
+        return self.rest_api.unlink_matched_asset_movements(
+            asset_movement_identifier=asset_movement,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -4571,3 +4571,7 @@ class FindPossibleMatchesSchema(Schema):
     asset_movement = fields.String(required=True)
     time_range = fields.Integer(required=False, load_default=ASSET_MOVEMENT_MATCH_WINDOW)
     only_expected_assets = fields.Boolean(required=False, load_default=True)
+
+
+class UnlinkMatchedAssetMovementSchema(Schema):
+    asset_movement = fields.Integer(required=True)


### PR DESCRIPTION
Related: #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074


Allows unlinking matched asset movements. I initially was going to try to also have it revert the changes to the matched event, by storing the original info in the extra_data, but finally decided that this is probably a bad idea. I seems a bit hacky for one thing, but also the user may edit the event after it is matched, and then if we were to revert it on unlink, it could be overwriting those user changes. Also at least for onchain events, they can be re-decoded to revert them to their original state if needed. Unlinking is going to be a manual process anyway that hopefully isn't needed often, so I believe leaving the matched event in its modified state is probably fine (we may want to have a note in the UI when unlinking, mentioning that the matched event may need attention though).