### PR TITLE
fix(frontend): handle relative base URL in buildUrl

### DIFF
--- a/frontend/app/src/modules/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/api/rotki-api.spec.ts
@@ -18,7 +18,7 @@ describe('modules/api/rotki-api', () => {
 
     // Mock window.location
     Object.defineProperty(window, 'location', {
-      value: { href: '' },
+      value: { href: '', origin: 'http://localhost:3000' },
       writable: true,
     });
   });
@@ -72,6 +72,15 @@ describe('modules/api/rotki-api', () => {
       expect(url).toContain('limit=10');
       expect(url).not.toContain('filter');
       expect(url).not.toContain('search');
+    });
+
+    it('handles relative base URL by using window.location.origin', () => {
+      const relativeApi = new RotkiApi();
+      // Simulate a relative base URL (e.g., when VITE_PUBLIC_PATH is set)
+      relativeApi.setup('/rotki');
+
+      const url = relativeApi.buildUrl('avatars/ens/vitalik.eth');
+      expect(url).toBe('http://localhost:3000/rotki/api/1/avatars/ens/vitalik.eth');
     });
   });
 

--- a/frontend/app/src/modules/api/rotki-api.ts
+++ b/frontend/app/src/modules/api/rotki-api.ts
@@ -78,7 +78,8 @@ export class RotkiApi {
   }
 
   buildUrl(path: string, query?: Record<string, unknown>): string {
-    const url = new URL(path, this._baseURL);
+    const base = /^https?:\/\//.test(this._baseURL) ? this._baseURL : `${window.location.origin}${this._baseURL}`;
+    const url = new URL(path, base);
     if (query) {
       const transformedQuery = queryTransformer(query);
       for (const [key, value] of Object.entries(transformedQuery)) {


### PR DESCRIPTION
## Summary
- Fix `TypeError: Failed to construct 'URL': Invalid base URL` in `buildUrl` when the API base URL is a relative path (e.g., Docker/web deployments using `VITE_PUBLIC_PATH`)
- Prepend `window.location.origin` when `_baseURL` is not an absolute URL

## Test plan
- [x] Existing 54 unit tests pass
- [x] New test added for relative base URL scenario
- [x] Verify ENS avatars load in Docker/web deployment