### PR TITLE
Reduce joins for history events query

### DIFF
--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -85,9 +85,11 @@ HISTORY_BASE_ENTRY_LENGTH: Final = 13
 GROUP_HAS_IGNORED_ASSETS_FIELD: Final = 'MAX(ignored) OVER (PARTITION BY group_identifier) AS group_has_ignored_assets'  # noqa: E501
 
 CHAIN_EVENT_FIELDS: Final = 'tx_ref, counterparty, address'
+CHAIN_EVENT_NULL_FIELDS: Final = 'NULL as tx_ref, NULL as counterparty, NULL as address'
 CHAIN_FIELD_LENGTH: Final = 3
 
 ETH_STAKING_EVENT_FIELDS: Final = 'validator_index, is_exit_or_blocknumber'
+ETH_STAKING_EVENT_NULL_FIELDS: Final = 'NULL as validator_index, NULL as is_exit_or_blocknumber'
 ETH_STAKING_FIELD_LENGTH: Final = 2
 
 EXTRAINTERNALTXPREFIX: Final = 'extrainternaltx'

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -17,8 +17,10 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.db.cache import ASSET_MOVEMENT_NO_MATCH_CACHE_VALUE, DBCacheDynamic, DBCacheStatic
 from rotkehlchen.db.constants import (
     CHAIN_EVENT_FIELDS,
+    CHAIN_EVENT_NULL_FIELDS,
     CHAIN_FIELD_LENGTH,
     ETH_STAKING_EVENT_FIELDS,
+    ETH_STAKING_EVENT_NULL_FIELDS,
     ETH_STAKING_FIELD_LENGTH,
     GROUP_HAS_IGNORED_ASSETS_FIELD,
     HISTORY_BASE_ENTRY_FIELDS,
@@ -30,6 +32,7 @@ from rotkehlchen.db.constants import (
 from rotkehlchen.db.filtering import (
     ALL_EVENTS_DATA_JOIN,
     EVENTS_WITH_COUNTERPARTY_JOIN,
+    DBMultiIntegerFilter,
     EthDepositEventFilterQuery,
     EthWithdrawalFilterQuery,
     EvmEventFilterQuery,
@@ -44,6 +47,7 @@ from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.constants import CHAIN_ENTRY_TYPES, STAKING_ENTRY_TYPES
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.base import (
     HistoryBaseEntry,
@@ -683,10 +687,13 @@ class DBHistoryEvents:
             include_order: bool = True,
     ) -> tuple[str, list]:
         """Returns the sql queries and bindings for the history events without pagination."""
+        chain_fields, staking_fields, join_clause = DBHistoryEvents._build_events_query_parts(
+            filter_query=filter_query,
+        )
         # group_has_ignored_assets is added at the END so existing slicing logic is not affected.
         # It's computed via a window function to detect groups with ignored assets even when
         # those rows are filtered out by exclude_ignored_assets.
-        base_suffix = f'{HISTORY_BASE_ENTRY_FIELDS}, {CHAIN_EVENT_FIELDS}, {ETH_STAKING_EVENT_FIELDS}, {GROUP_HAS_IGNORED_ASSETS_FIELD} {ALL_EVENTS_DATA_JOIN}'  # noqa: E501
+        base_suffix = f'{HISTORY_BASE_ENTRY_FIELDS}, {chain_fields}, {staking_fields}, {GROUP_HAS_IGNORED_ASSETS_FIELD} {join_clause}'  # noqa: E501
         if aggregate_by_group_ids:
             filters, query_bindings = filter_query.prepare(
                 with_group_by=True,
@@ -726,6 +733,54 @@ class DBHistoryEvents:
             )
 
         return f'{prefix} FROM (SELECT {suffix}) {filters}', limit + query_bindings
+
+    @staticmethod
+    def _build_events_query_parts(
+            filter_query: HistoryBaseEntryFilterQuery,
+    ) -> tuple[str, str, str]:
+        entry_type_filter_values: Sequence[int] | None = None
+        for filter_ in filter_query.filters:
+            if (
+                isinstance(filter_, DBMultiIntegerFilter) and
+                filter_.column == 'entry_type' and
+                filter_.operator == 'IN'
+            ):
+                entry_type_filter_values = filter_.values
+                break
+
+        include_chain = include_staking = False
+        if entry_type_filter_values is None:
+            include_chain = include_staking = True
+        else:
+            entry_types = {HistoryBaseEntryType(value) for value in entry_type_filter_values}
+            include_chain = len(entry_types & CHAIN_ENTRY_TYPES) > 0
+            include_staking = len(entry_types & STAKING_ENTRY_TYPES) > 0
+
+        if include_chain:
+            chain_fields = CHAIN_EVENT_FIELDS
+            chain_join = (
+                'LEFT JOIN chain_events_info ON '
+                'history_events.identifier=chain_events_info.identifier '
+            )
+        else:
+            chain_fields = CHAIN_EVENT_NULL_FIELDS
+            chain_join = ''
+
+        if include_staking:
+            staking_fields = ETH_STAKING_EVENT_FIELDS
+            staking_join = (
+                'LEFT JOIN eth_staking_events_info ON '
+                'history_events.identifier=eth_staking_events_info.identifier '
+            )
+        else:
+            staking_fields = ETH_STAKING_EVENT_NULL_FIELDS
+            staking_join = ''
+
+        return (
+            chain_fields,
+            staking_fields,
+            f'FROM history_events {chain_join}{staking_join}',
+        )
 
     @staticmethod
     def _create_history_events_count_query(

--- a/rotkehlchen/history/events/constants.py
+++ b/rotkehlchen/history/events/constants.py
@@ -1,0 +1,16 @@
+from typing import Final
+
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
+
+STAKING_ENTRY_TYPES: Final = {  # types that need the extra staking columns
+    HistoryBaseEntryType.ETH_DEPOSIT_EVENT,
+    HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT,
+    HistoryBaseEntryType.ETH_BLOCK_EVENT,
+}
+CHAIN_ENTRY_TYPES: Final = {  # types that need the chain event columns
+    HistoryBaseEntryType.EVM_EVENT,
+    HistoryBaseEntryType.EVM_SWAP_EVENT,
+    HistoryBaseEntryType.SOLANA_EVENT,
+    HistoryBaseEntryType.SOLANA_SWAP_EVENT,
+    HistoryBaseEntryType.ETH_DEPOSIT_EVENT,
+}

--- a/rotkehlchen/tests/unit/events/test_entry_types.py
+++ b/rotkehlchen/tests/unit/events/test_entry_types.py
@@ -1,0 +1,13 @@
+from rotkehlchen.history.events.constants import CHAIN_ENTRY_TYPES, STAKING_ENTRY_TYPES
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
+
+
+def test_entry_types_covered():
+    """Test that all entry types are covered by the constants"""
+    all_entry_types = set(HistoryBaseEntryType)
+    generic_types = {  # types that don't need any extra DB fields
+        HistoryBaseEntryType.HISTORY_EVENT,
+        HistoryBaseEntryType.ASSET_MOVEMENT_EVENT,
+        HistoryBaseEntryType.SWAP_EVENT,
+    }
+    assert all_entry_types == (generic_types | STAKING_ENTRY_TYPES | CHAIN_ENTRY_TYPES)


### PR DESCRIPTION
This change makes the history events query choose joins and fields based on the requested entry_type filter. When only base events are requested it now skips the chain/staking joins, and for non-needed fields it selects NULL placeholders so the deserialization offsets stay stable. For mixed or unspecified entry types it still includes both joins, so behavior remains unchanged while reducing unnecessary join work for common filters.

