### PR TITLE
fix(history): prevent scroll reset when editing events

### DIFF
--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -85,9 +85,14 @@ const { containerProps, list: virtualList, wrapperProps, scrollTo } = useVirtual
   overscan: 15, // Render 15 extra items above/below viewport for smoother fast scrolling
 });
 
-// Scroll to top when pagination changes
-watch(pagination, () => {
-  scrollTo(0);
+// Scroll to top only when pagination values actually change
+watch(pagination, (current, previous) => {
+  if (!previous)
+    return;
+
+  if (current.page !== previous.page || current.limit !== previous.limit || current.total !== previous.total) {
+    scrollTo(0);
+  }
 });
 
 // Event operations (delete, redecode, etc.)


### PR DESCRIPTION
## Summary
- Fix virtual scroll table resetting to top when editing a single event in history
- The watcher now compares previous and current pagination values instead of triggering on any object change
- Scroll to top only happens when page, limit, or total actually change

## Test plan
- [ ] Navigate to history events
- [ ] Scroll down in the virtual table
- [ ] Edit an event
- [ ] Verify scroll position is preserved after saving