### PR TITLE
fix(frontend): adjust navigation menu bug

### DIFF
--- a/frontend/app/src/components/NavigationMenu.vue
+++ b/frontend/app/src/components/NavigationMenu.vue
@@ -310,7 +310,7 @@ function isRouteMatch(location: RouteLocationRaw) {
               :to="navItem.items[0]?.route"
               parent
             >
-              <div :class="{ 'bg-rui-grey-200 dark:bg-rui-grey-800': isMini }">
+              <div :class="{ 'bg-rui-grey-200 dark:bg-rui-grey-800 rounded-md': isMini }">
                 <RouterLink
                   v-for="(subNavItem, si) in navItem.items"
                   :key="si"

--- a/frontend/app/src/components/NavigationMenuItem.vue
+++ b/frontend/app/src/components/NavigationMenuItem.vue
@@ -66,6 +66,11 @@ function onBodyClick(): void {
     toggleExpand();
   }
 }
+
+onMounted(() => {
+  if (props.parent && props.active)
+    set(subMenuExpanded, true);
+});
 </script>
 
 <template>
@@ -77,7 +82,7 @@ function onBodyClick(): void {
         'font-medium bg-transparent !text-rui-primary': active && parent,
         'pl-12 pr-0 text-sm': subMenu && !mini,
         'px-0 justify-center': mini,
-        'pl-0': mini && subMenu,
+        'pl-3': mini && subMenu,
       }"
       @click="onBodyClick()"
     >


### PR DESCRIPTION
the issue caused by DOM removal when it's hidden.

When a parent is expanded, and then we close the menu and reopen, the parent is closed. We need to make the parent keep opened.