### PR TITLE
Properly handle deposit_asset/remove_asset in matching

### DIFF
--- a/rotkehlchen/history/events/structures/base.py
+++ b/rotkehlchen/history/events/structures/base.py
@@ -61,6 +61,17 @@ def get_event_direction(
     for_balance_tracking special cases:
     - DEPOSIT/DEPOSIT_ASSET -> IN
     - WITHDRAWAL/REMOVE_ASSET -> OUT
+    - DEPOSIT/DEPOSIT_TO_PROTOCOL -> OUT
+    - WITHDRAWAL/WITHDRAW_FROM_PROTOCOL -> IN
+    - TRANSFER/NONE -> OUT
+    - EXCHANGE_TRANSFER/SPEND -> OUT
+    - EXCHANGE_TRANSFER/RECEIVE -> IN
+    - EXCHANGE_TRANSFER/FEE -> OUT
+
+    for_movement_matching special cases:
+    - DEPOSIT/DEPOSIT_ASSET -> OUT
+    - WITHDRAWAL/REMOVE_ASSET -> IN
+    - all other cases handled the same as for_balance_tracking
     """
     if event_type == HistoryEventType.INFORMATIONAL:
         return EventDirection.NEUTRAL
@@ -81,9 +92,9 @@ def get_event_direction(
 
     if (for_balance_tracking or for_movement_matching) and direction == EventDirection.NEUTRAL:
         if (event_type, event_subtype) == (HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET):  # noqa: E501
-            return EventDirection.IN
+            return EventDirection.OUT if for_movement_matching else EventDirection.IN
         if (event_type, event_subtype) == (HistoryEventType.WITHDRAWAL, HistoryEventSubType.REMOVE_ASSET):  # noqa: E501
-            return EventDirection.OUT
+            return EventDirection.IN if for_movement_matching else EventDirection.OUT
         if (event_type, event_subtype) == (HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_TO_PROTOCOL):  # noqa: E501
             return EventDirection.OUT
         if (event_type, event_subtype) == (HistoryEventType.WITHDRAWAL, HistoryEventSubType.WITHDRAW_FROM_PROTOCOL):  # noqa: E501

--- a/rotkehlchen/tasks/events.py
+++ b/rotkehlchen/tasks/events.py
@@ -1221,7 +1221,7 @@ def _find_close_matches(
         )
         direction_matches = [
             match for match in close_matches
-            if match.maybe_get_direction(for_balance_tracking=True) == expected_direction
+            if match.maybe_get_direction(for_movement_matching=True) == expected_direction
         ]
         if len(direction_matches) > 0:
             close_matches = direction_matches
@@ -1240,9 +1240,9 @@ def _find_close_matches(
             if match.asset == asset_movement.asset:
                 asset_matches.append(match)
 
-            if (  # Maybe match by balance tracking event direction
+            if (  # Maybe match by movement matching event direction
                 (match_direction := match.maybe_get_direction(
-                    for_balance_tracking=True,
+                    for_movement_matching=True,
                 )) != EventDirection.NEUTRAL and
                 ((is_deposit and match_direction == EventDirection.OUT) or
                 (not is_deposit and match_direction == EventDirection.IN))


### PR DESCRIPTION
For movement matching deposit_asset needs to be treated as an OUT and remove_asset needs to be treated as an IN. While this was handled properly in part of should_exclude_possible_match, it wasn't handled properly where maybe_get_direction is used.
