### PR TITLE
chore(frontend): update type definitions for session and local storag…

### DIFF
--- a/frontend/app/src/composables/dynamic-messages.ts
+++ b/frontend/app/src/composables/dynamic-messages.ts
@@ -12,10 +12,10 @@ export const serializer = {
 
 export const useDynamicMessages = createSharedComposable(() => {
   const branch = checkIfDevelopment() ? 'develop' : 'main';
-  const welcomeMessages = useSessionStorage<WelcomeSchema>('rotki.messages.welcome', null, {
+  const welcomeMessages = useSessionStorage<WelcomeSchema | null>('rotki.messages.welcome', null, {
     serializer,
   });
-  const dashboardMessages = useSessionStorage<DashboardSchema>('rotki.messages.dashboard', null, {
+  const dashboardMessages = useSessionStorage<DashboardSchema | null>('rotki.messages.dashboard', null, {
     serializer,
   });
 

--- a/frontend/app/src/composables/session/sync.ts
+++ b/frontend/app/src/composables/session/sync.ts
@@ -17,7 +17,7 @@ export const useSync = createSharedComposable(() => {
   const syncAction = ref<SyncAction>(SYNC_DOWNLOAD);
   const displaySyncConfirmation = ref(false);
   const confirmChecked = ref(false);
-  const uploadStatus = useSessionStorage<DbUploadResult>('rotki.upload_status.message', null, {
+  const uploadStatus = useSessionStorage<DbUploadResult | null>('rotki.upload_status.message', null, {
     serializer,
   });
   const uploadStatusAlreadyHandled = useSessionStorage<boolean>('rotki.upload_status.handled', false);

--- a/frontend/app/src/composables/update-message.ts
+++ b/frontend/app/src/composables/update-message.ts
@@ -2,14 +2,14 @@ import { externalLinks } from '@shared/external-links';
 import { useMainStore } from '@/store/main';
 
 export const useUpdateMessage = createSharedComposable(() => {
-  const lastUsedVersion = useLocalStorage<string>('rotki.last_version', null);
+  const lastUsedVersion = useLocalStorage<string | null>('rotki.last_version', null);
   const showReleaseNotes = ref(false);
 
   const { appVersion } = storeToRefs(useMainStore());
 
   const link = computed(() => externalLinks.releasesVersion.replace('$version', get(appVersion)));
 
-  const setShowNotes = (appVersion: string, lastUsed: string): void => {
+  const setShowNotes = (appVersion: string, lastUsed: string | null): void => {
     if (!appVersion || appVersion.includes('dev'))
       return;
 


### PR DESCRIPTION
…e usage

This is because vueuse 14 is has a breaking type change

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
