### PR TITLE
fix(frontend): latest prices double currency conversion

### DIFF
--- a/frontend/app/src/components/price-manager/latest/LatestPriceContent.vue
+++ b/frontend/app/src/components/price-manager/latest/LatestPriceContent.vue
@@ -180,7 +180,6 @@ onMounted(async () => {
             :value="row.usdPrice"
             :loading="!row.usdPrice || row.usdPrice.lt(0)"
             :price-asset="row.fromAsset"
-            from="USD"
           />
         </template>
         <template #item.actions="{ row }">

--- a/frontend/app/src/composables/price-manager/latest/index.spec.ts
+++ b/frontend/app/src/composables/price-manager/latest/index.spec.ts
@@ -1,0 +1,142 @@
+import type { ManualPrice } from '@/types/prices';
+import { bigNumberify } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLatestPrices } from '@/composables/price-manager/latest';
+import { useBalancePricesStore } from '@/store/balances/prices';
+import { useCurrencies } from '@/types/currencies';
+
+vi.mock('@/composables/api/assets/prices', () => ({
+  useAssetPricesApi: vi.fn().mockReturnValue({
+    addLatestPrice: vi.fn().mockResolvedValue(true),
+    deleteLatestPrice: vi.fn().mockResolvedValue(true),
+    fetchLatestPrices: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('@/modules/prices/use-price-refresh', () => ({
+  usePriceRefresh: vi.fn().mockReturnValue({
+    refreshPrices: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/composables/status', () => ({
+  useStatusUpdater: vi.fn().mockReturnValue({
+    resetStatus: vi.fn(),
+  }),
+}));
+
+function t(key: string): string {
+  return key;
+}
+
+describe('useLatestPrices', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  function setupPrices(currency: string, exchangeRates: Record<string, number>, assetPrices: Record<string, number>): void {
+    const { findCurrency } = useCurrencies();
+    updateGeneralSettings({ mainCurrency: findCurrency(currency) });
+
+    const store = useBalancePricesStore();
+    const { exchangeRates: rates, prices } = storeToRefs(store);
+
+    const priceEntries: Record<string, { isManualPrice: boolean; oracle: string; value: ReturnType<typeof bigNumberify> }> = {};
+    for (const [asset, value] of Object.entries(assetPrices)) {
+      priceEntries[asset] = {
+        isManualPrice: false,
+        oracle: 'coingecko',
+        value: bigNumberify(value),
+      };
+    }
+    set(prices, priceEntries);
+
+    const rateEntries: Record<string, ReturnType<typeof bigNumberify>> = {};
+    for (const [curr, rate] of Object.entries(exchangeRates)) {
+      rateEntries[curr] = bigNumberify(rate);
+    }
+    set(rates, rateEntries);
+  }
+
+  describe('items', () => {
+    it('computes usdPrice in current currency without double conversion', async () => {
+      setupPrices('EUR', { EUR: 0.85 }, { ETH: 2000 });
+
+      const { useAssetPricesApi } = await import('@/composables/api/assets/prices');
+      const { fetchLatestPrices } = useAssetPricesApi();
+
+      const manualPrices: ManualPrice[] = [
+        { fromAsset: 'ETH', price: bigNumberify(123), toAsset: 'EUR' },
+      ];
+      vi.mocked(fetchLatestPrices).mockResolvedValue(manualPrices);
+
+      const { items, getLatestPrices } = useLatestPrices(t as ReturnType<typeof useI18n>['t']);
+      await getLatestPrices();
+
+      const result = get(items);
+      expect(result).toHaveLength(1);
+      // ETH price is 2000 USD, with EUR rate 0.85, price in EUR = 2000 * 0.85 = 1700
+      expect(result[0].usdPrice.toNumber()).toBe(1700);
+    });
+
+    it('computes usdPrice correctly when main currency is USD', async () => {
+      setupPrices('USD', {}, { ETH: 2000 });
+
+      const { useAssetPricesApi } = await import('@/composables/api/assets/prices');
+      const { fetchLatestPrices } = useAssetPricesApi();
+
+      const manualPrices: ManualPrice[] = [
+        { fromAsset: 'ETH', price: bigNumberify(2000), toAsset: 'USD' },
+      ];
+      vi.mocked(fetchLatestPrices).mockResolvedValue(manualPrices);
+
+      const { items, getLatestPrices } = useLatestPrices(t as ReturnType<typeof useI18n>['t']);
+      await getLatestPrices();
+
+      const result = get(items);
+      expect(result).toHaveLength(1);
+      // USD is the main currency, ETH price is 2000, no conversion needed
+      expect(result[0].usdPrice.toNumber()).toBe(2000);
+    });
+
+    it('filters items when filter is provided', async () => {
+      setupPrices('USD', {}, { ETH: 2000, BTC: 50000 });
+
+      const { useAssetPricesApi } = await import('@/composables/api/assets/prices');
+      const { fetchLatestPrices } = useAssetPricesApi();
+
+      const manualPrices: ManualPrice[] = [
+        { fromAsset: 'ETH', price: bigNumberify(2000), toAsset: 'USD' },
+        { fromAsset: 'BTC', price: bigNumberify(50000), toAsset: 'USD' },
+      ];
+      vi.mocked(fetchLatestPrices).mockResolvedValue(manualPrices);
+
+      const filter = ref<string | undefined>('ETH');
+      const { items, getLatestPrices } = useLatestPrices(t as ReturnType<typeof useI18n>['t'], filter);
+      await getLatestPrices();
+
+      const result = get(items);
+      expect(result).toHaveLength(1);
+      expect(result[0].fromAsset).toBe('ETH');
+    });
+
+    it('returns all items when filter is undefined', async () => {
+      setupPrices('USD', {}, { ETH: 2000, BTC: 50000 });
+
+      const { useAssetPricesApi } = await import('@/composables/api/assets/prices');
+      const { fetchLatestPrices } = useAssetPricesApi();
+
+      const manualPrices: ManualPrice[] = [
+        { fromAsset: 'ETH', price: bigNumberify(2000), toAsset: 'USD' },
+        { fromAsset: 'BTC', price: bigNumberify(50000), toAsset: 'USD' },
+      ];
+      vi.mocked(fetchLatestPrices).mockResolvedValue(manualPrices);
+
+      const { items, getLatestPrices } = useLatestPrices(t as ReturnType<typeof useI18n>['t']);
+      await getLatestPrices();
+
+      expect(get(items)).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed double currency conversion in the latest prices table when the user's main currency is not USD
- `assetPrice()` returned values already converted to the user's currency, but `FiatDisplay` with `from="USD"` converted them again (e.g., 123 EUR displayed as ~103.64 EUR)
- Switched to `assetPriceInCurrentCurrency()` and removed the unnecessary `from="USD"` prop
- Added unit tests for the `useLatestPrices` composable

## Test plan
- [ ] Set main currency to EUR (or any non-USD currency)
- [ ] Add a custom latest price (e.g., Asset A = 123 EUR)
- [ ] Verify the "Price in EUR" column shows 123 EUR, not a converted value
- [ ] Switch main currency to USD and verify prices still display correctly
- [ ] Verify NFT custom prices also display correctly