### PR TITLE
fix: logic for unmatched asset movements button

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
@@ -27,7 +27,7 @@ const menuOpen = ref<boolean>(false);
 const checkingType = ref<IssueCheckType>();
 const noIssuesFeedback = ref<IssueCheckType>();
 
-const { refreshUnmatchedAssetMovements, unmatchedCount } = useUnmatchedAssetMovements();
+const { refreshUnmatchedAssetMovements, unmatchedCount, ignoredCount } = useUnmatchedAssetMovements();
 const { fetchCustomizedEventDuplicates, totalCount: duplicatesCount } = useCustomizedEventDuplicates();
 
 const { start: startFeedbackTimeout, stop: stopFeedbackTimeout } = useTimeoutFn(() => {
@@ -44,7 +44,7 @@ async function checkUnmatched(): Promise<void> {
   set(checkingType, 'unmatched');
   try {
     await refreshUnmatchedAssetMovements();
-    if (get(unmatchedCount) > 0) {
+    if (get(unmatchedCount) > 0 || get(ignoredCount) > 0) {
       set(menuOpen, false);
       emit('show:dialog', { type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS });
     }


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
