### PR TITLE
fix(frontend): align progress bars in sync panel

### DIFF
--- a/frontend/app/src/modules/sync-progress/components/ChainProgressItem.vue
+++ b/frontend/app/src/modules/sync-progress/components/ChainProgressItem.vue
@@ -110,7 +110,7 @@ function showMore(): void {
       </div>
 
       <span
-        class="tabular-nums"
+        class="tabular-nums text-right min-w-[3rem]"
         :class="[
           compact ? 'text-xs' : 'text-sm',
           isComplete ? 'text-rui-text-disabled' : 'text-rui-text-secondary',


### PR DESCRIPTION
The chain progress counters (e.g. 1/9, 10/12) have varying text widths which caused the progress bars to shift horizontally.

Add min-width and right-align to the counter span so progress bars stay vertically aligned across all chain items.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
