### PR TITLE
add retry logic with reduced chunk size for gas errors in multicall

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/node_inquirer.py
+++ b/rotkehlchen/chain/arbitrum_one/node_inquirer.py
@@ -1,20 +1,12 @@
 import logging
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal
-
-from web3.types import BlockIdentifier
+from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.chain.constants import DEFAULT_RPC_TIMEOUT
-from rotkehlchen.chain.ethereum.constants import (
-    EVM_INDEXERS_NODE,
-)
-from rotkehlchen.chain.ethereum.utils import MULTICALL_CHUNKS
 from rotkehlchen.chain.evm.constants import BALANCE_SCANNER_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
-from rotkehlchen.chain.evm.types import WeightedNode, string_to_evm_address
+from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
-from rotkehlchen.errors.misc import BlockchainQueryError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -74,35 +66,3 @@ class ArbitrumOneInquirer(EvmNodeInquirer):
             ARCHIVE_NODE_CHECK_BLOCK,
             ARCHIVE_NODE_CHECK_EXPECTED_BALANCE,
         )
-
-    def multicall(
-            self,
-            calls: list[tuple[ChecksumEvmAddress, str]],
-            require_success: bool = True,
-            call_order: Sequence['WeightedNode'] | None = None,
-            block_identifier: BlockIdentifier = 'latest',
-            calls_chunk_size: int = MULTICALL_CHUNKS,
-    ) -> Any:
-        """Overrides multicall to handle etherscan's gas limit constraints on Arbitrum.
-
-        Etherscan on Arbitrum has reduced gas limits which limits the number of multicall
-        calls that can be batched together. This implementation tries regular nodes first
-        with normal chunk sizes, then falls back to etherscan with smaller chunks (3).
-        """
-        call_order = self.default_call_order() if call_order is None else call_order
-        try:
-            return super().multicall(
-                calls=calls,
-                require_success=require_success,
-                call_order=[node for node in call_order if node != EVM_INDEXERS_NODE],
-                block_identifier=block_identifier,
-                calls_chunk_size=calls_chunk_size,
-            )
-        except (RemoteError, BlockchainQueryError):
-            return super().multicall(
-                calls=calls,
-                require_success=require_success,
-                call_order=[EVM_INDEXERS_NODE],
-                block_identifier=block_identifier,
-                calls_chunk_size=3,
-            )

--- a/rotkehlchen/errors/misc.py
+++ b/rotkehlchen/errors/misc.py
@@ -47,6 +47,10 @@ class NoAvailableIndexers(RemoteError):
     """Raised when there are no available indexers for a given chain."""
 
 
+class RequestTooLargeError(RemoteError):
+    """Raised when a request fails due to size limits (gas limit, URL too long)."""
+
+
 class XPUBError(Exception):
     """Error XPUB Parsing and address derivation"""
 

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -20,7 +20,7 @@ from rotkehlchen.db.constants import TX_DECODED
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.misc import RemoteError, RequestTooLargeError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.utils import get_earliest_ts
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -319,6 +319,8 @@ class EtherscanLikeApi(ABC):
                     chain_id=chain_id,
                 )
                 continue
