### PR TITLE
Avoid marking movement match events as customized

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5216,7 +5216,7 @@ Dealing with History Events
               "events": [{
                   "entry": {
                       "identifier": 1,
-		      "entry_type": "evm event",
+		              "entry_type": "evm event",
                       "asset": "ETH",
                       "amount": "0.00863351371344",
                       "counterparty": "gas",
@@ -5229,19 +5229,19 @@ Dealing with History Events
                       "sequence_index": 0,
                       "timestamp": 1642802807,
                       "event_accounting_rule_status": "not processed",
-		      "tx_ref": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
-		      "address": null,
-		      "product": null
+                      "tx_ref": "0x8d822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "address": null,
+                      "product": null
                   },
-                  "customized": false,
-		  "hidden": true,
+                  "states": ["customized"],
+		          "hidden": true,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 1
-                }, {
+              }, {
                   "entry": {
                       "identifier": 2,
-		      "entry_type": "evm event",
+                      "entry_type": "evm event",
                       "asset": "ETH",
                       "amount": "0.00163351371344",
                       "counterparty": "gas",
@@ -5254,18 +5254,17 @@ Dealing with History Events
                       "sequence_index": 0,
                       "timestamp": 1642802807,
                       "event_accounting_rule_status": "not processed",
-		      "tx_ref": "0x1c822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
-		      "address": null,
-		      "product": null
+                      "tx_ref": "0x1c822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "address": null,
+                      "product": null
                   },
-                  "customized": false,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 3
               }, {
                   "entry": {
                       "identifier": 3,
-		      "entry_type": "eth_withdrawal_event",
+		              "entry_type": "eth_withdrawal_event",
                       "asset": "ETH",
                       "amount": "0.00163351371344",
                       "group_identifier": "EW_1454_20453",
@@ -5277,18 +5276,17 @@ Dealing with History Events
                       "sequence_index": 0,
                       "timestamp": 1652802807,
                       "event_accounting_rule_status": "not processed",
-		      "validator_index": 1454,
-		      "is_exit": false
+                      "validator_index": 1454,
+                      "is_exit": false
                   },
-                  "customized": false,
-		  "hidden": true,
+		          "hidden": true,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 1
               }, {
-	          "entry": {
+	              "entry": {
                       "identifier": 4,
-		      "entry_type": "eth_block_event",
+		              "entry_type": "eth_block_event",
                       "asset": "ETH",
                       "amount": "0.00163351371344",
                       "group_identifier": "evm_1_block_15534342",
@@ -5300,17 +5298,16 @@ Dealing with History Events
                       "sequence_index": 0,
                       "timestamp": 1652802807,
                       "event_accounting_rule_status": "not processed",
-		      "validator_index": 1454,
-		      "block_number": 15534342
+                      "validator_index": 1454,
+		              "block_number": 15534342
                   },
-                  "customized": false,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 2
               },  {
                   "entry": {
                       "identifier": 5,
-		      "entry_type": "eth deposit event",
+		              "entry_type": "eth deposit event",
                       "asset": "ETH",
                       "amount": "32",
                       "counterparty": "eth2",
@@ -5323,12 +5320,11 @@ Dealing with History Events
                       "sequence_index": 15,
                       "timestamp": 1642802807,
                       "event_accounting_rule_status": "not processed",
-		      "tx_ref": "0x2c822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
-		      "address": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-		      "product": "staking",
-		      "validator_index": 4242
+                      "tx_ref": "0x2c822b87407698dd869e830699782291155d0276c5a7e5179cb173608554e41f",
+                      "address": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+                      "product": "staking",
+                      "validator_index": 4242
                   },
-                  "customized": false,
                   "ignored_in_accounting": false,
                   "has_details": false,
                   "grouped_events_num": 3
@@ -5495,30 +5491,36 @@ Dealing with History Events
           "message": ""
       }
 
-   :resjson list decoded_events: A list of history events, with some events grouped into sub-lists (for instance the spend/receive/fee events making up a swap). Each event is an object comprised of the event entry and a boolean denoting if the event has been customized by the user or not. Each entry may also have a `has_details` flag if true. If `has_details` is true, then it is possible to call /history/events/details endpoint to retrieve some extra information about the event. Also each entry may have a `customized` flag set to true. If it does, it means the event has been customized/added by the user. Each entry may also have a `hidden` flag if set to true. If it does then that means it should be hidden in the UI due to consolidation of events. Also if `aggregate_by_group_ids` exist and is true, each entry contains `grouped_events_num` which is an integer with the amount of events under the group identifier. The consumer has to query this endpoint again with `aggregate_by_group_ids` set to false and with the `group_identifiers` filter set to the identifier of the events having more than 1 event. `ignored_in_accounting` is set to `true` when the user has marked this event as ignored. `has_ignored_assets` is set to `true` when the event group contains ignored assets, indicating that some events may have been excluded by ignored assets filtering. Following are all possible entries depending on entry type.
-   :resjson string identifier: Common key. This is the identifier of a single event.
-   :resjson string entry_type: Common key. This identifies the category of the event and determines the schema. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
-   :resjson string group_identifier: Common key. An identifier grouping multiple events under a common group. This is how we group transaction events under a transaction, staking related events under block production etc.
-   :resjson string[optional] actual_group_identifier: The actual group identifier of the event as stored in the DB. Used when events from different underlying groups are all joined into a single group for display in the frontend.
-   :resjson int sequence_index: Common key. This is an index that tries to provide the order of history entries for a single group_identifier.
-   :resjson int timestamp: Common key. The timestamp of the entry
-   :resjson string event_accounting_rule_status: Common key. It explains the status of accounting rules for the event. Possible values are: ``has rule``: Meaning the event has a rule. ``processed``: meaning the event will be processed because it is affected by another event. ``not processed`` meaning it doesn't have any rule and won't be processed by accounting.
-   :resjson string location: Common key. The location of the entry. Such as "ethereum", "optimism", etc.
-   :resjson string asset: Common key. The asset involved in the event.
-   :resjson object balance: Common key. The balance of the asset involved in the event.
-   :resjson string event_type: Common key. The type of the event. Valid values are retrieved from the backend.
-   :resjson string event_subtype: Common key. The subtype of the event. Valid values are retrieved from the backend.
-   :resjson string location_label: Common key. The location_label of the event. This means different things depending on event category. For evm events it's the initiating address. For withdrawal events the recipient address. For block production events the fee recipient.
-   :resjson string user_notes: Common key. Custom notes for the event set by the user. Can be missing.
-   :resjson string auto_notes: Common key. Autogenerated string description of the event. Can be missing.
-   :resjson string tx_ref: Evm event, Solana event & eth deposit key. The transaction hash of the event.
-   :resjson string counterparty: Evm event & eth deposit key. The counterparty of the event. This is most of the times a protocol such as uniswap, but can also be an exchange name such as kraken. Possible values are requested by the backend.
-   :resjson string product: Evm event & eth deposit key. This is the product type with which the event interacts. Such as pool, staking contract etc. Possible values are requested by the backend.
-   :resjson string address: Evm event & eth deposit key. This is the address of the contract the event interacts with if there is one.
-   :resjson int validator_index: Eth staking (withdrawal + block production + eth deposit) key. The index of the validator related to the event.
-   :resjson bool is_exit: Eth withdrawal event key. A boolean denoting if the withdrawal is a full exit or not.
-   :resjson int block_number: Eth block event key. An integer representing the number of the block for which the event is made.
-
+   :resjson list events: A list of history events, with some events grouped into sub-lists (for instance the spend/receive/fee events making up a swap). Each event is an object comprised of the event entry object and various metadata fields and flags. See below for the complete structure.
+   :resjson string events[].entry.identifier: Common key. This is the identifier of a single event.
+   :resjson string events[].entry.entry_type: Common key. This identifies the category of the event and determines the schema. Possible values are: ``"history event"``, ``"evm event"``, ``"eth withdrawal event"``, ``"eth block event"``, ``"eth deposit event"``.
+   :resjson string events[].entry.group_identifier: Common key. An identifier grouping multiple events under a common group. This is how we group transaction events under a transaction, staking related events under block production etc.
+   :resjson string[optional] events[].entry.actual_group_identifier: The actual group identifier of the event as stored in the DB. Used when events from different underlying groups are all joined into a single group for display in the frontend.
+   :resjson int events[].entry.sequence_index: Common key. This is an index that tries to provide the order of history entries for a single group_identifier.
+   :resjson int events[].entry.timestamp: Common key. The timestamp of the entry
+   :resjson string events[].entry.event_accounting_rule_status: Common key. It explains the status of accounting rules for the event. Possible values are: ``has rule``: Meaning the event has a rule. ``processed``: meaning the event will be processed because it is affected by another event. ``not processed`` meaning it doesn't have any rule and won't be processed by accounting.
+   :resjson string events[].entry.location: Common key. The location of the entry. Such as "ethereum", "optimism", etc.
+   :resjson string events[].entry.asset: Common key. The asset involved in the event.
+   :resjson object events[].entry.amount: Common key. The amount of the asset involved in the event.
+   :resjson string events[].entry.event_type: Common key. The type of the event. Valid values are retrieved from the backend.
+   :resjson string events[].entry.event_subtype: Common key. The subtype of the event. Valid values are retrieved from the backend.
+   :resjson string events[].entry.location_label: Common key. The location_label of the event. This means different things depending on event category. For evm events it's the initiating address. For withdrawal events the recipient address. For block production events the fee recipient.
+   :resjson string events[].entry.user_notes: Common key. Custom notes for the event set by the user. Can be missing.
+   :resjson string events[].entry.auto_notes: Common key. Autogenerated string description of the event. Can be missing.
+   :resjson string events[].entry.tx_ref: Evm event, Solana event & eth deposit key. The transaction hash of the event.
+   :resjson string events[].entry.counterparty: Evm event & eth deposit key. The counterparty of the event. This is most of the times a protocol such as uniswap, but can also be an exchange name such as kraken. Possible values are requested by the backend.
+   :resjson string events[].entry.product: Evm event & eth deposit key. This is the product type with which the event interacts. Such as pool, staking contract etc. Possible values are requested by the backend.
+   :resjson string events[].entry.address: Evm event & eth deposit key. This is the address of the contract the event interacts with if there is one.
+   :resjson int events[].entry.validator_index: Eth staking (withdrawal + block production + eth deposit) key. The index of the validator related to the event.
+   :resjson bool events[].entry.is_exit: Eth withdrawal event key. A boolean denoting if the withdrawal is a full exit or not.
+   :resjson int events[].entry.block_number: Eth block event key. An integer representing the number of the block for which the event is made.
+   :resjson object events[].entry.extra_data: Optional. Additional data specific to the event type.
+   :resjson list events[].states: Optional. List of state tags for the event. Valid states are ``customized``, ``profit_adjustment``, ``auto_matched``, ``imported_from_csv``.
+   :resjson bool events[].hidden: Optional. If true, this event should be hidden in the UI due to consolidation of events.
+   :resjson bool events[].ignored_in_accounting: Set to true when the user has marked this event as ignored.
+   :resjson bool events[].has_ignored_assets: Optional. Set to true when the event group contains ignored assets, indicating that some events may have been excluded by ignored assets filtering.
+   :resjson bool events[].has_details: If true, it is possible to call /history/events/details endpoint to retrieve extra information about the event.
+   :resjson int events[].grouped_events_num: Optional. Present when ``aggregate_by_group_ids`` is true. The number of events under this group identifier. The consumer has to query this endpoint again with ``aggregate_by_group_ids`` set to false and with the ``group_identifiers`` filter set to the identifier of the events having more than 1 event.
    :resjson int entries_found: The number of entries found for the current filter. Ignores pagination.
    :resjson int entries_limit: The limit of entries if free version. -1 for premium.
    :resjson int entries_total: The number of total entries ignoring all filters.

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -48,7 +48,8 @@ Exchange asset movement events may now be manually matched with specific onchain
 * **Modified Endpoint**: ``POST /api/(version)/history/events``
 
   - New optional ``actual_group_identifier`` field in the response, containing the actual group identifier of the event as stored in the DB.
-  - This change preserves the actual group identifier when asset movements are combined with the group of their matched event for display as a single unit in the frontend.
+    This preserves the actual group identifier when asset movements are combined with the group of their matched event for display as a single unit in the frontend.
+  - Replaced the ``customized`` flag with a ``states`` list. Valid states are ``customized``, ``profit_adjustment``, ``auto_matched``, ``imported_from_csv``.
 
 * **New Settings** (new fields in both ``PUT`` and ``POST`` on ``/api/(version)/settings``)
   - ``asset_movement_amount_tolerance`` The tolerance value used when matching asset movement amounts with onchain events. Must be a positive decimal number. Default is ``"0.000001"``.

--- a/rotkehlchen/api/rest_helpers/history_events.py
+++ b/rotkehlchen/api/rest_helpers/history_events.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryBaseEntryType
 
@@ -66,7 +66,7 @@ def edit_grouped_events_with_optional_fee(
         events_db.add_history_event(  # Add the new fee event. Mark as customized since its being manually added by the user.  # noqa: E501
             write_cursor=write_cursor,
             event=events[-1],
-            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
         )
     else:
         assert new_event_count == existing_event_count and existing_event_count in (no_fee_num, with_fee_num)  # noqa: E501
@@ -126,5 +126,5 @@ def edit_grouped_swap_events(
         events_db.add_history_event(
             write_cursor=write_cursor,
             event=event,
-            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
         )

--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
         MissingPrice,
     )
     from rotkehlchen.assets.asset import Asset
+    from rotkehlchen.db.constants import HistoryMappingState
     from rotkehlchen.db.filtering import HistoryBaseEntryFilterQuery
     from rotkehlchen.fval import FVal
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
@@ -325,7 +326,7 @@ class HistoryService:
                 entries_table='history_events',
                 group_by='group_identifier' if aggregate_by_group_ids else None,
             )
-            customized_event_ids = dbevents.get_customized_group_identifiers(
+            event_mapping_states = dbevents.get_event_mapping_states(
                 cursor=cursor,
                 location=filter_query.location,
             )
@@ -373,7 +374,7 @@ class HistoryService:
                     accountant=self.rotkehlchen.accountant,
                 ),
                 grouped_events_nums=grouped_events_nums,
-                customized_event_ids=customized_event_ids,
+                mapping_states=event_mapping_states,
                 ignored_ids=ignored_ids,
                 hidden_event_ids=hidden_event_ids,
                 joined_group_ids=joined_group_ids,
@@ -631,7 +632,7 @@ class HistoryService:
             aggregate_by_group_ids: bool,
             event_accounting_rule_statuses: list[EventAccountingRuleStatus],
             grouped_events_nums: list[int | None],
-            customized_event_ids: list[int],
+            mapping_states: dict[int, list[HistoryMappingState]],
             ignored_ids: set[str],
             hidden_event_ids: list[int],
             joined_group_ids: dict[str, str],
@@ -671,7 +672,7 @@ class HistoryService:
         ):
             replacement_group_id = joined_group_ids.get(event.group_identifier)
             serialized = event.serialize_for_api(
-                customized_event_ids=customized_event_ids,
+                mapping_states=mapping_states,
                 ignored_ids=ignored_ids,
                 hidden_event_ids=hidden_event_ids,
                 event_accounting_rule_status=event_accounting_rule_status,

--- a/rotkehlchen/api/services/history_events.py
+++ b/rotkehlchen/api/services/history_events.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pysqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.api.rest_helpers.history_events import edit_grouped_events_with_optional_fee
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import AlreadyExists, InputError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -38,7 +38,7 @@ class HistoryEventsService:
                         write_cursor=cursor,
                         event=event,
                         mapping_values={
-                            HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED,
+                            HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED,
                         },
                     )
                     if idx == 0:

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Final, Literal
 
 from rotkehlchen.errors.serialization import DeserializationError
@@ -19,10 +19,17 @@ TX_SPAM: Final = 1
 
 # -- history_events_mappings values --
 HISTORY_MAPPING_KEY_STATE: Final = 'state'
-HISTORY_MAPPING_STATE_CUSTOMIZED: Final = 1
-# Marks profit events auto-created during historical balances processing
-# when withdrawals exceed deposits
-HISTORY_MAPPING_STATE_VIRTUAL: Final = 2
+
+
+class HistoryMappingState(IntEnum):
+    CUSTOMIZED = 1
+    PROFIT_ADJUSTMENT = 2  # events auto-created during historical balances processing when withdrawals exceed deposits  # noqa: E501
+    AUTO_MATCHED = 3  # events matched with asset movements, and fees created during matching.
+    IMPORTED_FROM_CSV = 4
+
+    def serialize_for_api(self) -> str:
+        """Serializes the mapping state for the API"""
+        return self.name.lower()
 
 
 EVM_ACCOUNTS_DETAILS_LAST_QUERIED_TS: Final = 'last_queried_timestamp'

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -22,9 +22,8 @@ from rotkehlchen.db.constants import (
     ETH_STAKING_EVENT_FIELDS,
     HISTORY_BASE_ENTRY_FIELDS,
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
-    HISTORY_MAPPING_STATE_VIRTUAL,
     TX_DECODED,
+    HistoryMappingState,
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
@@ -724,7 +723,7 @@ class HistoryEventCustomizedOnlyJoinsFilter(DBFilter):
             'ON history_events_mappings.parent_identifier = history_events_identifier '
             'WHERE history_events_mappings.name = ? AND history_events_mappings.value = ?'
         )
-        bindings: list[str | int] = [HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED]
+        bindings: list[str | int] = [HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED]
         return [query], bindings
 
 
@@ -737,8 +736,7 @@ class HistoryEventVirtualOnlyJoinsFilter(DBFilter):
             'ON history_events_mappings.parent_identifier = history_events_identifier '
             'WHERE history_events_mappings.name = ? AND history_events_mappings.value = ?'
         )
