### PR TITLE
fix(workflows): skip noisy SmolDapp error logs in e2e tests

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -260,6 +260,7 @@ jobs:
             while IFS=: read -r linenum content; do
               # Skip known noisy errors
               [[ "$content" == *"Failed to add the location asset mapping of"* ]] && continue
+              [[ "$content" == *"Got non success response status when querying SmolDapp"* ]] && continue
               short_content=$(sanitize "${content:0:250}")
               echo "::error file=$filename,line=$linenum::$short_content"
             done < <(grep -n -E " ERROR " "$logfile" 2>/dev/null | head -n 20 || true)


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
