### PR TITLE
Manage customized events conflicts

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6497,6 +6497,97 @@ Match exchange asset movements with onchain events
    :statuscode 409: No user is logged in or failure.
    :statuscode 500: Internal rotki error
 
+Customized history event duplicates
+===================================
+
+.. http:get:: /api/(version)/history/events/duplicates/customized
+
+   Get group identifiers for customized event duplicate candidates.
+
+   Supports async execution via the `async_query` query parameter.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      GET /api/1/history/events/duplicates/customized?async_query=false HTTP/1.1
+      Host: localhost:5042
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "result": {
+              "auto_fix_group_ids": [
+                  "0x7f9b1d9b3d6c80b6f699a25f3e91c408155cbff965d0f3a0df4d3a4f8f4b73c7"
+              ],
+              "manual_review_group_ids": [
+                  "0xa8e4c2f6b79a1b9d6288a763dc6243cbce1e2c35c8b65ec79a9d35a1f4ec6a20"
+              ]
+          },
+          "message": ""
+      }
+
+   :reqquery bool[optional] async_query: Whether to execute as an async task.
+   :resjson list result.auto_fix_group_ids: Group identifiers where a customized EVM/Solana event has a non-customized duplicate that only differs by sequence index.
+   :resjson list result.manual_review_group_ids: Group identifiers where customized and non-customized EVM/Solana events share asset and direction but are not exact matches.
+   :resjson str message: Error message if any errors occurred.
+   :statuscode 200: Group identifiers returned successfully
+   :statuscode 401: No user is currently logged in
+   :statuscode 500: Internal rotki error
+
+.. http:post:: /api/(version)/history/events/duplicates/customized
+
+   Remove non-customized duplicates that only differ by sequence index and return updated groups.
+   Supports async execution via the `async_query` query parameter.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      POST /api/1/history/events/duplicates/customized?async_query=false HTTP/1.1
+      Host: localhost:5042
+      Content-Type: application/json;charset=UTF-8
+
+      {
+          "group_identifiers": [
+              "0x7f9b1d9b3d6c80b6f699a25f3e91c408155cbff965d0f3a0df4d3a4f8f4b73c7"
+          ]
+      }
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "result": {
+              "removed_event_identifiers": [123, 124],
+              "auto_fix_group_ids": [],
+              "manual_review_group_ids": [
+                  "0xa8e4c2f6b79a1b9d6288a763dc6243cbce1e2c35c8b65ec79a9d35a1f4ec6a20"
+              ]
+          },
+          "message": ""
+      }
+
+   :reqquery bool[optional] async_query: Whether to execute as an async task.
+   :reqjson list[optional] group_identifiers: Optional list of group identifiers to auto-fix. If omitted, all auto-fixable groups are processed.
+   :resjson list result.removed_event_identifiers: Event identifiers removed by the auto-fix operation.
+   :resjson list result.auto_fix_group_ids: Remaining auto-fixable group identifiers after removal.
+   :resjson list result.manual_review_group_ids: Remaining manual review group identifiers after removal.
+   :resjson str message: Error message if any errors occurred.
+   :statuscode 200: Auto-fix operation completed successfully
+   :statuscode 401: No user is currently logged in
+   :statuscode 409: Auto-fix failed due to a deletion constraint
+   :statuscode 500: Internal rotki error
+
 Querying messages to show to the user
 =====================================
 

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -58,6 +58,7 @@ from rotkehlchen.api.v1.resources import (
     CounterpartyAssetMappingsResource,
     CustomAssetsResource,
     CustomAssetsTypesResource,
+    CustomizedEventDuplicatesResource,
     DatabaseBackupsResource,
     DatabaseInfoResource,
     DataImportResource,
@@ -246,6 +247,7 @@ URLS_V1: URLS = [
     ('/history/events/export', ExportHistoryEventResource),
     ('/history/events/export/download', ExportHistoryDownloadResource),
     ('/history/events/match/asset_movements', MatchAssetMovementsResource),
+    ('/history/events/duplicates/customized', CustomizedEventDuplicatesResource),
     ('/history/actionable_items', HistoryActionableItemsResource),
     ('/reports', AccountingReportsResource),
     (

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -72,6 +72,7 @@ from rotkehlchen.api.v1.schemas import (
     CreateHistoryEventSchema,
     CurrentAssetsPriceSchema,
     CustomAssetsQuerySchema,
+    CustomizedEventDuplicatesFixSchema,
     DataImportSchema,
     DeletePremiumDeviceSchema,
     DetectTokensSchema,
@@ -3701,4 +3702,23 @@ class MatchAssetMovementsResource(BaseMethodView):
     def delete(self, asset_movement: int) -> Response:
         return self.rest_api.unlink_matched_asset_movements(
             asset_movement_identifier=asset_movement,
+        )
+
+
+class CustomizedEventDuplicatesResource(BaseMethodView):
+
+    get_schema = AsyncQueryArgumentSchema()
+    post_schema = CustomizedEventDuplicatesFixSchema()
+
+    @require_loggedin_user()
+    @use_kwargs(get_schema, location='json_and_query')
+    def get(self, async_query: bool) -> Response:
+        return self.rest_api.get_customized_event_duplicates(async_query=async_query)
+
+    @require_loggedin_user()
+    @use_kwargs(post_schema, location='json_and_query')
+    def post(self, group_identifiers: list[str] | None, async_query: bool) -> Response:
+        return self.rest_api.fix_customized_event_duplicates(
+            async_query=async_query,
+            group_identifiers=group_identifiers,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -4694,3 +4694,7 @@ class UnlinkMatchedAssetMovementSchema(Schema):
 
 class TriggerTaskSchema(AsyncQueryArgumentSchema):
     task = SerializableEnumField(enum_class=TaskName, required=True)
+
+
+class CustomizedEventDuplicatesFixSchema(AsyncQueryArgumentSchema):
+    group_identifiers = fields.List(NonEmptyStringField(), load_default=None)

--- a/rotkehlchen/tests/api/test_customized_event_duplicates.py
+++ b/rotkehlchen/tests/api/test_customized_event_duplicates.py
@@ -1,0 +1,154 @@
+import random
+from typing import TYPE_CHECKING
+
+import requests
+
+from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.constants.misc import ONE
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType
+from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.factories import make_evm_tx_hash
+from rotkehlchen.types import Location, TimestampMS
+
+if TYPE_CHECKING:
+    from rotkehlchen.api.server import APIServer
+    from rotkehlchen.db.drivers.gevent import DBCursor
+
+
+def duplicated_events_setup(
+        events_db: DBHistoryEvents,
+        write_cursor: 'DBCursor',
+        auto_fix_groups: int,
+        include_manual_review: bool,
+        timestamp: TimestampMS,
+) -> tuple[list[EvmSwapEvent], list[int], EvmSwapEvent | None]:
+    """Insert duplicate candidates for auto-fix and optional manual review cases."""
+    auto_fix_events: list[EvmSwapEvent] = []
+    auto_fix_event_ids: list[int] = []
+    for _ in range(auto_fix_groups):
+        event = EvmSwapEvent(
+            tx_ref=(tx_hash := make_evm_tx_hash()),
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=ONE,
+        )
+        customized_event = EvmSwapEvent(
+            tx_ref=tx_hash,
+            sequence_index=1,  # changes only the sequence index
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=ONE,
+        )
+        event_id = events_db.add_history_event(write_cursor=write_cursor, event=event)
+        events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=customized_event,
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+        )
+        assert event_id is not None
+        auto_fix_events.append(event)
+        auto_fix_event_ids.append(event_id)
+
+    manual_review_event: EvmSwapEvent | None = None
+    if include_manual_review:
+        manual_review_event = EvmSwapEvent(
+            tx_ref=(manual_tx_hash := make_evm_tx_hash()),
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=ONE,
+        )
+        manual_review_customized = EvmSwapEvent(
+            tx_ref=manual_tx_hash,
+            sequence_index=1,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=FVal('2'),  # this is the amount difference that makes it a manual review event
+        )
+        events_db.add_history_event(write_cursor=write_cursor, event=manual_review_event)
+        events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=manual_review_customized,
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+        )
+
+    return auto_fix_events, auto_fix_event_ids, manual_review_event
+
+
+def test_customized_event_duplicates_endpoint(rotkehlchen_api_server: 'APIServer') -> None:
+    """Ensure the duplicates endpoint separates auto-fix and manual review groups."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    events_db = DBHistoryEvents(rotki.data.db)
+    timestamp = TimestampMS(1710000000000)
+
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        auto_fix_events, _, manual_event = duplicated_events_setup(
+            events_db=events_db,
+            write_cursor=write_cursor,
+            auto_fix_groups=1,
+            include_manual_review=True,
+            timestamp=timestamp,
+        )
+
+    async_query = random.choice([True, False])
+    response = requests.get(
+        api_url_for(rotkehlchen_api_server, 'customizedeventduplicatesresource'),
+        params={'async_query': async_query},
+    )
+    result = assert_proper_response_with_result(response, rotkehlchen_api_server, async_query)
+
+    assert set(result['auto_fix_group_ids']) == {auto_fix_events[0].group_identifier}
+    assert manual_event is not None
+    assert set(result['manual_review_group_ids']) == {manual_event.group_identifier}
+
+
+def test_fix_customized_event_duplicates(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """Check that auto fixing works properly with and without a group identifier filter"""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    events_db = DBHistoryEvents(rotki.data.db)
+    timestamp = TimestampMS(1710000000000)
+
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        auto_fix_events, auto_fix_event_ids, _ = duplicated_events_setup(
+            events_db=events_db,
+            write_cursor=write_cursor,
+            auto_fix_groups=2,
+            include_manual_review=False,
+            timestamp=timestamp,
+        )
+    async_query = random.choice([True, False])
+    # First check with a group_identifier filter. Should only fix the provided group.
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'customizedeventduplicatesresource'),
+        json={
+            'async_query': async_query,
+            'group_identifiers': [auto_fix_events[0].group_identifier],
+        },
+    )
+    result = assert_proper_response_with_result(response, rotkehlchen_api_server, async_query)
+    assert set(result['removed_event_identifiers']) == {auto_fix_event_ids[0]}
+    assert auto_fix_events[1].group_identifier in result['auto_fix_group_ids']
+    assert auto_fix_events[0].group_identifier not in result['auto_fix_group_ids']
+    # Then fix without a filter. Should fix the remaining group.
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'customizedeventduplicatesresource'),
+        json={'async_query': async_query},
+    )
+    result = assert_proper_response_with_result(response, rotkehlchen_api_server, async_query)
+    assert result['removed_event_identifiers'] == [auto_fix_event_ids[1]]
+    assert result['auto_fix_group_ids'] == []


### PR DESCRIPTION
This PR adds on-demand detection and cleanup for duplicate on-chain events caused by customized history entries. 

The API now distinguishes between two cases: auto-fixable duplicates (same asset/type/subtype/amount/etc., only sequence index differs) and manual-review cases (same asset and direction but the customized event changes data like amount).

The POST endpoint removes only the auto-fixable duplicates (keeping the customized event) and leaves manual-review groups intact, while GET returns both sets so the UI can surface them separately.

Part of https://github.com/rotki/rotki/issues/11334