### PR TITLE
Remove base from routescan supported chains list

### DIFF
--- a/rotkehlchen/externalapis/routescan.py
+++ b/rotkehlchen/externalapis/routescan.py
@@ -31,9 +31,9 @@ log = RotkehlchenLogsAdapter(logger)
 # follows: `Result window is too large, PageNo x Offset size must be less than or equal to 10000`
 ROUTESCAN_PAGINATION_LIMIT: Final = 10000
 ROUTESCAN_BASE_URL: Final = 'https://api.routescan.io/v2/network/mainnet/evm/{chain_id}/etherscan/api'
-# Arbitrum One is also supported, but currently (2025-11-28) has a status of `Indexing in progress`
-# so may have some missing data. See https://docs.routescan.io/indexing-status
-ROUTESCAN_SUPPORTED_CHAINS: Final = (ChainID.ETHEREUM, ChainID.OPTIMISM, ChainID.BASE)
+# Arbitrum One and Base are also partially supported, but currently (2026-02-13) have a status
+# of `Not fully indexed` so may be missing data. See https://docs.routescan.io/indexing-status
+ROUTESCAN_SUPPORTED_CHAINS: Final = (ChainID.ETHEREUM, ChainID.OPTIMISM)
 
 
 class Routescan(ExternalServiceWithApiKey, EtherscanLikeApi):

--- a/rotkehlchen/tests/api/blockchain/test_evm.py
+++ b/rotkehlchen/tests/api/blockchain/test_evm.py
@@ -606,7 +606,7 @@ def test_argent_names(rotkehlchen_api_server: 'APIServer') -> None:
 @pytest.mark.parametrize('optimism_manager_connect_at_start', [(OPTIMISM_MAINNET_NODE,)])
 @pytest.mark.parametrize('binance_sc_manager_connect_at_start', BSC_NODES_TO_CONNECT)
 @pytest.mark.parametrize('base_manager_connect_at_start', [(BASE_MAINNET_NODE,)])
-def test_adding_safe(rotkehlchen_api_server: 'APIServer') -> None:
+def test_adding_safe(rotkehlchen_api_server: 'APIServer', allow_base_routescan: None) -> None:
     """Test adding a safe proxy. The address is deployed on arb and base only"""
     safe_address = string_to_evm_address('0x9d25AdBcffE28923E619f4Af88ECDe732c985b63')
     request_data = {'accounts': [{'address': safe_address}]}

--- a/rotkehlchen/tests/unit/decoders/test_basenames.py
+++ b/rotkehlchen/tests/unit/decoders/test_basenames.py
@@ -11,9 +11,7 @@ from rotkehlchen.chain.base.modules.basenames.constants import (
 )
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import (
-    EvmIndexer,
     NodeName,
-    SerializableChainIndexerOrder,
     WeightedNode,
     string_to_evm_address,
 )
