### PR TITLE
Ensure that repulling transactions returns the new transactions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14454,9 +14454,22 @@ Refetch transactions for a specific time period
       HTTP/1.1 200 OK
       Content-Type: application/json
 
-      { "result": {"new_transactions_count": 12}, "message": "" }
+      {
+          "result": {
+              "new_transactions_count": 2,
+              "new_transactions": {
+                  "eth": [
+                      "0x1234...",
+                      "0xabcd..."
+                  ]
+              }
+          },
+          "message": ""
+      }
 
    :resjson int new_transactions_count: The number of new transactions found and added to the database.
+   :resjson dict new_transactions: Mapping of chain to list of new transaction hashes.
+   :resjson list new_transactions[chain]: New transaction hashes for the chain (Solana uses the transaction signature).
    :statuscode 200: Transactions successfully refetched.
    :statuscode 401: User is not logged in.
    :statuscode 400: Invalid parameters such as from_timestamp > to_timestamp. Address not tracked by rotki.

--- a/rotkehlchen/tests/api/test_solana_transactions.py
+++ b/rotkehlchen/tests/api/test_solana_transactions.py
@@ -167,6 +167,10 @@ def test_refetch_txs_in_range(
         },
     ))
     assert result['new_transactions_count'] == 2
+    assert set(result['new_transactions'][SupportedBlockchain.SOLANA.serialize()]) == {
+        '5HzJs4E3KobYW4dfDAvxzuUPriKdK71iPG7g7w3VQBC1bgpQmHjeevkBBmp8WFf3FeosqMkcgSHV5LPqwDfmvr2X',
+        '4UoyrhPVWBCkiWUMWdyHUQQ29qMxCFXM6iXt7pL9ufaGgcnA8nz1qGQZfgKJcRURgvwmpLWeBVwfp1EJDZoVXPDA',
+    }
     websocket_connection.wait_until_messages_num(num=3, timeout=2)
     assert [msg['data']['status'] for msg in websocket_connection.messages if msg['data'].get('service') is None] == [  # skip helius message  # noqa: E501
         'querying_transactions_finished',


### PR DESCRIPTION
Refetch transactions endpoint (/api/(version)/blockchains/transactions/refetch) now returns the newly fetched tx hashes (with chain) in addition to the count, whereas it previously returned only new_transactions_count.

backend of #11332