### PR TITLE
chore(frontend): upgrade bignumber.js to v9.3.1 and update patches

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -48,7 +48,7 @@
     "@vueuse/math": "13.9.0",
     "@vueuse/shared": "13.9.0",
     "@walletconnect/core": "2.23.3",
-    "bignumber.js": "9.1.2",
+    "bignumber.js": "9.3.1",
     "bufferutil": "4.1.0",
     "consola": "3.4.2",
     "dayjs": "1.11.19",

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -20,13 +20,13 @@
   },
   "peerDependencies": {
     "@vueuse/core": ">=10.11.0",
-    "bignumber.js": "9.1.2",
+    "bignumber.js": "9.3.1",
     "vue": ">=3.4.0",
     "zod": "3.23.8"
   },
   "devDependencies": {
     "@vueuse/core": "13.9.0",
-    "bignumber.js": "9.1.2",
+    "bignumber.js": "9.3.1",
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "vue": "3.5.26",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
   "pnpm": {
     "allowUnusedPatches": true,
     "patchedDependencies": {
-      "bignumber.js@9.1.2": "patches/bignumber.js@9.1.2.patch"
+      "bignumber.js@9.3.1": "patches/bignumber.js@9.3.1.patch"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/frontend/patches/bignumber.js@9.3.1.patch
+++ b/frontend/patches/bignumber.js@9.3.1.patch
@@ -1,13 +1,13 @@
-diff --git a/bignumber.d.ts b/bignumber.d.ts
+diff --git a/types.d.ts b/types.d.ts
 index c5a60a8bdb2ab7b14fcd61a796fd63212fe7bab2..26c7be1a34aa6e9f1e5d832a4a8377f6d802cb4e 100644
---- a/bignumber.d.ts
-+++ b/bignumber.d.ts
-@@ -330,7 +330,7 @@ export namespace BigNumber {
- export declare class BigNumber implements BigNumber.Instance {
- 
+--- a/types.d.ts
++++ b/types.d.ts
+@@ -326,7 +326,7 @@ declare namespace BigNumber {
+ declare class BigNumber implements BigNumber.Instance {
+
    /** Used internally to identify a BigNumber instance. */
 -  private readonly _isBigNumber: true;
 +  readonly _isBigNumber: true;
- 
+
    /** The coefficient of the value of this BigNumber, an array of base 1e14 integer numbers, or null. */
    readonly c: number[] | null;

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  bignumber.js@9.1.2:
-    hash: 2c35359c8347a121958cdaae415acc2ab014f4c2112e5b45239b23e35670aa10
-    path: patches/bignumber.js@9.1.2.patch
+  bignumber.js@9.3.1:
+    hash: 61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d
+    path: patches/bignumber.js@9.3.1.patch
 
 importers:
 
@@ -95,8 +95,8 @@ importers:
         specifier: 2.23.3
         version: 2.23.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       bignumber.js:
-        specifier: 9.1.2
-        version: 9.1.2(patch_hash=2c35359c8347a121958cdaae415acc2ab014f4c2112e5b45239b23e35670aa10)
+        specifier: 9.3.1
+        version: 9.3.1(patch_hash=61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d)
       bufferutil:
         specifier: 4.1.0
         version: 4.1.0
@@ -315,8 +315,8 @@ importers:
         specifier: 13.9.0
         version: 13.9.0(vue@3.5.26(typescript@5.9.3))
       bignumber.js:
-        specifier: 9.1.2
-        version: 9.1.2(patch_hash=2c35359c8347a121958cdaae415acc2ab014f4c2112e5b45239b23e35670aa10)
+        specifier: 9.3.1
+        version: 9.3.1(patch_hash=61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d)
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -2857,8 +2857,8 @@ packages:
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
-  bignumber.js@9.1.2:
-    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -6203,10 +6203,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -10579,7 +10581,7 @@ snapshots:
 
   big.js@6.2.2: {}
 
-  bignumber.js@9.1.2(patch_hash=2c35359c8347a121958cdaae415acc2ab014f4c2112e5b45239b23e35670aa10): {}
+  bignumber.js@9.3.1(patch_hash=61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d): {}
 
   binary-extensions@2.3.0: {}
 


### PR DESCRIPTION
Closes #(issue_number)

I tried a few times in the past but things didn't work out
now it seems at least that there are no build errors

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
