### PR TITLE
fix(frontend): don't auto refresh duplicate custom event list

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -235,7 +235,7 @@ function openMatchAssetMovementsDialog(): void {
       <div>
         <HistoryEventsAlerts
           v-model:show="showAlerts"
-          :loading="debouncedProcessing || groupLoading"
+          :loading="debouncedProcessing"
           :main-page="mainPage"
           @open:match-asset-movements="openMatchAssetMovementsDialog()"
         />

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2042,6 +2042,10 @@
       "view_action": "View"
     },
     "chips": {
+      "added_count": "{count} new duplicate(s) detected.",
+      "all_resolved": "All duplicates in this view have been resolved.",
+      "clear_filter": "Clear filter",
+      "resolved_count": "{count} duplicate(s) resolved.",
       "viewing_auto_fixable": "Showing auto-fixable duplicate events",
       "viewing_manual_review": "Showing duplicates requiring manual review"
     }


### PR DESCRIPTION
https://discord.com/channels/657906918408585217/683245846070165504/1465317394376298528

After fixing any event, you need to refresh first 
<img width="1238" height="620" alt="image" src="https://github.com/user-attachments/assets/5d715743-47ca-42af-b1b5-b4b882760a82" />

If you fix all events, until nothing remains
<img width="1222" height="593" alt="image" src="https://github.com/user-attachments/assets/d7c28369-5d02-4104-8fa2-17bedec19d29" />

