### PR TITLE
Skip eth staking events in possible movement match list

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -6575,6 +6575,14 @@ class RestAPI:
                     assets=GlobalDBHandler.get_assets_in_same_collection(
                         identifier=asset_movement.asset.identifier,
                     ) if only_expected_assets else None,
+                    entry_types=IncludeExcludeFilterData(
+                        values=[  # Don't include eth staking events
+                            HistoryBaseEntryType.ETH_BLOCK_EVENT,
+                            HistoryBaseEntryType.ETH_DEPOSIT_EVENT,
+                            HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT,
+                        ],
+                        operator='NOT IN',
+                    ),
                 ),
             )
 

--- a/rotkehlchen/tests/api/test_event_matching.py
+++ b/rotkehlchen/tests/api/test_event_matching.py
@@ -10,6 +10,7 @@ from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.base import HistoryEvent
+from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -362,6 +363,13 @@ def test_get_possible_matches(rotkehlchen_api_server: 'APIServer') -> None:
                 location=Location.EXTERNAL,
                 asset=A_BTC,  # asset not in the same collection as the movement.
                 amount=matched_movement.amount,
+            ), EthWithdrawalEvent(  # ETH staking event that should be ignored.
+                identifier=10,
+                validator_index=12345,
+                timestamp=matched_movement.timestamp,
+                amount=FVal('0.1'),
+                withdrawal_address=make_evm_address(),
+                is_exit=False,
             )],
         )
 


### PR DESCRIPTION
Related: #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

skips eth staking events in the list of possible matches for asset movements since these will never be the correct match. Afaics all the other places where we query events for matching etc we are already limiting event type or entry type and no further adjustment is needed to ignore eth staking events in those queries.