### PR TITLE
fix(frontend): restrict mark as spam to EVM and Solana

### DIFF
--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetActions.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetActions.vue
@@ -15,9 +15,10 @@ const ignoredFilter = defineModel<IgnoredFilter>('ignoredFilter', { required: tr
 const selected = defineModel<string[]>('selected', { required: true });
 const filtersModel = defineModel<Filters>('matches', { required: true });
 
-defineProps<{
+const { spamDisabled = false } = defineProps<{
   ignoredAssets: string[];
   matchers: Matcher[];
+  spamDisabled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -71,7 +72,7 @@ function handleRefreshIgnored(): void {
               class="min-w-[5.625rem]"
               variant="outlined"
               color="error"
-              :disabled="selected.length === 0"
+              :disabled="selected.length === 0 || spamDisabled"
               @click="handleMarkSpam()"
             >
               <template #prepend>

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetIgnoreSwitch.spec.ts
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetIgnoreSwitch.spec.ts
@@ -1,0 +1,67 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ManagedAssetIgnoreSwitch from './ManagedAssetIgnoreSwitch.vue';
+
+vi.mock('@/store/assets/ignored', () => ({
+  useIgnoredAssetsStore: vi.fn().mockReturnValue({
+    useIsAssetIgnored: (): Ref<boolean> => ref(false),
+  }),
+}));
+
+vi.mock('@/store/assets/whitelisted', () => ({
+  useWhitelistedAssetsStore: vi.fn().mockReturnValue({
+    useIsAssetWhitelisted: (): Ref<boolean> => ref(false),
+  }),
+}));
+
+describe('managedAssetIgnoreSwitch', () => {
+  let wrapper: VueWrapper;
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createCustomPinia();
+    setActivePinia(pinia);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  function createWrapper(asset: { identifier: string; assetType?: string | null; protocol?: string | null }): VueWrapper {
+    return mount(ManagedAssetIgnoreSwitch, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+      },
+      props: { asset },
+    });
+  }
+
+  it('shows spam/whitelist menu for EVM token assets', () => {
+    wrapper = createWrapper({ identifier: 'eip155:1/erc20:0x1234', assetType: 'evm token' });
+    expect(wrapper.findComponent({ name: 'RuiMenu' }).exists()).toBe(true);
+  });
+
+  it('shows spam/whitelist menu for Solana token assets', () => {
+    wrapper = createWrapper({ identifier: 'solana:SOL/spl:TokenAddr', assetType: 'solana token' });
+    expect(wrapper.findComponent({ name: 'RuiMenu' }).exists()).toBe(true);
+  });
+
+  it('hides spam/whitelist menu for custom assets', () => {
+    wrapper = createWrapper({ identifier: 'my-custom-asset', assetType: 'custom asset' });
+    expect(wrapper.findComponent({ name: 'RuiMenu' }).exists()).toBe(false);
+  });
+
+  it('hides spam/whitelist menu for assets with no type', () => {
+    wrapper = createWrapper({ identifier: 'BTC', assetType: null });
+    expect(wrapper.findComponent({ name: 'RuiMenu' }).exists()).toBe(false);
+  });
+
+  it('hides spam/whitelist menu for unknown asset types', () => {
+    wrapper = createWrapper({ identifier: 'some-asset', assetType: 'other type' });
+    expect(wrapper.findComponent({ name: 'RuiMenu' }).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetIgnoreSwitch.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetIgnoreSwitch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useIgnoredAssetsStore } from '@/store/assets/ignored';
 import { useWhitelistedAssetsStore } from '@/store/assets/whitelisted';
-import { EVM_TOKEN } from '@/types/asset';
+import { isSpammableAssetType } from '@/types/asset';
 
 interface AssetForIgnoreSwitch {
   identifier: string;
@@ -34,7 +34,7 @@ const { useIsAssetWhitelisted } = useWhitelistedAssetsStore();
 
 const identifier = computed<string>(() => props.asset.identifier);
 const isSpam = computed<boolean>(() => props.asset.protocol === 'spam');
-const showMoreOptions = computed<boolean>(() => props.asset.assetType === EVM_TOKEN);
+const showMoreOptions = computed<boolean>(() => isSpammableAssetType(props.asset.assetType));
 
 const isIgnored = useIsAssetIgnored(identifier);
 const isWhitelisted = useIsAssetWhitelisted(identifier);

--- a/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
+++ b/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
@@ -6,7 +6,7 @@ import { useSpamAsset } from '@/composables/assets/spam';
 import { useRefMap } from '@/composables/utils/useRefMap';
 import HashLink from '@/modules/common/links/HashLink.vue';
 import { useIgnoredAssetsStore } from '@/store/assets/ignored';
-import { EVM_TOKEN } from '@/types/asset';
+import { isSpammableAssetType } from '@/types/asset';
 
 const props = defineProps<{
   asset: NftAsset;
@@ -179,7 +179,7 @@ defineExpose({
                   {{ t('assets.action.ignore') }}
                 </RuiTooltip>
                 <RuiTooltip
-                  v-if="asset.assetType === EVM_TOKEN"
+                  v-if="isSpammableAssetType(asset.assetType)"
                   :open-delay="200"
                   :popper="{ placement: 'top' }"
                 >

--- a/frontend/app/src/types/asset/index.ts
+++ b/frontend/app/src/types/asset/index.ts
@@ -118,6 +118,10 @@ export const SOLANA_CHAIN = 'solana';
 
 export const CUSTOM_ASSET = 'custom asset';
 
+export function isSpammableAssetType(assetType?: string | null): boolean {
+  return assetType === EVM_TOKEN || assetType === SOLANA_TOKEN;
+}
+
 export interface AssetUpdatePayload {
   readonly resolution?: ConflictResolution;
   readonly version: number;


### PR DESCRIPTION
## Summary
- The mark as spam feature only works for EVM and Solana tokens on the backend, but the UI allowed it for all asset types
- Add a centralized `isSpammableAssetType()` helper in `types/asset` and use it across all spam entry points
- Disable the bulk "Mark as spam" button in the managed assets table when no selected assets are EVM/Solana
- Add unit tests for `ManagedAssetIgnoreSwitch` to verify the spam menu visibility per asset type

## Test plan
- [x] Unit tests pass for `ManagedAssetIgnoreSwitch` (5 tests)
- [ ] Verify spam/whitelist menu appears on EVM token asset detail pages
- [ ] Verify spam/whitelist menu appears on Solana token asset detail pages
- [ ] Verify spam/whitelist menu does not appear on non-EVM/non-Solana assets
- [ ] Verify bulk "Mark as spam" button is disabled when only non-EVM/non-Solana assets are selected