### PR TITLE
fix(history): only scroll to top on page change

### DIFF
--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -85,12 +85,12 @@ const { containerProps, list: virtualList, wrapperProps, scrollTo } = useVirtual
   overscan: 15, // Render 15 extra items above/below viewport for smoother fast scrolling
 });
 
-// Scroll to top only when pagination values actually change
+// Scroll to top only when page changes (limit change resets page to 1, which triggers this)
 watch(pagination, (current, previous) => {
   if (!previous)
     return;
 
-  if (current.page !== previous.page || current.limit !== previous.limit || current.total !== previous.total) {
+  if (current.page !== previous.page) {
     scrollTo(0);
   }
 });


### PR DESCRIPTION
## Summary
- Only scroll to top when the page actually changes
- Removes unnecessary scroll on total/limit changes (limit change already resets page to 1)
- Fixes disruptive scroll behavior when unlinking items or other data refreshes