### PR TITLE
fix(frontend): movement group show all tx hashes

### DIFF
--- a/frontend/app/src/components/common/AppImage.vue
+++ b/frontend/app/src/components/common/AppImage.vue
@@ -17,6 +17,7 @@ const props = withDefaults(
     contain?: boolean;
     cover?: boolean;
     loading?: boolean;
+    imageClass?: string;
   }>(),
   {
     alt: undefined,
@@ -30,6 +31,7 @@ const props = withDefaults(
     src: undefined,
     srcset: undefined,
     width: undefined,
+    imageClass: undefined,
   },
 );
 
@@ -81,7 +83,7 @@ function onLoadStart() {
     <img
       v-else-if="error"
       :src="getPublicPlaceholderImagePath('image.svg')"
-      :class="{ 'object-contain': contain, 'object-cover': cover }"
+      :class="[{ 'object-contain': contain, 'object-cover': cover }, imageClass]"
       loading="lazy"
       :style="style"
       :sizes="sizes"
@@ -90,7 +92,7 @@ function onLoadStart() {
     <img
       v-else
       :alt="alt"
-      :class="{ 'object-contain': contain, 'object-cover': cover }"
+      :class="[{ 'object-contain': contain, 'object-cover': cover }, imageClass]"
       :style="style"
       :src="src"
       :sizes="sizes"

--- a/frontend/app/src/components/history/LocationIcon.vue
+++ b/frontend/app/src/components/history/LocationIcon.vue
@@ -9,6 +9,7 @@ const props = withDefaults(
     icon?: boolean;
     size?: string;
     noPadding?: boolean;
+    imageClass?: string;
   }>(),
   {
     horizontal: false,
@@ -47,6 +48,7 @@ const location = locationData(item);
         :src="location.image"
         :alt="location.name"
         contain
+        :image-class="imageClass"
         :size="size"
         class="icon-bg"
       />

--- a/frontend/app/src/components/history/events/HistoryEventAsset.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAsset.vue
@@ -64,8 +64,8 @@ function openMenuHandler(event: MouseEvent): void {
   >
     <template #activator="{ attrs }">
       <div
-        class="flex items-center py-2 gap-2 overflow-hidden"
-        :class="!disableOptions && 'cursor-pointer hover:bg-rui-grey-200 dark:hover:bg-rui-grey-900 rounded-md group/asset -ml-1 pl-1 min-h-14 pr-14 relative'"
+        class="flex items-center py-2 gap-2 overflow-hidden transition-colors"
+        :class="!disableOptions && 'cursor-pointer hover:bg-rui-grey-300 dark:hover:bg-rui-grey-900 rounded-md group/asset -ml-1 pl-1 min-h-14 pr-14 relative'"
         v-bind="attrs"
         @contextmenu="openMenuHandler($event)"
       >

--- a/frontend/app/src/components/history/events/HistoryEventType.vue
+++ b/frontend/app/src/components/history/events/HistoryEventType.vue
@@ -62,7 +62,7 @@ const showLocationLabel = computed<boolean>(() => {
       class="shrink-0"
     />
 
-    <div class="ml-3.5 min-w-0">
+    <div class="ml-3 min-w-0">
       <div class="font-medium uppercase text-sm truncate">
         {{ attrs.label }}
       </div>

--- a/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
+++ b/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
@@ -68,7 +68,7 @@ const displayAddress = computed<string | undefined>(() => {
     v-if="counterpartyData || displayAddress"
     class="[&_span]:!px-0"
     color="default"
-    offset-x="-6"
+    offset-x="-8"
     offset-y="6"
   >
     <template #icon>

--- a/frontend/app/src/components/history/events/HistoryEventsIdentifier.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsIdentifier.vue
@@ -10,19 +10,25 @@ import {
 
 const props = defineProps<{
   event: HistoryEventEntry;
-  truncate?: boolean;
+  groupEvents?: HistoryEventEntry[];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { event } = toRefs(props);
 
-const { is2xlAndUp } = useBreakpoint();
+const { is2xlAndUp, isMd } = useBreakpoint();
 
 const truncateLength = computed<number>(() => {
-  if (props.truncate)
-    return 8;
-  return get(is2xlAndUp) ? 0 : 8;
+  if (get(is2xlAndUp)) {
+    return 12;
+  }
+
+  if (get(isMd)) {
+    return 6;
+  }
+
+  return 8;
 });
 
 const blockEvent = isEthBlockEventRef(event);
@@ -38,6 +44,31 @@ const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>
   }
   return undefined;
 });
+
+const allTxRefs = computed<{ location: string; txRef: string }[]>(() => {
+  if (!get(assetMovementEvent) || !props.groupEvents)
+    return [];
+
+  const seen = new Set<string>();
+  const result: { location: string; txRef: string }[] = [];
+
+  for (const child of props.groupEvents) {
+    if (!('txRef' in child) || !child.txRef || seen.has(child.txRef))
+      continue;
+
+    seen.add(child.txRef);
+    result.push({
+      location: child.location,
+      txRef: child.txRef,
+    });
+  }
+
+  return result;
+});
+
+const extraHashCount = computed<number>(() => Math.max(get(allTxRefs).length - 1, 0));
+
+const hashMenuOpen = ref<boolean>(false);
 
 const translationKey = computed<string>(() => {
   // consider an evm swap event as a case of evm event
@@ -111,25 +142,69 @@ const key = computed(() => {
     </template>
 
     <template
-      v-if="eventWithTxRef || assetMovementTransactionId"
+      v-if="eventWithTxRef || assetMovementTransactionId || allTxRefs.length > 0"
       #txRef
     >
+      <!-- Asset movement: show all tx hashes with location icon -->
+      <template v-if="assetMovementEvent && allTxRefs.length > 0">
+        <HashLink
+          class="bg-rui-grey-300 dark:bg-rui-grey-800 pr-1 pl-2 rounded-full m-0.5"
+          :text="allTxRefs[0].txRef"
+          type="transaction"
+          :location="allTxRefs[0].location"
+          :truncate-length="truncateLength"
+          show-location-icon
+        />
+        <RuiMenu
+          v-if="extraHashCount > 0"
+          v-model="hashMenuOpen"
+          :popper="{ placement: 'bottom-start' }"
+        >
+          <template #activator="{ attrs }">
+            <RuiButton
+              size="sm"
+              icon
+              class="-ml-1 !h-6 !px-2 text-xs !bg-rui-grey-300 hover:!bg-rui-grey-400 dark:!bg-rui-grey-800 hover:dark:!bg-rui-grey-700 dark:!text-white"
+              v-bind="attrs"
+            >
+              {{ extraHashCount }}+
+            </RuiButton>
+          </template>
+          <div class="flex flex-col gap-1 p-2">
+            <HashLink
+              v-for="(item, index) in allTxRefs.slice(1)"
+              :key="index"
+              class="bg-rui-grey-200 dark:bg-rui-grey-800 pr-1 pl-2 rounded-full text-xs"
+              :text="item.txRef"
+              type="transaction"
+              :location="item.location"
+              :truncate-length="truncateLength"
+              show-location-icon
+            />
+          </div>
+        </RuiMenu>
+      </template>
+
+      <!-- Asset movement fallback: transactionId from extraData -->
       <HashLink
-        v-if="eventWithTxRef"
-        class="bg-rui-grey-300 dark:bg-rui-grey-800 pr-1 pl-2 rounded-full m-0.5"
-        :text="eventWithTxRef.txRef"
-        type="transaction"
-        :location="eventWithTxRef.location"
-        :truncate-length="truncateLength"
-      />
-      <HashLink
-        v-else-if="assetMovementTransactionId"
+        v-else-if="assetMovementEvent && assetMovementTransactionId"
         class="bg-rui-grey-300 dark:bg-rui-grey-800 pr-1 pl-2 rounded-full m-0.5"
         :text="assetMovementTransactionId"
         type="transaction"
         :location="assetMovementEvent?.extraData?.blockchain || undefined"
         :truncate-length="truncateLength"
         :display-mode="assetMovementEvent?.extraData?.blockchain ? 'default' : 'copy'"
+        show-location-icon
+      />
+
+      <!-- Non-asset-movement: show single hash as before -->
+      <HashLink
+        v-else-if="eventWithTxRef"
+        class="bg-rui-grey-300 dark:bg-rui-grey-800 pr-1 pl-2 rounded-full m-0.5"
+        :text="eventWithTxRef.txRef"
+        type="transaction"
+        :location="eventWithTxRef.location"
+        :truncate-length="truncateLength"
       />
     </template>
 

--- a/frontend/app/src/modules/common/links/HashLink.vue
+++ b/frontend/app/src/modules/common/links/HashLink.vue
@@ -2,6 +2,7 @@
 import type { RuiTooltip } from '@rotki/ui-library';
 import { Blockchain, consistOfNumbers } from '@rotki/common';
 import EnsAvatar from '@/components/display/EnsAvatar.vue';
+import LocationIcon from '@/components/history/LocationIcon.vue';
 import TagDisplay from '@/components/tags/TagDisplay.vue';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useScramble } from '@/composables/scramble';
@@ -63,6 +64,11 @@ interface HashLinkProps {
    */
   type?: keyof ExplorerUrls;
   noScramble?: boolean;
+  /**
+   * Whether to show a location/chain icon before the hash text.
+   * Requires `location` to be set.
+   */
+  showLocationIcon?: boolean;
 }
 
 const props = withDefaults(defineProps<HashLinkProps>(), {
@@ -70,6 +76,7 @@ const props = withDefaults(defineProps<HashLinkProps>(), {
   hideText: false,
   location: undefined,
   noScramble: false,
+  showLocationIcon: false,
   size: 12,
   truncateLength: 4,
   type: 'address',
@@ -196,6 +203,15 @@ const tags = useAccountTags(text);
 
 <template>
   <div class="flex flex-row shrink items-center gap-1.5 text-xs [&_*]:font-mono [&_*]:leading-6 min-h-[22px] min-w-0">
+    <LocationIcon
+      v-if="showLocationIcon && location"
+      icon
+      :item="location"
+      image-class="!size-4"
+      size="20px"
+      class="min-w-5 bg-white !rounded-full overflow-hidden -ml-1.5"
+    />
+
     <EnsAvatar
       v-if="showIcon"
       :address="displayText"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -11,6 +11,7 @@ import LocationIcon from '@/components/history/LocationIcon.vue';
 
 const props = withDefaults(defineProps<{
   group: HistoryEventEntry;
+  groupEvents?: HistoryEventEntry[];
   hideActions?: boolean;
   loading?: boolean;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<{
   showingIgnoredAssets?: boolean;
   variant?: 'row' | 'card';
 }>(), {
+  groupEvents: () => [],
   variant: 'row',
 });
 
@@ -94,7 +96,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
 
         <HistoryEventsIdentifier
           :event="group"
-          truncate
+          :group-events="groupEvents"
           class="min-w-0 flex-1"
         />
       </div>
@@ -134,7 +136,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
   <!-- Row Layout -->
   <div
     v-else
-    class="h-12 flex items-center gap-2.5 border-b border-default !border-t-rui-grey-400 dark:!border-t-rui-grey-600 pl-2 pr-4 bg-rui-grey-100 dark:bg-dark-elevated contain-content"
+    class="h-12 flex items-center gap-2.5 border-b border-default !border-t-rui-grey-400 dark:!border-t-rui-grey-600 pl-2 pr-4 bg-white dark:bg-dark-elevated contain-content"
   >
     <IgnoredInAccountingIcon
       v-if="group.ignoredInAccounting"
@@ -181,7 +183,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
     <div class="flex items-center gap-2.5 min-w-0 flex-1">
       <HistoryEventsIdentifier
         :event="group"
-        truncate
+        :group-events="groupEvents"
         class="min-w-0"
       />
 
@@ -199,7 +201,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
     <DateDisplay
       :timestamp="group.timestamp"
       milliseconds
-      class="w-40 text-right shrink-0 text-sm"
+      class="text-right shrink-0 text-sm"
     />
 
     <HistoryEventsAction

--- a/frontend/app/src/modules/history/events/components/HistoryEventsSwapCollapseRow.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsSwapCollapseRow.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/types/history/events/schemas';
-import HashLink from '@/modules/common/links/HashLink.vue';
 
 const props = defineProps<{
   eventCount: number;
@@ -18,28 +17,11 @@ const { t } = useI18n({ useScope: 'global' });
 const isMovement = computed<boolean>(() => props.labelType === 'movement');
 
 const { isMdAndUp } = useBreakpoint();
-
-const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>(() => {
-  const events = props.events;
-  if (!events)
-    return undefined;
-
-  for (const event of events) {
-    const isDepositOrWithdrawal = event.eventType === 'deposit' || event.eventType === 'withdrawal' || event.eventType === 'exchange transfer';
-    if (isDepositOrWithdrawal && 'txRef' in event && event.txRef) {
-      return {
-        location: event.location,
-        txRef: event.txRef,
-      };
-    }
-  }
-  return undefined;
-});
 </script>
 
 <template>
   <div
-    class="h-9 flex items-center gap-2 border-default pr-4 pl-2 bg-gradient-to-b from-rui-grey-100 to-transparent dark:from-rui-grey-900 group/row relative mx-2 rounded-t-2xl mt-0.5"
+    class="h-9 flex items-center gap-2 border-default pr-4 pl-2 bg-gradient-to-b from-rui-grey-300 to-transparent dark:from-rui-grey-900 group/row relative mx-2 rounded-t-2xl mt-[3px]"
   >
     <!-- Collapse button (absolute top-left like expand) -->
     <RuiButton
@@ -66,15 +48,6 @@ const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>
       }}
     </span>
 
-    <!-- Transaction hash -->
-    <HashLink
-      v-if="eventWithTxRef"
-      class="bg-rui-grey-200 dark:bg-rui-grey-800 pr-1 pl-2 rounded-full text-xs"
-      :text="eventWithTxRef.txRef"
-      type="transaction"
-      :location="eventWithTxRef.location"
-      :truncate-length="8"
-    />
     <RuiTooltip
       :open-delay="200"
       :disabled="isMdAndUp"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
@@ -77,7 +77,7 @@ const limits = [10, 25, 50, 100];
 </script>
 
 <template>
-  <div class="relative flex items-center justify-between gap-2 md:gap-4 px-3 md:px-4 h-10 lg:h-12 border-b border-default bg-rui-grey-50 dark:bg-dark-elevated/[0.9] sticky top-0 z-5">
+  <div class="relative flex items-center justify-between gap-2 md:gap-4 px-3 md:px-4 h-10 lg:h-12 border-b border-default bg-white dark:bg-dark-elevated/[0.9] sticky top-0 z-5">
     <RuiProgress
       v-if="loading"
       class="!absolute -bottom-0.5 left-0 w-full pointer-events-none"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -198,7 +198,7 @@ function unlinkGroup(groupId: string): void {
 </script>
 
 <template>
-  <div class="flex flex-col border border-default rounded-lg overflow-hidden bg-white dark:bg-dark-surface">
+  <div class="flex flex-col border border-default rounded-lg overflow-hidden bg-slate-50 dark:bg-dark-surface">
     <!-- Sticky Header with Sort + Pagination -->
     <HistoryEventsVirtualHeader
       v-model:sort="sort"
@@ -265,6 +265,7 @@ function unlinkGroup(groupId: string): void {
           <HistoryEventsGroupItem
             v-if="row.type === 'group-header'"
             :group="row.data"
+            :group-events="getGroupEvents(row.groupId)"
             :hide-actions="hideActions"
             :loading="eventsLoading"
             :duplicate-handling-status="duplicateHandlingStatus"


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=156941805

- [x] move movements group tx hashes to the top.
- [x] some styling adjustment (bg colors)