### PR TITLE
Use COUNT(DISTINCT) for grouped counts

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2442,19 +2442,16 @@ class DBHandler:
             **kwargs: Any,
     ) -> int:
         """Returns how many of a certain type of entry are saved in the DB"""
-        cursorstr = f'SELECT COUNT(*) from {entries_table}'
+        if group_by is not None:
+            cursorstr = f'SELECT COUNT(DISTINCT {group_by}) from {entries_table}'
+        else:
+            cursorstr = f'SELECT COUNT(*) from {entries_table}'
         if len(kwargs) != 0:
             cursorstr += ' WHERE'
             cursorstr += op.join([f' {arg} = "{val}" ' for arg, val in kwargs.items()])
-        if group_by is not None:
-            cursorstr += f' GROUP BY {group_by}'
-
         cursorstr += ';'
         cursor.execute(cursorstr)
 
-        if group_by is not None:
-            return len(cursor.fetchall())
-        # else
         return cursor.fetchone()[0]
 
     def delete_data_for_evm_address(

--- a/rotkehlchen/tests/api/test_addressbook.py
+++ b/rotkehlchen/tests/api/test_addressbook.py
@@ -618,10 +618,7 @@ def test_delete_addressbook(
                 rotkehlchen_api_server,
                 'addressbookresource',
                 book_type=book_type,
-            ),
-            json={
-                'addresses': [],
-            },
+            ), json={'addresses': []},
         )
         assert_error_response(
             response=response,

--- a/rotkehlchen/tests/api/test_ens.py
+++ b/rotkehlchen/tests/api/test_ens.py
@@ -147,10 +147,7 @@ def test_reverse_ens(rotkehlchen_api_server: 'APIServer') -> None:
         )
 
         response = requests.post(
-            api_url_for(
-                rotkehlchen_api_server,
-                'reverseensresource',
-            ),
+            api_url_for(rotkehlchen_api_server, 'reverseensresource'),
             json={'ethereum_addresses': []},
         )
         assert_error_response(


### PR DESCRIPTION
Switched grouped counts to use a single-row SQL aggregate instead of materializing every group in Python. Specifically, get_entries_count() now issues SELECT COUNT(DISTINCT group_identifier) FROM history_events when a group_by is requested, removing the GROUP BY + fetchall() path and reducing memory/CPU on large datasets while returning the same group count

