### PR TITLE
fix(frontend): exclude exchanges from counterparty mapping input

### DIFF
--- a/frontend/app/src/components/inputs/CounterpartyInput.vue
+++ b/frontend/app/src/components/inputs/CounterpartyInput.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import CounterpartyDisplay from '@/components/history/CounterpartyDisplay.vue';
 import { useHistoryEventCounterpartyMappings } from '@/composables/history/events/mapping/counterparty';
+import { useLocationStore } from '@/store/locations';
 
 defineOptions({
   inheritAttrs: false,
@@ -8,7 +9,20 @@ defineOptions({
 
 const modelValue = defineModel<string | undefined>({ required: true });
 
+const { excludeExchanges = false } = defineProps<{
+  excludeExchanges?: boolean;
+}>();
+
 const { counterparties } = useHistoryEventCounterpartyMappings();
+const { allExchanges } = storeToRefs(useLocationStore());
+
+const filteredCounterparties = computed<string[]>(() => {
+  if (!excludeExchanges)
+    return get(counterparties);
+
+  const exchanges = get(allExchanges);
+  return get(counterparties).filter(c => !exchanges.includes(c));
+});
 </script>
 
 <template>
@@ -18,7 +32,7 @@ const { counterparties } = useHistoryEventCounterpartyMappings();
     clearable
     v-bind="$attrs"
     auto-select-first
-    :options="counterparties"
+    :options="filteredCounterparties"
   >
     <template #item="{ item }">
       <CounterpartyDisplay :counterparty="item" />

--- a/frontend/app/src/modules/asset-manager/counterparty-mapping/CounterpartyMappingFilter.vue
+++ b/frontend/app/src/modules/asset-manager/counterparty-mapping/CounterpartyMappingFilter.vue
@@ -21,6 +21,7 @@ const { t } = useI18n({ useScope: 'global' });
       v-model="counterparty"
       :label="t('asset_management.counterparty_mapping.filter_by_counterparty')"
       class="w-full"
+      exclude-exchanges
       dense
       hide-details
       clearable

--- a/frontend/app/src/modules/asset-manager/counterparty-mapping/ManageCounterpartyMappingForm.vue
+++ b/frontend/app/src/modules/asset-manager/counterparty-mapping/ManageCounterpartyMappingForm.vue
@@ -72,6 +72,7 @@ defineExpose({
       v-model="counterpartyModel"
       :label="t('common.counterparty')"
       :disabled="editMode"
+      exclude-exchanges
       clearable
       :error-messages="toMessages(v$.counterparty)"
     />


### PR DESCRIPTION
## Summary
- Exchange locations (e.g. iconomi, okx) were shown in the counterparty mapping dropdown but rejected by the backend with a 400 error since only decoder counterparties are valid
- Added `excludeExchanges` prop to `CounterpartyInput` that filters out exchange identifiers using the location store
- Applied the filter in both the counterparty mapping form and its filter component

## Test plan
- [ ] Open counterparty mapping page and verify exchanges no longer appear in the counterparty dropdown
- [ ] Verify adding a decoder counterparty mapping still works
- [ ] Verify the counterparty filter dropdown also excludes exchanges
- [ ] Verify other usages of `CounterpartyInput` (e.g. event forms) still show exchanges