### PR TITLE
fix(frontend): optimize Vue reactivity and fix test issues

### DIFF
--- a/frontend/app/src/composables/balances/use-balance-queue.ts
+++ b/frontend/app/src/composables/balances/use-balance-queue.ts
@@ -53,7 +53,7 @@ const sharedStats = ref<QueueStats>({
   total: 0,
 });
 
-const sharedItems = ref<Map<string, BalanceQueryQueueItem>>(new Map());
+const sharedItems = shallowRef<Map<string, BalanceQueryQueueItem>>(new Map());
 
 // Cached reference to the balance queue singleton
 let balanceQueue: BalanceQueueService<BalanceQueueMetadata> | null = null;

--- a/frontend/app/src/modules/history/events/composables/use-history-events-data.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-events-data.ts
@@ -136,7 +136,7 @@ export function useHistoryEventsData(
   });
 
   // Track which groups have opted to show ignored assets (per-group toggle)
-  const groupsShowingIgnoredAssets = ref<Set<string>>(new Set());
+  const groupsShowingIgnoredAssets = shallowRef<Set<string>>(new Set());
 
   function toggleShowIgnoredAssets(groupId: string): void {
     const current = get(groupsShowingIgnoredAssets);

--- a/frontend/app/src/modules/history/events/composables/use-selection-mode.ts
+++ b/frontend/app/src/modules/history/events/composables/use-selection-mode.ts
@@ -37,7 +37,7 @@ export interface UseHistoryEventsSelectionModeReturn {
 
 export function useHistoryEventsSelectionMode(): UseHistoryEventsSelectionModeReturn {
   const isActive = ref<boolean>(false);
-  const selectedIds = ref<Set<number>>(new Set());
+  const selectedIds = shallowRef<Set<number>>(new Set());
   const availableIds = ref<number[]>([]);
   const selectAllMatching = ref<boolean>(false);
   const totalMatchingCount = ref<number>(0);

--- a/frontend/app/src/modules/history/events/composables/use-virtual-rows.ts
+++ b/frontend/app/src/modules/history/events/composables/use-virtual-rows.ts
@@ -114,11 +114,11 @@ export function useVirtualRows(
   eventsByGroup: ComputedRef<Record<string, HistoryEventRow[]>>,
 ): UseVirtualRowsReturn {
   // Track how many items are visible per group (beyond initial limit)
-  const groupVisibleCounts = ref<Map<string, number>>(new Map());
+  const groupVisibleCounts = shallowRef<Map<string, number>>(new Map());
   // Track which swap rows are expanded (key: groupId-index)
-  const expandedSwaps = ref<Set<string>>(new Set());
+  const expandedSwaps = shallowRef<Set<string>>(new Set());
   // Track which matched movement rows are expanded (key: groupId-index)
-  const expandedMovements = ref<Set<string>>(new Set());
+  const expandedMovements = shallowRef<Set<string>>(new Set());
 
   const flattenedRows = computed<VirtualRow[]>(() => {
     const rows: VirtualRow[] = [];

--- a/frontend/app/src/store/assets/icon.ts
+++ b/frontend/app/src/store/assets/icon.ts
@@ -18,17 +18,13 @@ const CACHE_TTL = 5 * 60 * 1000;
 export const useAssetIconStore = defineStore('assets/icon', () => {
   const lastRefreshedAssetIcon = ref<number>(0);
   // Cache for asset existence checks to avoid redundant HTTP requests
-  const assetExistsCache = ref<Map<string, CachedAssetResult>>(new Map());
+  const assetExistsCache = shallowRef<Map<string, CachedAssetResult>>(new Map());
   // Track pending requests to avoid duplicate in-flight requests
-  const pendingRequests = ref<Map<string, Promise<boolean>>>(new Map());
+  const pendingRequests = shallowRef<Map<string, Promise<boolean>>>(new Map());
 
   const setLastRefreshedAssetIcon = (): void => {
     set(lastRefreshedAssetIcon, Date.now());
   };
-
-  onBeforeMount(() => {
-    setLastRefreshedAssetIcon();
-  });
 
   const { assetImageUrl, checkAsset } = useAssetIconApi();
 

--- a/frontend/app/src/store/history/refresh-state.ts
+++ b/frontend/app/src/store/history/refresh-state.ts
@@ -6,8 +6,8 @@ import { logger } from '@/utils/logging';
 export const useHistoryRefreshStateStore = defineStore('history/refresh-state', () => {
   const isRefreshing = ref<boolean>(false);
   const lastRefreshTime = ref<number | null>(null);
-  const refreshedKeys = ref<Set<string>>(new Set<string>());
-  const pendingKeys = ref<Set<string>>(new Set<string>());
+  const refreshedKeys = shallowRef<Set<string>>(new Set<string>());
+  const pendingKeys = shallowRef<Set<string>>(new Set<string>());
 
   // Prefix keys to distinguish accounts from exchanges
   const BLOCKCHAIN_PREFIX = 'blockchain:';

--- a/frontend/app/src/utils/date.ts
+++ b/frontend/app/src/utils/date.ts
@@ -1,4 +1,3 @@
-import type { Ref } from 'vue';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
@@ -9,6 +8,7 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import weekday from 'dayjs/plugin/weekday';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
+import { markRaw, type Ref } from 'vue';
 import { DateFormat } from '@/types/date-format';
 
 export function getDateInputISOFormat(format: DateFormat): string {
@@ -85,6 +85,7 @@ export function getDayNames(locale = 'en'): string[] {
 }
 
 export function setupDayjs(): void {
+  markRaw(dayjs.prototype);
   dayjs.extend(customParseFormat);
   dayjs.extend(utc);
   dayjs.extend(timezone);

--- a/frontend/app/tests/unit/setup-files/handlers/index.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/index.ts
@@ -25,3 +25,5 @@ export * from './skipped-external-events';
 export * from './staking';
 
 export * from './supported-chains';
+
+export * from './task-scheduler';

--- a/frontend/app/tests/unit/setup-files/handlers/task-scheduler.ts
+++ b/frontend/app/tests/unit/setup-files/handlers/task-scheduler.ts
@@ -1,0 +1,9 @@
+import process from 'node:process';
+import { http, HttpResponse } from 'msw';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+
+export const taskSchedulerHandlers = [
+  http.put(`${backendUrl}/api/1/tasks/scheduler`, () =>
+    HttpResponse.json({ result: { enabled: true }, message: '' }, { status: 200 })),
+];

--- a/frontend/app/tests/unit/setup-files/server.ts
+++ b/frontend/app/tests/unit/setup-files/server.ts
@@ -14,6 +14,7 @@ import {
   skippedExternalEventsHandlers,
   stakingHandlers,
   supportedChainsHandlers,
+  taskSchedulerHandlers,
 } from './handlers';
 
 const server = setupServer(
@@ -31,6 +32,7 @@ const server = setupServer(
   ...settingsHandlers,
   ...skippedExternalEventsHandlers,
   ...assetsHandlers,
+  ...taskSchedulerHandlers,
 );
 
 export { server };

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -16,7 +16,7 @@ beforeAll(() => {
 
   vi.mock('@/composables/api/assets/info', () => ({
     useAssetInfoApi: vi.fn().mockReturnValue({
-      assetMapping: vi.fn().mockResolvedValue({}),
+      assetMapping: vi.fn().mockResolvedValue({ assets: {}, assetCollections: {} }),
     }),
   }));
 

--- a/frontend/app/tests/unit/specs/components/settings/premium-settings.spec.ts
+++ b/frontend/app/tests/unit/specs/components/settings/premium-settings.spec.ts
@@ -19,7 +19,11 @@ vi.mock('@/composables/electron-interop', () => {
 });
 
 vi.mock('@/composables/api/session/premium-credentials', () => ({
-  usePremiumCredentialsApi: vi.fn().mockReturnValue({}),
+  usePremiumCredentialsApi: vi.fn().mockReturnValue({
+    deletePremiumCredentials: vi.fn(),
+    getPremiumCapabilities: vi.fn().mockResolvedValue({}),
+    setPremiumCredentials: vi.fn(),
+  }),
 }));
 
 describe('premiumSettings.vue', () => {

--- a/frontend/app/tests/unit/specs/composables/assets/asset-select-info.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/assets/asset-select-info.spec.ts
@@ -1,3 +1,4 @@
+import type { EffectScope } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -8,22 +9,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // The composable is designed to share cached data efficiently in production.
 
 describe('composables/assets/asset-select-info', () => {
+  let scope: EffectScope;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
 
     // Set up Pinia for the tests
     setActivePinia(createPinia());
+    scope = effectScope();
   });
 
   afterEach(() => {
+    scope.stop();
     vi.useRealTimers();
   });
 
   describe('basic functionality', () => {
     it('should return null when identifier is undefined', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const result = assetSelectInfo.assetInfo(undefined);
       expect(get(result)).toBeNull();
@@ -31,7 +36,7 @@ describe('composables/assets/asset-select-info', () => {
 
     it('should return null when identifier is empty string', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const result = assetSelectInfo.assetInfo('');
       expect(get(result)).toBeNull();
@@ -39,7 +44,7 @@ describe('composables/assets/asset-select-info', () => {
 
     it('should return empty string for symbol when identifier is undefined', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const result = assetSelectInfo.assetSymbol(undefined);
       expect(get(result)).toBe('');
@@ -47,7 +52,7 @@ describe('composables/assets/asset-select-info', () => {
 
     it('should return empty string for symbol when identifier is empty', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const result = assetSelectInfo.assetSymbol('');
       expect(get(result)).toBe('');
@@ -55,7 +60,7 @@ describe('composables/assets/asset-select-info', () => {
 
     it('should return empty string for name when identifier is undefined', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const result = assetSelectInfo.assetName(undefined);
       expect(get(result)).toBe('');
@@ -63,7 +68,7 @@ describe('composables/assets/asset-select-info', () => {
 
     it('should return empty string for name when identifier is empty', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const result = assetSelectInfo.assetName('');
       expect(get(result)).toBe('');
@@ -73,7 +78,7 @@ describe('composables/assets/asset-select-info', () => {
   describe('reactive behavior', () => {
     it('should handle reactive identifier changes', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const identifier = ref<string | undefined>(undefined);
       const nameResult = assetSelectInfo.assetName(identifier);
@@ -107,7 +112,7 @@ describe('composables/assets/asset-select-info', () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const { useAssetInfoApi } = await import('@/composables/api/assets/info');
 
-      const assetSelectInfo = useAssetSelectInfo();
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       // Mock the API to return undefined
       const mockAssetMapping = vi.fn().mockResolvedValue(undefined);
@@ -136,8 +141,8 @@ describe('composables/assets/asset-select-info', () => {
     it('should share the same instance between multiple calls', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
 
-      const instance1 = useAssetSelectInfo();
-      const instance2 = useAssetSelectInfo();
+      const instance1 = scope.run(() => useAssetSelectInfo())!;
+      const instance2 = scope.run(() => useAssetSelectInfo())!;
 
       // Both instances should be the same due to createSharedComposable
       expect(instance1).toBe(instance2);

--- a/frontend/common/src/numbers/index.ts
+++ b/frontend/common/src/numbers/index.ts
@@ -1,5 +1,8 @@
 import { BigNumber } from 'bignumber.js';
+import { markRaw } from 'vue';
 import z from 'zod/v4';
+
+markRaw(BigNumber.prototype);
 
 export const Zero = bigNumberify(0);
 


### PR DESCRIPTION
## Summary

- Use `markRaw` on `BigNumber.prototype` and `dayjs.prototype` to prevent Vue from wrapping these immutable types in reactive Proxies, avoiding unnecessary overhead when they appear in deeply nested reactive objects
- Convert `ref<Map>` and `ref<Set>` to `shallowRef` across 6 files where all usage replaces collections via `set()` rather than mutating in-place
- Remove unnecessary `onBeforeMount` lifecycle hook from the asset icon store (it was misused inside a Pinia store causing Vue warnings in tests)
- Fix three test infrastructure issues: incomplete `assetMapping` mock, incomplete `usePremiumCredentialsApi` mock missing `getPremiumCapabilities`, and missing MSW handler for the task scheduler endpoint
- Add proper `effectScope` wrapping to composable tests that were missing it