### PR TITLE
fix(frontend): format event type in sync progress

### DIFF
--- a/frontend/app/src/modules/sync-progress/components/LocationProgressItem.vue
+++ b/frontend/app/src/modules/sync-progress/components/LocationProgressItem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { toSentenceCase } from '@rotki/common';
 import LocationIcon from '@/components/history/LocationIcon.vue';
 import { type LocationProgress, LocationStatus } from '../types';
 
@@ -36,7 +37,7 @@ const statusText = computed<string>(() => {
 
   if (get(isQuerying)) {
     if (props.location.eventType) {
-      return t('sync_progress.status.querying_event_type', { type: props.location.eventType });
+      return t('sync_progress.status.querying_event_type', { type: toSentenceCase(props.location.eventType) });
     }
     return t('sync_progress.status.querying');
   }


### PR DESCRIPTION
## Summary
- Use `toSentenceCase` on the event type shown during exchange sync progress so that `history_query` displays as "History Query" instead of raw snake_case.

## Test plan
- [ ] Trigger an exchange sync and verify the progress status shows a readable event type