### PR TITLE
Allow suppressing missing key ws messages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -801,7 +801,8 @@ Getting or modifying settings
               "auto_detect_tokens": true,
               "csv_export_delimiter": ",",
               "events_processing_frequency": 86400,
-              "asset_movement_amount_tolerance": "0.000001"
+              "asset_movement_amount_tolerance": "0.000001",
+              "suppress_missing_key_msg_services": ["etherscan"]
           },
           "message": ""
       }
@@ -844,6 +845,7 @@ Getting or modifying settings
    :resjson string csv_export_delimiter: The delimiter character to use when exporting data to CSV files. Default is ``","``.
    :resjson int events_processing_frequency: The frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds. Default is 86400 (24 hours).
    :resjson string asset_movement_amount_tolerance: The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number. Default is ``"0.000001"``.
+   :resjson list suppress_missing_key_msg_services: A list of services for which the missing api key WS message should be suppressed. Empty list by default.
 
    :statuscode 200: Querying of settings was successful
    :statuscode 409: There is no logged in user
@@ -900,6 +902,7 @@ Getting or modifying settings
    :resjson string[optional] csv_export_delimiter: The delimiter character to use when exporting data to CSV files.
    :resjson int[optional] events_processing_frequency: The frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds.
    :resjson string[optional] asset_movement_amount_tolerance: The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number.
+   :resjson list[optional] suppress_missing_key_msg_services: A list of services for which the missing api key WS message should be suppressed. Empty list by default.
 
    **Example Response**:
 
@@ -936,7 +939,8 @@ Getting or modifying settings
               "auto_detect_tokens": true,
               "csv_export_delimiter": ",",
               "events_processing_frequency": 86400,
-              "asset_movement_amount_tolerance": "0.000001"
+              "asset_movement_amount_tolerance": "0.000001",
+              "suppress_missing_key_msg_services": ["etherscan"]
           },
           "message": ""
       }

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -51,8 +51,9 @@ Exchange asset movement events may now be manually matched with specific onchain
   - This change preserves the actual group identifier when asset movements are combined with the group of their matched event for display as a single unit in the frontend.
 
 * **New Settings** (new fields in both ``PUT`` and ``POST`` on ``/api/(version)/settings``)
-  - ``events_processing_frequency`` Boolean flag indicating the frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds. Default is 86400 (24 hours).
+  - ``events_processing_frequency`` The frequency in seconds at which to process events and match asset movements. Must be >= 60 seconds. Default is 86400 (24 hours).
   - ``asset_movement_amount_tolerance`` The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number. Default is ``"0.000001"``.
+  - ``suppress_missing_key_msg_services`` A list of services for which the missing api key WS message should be suppressed. Empty list by default.
 
 Event/Group Identifier Renaming
 -------------------------------

--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pysqlcipher3 import dbapi2 as sqlcipher
 
-from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.types import NodeName
@@ -42,7 +41,6 @@ from rotkehlchen.types import (
     EVM_CHAINS_WITH_TRANSACTIONS,
     SUPPORTED_EVM_CHAINS_TYPE,
     ExternalService,
-    HistoryEventQueryType,
     ListOfBlockchainAddresses,
     Location,
     SupportedBlockchain,
@@ -850,15 +848,9 @@ class TransactionsService:
                 service_name=ExternalService.GNOSIS_PAY,
             ) is None
         ):
-            self.rotkehlchen.msg_aggregator.add_message(
-                message_type=WSMessageType.MISSING_API_KEY,
-                data={'service': HistoryEventQueryType.GNOSIS_PAY.serialize()},
-            )
+            self.rotkehlchen.msg_aggregator.add_missing_key_message(ExternalService.GNOSIS_PAY)
         elif has_monerium and init_monerium(self.rotkehlchen.data.db) is None:
-            self.rotkehlchen.msg_aggregator.add_message(
-                message_type=WSMessageType.MISSING_API_KEY,
-                data={'service': HistoryEventQueryType.MONERIUM.serialize()},
-            )
+            self.rotkehlchen.msg_aggregator.add_missing_key_message(ExternalService.MONERIUM)
 
     def _decode_given_evmlike_tx(self, tx_ref: EVMTxHash, delete_custom: bool) -> None:
         with self.rotkehlchen.data.db.user_write() as write_cursor:

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -1674,6 +1674,11 @@ class ModifiableSettingsSchema(Schema):
         as_string=True,
         validate=validate.Range(min=0, max=1, min_inclusive=False, max_inclusive=False),
     )
