### PR TITLE
chore(frontend): refactor imports to use `MaybeRef` from `vue` instea…

### DIFF
--- a/frontend/app/src/components/common/AppImage.vue
+++ b/frontend/app/src/components/common/AppImage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import { toRem } from '@/utils/data';
 import { getPublicPlaceholderImagePath } from '@/utils/file';
 

--- a/frontend/app/src/components/settings/controls/SettingsOption.vue
+++ b/frontend/app/src/components/settings/controls/SettingsOption.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { SessionSettings } from '@/types/session';
 import type { FrontendSettingsPayload } from '@/types/settings/frontend-settings';
 import type { SettingsUpdate } from '@/types/user';

--- a/frontend/app/src/composables/accounts/blockchain/use-account-loading.ts
+++ b/frontend/app/src/composables/accounts/blockchain/use-account-loading.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { useAccountCategoryHelper } from '@/composables/accounts/use-account-category-helper';
 import { useBlockchainTokensStore } from '@/store/blockchain/tokens';
 import { useStatusStore } from '@/store/status';

--- a/frontend/app/src/composables/accounts/use-account-category-helper.ts
+++ b/frontend/app/src/composables/accounts/use-account-category-helper.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { useSupportedChains } from '@/composables/info/chains';
 
 interface UseBlockchainAccountLoadingReturn {

--- a/frontend/app/src/composables/address-book/use-address-book-deletion.ts
+++ b/frontend/app/src/composables/address-book/use-address-book-deletion.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { AddressBookEntry, AddressBookLocation } from '@/types/eth-names';
 import { NotificationCategory, Severity } from '@rotki/common';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';

--- a/frontend/app/src/composables/api/assets/cex-mapping.ts
+++ b/frontend/app/src/composables/api/assets/cex-mapping.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import { omit } from 'es-toolkit';
 import { api } from '@/modules/api/rotki-api';

--- a/frontend/app/src/composables/api/assets/management.ts
+++ b/frontend/app/src/composables/api/assets/management.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import { OwnedAssets, type SupportedAsset } from '@rotki/common';
 import { api } from '@/modules/api/rotki-api';

--- a/frontend/app/src/composables/api/session/user-notes.ts
+++ b/frontend/app/src/composables/api/session/user-notes.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import { api } from '@/modules/api/rotki-api';
 import { type UserNote, UserNoteCollectionResponse, type UserNotesRequestPayload } from '@/types/notes';

--- a/frontend/app/src/composables/array/index.ts
+++ b/frontend/app/src/composables/array/index.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 
 export function useArrayInclude<T>(array: MaybeRef<T[]>, t: MaybeRef<T>): ComputedRef<boolean> {
   return computed(() => {

--- a/frontend/app/src/composables/assets/asset-select-info.ts
+++ b/frontend/app/src/composables/assets/asset-select-info.ts
@@ -1,6 +1,5 @@
 import type { AssetInfo } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { AssetMap } from '@/types/asset';
 import { useAssetInfoApi } from '@/composables/api/assets/info';
 import { getAssociatedAssetIdentifier, processAssetInfo, useAssetAssociationMap } from '@/composables/assets/common';

--- a/frontend/app/src/composables/assets/retrieval.ts
+++ b/frontend/app/src/composables/assets/retrieval.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { ERC20Token } from '@/types/blockchain/accounts';
 import type { EvmChainAddress } from '@/types/history/events';
 import type { TaskMeta } from '@/types/task';

--- a/frontend/app/src/composables/balances/location-breakdown.ts
+++ b/frontend/app/src/composables/balances/location-breakdown.ts
@@ -1,11 +1,10 @@
 import type { AssetBalanceWithPrice, BigNumber } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
 import type { AssetBalances } from '@/types/balances';
 import type { Balances } from '@/types/blockchain/accounts';
 import type { AssetProtocolBalances } from '@/types/blockchain/balances';
 import type { ExchangeInfo } from '@/types/exchanges';
 import type { ManualBalanceWithValue } from '@/types/manual-balances';
-import { computed, type ComputedRef } from 'vue';
+import { computed, type ComputedRef, type MaybeRef } from 'vue';
 import { summarizeAssetProtocols } from '@/composables/balances/asset-summary';
 import { blockchainToAssetProtocolBalances, manualToAssetProtocolBalances } from '@/composables/balances/balance-transformations';
 import { TRADE_LOCATION_BLOCKCHAIN } from '@/data/defaults';

--- a/frontend/app/src/composables/balances/refresh.ts
+++ b/frontend/app/src/composables/balances/refresh.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import { Blockchain } from '@rotki/common';
 import { useTokenDetection } from '@/composables/balances/token-detection';
 import { useSupportedChains } from '@/composables/info/chains';

--- a/frontend/app/src/composables/balances/token-detection.ts
+++ b/frontend/app/src/composables/balances/token-detection.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { EthDetectedTokensInfo } from '@/types/balances';
 import { assert } from '@rotki/common';
 import { useBalanceQueue } from '@/composables/balances/use-balance-queue';

--- a/frontend/app/src/composables/balances/use-aggregated-balances.ts
+++ b/frontend/app/src/composables/balances/use-aggregated-balances.ts
@@ -1,9 +1,8 @@
-import type { MaybeRef } from '@vueuse/core';
 import type { EthBalance } from '@/types/blockchain/balances';
 import type { AssetPriceInfo } from '@/types/prices';
 import { type AssetBalanceWithPrice, type AssetBalanceWithPriceAndChains, type BigNumber, type ExclusionSource, NoPrice, Zero } from '@rotki/common';
 import { storeToRefs } from 'pinia';
-import { computed, type ComputedRef, ref } from 'vue';
+import { computed, type ComputedRef, type MaybeRef, ref } from 'vue';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { summarizeAssetProtocols } from '@/composables/balances/asset-summary';
 import { blockchainToAssetProtocolBalances, manualToAssetProtocolBalances } from '@/composables/balances/balance-transformations';

--- a/frontend/app/src/composables/blockchain/use-account-operations.ts
+++ b/frontend/app/src/composables/blockchain/use-account-operations.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { AddressBookSimplePayload } from '@/types/eth-names';
 import type { TaskMeta } from '@/types/task';
 import { Blockchain } from '@rotki/common';

--- a/frontend/app/src/composables/defi/airdrops/metadata.ts
+++ b/frontend/app/src/composables/defi/airdrops/metadata.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ProtocolMetadata } from '@/types/defi';
 import { transformCase } from '@rotki/common';
 import { camelCase } from 'es-toolkit';

--- a/frontend/app/src/composables/defi/metadata.ts
+++ b/frontend/app/src/composables/defi/metadata.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ProtocolMetadata } from '@/types/defi';
 import { decodeHtmlEntities } from '@rotki/common';
 import { camelCase } from 'es-toolkit';

--- a/frontend/app/src/composables/filters/blockchain-account.ts
+++ b/frontend/app/src/composables/filters/blockchain-account.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/types/filtering';
 import { z } from 'zod/v4';

--- a/frontend/app/src/composables/filters/custom-assets.ts
+++ b/frontend/app/src/composables/filters/custom-assets.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type { MatchedKeyword, SearchMatcher } from '@/types/filtering';
 import { z } from 'zod/v4';

--- a/frontend/app/src/composables/filters/events.ts
+++ b/frontend/app/src/composables/filters/events.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type {
   MatchedKeywordWithBehaviour,

--- a/frontend/app/src/composables/filters/manual-balances.ts
+++ b/frontend/app/src/composables/filters/manual-balances.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type { MatchedKeyword, SearchMatcher } from '@/types/filtering';
 import z from 'zod/v4';

--- a/frontend/app/src/composables/filters/saved.ts
+++ b/frontend/app/src/composables/filters/saved.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { ActionStatus } from '@/types/action';
 import type { BaseSuggestion, SavedFilterLocation, Suggestion } from '@/types/filtering';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';

--- a/frontend/app/src/composables/form.ts
+++ b/frontend/app/src/composables/form.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ModelRef } from 'vue';
+import type { MaybeRef, ModelRef } from 'vue';
 
 export function useFormStateWatcher(
   states: Record<string, MaybeRef<any>>,

--- a/frontend/app/src/composables/history/calendar/index.ts
+++ b/frontend/app/src/composables/history/calendar/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import { api } from '@/modules/api/rotki-api';
 import {

--- a/frontend/app/src/composables/history/events/index.ts
+++ b/frontend/app/src/composables/history/events/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { ActionStatus } from '@/types/action';
 import type { Collection } from '@/types/collection';

--- a/frontend/app/src/composables/history/events/mapping/counterparty.ts
+++ b/frontend/app/src/composables/history/events/mapping/counterparty.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ActionDataEntry } from '@/types/action';
 import { isValidEthAddress, toHumanReadable } from '@rotki/common';
 import { startPromise } from '@shared/utils';

--- a/frontend/app/src/composables/history/events/mapping/index.ts
+++ b/frontend/app/src/composables/history/events/mapping/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ActionDataEntry } from '@/types/action';
 import type {
   HistoryEventCategoryDetailWithId,

--- a/frontend/app/src/composables/history/events/notes.ts
+++ b/frontend/app/src/composables/history/events/notes.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import {
   type BigNumber,
   bigNumberify,

--- a/frontend/app/src/composables/info/chains.ts
+++ b/frontend/app/src/composables/info/chains.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type {
   ChainInfo,
   EvmChainEntries,

--- a/frontend/app/src/composables/item-cache.ts
+++ b/frontend/app/src/composables/item-cache.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 import { assert } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { logger } from '@/utils/logging';

--- a/frontend/app/src/composables/links.ts
+++ b/frontend/app/src/composables/links.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { externalLinks } from '@shared/external-links';
 import { useInterop } from '@/composables/electron-interop';
 

--- a/frontend/app/src/composables/locations.ts
+++ b/frontend/app/src/composables/locations.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { TradeLocationData } from '@/types/history/trade/location';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useLocationStore } from '@/store/locations';

--- a/frontend/app/src/composables/ref.ts
+++ b/frontend/app/src/composables/ref.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 
 export function refIsTruthy<T>(ref: MaybeRef<T>): ComputedRef<boolean> {
   return computed(() => !!get(ref));

--- a/frontend/app/src/composables/session/cache-clear.ts
+++ b/frontend/app/src/composables/session/cache-clear.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { Ref } from 'vue';
+import type { MaybeRef, Ref } from 'vue';
 import type { BaseMessage } from '@/types/messages';
 import { useConfirmStore } from '@/store/confirm';
 

--- a/frontend/app/src/composables/session/use-locale.ts
+++ b/frontend/app/src/composables/session/use-locale.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import { useSessionAuthStore } from '@/store/session/auth';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { SupportedLanguage } from '@/types/settings/frontend-settings';

--- a/frontend/app/src/composables/settings/accounting/index.ts
+++ b/frontend/app/src/composables/settings/accounting/index.ts
@@ -1,5 +1,5 @@
 import type { Message } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ActionStatus } from '@/types/action';
 import type { Collection } from '@/types/collection';
 import type {

--- a/frontend/app/src/composables/settings/accounting/rule-mapping.ts
+++ b/frontend/app/src/composables/settings/accounting/rule-mapping.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { AccountingRuleLinkedSettingMap } from '@/types/settings/accounting';
 import { assert, toHumanReadable, transformCase } from '@rotki/common';
 import { useAccountingApi } from '@/composables/api/settings/accounting-api';

--- a/frontend/app/src/composables/settings/api-keys/external/index.ts
+++ b/frontend/app/src/composables/settings/api-keys/external/index.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 import type ServiceKey from '@/components/settings/api-keys/ServiceKey.vue';
 import type { ConfirmationMessage } from '@/modules/history/events/composables/use-deletion-strategies';
 import type { ExternalServiceKey, ExternalServiceKeys, ExternalServiceName } from '@/types/user';

--- a/frontend/app/src/composables/staking/eth2/eth2.ts
+++ b/frontend/app/src/composables/staking/eth2/eth2.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 import type { TaskMeta } from '@/types/task';
 import { assert, Blockchain, type EthStakingPayload, type EthStakingPerformance, type EthStakingPerformanceResponse } from '@rotki/common';
 import { omit } from 'es-toolkit';

--- a/frontend/app/src/composables/use-pagination-filter/index.ts
+++ b/frontend/app/src/composables/use-pagination-filter/index.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-lines */
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
-import type { MaybeRef } from '@vueuse/core';
 import type { FetchError } from 'ofetch';
-import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef, Ref, WritableComputedRef } from 'vue';
 import type { FilterSchema, Sorting } from '@/composables/use-pagination-filter/types';
 import type { TableId } from '@/modules/table/use-remember-table-sorting';
 import type { Collection } from '@/types/collection';

--- a/frontend/app/src/composables/utils/useValueOrDefault/index.ts
+++ b/frontend/app/src/composables/utils/useValueOrDefault/index.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 
 export function useValueOrDefault<T, D>(item: Ref<T | undefined>, defaultValue: MaybeRef<D>): ComputedRef<T | D> {
   return computed(() => {

--- a/frontend/app/src/composables/validation.ts
+++ b/frontend/app/src/composables/validation.ts
@@ -1,5 +1,5 @@
 import type { Validation, ValidationArgs } from '@vuelidate/core';
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 
 interface UseValidationReturn {
   callIfValid: <T = unknown>(value: T, method: (e: T) => void, invalid?: () => boolean) => void;

--- a/frontend/app/src/modules/amount-display/composables/use-amount-formatter.ts
+++ b/frontend/app/src/modules/amount-display/composables/use-amount-formatter.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { RoundingType } from '@/modules/amount-display/types';
 import { BigNumber, bigNumberify } from '@rotki/common';
 import { displayAmountFormatter } from '@/data/amount-formatter';

--- a/frontend/app/src/modules/amount-display/composables/use-asset-value.ts
+++ b/frontend/app/src/modules/amount-display/composables/use-asset-value.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { type BigNumber, Zero } from '@rotki/common';
 import { normalizeTimestamp, type Timestamp } from '@/modules/amount-display/types';
 import { usePriceUtils } from '@/modules/prices/use-price-utils';

--- a/frontend/app/src/modules/amount-display/composables/use-fiat-conversion.ts
+++ b/frontend/app/src/modules/amount-display/composables/use-fiat-conversion.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { type BigNumber, One, Zero } from '@rotki/common';
 import { useAmountDisplaySettings } from '@/modules/amount-display/composables/use-amount-display-settings';
 import { normalizeTimestamp, type Timestamp } from '@/modules/amount-display/types';

--- a/frontend/app/src/modules/amount-display/composables/use-scrambled-value.ts
+++ b/frontend/app/src/modules/amount-display/composables/use-scrambled-value.ts
@@ -1,6 +1,5 @@
 import type { BigNumber } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { useNumberScrambler } from '@/composables/utils/useNumberScrambler';
 import { generateRandomScrambleMultiplier } from '@/utils/session';
 import { useAmountDisplaySettings } from './use-amount-display-settings';

--- a/frontend/app/src/modules/asset-manager/counterparty-mapping/use-counterparty-mapping-api.ts
+++ b/frontend/app/src/modules/asset-manager/counterparty-mapping/use-counterparty-mapping-api.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import { omit } from 'es-toolkit';
 import { api } from '@/modules/api/rotki-api';

--- a/frontend/app/src/modules/asset-manager/missing-mappings/use-missing-mappings-db.ts
+++ b/frontend/app/src/modules/asset-manager/missing-mappings/use-missing-mappings-db.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { MissingMapping } from '@/modules/data/schemas';
 import type { Collection } from '@/types/collection';
 import type { PaginationRequestPayload } from '@/types/common';

--- a/frontend/app/src/modules/assets/use-collection-info.ts
+++ b/frontend/app/src/modules/assets/use-collection-info.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { AssetMap } from '@/types/asset';
 import { useAssetInfoApi } from '@/composables/api/assets/info';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type {
   Accounts,
   Balances,

--- a/frontend/app/src/modules/balances/exchanges/use-binance-savings.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-binance-savings.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type {
   ExchangeSavingsCollection,
   ExchangeSavingsCollectionResponse,

--- a/frontend/app/src/modules/balances/exchanges/use-exchange-data.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-exchange-data.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { AssetProtocolBalances } from '@/types/blockchain/balances';
 import type { ExchangeInfo } from '@/types/exchanges';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';

--- a/frontend/app/src/modules/balances/manual/use-manual-balance-pagination.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balance-pagination.ts
@@ -1,5 +1,5 @@
 import type { BigNumber } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import type { ManualBalanceRequestPayload, ManualBalanceWithPrice } from '@/types/manual-balances';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';

--- a/frontend/app/src/modules/balances/manual/use-manual-balances-or-liabilities.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balances-or-liabilities.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 import type { Collection } from '@/types/collection';
 import type {
   ManualBalanceRequestPayload,

--- a/frontend/app/src/modules/balances/nft/use-nft-balances.ts
+++ b/frontend/app/src/modules/balances/nft/use-nft-balances.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import type {
   NonFungibleBalance,

--- a/frontend/app/src/modules/balances/protocols/use-protocol-data.ts
+++ b/frontend/app/src/modules/balances/protocols/use-protocol-data.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { toSentenceCase } from '@rotki/common';
 import { useDefiMetadata } from '@/composables/defi/metadata';
 import { useHistoryEventCounterpartyMappings } from '@/composables/history/events/mapping/counterparty';

--- a/frontend/app/src/modules/balances/use-balances-store.ts
+++ b/frontend/app/src/modules/balances/use-balances-store.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Balances } from '@/types/blockchain/accounts';
 import type { BlockchainAssetBalances, BlockchainBalances } from '@/types/blockchain/balances';
 import type { ExchangeData } from '@/types/exchanges';

--- a/frontend/app/src/modules/onchain/use-tradable-asset.ts
+++ b/frontend/app/src/modules/onchain/use-tradable-asset.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { TradableAsset, TradableAssetWithoutValue } from '@/modules/onchain/types';
 import type { BlockchainAssetBalances, EthBalance, ProtocolBalances } from '@/types/blockchain/balances';
 import { Zero } from '@rotki/common';

--- a/frontend/app/src/modules/prices/use-price-refresh.ts
+++ b/frontend/app/src/modules/prices/use-price-refresh.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { AssetPrices } from '@/types/prices';
 import { startPromise } from '@shared/utils';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';

--- a/frontend/app/src/modules/prices/use-price-utils.ts
+++ b/frontend/app/src/modules/prices/use-price-utils.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { ExchangeRates } from '@/types/user';
 import { type BigNumber, One } from '@rotki/common';
 import { useBalancePricesStore } from '@/store/balances/prices';

--- a/frontend/app/src/premium/premium-apis.ts
+++ b/frontend/app/src/premium/premium-apis.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import {
   type AssetsApi,
   type BalancesApi,

--- a/frontend/app/src/store/assets/ignored.ts
+++ b/frontend/app/src/store/assets/ignored.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ActionStatus } from '@/types/action';
 import { useAssetIgnoreApi } from '@/composables/api/assets/ignore';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';

--- a/frontend/app/src/store/assets/whitelisted.ts
+++ b/frontend/app/src/store/assets/whitelisted.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { ActionStatus } from '@/types/action';
 import { useAssetWhitelistApi } from '@/composables/api/assets/whitelist';
 import { useIgnoredAssetsStore } from '@/store/assets/ignored';

--- a/frontend/app/src/store/blockchain/accounts/addresses-names.ts
+++ b/frontend/app/src/store/blockchain/accounts/addresses-names.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { Collection } from '@/types/collection';
 import type {
   AddressBookEntries,

--- a/frontend/app/src/store/blockchain/accounts/migrate.ts
+++ b/frontend/app/src/store/blockchain/accounts/migrate.ts
@@ -1,7 +1,8 @@
+import type { MaybeRef } from 'vue';
 import type { MigratedAddresses } from '@/modules/messaging/types';
 import { assert, type Notification, NotificationCategory, Severity } from '@rotki/common';
 import { startPromise } from '@shared/utils';
-import { type MaybeRef, useSessionStorage } from '@vueuse/core';
+import { useSessionStorage } from '@vueuse/core';
 import { useTokenDetection } from '@/composables/balances/token-detection';
 import { useBlockchains } from '@/composables/blockchain';
 import { useSupportedChains } from '@/composables/info/chains';

--- a/frontend/app/src/store/blockchain/tokens.ts
+++ b/frontend/app/src/store/blockchain/tokens.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { EthDetectedTokensInfo, EvmTokensRecord } from '@/types/balances';
 import type { BlockchainAssetBalances } from '@/types/blockchain/balances';
 import type { TaskMeta } from '@/types/task';

--- a/frontend/app/src/store/blockchain/validators.ts
+++ b/frontend/app/src/store/blockchain/validators.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type {
   BlockchainAccount,
   EthereumValidator,

--- a/frontend/app/src/store/statistics/index.ts
+++ b/frontend/app/src/store/statistics/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import { type AssetBalanceWithPriceAndChains, type BigNumber, type NetValue, One, type TimeFramePeriod, timeframes, TimeUnit, Zero } from '@rotki/common';
 import dayjs from 'dayjs';
 import { useStatisticsApi } from '@/composables/api/statistics/statistics-api';

--- a/frontend/app/src/utils/blockchain/accounts/index.ts
+++ b/frontend/app/src/utils/blockchain/accounts/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type { AssetBalances } from '@/types/balances';
 import type {
   AddressData,

--- a/frontend/app/src/utils/history/events.ts
+++ b/frontend/app/src/utils/history/events.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { HistoryEventEntryType } from '@rotki/common';
 import {
   type AssetMovementEvent,

--- a/frontend/app/src/utils/prices.ts
+++ b/frontend/app/src/utils/prices.ts
@@ -1,6 +1,5 @@
 import type { Balance, BigNumber } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import type { AssetBalances } from '@/types/balances';
 import type {
   AssetProtocolBalances,

--- a/frontend/app/src/utils/tags.ts
+++ b/frontend/app/src/utils/tags.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 
 /**
  * Deduplicates an array of tags using case-insensitive comparison.

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-exchange-balances.spec.ts
@@ -1,5 +1,5 @@
 import type { AssetBalance } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { Collection } from '@/types/collection';
 import type { ExchangeSavingsCollection, ExchangeSavingsEvent, ExchangeSavingsRequestPayload } from '@/types/exchanges';

--- a/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/accounts/filter-paginate-nfts.spec.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { Collection } from '@/types/collection';
 import type { NonFungibleBalance, NonFungibleBalancesRequestPayload } from '@/types/nfbalances';

--- a/frontend/app/tests/unit/specs/composables/assets/filter-paginate-assets.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/assets/filter-paginate-assets.spec.ts
@@ -1,5 +1,5 @@
 import type { SupportedAsset } from '@rotki/common';
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { AssetRequestPayload } from '@/types/asset';
 import type { Collection } from '@/types/collection';

--- a/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/history/filter-paginate-transactions.spec.ts
@@ -1,5 +1,5 @@
 import type { Account } from '@rotki/common/src/account';
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { Collection } from '@/types/collection';

--- a/frontend/common/src/premium/index.ts
+++ b/frontend/common/src/premium/index.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
 import type { AssetBalanceWithPrice } from '../balances';
 import type { AssetInfoWithId } from '../data';
 import type { BigNumber } from '../numbers';


### PR DESCRIPTION
…d of `@vueuse/core`

In VueUse 14 MaybeRef is dropped in favor of the vue type

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
