### PR TITLE
Include linked events when filtering by AUTO_MATCHED

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -80,3 +80,4 @@ datas = "datas"  # used in packaging
 requeried = "requeried"
 othere = "othere"  # other exception
 queriable = "queriable"  # https://en.wiktionary.org/wiki/queriable
+hel = "hel"  # sql alias for history_event_links table


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=157420307

## Benchmark results

Benchmarked with 100k synthetic events, 410 MATCHED markers, 410 event links, seed=42.
Scripts: https://gist.github.com/prettyirrelevant/b7b3147dd8f954afa6f88cba55daa609

### state_markers=[AUTO_MATCHED] (median, ms)

| | **develop** | **this PR** | **delta** |
|---|---|---|---|
| events_query (page=10) | 287 | 169 | -118ms (-41%) |
| events_query (page=25) | 288 | 167 | -121ms (-42%) |
| events_query (page=50) | 287 | 169 | -118ms (-41%) |
| events_query (page=100) | 287 | 173 | -114ms (-40%) |
| count_query (avg) | 0.1 | 0.3 | +0.2ms |

### AUTO_MATCHED + location filter (median, ms)

| | **develop** | **this PR** | **delta** |
|---|---|---|---|
| kraken events | 161 | 165 | +4ms |
| kraken count | 0.4 | 0.3 | -0.1ms |
| ethereum events | 165 | 172 | +7ms |
| ethereum count | 1.1 | 0.3 | -0.8ms |
| coinbase events | 162 | 166 | +4ms |
| coinbase count | 0.4 | 0.3 | -0.1ms |

### AUTO_MATCHED + grouped (median, ms)

| | **develop** | **this PR** | **delta** |
|---|---|---|---|
| events_query (page=10) | 165 | 162 | -3ms |
| events_query (page=25) | 166 | 164 | -2ms |
| events_query (page=50) | 166 | 162 | -4ms |
| events_query (page=100) | 165 | 164 | -1ms |
| count_query (avg) | 0.5 | 0.6 | +0.1ms |

### state_markers=[CUSTOMIZED] (median, ms)

| | **develop** | **this PR** | **delta** |
|---|---|---|---|
| events_query (page=25) | 0.0 | 0.0 | |
| count_query | 0.0 | 0.0 | |

### Baseline: no state marker filter (median, ms)

| | **develop** | **this PR** |
|---|---|---|
| page=10 | 158 | 162 |
| page=25 | 159 | 163 |
| page=50 | 161 | 161 |
| page=100 | 161 | 164 |