### PR TITLE
Improve historical balance interest event handling

### DIFF
--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -277,12 +277,7 @@ class DBHistoryEvents:
             else:  # all other data
                 write_cursor.execute(f'{updatestr} WHERE identifier=?', (*bindings, event.identifier))  # noqa: E501
 
-        # Also mark it as customized
-        write_cursor.execute(
-            'INSERT OR IGNORE INTO history_events_mappings(parent_identifier, name, value) '
-            'VALUES(?, ?, ?)',
-            (event.identifier, HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
-        )
+        self.mark_event_customized(write_cursor=write_cursor, event=event)
 
         # Track modification only if balance-affecting fields changed. cannot be None here
         if old_data == (
@@ -298,6 +293,14 @@ class DBHistoryEvents:
         self._mark_events_modified(
             write_cursor=write_cursor,
             timestamp=TimestampMS(min(old_data[0], event.timestamp)),
+        )
+
+    def mark_event_customized(self, write_cursor: 'DBCursor', event: HistoryBaseEntry) -> None:
+        """Mark an event as customized."""
+        write_cursor.execute(
+            'INSERT OR IGNORE INTO history_events_mappings(parent_identifier, name, value) '
+            'VALUES(?, ?, ?)',
+            (event.identifier, HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
         )
 
     def delete_history_events_by_identifier(


### PR DESCRIPTION
Related #2227 

* Fixes the sequence index incrementing query
* Fixes the problem where the new interest events kept being created each time the processing ran
* Adjusts the amount of the withdraw event so the interest amount is not double counted.
