### PR TITLE
fix(frontend): chain selector issue

### DIFF
--- a/frontend/app/src/components/accounts/management/AccountForm.vue
+++ b/frontend/app/src/components/accounts/management/AccountForm.vue
@@ -274,7 +274,6 @@ defineExpose({
     </RuiAlert>
 
     <AccountSelector
-      v-if="chain"
       v-model:input-mode="inputMode"
       v-model:chain="chain"
       :chain-ids="chainIds"

--- a/frontend/app/src/components/accounts/management/inputs/AccountSelector.vue
+++ b/frontend/app/src/components/accounts/management/inputs/AccountSelector.vue
@@ -5,7 +5,7 @@ import InputModeSelect from '@/components/accounts/management/inputs/InputModeSe
 import { useAccountLoading } from '@/composables/accounts/loading';
 import { isBtcChain } from '@/types/blockchain/chains';
 
-const chain = defineModel<string>('chain', { required: true });
+const chain = defineModel<string | undefined>('chain', { required: true });
 const inputMode = defineModel<InputMode>('inputMode', { required: true });
 
 defineProps<{
@@ -15,8 +15,10 @@ defineProps<{
 
 const { loading } = useAccountLoading();
 
+const selectedChain = computed<string>(() => get(chain) ?? '');
+
 const showInputModeSelector = logicOr(
-  computed<boolean>(() => isBtcChain(get(chain))),
+  computed<boolean>(() => isBtcChain(get(selectedChain))),
 );
 </script>
 
@@ -30,6 +32,6 @@ const showInputModeSelector = logicOr(
   <InputModeSelect
     v-if="!editMode && showInputModeSelector"
     v-model:input-mode="inputMode"
-    :blockchain="chain"
+    :blockchain="selectedChain"
   />
 </template>


### PR DESCRIPTION
Fix this issue:
- Open add account dialog, when the blockchain input is focused, press backspace / delete, it will then hide the input.