### PR TITLE
Improve asset movement event grouping etc

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -223,6 +223,7 @@ class DBHandler:
         self.conn_transient: DBConnection = None  # type: ignore
         # Lock to make sure that 2 callers of get_or_create_evm_token do not go in at the same time
         self.get_or_create_token_lock = Semaphore()
+        self.match_asset_movements_lock = Semaphore()
         self.password = password
         self._connect()
         self._check_unfinished_upgrades(resume_from_backup=resume_from_backup)

--- a/rotkehlchen/tasks/events.py
+++ b/rotkehlchen/tasks/events.py
@@ -39,7 +39,8 @@ def process_events(
         eth2.combine_block_with_tx_events()
         eth2.refresh_activated_validators_deposits()
 
-    match_asset_movements(database)
+    with database.match_asset_movements_lock:
+        match_asset_movements(database)
 
     with database.user_write() as write_cursor:
         database.set_static_cache(  # update last event processing timestamp

--- a/rotkehlchen/tests/api/test_event_matching.py
+++ b/rotkehlchen/tests/api/test_event_matching.py
@@ -11,7 +11,7 @@ from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
-from rotkehlchen.history.events.structures.base import HistoryEvent
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType, HistoryEvent
 from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.swap import SwapEvent
@@ -374,6 +374,16 @@ def test_get_possible_matches(rotkehlchen_api_server: 'APIServer') -> None:
                 amount=FVal('0.1'),
                 withdrawal_address=make_evm_address(),
                 is_exit=False,
+            ), EvmEvent(  # INFO/APPROVE event that should be ignored.
+                identifier=11,
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=matched_movement.timestamp,
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.INFORMATIONAL,
+                event_subtype=HistoryEventSubType.APPROVE,
+                asset=matched_movement.asset,
+                amount=matched_movement.amount,
             )],
         )
 
@@ -485,20 +495,26 @@ def test_get_history_events_with_matched_asset_movements(
             is_deposit=False,
         )
 
-    # First query history aggregated by group
-    result = assert_proper_response_with_result(
-        response=requests.post(
-            api_url_for(rotkehlchen_api_server, 'historyeventresource'),
-            json={'aggregate_by_group_ids': True},
-        ),
-        rotkehlchen_api_server=rotkehlchen_api_server,
-    )
-    assert result['entries_found'] == result['entries_found_total'] == result['entries_total'] == 2
-    assert len(result['entries']) == 2
-    assert result['entries'][0]['grouped_events_num'] == 3  # includes both evm events and the matched asset movement  # noqa: E501
-    assert result['entries'][0]['entry']['group_identifier'] == evm_event_1.group_identifier
-    assert result['entries'][1]['grouped_events_num'] == 4  # the two matched movements and their fees  # noqa: E501
-    assert result['entries'][1]['entry']['group_identifier'] == movement2.group_identifier
+    # Check aggregating by group with several filters that should all get the same groups.
+    for filters in (
+        {},
+        {'entry_types': {'values': [HistoryBaseEntryType.ASSET_MOVEMENT_EVENT.serialize()]}},
+        {'group_identifiers': [evm_event_1.group_identifier, movement2.group_identifier]},
+    ):
+        filters['aggregate_by_group_ids'] = True  # type: ignore[assignment]
+        result = assert_proper_response_with_result(
+            response=requests.post(
+                api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+                json=filters,
+            ),
+            rotkehlchen_api_server=rotkehlchen_api_server,
+        )
+        assert result['entries_found'] == result['entries_found_total'] == result['entries_total'] == 2  # noqa: E501
+        assert len(result['entries']) == 2
+        assert result['entries'][0]['grouped_events_num'] == 3  # includes both evm events and the matched asset movement  # noqa: E501
+        assert result['entries'][0]['entry']['group_identifier'] == evm_event_1.group_identifier
+        assert result['entries'][1]['grouped_events_num'] == 4  # the two matched movements and their fees  # noqa: E501
+        assert result['entries'][1]['entry']['group_identifier'] == movement2.group_identifier
 
     # Then query the evm event group and the matched asset movement should be included
     result = assert_proper_response_with_result(


### PR DESCRIPTION
Related: #10467 and https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=139839074

* Adds a lock to prevent the asset movement matching from being run simultaneously by both the api and periodic task.
* Skips info/approve events in the possible matches list
* Fixes bugs in the joined groups logic where if the filters only returned asset movements without including their matched events, then the entire group was skipped.