### PR TITLE
refactor(history): improve action buttons UX

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsExport.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsExport.vue
@@ -117,16 +117,18 @@ const taskRunning = useIsTaskRunning(TaskType.EXPORT_HISTORY_EVENTS);
 </script>
 
 <template>
-  <RuiButton
-    color="primary"
-    variant="outlined"
-    class="!py-2"
-    :disabled="taskRunning"
-    @click="showConfirmation()"
-  >
-    <template #prepend>
-      <RuiIcon name="lu-file-down" />
+  <RuiTooltip :open-delay="400">
+    <template #activator>
+      <RuiButton
+        color="primary"
+        variant="outlined"
+        class="!p-2"
+        :disabled="taskRunning"
+        @click="showConfirmation()"
+      >
+        <RuiIcon name="lu-file-down" />
+      </RuiButton>
     </template>
     {{ t('common.actions.export_csv') }}
-  </RuiButton>
+  </RuiTooltip>
 </template>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5571,6 +5571,7 @@
       "fetching": "Checking transaction decoding status",
       "preparing": "Decoding transactions, please wait...",
       "progress": "Progress",
+      "redecode": "Redecode",
       "redecode_all": "Redecode All Transactions",
       "title": "Transaction decoding status",
       "transactions_processed": "{processed} / {total} transactions processed",

--- a/frontend/app/src/modules/history/redecode/HistoryRedecodeButton.vue
+++ b/frontend/app/src/modules/history/redecode/HistoryRedecodeButton.vue
@@ -25,21 +25,20 @@ const isDevelopment = checkIfDevelopment();
       class="!py-2"
       @click="emit('redecode', 'all')"
     >
-      {{ t('transactions.events_decoding.redecode_all') }}
+      <template #prepend>
+        <RuiIcon
+          name="lu-refresh-cw"
+          size="16"
+        />
+      </template>
+      {{ t('transactions.events_decoding.redecode') }}
     </RuiButton>
 
     <HistoryRedecodeSelection
       :loading="processing"
       :disabled="processing"
+      :show-redecode-page="isDevelopment && !isDemoMode"
       @redecode="emit('redecode', $event)"
     />
-
-    <RuiButton
-      v-if="isDevelopment && !isDemoMode"
-      class="!py-2"
-      @click="emit('redecode', 'page')"
-    >
-      {{ t('transactions.actions.redecode_page') }}
-    </RuiButton>
   </RuiButtonGroup>
 </template>

--- a/frontend/app/src/modules/history/redecode/HistoryRedecodeSelection.vue
+++ b/frontend/app/src/modules/history/redecode/HistoryRedecodeSelection.vue
@@ -1,25 +1,25 @@
 <script setup lang="ts">
 import type { EvmChainInfo } from '@/types/api/chains';
 import { getTextToken } from '@rotki/common';
-import { checkIfDevelopment } from '@shared/utils';
 import { useSupportedChains } from '@/composables/info/chains';
 import HistoryRedecodeChainItem from '@/modules/history/redecode/HistoryRedecodeChainItem.vue';
 
 withDefaults(defineProps<{
   loading: boolean;
   disabled?: boolean;
+  showRedecodePage?: boolean;
 }>(), {
   disabled: false,
+  showRedecodePage: false,
 });
 
-const emit = defineEmits<{ redecode: [payload: string[]] }>();
+const emit = defineEmits<{
+  redecode: [payload: string[] | 'page'];
+}>();
 
 const open = ref<boolean>(false);
 const search = ref<string>('');
 const selection = ref<string[]>([]);
-
-const isDemoMode = import.meta.env.VITE_DEMO_MODE !== undefined;
-const isDevelopment = checkIfDevelopment();
 
 const { t } = useI18n({ useScope: 'global' });
 const { txEvmChains } = useSupportedChains();
@@ -80,9 +80,6 @@ function redecode() {
       <RuiButton
         color="primary"
         class="px-3 py-3 rounded-l-none -ml-[1px] border-l border-rui-primary-darker disabled:border-rui-grey-200 disabled:dark:border-rui-grey-800"
-        :class="{
-          'rounded-r-none': isDevelopment && !isDemoMode,
-        }"
         :disabled="disabled"
         v-bind="attrs"
       >
@@ -152,6 +149,26 @@ function redecode() {
           {{ t('history_redecode_selection.redecode', { total: selection.length }) }}
         </RuiButton>
       </div>
+    </div>
+
+    <div
+      v-if="showRedecodePage"
+      class="px-4 py-2 border-t border-default"
+    >
+      <RuiButton
+        variant="text"
+        size="sm"
+        class="w-full !justify-start"
+        @click="emit('redecode', 'page'); reset()"
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-file-text"
+            size="16"
+          />
+        </template>
+        {{ t('transactions.actions.redecode_page') }}
+      </RuiButton>
     </div>
   </RuiMenu>
 </template>


### PR DESCRIPTION
- Add icon to redecode button and simplify text
- Move redecode page option into dropdown menu
- Convert export CSV to icon-only button with tooltip

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
