### PR TITLE
Adapt tokens_balance chunking on RPC gas limits

### DIFF
--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -15,7 +15,7 @@ from rotkehlchen.chain.evm.types import WeightedNode, asset_id_is_evm_token
 from rotkehlchen.chain.structures import EvmTokenDetectionData
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.resolver import tokenid_to_collectible_id
-from rotkehlchen.errors.misc import NotFoundError, RemoteError
+from rotkehlchen.errors.misc import NotFoundError, RemoteError, RequestTooLargeError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -186,6 +186,9 @@ class EvmTokens(ABC):  # noqa: B024
                 arguments=[address, [x.address for x in tokens]],
                 call_order=call_order,
             )
+        except RequestTooLargeError:
+            # Let callers reduce chunk size and retry.
+            raise
         except RemoteError as e:
             log.error(
                 f'{self.evm_inquirer.chain_name} tokensBalance call failed for address {address}.'
@@ -272,13 +275,35 @@ class EvmTokens(ABC):  # noqa: B024
         Uses Asset objects directly instead of EvmToken to minimize database queries.
         """
         total_token_balances: dict[Asset, FVal] = defaultdict(FVal)
-        chunks = get_chunks(tokens, n=chunk_size)
-        for chunk in chunks:
-            new_token_balances = self.get_token_balances(
-                address=address,
-                tokens=chunk,
-                call_order=call_order,
-            )
+        chunks_to_process = list(get_chunks(tokens, n=chunk_size))
+        while len(chunks_to_process) > 0:
+            chunk = chunks_to_process.pop(0)
+            try:
+                new_token_balances = self.get_token_balances(
+                    address=address,
+                    tokens=chunk,
+                    call_order=call_order,
+                )
+            except RequestTooLargeError:
+                if len(chunk) == 1:
+                    log.error(
+                        f'{self.evm_inquirer.chain_name} tokensBalance call failed '
+                        f'for address {address}. Could not query a single token '
+                        f'{chunk[0].address} due to request size limits.',
+                    )
+                    continue
+
+                smaller_chunk_size = max(1, len(chunk) // 2)
+                log.warning(
+                    f'{self.evm_inquirer.chain_name} tokensBalance chunk too large '
+                    f'for address {address}. Retrying by splitting {len(chunk)} '
+                    f'tokens into chunks of {smaller_chunk_size}.',
+                )
+                chunks_to_process = (
+                    list(get_chunks(chunk, n=smaller_chunk_size)) + chunks_to_process
+                )
+                continue
+
             total_token_balances = combine_dicts(total_token_balances, new_token_balances)
         return total_token_balances
 


### PR DESCRIPTION
 This PR improves ERC20 token detection resilience when tokens_balance(owner, token[]) hits RPC eth_call gas caps (for example out of gas: gas required exceeds: 1000000).

  Changes:

  1. Propagate RequestTooLargeError from EvmTokens.get_token_balances() instead of swallowing it as a generic remote failure.
  2. Add adaptive retry logic in EvmTokens._query_chunks():

  - On RequestTooLargeError, split the failing chunk into smaller chunks and retry.
  - Continue splitting until success or single-token granularity.
  - If a single-token call still fails due to size limits, log and skip that token.

  3. Add unit tests covering:

  - propagation of RequestTooLargeError
  - adaptive chunk splitting and retry behavior

  This keeps the fast default chunk size for normal nodes while automatically degrading on stricter public RPCs, reducing full-call failures during token detection.

  Tracking reference:

  - Internal issue note: https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=154773047