### PR TITLE
fix(frontend): hide action button text on smaller screens

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsIssueCheckButton.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsIssueCheckButton.vue
@@ -160,7 +160,7 @@ watch(showWarningButton, (value) => {
             size="18"
           />
         </template>
-        {{ t('transactions.alerts.button') }}
+        <span class="hidden md:inline">{{ t('transactions.alerts.button') }}</span>
         <template #append>
           <RuiIcon
             name="lu-chevron-down"
@@ -188,7 +188,7 @@ watch(showWarningButton, (value) => {
           size="18"
         />
       </template>
-      {{ noIssuesFound ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_issues') }}
+      <span class="hidden md:inline">{{ noIssuesFound ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_issues') }}</span>
     </RuiButton>
 
     <RuiMenu

--- a/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
@@ -36,6 +36,7 @@ const { t } = useI18n({ useScope: 'global' });
 
   <RuiButton
     color="primary"
+    class="h-9"
     data-cy="history-events__add"
     @click="emit('show:dialog', { type: DIALOG_TYPES.EVENT_FORM, data: { type: 'add', nextSequenceId: '0' } })"
   >
@@ -45,7 +46,7 @@ const { t } = useI18n({ useScope: 'global' });
         size="18"
       />
     </template>
-    {{ t('transactions.actions.add_event') }}
+    <span class="hidden lg:inline">{{ t('transactions.actions.add_event') }}</span>
   </RuiButton>
 
   <RuiMenu

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshButton.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshButton.vue
@@ -45,7 +45,7 @@ function confirmRefresh() {
               size="18"
             />
           </template>
-          {{ t('common.refresh') }}
+          <span class="hidden lg:inline">{{ t('common.refresh') }}</span>
         </RuiButton>
       </template>
 


### PR DESCRIPTION
## Summary
- Hide button text for issue check, refresh, and add event buttons on smaller viewports
- Icons remain visible to preserve functionality
- Uses Tailwind responsive classes (`hidden md:inline`, `hidden lg:inline`)

## Test plan
- [ ] Resize browser to verify button text hides on smaller screens
- [ ] Verify icons remain visible and buttons are functional
- [ ] Test on history events page with various screen sizes