### PR TITLE
fix(11395): table filter enter with num pad

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11395` The table filter input will now respond to the numpad Enter key when editing an filter.
 * :bug:`11381` Users will no longer see a non-working edit button when viewing accounts filtered by a specific chain.
 * :bug:`11380` Tags will no longer appear duplicated in the asset location breakdown view.
 * :bug:`11339` Restoring the DB while background tasks that modify the DB are running will no longer result in malformed DB disk image errors.

--- a/frontend/app/src/components/table-filter/SuggestedItem.vue
+++ b/frontend/app/src/components/table-filter/SuggestedItem.vue
@@ -108,7 +108,7 @@ const truncatedDisplayValue = computed<string>(() => {
 const keyCodeToPropagate: string[] = ['Enter', 'Esc', 'ArrowUp', 'ArrowDown'] as const;
 
 function onKeyDown(e: KeyboardEvent) {
-  if (!keyCodeToPropagate.includes(e.code)) {
+  if (!keyCodeToPropagate.includes(e.key)) {
     e.stopPropagation();
   }
 


### PR DESCRIPTION
Closes #11395

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
