### PR TITLE
Add asset movement amount match tolerance setting

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -792,11 +792,16 @@ Getting or modifying settings
               "cost_basis_method": "fifo",
               "oracle_penalty_threshold_count": 5,
               "oracle_penalty_duration": 1800,
+              "auto_delete_calendar_entries": true,
               "auto_create_calendar_reminders": true,
               "address_name_priority": ["private_addressbook", "blockchain_account",
                                         "global_addressbook", "ethereum_tokens",
                                         "hardcoded_mappings", "ens_names"],
               "ask_user_upon_size_discrepancy": true,
+              "auto_detect_tokens": true,
+              "csv_export_delimiter": ",",
+              "events_processing_frequency": 86400,
+              "asset_movement_amount_tolerance": "0.000001"
           },
           "message": ""
       }
@@ -832,8 +837,13 @@ Getting or modifying settings
    :resjson int read_timeout: The number of seconds to wait for the first byte after a connection to an external service has been established. Default is 30.
    :resjson int oracle_penalty_threshold_count: The number of failures after which an oracle is penalized. Default is 5.
    :resjson int oracle_penalty_duration: The duration in seconds for which an oracle is penalized. Default is 1800.
+   :resjson bool auto_delete_calendar_entries: A boolean denoting whether calendar entries are automatically deleted when related blockchain accounts are removed. Default is ``true``.
    :resjson bool auto_create_calendar_reminders: A boolean denoting whether reminders are created automatically for calendar entries based on the decoded history events. Default is ``true``.
    :resjson bool ask_user_upon_size_discrepancy: A boolean denoting whether to prompt the user for confirmation each time the remote database is bigger than the local one or directly force push. Default is ``true``.
+   :resjson bool auto_detect_tokens: A boolean denoting whether to automatically detect and add tokens for EVM addresses. Default is ``true``.
+   :resjson string csv_export_delimiter: The delimiter character to use when exporting data to CSV files. Default is ``","``.
+   :resjson int events_processing_frequency: The frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds. Default is 86400 (24 hours).
+   :resjson string asset_movement_amount_tolerance: The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number. Default is ``"0.000001"``.
 
    :statuscode 200: Querying of settings was successful
    :statuscode 409: There is no logged in user
@@ -883,8 +893,13 @@ Getting or modifying settings
    :resjson int read_timeout: The number of seconds to wait for the first byte after a connection to an external service has been established. Default is 30.
    :resjson int oracle_penalty_threshold_count: The number of failures after which an oracle is penalized. Default is 5.
    :resjson int oracle_penalty_duration: The duration in seconds for which an oracle is penalized. Default is 1800.
+   :resjson bool[optional] auto_delete_calendar_entries: A boolean denoting whether calendar entries are automatically deleted when related blockchain accounts are removed.
    :resjson bool[optional] auto_create_calendar_reminders: A boolean denoting whether reminders are created automatically for calendar entries based on the decoded history events.
    :resjson bool[optional] ask_user_upon_size_discrepancy: A boolean denoting whether to prompt the user for confirmation each time the remote database is bigger than the local one or directly force push.
+   :resjson bool[optional] auto_detect_tokens: A boolean denoting whether to automatically detect and add tokens for EVM addresses.
+   :resjson string[optional] csv_export_delimiter: The delimiter character to use when exporting data to CSV files.
+   :resjson int[optional] events_processing_frequency: The frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds.
+   :resjson string[optional] asset_movement_amount_tolerance: The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number.
 
    **Example Response**:
 
@@ -914,9 +929,14 @@ Getting or modifying settings
               "current_price_oracles": ["cryptocompare"],
               "historical_price_oracles": ["coingecko", "cryptocompare"],
               "ssf_graph_multiplier": 2,
-              "non_sync_exchanges": [{"location": "binance", "name": "binance1"}]
+              "non_sync_exchanges": [{"location": "binance", "name": "binance1"}],
+              "auto_delete_calendar_entries": true,
               "auto_create_calendar_reminders": true,
               "ask_user_upon_size_discrepancy": true,
+              "auto_detect_tokens": true,
+              "csv_export_delimiter": ",",
+              "events_processing_frequency": 86400,
+              "asset_movement_amount_tolerance": "0.000001"
           },
           "message": ""
       }

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -50,6 +50,10 @@ Exchange asset movement events may now be manually matched with specific onchain
   - New optional ``actual_group_identifier`` field in the response, containing the actual group identifier of the event as stored in the DB.
   - This change preserves the actual group identifier when asset movements are combined with the group of their matched event for display as a single unit in the frontend.
 
