### PR TITLE
fix missing l1 fee  for l2 chains

### DIFF
--- a/rotkehlchen/chain/evm/l2_with_l1_fees/transactions.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/transactions.py
@@ -56,8 +56,8 @@ class L2WithL1FeesTransactions(EvmTransactions, ABC):
             (tx_hash,),
         ).fetchone()
 
-        if l1_fee is not None:
-            return evm_tx, tx_receipt  # type: ignore[return-value]  # all good, l1_fee is in the database
+        if l1_fee is not None and l1_fee[0] != 0:
+            return evm_tx, tx_receipt  # type: ignore[return-value]  # all good, l1_fee is valid and in the database
 
         transaction, _ = self.evm_inquirer.get_transaction_by_hash(tx_hash=tx_hash)
         transaction = cast('L2WithL1FeesTransaction', transaction)

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -545,6 +545,7 @@ class EtherscanLikeApi(ABC):
                             chain_id=chain_id,
                             evm_inquirer=None,
                             parent_tx_hash=parent_tx_hash,
+                            indexer=self,
                         )
                     else:  # Handling genesis transactions
                         assert self.db is not None, 'self.db should exists at this point'


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=151991053

when querying transactions for l2 chains using non-etherscan indexers (blockscout, routescan), the l1 fee wasn't included in the response. only etherscan returns it in their txlist endpoint. so the fee would get set to 0 during deserialization.

there was a working code path though. when querying erc20 transfers, it goes through `get_or_create_transaction`, which makes an rpc call to `eth_getTransactionReceipt`. the receipt includes the l1 fee, so those transactions get the correct value. existing tests used this code path. nothing was testing the direct txlist query code path.

`ensure_tx_data_exists` couldn't catch this either, since it only checks if the row exists, not whether the l1 fee is populated. also, `deserialize_evm_transaction` can't populate the `l1fee` since `evm_inquirer=None` from the `EtherscanLike` implementation.