### PR TITLE
fix(11380): fix duplicated tags issue in asset breakdown

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11380` Tags will no longer appear duplicated in the asset location breakdown view.
 * :bug:`11339` Restoring the DB while background tasks that modify the DB are running will no longer result in malformed DB disk image errors.
 * :bug:`11258` 1inch v6 limit order swaps will now be understood properly.
 * :feature:`-` Users can now search blockchain accounts by either address or label using a single unified filter.

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
@@ -24,6 +24,7 @@ import { createAccountWithBalance } from '@/utils/blockchain/accounts/create-acc
 import { getAccountAddress, getAccountLabel } from '@/utils/blockchain/accounts/utils';
 import { assetSum, balanceSum } from '@/utils/calculation';
 import { uniqueStrings } from '@/utils/data';
+import { deduplicateTags } from '@/utils/tags';
 
 interface AccountBalances {
   assets: AssetBalance[];
@@ -194,12 +195,14 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
 
           balance.usdValue = balance.usdValue.plus(subBalance.usdValue);
         }
+        const tags = account.tags ? deduplicateTags(account.tags) : undefined;
         return {
           ...omit(account, ['chain', 'groupId', 'groupHeader']),
           ...balance,
           category: getChainAccountType(account.chain),
           chains: [account.chain],
           expansion: groupAccounts.length > 0 ? 'accounts' : undefined,
+          tags,
           type: 'group',
         } satisfies BlockchainAccountGroupWithBalance;
       });

--- a/frontend/app/src/utils/blockchain/accounts/create-account-with-balance.ts
+++ b/frontend/app/src/utils/blockchain/accounts/create-account-with-balance.ts
@@ -2,6 +2,7 @@ import type { BlockchainAccount, BlockchainAccountWithBalance } from '@/types/bl
 import type { BlockchainAssetBalances } from '@/types/blockchain/balances';
 import { getAccountBalance } from '@/utils/blockchain/accounts/index';
 import { getAccountAddress } from '@/utils/blockchain/accounts/utils';
+import { deduplicateTags } from '@/utils/tags';
 
 export function createAccountWithBalance(
   account: BlockchainAccount,
@@ -9,6 +10,7 @@ export function createAccountWithBalance(
 ): BlockchainAccountWithBalance {
   const { balance, expansion } = getAccountBalance(account, chainBalances);
   const address = getAccountAddress(account);
+  const tags = account.tags ? deduplicateTags(account.tags) : undefined;
 
   return {
     groupId: address,
@@ -16,5 +18,6 @@ export function createAccountWithBalance(
     ...account,
     ...balance,
     expansion,
+    tags,
   } satisfies BlockchainAccountWithBalance;
 }

--- a/frontend/app/src/utils/tags.ts
+++ b/frontend/app/src/utils/tags.ts
@@ -1,4 +1,21 @@
-import type { MaybeRef } from '@vueuse/core';
+import type { MaybeRef } from 'vue';
+
+/**
+ * Deduplicates an array of tags using case-insensitive comparison.
+ * Keeps the first occurrence of each tag.
+ */
+export function deduplicateTags(tags: string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const tag of tags) {
+    const tagLower = tag.toLowerCase();
+    if (seen.has(tagLower))
+      continue;
+    seen.add(tagLower);
+    result.push(tag);
+  }
+  return result;
+}
 
 function removeTag(tagName: string, tags?: string[]): string[] | undefined {
   if (!tags)


### PR DESCRIPTION
Closes #11380 

This is to make sure the tags isn't duplicated in the asset location breakdown