### PR TITLE
fix(frontend): warn on purge for exchanges with limited trade history

### DIFF
--- a/frontend/app/src/components/settings/data-security/data-management/PurgeData.vue
+++ b/frontend/app/src/components/settings/data-security/data-management/PurgeData.vue
@@ -125,6 +125,17 @@ const { pending, showConfirmation, status } = useCacheClear<Purgeable>(
       });
     }
 
+    const exchangeTradeHistoryLimits: Record<string, number> = {
+      poloniex: 180,
+    };
+
+    if (source === Purgeable.CENTRALIZED_EXCHANGES && value && value in exchangeTradeHistoryLimits) {
+      message += `\n\n${t('data_management.purge_data.confirm.exchange_trade_history_warning', {
+        days: exchangeTradeHistoryLimits[value],
+        exchange: toSentenceCase(value),
+      })}`;
+    }
+
     return {
       message,
       title: t('data_management.purge_data.confirm.title'),

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2246,6 +2246,7 @@
   "data_management": {
     "purge_data": {
       "confirm": {
+        "exchange_trade_history_warning": "Please note that {exchange} only allows retrieving the last {days} days of trade history. Any older trades will be permanently lost.",
         "message": "Are you sure you want to purge the cached data for {source} ({value})?",
         "message_all": "Are you sure you want to purge the cached data for all {source}?",
         "title": "Confirm cached data purge"


### PR DESCRIPTION
## Summary
- When purging Poloniex exchange data, show a warning in the confirmation dialog that only the last 180 days of trades can be re-pulled from the API
- Uses an extensible lookup map so other exchanges with similar limitations can be easily added

## Test plan
- [ ] Go to Settings > Data Security > Data Management > Purge Data
- [ ] Select "Centralized Exchanges" and pick "Poloniex"
- [ ] Click "Purge data" and verify the confirmation dialog shows the 180-day warning
- [ ] Verify other exchanges do not show the warning
- [ ] Verify "purge all" (no exchange selected) does not show the warning