@@ -26,7 +24,6 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.tests.unit.test_types import LEGACY_TESTS_INDEXER_ORDER
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import (
-    ChainID,
     Location,
     SupportedBlockchain,
     Timestamp,
@@ -478,13 +475,6 @@ def test_basenames_new_owner(
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('db_settings', [{
-    'evm_indexers_order': SerializableChainIndexerOrder(
-        order={
-            ChainID.BASE: [EvmIndexer.ROUTESCAN],
-        },
-    ),
-}])
 @pytest.mark.parametrize('base_manager_connect_at_start', [(
     WeightedNode(
         node_info=NodeName(
@@ -499,6 +489,7 @@ def test_basenames_new_owner(
 def test_basenames_ignore_untracked_events(
         base_inquirer: 'BaseInquirer',
         base_accounts: list['ChecksumEvmAddress'],
+        allow_base_routescan: None,
 ) -> None:
     """Regression test for https://github.com/rotki/rotki/issues/11551"""
     tx_hash = deserialize_evm_tx_hash('0x2cb9dcf83b3fd1bbbec4cd5f8d0b688bfc3f6aadd99081f28eaccafcd26c4243')  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_mintclub.py
+++ b/rotkehlchen/tests/unit/decoders/test_mintclub.py
@@ -5,9 +5,7 @@ from rotkehlchen.chain.base.modules.mintclub.constants import CPT_MINTCLUB
 from rotkehlchen.chain.base.transactions import BaseTransactions
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.types import (
-    EvmIndexer,
     NodeName,
-    SerializableChainIndexerOrder,
     WeightedNode,
     string_to_evm_address,
 )
@@ -18,7 +16,6 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import (
-    ChainID,
     Location,
     SupportedBlockchain,
     Timestamp,
@@ -28,11 +25,6 @@ from rotkehlchen.types import (
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('db_settings', [{
-    'evm_indexers_order': SerializableChainIndexerOrder(
-        order={ChainID.BASE: [EvmIndexer.ROUTESCAN]},
-    ),
-}])
 @pytest.mark.parametrize('base_manager_connect_at_start', [(
     WeightedNode(  # give some open RPC for Base to get the data from
         node_info=NodeName(
@@ -46,7 +38,7 @@ from rotkehlchen.types import (
     ),
 )])
 @pytest.mark.parametrize('base_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
-def test_mintclub_claim(base_inquirer, base_accounts) -> None:
+def test_mintclub_claim(base_inquirer, base_accounts, allow_base_routescan) -> None:
     tx_hash = deserialize_evm_tx_hash('0xfaa51ffecb5388ef59808d4f3f5e6e07b8a47d4a7d195c467bf77c24ee77b287')  # noqa: E501
     transactions = BaseTransactions(base_inquirer, base_inquirer.database)
     transactions.single_address_query_transactions(  # temporary hack at the time of writing get_decoded_events_of_transaction does not respect the `evm_indexers_order` so we do this here to use the given order  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_morpho.py
+++ b/rotkehlchen/tests/unit/decoders/test_morpho.py
@@ -593,7 +593,11 @@ def test_morpho_deposit_eth_and_weth_base(
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('base_accounts', [['0x21f2a9b5F420245d86E8Faa753022dA01946B13F']])
-def test_vault_withdrawal_deposit_with_wallet_tokens(base_inquirer: 'BaseInquirer', base_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
+def test_vault_withdrawal_deposit_with_wallet_tokens(
+        base_inquirer: 'BaseInquirer',
+        base_accounts: list['ChecksumEvmAddress'],
+        allow_base_routescan: None,
+) -> None:
     """Regression test for morpho transaction where a user withdraws from one vault and
     deposits into another vault, combining it with additional tokens from their wallet.
     """

--- a/rotkehlchen/tests/unit/decoders/test_safe.py
+++ b/rotkehlchen/tests/unit/decoders/test_safe.py
@@ -13,9 +13,7 @@ from rotkehlchen.chain.ethereum.modules.safe.constants import (
 )
 from rotkehlchen.chain.evm.decoding.safe.constants import CPT_SAFE_MULTISIG
 from rotkehlchen.chain.evm.types import (
-    EvmIndexer,
     NodeName,
-    SerializableChainIndexerOrder,
     WeightedNode,
     string_to_evm_address,
 )
@@ -27,7 +25,6 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.types import (
-    ChainID,
     Location,
     SupportedBlockchain,
     Timestamp,
@@ -264,11 +261,6 @@ def test_execution_failure(ethereum_inquirer, ethereum_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
-@pytest.mark.parametrize('db_settings', [{
-    'evm_indexers_order': SerializableChainIndexerOrder(
-        order={ChainID.BASE: [EvmIndexer.ROUTESCAN]},
-    ),
-}])
 @pytest.mark.parametrize('base_manager_connect_at_start', [(
     WeightedNode(
         node_info=NodeName(

--- a/rotkehlchen/tests/unit/test_indexers.py
+++ b/rotkehlchen/tests/unit/test_indexers.py
@@ -51,16 +51,6 @@ def fixture_check_all_indexers(request: pytest.FixtureRequest) -> Iterator[None]
     yield from _patch_indexers(request.param)
 
 
-@pytest.fixture(name='check_all_indexers_excluding_etherscan', params=[
-    [ETHERSCAN_PATCH, ROUTESCAN_PATCH],  # Uses blockscout
-    [ETHERSCAN_PATCH, BLOCKSCOUT_PATCH],  # Uses routescan.
-])
-def fixture_check_all_indexers_excluding_etherscan(request: pytest.FixtureRequest) -> Iterator[None]:  # noqa: E501
-    """Run the test once for each indexer except for etherscan. Used for chains that etherscan
-    doesn't support."""
-    yield from _patch_indexers(request.param)
-
-
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_get_contract_abi(
         ethereum_inquirer: 'EthereumInquirer',
@@ -186,7 +176,6 @@ def test_get_transaction_by_hash(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 def test_get_transaction_by_hash_l1_fee(
         base_inquirer: 'BaseInquirer',
-        check_all_indexers_excluding_etherscan,
 ) -> None:
     """Check that we can properly retrieve the gas amount for a chain that has an L1 fee."""
     tx, _ = base_inquirer.get_transaction_by_hash(


### PR DESCRIPTION
Removes Base from the list of chains supported by routescan since they have stopped indexing it, and it now has a `Not fully indexed` status: https://docs.routescan.io/indexing-status
