### PR TITLE
fix(frontend): handle EPIPE on stdout/stderr

### DIFF
--- a/frontend/app/electron/main/index.ts
+++ b/frontend/app/electron/main/index.ts
@@ -1,6 +1,15 @@
 import process from 'node:process';
 import { Application } from '@electron/main/application';
 
+function ignoreEpipe(err: NodeJS.ErrnoException): void {
+  if (err.code === 'EPIPE')
+    return;
+  throw err;
+}
+
+process.stdout.on('error', ignoreEpipe);
+process.stderr.on('error', ignoreEpipe);
+
 const app = new Application();
 
 // eslint-disable-next-line unicorn/prefer-top-level-await


### PR DESCRIPTION
## Summary
- When the backend process exits, the stdout/stderr pipes are closed. LogService.outputToConsole writing to these pipes causes an EPIPE error that surfaces as an uncaught exception, crashing Electron with an error dialog.
- Add error handlers on process.stdout/stderr to silently ignore EPIPE while re-throwing any other errors. File-based logging is unaffected.

## Test plan
- [ ] Kill the backend process while Electron is running and verify no crash dialog appears