### PR TITLE
feat(frontend): lazy-load i18n locale files

### DIFF
--- a/frontend/app/src/components/GlobalSearch.vue
+++ b/frontend/app/src/components/GlobalSearch.vue
@@ -44,7 +44,6 @@ type SearchItemWithoutValue = Omit<SearchItem, 'value'>;
 
 const { t } = useI18n({ useScope: 'global' });
 const { appRoutes } = useAppRoutes();
-const Routes = get(appRoutes);
 const open = ref<boolean>(false);
 const isMac = ref<boolean>(false);
 
@@ -91,6 +90,7 @@ function filterItems(items: SearchItemWithoutValue[], keyword: string): SearchIt
 }
 
 function getRoutes(keyword: string): SearchItemWithoutValue[] {
+  const Routes = get(appRoutes);
   const routeItems: SearchItemWithoutValue[] = [
     { ...Routes.DASHBOARD },
     {
@@ -218,6 +218,7 @@ function getRoutes(keyword: string): SearchItemWithoutValue[] {
 }
 
 function getExchanges(keyword: string): SearchItemWithoutValue[] {
+  const Routes = get(appRoutes);
   const exchanges = get(connectedExchanges);
   const exchangeItems: SearchItemWithoutValue[] = exchanges.map((exchange: Exchange) => {
     const identifier = exchange.location;
@@ -234,6 +235,7 @@ function getExchanges(keyword: string): SearchItemWithoutValue[] {
 }
 
 function getActions(keyword: string): SearchItemWithoutValue[] {
+  const Routes = get(appRoutes);
   const actionItems: SearchItemWithoutValue[] = [
     {
       route: `${Routes.API_KEYS_EXCHANGES.route}?add=true`,

--- a/frontend/app/src/components/NavigationMenu.vue
+++ b/frontend/app/src/components/NavigationMenu.vue
@@ -38,212 +38,214 @@ withDefaults(
 );
 
 const { appRoutes } = useAppRoutes();
-const Routes = get(appRoutes);
-const navItems: MenuItem[] = [
-  {
-    class: 'dashboard',
-    type: 'item',
-    ...Routes.DASHBOARD,
-  },
-  {
-    class: 'accounts',
-    type: 'group',
-    ...Routes.ACCOUNTS,
-    items: [
-      {
-        class: 'accounts-evm',
-        type: 'item',
-        ...Routes.ACCOUNTS_EVM,
-      },
-      {
-        class: 'accounts-bitcoin',
-        type: 'item',
-        ...Routes.ACCOUNTS_BITCOIN,
-      },
-      {
-        class: 'accounts-solana',
-        type: 'item',
-        ...Routes.ACCOUNTS_SOLANA,
-      },
-      {
-        class: 'accounts-substrate',
-        type: 'item',
-        ...Routes.ACCOUNTS_SUBSTRATE,
-      },
-    ],
-  },
-  {
-    class: 'balances',
-    type: 'group',
-    ...Routes.BALANCES,
-    items: [
-      {
-        class: 'balances-blockchain',
-        type: 'item',
-        ...Routes.BALANCES_BLOCKCHAIN,
-      },
-      {
-        class: 'balances-exchange',
-        type: 'item',
-        ...Routes.BALANCES_EXCHANGE,
-      },
-      {
-        class: 'balances-manual',
-        type: 'item',
-        ...Routes.BALANCES_MANUAL,
-      },
-      {
-        class: 'balances-non-fungible',
-        type: 'item',
-        ...Routes.BALANCES_NON_FUNGIBLE,
-      },
-    ],
-  },
-  {
-    class: 'history',
-    type: 'item',
-    ...Routes.HISTORY,
-    route: Routes.HISTORY_EVENTS.route,
-  },
-  {
-    class: 'onchain',
-    type: 'group',
-    ...Routes.ONCHAIN,
-    items: [
-      {
-        class: 'onchain-send',
-        type: 'item',
-        ...Routes.ONCHAIN_SEND,
-      },
-    ],
-  },
-  {
-    class: 'staking',
-    type: 'item',
-    ...Routes.STAKING,
-    route: '/staking',
-  },
-  {
-    class: 'statistics',
-    type: 'group',
-    ...Routes.STATISTICS,
-    items: [
-      {
-        class: 'statistics-graph',
-        type: 'item',
-        ...Routes.STATISTICS_GRAPHS,
-      },
-      {
-        class: 'statistics-history-events',
-        type: 'item',
-        ...Routes.STATISTICS_HISTORY_EVENTS,
-      },
-    ],
-  },
-  {
-    class: 'profit-loss-report',
-    type: 'item',
-    ...Routes.PROFIT_LOSS_REPORTS,
-  },
-  {
-    class: 'airdrops',
-    type: 'item',
-    ...Routes.AIRDROPS,
-  },
-  {
-    class: 'nfts',
-    type: 'item',
-    ...Routes.NFTS,
-  },
-  {
-    type: 'divider',
-  },
-  {
-    class: 'tag-manager',
-    type: 'item',
-    ...Routes.TAG_MANAGER,
-  },
-  {
-    class: 'asset-manager',
-    type: 'group',
-    ...Routes.ASSET_MANAGER,
-    items: [
-      {
-        class: 'asset-manager-managed',
-        type: 'item',
-        ...Routes.ASSET_MANAGER_MANAGED,
-      },
-      {
-        class: 'asset-manager-custom',
-        type: 'item',
-        ...Routes.ASSET_MANAGER_CUSTOM,
-      },
-      {
-        class: 'asset-manager-more',
-        type: 'item',
-        ...Routes.ASSET_MANAGER_MORE,
-      },
-    ],
-  },
-  {
-    class: 'price-manager',
-    type: 'group',
-    ...Routes.PRICE_MANAGER,
-    items: [
-      {
-        class: 'price-manager-latest',
-        type: 'item',
-        ...Routes.PRICE_MANAGER_LATEST,
-      },
-      {
-        class: 'price-manager-historic',
-        type: 'item',
-        ...Routes.PRICE_MANAGER_HISTORIC,
-      },
-    ],
-  },
-  {
-    class: 'address-book-manager',
-    type: 'item',
-    ...Routes.ADDRESS_BOOK_MANAGER,
-  },
-  {
-    type: 'divider',
-  },
-  {
-    class: 'api-keys',
-    type: 'group',
-    ...Routes.API_KEYS,
-    items: [
-      {
-        class: 'api-keys-premium',
-        type: 'item',
-        ...Routes.API_KEYS_ROTKI_PREMIUM,
-      },
-      {
-        class: 'api-keys-exchanges',
-        type: 'item',
-        ...Routes.API_KEYS_EXCHANGES,
-      },
-      {
-        class: 'api-keys-external-services',
-        type: 'item',
-        ...Routes.API_KEYS_EXTERNAL_SERVICES,
-      },
-    ],
-  },
-  {
-    type: 'item',
-    ...Routes.IMPORT,
-  },
-  {
-    type: 'divider',
-  },
-  {
-    type: 'item',
-    ...Routes.CALENDAR,
-  },
-];
+const navItems = computed<MenuItem[]>(() => {
+  const Routes = get(appRoutes);
+  return [
+    {
+      class: 'dashboard',
+      type: 'item',
+      ...Routes.DASHBOARD,
+    },
+    {
+      class: 'accounts',
+      type: 'group',
+      ...Routes.ACCOUNTS,
+      items: [
+        {
+          class: 'accounts-evm',
+          type: 'item',
+          ...Routes.ACCOUNTS_EVM,
+        },
+        {
+          class: 'accounts-bitcoin',
+          type: 'item',
+          ...Routes.ACCOUNTS_BITCOIN,
+        },
+        {
+          class: 'accounts-solana',
+          type: 'item',
+          ...Routes.ACCOUNTS_SOLANA,
+        },
+        {
+          class: 'accounts-substrate',
+          type: 'item',
+          ...Routes.ACCOUNTS_SUBSTRATE,
+        },
+      ],
+    },
+    {
+      class: 'balances',
+      type: 'group',
+      ...Routes.BALANCES,
+      items: [
+        {
+          class: 'balances-blockchain',
+          type: 'item',
+          ...Routes.BALANCES_BLOCKCHAIN,
+        },
+        {
+          class: 'balances-exchange',
+          type: 'item',
+          ...Routes.BALANCES_EXCHANGE,
+        },
+        {
+          class: 'balances-manual',
+          type: 'item',
+          ...Routes.BALANCES_MANUAL,
+        },
+        {
+          class: 'balances-non-fungible',
+          type: 'item',
+          ...Routes.BALANCES_NON_FUNGIBLE,
+        },
+      ],
+    },
+    {
+      class: 'history',
+      type: 'item',
+      ...Routes.HISTORY,
+      route: Routes.HISTORY_EVENTS.route,
+    },
+    {
+      class: 'onchain',
+      type: 'group',
+      ...Routes.ONCHAIN,
+      items: [
+        {
+          class: 'onchain-send',
+          type: 'item',
+          ...Routes.ONCHAIN_SEND,
+        },
+      ],
+    },
+    {
+      class: 'staking',
+      type: 'item',
+      ...Routes.STAKING,
+      route: '/staking',
+    },
+    {
+      class: 'statistics',
+      type: 'group',
+      ...Routes.STATISTICS,
+      items: [
+        {
+          class: 'statistics-graph',
+          type: 'item',
+          ...Routes.STATISTICS_GRAPHS,
+        },
+        {
+          class: 'statistics-history-events',
+          type: 'item',
+          ...Routes.STATISTICS_HISTORY_EVENTS,
+        },
+      ],
+    },
+    {
+      class: 'profit-loss-report',
+      type: 'item',
+      ...Routes.PROFIT_LOSS_REPORTS,
+    },
+    {
+      class: 'airdrops',
+      type: 'item',
+      ...Routes.AIRDROPS,
+    },
+    {
+      class: 'nfts',
+      type: 'item',
+      ...Routes.NFTS,
+    },
+    {
+      type: 'divider',
+    },
+    {
+      class: 'tag-manager',
+      type: 'item',
+      ...Routes.TAG_MANAGER,
+    },
+    {
+      class: 'asset-manager',
+      type: 'group',
+      ...Routes.ASSET_MANAGER,
+      items: [
+        {
+          class: 'asset-manager-managed',
+          type: 'item',
+          ...Routes.ASSET_MANAGER_MANAGED,
+        },
+        {
+          class: 'asset-manager-custom',
+          type: 'item',
+          ...Routes.ASSET_MANAGER_CUSTOM,
+        },
+        {
+          class: 'asset-manager-more',
+          type: 'item',
+          ...Routes.ASSET_MANAGER_MORE,
+        },
+      ],
+    },
+    {
+      class: 'price-manager',
+      type: 'group',
+      ...Routes.PRICE_MANAGER,
+      items: [
+        {
+          class: 'price-manager-latest',
+          type: 'item',
+          ...Routes.PRICE_MANAGER_LATEST,
+        },
+        {
+          class: 'price-manager-historic',
+          type: 'item',
+          ...Routes.PRICE_MANAGER_HISTORIC,
+        },
+      ],
+    },
+    {
+      class: 'address-book-manager',
+      type: 'item',
+      ...Routes.ADDRESS_BOOK_MANAGER,
+    },
+    {
+      type: 'divider',
+    },
+    {
+      class: 'api-keys',
+      type: 'group',
+      ...Routes.API_KEYS,
+      items: [
+        {
+          class: 'api-keys-premium',
+          type: 'item',
+          ...Routes.API_KEYS_ROTKI_PREMIUM,
+        },
+        {
+          class: 'api-keys-exchanges',
+          type: 'item',
+          ...Routes.API_KEYS_EXCHANGES,
+        },
+        {
+          class: 'api-keys-external-services',
+          type: 'item',
+          ...Routes.API_KEYS_EXTERNAL_SERVICES,
+        },
+      ],
+    },
+    {
+      type: 'item',
+      ...Routes.IMPORT,
+    },
+    {
+      type: 'divider',
+    },
+    {
+      type: 'item',
+      ...Routes.CALENDAR,
+    },
+  ];
+});
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend/app/src/components/app/AppHost.vue
+++ b/frontend/app/src/components/app/AppHost.vue
@@ -22,11 +22,11 @@ const { adaptiveLanguage, setLanguage } = useLocale();
 
 onBeforeMount(() => {
   startPromise(setupBackend());
-  setLanguage(get(adaptiveLanguage));
+  startPromise(setLanguage(get(adaptiveLanguage)));
 });
 
-watch(adaptiveLanguage, (language) => {
-  setLanguage(language);
+watch(adaptiveLanguage, async (language) => {
+  await setLanguage(language);
 });
 </script>
 
@@ -34,7 +34,6 @@ watch(adaptiveLanguage, (language) => {
   <div
     v-if="!isPlayground"
     id="rotki"
-    :key="adaptiveLanguage"
     class="overflow-hidden !text-rui-text bg-rui-grey-50 dark:bg-dark-surface"
     :class="{ 'animations-disabled': !animationsEnabled }"
   >

--- a/frontend/app/src/composables/session/use-locale.ts
+++ b/frontend/app/src/composables/session/use-locale.ts
@@ -1,4 +1,5 @@
 import type { MaybeRef } from 'vue';
+import { loadLocaleMessages } from '@/i18n';
 import { useSessionAuthStore } from '@/store/session/auth';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { SupportedLanguage } from '@/types/settings/frontend-settings';
@@ -26,9 +27,12 @@ export const useLocale = createSharedComposable(() => {
       set(lastLanguage, SupportedLanguage.EN);
   };
 
-  function setLanguage(language: string): void {
-    if (language !== get(locale))
+  async function setLanguage(language: string): Promise<void> {
+    if (language !== get(locale)) {
+      await loadLocaleMessages(language);
       set(locale, language);
+      document.querySelector('html')?.setAttribute('lang', language);
+    }
   }
 
   watch([language, forceUpdateMachineLanguage], () => {

--- a/frontend/app/src/i18n.ts
+++ b/frontend/app/src/i18n.ts
@@ -1,11 +1,13 @@
-import messages from '@intlify/unplugin-vue-i18n/messages';
+import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
+import en from './locales/en.json';
+
+const loadedLocales = new Set<string>(['en']);
 
 export const i18n = createI18n({
   fallbackLocale: (import.meta.env.VITE_I18N_FALLBACK_LOCALE as string | undefined) || 'en',
-  legacy: false,
   locale: (import.meta.env.VITE_I18N_LOCALE as string | undefined) || 'en',
-  messages,
+  messages: { en },
   modifiers: {
     quote: (val, type) => type === 'text' && typeof val === 'string'
       ? `"${val}"`
@@ -15,3 +17,13 @@ export const i18n = createI18n({
   },
   silentTranslationWarn: import.meta.env.VITE_SILENT_TRANSLATION_WARN === 'true',
 });
+
+export async function loadLocaleMessages(locale: string): Promise<void> {
+  if (loadedLocales.has(locale))
+    return;
+
+  const messages = await import(`./locales/${locale}.json`);
+  i18n.global.setLocaleMessage(locale, messages.default);
+  loadedLocales.add(locale);
+  return nextTick();
+}

--- a/frontend/app/src/pages/settings/account/index.vue
+++ b/frontend/app/src/pages/settings/account/index.vue
@@ -18,9 +18,9 @@ enum Category {
   SECURITY = 'security',
 }
 
-const navigation = [
+const navigation = computed<{ id: Category; label: string }[]>(() => [
   { id: Category.SECURITY, label: t('settings.security_settings.title') },
-];
+]);
 </script>
 
 <template>

--- a/frontend/app/src/pages/settings/database/index.vue
+++ b/frontend/app/src/pages/settings/database/index.vue
@@ -23,13 +23,13 @@ enum Category {
   ASSET_DATABASE = 'asset-database',
 }
 
-const navigation = [
+const navigation = computed<{ id: Category; label: string }[]>(() => [
   { id: Category.DATABASE_INFO, label: t('database_settings.database_info.title') },
   { id: Category.USER_BACKUPS, label: t('database_settings.user_backups.title') },
   { id: Category.MANAGE_DATA, label: t('database_settings.manage_data.title') },
   { id: Category.IMPORT_EXPORT, label: t('database_settings.import_export.title') },
   { id: Category.ASSET_DATABASE, label: t('database_settings.asset_database.title') },
-];
+]);
 </script>
 
 <template>

--- a/frontend/app/src/pages/settings/evm/index.vue
+++ b/frontend/app/src/pages/settings/evm/index.vue
@@ -20,10 +20,10 @@ enum Category {
   INDEXER = 'indexer',
 }
 
-const navigation = [
+const navigation = computed<{ id: Category; label: string }[]>(() => [
   { id: Category.CHAINS, label: t('evm_settings.general.title') },
   { id: Category.INDEXER, label: t('evm_settings.indexer.title') },
-];
+]);
 </script>
 
 <template>

--- a/frontend/app/src/pages/settings/general/index.vue
+++ b/frontend/app/src/pages/settings/general/index.vue
@@ -25,14 +25,14 @@ enum Category {
   BACKEND = 'backend',
 }
 
-const navigation = [
+const navigation = computed<{ id: Category; label: string }[]>(() => [
   { id: Category.GENERAL, label: t('general_settings.title') },
   { id: Category.AMOUNT, label: t('general_settings.amount.title') },
   { id: Category.NFT, label: t('general_settings.nft_setting.title') },
   { id: Category.HISTORY_EVENT, label: t('general_settings.history_event.title') },
   { id: Category.EXTERNAL_SERVICE, label: t('general_settings.external_service_setting.title') },
   { id: Category.BACKEND, label: t('backend_settings.title') },
-];
+]);
 </script>
 
 <template>

--- a/frontend/app/src/pages/settings/interface/index.vue
+++ b/frontend/app/src/pages/settings/interface/index.vue
@@ -23,13 +23,13 @@ enum Category {
   THEME = 'theme',
 }
 
-const navigation = [
+const navigation = computed<{ id: Category; label: string }[]>(() => [
   { id: Category.INTERFACE_ONLY, label: t('frontend_settings.title') },
   { id: Category.GRAPH, label: t('frontend_settings.subtitle.graph_settings') },
   { id: Category.ALIAS, label: t('frontend_settings.subtitle.alias_names') },
   { id: Category.NEWLY_DETECTED_TOKENS, label: t('frontend_settings.newly_detected_tokens.title') },
   { id: Category.THEME, label: t('premium_components.theme_manager.text') },
-];
+]);
 </script>
 
 <template>

--- a/frontend/app/src/pages/settings/oracle/index.vue
+++ b/frontend/app/src/pages/settings/oracle/index.vue
@@ -19,11 +19,11 @@ enum Category {
   PENALTY = 'penalty',
 }
 
-const navigation = [
+const navigation = computed<{ id: Category; label: string }[]>(() => [
   { id: Category.PRICE_ORACLE, label: t('price_oracle_settings.title') },
   { id: Category.CACHE_MANAGEMENT, label: t('oracle_cache_management.title') },
   { id: Category.PENALTY, label: t('oracle_cache_management.penalty.title') },
-];
+]);
 </script>
 
 <template>

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -1,6 +1,6 @@
 import type { ComponentResolver } from 'unplugin-vue-components';
 import { builtinModules } from 'node:module';
-import path, { join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import process from 'node:process';
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
 import { ruiIconsPlugin } from '@rotki/ui-library/vite-plugin';
@@ -158,7 +158,7 @@ export default defineConfig({
       ],
     }),
     VueI18nPlugin({
-      include: [path.resolve(__dirname, './src/locales/**')],
+      include: [resolve(PACKAGE_ROOT, './src/locales/**')],
     }),
     ...(!isTest && process.env.ENABLE_DEV_TOOLS ? [vueDevTools()] : []),
   ],


### PR DESCRIPTION
## Summary
- Load only the English locale eagerly as the default/fallback
- Other locales (ru, fr, gr, es, cn, de) are loaded on demand via dynamic `import()` when the user switches language
- Remove the `@intlify/unplugin-vue-i18n/messages` bulk import that bundled all 7 locales into one chunk (~1,355 KB)

This splits each locale into its own lazy-loaded chunk, removing ~1,100 KB from the initial bundle.

## Test plan
- [x] App loads with English locale
- [x] Switching language in settings loads the new locale (check Network tab for dynamic chunk)
- [x] Fallback to English works when a translation key is missing in another locale