### PR TITLE
Improve protocol cache ws messages

### DIFF
--- a/rotkehlchen/chain/evm/decoding/morpho/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/morpho/decoder.py
@@ -76,7 +76,10 @@ class MorphoCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
                 cache_key=CacheType.MORPHO_VAULTS,
                 args=(str(self.node_inquirer.chain_id.serialize()),),
         ) is True:
-            query_morpho_vaults(chain_id=self.node_inquirer.chain_id)
+            query_morpho_vaults(
+                chain_id=self.node_inquirer.chain_id,
+                msg_aggregator=self.msg_aggregator,
+            )
             updated = True
         if should_update_protocol_cache(
                 userdb=self.base.database,

--- a/rotkehlchen/chain/evm/decoding/stakedao/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/v2/decoder.py
@@ -59,7 +59,10 @@ class Stakedaov2CommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
             cache_key=CacheType.STAKEDAO_V2_VAULTS,
             args=(str(self.node_inquirer.chain_id.serialize()),),
         ):
-            query_stakedao_v2_vaults(chain_id=self.node_inquirer.chain_id)
+            query_stakedao_v2_vaults(
+                chain_id=self.node_inquirer.chain_id,
+                msg_aggregator=self.msg_aggregator,
+            )
         elif len(self.vaults) != 0:
             return None  # didn't update cache and we already have the vault info
 

--- a/rotkehlchen/chain/evm/decoding/stakedao/v2/utils.py
+++ b/rotkehlchen/chain/evm/decoding/stakedao/v2/utils.py
@@ -5,6 +5,7 @@ from rotkehlchen.assets.asset import UnderlyingToken
 from rotkehlchen.assets.utils import TokenEncounterInfo, get_or_create_evm_token
 from rotkehlchen.chain.evm.decoding.stakedao.utils import STAKEDAO_API
 from rotkehlchen.chain.evm.decoding.stakedao.v2.constants import CPT_STAKEDAO_V2
+from rotkehlchen.chain.evm.utils import maybe_notify_cache_query_status
 from rotkehlchen.constants import ONE
 from rotkehlchen.errors.misc import RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.errors.serialization import DeserializationError
@@ -15,12 +16,13 @@ from rotkehlchen.globaldb.cache import (
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
-from rotkehlchen.types import CacheType, ChainID, TokenKind
+from rotkehlchen.types import CacheType, ChainID, Timestamp, TokenKind
 from rotkehlchen.utils.network import request_get
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.types import ChecksumEvmAddress
+    from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -72,7 +74,7 @@ def ensure_stakedao_v2_vault_token_exists(
     )
 
 
-def query_stakedao_v2_vaults(chain_id: ChainID) -> None:
+def query_stakedao_v2_vaults(chain_id: ChainID, msg_aggregator: 'MessagesAggregator') -> None:
     """Query StakeDAO V2 vaults from the API and cache the vault and underlying token addresses."""
     if (vault_data := _query_stakedao_v2_api(chain_id)) is None:
         with GlobalDBHandler().conn.write_ctx() as write_cursor:
@@ -83,8 +85,8 @@ def query_stakedao_v2_vaults(chain_id: ChainID) -> None:
             )  # Update cache timestamp to prevent repeated errors.
         return
 
