### PR TITLE
Small perf improvements

### DIFF
--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -645,7 +645,12 @@ class TransactionsService:
             addresses_to_query: tuple[ChecksumEvmAddress | SolanaAddress, ...] = (address,)
         else:
             with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
-                addresses_to_query = self.rotkehlchen.data.db.get_blockchain_accounts(cursor).get(blockchain)  # noqa: E501
+                addresses_to_query = tuple(
+                    self.rotkehlchen.data.db.get_single_blockchain_addresses(
+                        cursor=cursor,
+                        blockchain=blockchain,
+                    ),
+                )
 
         if len(addresses_to_query) == 0:
             return set()

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1168,10 +1168,19 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         existed_accounts: list[tuple[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE, ChecksumEvmAddress]] = []
         no_activity_accounts: list[tuple[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE, ChecksumEvmAddress]] = []  # noqa: E501
         evm_contract_addresses: set[ChecksumEvmAddress] = set()
+        accounts_by_chain = {
+            chain: set(self.accounts.get(chain))
+            for chain in SUPPORTED_EVM_EVMLIKE_CHAINS
+        }
 
         for account in accounts:
-            existed_accounts += [(chain, account) for chain in SUPPORTED_EVM_EVMLIKE_CHAINS if account in self.accounts.get(chain)]  # noqa: E501
-            chains_to_check = [x for x in SUPPORTED_EVM_EVMLIKE_CHAINS if account not in self.accounts.get(x)]  # noqa: E501
+            chains_to_check = []
+            for chain in SUPPORTED_EVM_EVMLIKE_CHAINS:
+                if account in accounts_by_chain[chain]:
+                    existed_accounts.append((chain, account))
+                else:
+                    chains_to_check.append(chain)
+
             chains_with_valid_addresses = []
             for chain in chains_to_check:
                 chains_with_valid_addresses.append(chain)


### PR DESCRIPTION
1. services/transactions -> Query only single chain for DB
2. Precompute account sets to avoid repeated membership in add_accounts_to_all_evm

