### PR TITLE
fix(websocket, vite): add reconnect delay and update ignored paths

### DIFF
--- a/frontend/app/src/store/websocket.ts
+++ b/frontend/app/src/store/websocket.ts
@@ -2,7 +2,11 @@ import type { Nullable } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { api } from '@/modules/api/rotki-api';
 import { useMessageHandling } from '@/modules/messaging';
+import { delay } from '@/utils/async-utilities';
 import { logger } from '@/utils/logging';
+
+/** Delay in milliseconds before attempting to reconnect to websocket */
+const RECONNECT_DELAY_MS = 2000;
 
 export const useWebsocketStore = defineStore('websocket', () => {
   const connection = ref<Nullable<WebSocket>>(null);
@@ -11,7 +15,8 @@ export const useWebsocketStore = defineStore('websocket', () => {
   const { handleMessage } = useMessageHandling();
 
   const reconnect = async (): Promise<void> => {
-    logger.debug('Close was not clean attempting reconnect');
+    logger.debug(`Close was not clean, waiting ${RECONNECT_DELAY_MS}ms before reconnect`);
+    await delay(RECONNECT_DELAY_MS);
     try {
       await connect();
       logger.debug('websocket reconnection complete');

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -165,7 +165,11 @@ export default defineConfig({
     port: 8080,
     hmr: hmrEnabled,
     watch: {
-      ignored: ['**/.e2e/**'],
+      ignored: [
+        '**/.e2e/**',
+        '**/*.spec.ts',
+        '**/coverage/**',
+      ],
     },
   },
   build: {


### PR DESCRIPTION
- Introduces a 2-second delay before websocket reconnect attempts to improve stability.
- Updates Vite config to ignore additional paths (`*.spec.ts`, `coverage/`) during watch.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
