### PR TITLE
fix(frontend): strip isArchive from RPC node save payload

### DIFF
--- a/frontend/app/src/components/settings/general/rpc/BlockchainRpcNodeFormDialog.vue
+++ b/frontend/app/src/components/settings/general/rpc/BlockchainRpcNodeFormDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { BlockchainRpcNodeManageState } from '@/types/settings/rpc';
+import type { BlockchainRpcNode, BlockchainRpcNodeManageState } from '@/types/settings/rpc';
 import { assert, Blockchain } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import BigDialog from '@/components/dialogs/BigDialog.vue';
@@ -85,12 +85,13 @@ async function save() {
       set(errorMessages, messages);
 
       const keys = Object.keys(messages);
-      const knownKeys = Object.keys(node);
-      const unknownKeys = keys.filter(key => !knownKeys.includes(key));
+      const formKeys: string[] = ['name', 'endpoint', 'weight', 'owned', 'active'] satisfies (keyof BlockchainRpcNode)[];
+      const nodeKeys = Object.keys(node);
+      const nonFormKeys = keys.filter(key => !formKeys.includes(key) && nodeKeys.includes(key));
 
-      if (unknownKeys.length > 0) {
+      if (nonFormKeys.length > 0) {
         setMessage({
-          description: unknownKeys.map(key => `${key}: ${messages[key]}`).join(', '),
+          description: nonFormKeys.map(key => `${key}: ${messages[key]}`).join(', '),
           success: false,
           title: errorTitle,
         });

--- a/frontend/app/src/composables/api/settings/evm-nodes-api.spec.ts
+++ b/frontend/app/src/composables/api/settings/evm-nodes-api.spec.ts
@@ -116,6 +116,35 @@ describe('composables/api/settings/evm-nodes-api', () => {
         blockchain: 'ETH',
       });
     });
+
+    it('strips isArchive from the payload', async () => {
+      let requestBody: Record<string, unknown> | null = null;
+
+      server.use(
+        http.put(`${backendUrl}/api/1/blockchains/ETH/nodes`, async ({ request }) => {
+          requestBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            result: true,
+            message: '',
+          });
+        }),
+      );
+
+      const { addEvmNode } = useEvmNodesApi();
+      const newNode = {
+        name: 'Archive Node',
+        endpoint: 'https://archive.example.com',
+        active: true,
+        owned: true,
+        weight: 100,
+        blockchain: 'ETH',
+        isArchive: true,
+      };
+
+      await addEvmNode(newNode);
+
+      expect(requestBody).not.toHaveProperty('isArchive');
+    });
   });
 
   describe('editEvmNode', () => {
@@ -155,6 +184,36 @@ describe('composables/api/settings/evm-nodes-api', () => {
         weight: 25,
         blockchain: 'ETH',
       });
+    });
+
+    it('strips isArchive from the payload', async () => {
+      let requestBody: Record<string, unknown> | null = null;
+
+      server.use(
+        http.patch(`${backendUrl}/api/1/blockchains/ETH/nodes`, async ({ request }) => {
+          requestBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            result: true,
+            message: '',
+          });
+        }),
+      );
+
+      const { editEvmNode } = useEvmNodesApi();
+      const editedNode: BlockchainRpcNode = {
+        identifier: 1,
+        name: 'Archive Node',
+        endpoint: 'https://archive.example.com',
+        active: true,
+        owned: true,
+        weight: 100,
+        blockchain: 'ETH',
+        isArchive: true,
+      };
+
+      await editEvmNode(editedNode);
+
+      expect(requestBody).not.toHaveProperty('isArchive');
     });
   });
 

--- a/frontend/app/src/composables/api/settings/evm-nodes-api.ts
+++ b/frontend/app/src/composables/api/settings/evm-nodes-api.ts
@@ -1,7 +1,10 @@
 import type { MaybeRef } from 'vue';
 import { Blockchain } from '@rotki/common';
+import { omit } from 'es-toolkit';
 import { api } from '@/modules/api/rotki-api';
 import { type BlockchainRpcNode, BlockchainRpcNodeList } from '@/types/settings/rpc';
+
+const READ_ONLY_FIELDS = ['isArchive'] as const;
 
 interface UseEvmNodesApiReturn {
   fetchEvmNodes: () => Promise<BlockchainRpcNodeList>;
@@ -19,9 +22,9 @@ export function useEvmNodesApi(chain: MaybeRef<string> = Blockchain.ETH): UseEvm
     return BlockchainRpcNodeList.parse(response);
   };
 
-  const addEvmNode = async (node: Omit<BlockchainRpcNode, 'identifier'>): Promise<boolean> => api.put<boolean>(get(url), node);
+  const addEvmNode = async (node: Omit<BlockchainRpcNode, 'identifier'>): Promise<boolean> => api.put<boolean>(get(url), omit(node, READ_ONLY_FIELDS));
 
-  const editEvmNode = async (node: BlockchainRpcNode): Promise<boolean> => api.patch<boolean>(get(url), node);
+  const editEvmNode = async (node: BlockchainRpcNode): Promise<boolean> => api.patch<boolean>(get(url), omit(node, READ_ONLY_FIELDS));
 
   const deleteEvmNode = async (identifier: number): Promise<boolean> => api.delete<boolean>(get(url), {
     body: { identifier },


### PR DESCRIPTION
## Summary
- Strip the read-only `isArchive` property from the payload when adding or editing RPC nodes, preventing backend 400 errors.
- Improve validation error handling in the RPC node form dialog to surface errors for node fields that aren't editable in the form (e.g. `isArchive`, `identifier`, `blockchain`).
- Add tests verifying `isArchive` is stripped from both add and edit payloads.

## Test plan
- [x] Existing tests pass (10/10)
- [x] Manually edit an RPC node that has `isArchive: true` and verify no 400 error
- [x] Verify validation errors for non-form fields are shown as a message