### PR TITLE
fix(frontend): reset clears persisted backend options

### DIFF
--- a/frontend/app/src/composables/backend.ts
+++ b/frontend/app/src/composables/backend.ts
@@ -32,6 +32,10 @@ export function saveUserOptions(config: Partial<BackendOptions>): void {
   localStorage.setItem(BACKEND_OPTIONS, options);
 }
 
+export function clearUserOptions(): void {
+  localStorage.removeItem(BACKEND_OPTIONS);
+}
+
 interface UseBackendManagementReturn {
   applyUserOptions: (config: Partial<BackendOptions>, skipRestart: boolean) => Promise<void>;
   logLevel: Ref<LogLevel>;
@@ -100,7 +104,9 @@ export function useBackendManagement(loaded: () => void = () => {}): UseBackendM
   };
 
   const resetOptions = async (): Promise<void> => {
-    await applyUserOptions({});
+    clearUserOptions();
+    set(userOptions, {});
+    await restartBackendWithOptions(get(options));
   };
 
   const restartBackend = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- `resetOptions()` called `saveUserOptions({})` which merged `{}` with existing localStorage, preserving stale values like `dataDirectory`. This caused the frontend to show `data` instead of `develop_data` from `/api/info` after reset.
- Added `clearUserOptions()` that removes the localStorage entry entirely and use it in `resetOptions()`.
- Co-located and consolidated backend composable tests from `tests/unit/specs/` into `src/composables/`.

## Test plan
- [x] Existing backend composable tests updated and passing (20 tests)
- [x] Full frontend test suite passes (2417 tests, 0 failures)
- [x] Manual: Open backend settings, set a custom data directory, click Reset, verify the data directory shows the value from `/api/info`