+* **New Settings** (new fields in both ``PUT`` and ``POST`` on ``/api/(version)/settings``)
+  - ``events_processing_frequency`` Boolean flag indicating the frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds. Default is 86400 (24 hours).
+  - ``asset_movement_amount_tolerance`` The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number. Default is ``"0.000001"``.
+
 Event/Group Identifier Renaming
 -------------------------------
 

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -90,6 +90,7 @@ from rotkehlchen.exchanges.constants import (
 )
 from rotkehlchen.exchanges.kraken import KrakenAccountType
 from rotkehlchen.exchanges.okx import OkxLocation
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     AssetMovementExtraData,
@@ -1667,6 +1668,11 @@ class ModifiableSettingsSchema(Schema):
             error='The frequency should be >= 60 seconds',
         ),
     )
+    asset_movement_amount_tolerance = fields.Decimal(
+        load_default=None,
+        as_string=True,
+        validate=validate.Range(min=0, max=1, min_inclusive=False, max_inclusive=False),
+    )
 
     @validates_schema
     def validate_settings_schema(
@@ -1733,6 +1739,7 @@ class ModifiableSettingsSchema(Schema):
             auto_detect_tokens=data['auto_detect_tokens'],
             csv_export_delimiter=data['csv_export_delimiter'],
             events_processing_frequency=data['events_processing_frequency'],
+            asset_movement_amount_tolerance=FVal(data['asset_movement_amount_tolerance']) if data['asset_movement_amount_tolerance'] is not None else None,  # noqa: E501
         )
 
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -455,8 +455,9 @@ class DBHandler:
                 'main_currency',
                 'non_syncing_exchanges',
                 'ask_user_upon_size_discrepancy',
+                'asset_movement_amount_tolerance',
             ],
-            value: int | (Timestamp | Asset) | str | bool,
+            value: int | (Timestamp | Asset) | str | bool | FVal,
     ) -> None:
         write_cursor.execute(
             'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -231,6 +231,8 @@ def test_set_settings(rotkehlchen_api_server: 'APIServer') -> None:
             value = ';'
         elif setting == 'events_processing_frequency':
             value = HOUR_IN_SECONDS
+        elif setting == 'asset_movement_amount_tolerance':
+            value = '0.0001'
         else:
             raise AssertionError(f'Unexpected setting {setting} encountered')
 

--- a/rotkehlchen/tests/data/pnl_debug.json
+++ b/rotkehlchen/tests/data/pnl_debug.json
@@ -201,7 +201,8 @@
     "csv_export_delimiter": ",",
     "default_evm_indexer_order": ["etherscan", "blockscout", "routescan"],
     "evm_indexers_order": {"ethereum": ["etherscan", "blockscout", "routescan"], "optimism": ["etherscan", "blockscout", "routescan"], "polygon_pos": ["etherscan", "blockscout", "routescan"], "arbitrum_one": ["etherscan", "blockscout", "routescan"], "base": ["etherscan", "blockscout", "routescan"], "gnosis": ["etherscan", "blockscout", "routescan"], "scroll": ["etherscan", "blockscout", "routescan"], "binance_sc": ["etherscan", "blockscout", "routescan"]},
-    "events_processing_frequency": 86400
+    "events_processing_frequency": 86400,
+    "asset_movement_amount_tolerance": "0.000001"
   },
   "ignored_events_ids": ["100x0xca0a482213c17ccb0471b02ffab40b92279ae7f25da53e426fda5e73e915509f"],
   "pnl_settings": {

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -43,6 +43,7 @@ from rotkehlchen.db.schema import DB_CREATE_USER_NOTES
 from rotkehlchen.db.settings import (
     DEFAULT_ACTIVE_MODULES,
     DEFAULT_ASK_USER_UPON_SIZE_DISCREPANCY,
+    DEFAULT_ASSET_MOVEMENT_AMOUNT_TOLERANCE,
     DEFAULT_AUTO_CREATE_CALENDAR_REMINDERS,
     DEFAULT_AUTO_DELETE_CALENDAR_ENTRIES,
     DEFAULT_AUTO_DETECT_TOKENS,
@@ -541,6 +542,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         'auto_detect_tokens': DEFAULT_AUTO_DETECT_TOKENS,
         'csv_export_delimiter': DEFAULT_CSV_EXPORT_DELIMITER,
         'events_processing_frequency': DEFAULT_EVENTS_PROCESSING_FREQUENCY,
+        'asset_movement_amount_tolerance': DEFAULT_ASSET_MOVEMENT_AMOUNT_TOLERANCE,
     }
     assert len(expected_dict) == len(dataclasses.fields(DBSettings)), 'One or more settings are missing'  # noqa: E501
 


### PR DESCRIPTION
Related: #10467 

* Adds a new `asset_movement_amount_tolerance` setting
* Updates the api docs for the settings endpoints to include several other settings that missed getting added there when they were added.