+    suppress_missing_key_msg_services = fields.List(
+        SerializableEnumField(enum_class=ExternalService, required=True),
+        required=False,
+        load_default=[],
+    )
 
     @validates_schema
     def validate_settings_schema(
@@ -1741,6 +1746,7 @@ class ModifiableSettingsSchema(Schema):
             csv_export_delimiter=data['csv_export_delimiter'],
             events_processing_frequency=data['events_processing_frequency'],
             asset_movement_amount_tolerance=FVal(data['asset_movement_amount_tolerance']) if data['asset_movement_amount_tolerance'] is not None else None,  # noqa: E501
+            suppress_missing_key_msg_services=data['suppress_missing_key_msg_services'],
         )
 
 

--- a/rotkehlchen/chain/evm/types.py
+++ b/rotkehlchen/chain/evm/types.py
@@ -159,14 +159,17 @@ DEFAULT_EVM_INDEXER_ORDER: Final = (
     EvmIndexer.BLOCKSCOUT,
     EvmIndexer.ROUTESCAN,
 )
-# list based on https://info.etherscan.com/whats-changing-in-the-free-api-tier-coverage-and-why/
-# might need adjustment in the future.
-CHAINS_WITH_PAID_ETHERSCAN: Final = {ChainID.BASE, ChainID.OPTIMISM, ChainID.BINANCE_SC}
+# Special order for chains that Etherscan doesn't currently support in the free tier
+# https://info.etherscan.com/whats-changing-in-the-free-api-tier-coverage-and-why/
 BLOCKSCOUT_PRIORITY_ORDER: Final = (
     EvmIndexer.BLOCKSCOUT,
-    EvmIndexer.ETHERSCAN,
     EvmIndexer.ROUTESCAN,
+    EvmIndexer.ETHERSCAN,
 )
 DEFAULT_INDEXERS_ORDER: Final = SerializableChainIndexerOrder(
-    order=dict.fromkeys(CHAINS_WITH_PAID_ETHERSCAN, BLOCKSCOUT_PRIORITY_ORDER),
+    order={
+        ChainID.BASE: BLOCKSCOUT_PRIORITY_ORDER,
+        ChainID.OPTIMISM: BLOCKSCOUT_PRIORITY_ORDER,
+        ChainID.BINANCE_SC: (EvmIndexer.ETHERSCAN,),  # Blockscout and Routescan do not support BSC (will only work with premium etherscan)  # noqa: E501
+    },
 )

--- a/rotkehlchen/externalapis/graph.py
+++ b/rotkehlchen/externalapis/graph.py
@@ -10,7 +10,6 @@ from gql.transport.exceptions import TransportError, TransportQueryError, Transp
 from gql.transport.requests import RequestsHTTPTransport
 from graphql.error import GraphQLError
 
-from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.ethereum.modules.ens.constants import CPT_ENS
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.api import APIKeyNotConfigured
@@ -62,12 +61,9 @@ class Graph(ExternalServiceWithApiKey):
         if (api_key := self._get_api_key()) is None and self.graph_label == CPT_ENS:
             api_key = ApiKey('d943ea1af415001154223fdf46b6f193')  # key created by yabir enabled for ens  # noqa: E501
             if self.warning_given is False:
-                self.db.msg_aggregator.add_message(
-                    message_type=WSMessageType.MISSING_API_KEY,
-                    data={
-                        'service': ExternalService.THEGRAPH.serialize(),
-                        'location': self.graph_label,
-                    },
+                self.db.msg_aggregator.add_missing_key_message(
+                    service=ExternalService.THEGRAPH,
+                    location=self.graph_label,
                 )
                 self.warning_given = True
         elif api_key is None:  # don't bother the user and fail silently. We avoid exhausting the default key  # noqa: E501

--- a/rotkehlchen/externalapis/interface.py
+++ b/rotkehlchen/externalapis/interface.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.types import ApiKey, ExternalService, Timestamp
 from rotkehlchen.utils.interfaces import DBSetterMixin
 from rotkehlchen.utils.misc import ts_now
@@ -76,8 +75,5 @@ class ExternalServiceWithRecommendedApiKey(ExternalServiceWithApiKey):
     def maybe_warn_missing_key(self) -> None:
         """Warns the user once if the Helius api key is missing."""
         if not self.warning_given:
-            self.db.msg_aggregator.add_message(
-                message_type=WSMessageType.MISSING_API_KEY,
-                data={'service': self.service_name.serialize()},
-            )
+            self.db.msg_aggregator.add_missing_key_message(self.service_name)
             self.warning_given = True

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -233,6 +233,8 @@ def test_set_settings(rotkehlchen_api_server: 'APIServer') -> None:
             value = HOUR_IN_SECONDS
         elif setting == 'asset_movement_amount_tolerance':
             value = '0.0001'
+        elif setting == 'suppress_missing_key_msg_services':
+            value = [ExternalService.ETHERSCAN.serialize()]
         else:
             raise AssertionError(f'Unexpected setting {setting} encountered')
 
@@ -618,7 +620,7 @@ def test_set_evm_indexers_order(rotkehlchen_api_server: 'APIServer') -> None:
         response=requests.get(settings_url),
         rotkehlchen_api_server=rotkehlchen_api_server,
     )
