### PR TITLE
fix: kraken staking page stuck loading on timeout

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The Kraken staking page will no longer get stuck on the loading screen when the backend is unresponsive.
 * :feature:`-` Users can now export CSV reports for any PnL report, including the old ones.
 * :bug:`11551` Unrelated ENS events should no longer appear in your events if bundled in a transaction affecting you.
 * :bug:`-` More Gearbox reward claims will now be automatically decoded in the history view.

--- a/frontend/app/src/store/staking/kraken.spec.ts
+++ b/frontend/app/src/store/staking/kraken.spec.ts
@@ -1,0 +1,113 @@
+import type { KrakenStakingEvents } from '@/types/staking';
+import { Zero } from '@rotki/common';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Section, Status } from '@/types/status';
+import { useKrakenStakingStore } from './kraken';
+
+const mockFetchKrakenStakingEvents = vi.fn();
+const mockRefreshKrakenStaking = vi.fn();
+const mockNotify = vi.fn();
+
+vi.mock('@/composables/api/staking/kraken', () => ({
+  useKrakenApi: vi.fn(() => ({
+    fetchKrakenStakingEvents: mockFetchKrakenStakingEvents,
+    refreshKrakenStaking: mockRefreshKrakenStaking,
+  })),
+}));
+
+vi.mock('@/composables/assets/retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn(() => ({
+    getAssociatedAssetIdentifier: vi.fn((asset: string) => computed(() => asset)),
+  })),
+}));
+
+vi.mock('@/store/notifications', () => ({
+  useNotificationsStore: vi.fn(() => ({
+    notify: mockNotify,
+  })),
+}));
+
+vi.mock('@/store/tasks', () => ({
+  useTaskStore: vi.fn(() => ({
+    awaitTask: vi.fn().mockResolvedValue({}),
+    isTaskRunning: vi.fn().mockReturnValue(false),
+  })),
+}));
+
+vi.mock('@/store/settings/frontend', () => ({
+  useFrontendSettingsStore: vi.fn(() => ({
+    itemsPerPage: 10,
+  })),
+}));
+
+function defaultEvents(): KrakenStakingEvents {
+  return {
+    assets: [],
+    entriesFound: 0,
+    entriesLimit: 0,
+    entriesTotal: 0,
+    received: [],
+    totalValue: Zero,
+  };
+}
+
+describe('store/staking/kraken', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('sets status to LOADED on first load error so the UI is not stuck loading', async () => {
+    const { useStatusStore } = await import('@/store/status');
+
+    mockFetchKrakenStakingEvents.mockRejectedValueOnce(new Error('Request timeout'));
+
+    const store = useKrakenStakingStore();
+    const statusStore = useStatusStore();
+
+    await store.load();
+
+    const status = statusStore.getStatus(Section.STAKING_KRAKEN);
+    expect(status).toBe(Status.LOADED);
+    expect(mockNotify).toHaveBeenCalledOnce();
+  });
+
+  it('loads events successfully on first load', async () => {
+    const { useStatusStore } = await import('@/store/status');
+
+    const eventsData = {
+      ...defaultEvents(),
+      entriesFound: 1,
+      entriesTotal: 1,
+    };
+
+    mockFetchKrakenStakingEvents.mockResolvedValue(eventsData);
+    mockRefreshKrakenStaking.mockResolvedValue({ taskId: 1 });
+
+    const store = useKrakenStakingStore();
+    const statusStore = useStatusStore();
+
+    await store.load();
+
+    const status = statusStore.getStatus(Section.STAKING_KRAKEN);
+    expect(status).toBe(Status.LOADED);
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('sets status to LOADED when refresh task fails', async () => {
+    const { useStatusStore } = await import('@/store/status');
+
+    mockFetchKrakenStakingEvents.mockResolvedValueOnce(defaultEvents());
+    mockRefreshKrakenStaking.mockRejectedValueOnce(new Error('Backend unresponsive'));
+
+    const store = useKrakenStakingStore();
+    const statusStore = useStatusStore();
+
+    await store.load();
+
+    const status = statusStore.getStatus(Section.STAKING_KRAKEN);
+    expect(status).toBe(Status.LOADED);
+    expect(mockNotify).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/store/staking/kraken.ts
+++ b/frontend/app/src/store/staking/kraken.ts
@@ -76,7 +76,7 @@ export const useKrakenStakingStore = defineStore('staking/kraken', () => {
 
   const { awaitTask, isTaskRunning } = useTaskStore();
   const { notify } = useNotificationsStore();
-  const { isFirstLoad, loading, resetStatus, setStatus } = useStatusUpdater(Section.STAKING_KRAKEN);
+  const { isFirstLoad, loading, setStatus } = useStatusUpdater(Section.STAKING_KRAKEN);
 
   const refreshEvents = async (): Promise<void> => {
     const { taskId } = await api.refreshKrakenStaking();
@@ -120,7 +120,7 @@ export const useKrakenStakingStore = defineStore('staking/kraken', () => {
     }
     catch (error: any) {
       logger.error(error);
-      resetStatus();
+      setStatus(Status.LOADED);
       notify({
         display: true,
         message: t('actions.kraken_staking.error.message', {


### PR DESCRIPTION
## Summary

- When the backend was unresponsive, the initial fetch for Kraken staking events would time out, leaving the UI permanently stuck on the loading screen with no way for the user to retry.
- The root cause was `resetStatus()` setting the section status back to `NONE`, which `shouldShowLoadingScreen` treats as "should show loading" — the same as the initial `LOADING` state.
- Changed the error handler to `setStatus(Status.LOADED)` so the page renders with empty data and the refresh button becomes available.