### PR TITLE
fix(frontend): handle hash-based "skip_update" flag in session storage

### DIFF
--- a/frontend/app/src/main.ts
+++ b/frontend/app/src/main.ts
@@ -45,7 +45,8 @@ const rui = createRuiPlugin({
 });
 
 const search = window.location.search;
-const skipUpdate = search.includes('skip_update');
+const hash = window.location.hash;
+const skipUpdate = search.includes('skip_update') || hash.includes('skip_update');
 if (skipUpdate)
   sessionStorage.setItem('skip_update', '1');
 


### PR DESCRIPTION
Enhance skip_update logic to include URL hash alongside query string when checking for the flag.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
