### PR TITLE
handle concurrent modifications in balance processing

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -5962,7 +5962,7 @@ class RestAPI:
         """Trigger the specified async task."""
         if task == TaskName.HISTORICAL_BALANCE_PROCESSING:
             with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
-                stale_from_ts = TimestampMS(value) if (value := self.rotkehlchen.data.db.get_static_cache(  # noqa: E501
+                stale_from_ts = TimestampMS(int(value)) if (value := self.rotkehlchen.data.db.get_static_cache(  # noqa: E501
                     cursor=cursor,
                     name=DBCacheStatic.STALE_BALANCES_FROM_TS,
                 )) is not None else None

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -34,6 +34,9 @@ class DBCacheStatic(Enum):
     # Earliest timestamp from which balance caches are stale due to event modifications.
     # When events are added/edited/deleted, balances must be recalculated from this point.
     STALE_BALANCES_FROM_TS: Final = 'stale_balances_from_ts'
+    # Timestamp when events were last modified. Used to detect concurrent modifications
+    # during historical balance processing.
+    STALE_BALANCES_MODIFICATION_TS: Final = 'stale_balances_modification_ts'
     LAST_HISTORICAL_BALANCE_PROCESSING_TS: Final = 'last_historical_balance_processing_ts'
 
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -675,6 +675,7 @@ class DBHandler:
             name: Literal[
                 DBCacheStatic.DOCKER_DEVICE_INFO,
                 DBCacheStatic.MONERIUM_OAUTH_CREDENTIALS,
+                DBCacheStatic.STALE_BALANCES_FROM_TS,
             ],
     ) -> str | None:
         ...
@@ -701,7 +702,6 @@ class DBHandler:
                 DBCacheStatic.LAST_GNOSISPAY_QUERY_TS,
                 DBCacheStatic.LAST_SPARK_ASSETS_UPDATE,
                 DBCacheStatic.LAST_DB_UPGRADE,
-                DBCacheStatic.STALE_BALANCES_FROM_TS,
                 DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
             ],
     ) -> Timestamp | None:
@@ -727,10 +727,11 @@ class DBHandler:
         ).fetchone()) is None:
             return None
 
-        # Return string for DOCKER_DEVICE_INFO & MONERIUM_OAUTH_CREDENTIALS, timestamp for all others  # noqa: E501
+        # Return string for these cache entries, timestamp for all others
         if name in (
             DBCacheStatic.DOCKER_DEVICE_INFO,
             DBCacheStatic.MONERIUM_OAUTH_CREDENTIALS,
+            DBCacheStatic.STALE_BALANCES_FROM_TS,  # format: "{event_ts},{modification_ts}"
         ):
             return value[0]
 

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -73,6 +73,7 @@ from rotkehlchen.types import (
     Optional,
     SupportedBlockchain,
     Timestamp,
+    TimestampMS,
 )
 from rotkehlchen.utils.misc import ts_now
 
