### PR TITLE
refactor(frontend): remove dead scroller prop

### DIFF
--- a/frontend/app/src/components/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
@@ -48,7 +48,6 @@ const indexToEdit = ref<number | null>(null);
 const indexToDelete = ref<number | null>(null);
 const locationToDelete = ref<string>('');
 const formModel = ref<(BalanceSnapshotPayload & { location: string }) | null>(null);
-const tableRef = ref<any>();
 const sort = ref<DataTableSortData<BalanceSnapshot>>({
   column: 'usdValue',
   direction: 'desc',
@@ -385,12 +384,10 @@ function confirmDelete(): void {
       />
     </div>
     <RuiDataTable
-      ref="tableRef"
       v-model:sort="sort"
       class="table-inside-dialog !max-h-[calc(100vh-26.25rem)]"
       :cols="tableHeaders"
       :rows="filteredData"
-      :scroller="tableRef?.$el"
       row-attr="assetIdentifier"
       dense
     >

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
@@ -37,7 +37,6 @@ const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const editedIndex = ref<number | null>(null);
 const formModel = ref<LocationDataSnapshotPayload | null>(null);
 const excludedLocations = ref<string[]>([]);
-const tableRef = ref<any>();
 const sort = ref<DataTableSortData<LocationDataSnapshot>>({
   column: 'usdValue',
   direction: 'desc' as const,
@@ -198,12 +197,10 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
 <template>
   <div>
     <RuiDataTable
-      ref="tableRef"
       v-model:sort="sort"
       class="table-inside-dialog !max-h-[calc(100vh-26.25rem)]"
       :cols="tableHeaders"
       :rows="data"
-      :scroller="tableRef?.$el"
       row-attr="location"
       dense
     >

--- a/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
@@ -68,15 +68,11 @@ const groupedMissingAcquisitions = computed<MappedGroupedItems[]>(() => {
 
 const expanded = ref<MappedGroupedItems[]>([]);
 
-const tableRef = ref<any>(null);
-
 const sort = ref<DataTableSortData<MappedGroupedItems>>([]);
 const childSort = ref<DataTableSortData<MissingAcquisition>>({
   column: 'time',
   direction: 'asc' as const,
 });
-
-const tableContainer = computed(() => get(tableRef)?.$el);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -168,7 +164,6 @@ async function showInHistoryEvent(identifier: number) {
   </CreateDate>
   <div>
     <RuiDataTable
-      ref="tableRef"
       v-model:sort="sort"
       v-model:expanded="expanded"
       class="table-inside-dialog"
@@ -179,7 +174,6 @@ async function showInHistoryEvent(identifier: number) {
       :rows="groupedMissingAcquisitions"
       row-attr="asset"
       single-expand
-      :scroller="tableContainer"
       :dense="isPinned"
     >
       <template #item.asset="{ row }">
@@ -256,7 +250,6 @@ async function showInHistoryEvent(identifier: number) {
           v-model:sort="childSort"
           :cols="childHeaders"
           :rows="row.acquisitions"
-          :scroller="tableContainer"
           class="bg-white dark:bg-rui-grey-900"
           :class="{ 'my-2': isPinned }"
           outlined

--- a/frontend/app/src/components/profitloss/ReportMissingPrices.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingPrices.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import type { BigNumber } from '@rotki/common';
+import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
 import type { HistoricalPrice, HistoricalPriceDeletePayload, HistoricalPriceFormPayload } from '@/types/prices';
 import type { EditableMissingPrice, MissingPrice } from '@/types/reports';
-import { type DataTableColumn, type DataTableSortData, RuiDataTable } from '@rotki/ui-library';
-import { useTemplateRef } from 'vue';
 import DateDisplay from '@/components/display/DateDisplay.vue';
 import AssetDetails from '@/components/helper/AssetDetails.vue';
 import AmountInput from '@/components/inputs/AmountInput.vue';
@@ -30,10 +29,6 @@ const refreshing = ref<boolean>(false);
 
 const refreshedHistoricalPrices = ref<Record<string, BigNumber>>({});
 const sort = ref<DataTableSortData<EditableMissingPrice>>([]);
-
-const tableRef = useTemplateRef<ComponentPublicInstance<typeof RuiDataTable>>('tableRef');
-
-const tableContainer = computed(() => get(tableRef)?.$el);
 
 const { resetHistoricalPricesData } = useHistoricCachePriceStore();
 const { addHistoricalPrice, deleteHistoricalPrice, editHistoricalPrice, fetchHistoricalPrices } = useAssetPricesApi();
@@ -177,7 +172,6 @@ onMounted(async () => {
 <template>
   <div>
     <RuiDataTable
-      ref="tableRef"
       v-model:sort="sort"
       class="table-inside-dialog"
       :class="{
@@ -185,7 +179,6 @@ onMounted(async () => {
       }"
       :cols="headers"
       :rows="formattedItems"
-      :scroller="tableContainer"
       :dense="isPinned"
       row-attr="fromAsset"
     >

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -186,7 +186,7 @@ async function save() {
     @cancel="close()"
     @confirm="save()"
   >
-    <template #default="{ wrapper }">
+    <template #default>
       <div class="flex justify-end items-center gap-8 border border-default rounded p-4 mb-4">
         <RuiCheckbox
           :model-value="!!solveAllUsing"
@@ -254,7 +254,6 @@ async function save() {
         mobile-breakpoint="0"
         outlined
         row-attr="localId"
-        :scroller="wrapper"
       >
         <template #header.taxable>
           <RuiTooltip

--- a/frontend/app/src/components/status/update/AssetConflictDialog.vue
+++ b/frontend/app/src/components/status/update/AssetConflictDialog.vue
@@ -170,7 +170,7 @@ onMounted(() => {
         </template>
       </i18n-t>
     </template>
-    <template #default="{ wrapper }">
+    <template #default>
       <RuiAlert
         v-if="warnDuplicate"
         class="my-2"
@@ -250,7 +250,6 @@ onMounted(() => {
         <RuiDataTable
           :rows="conflicts"
           :cols="tableHeaders"
-          :scroller="wrapper"
           row-attr="identifier"
           outlined
           dense


### PR DESCRIPTION
## Summary
- Remove all `:scroller` bindings from `RuiDataTable` usages across 6 components
- Clean up associated `tableRef`, `tableContainer`, and unused `wrapper` slot destructurings
- Remove now-unnecessary imports (`RuiDataTable` value import, `useTemplateRef`)