-    cache_entries = []
-    for vault in vault_data:
+    cache_entries, last_notified_ts, total_entries = [], Timestamp(0), len(vault_data)
+    for idx, vault in enumerate(vault_data):
         try:
             cache_entries.append(','.join((
                 deserialize_evm_address(vault['vault']),
@@ -96,6 +98,15 @@ def query_stakedao_v2_vaults(chain_id: ChainID) -> None:
                 'Failed to cache StakeDAO V2 vault address and underlying token address for '
                 f'vault {vault} due to {error}. Skipping.',
             )
+
+        last_notified_ts = maybe_notify_cache_query_status(
+            msg_aggregator=msg_aggregator,
+            last_notified_ts=last_notified_ts,
+            protocol=CPT_STAKEDAO_V2,
+            chain=chain_id,
+            processed=idx + 1,
+            total=total_entries,
+        )
 
     if len(cache_entries) > 0:
         with GlobalDBHandler().conn.write_ctx() as write_cursor:

--- a/rotkehlchen/chain/evm/utils.py
+++ b/rotkehlchen/chain/evm/utils.py
@@ -208,8 +208,11 @@ def maybe_notify_cache_query_status(
         total: int,
 ) -> Timestamp:
     """Helper function to notify the cache query status if it's been more than 5 seconds since the
-    last notification, and returns the last notified timestamp."""
-    if (current_time := ts_now()) - last_notified_ts > 5:
+    last notification, and returns the last notified timestamp. Also sends the message if the
+    processed number has reached the total to ensure the frontend is always notified when a cache
+    is finished being queried even if a previous update msg was sent <5 seconds before.
+    """
+    if (current_time := ts_now()) - last_notified_ts > 5 or processed == total:
         msg_aggregator.add_message(
             message_type=WSMessageType.PROGRESS_UPDATES,
             data={

--- a/rotkehlchen/tests/external_apis/test_morpho.py
+++ b/rotkehlchen/tests/external_apis/test_morpho.py
@@ -57,7 +57,7 @@ def test_morpho_vaults_api(database: 'DBHandler') -> None:
         target='rotkehlchen.chain.evm.decoding.morpho.utils.requests.post',
         return_value=MockResponse(HTTPStatus.OK, '{"data":{"vaults":{"items":[{"address":"0xc43f5F199a055F38de4629dd14d18e69dAe9f29D","symbol":"AnzenUSDC","name":"Anzen Boosted USDC","asset":{"address":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","symbol":"USDC","name":"USD Coin","decimals":6},"chain":{"id":8453}},{"address":"0xc28ca6bFA6C1dfEF94989DC0D0A862eff8d71065","symbol":"glocWETHezETH","name":"Glocusent WETH ezETH","asset":{"address":"0x4200000000000000000000000000000000000006","symbol":"WETH","name":"Wrapped Ether","decimals":18},"chain":{"id":8453}}]}}}'),  # noqa: E501,
     )):
-        query_morpho_vaults(chain_id=ChainID.BASE)
+        query_morpho_vaults(chain_id=ChainID.BASE, msg_aggregator=database.msg_aggregator)
 
     with GlobalDBHandler().conn.read_ctx() as cursor:
         assert globaldb_get_general_cache_values(
@@ -70,7 +70,10 @@ def test_morpho_vaults_api(database: 'DBHandler') -> None:
 
     check_new_query_updates_timestamp(
         query_patch=query_patch,
-        query_func=lambda: query_morpho_vaults(chain_id=ChainID.BASE),
+        query_func=lambda: query_morpho_vaults(
+            chain_id=ChainID.BASE,
+            msg_aggregator=database.msg_aggregator,
+        ),
         key_parts=(CacheType.MORPHO_VAULTS, str(ChainID.BASE.serialize())),
     )
 

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -562,6 +562,7 @@ def test_gearbox_cache(ethereum_inquirer: EthereumInquirer):
     assert mock_notify.call_args_list == [
         make_call_object(CPT_GEARBOX, ChainID.ETHEREUM, processed=0, total=0),
         make_call_object(CPT_GEARBOX, ChainID.ETHEREUM, processed=1, total=8),
+        make_call_object(CPT_GEARBOX, ChainID.ETHEREUM, processed=8, total=8),
     ]
 
 


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=149302105

* Ensures the final ws message gets sent even if a previous update message was sent <5 seconds before
* Adds ws messages back to several caches where they were removed when reworking how the cache works. While these no longer take so much time, its probably good for them to still notify and provide info on how many pool/vault addresses are loaded from each protocol.
