### PR TITLE
chore: improve docker build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 
 
 docker-image:
-	packaging/docker-image.sh
+	packaging/build-docker.sh
 
 
 test-assets:

--- a/packaging/build-docker.sh
+++ b/packaging/build-docker.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NO_CACHE=""
+CUSTOM_TAG=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --no-cache)
+      NO_CACHE="--no-cache"
+      shift
+      ;;
+    --tag)
+      CUSTOM_TAG="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+REVISION=$(git rev-parse HEAD)
+SHORT_HASH=$(git rev-parse --short HEAD)
+DIRTY=$(if git diff --quiet HEAD 2>/dev/null; then echo '0'; else echo '1'; fi)
+ROTKI_VERSION=$(grep 'current_version = ' .bumpversion.cfg | sed 's/current_version = //')
+POSTFIX=$(if git describe --tags --exact-match "$REVISION" &>/dev/null; then echo ''; else echo '-dev'; fi)
+ROTKI_VERSION=${ROTKI_VERSION}${POSTFIX}
+TAG="rotki/rotki:${CUSTOM_TAG:-${DIRTY}${SHORT_HASH}}"
+
+echo "Building ${TAG} (version: ${ROTKI_VERSION})"
+
+docker buildx build \
+  --pull \
+  --load \
+  $NO_CACHE \
+  --build-arg REVISION="$REVISION" \
+  --build-arg ROTKI_VERSION="$ROTKI_VERSION" \
+  -t "$TAG" \
+  .
+
+echo ""
+echo "Run with:"
+echo "  mkdir -p ~/.rotki/data ~/.rotki/logs"
+echo "  docker run -d --name rotki -v ~/.rotki/data:/data -v ~/.rotki/logs:/logs -p 8084:80 -e LOGLEVEL=debug ${TAG}"

--- a/packaging/docker-image.sh
+++ b/packaging/docker-image.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-REVISION=$(git rev-parse HEAD)
-ROTKI_VERSION=$(cat .bumpversion.cfg | grep 'current_version = ' | sed -n -e 's/current_version = //p')
-POSTFIX=$(if git describe --tags --exact-match "$REVISION" &>/dev/null; then echo ''; else echo '-dev'; fi)
-ROTKI_VERSION=${ROTKI_VERSION}${POSTFIX}
-
-docker build --pull --no-cache -t rotki . --build-arg REVISION="$REVISION" --build-arg ROTKI_VERSION="$ROTKI_VERSION"


### PR DESCRIPTION
## Summary
- Rename `docker-image.sh` to `build-docker.sh`
- Use `docker buildx build` with `--load`
- Make `--no-cache` optional (pass `--no-cache` flag to enable)
- Tag as `rotki/rotki:<dirty><short-hash>` with dirty flag (0=clean, 1=dirty)
- Support custom tag via `--tag <name>`
- Print a ready-to-use `docker run` command after build

## Usage
```bash
make docker-image                                  # default tag
packaging/build-docker.sh --no-cache               # without cache
packaging/build-docker.sh --tag my-feature         # custom tag → rotki/rotki:my-feature
```