@@ -746,8 +747,6 @@ class TaskManager:
         Processes history events to compute and store pre-computed balance metrics
         in the event_metrics table.
         """
-        # TODO: Prevent this from running concurrently with tasks that add or modify events,
-        # such as transaction queries, exchange history sync, decoding, and event processing.
         if should_run_periodic_task(
             database=self.database,
             key_name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
@@ -769,7 +768,7 @@ class TaskManager:
             method=process_historical_balances,
             database=self.database,
             msg_aggregator=self.msg_aggregator,
-            from_ts=stale_from_ts,
+            from_ts=TimestampMS(int(stale_from_ts)) if stale_from_ts else None,
         )]
 
     def _maybe_check_data_updates(self) -> Optional[list[gevent.Greenlet]]:

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -1,6 +1,7 @@
 from typing import Any
 from unittest.mock import patch
 
+import gevent
 import pytest
 
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
@@ -607,13 +608,13 @@ def test_match_exact_events(database: 'DBHandler', start_with_valid_premium: boo
 
 def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> None:
     db = DBHistoryEvents(database)
-    cache_key = DBCacheStatic.STALE_BALANCES_FROM_TS.value
+    event_ts_key = DBCacheStatic.STALE_BALANCES_FROM_TS.value
+    modification_ts_key = DBCacheStatic.STALE_BALANCES_MODIFICATION_TS.value
 
     with database.conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT value FROM key_value_cache WHERE name=?', (cache_key,),
-        ).fetchone()
-        assert result is None
+        assert cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone() is None
 
     with database.user_write() as write_cursor:
         db.add_history_events(
@@ -640,10 +641,12 @@ def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> 
         )
 
     with database.conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT value FROM key_value_cache WHERE name=?', (cache_key,),
-        ).fetchone()
-        assert result[0] == str(ts_2000)  # global minimum across all assets
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone()[0]) == ts_2000  # global minimum across all assets
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (modification_ts_key,),
+        ).fetchone()[0]) > 0
 
     with database.user_write() as write_cursor:
         db.add_history_event(
@@ -661,10 +664,9 @@ def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> 
         )
 
     with database.conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT value FROM key_value_cache WHERE name=?', (cache_key,),
-        ).fetchone()
-        assert result[0] == str(ts_1000)  # updated to earlier timestamp
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone()[0]) == ts_1000  # updated to earlier timestamp
 
     # add event at later timestamp 5000 and cache should remain at 1000
     with database.user_write() as write_cursor:
@@ -683,10 +685,9 @@ def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> 
         )
 
     with database.conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT value FROM key_value_cache WHERE name=?', (cache_key,),
-        ).fetchone()
-        assert result[0] == str(ts_1000)  # remains at minimum
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone()[0]) == ts_1000  # remains at minimum
 
     # edit notes only and _mark_events_modified should NOT be called
     with (
@@ -704,10 +705,9 @@ def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> 
         db.edit_history_event(write_cursor=write_cursor, event=eth_event)
 
     with database.conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT value FROM key_value_cache WHERE name=?', (cache_key,),
-        ).fetchone()
-        assert result[0] == str(ts_1000)  # still the global minimum
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone()[0]) == ts_1000  # still the global minimum
 
     # test purge_exchange_data updates cache via delete_events_and_track
     with database.user_write() as write_cursor:
@@ -727,7 +727,57 @@ def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> 
         database.purge_exchange_data(write_cursor=write_cursor, location=Location.KRAKEN)
 
     with database.conn.read_ctx() as cursor:
-        result = cursor.execute(
-            'SELECT value FROM key_value_cache WHERE name=?', (cache_key,),
-        ).fetchone()
-        assert result[0] == str(ts_500)  # updated to deleted event's timestamp
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone()[0]) == ts_500  # updated to deleted event's timestamp
+
+
+def test_modification_ts_updated_on_each_modification(database: 'DBHandler') -> None:
+    db = DBHistoryEvents(database)
+    event_ts_key = DBCacheStatic.STALE_BALANCES_FROM_TS.value
+    modification_ts_key = DBCacheStatic.STALE_BALANCES_MODIFICATION_TS.value
+
+    with database.user_write() as write_cursor:
+        db.add_history_event(
+            write_cursor=write_cursor,
+            event=HistoryEvent(
+                group_identifier='TEST1',
+                sequence_index=1,
+                timestamp=TimestampMS(1000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.TRADE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_ETH,
+                amount=ONE,
+            ),
+        )
+
+    with database.conn.read_ctx() as cursor:
+        modification_ts1 = int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (modification_ts_key,),
+        ).fetchone()[0])
+
+    gevent.sleep(0.01)  # ensure different modification_ts between events
+
+    with database.user_write() as write_cursor:
+        db.add_history_event(
+            write_cursor=write_cursor,
+            event=HistoryEvent(
+                group_identifier='TEST2',
+                sequence_index=1,
+                timestamp=TimestampMS(2000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.TRADE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_ETH,
+                amount=ONE,
+            ),
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (event_ts_key,),
+        ).fetchone()[0]) == 1000
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?', (modification_ts_key,),
+        ).fetchone()[0]) >= modification_ts1

--- a/rotkehlchen/tests/unit/test_utils.py
+++ b/rotkehlchen/tests/unit/test_utils.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from json.decoder import JSONDecodeError
 from unittest.mock import patch
 
+import gevent
 import pytest
 from eth_typing import HexAddress, HexStr
 from eth_utils import to_checksum_address
@@ -34,6 +35,7 @@ from rotkehlchen.utils.misc import (
     timestamp_to_date,
 )
 from rotkehlchen.utils.mixins.cacheable import CacheableMixIn, cache_response_timewise
+from rotkehlchen.utils.mixins.lockable import skip_if_running
 from rotkehlchen.utils.serialization import jsonloads_dict, jsonloads_list
 from rotkehlchen.utils.version_check import get_current_version
 
@@ -526,3 +528,31 @@ def test_identifier_to_evm_address():
     assert identifier_to_evm_address(identifier='eip155:/:') is None
     assert identifier_to_evm_address(identifier='eip155:1/erc20:') is None
     assert identifier_to_evm_address(identifier='eip155:1/erc20:xyz') is None
+
+
+def test_skip_if_running():
+    """Test that skip_if_running decorator skips concurrent calls"""
+    call_count = 0
+    execution_order = []
+
+    @skip_if_running
+    def slow_function():
+        nonlocal call_count
+        call_count += 1
+        execution_order.append(f'start_{call_count}')
+        gevent.sleep(0.05)
+        execution_order.append(f'end_{call_count}')
+        return call_count
+
+    greenlet1 = gevent.spawn(slow_function)
+    gevent.sleep(0.01)  # ensure greenlet1 starts first
+    greenlet2 = gevent.spawn(slow_function)
+    greenlet3 = gevent.spawn(slow_function)
+
+    gevent.joinall([greenlet1, greenlet2, greenlet3])
+
+    assert greenlet1.value == 1
+    assert greenlet2.value is None  # skipped - already running
+    assert greenlet3.value is None  # skipped - already running
+    assert call_count == 1
+    assert execution_order == ['start_1', 'end_1']

--- a/rotkehlchen/utils/mixins/lockable.py
+++ b/rotkehlchen/utils/mixins/lockable.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from collections.abc import Callable
 from functools import wraps
@@ -5,7 +6,27 @@ from typing import Any
 
 from gevent.lock import Semaphore
 
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+
 from .common import function_sig_key
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+def skip_if_running(f: Callable) -> Callable:
+    """Decorator that skips execution if the function is already running."""
+    lock = Semaphore()
+
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if lock.locked():
+            log.debug(f'{f.__name__} already running, skipping')
+            return None
+        with lock:
+            return f(*args, **kwargs)
+
+    return wrapper
 
 
 class LockableQueryMixIn:


### PR DESCRIPTION
Related https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=146319110 & #2227

this pr implements synchronization for historical balance processing to handle concurrent event modifications.

the previous implementation unconditionally cleared the stale marker after processing. if other background tasks modified events during processing, the marker would be cleared despite metrics being incorrect, leaving users with silently stale data.

instead of locks, the `STALE_BALANCES_FROM_TS` marker now stores `{event_ts},{modification_ts}`. after processing, the marker is only cleared if the modification happened before processing started. otherwise it remains set for the next cycle. this keeps sync tasks non-blocking and auto-corrects any stale metrics the next time it runs.