### PR TITLE
fix(history): prevent account text overflow in event rows

### DIFF
--- a/frontend/app/src/components/display/EnsAvatar.vue
+++ b/frontend/app/src/components/display/EnsAvatar.vue
@@ -30,6 +30,7 @@ const { getBlockie } = useBlockie();
 const style = computed(() => ({
   height: props.size,
   width: props.size,
+  minWidth: props.size,
 }));
 </script>
 

--- a/frontend/app/src/components/history/events/HistoryEventAccount.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAccount.vue
@@ -26,7 +26,7 @@ const isExchangeLocation = computed<boolean>(() => !matchChain(props.location));
       :text="locationLabel"
       :location="location"
       :no-scramble="isExchangeLocation"
-      class="truncate"
+      class="min-w-0"
     />
   </div>
 </template>

--- a/frontend/app/src/components/history/events/HistoryEventType.vue
+++ b/frontend/app/src/components/history/events/HistoryEventType.vue
@@ -38,12 +38,13 @@ const showLocationLabel = computed<boolean>(() => {
 </script>
 
 <template>
-  <div class="flex items-center text-left">
+  <div class="flex items-center text-left min-w-0">
     <HistoryEventTypeCounterparty
       v-if="('counterparty' in event && event.counterparty) || ('address' in event && event.address)"
       :counterparty="event.counterparty || undefined"
       :address="event.address || undefined"
       :location="event.location"
+      class="shrink-0"
     >
       <HistoryEventTypeCombination
         :highlight="highlight"
@@ -58,10 +59,11 @@ const showLocationLabel = computed<boolean>(() => {
       :icon="icon"
       :type="attrs"
       :show-info="isInformational"
+      class="shrink-0"
     />
 
-    <div class="ml-3.5">
-      <div class="font-medium uppercase text-sm">
+    <div class="ml-3.5 min-w-0">
+      <div class="font-medium uppercase text-sm truncate">
         {{ attrs.label }}
       </div>
       <HistoryEventAccount

--- a/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
@@ -2,6 +2,7 @@
 import { useCustomizedEventDuplicates } from '@/composables/history/events/use-customized-event-duplicates';
 import { DuplicateHandlingStatus } from '@/composables/history/events/use-history-events-filters';
 import { useUnmatchedAssetMovements } from '@/composables/history/events/use-unmatched-asset-movements';
+import { useRefWithDebounce } from '@/composables/ref';
 import { Routes } from '@/router/routes';
 import { useStatusStore } from '@/store/status';
 import { Section, Status } from '@/types/status';
@@ -9,7 +10,7 @@ import { Section, Status } from '@/types/status';
 const show = defineModel<boolean>('show', { required: true });
 
 const props = defineProps<{
-  loading: boolean;
+  processing: boolean;
   mainPage: boolean;
   manualIssueCheck: boolean;
 }>();
@@ -22,7 +23,7 @@ const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 const { getStatus } = useStatusStore();
 
-const { loading, mainPage, manualIssueCheck } = toRefs(props);
+const { mainPage, manualIssueCheck, processing } = toRefs(props);
 
 const {
   autoMatchLoading,
@@ -30,6 +31,8 @@ const {
   refreshUnmatchedAssetMovements,
   unmatchedCount,
 } = useUnmatchedAssetMovements();
+
+const loading = useRefWithDebounce(logicOr(processing, autoMatchLoading), 200);
 
 const {
   autoFixCount,

--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -14,7 +14,6 @@ import { HISTORY_EVENT_ACTIONS, type HistoryEventAction } from '@/composables/hi
 import { useHistoryEventsActions } from '@/composables/history/events/use-history-events-actions';
 import { useHistoryEventsFilters } from '@/composables/history/events/use-history-events-filters';
 import { useUnmatchedAssetMovements } from '@/composables/history/events/use-unmatched-asset-movements';
-import { useRefWithDebounce } from '@/composables/ref';
 import HistoryEventsVirtualTable from '@/modules/history/events/components/HistoryEventsVirtualTable.vue';
 import { useHistoryEventsDeletion } from '@/modules/history/events/composables/use-history-events-deletion';
 import { useHistoryEventsSelectionActions } from '@/modules/history/events/composables/use-history-events-selection-actions';
@@ -169,7 +168,6 @@ const {
 const debouncedProcessing = refDebounced(processing, 200);
 const { autoMatchLoading, refreshUnmatchedAssetMovements } = useUnmatchedAssetMovements();
 const backgroundLoading = logicOr(debouncedProcessing, autoMatchLoading);
-const debouncedBackgroundLoading = useRefWithDebounce(logicOr(processing, autoMatchLoading), 200);
 
 // Handle updating available event IDs from the table
 function handleUpdateEventIds({ eventIds, groupedEvents, rawEvents }: { eventIds: number[]; groupedEvents: Record<string, HistoryEventRow[]>; rawEvents?: HistoryEventRow[] }): void {
@@ -252,7 +250,7 @@ watchDebounced(route, async () => {
       <div>
         <HistoryEventsAlerts
           v-model:show="showAlerts"
-          :loading="debouncedBackgroundLoading"
+          :processing="processing"
           :main-page="mainPage"
           :manual-issue-check="manualIssueCheck"
           @open:match-asset-movements="openMatchAssetMovementsDialog()"

--- a/frontend/app/src/modules/common/links/HashLink.vue
+++ b/frontend/app/src/modules/common/links/HashLink.vue
@@ -195,17 +195,19 @@ const tags = useAccountTags(text);
 </script>
 
 <template>
-  <div class="flex flex-row shrink items-center gap-1.5 text-xs [&_*]:font-mono [&_*]:leading-6 min-h-[22px]">
+  <div class="flex flex-row shrink items-center gap-1.5 text-xs [&_*]:font-mono [&_*]:leading-6 min-h-[22px] min-w-0">
     <EnsAvatar
       v-if="showIcon"
       :address="displayText"
       avatar
       size="22px"
+      class="shrink-0 aspect-square"
     />
 
     <RuiTooltip
       v-if="!hideText"
       ref="tooltip"
+      class="min-w-0 overflow-hidden"
       :popper="{ placement: 'top', scroll: false, resize: false }"
       :open-delay="400"
       :disabled="truncateLength === 0"
@@ -213,9 +215,12 @@ const tags = useAccountTags(text);
       persist-on-tooltip-hover
     >
       <template #activator>
-        <div :class="{ blur: !shouldShowAmount }">
+        <span
+          class="block truncate"
+          :class="{ blur: !shouldShowAmount }"
+        >
           {{ finalDisplayText }}
-        </div>
+        </span>
       </template>
 
       <TagDisplay
@@ -255,7 +260,7 @@ const tags = useAccountTags(text);
 
     <div
       v-if="showLink || showCopy"
-      class="flex items-center gap-1"
+      class="flex items-center gap-1 shrink-0"
     >
       <CopyButton
         v-if="showCopy"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -189,7 +189,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
         <HistoryEventAccount
           :location="group.location"
           :location-label="group.locationLabel"
-          class="text-sm shrink-0"
+          class="text-sm min-w-0"
         />
       </template>
     </div>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
@@ -121,7 +121,7 @@ const limits = [10, 25, 50, 100];
 
       <!-- Items per page -->
       <div class="flex items-center gap-1 md:gap-2">
-        <span class="hidden lg:inline text-sm text-rui-text-secondary">{{ t('data_table.rows_per_page') }}</span>
+        <span class="hidden lg:inline text-xs text-rui-text-secondary whitespace-nowrap">{{ t('data_table.rows_per_page') }}</span>
         <RuiIcon
           class="lg:hidden text-rui-text-secondary"
           name="lu-rows-3"

--- a/frontend/app/tests/e2e/helpers/api.ts
+++ b/frontend/app/tests/e2e/helpers/api.ts
@@ -228,7 +228,7 @@ export async function apiAddEtherscanKey(
  * Waits for all running tasks to complete by checking the notification indicator.
  * Uses polling with expect().toPass() instead of hardcoded delays.
  */
-export async function waitForNoRunningTasks(page: Page, timeout: number = 120000): Promise<void> {
+export async function waitForNoRunningTasks(page: Page, timeout: number = 180000): Promise<void> {
   const { expect } = await import('@playwright/test');
   const indicator = page.locator('[data-cy=notification-indicator-progress]');
 


### PR DESCRIPTION
## Summary

- Add proper width constraints to HashLink component to enable text truncation
- Fix HistoryEventType to constrain content within fixed-width column
- Prevent EnsAvatar from being squished in flex containers
- Update HistoryEventsGroupItem to allow account shrinking instead of overflow

## Test plan

- [x] Verify account text (ENS names, addresses) truncates properly in event detail rows instead of overflowing into price column
- [x] Verify avatars display as round circles, not squished ovals