### PR TITLE
perf: remove price queries from historical balance endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14076,14 +14076,8 @@ Historical Balance Queries
           "result": {
             "processing_required": false,
             "entries": {
-              "BTC": {
-                "amount": "2.0",
-                "price": "20000"
-              },
-              "ETH": {
-                "amount": "10.0",
-                "price": "1500"
-              }
+              "BTC": "2.0",
+              "ETH": "10.0"
             }
           },
           "status_code": 200
@@ -14101,8 +14095,7 @@ Historical Balance Queries
         "result": {
           "processing_required": false,
           "entries": {
-            "amount": "2.0",
-            "price": "20000"
+            "BTC": "2.0"
           }
         },
         "status_code": 200
@@ -14124,9 +14117,7 @@ Historical Balance Queries
       }
 
       :resjson bool processing_required: Whether historical events exist but need processing. If true, call the processing endpoint and retry.
-      :resjson object entries: (Only present when data is available) Either a mapping of all assets to their balance info, or single asset balance info if asset was provided
-      :resjson string amount: The amount of the asset held at the timestamp
-      :resjson string price: The price of the asset at the timestamp in the user's profit currency
+      :resjson object entries: (Only present when data is available) A mapping of asset identifiers to their amount as string.
       :statuscode 200: Historical balances returned
       :statuscode 400: Malformed query
       :statuscode 403: User does not have premium access

--- a/docs/websockets.rst
+++ b/docs/websockets.rst
@@ -725,7 +725,8 @@ Sent when historical balance processing detects a negative balance for an asset,
             "event_identifier": 12345,
             "group_identifier": "0xabc123...",
             "asset": "eip155:1/erc20:0x6B175474E89094C44Da98b954EesdedfFE3F46F5D",
-            "balance_before": "100.5"
+            "balance_before": "100.5",
+            "last_run_ts": 1672531200
         }
     }
 
@@ -734,3 +735,4 @@ Sent when historical balance processing detects a negative balance for an asset,
 - ``group_identifier``: Group identifier (usually transaction hash) of the problematic event
 - ``asset``: Asset identifier that went negative
 - ``balance_before``: The balance before processing the event that caused it to go negative
+- ``last_run_ts``: Unix timestamp of the last successful historical balance processing run, or ``null`` if this is the first run

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -5904,7 +5904,10 @@ class RestAPI:
 
         result: dict[str, Any] = {'processing_required': processing_required}
         if balances is not None:
-            result['entries'] = process_result(balances)
+            result['entries'] = {
+                asset.identifier: str(amount)
+                for asset, amount in balances.items()
+            }
 
         return _wrap_in_ok_result(result=result, status_code=HTTPStatus.OK)
 
@@ -5913,13 +5916,13 @@ class RestAPI:
         """Query historical balance of a specific asset at a given timestamp
         by processing historical events
         """
-        processing_required, balance = HistoricalBalancesManager(
+        processing_required, amount = HistoricalBalancesManager(
             self.rotkehlchen.data.db,
         ).get_asset_balance(asset=asset, timestamp=timestamp)
 
         result: dict[str, Any] = {'processing_required': processing_required}
-        if balance is not None:
-            result['entries'] = balance
+        if amount is not None:
+            result['entries'] = {asset.identifier: str(amount)}
 
         return _wrap_in_ok_result(result=result)
 

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -119,6 +119,10 @@ def process_historical_balances(
         bucket_balances = _load_bucket_balances_before_ts(database, from_ts)
 
     with database.conn.read_ctx() as cursor:
+        last_run_ts = database.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
+        )
         events = DBHistoryEvents(database).get_history_events_internal(
             cursor=cursor,
             filter_query=HistoryEventFilterQuery.make(
@@ -153,6 +157,7 @@ def process_historical_balances(
                         'group_identifier': event.group_identifier,
                         'asset': event.asset.identifier,
                         'balance_before': str(current_balance_in_bucket),
+                        'last_run_ts': last_run_ts,
                     },
                 )
                 log.warning(

--- a/rotkehlchen/tests/api/test_historical_balances.py
+++ b/rotkehlchen/tests/api/test_historical_balances.py
@@ -112,9 +112,7 @@ def fixture_setup_historical_data(rotkehlchen_api_server: 'APIServer') -> None:
     )
 
 
-@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-@pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_balance(
         rotkehlchen_api_server: 'APIServer',
         setup_historical_data: None,
@@ -129,10 +127,8 @@ def test_get_historical_balance(
 
     result = assert_proper_sync_response_with_result(response)
     assert result['processing_required'] is False
-    assert result['entries']['BTC']['amount'] == '1.5'
-    assert result['entries']['BTC']['price'] == '15806.226022787'
-    assert result['entries']['ETH']['amount'] == '10'
-    assert result['entries']['ETH']['price'] == '1151.10913718085'
+    assert result['entries']['BTC'] == '1.5'
+    assert result['entries']['ETH'] == '10'
 
     # try retrieving the balance of a day without event and
     # see that the balance of the previous day is used.
@@ -153,13 +149,11 @@ def test_get_historical_balance(
     )
     # Balances(amount) should be same as day 1
     assert outcome['result']['processing_required'] is False
-    assert outcome['result']['entries']['BTC']['amount'] == '2'
-    assert outcome['result']['entries']['ETH']['amount'] == '10'
+    assert outcome['result']['entries']['BTC'] == '2'
+    assert outcome['result']['entries']['ETH'] == '10'
 
 
-@pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-@pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_asset_balance(
         rotkehlchen_api_server: 'APIServer',
         setup_historical_data: None,
@@ -194,9 +188,7 @@ def test_get_historical_asset_balance(
 
     result = assert_proper_sync_response_with_result(response)
     assert result['processing_required'] is False
-    # Should show post-withdrawal balance
-    assert result['entries']['amount'] == '1.7'  # 2 - 0.5 + 0.2
-    assert result['entries']['price'] == '15806.226022787'
+    assert result['entries']['BTC'] == '1.7'  # 2 - 0.5 + 0.2
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -371,7 +363,6 @@ def test_get_historical_assets_in_collection_amounts_over_time(
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-@pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_balance_before_first_event(
         rotkehlchen_api_server: 'APIServer',
         setup_historical_data: None,
@@ -391,7 +382,6 @@ def test_get_historical_balance_before_first_event(
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
-@pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_get_historical_balance_unknown_asset(rotkehlchen_api_server: 'APIServer') -> None:
     response = requests.post(
         api_url_for(


### PR DESCRIPTION
Related https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=146319110 

- The reason for the slow response was because the backend was performing price queries. Now, that's switched to a two-step process and the frontend handles the price query.

- Addition `last_run_ts` is for the frontend to invalidate old ws messages.