### PR TITLE
feat(frontend): debounce and cancel history events fetching

### DIFF
--- a/frontend/app/src/composables/api/history/events/index.ts
+++ b/frontend/app/src/composables/api/history/events/index.ts
@@ -56,7 +56,7 @@ interface UseHistoryEventsApiReturn {
   repullingExchangeEvents: (payload: RepullingExchangeEventsPayload) => Promise<PendingTask>;
   getTransactionTypeMappings: () => Promise<HistoryEventTypeData>;
   getHistoryEventCounterpartiesData: () => Promise<ActionDataEntry[]>;
-  fetchHistoryEvents: (payload: HistoryEventRequestPayload) => Promise<CollectionResponse<HistoryEventCollectionRow>>;
+  fetchHistoryEvents: (payload: HistoryEventRequestPayload, options?: { tags?: string[] }) => Promise<CollectionResponse<HistoryEventCollectionRow>>;
   queryOnlineHistoryEvents: (payload: OnlineHistoryEventsRequestPayload) => Promise<PendingTask>;
   queryExchangeEvents: (payload: QueryExchangeEventsPayload) => Promise<PendingTask>;
   exportHistoryEventsCSV: (filters: HistoryEventExportPayload, directoryPath?: string) => Promise<PendingTask>;
@@ -210,6 +210,7 @@ export function useHistoryEventsApi(): UseHistoryEventsApiReturn {
 
   const fetchHistoryEvents = async (
     payload: HistoryEventRequestPayload,
+    options?: { tags?: string[] },
   ): Promise<CollectionResponse<HistoryEventCollectionRow>> => {
     const response = await api.post<CollectionResponse<HistoryEventCollectionRow>>(
       '/history/events',
@@ -217,6 +218,7 @@ export function useHistoryEventsApi(): UseHistoryEventsApiReturn {
       {
         dedupe: true,
         maxQueueTime: 120_000,
+        tags: options?.tags,
         timeout: 90_000,
       },
     );

--- a/frontend/app/src/composables/use-pagination-filter/index.spec.ts
+++ b/frontend/app/src/composables/use-pagination-filter/index.spec.ts
@@ -10,7 +10,8 @@ import { usePaginationFilters } from '@/composables/use-pagination-filter';
 import { TableId } from '@/modules/table/use-remember-table-sorting';
 import { arrayify } from '@/utils/array';
 
-const { restorePersistedFilterSpy, savePersistedFilterSpy, useRouteMock, useRouterMock } = vi.hoisted(() => ({
+const { cancelByTagSpy, restorePersistedFilterSpy, savePersistedFilterSpy, useRouteMock, useRouterMock } = vi.hoisted(() => ({
+  cancelByTagSpy: vi.fn<(tag: string) => void>(),
   restorePersistedFilterSpy: vi.fn<() => Promise<void>>(),
   savePersistedFilterSpy: vi.fn<(query: Record<string, unknown>) => void>(),
   useRouteMock: vi.fn(),
@@ -22,6 +23,18 @@ vi.mock('@/modules/table/use-remember-table-filter', () => ({
     savePersistedFilter: savePersistedFilterSpy,
     restorePersistedFilter: restorePersistedFilterSpy,
   }),
+}));
+
+vi.mock('@/modules/api', () => ({
+  RequestCancelledError: class RequestCancelledError extends Error {
+    constructor(message: string = 'Request was cancelled') {
+      super(message);
+      this.name = 'RequestCancelledError';
+    }
+  },
+  api: {
+    cancelByTag: (tag: string): void => cancelByTagSpy(tag),
+  },
 }));
 
 vi.mock('vue-router', () => ({
@@ -41,6 +54,10 @@ interface TestItem {
 }
 
 type TestPayload = PaginationRequestPayload<TestItem>;
+
+interface TestPayloadWithLabels extends PaginationRequestPayload<TestItem> {
+  locationLabels?: string[];
+}
 
 interface TestFilters extends MatchedKeywordWithBehaviour<string> {
   asset?: string;
@@ -720,6 +737,305 @@ describe('composables::use-pagination-filter', () => {
         expect(savedQuery).toHaveProperty('asset');
         expect(savedQuery).not.toHaveProperty('txRefs');
       });
+    });
+  });
+
+  describe('fetchDebounce', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should debounce fetchData when fetchDebounce is set', async () => {
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const { filters } = scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        fetchDebounce: 200,
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }))!;
+
+      await nextTick();
+      await flushPromises();
+      requestFn.mockClear();
+
+      // Rapid filter changes within the debounce window
+      set(filters, { asset: 'ETH' });
+      await nextTick();
+      set(filters, { asset: 'BTC' });
+      await nextTick();
+      set(filters, { asset: 'USDT' });
+      await nextTick();
+
+      // Before debounce fires, no fetch should have been made
+      expect(requestFn).not.toHaveBeenCalled();
+
+      // Advance past the debounce window
+      await vi.advanceTimersByTimeAsync(250);
+      await flushPromises();
+
+      // Only one fetch should have been made (the final value)
+      expect(requestFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch immediately when fetchDebounce is 0 (default)', async () => {
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const { filters } = scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }))!;
+
+      await nextTick();
+      await flushPromises();
+      requestFn.mockClear();
+
+      set(filters, { asset: 'ETH' });
+      await nextTick();
+      await flushPromises();
+
+      // Should fetch immediately without waiting for debounce
+      expect(requestFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cancelTag', () => {
+    it('should call api.cancelByTag before each fetchData when cancelTag is set', async () => {
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const { filters } = scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        cancelTag: 'test-cancel-tag',
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }))!;
+
+      await nextTick();
+      await flushPromises();
+      cancelByTagSpy.mockClear();
+
+      set(filters, { asset: 'ETH' });
+      await nextTick();
+      await flushPromises();
+
+      expect(cancelByTagSpy).toHaveBeenCalledWith('test-cancel-tag');
+    });
+
+    it('should not call api.cancelByTag when cancelTag is not set', async () => {
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const { filters } = scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }))!;
+
+      await nextTick();
+      await flushPromises();
+      cancelByTagSpy.mockClear();
+
+      set(filters, { asset: 'ETH' });
+      await nextTick();
+      await flushPromises();
+
+      expect(cancelByTagSpy).not.toHaveBeenCalled();
+    });
+
+    it('should silently ignore RequestCancelledError in onError', async () => {
+      const { RequestCancelledError: MockRequestCancelledError } = await import('@/modules/api');
+      const requestFn = vi.fn().mockRejectedValue(new MockRequestCancelledError());
+
+      scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        cancelTag: 'test-cancel-tag',
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }));
+
+      await nextTick();
+      await flushPromises();
+
+      // Should not throw and state should remain at default (empty collection)
+      // The test passes if no unhandled error is thrown
+    });
+
+    it('should still fetch when queryParamsOnly and requestParams change from the same source', async () => {
+      vi.useFakeTimers();
+
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const locationLabels = ref<string[]>([]);
+
+      scope.run(() => usePaginationFilters<TestItem, TestPayloadWithLabels, TestFilters, TestMatcher>(requestFn, {
+        fetchDebounce: 200,
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+        requestParams: computed<Partial<{ locationLabels: string[] }>>(() => {
+          const labels = get(locationLabels);
+          return labels.length > 0 ? { locationLabels: labels } : {};
+        }),
+        queryParamsOnly: computed(() => ({
+          locationLabels: get(locationLabels),
+        })),
+      }));
+
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(250);
+      await flushPromises();
+      requestFn.mockClear();
+
+      // Simulate account filter change — this triggers both requestParams
+      // (which feeds into pageParams) and queryParamsOnly (which pushes the URL).
+      // Without the selfPush guard, the route push would trigger applyRouteFilter
+      // which re-sets filters/pagination, causing pageParams to recompute and
+      // overwrite watchDebounced's old value — making it skip the fetch.
+      set(locationLabels, ['0x1aEa862845522cFF463D11B9371EedEa73e458bE']);
+      await nextTick();
+      await flushPromises();
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flushPromises();
+
+      expect(requestFn).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('should fetch when clearing locationLabels after having values', async () => {
+      vi.useFakeTimers();
+
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const locationLabels = ref<string[]>(['0x1aEa862845522cFF463D11B9371EedEa73e458bE']);
+
+      scope.run(() => usePaginationFilters<TestItem, TestPayloadWithLabels, TestFilters, TestMatcher>(requestFn, {
+        fetchDebounce: 200,
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+        requestParams: computed<Partial<{ locationLabels: string[] }>>(() => {
+          const labels = get(locationLabels);
+          return labels.length > 0 ? { locationLabels: labels } : {};
+        }),
+        queryParamsOnly: computed(() => ({
+          locationLabels: get(locationLabels),
+        })),
+      }));
+
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(250);
+      await flushPromises();
+      requestFn.mockClear();
+
+      // Clear the account filter
+      set(locationLabels, []);
+      await nextTick();
+      await flushPromises();
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flushPromises();
+
+      expect(requestFn).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('should apply route filter on external navigation (browser back/forward)', async () => {
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const { filters } = scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }))!;
+
+      await nextTick();
+      await flushPromises();
+
+      // Simulate external navigation (browser back/forward) by directly changing the route
+      // This should apply filters from the route, unlike self-pushes which skip applyRouteFilter
+      set(mockRoute, { query: { asset: 'ETH', limit: '10' } });
+      await nextTick();
+      await flushPromises();
+
+      expect(get(filters)).toEqual(expect.objectContaining({ asset: 'ETH' }));
+    });
+
+    it('should cancel before fetching when combined with fetchDebounce', async () => {
+      vi.useFakeTimers();
+
+      const requestFn = vi.fn().mockResolvedValue({
+        data: [],
+        found: 0,
+        limit: -1,
+        total: 0,
+      });
+
+      const { filters } = scope.run(() => usePaginationFilters<TestItem, TestPayload, TestFilters, TestMatcher>(requestFn, {
+        cancelTag: 'debounced-cancel-tag',
+        fetchDebounce: 200,
+        history: 'router',
+        filterSchema: () => createTestFilterSchema(),
+      }))!;
+
+      await nextTick();
+      await flushPromises();
+      cancelByTagSpy.mockClear();
+      requestFn.mockClear();
+
+      set(filters, { asset: 'ETH' });
+      await nextTick();
+
+      // Before debounce, cancel should not have been called yet
+      expect(cancelByTagSpy).not.toHaveBeenCalled();
+
+      // Advance past debounce
+      await vi.advanceTimersByTimeAsync(250);
+      await flushPromises();
+
+      // Cancel should be called before the fetch
+      expect(cancelByTagSpy).toHaveBeenCalledWith('debounced-cancel-tag');
+      expect(requestFn).toHaveBeenCalledTimes(1);
+
+      // Verify cancel was called before fetch (cancel call index < request call index)
+      const cancelOrder = cancelByTagSpy.mock.invocationCallOrder[0];
+      const fetchOrder = requestFn.mock.invocationCallOrder[0];
+      expect(cancelOrder).toBeLessThan(fetchOrder);
+
+      vi.useRealTimers();
     });
   });
 });