-        bindings: list[str | int] = [HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_VIRTUAL]
-        return [query], bindings
+        return [query], [HISTORY_MAPPING_KEY_STATE, HistoryMappingState.PROFIT_ADJUSTMENT]
 
 
 class HistoryBaseEntryFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLocation, ABC):

--- a/rotkehlchen/db/upgrades/v35_v36.py
+++ b/rotkehlchen/db/upgrades/v35_v36.py
@@ -6,7 +6,7 @@ from rotkehlchen.chain.ethereum.modules.eth2.constants import MIN_EFFECTIVE_BALA
 from rotkehlchen.constants import ONE
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.settings import DEFAULT_ACTIVE_MODULES
 from rotkehlchen.db.utils import table_exists, update_table_schema
@@ -567,7 +567,7 @@ def upgrade_v35_to_v36(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         tx_hashes = [x[0] for x in write_cursor]
         write_cursor.execute(
             'SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?',
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         )
         customized_event_ids = [x[0] for x in write_cursor]
         length = len(customized_event_ids)

--- a/rotkehlchen/db/upgrades/v36_v37.py
+++ b/rotkehlchen/db/upgrades/v36_v37.py
@@ -7,7 +7,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH2
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.fval import FVal
@@ -34,7 +34,7 @@ def _reset_decoded_events(write_cursor: 'DBCursor') -> None:
     tx_hashes = [x[0] for x in write_cursor]
     write_cursor.execute(
         'SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?',
-        (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+        (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
     )
     customized_event_ids = [x[0] for x in write_cursor]
     length = len(customized_event_ids)

--- a/rotkehlchen/db/upgrades/v37_v38.py
+++ b/rotkehlchen/db/upgrades/v37_v38.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import enter_exit_debug_log
@@ -99,7 +99,7 @@ def upgrade_v37_to_v38(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
 
         customized_events = write_cursor.execute(
             'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         ).fetchone()[0]
         querystr = (
             'DELETE FROM history_events WHERE identifier IN ('
@@ -110,7 +110,7 @@ def upgrade_v37_to_v38(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         bindings: tuple = ()
         if customized_events != 0:
             querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-            bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+            bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v38_v39.py
+++ b/rotkehlchen/db/upgrades/v38_v39.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
@@ -293,7 +293,7 @@ def upgrade_v38_to_v39(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
 
         customized_events = write_cursor.execute(
             'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         ).fetchone()[0]
         querystr = (
             'DELETE FROM history_events WHERE identifier IN ('
@@ -304,7 +304,7 @@ def upgrade_v38_to_v39(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         bindings: tuple = ()
         if customized_events != 0:
             querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-            bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+            bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v39_v40.py
+++ b/rotkehlchen/db/upgrades/v39_v40.py
@@ -8,8 +8,8 @@ from pysqlcipher3 import dbapi2 as sqlcipher
 from rotkehlchen.constants import ZERO
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
     NO_ACCOUNTING_COUNTERPARTY,
+    HistoryMappingState,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.errors.serialization import DeserializationError
@@ -339,7 +339,7 @@ def upgrade_v39_to_v40(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
 
         customized_events = write_cursor.execute(
             'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         ).fetchone()[0]
         querystr = (
             'DELETE FROM history_events WHERE identifier IN ('
@@ -350,7 +350,7 @@ def upgrade_v39_to_v40(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         bindings: tuple = ()
         if customized_events != 0:
             querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-            bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+            bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
         write_cursor.execute(querystr, bindings)
         write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v40_v41.py
+++ b/rotkehlchen/db/upgrades/v40_v41.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
@@ -211,7 +211,7 @@ def upgrade_v40_to_v41(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 'DELETE FROM history_events WHERE identifier IN ('
@@ -222,7 +222,7 @@ def upgrade_v40_to_v41(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v41_v42.py
+++ b/rotkehlchen/db/upgrades/v41_v42.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.types import ChainID, Location
@@ -166,7 +166,7 @@ def upgrade_v41_to_v42(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 'DELETE FROM history_events WHERE identifier IN ('
@@ -177,7 +177,7 @@ def upgrade_v41_to_v42(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v42_v43.py
+++ b/rotkehlchen/db/upgrades/v42_v43.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from rotkehlchen.constants.misc import AIRDROPSDIR_NAME, APPDIR_NAME
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.types import Location
@@ -76,7 +76,7 @@ def upgrade_v42_to_v43(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -87,7 +87,7 @@ def upgrade_v42_to_v43(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v43_v44.py
+++ b/rotkehlchen/db/upgrades/v43_v44.py
@@ -7,7 +7,7 @@ from eth_utils import to_checksum_address
 
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.upgrades.utils import fix_address_book_duplications
 from rotkehlchen.history.types import HistoricalPriceOracle
@@ -212,7 +212,7 @@ def upgrade_v43_to_v44(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -223,7 +223,7 @@ def upgrade_v43_to_v44(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v44_v45.py
+++ b/rotkehlchen/db/upgrades/v44_v45.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.utils.progress import perform_userdb_upgrade_steps, progress_step
@@ -39,7 +39,7 @@ def upgrade_v44_to_v45(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -50,7 +50,7 @@ def upgrade_v44_to_v45(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v45_v46.py
+++ b/rotkehlchen/db/upgrades/v45_v46.py
@@ -7,7 +7,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ALLASSETIMAGESDIR_NAME, ASSETIMAGESDIR_NAME, IMAGESDIR_NAME
 from rotkehlchen.constants.assets import A_COW, A_GNOSIS_COW, A_LQTY
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
@@ -160,7 +160,7 @@ def upgrade_v45_to_v46(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -171,7 +171,7 @@ def upgrade_v45_to_v46(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v46_v47.py
+++ b/rotkehlchen/db/upgrades/v46_v47.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from rotkehlchen.data_import.importers.constants import ROTKI_EVENT_PREFIX
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.settings import DEFAULT_ACTIVE_MODULES
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import DEFAULT_HISTORICAL_PRICE_ORACLES_ORDER
@@ -50,7 +50,7 @@ def upgrade_v46_to_v47(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -61,7 +61,7 @@ def upgrade_v46_to_v47(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v47_v48.py
+++ b/rotkehlchen/db/upgrades/v47_v48.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rotkehlchen.assets.asset import Asset
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.migration_utils import (
     create_swap_events_v47_v48,
     get_swap_spend_receive_v47_48,
@@ -152,7 +152,7 @@ def upgrade_v47_to_v48(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -163,7 +163,7 @@ def upgrade_v47_to_v48(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(
@@ -336,7 +336,7 @@ def upgrade_v47_to_v48(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         write_cursor.execute(
             'UPDATE history_events SET notes = NULL WHERE entry_type = 6 AND notes IS NOT NULL '
             'AND NOT EXISTS (SELECT 1 FROM history_events_mappings WHERE parent_identifier = history_events.identifier AND name=? AND value=?)',  # noqa: E501
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         )
 
     @progress_step(description='Upgrade internal transactions table')

--- a/rotkehlchen/db/upgrades/v48_v49.py
+++ b/rotkehlchen/db/upgrades/v48_v49.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.upgrades.upgrade_utils import process_solana_asset_migration
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
@@ -91,7 +91,7 @@ def upgrade_v48_to_v49(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -102,7 +102,7 @@ def upgrade_v48_to_v49(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(

--- a/rotkehlchen/db/upgrades/v49_v50.py
+++ b/rotkehlchen/db/upgrades/v49_v50.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.utils.progress import perform_userdb_upgrade_steps, progress_step
 
@@ -27,7 +27,7 @@ def upgrade_v49_to_v50(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
         if write_cursor.execute('SELECT COUNT(*) FROM evm_transactions').fetchone()[0] > 0:
             customized_events = write_cursor.execute(
                 'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-                (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+                (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
             ).fetchone()[0]
             querystr = (
                 "DELETE FROM history_events WHERE identifier IN ("
@@ -38,7 +38,7 @@ def upgrade_v49_to_v50(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             bindings: tuple = ()
             if customized_events != 0:
                 querystr += ' AND identifier NOT IN (SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)'  # noqa: E501
-                bindings = (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED)
+                bindings = (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED)
 
             write_cursor.execute(querystr, bindings)
             write_cursor.execute(
@@ -53,7 +53,7 @@ def upgrade_v49_to_v50(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             "UPDATE history_events SET location_label='Crypto.com App' WHERE "
             "location='P' AND location_label IS NULL AND identifier NOT IN "
             "(SELECT parent_identifier FROM history_events_mappings WHERE name=? AND value=?)",
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         )
 
     @progress_step(description='Update accounting_rules table with is_event_specific column and constraint.')  # noqa: E501

--- a/rotkehlchen/db/upgrades/v50_v51.py
+++ b/rotkehlchen/db/upgrades/v50_v51.py
@@ -13,7 +13,7 @@ from rotkehlchen.constants import (
     CONTRACT_TAG_NAME,
 )
 from rotkehlchen.db.cache import DBCacheStatic
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -290,7 +290,7 @@ def upgrade_v50_to_v51(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
                 # WHERE: exclude asset movements, only customized, only with counterparty
                 HistoryBaseEntryType.ASSET_MOVEMENT_EVENT.value,
                 HISTORY_MAPPING_KEY_STATE,
-                HISTORY_MAPPING_STATE_CUSTOMIZED,
+                HistoryMappingState.CUSTOMIZED,
                 HistoryEventType.DEPOSIT.serialize(),
                 HistoryEventSubType.DEPOSIT_ASSET.serialize(),
                 HistoryEventType.WITHDRAWAL.serialize(),

--- a/rotkehlchen/history/events/structures/onchain_event.py
+++ b/rotkehlchen/history/events/structures/onchain_event.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar, cast
 from rotkehlchen.accounting.mixins.event import AccountingEventMixin, AccountingEventType
 from rotkehlchen.accounting.types import EventAccountingRuleStatus
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.db.constants import HistoryMappingState
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import (
     HISTORY_EVENT_DB_TUPLE_WRITE,
@@ -190,7 +191,7 @@ class OnchainEvent(HistoryBaseEntry, Generic[T_TxRef, T_Address]):
 
     def serialize_for_api(
             self,
-            customized_event_ids: list[int],
+            mapping_states: dict[int, list[HistoryMappingState]],
             ignored_ids: set[str],
             hidden_event_ids: list[int],
             event_accounting_rule_status: EventAccountingRuleStatus,
@@ -198,7 +199,7 @@ class OnchainEvent(HistoryBaseEntry, Generic[T_TxRef, T_Address]):
             has_ignored_assets: bool = False,
     ) -> dict[str, Any]:
         result = super().serialize_for_api(
-            customized_event_ids=customized_event_ids,
+            mapping_states=mapping_states,
             ignored_ids=ignored_ids,
             hidden_event_ids=hidden_event_ids,
             event_accounting_rule_status=event_accounting_rule_status,

--- a/rotkehlchen/tasks/events.py
+++ b/rotkehlchen/tasks/events.py
@@ -14,7 +14,7 @@ from rotkehlchen.db.constants import (
     CHAIN_EVENT_FIELDS,
     HISTORY_BASE_ENTRY_FIELDS,
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
+    HistoryMappingState,
 )
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -182,9 +182,9 @@ def _load_customized_event_candidates(
     )
     bindings_base = (
         HISTORY_MAPPING_KEY_STATE,
-        HISTORY_MAPPING_STATE_CUSTOMIZED,
+        HistoryMappingState.CUSTOMIZED,
         HISTORY_MAPPING_KEY_STATE,
-        HISTORY_MAPPING_STATE_CUSTOMIZED,
+        HistoryMappingState.CUSTOMIZED,
         *entry_type_values,
         *entry_type_values,
     )
@@ -512,13 +512,14 @@ def _maybe_adjust_fee(
                     is_fee=True,
                     location_label=asset_movement.location_label,
                 ),
-                mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+                mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.AUTO_MATCHED},
             )
         else:
             movement_fee.amount += amount_diff
             events_db.edit_history_event(
                 write_cursor=write_cursor,
                 event=movement_fee,
+                mapping_state=HistoryMappingState.AUTO_MATCHED,
             )
 
 
@@ -582,6 +583,7 @@ def update_asset_movement_matched_event(
         events_db.edit_history_event(
             write_cursor=write_cursor,
             event=matched_event,
+            mapping_state=HistoryMappingState.AUTO_MATCHED,
         )
         events_db.db.set_dynamic_cache(  # type: ignore[call-overload]  # identifiers will not be None here since the events are from the db
             write_cursor=write_cursor,

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Final, Literal, NamedTuple, TypeAlias
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
 from rotkehlchen.constants import ZERO
 from rotkehlchen.db.cache import DBCacheStatic
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_VIRTUAL
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
@@ -518,7 +518,7 @@ def _maybe_add_profit_event(
             write_cursor.execute(
                 'INSERT OR IGNORE INTO history_events_mappings(parent_identifier, name, value) '
                 'VALUES(?, ?, ?)',
-                (event.identifier, HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_VIRTUAL),
+                (event.identifier, HISTORY_MAPPING_KEY_STATE, HistoryMappingState.PROFIT_ADJUSTMENT),  # noqa: E501
             )
             return (event,)
 
@@ -562,7 +562,7 @@ def _maybe_add_profit_event(
                 counterparty=bucket.protocol,
                 address=event.address,
             )),
-            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_VIRTUAL},
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.PROFIT_ADJUSTMENT},
         )
         profit_event.identifier = identifier
         return profit_event, event

--- a/rotkehlchen/tests/api/test_bitcoin.py
+++ b/rotkehlchen/tests/api/test_bitcoin.py
@@ -9,7 +9,7 @@ import requests
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE
 from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.db.cache import DBCacheDynamic
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.history.events.structures.base import HistoryEvent
@@ -631,7 +631,7 @@ def test_delete_btc_account(
     with rotki.data.db.conn.write_ctx() as write_cursor:
         for address in btc_accounts:
             for mapping_values in (
-                {HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+                {HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
                 None,
             ):  # Add both a normal event and a customized event for each address
                 dbevents.add_history_event(
@@ -674,9 +674,10 @@ def test_delete_btc_account(
         )
         assert len(events) == 3  # Events remaining are the customized event from address1 and both events from address2  # noqa: E501
         assert events[0].location_label == btc_accounts[0]
-        assert events[0].identifier in dbevents.get_customized_group_identifiers(
+        assert events[0].identifier in dbevents.get_event_mapping_states(
             cursor=cursor,
             location=Location.BITCOIN,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
         )
         assert events[1].location_label == btc_accounts[1]
         assert events[2].location_label == btc_accounts[1]

--- a/rotkehlchen/tests/api/test_customized_event_duplicates.py
+++ b/rotkehlchen/tests/api/test_customized_event_duplicates.py
@@ -5,7 +5,7 @@ import requests
 
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
@@ -52,7 +52,7 @@ def duplicated_events_setup(
         events_db.add_history_event(
             write_cursor=write_cursor,
             event=customized_event,
-            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
         )
         assert event_id is not None
         auto_fix_events.append(event)
@@ -82,7 +82,7 @@ def duplicated_events_setup(
         events_db.add_history_event(
             write_cursor=write_cursor,
             event=manual_review_customized,
-            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
         )
 
     return auto_fix_events, auto_fix_event_ids, manual_review_event

--- a/rotkehlchen/tests/api/test_data_purging.py
+++ b/rotkehlchen/tests/api/test_data_purging.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.zksync_lite.structures import (
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_SOL
 from rotkehlchen.db.cache import DBCacheDynamic, DBCacheStatic
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import (
     EvmTransactionsFilterQuery,
@@ -268,7 +268,7 @@ def test_purge_blockchain_transaction_data(rotkehlchen_api_server: 'APIServer') 
                 write_cursor=write_cursor,
                 event=event,
                 mapping_values=(  # Mark the first event as customized
-                    {HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED}
+                    {HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED}
                     if btc_tx_hash1 in event.group_identifier or bch_tx_hash1 in event.group_identifier else {}  # noqa: E501
                 ),
             )
@@ -347,7 +347,7 @@ def test_purge_solana_transaction_data(rotkehlchen_api_server: 'APIServer') -> N
         events_db.add_history_event(
             write_cursor=write_cursor,
             event=(customized_event := events[0]),
-            mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
         )
 
     # check deleting by hash

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -22,6 +22,7 @@ from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_EUR, A_MKR, A_USDT, A_WETH
 from rotkehlchen.constants.limits import FREE_HISTORY_EVENTS_LIMIT
 from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.constants import HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import (
     EvmEventFilterQuery,
@@ -873,7 +874,7 @@ def test_query_transactions_check_decoded_events(
     event['event_type'] = 'spend'
     event['event_subtype'] = 'payback debt'
     event['user_notes'] = 'Edited event'
-    tx2_events[1]['customized'] = True
+    tx2_events[1]['states'] = [HistoryMappingState.CUSTOMIZED.serialize_for_api()]
     response = requests.patch(
         api_url_for(rotkehlchen_api_server, 'historyeventresource'),
         json={key: value for key, value in event.items() if key != 'group_identifier'},
@@ -898,7 +899,7 @@ def test_query_transactions_check_decoded_events(
             'tx_ref': '0xccb6a445e136492b242d1c2c0221dc4afd4447c96601e88c156ec4d52e993b8f',
             'extra_data': None,
         },
-        'customized': True,
+        'states': [HistoryMappingState.CUSTOMIZED.serialize_for_api()],
         'event_accounting_rule_status': 'not processed',
     })
     response = requests.put(

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -29,8 +29,8 @@ from rotkehlchen.db.cache import DBCacheDynamic, DBCacheStatic
 from rotkehlchen.db.checks import sanity_check_impl
 from rotkehlchen.db.constants import (
     HISTORY_MAPPING_KEY_STATE,
-    HISTORY_MAPPING_STATE_CUSTOMIZED,
     NO_ACCOUNTING_COUNTERPARTY,
+    HistoryMappingState,
 )
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType
@@ -2147,7 +2147,7 @@ def test_upgrade_db_40_to_41(user_data_dir, address_name_priority, messages_aggr
         assert cursor.execute('SELECT COUNT(*) FROM evm_events_info').fetchone()[0] == 8
         assert cursor.execute(
             'SELECT COUNT(*) FROM history_events_mappings WHERE name=? AND value=?',
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         ).fetchone()[0] == 1  # one event is customized
 
         # test eth2 validators and daily stats are there
@@ -2669,7 +2669,7 @@ def test_upgrade_db_45_to_46(user_data_dir: 'Path', messages_aggregator):
         # Make the existing evm event customized so it isn't removed during the upgrade
         write_cursor.execute(
             "INSERT INTO history_events_mappings(parent_identifier, name, value) VALUES ('35', ?, ?)",  # noqa: E501
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         )
 
     # Execute upgrade
@@ -2830,7 +2830,7 @@ def test_upgrade_db_46_to_47(user_data_dir, messages_aggregator):
         )
         write_cursor.execute(  # mark it a custom event to so event reset doesn't affect it.
             "INSERT INTO history_events_mappings(parent_identifier, name, value) VALUES ((SELECT identifier FROM history_events WHERE event_identifier='TEST1'), ?, ?)",  # noqa: E501
-            (HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         )
         write_cursor.executemany(
             'INSERT INTO evm_accounts_details(account, chain_id, key, value) VALUES(?, ?, ?, ?)',
@@ -3677,7 +3677,7 @@ def test_upgrade_db_49_to_50(user_data_dir, messages_aggregator):
         ]
         assert cursor.execute(
             'SELECT COUNT(*) FROM history_events_mappings WHERE parent_identifier=? AND name=? AND value=?',  # noqa: E501
-            (2, HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED),
+            (2, HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED),
         ).fetchone()[0] == 1  # TEST_EVENT_2 is customized.
         assert not table_exists(cursor=cursor, name='accounting_rule_events')
         assert cursor.execute('SELECT type, subtype, counterparty FROM accounting_rules ORDER BY identifier').fetchall() == (rules := [  # noqa: E501

--- a/rotkehlchen/tests/unit/events/test_customized_event_duplicates.py
+++ b/rotkehlchen/tests/unit/events/test_customized_event_duplicates.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HISTORY_MAPPING_STATE_CUSTOMIZED
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.drivers.gevent import DBCursor
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
@@ -44,7 +44,7 @@ def _insert_duplicate_group(
     events_db.add_history_event(
         write_cursor=write_cursor,
         event=customized_event,
-        mapping_values={HISTORY_MAPPING_KEY_STATE: HISTORY_MAPPING_STATE_CUSTOMIZED},
+        mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
     )
     assert base_event_id is not None
     return base_event.group_identifier, base_event_id

--- a/rotkehlchen/tests/unit/events/test_match_asset_movements.py
+++ b/rotkehlchen/tests/unit/events/test_match_asset_movements.py
@@ -340,6 +340,17 @@ def test_match_asset_movements(database: 'DBHandler') -> None:
     withdrawal2.identifier = 9
     assert find_match_mock.call_args_list[1].kwargs['asset_movement'] == withdrawal2
 
+    # Check that the modified matched events are not removed when resetting for redecode
+    assert deposit2_matched_event.identifier is not None
+    with database.conn.write_ctx() as write_cursor:
+        events_db.reset_events_for_redecode(write_cursor, Location.ETHEREUM)
+        assert len(events_db.get_history_events_internal(
+            cursor=write_cursor,
+            filter_query=HistoryEventFilterQuery.make(
+                identifiers=[deposit2_matched_event.identifier],
+            ),
+        )) == 1
+
 
 def test_match_asset_movements_settings(database: 'DBHandler') -> None:
     """Test that the amount tolerance and time range settings works correctly, with the match

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -45,7 +45,7 @@ def test_serialize_with_invalid_type_subtype():
     )
     event.event_subtype = event_subtype  # do here cause ctor will raise for invalid subtype
     assert event.serialize_for_api(
-        customized_event_ids=[],
+        mapping_states={},
         ignored_ids=set(),
         hidden_event_ids=[],
         event_accounting_rule_status=EventAccountingRuleStatus.NOT_PROCESSED,  # needed to recreate the error this tests for  # noqa: E501

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -179,7 +179,7 @@ def generate_events_response(
 
     return [
         x.serialize_for_api(
-            customized_event_ids=[],
+            mapping_states={},
             ignored_ids=set(),
             hidden_event_ids=[],
             event_accounting_rule_status=accounting_status,


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=152121302

* Changes the movement matching logic to mark the matched events with a new mapping state instead of marking them as customized.
* Adjusts the reset for redecode logic to also avoid deleting events marked with this state.
* Adjusts the api to return a list of states instead of just a customized flag for each event.