-    assert settings['evm_indexers_order'][ChainID.OPTIMISM.to_name()] == ['blockscout', 'etherscan', 'routescan']  # noqa: E501
+    assert settings['evm_indexers_order'][ChainID.OPTIMISM.to_name()] == ['blockscout', 'routescan', 'etherscan']  # noqa: E501
 
     # try editing the order of ethereum
     assert_proper_response(

--- a/rotkehlchen/tests/data/pnl_debug.json
+++ b/rotkehlchen/tests/data/pnl_debug.json
@@ -202,7 +202,8 @@
     "default_evm_indexer_order": ["etherscan", "blockscout", "routescan"],
     "evm_indexers_order": {"ethereum": ["etherscan", "blockscout", "routescan"], "optimism": ["etherscan", "blockscout", "routescan"], "polygon_pos": ["etherscan", "blockscout", "routescan"], "arbitrum_one": ["etherscan", "blockscout", "routescan"], "base": ["etherscan", "blockscout", "routescan"], "gnosis": ["etherscan", "blockscout", "routescan"], "scroll": ["etherscan", "blockscout", "routescan"], "binance_sc": ["etherscan", "blockscout", "routescan"]},
     "events_processing_frequency": 86400,
-    "asset_movement_amount_tolerance": "0.000001"
+    "asset_movement_amount_tolerance": "0.000001",
+    "suppress_missing_key_msg_services": []
   },
   "ignored_events_ids": ["100x0xca0a482213c17ccb0471b02ffab40b92279ae7f25da53e426fda5e73e915509f"],
   "pnl_settings": {

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -543,6 +543,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         'csv_export_delimiter': DEFAULT_CSV_EXPORT_DELIMITER,
         'events_processing_frequency': DEFAULT_EVENTS_PROCESSING_FREQUENCY,
         'asset_movement_amount_tolerance': DEFAULT_ASSET_MOVEMENT_AMOUNT_TOLERANCE,
+        'suppress_missing_key_msg_services': [],
     }
     assert len(expected_dict) == len(dataclasses.fields(DBSettings)), 'One or more settings are missing'  # noqa: E501
 

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -44,7 +44,12 @@ from rotkehlchen.chain.evm.decoding.uniswap.constants import (
 )
 from rotkehlchen.chain.evm.decoding.velodrome.constants import CPT_AERODROME, CPT_VELODROME
 from rotkehlchen.chain.evm.node_inquirer import _query_web3_get_logs, construct_event_filter_params
-from rotkehlchen.chain.evm.types import NodeName, string_to_evm_address
+from rotkehlchen.chain.evm.types import (
+    EvmIndexer,
+    NodeName,
+    SerializableChainIndexerOrder,
+    string_to_evm_address,
+)
 from rotkehlchen.chain.gnosis.transactions import ADDED_RECEIVER_ABI, BLOCKREWARDS_ADDRESS
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import (
@@ -1488,6 +1493,12 @@ def test_find_beefy_finance_reward_pool_vault_price(ethereum_inquirer: 'Ethereum
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'], match_on=['uri', 'method', 'body'])
+@pytest.mark.parametrize('db_settings', [{
+    'evm_indexers_order': SerializableChainIndexerOrder(order={
+        ChainID.OPTIMISM: [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN],
+        ChainID.BASE: [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN],
+    }),  # Use the order the VCR was originally recorded with
+}])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_uniswap_v3_position_price(database: 'DBHandler', inquirer_defi: 'Inquirer') -> None:

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -106,6 +106,7 @@ class ExternalService(SerializableEnumNameMixin):
     BLOCKSCOUT = auto()
     THEGRAPH = auto()
     GNOSIS_PAY = auto()
+    MONERIUM = auto()
     OPTIMISM_BLOCKSCOUT = auto()
     POLYGON_POS_BLOCKSCOUT = auto()
     ARBITRUM_ONE_BLOCKSCOUT = auto()


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=149819716

* Adds a new `suppress_missing_key_msg_services` setting to allow suppressing missing key messages for specific services
* Adjusts the default indexer order for BSC to be only Etherscan, and also moves routescan to be second in the list for Base and OP.