--- a/frontend/app/src/modules/history/events/composables/use-history-events-data.spec.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-events-data.spec.ts
@@ -3,6 +3,7 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { Collection } from '@/types/collection';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestCancelledError } from '@/modules/api/request-queue/errors';
 import { HistoryEventAccountingRuleStatus, type HistoryEventEntry, type HistoryEventRow } from '@/types/history/events/schemas';
 
 const mockItemsPerPage = ref<number>(10);
@@ -10,11 +11,18 @@ const mockItemsPerPage = ref<number>(10);
 // Mock external dependencies
 const mockFetchHistoryEvents = vi.fn();
 const mockIsAssetIgnored = vi.fn();
+const mockCancelByTag = vi.fn();
 
 vi.mock('@/composables/history/events', () => ({
   useHistoryEvents: vi.fn(() => ({
     fetchHistoryEvents: mockFetchHistoryEvents,
   })),
+}));
+
+vi.mock('@/modules/api/rotki-api', () => ({
+  api: {
+    cancelByTag: (...args: any[]): void => mockCancelByTag(...args),
+  },
 }));
 
 vi.mock('@/composables/ref', () => ({
@@ -254,9 +262,8 @@ describe('use-history-events-data', () => {
   });
 
   describe('async event fetching and mapping', () => {
-    async function waitForAsyncComputed(result: { events: any }): Promise<void> {
-      // Trigger lazy asyncComputed by accessing the value
-      get(result.events);
+    async function waitForFetchEvents(): Promise<void> {
+      // Wait for the watchImmediate callback and its async fetchEvents() to resolve
       await nextTick();
       await vi.runAllTimersAsync();
       await nextTick();
@@ -289,15 +296,18 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      useHistoryEventsData(options, emit);
 
-      await waitForAsyncComputed(result);
+      await waitForFetchEvents();
 
       expect(mockFetchHistoryEvents).toHaveBeenCalledWith(
         expect.objectContaining({
           groupIdentifiers: ['group1', 'group2'],
           limit: -1,
           offset: 0,
+        }),
+        expect.objectContaining({
+          tags: ['history-events-detail'],
         }),
       );
     });
@@ -322,7 +332,7 @@ describe('use-history-events-data', () => {
       const emit = vi.fn();
       const result = useHistoryEventsData(options, emit);
 
-      await waitForAsyncComputed(result);
+      await waitForFetchEvents();
 
       const mapped = get(result.allEventsMapped);
       expect(mapped.group1).toHaveLength(2);
@@ -348,7 +358,7 @@ describe('use-history-events-data', () => {
       const emit = vi.fn();
       const result = useHistoryEventsData(options, emit);
 
-      await waitForAsyncComputed(result);
+      await waitForFetchEvents();
 
       const mapped = get(result.allEventsMapped);
       expect(mapped.group1).toHaveLength(1);
@@ -373,7 +383,7 @@ describe('use-history-events-data', () => {
       const emit = vi.fn();
       const result = useHistoryEventsData(options, emit);
 
-      await waitForAsyncComputed(result);
+      await waitForFetchEvents();
 
       expect(get(result.displayedEventsMapped)).toEqual(get(result.allEventsMapped));
     });
@@ -398,7 +408,7 @@ describe('use-history-events-data', () => {
       const emit = vi.fn();
       const result = useHistoryEventsData(options, emit);
 
-      await waitForAsyncComputed(result);
+      await waitForFetchEvents();
 
       const displayed = get(result.displayedEventsMapped);
       expect(displayed.group1).toHaveLength(1);
@@ -424,10 +434,306 @@ describe('use-history-events-data', () => {
       const emit = vi.fn();
       const result = useHistoryEventsData(options, emit);
 
-      await waitForAsyncComputed(result);
+      await waitForFetchEvents();
 
       const displayed = get(result.displayedEventsMapped);
       expect(displayed.group1).toBeUndefined();
+    });
+  });
+
+  describe('cancellation and stale response protection', () => {
+    async function waitForFetchEvents(): Promise<void> {
+      await nextTick();
+      await vi.runAllTimersAsync();
+      await nextTick();
+      await vi.runAllTimersAsync();
+      await nextTick();
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should call api.cancelByTag before each fetch', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+      mockFetchHistoryEvents.mockResolvedValue({ data: [event1] });
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      useHistoryEventsData(options, emit);
+
+      await waitForFetchEvents();
+
+      expect(mockCancelByTag).toHaveBeenCalledWith('history-events-detail');
+    });
+
+    it('should discard stale response when a newer fetch has started', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+      const event2 = createMockEvent({ groupIdentifier: 'group2', identifier: 2 });
+
+      // First call: slow, resolves after second call completes
+      let resolveFirst: ((value: { data: HistoryEventRow[] }) => void) | undefined;
+      const firstPromise = new Promise<{ data: HistoryEventRow[] }>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      mockFetchHistoryEvents
+        .mockReturnValueOnce(firstPromise)
+        .mockResolvedValueOnce({ data: [event2] });
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = useHistoryEventsData(options, emit);
+
+      // Let the first (immediate) fetch start
+      await nextTick();
+
+      // Trigger a second fetch by changing groups
+      set(groups, createMockCollection([event2]));
+      await nextTick();
+      await vi.runAllTimersAsync();
+      await nextTick();
+
+      // Now resolve the first (stale) promise
+      resolveFirst!({ data: [event1] });
+      await vi.runAllTimersAsync();
+      await nextTick();
+
+      // The events should contain data from the second (newer) fetch, not the stale first
+      const rawEvents = get(result.rawEvents);
+      expect(rawEvents).toHaveLength(1);
+      expect(rawEvents[0]).toEqual(event2);
+    });
+
+    it('should handle RequestCancelledError silently without clearing events', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+
+      // First call succeeds
+      mockFetchHistoryEvents.mockResolvedValueOnce({ data: [event1] });
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = useHistoryEventsData(options, emit);
+
+      await waitForFetchEvents();
+      expect(get(result.rawEvents)).toHaveLength(1);
+
+      // Second call throws RequestCancelledError
+      mockFetchHistoryEvents.mockRejectedValueOnce(new RequestCancelledError());
+
+      // Trigger a new fetch by changing groups
+      const event2 = createMockEvent({ groupIdentifier: 'group2', identifier: 2 });
+      set(groups, createMockCollection([event2]));
+      await waitForFetchEvents();
+
+      // Previous data should be preserved (not cleared)
+      expect(get(result.rawEvents)).toHaveLength(1);
+      expect(get(result.rawEvents)[0]).toEqual(event1);
+    });
+
+    it('should set eventsLoading during fetch and reset after', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+
+      let resolvePromise: ((value: { data: HistoryEventRow[] }) => void) | undefined;
+      mockFetchHistoryEvents.mockReturnValue(new Promise<{ data: HistoryEventRow[] }>((resolve) => {
+        resolvePromise = resolve;
+      }));
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = useHistoryEventsData(options, emit);
+
+      // After immediate watch fires, eventsLoading should be true
+      await nextTick();
+      expect(get(result.eventsLoading)).toBe(true);
+
+      // Resolve the fetch
+      resolvePromise!({ data: [event1] });
+      await vi.runAllTimersAsync();
+      await nextTick();
+
+      expect(get(result.eventsLoading)).toBe(false);
+    });
+
+    it('should not reset eventsLoading when a stale fetch completes', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+      const event2 = createMockEvent({ groupIdentifier: 'group2', identifier: 2 });
+
+      let resolveFirst: ((value: { data: HistoryEventRow[] }) => void) | undefined;
+      const firstPromise = new Promise<{ data: HistoryEventRow[] }>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      let resolveSecond: ((value: { data: HistoryEventRow[] }) => void) | undefined;
+      const secondPromise = new Promise<{ data: HistoryEventRow[] }>((resolve) => {
+        resolveSecond = resolve;
+      });
+
+      mockFetchHistoryEvents
+        .mockReturnValueOnce(firstPromise)
+        .mockReturnValueOnce(secondPromise);
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = useHistoryEventsData(options, emit);
+
+      // Let first fetch start
+      await nextTick();
+      expect(get(result.eventsLoading)).toBe(true);
+
+      // Trigger second fetch
+      set(groups, createMockCollection([event2]));
+      await nextTick();
+      await vi.runAllTimersAsync();
+      await nextTick();
+
+      // Resolve the stale first promise
+      resolveFirst!({ data: [event1] });
+      await vi.runAllTimersAsync();
+      await nextTick();
+
+      // eventsLoading should still be true because the second (current) fetch is pending
+      expect(get(result.eventsLoading)).toBe(true);
+
+      // Resolve the second (current) promise
+      resolveSecond!({ data: [event2] });
+      await vi.runAllTimersAsync();
+      await nextTick();
+
+      expect(get(result.eventsLoading)).toBe(false);
+    });
+
+    it('should cancel stale events fetch when groupLoading becomes true', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+      mockFetchHistoryEvents.mockResolvedValue({ data: [event1] });
+
+      const groupLoading = ref<boolean>(false);
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading,
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      useHistoryEventsData(options, emit);
+
+      await waitForFetchEvents();
+      mockCancelByTag.mockClear();
+
+      // Simulate groups fetch starting (e.g. user changed page)
+      set(groupLoading, true);
+      await nextTick();
+
+      expect(mockCancelByTag).toHaveBeenCalledWith('history-events-detail');
+    });
+
+    it('should not cancel events when groupLoading becomes false', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+      mockFetchHistoryEvents.mockResolvedValue({ data: [event1] });
+
+      const groupLoading = ref<boolean>(true);
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading,
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      useHistoryEventsData(options, emit);
+
+      await waitForFetchEvents();
+      mockCancelByTag.mockClear();
+
+      // groupLoading goes false (groups fetch completed)
+      set(groupLoading, false);
+      await nextTick();
+
+      // cancelByTag should NOT be called when loading stops
+      expect(mockCancelByTag).not.toHaveBeenCalled();
+    });
+
+    it('should clear events when groups become empty', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const event1 = createMockEvent({ groupIdentifier: 'group1', identifier: 1 });
+      mockFetchHistoryEvents.mockResolvedValueOnce({ data: [event1] });
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([event1]));
+      const options = {
+        excludeIgnored: ref<boolean>(false),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = useHistoryEventsData(options, emit);
+
+      await waitForFetchEvents();
+      expect(get(result.rawEvents)).toHaveLength(1);
+
+      // Set groups to empty
+      set(groups, createMockCollection([]));
+      await waitForFetchEvents();
+
+      expect(get(result.rawEvents)).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `fetchDebounce` and `cancelTag` options to `usePaginationFilters` to debounce rapid parameter changes and cancel stale in-flight requests
- Replace `asyncComputed` in `use-history-events-data` with explicit `fetchEvents()` supporting cancellation via tagged requests and stale response protection via version tracking
- Fix account/location filter not triggering reload by adding `selfPush` flag to skip redundant `applyRouteFilter` on self-caused route changes
- Cancel stale events detail requests immediately when a new groups fetch starts via `watch(groupLoading)`