### PR TITLE
Ensure that before saving internal tx we delete first

### DIFF
--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -155,6 +155,19 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
             relevant_address=relevant_address,
         )
 
+    def delete_evm_internal_transactions_by_parent_tx_hash(
+            self,
+            write_cursor: 'DBCursor',
+            parent_tx_hash: EVMTxHash,
+            chain_id: ChainID,
+    ) -> None:
+        """Delete all internal transactions for a single parent tx hash and chain."""
+        write_cursor.execute(
+            'DELETE FROM evm_internal_transactions WHERE parent_tx IN ('
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?)',
+            (parent_tx_hash, chain_id.serialize_for_db()),
+        )
+
     def get_evm_internal_transactions(
             self,
             parent_tx_hash: EVMTxHash,


### PR DESCRIPTION
The idea of this chnage is prevent us from saving  internal tx if there are already any. In theory the primary key protects us but we saw that due to bad data we can duplicate stuff (gas 0 vs != 0). So this wipes the data before saving 