### PR TITLE
fix(frontend): allow empty selection for copy actions and refactor us…

### DIFF
--- a/frontend/scripts/copy-data.ts
+++ b/frontend/scripts/copy-data.ts
@@ -43,9 +43,9 @@ async function promptUser(appDataDir: string): Promise<void> {
     }));
 
   const selectedDataDirs = await multiselect({
-    message: 'Select what to copy from data to develop_data.',
+    message: 'Select what to copy from data to develop_data (submit empty to skip).',
     options: dataDirs,
-    required: true,
+    required: false,
   });
 
   if (isCancel(selectedDataDirs)) {


### PR DESCRIPTION
…er data copying

Make `multiselect` optional for data copying and reorder the user data copying logic for clarity and consistency.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
