### PR TITLE
fix(frontend): asset movement location label fallback

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1267,8 +1267,10 @@
       "message": "There are {count} unmatched asset movements that require manual matching."
     },
     "compact_notes": {
-      "deposit": "Deposit {amount} {asset} to {locationLabel} from {address}",
-      "withdraw": "Withdraw {amount} {asset} from {locationLabel} to {address}"
+      "deposit": "Deposit {amount} {asset}{to}{from}",
+      "from_part": " from {address}",
+      "to_part": " to {locationLabel}",
+      "withdraw": "Withdraw {amount} {asset}{from}{to}"
     },
     "dialog": {
       "confirm_match": "Confirm Match",

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -121,6 +121,7 @@ const {
   confirmRedecode,
   confirmTxAndEventsDelete,
   confirmUnlink,
+  unlinkGroup,
   hasCustomEvents,
   redecode,
   redecodePayload,
@@ -183,17 +184,6 @@ function hasHiddenIgnoredAssets(groupId: string): boolean {
 // Helper to check if a group is currently showing ignored assets
 function isShowingIgnoredAssets(groupId: string): boolean {
   return get(groupsShowingIgnoredAssets).has(groupId);
-}
-
-function unlinkGroup(groupId: string): void {
-  const events = getGroupEvents(groupId);
-  const event = events.find(item => item.eventSubtype !== 'fee' && !!item.actualGroupIdentifier);
-  if (event) {
-    confirmUnlink({ identifier: event.identifier });
-  }
-  else {
-    console.warn(`No unlinkable event found for group ${groupId}`);
-  }
 }
 </script>
 

--- a/frontend/app/src/modules/history/events/composables/use-complete-events.ts
+++ b/frontend/app/src/modules/history/events/composables/use-complete-events.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef } from 'vue';
 import type { HistoryEventEntry, HistoryEventRow } from '@/types/history/events/schemas';
+import { flatten } from 'es-toolkit';
 
 interface UseCompleteEventsReturn {
   /**
@@ -39,7 +40,7 @@ export function useCompleteEvents(
 ): UseCompleteEventsReturn {
   function getGroupEvents(groupId: string): HistoryEventEntry[] {
     const groupEvents = get(completeEventsMapped)[groupId] || [];
-    return groupEvents.flatMap(e => (Array.isArray(e) ? e : [e]));
+    return flatten(groupEvents);
   }
 
   /**


### PR DESCRIPTION
- [x] use location name as fallback if locationLabel is not present, for matched asset movements
- [x] fix bug with unlink, if the matched subgroup is not the first event in the group