### PR TITLE
Mark impersonation spam tokens as ignored

### DIFF
--- a/rotkehlchen/assets/spam_assets.py
+++ b/rotkehlchen/assets/spam_assets.py
@@ -120,6 +120,7 @@ def _get_dangerous_token_collection_members(
 
 
 def check_token_impersonates_dangerous_tokens(
+        database: 'DBHandler',
         token: 'EvmToken',
         native_token: 'CryptoAsset',
 ) -> None:
@@ -175,6 +176,12 @@ def check_token_impersonates_dangerous_tokens(
                 write_cursor=write_cursor,
                 token=token,
                 is_spam=True,
+            )
+
+        with database.user_write() as write_cursor:
+            database.add_to_ignored_assets(
+                write_cursor=write_cursor,
+                asset=token,
             )
 
         log.debug(f'Flagged {token} as spam trying to impersonate {impersonated_symbol}')

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -1090,6 +1090,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             found_token = token
 
         check_token_impersonates_dangerous_tokens(
+            database=self.database,
             token=found_token,
             native_token=self.evm_inquirer.native_token,
         )


### PR DESCRIPTION
Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=157789677

> also check because I believe we have a function that does both already

We do have `update_spam_assets` but it operates on the spam asset dict from spam updates rather than just a list of assets. So just added a call to `database.add_to_ignored_assets`.