+            elif response.status_code == HTTPStatus.REQUEST_URI_TOO_LONG:
+                raise RequestTooLargeError(f'Failed to query {chain_id} due to: request URI too long')  # noqa: E501
             elif response.status_code != 200:
                 raise RemoteError(
                     f'{self.name} API request {response.url} failed '

--- a/rotkehlchen/tests/unit/test_arbitrum_one_inquirer.py
+++ b/rotkehlchen/tests/unit/test_arbitrum_one_inquirer.py
@@ -1,10 +1,7 @@
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
-from rotkehlchen.chain.evm.contracts import EvmContract
-from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.tests.utils.arbitrum_one import (
     ARBITRUM_ONE_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED,
 )
@@ -50,40 +47,3 @@ def test_block_by_time_close_to_genesis(arbitrum_one_inquirer):
     very close to genesis"""
     result = arbitrum_one_inquirer.get_blocknumber_by_time(1622243344)
     assert result == 1
-
-
-@pytest.mark.vcr(filter_query_parameters=['apikey'])
-def test_multicall_with_etherscan_fallback(arbitrum_one_inquirer):
-    """Test that multicall works and can fallback to etherscan with reduced chunk size"""
-    contract = EvmContract(
-        address=(usdc_arbitrum := string_to_evm_address('0xaf88d065e77c8cC2239327C5EDb3A432268e5831')),  # noqa: E501
-        abi=arbitrum_one_inquirer.contracts.erc20_abi,
-        deployed_block=0,
-    )
-    call_count = 0
-    original_query = arbitrum_one_inquirer._query
-
-    def count_calls(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        return original_query(*args, **kwargs)
-
-    methods = ['totalSupply', 'name', 'symbol', 'decimals']
-    with patch.object(arbitrum_one_inquirer, '_query', side_effect=count_calls):
-        assert (result := arbitrum_one_inquirer.multicall(calls=(test_calls := [
-            (usdc_arbitrum, contract.encode(method_name=method))
-            for method in methods
-        ]))) is not None
-
-    assert len(result) == len(test_calls)
-    # Expected 3 calls: Call #1 fails on non-etherscan nodes (empty call order),
-    # Call #2 succeeds on etherscan with first chunk (3 calls: totalSupply, name, symbol),
-    # Call #3 succeeds on etherscan with second chunk (1 call: decimals)
-    assert call_count == 3
-
-    decoded = [contract.decode(result[i], methods[i])[0] for i in range(len(methods))]
-    total_supply, name, symbol, decimals = decoded
-    assert total_supply == 6800074379367774
-    assert name == 'USD Coin'
-    assert symbol == 'USDC'
-    assert decimals == 6

--- a/rotkehlchen/tests/unit/test_evm_misc.py
+++ b/rotkehlchen/tests/unit/test_evm_misc.py
@@ -1,16 +1,34 @@
 import typing
+from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
 from rotkehlchen.chain.aggregator import ChainsAggregator
 from rotkehlchen.chain.evm.constants import EVM_ADDRESS_REGEX
+from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.weth.constants import (
     CHAIN_ID_TO_WETH_MAPPING,
     CHAINS_WITHOUT_NATIVE_ETH,
 )
-from rotkehlchen.chain.evm.types import asset_id_is_evm_token, string_to_evm_address
+from rotkehlchen.chain.evm.types import (
+    NodeName,
+    WeightedNode,
+    asset_id_is_evm_token,
+    string_to_evm_address,
+)
+from rotkehlchen.constants import ONE
+from rotkehlchen.errors.misc import RemoteError, RequestTooLargeError
+from rotkehlchen.tests.utils.ethereum import (
+    ETHEREUM_WEB3_AND_ETHERSCAN_TEST_PARAMETERS,
+    wait_until_all_nodes_connected,
+)
 from rotkehlchen.tests.utils.factories import make_evm_address
-from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ChainID
+from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ChainID, SupportedBlockchain
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
 
 
 def test_asset_id_is_evm_token():
@@ -76,3 +94,90 @@ def test_is_safe_proxy(blockchain: ChainsAggregator):
     assert blockchain.ethereum.node_inquirer.is_safe_proxy_or_eoa(  # old safe
         address=string_to_evm_address('0xd12745b5CA546A408a35e8C77d81Aa0a7526DE7b'),
     ) is True
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_manager_connect_at_start', [(WeightedNode(
+    node_info=NodeName(
+        name='gnosischain',
+        endpoint='https://rpc.gnosischain.com',
+        owned=False,
+        blockchain=SupportedBlockchain.GNOSIS,
+    ),
+    active=True,
+    weight=ONE,
+),)])
+def test_multicall_error_retry(
+        gnosis_inquirer: 'GnosisInquirer',
+        gnosis_manager_connect_at_start: list[tuple],
+):
+    """Test multicall retries with smaller chunks on errors."""
+    wait_until_all_nodes_connected(gnosis_manager_connect_at_start, gnosis_inquirer)
+
+    contract = EvmContract(
+        address=(wxdai := string_to_evm_address('0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d')),
+        abi=gnosis_inquirer.contracts.erc20_abi,
+        deployed_block=0,
+    )
+    calls = [(wxdai, contract.encode(method_name='symbol')) for _ in range(4)]
+
+    call_count = 0
+    original_call_contract = gnosis_inquirer.call_contract
+
+    def mock_call_contract(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RequestTooLargeError('Multicall failed')
+        return original_call_contract(*args, **kwargs)
+
+    with patch.object(gnosis_inquirer, 'call_contract', side_effect=mock_call_contract):
+        result = gnosis_inquirer.multicall(calls=calls)
+
+    # 1 failed (large chunk) + 2 successful (chunk_size=3, 4 calls = 2 chunks)
+    assert len(result) == 4
+    assert call_count == 3
+
+    # set `_multicall_failed_length` and see that is respected.
+    estimated_length = sum(len(call[1]) for call in calls)
+    assert gnosis_inquirer._multicall_failed_length.get('nodes') == estimated_length
+
+    call_count = 0
+
+    def mock_call_contract_no_fail(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_call_contract(*args, **kwargs)
+
+    with patch.object(gnosis_inquirer, 'call_contract', side_effect=mock_call_contract_no_fail):
+        result = gnosis_inquirer.multicall(calls=calls)
+
+    # proactive chunk_size=3 from start (4 calls = 2 chunks), no retry
+    assert len(result) == 4
+    assert call_count == 2
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize(*ETHEREUM_WEB3_AND_ETHERSCAN_TEST_PARAMETERS)
+def test_query_raises_request_too_large_when_gas_limit_seen(
+        ethereum_inquirer: 'EthereumInquirer',
+        ethereum_manager_connect_at_start: list[tuple],
+) -> None:
+    """Test that _query raises RequestTooLargeError when any node returns gas limit error,
+    even if later nodes fail with different errors."""
+    wait_until_all_nodes_connected(ethereum_manager_connect_at_start, ethereum_inquirer)
+
+    call_count = 0
+
+    def mock_method(web3, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RemoteError('out of gas')
+        raise RemoteError('connection timeout')
+
+    call_order = ethereum_inquirer.default_call_order()
+    with pytest.raises(RequestTooLargeError):
+        ethereum_inquirer._query(method=mock_method, call_order=call_order)
+
+    assert call_count == len(call_order)

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -854,6 +854,7 @@ def test_find_gearbox_lp_price(inquirer: 'Inquirer', arbitrum_one_manager: 'Arbi
             assert result and result[0].address == underlying_token.resolve_to_evm_token().evm_address  # noqa: E501
 
 
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_protocol_price_fallback_to_oracle(inquirer_defi):


### PR DESCRIPTION
closes #11391

this simplifies the retry logic in the base multicall method. when a multicall fails with any error and the chunk size is greater than 3, it retries with a smaller chunk size of 3. this handles possible gas limit errors and url too long issues as seen in the issue linked