### PR TITLE
fix(frontend): disable snapshot actions for non-snapshot data points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Clicking on non-snapshot data points in the net worth graph will no longer open the snapshot export dialog.
 * :bug:`-` 1inch v5 swaps routed through wombat router will now be decoded properly
 * :feature:`11583` Users can now re-pull missing ETH staking withdrawal events for specific validators or addresses within a chosen time range.
 * :feature:`11582` Users can now re-pull missing ETH staking block production events for specific validators or addresses within a chosen time range.

--- a/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
+++ b/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { type BigNumber, type NetValue, Zero } from '@rotki/common';
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
+import { type BigNumber, Zero } from '@rotki/common';
 import VChart from 'vue-echarts';
 import ExportSnapshotDialog from '@/components/dashboard/ExportSnapshotDialog.vue';
 import DateDisplay from '@/components/display/DateDisplay.vue';
@@ -9,7 +10,7 @@ import { useNetValueChartConfig } from '@/modules/dashboard/graph/use-net-value-
 import { useNetValueEventHandlers } from '@/modules/dashboard/graph/use-net-value-event-handlers';
 
 const props = defineProps<{
-  chartData: NetValue;
+  chartData: NetValueChartData;
 }>();
 
 const { chartData } = toRefs(props);

--- a/frontend/app/src/modules/dashboard/graph/types.ts
+++ b/frontend/app/src/modules/dashboard/graph/types.ts
@@ -1,0 +1,5 @@
+import type { NetValue } from '@rotki/common';
+
+export interface NetValueChartData extends NetValue {
+  snapshotCount: number;
+}

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
@@ -1,4 +1,3 @@
-import type { NetValue } from '@rotki/common';
 import type {
   BrushComponentOption,
   EChartsOption,
@@ -9,6 +8,7 @@ import type {
 } from 'echarts';
 import type { DataZoomComponentOption, GridComponentOption } from 'echarts/components';
 import type { ComputedRef, Ref } from 'vue';
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { useGraph } from '@/composables/graphs';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 
@@ -21,7 +21,7 @@ interface UseNetValueChartConfigReturn {
   chartOption: ComputedRef<EChartsOption>;
 }
 
-export function useNetValueChartConfig(chartData: Ref<NetValue>): UseNetValueChartConfigReturn {
+export function useNetValueChartConfig(chartData: Ref<NetValueChartData>): UseNetValueChartConfigReturn {
   const data = computed<number[][]>(() => {
     const { data, times } = get(chartData);
     if (!(times?.length && data?.length)) {

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
@@ -1,13 +1,14 @@
 import type { EChartsType } from 'echarts/core';
 import type { Ref } from 'vue';
 import type VChart from 'vue-echarts';
-import { assert, type BigNumber, type NetValue } from '@rotki/common';
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
+import { assert, type BigNumber } from '@rotki/common';
 import { type TooltipData, useGraphTooltip } from '@/composables/graphs';
 
 interface UseNetValueEventHandlersParams {
   chartInstance: Ref<InstanceType<typeof VChart> | undefined>;
   chartContainer: Ref<HTMLElement | undefined>;
-  chartData: Ref<NetValue>;
+  chartData: Ref<NetValueChartData>;
   onHover: (timestamp: number, value: BigNumber) => void;
 }
 
@@ -97,9 +98,10 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
       const { axesInfo, dataIndex } = event;
       const xAxisInfo = axesInfo?.[0];
 
-      const netValues = get(chartData).data;
+      const { data: netValues, snapshotCount } = get(chartData);
       const netValue = netValues[dataIndex];
       const currentBalance = dataIndex === netValues.length - 1;
+      const isSnapshot = dataIndex < snapshotCount;
 
       if (!xAxisInfo || !netValue) {
         resetTooltip();
@@ -117,7 +119,7 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
         ...tooltipPosition,
       });
 
-      updateLastHover(currentBalance, timestamp, netValue);
+      updateLastHover(!isSnapshot, timestamp, netValue);
     });
   }
 

--- a/frontend/app/src/store/statistics/index.ts
+++ b/frontend/app/src/store/statistics/index.ts
@@ -1,4 +1,5 @@
 import type { MaybeRef } from 'vue';
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { type AssetBalanceWithPriceAndChains, type BigNumber, type NetValue, One, type TimeFramePeriod, timeframes, TimeUnit, Zero } from '@rotki/common';
 import dayjs from 'dayjs';
 import { useStatisticsApi } from '@/composables/api/statistics/statistics-api';
@@ -142,8 +143,8 @@ export const useStatisticsStore = defineStore('statistics', () => {
 
   const totalNetWorthUsd = calculateTotalValue(true);
 
-  function getNetValue(startingDate: number): ComputedRef<NetValue> {
-    return computed<NetValue>(() => {
+  function getNetValue(startingDate: number): ComputedRef<NetValueChartData> {
+    return computed<NetValueChartData>(() => {
       const currency = get(currencySymbol);
       const rate = get(useExchangeRate(currency)) ?? One;
 
@@ -159,6 +160,7 @@ export const useStatisticsStore = defineStore('statistics', () => {
 
         return {
           data: [Zero, netWorth],
+          snapshotCount: 0,
           times: [now - oneDayTimestamp, now],
         };
       }
@@ -175,6 +177,7 @@ export const useStatisticsStore = defineStore('statistics', () => {
 
       return {
         data: [...nv.data, netWorth],
+        snapshotCount: nv.data.length,
         times: [...nv.times, now],
       };
     });


### PR DESCRIPTION
## Summary
- Clicking on non-snapshot data points (current balance or synthetic zero) in the net worth graph no longer opens the snapshot export dialog
- Added a `snapshotCount` field to track which data points are real backend snapshots vs code-injected values
- Only data points within the real snapshot range are now clickable

## What was the issue?

The net worth graph appends a live "current balance" data point at the end, and when there's no backend data, it also prepends a synthetic zero point. Both of these are code-injected values with no real snapshot behind them. Clicking on these points opened the snapshot export dialog, but downloading/editing would fail or produce incorrect results since no actual snapshot exists for those timestamps.

## How was it fixed?

The `getNetValue` computed in the statistics store now returns a `snapshotCount` indicating how many of the data points are real backend snapshots. The chart event handler uses this count (`dataIndex < snapshotCount`) to determine if a point is clickable, replacing the previous check that only guarded the last element.

## Test plan
- [x] Added unit tests for `snapshotCount` in the statistics store:
  - Returns 0 when no backend data exists
  - Returns correct count matching real backend data points  
  - Correctly excludes points before `startingDate` from the count
- [ ] Manual: verify clicking on the current balance (rightmost) point does not open the dialog
- [ ] Manual: verify clicking on real snapshot points still opens the dialog correctly