### PR TITLE
feat(e2e): add CSV import E2E tests

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [ app, settings, balances, history ]
+        group: [ app, settings, balances, history, import ]
     permissions:
       actions: write
       contents: read

--- a/frontend/app/src/components/NavigationMenu.vue
+++ b/frontend/app/src/components/NavigationMenu.vue
@@ -234,6 +234,7 @@ const navItems = computed<MenuItem[]>(() => {
       ],
     },
     {
+      class: 'import',
       type: 'item',
       ...Routes.IMPORT,
     },

--- a/frontend/app/src/components/import/FileUpload.vue
+++ b/frontend/app/src/components/import/FileUpload.vue
@@ -269,12 +269,14 @@ defineExpose({
             <div
               v-if="uploaded"
               class="text-rui-success"
+              data-cy="import-complete"
             >
               {{ t('file_upload.import_complete') }}
             </div>
             <div
               v-else-if="error"
               class="text-rui-error"
+              data-cy="import-error"
             >
               {{ error }}
             </div>
@@ -292,6 +294,7 @@ defineExpose({
           type="file"
           :accept="fileFilter"
           hidden
+          data-cy="file-input"
           @change="onSelect($event)"
         />
       </div>

--- a/frontend/app/src/components/import/GroupedImport.vue
+++ b/frontend/app/src/components/import/GroupedImport.vue
@@ -139,6 +139,7 @@ const [DefineDisplay, ReuseDisplay] = createReusableTemplate<{
       auto-select-first
       variant="outlined"
       key-attr="key"
+      data-cy="import-source-select"
     >
       <template #selection="{ item }">
         <ReuseDisplay v-bind="item" />

--- a/frontend/app/src/components/import/ImportSource.vue
+++ b/frontend/app/src/components/import/ImportSource.vue
@@ -134,7 +134,7 @@ const isRotkiCustomImport = computed(() => get(source).startsWith('rotki_'));
 </script>
 
 <template>
-  <div>
+  <div :data-cy="`import-source-${source}`">
     <div class="mb-2">
       <slot name="upload-title" />
     </div>

--- a/frontend/app/src/components/status/notifications/Notification.vue
+++ b/frontend/app/src/components/status/notifications/Notification.vue
@@ -179,6 +179,7 @@ function getIcon(action: NotificationAction): RuiIcons {
     class="!p-2 !pb-1.5 max-w-[400px]"
     no-padding
     :variant="popup ? 'flat' : 'outlined'"
+    data-id="notification"
   >
     <div class="flex pb-1 items-center overflow-hidden">
       <div
@@ -203,6 +204,7 @@ function getIcon(action: NotificationAction): RuiIcons {
         </div>
       </div>
       <RuiButton
+        data-id="notification_dismiss"
         variant="text"
         icon
         class="!p-2"

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -117,6 +117,24 @@ export class HistoryEventsPage {
     await this.page.locator('[data-cy=bottom-dialog]').waitFor({ state: 'detached', timeout: TIMEOUT_LONG });
   }
 
+  async applyTableFilter(key: string, value: string): Promise<void> {
+    const filter = this.page.locator('[data-cy=table-filter]');
+    // Click the activator to open the autocomplete and reveal the input
+    await filter.locator('[data-id=activator]').click();
+    const input = filter.locator('input');
+    await input.pressSequentially(`${key}=`, { delay: 50 });
+
+    // Wait for suggestions dropdown to show filter values
+    const suggestions = this.page.locator('[data-cy=suggestions]');
+    await suggestions.waitFor({ state: 'visible' });
+
+    // Type the value character by character to trigger reactive suggestion updates
+    await input.pressSequentially(value, { delay: 50 });
+    const option = suggestions.getByText(value, { exact: false }).first();
+    await option.waitFor({ state: 'visible' });
+    await option.click();
+  }
+
   async getEventRows(): Promise<number> {
     const rows = this.page.locator('[data-cy=history-event-row]');
     return rows.count();

--- a/frontend/app/tests/e2e/pages/import-page.ts
+++ b/frontend/app/tests/e2e/pages/import-page.ts
@@ -1,0 +1,61 @@
+import type { Page } from '@playwright/test';
+import path from 'node:path';
+import { TIMEOUT_LONG } from '../helpers/constants';
+import { RotkiApp } from './rotki-app';
+
+/**
+ * Path to shared backend test data directory.
+ * CSV fixtures live here — no need to duplicate them in the frontend.
+ */
+const BACKEND_TEST_DATA = path.resolve(import.meta.dirname, '..', '..', '..', '..', '..', 'rotkehlchen', 'tests', 'data');
+
+export class ImportPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'import');
+  }
+
+  async selectSource(label: string): Promise<void> {
+    const select = this.page.locator('[data-cy=import-source-select]');
+    await select.locator('[data-id=activator]').click();
+    const menu = this.page.locator('[role=menu]').last();
+    await menu.waitFor({ state: 'visible' });
+    await select.locator('input').fill(label);
+    const option = menu.getByText(label, { exact: false }).first();
+    await option.waitFor({ state: 'visible' });
+    await option.click();
+  }
+
+  async uploadFile(sourceKey: string, csvFileName: string): Promise<void> {
+    const container = this.page.locator(`[data-cy="import-source-${sourceKey}"]`);
+    const fileInput = container.locator('[data-cy=file-input]');
+    const filePath = path.resolve(BACKEND_TEST_DATA, csvFileName);
+    await fileInput.setInputFiles(filePath);
+  }
+
+  async submitImport(sourceKey: string): Promise<void> {
+    const container = this.page.locator(`[data-cy="import-source-${sourceKey}"]`);
+    await container.locator('[data-cy=button-import]').click();
+  }
+
+  async waitForImportComplete(sourceKey: string): Promise<void> {
+    const container = this.page.locator(`[data-cy="import-source-${sourceKey}"]`);
+    await container.locator('[data-cy=import-complete]').waitFor({ state: 'visible', timeout: TIMEOUT_LONG });
+  }
+
+  async dismissNotifications(): Promise<void> {
+    const dismissButton = this.page.locator('[data-id=notification_dismiss]');
+    if (await dismissButton.isVisible()) {
+      await dismissButton.click();
+      await this.page.locator('[data-id=notification]').waitFor({ state: 'detached' });
+    }
+  }
+
+  async importCsv(sourceKey: string, csvFileName: string): Promise<void> {
+    await this.uploadFile(sourceKey, csvFileName);
+    await this.submitImport(sourceKey);
+    await this.waitForImportComplete(sourceKey);
+    await this.dismissNotifications();
+  }
+}

--- a/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
+++ b/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { waitForNoRunningTasks } from '../../helpers/api';
+import { TIMEOUT_MEDIUM } from '../../helpers/constants';
+import { HistoryEventsPage } from '../../pages/history-events-page';
+import { ImportPage } from '../../pages/import-page';
+
+/**
+ * Amount formatting notes:
+ * Default settings: floatingPrecision=2, amountRoundingMode=ROUND_UP
+ * - Values with >2 decimals are rounded up and prefixed with '<'
+ *   e.g. 0.091 → "<0.10", 392.887 → "<392.89", 0.0513 → "<0.06"
+ * - Values with ≤2 decimals display as-is: 5 → "5.00"
+ */
+
+test.describe.serial('csv import', () => {
+  let ctx: SharedTestContext;
+  let importPage: ImportPage;
+  let historyPage: HistoryEventsPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request);
+    importPage = new ImportPage(ctx.sharedPage);
+    historyPage = new HistoryEventsPage(ctx.sharedPage);
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('import rotki generic events', async () => {
+    await importPage.visit();
+    await importPage.selectSource('Custom');
+    await importPage.importCsv('rotki_events', 'rotki_generic_events.csv');
+
+    // Navigate to history and filter by coinbase (unique to this CSV: 0.091 BTC loss)
+    await historyPage.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+    await historyPage.applyTableFilter('location', 'coinbase');
+
+    await expect(async () => {
+      const count = await historyPage.getEventRows();
+      expect(count).toBeGreaterThanOrEqual(1);
+    }).toPass({ timeout: TIMEOUT_MEDIUM });
+
+    // 0.091 BTC → rounded up to 0.10 with '<' prefix
+    await historyPage.verifyEventAmount('[data-cy=history-event-row]', 0, '0.10');
+  });
+
+  test('import rotki generic trades', async () => {
+    await importPage.visit();
+    await importPage.selectSource('Custom');
+    await importPage.importCsv('rotki_trades', 'rotki_generic_trades.csv');
+
+    // Navigate to history and filter by kraken (has LTC→BTC trade from this CSV)
+    await historyPage.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+    await historyPage.applyTableFilter('location', 'kraken');
+
+    await expect(async () => {
+      const count = await historyPage.getSwapRows();
+      expect(count).toBeGreaterThanOrEqual(1);
+    }).toPass({ timeout: TIMEOUT_MEDIUM });
+
+    // 392.887 LTC → rounded up to 392.89 with '<' prefix
+    await historyPage.verifyEventAmount('[data-cy=history-event-swap]', 0, '392.89');
+  });
+
+  test('import cointracking csv', async () => {
+    await importPage.visit();
+    await importPage.selectSource('Cointracking');
+    await importPage.importCsv('cointracking', 'cointracking_trades_list.csv');
+
+    // Navigate to history and filter by poloniex (unique: 5 XMR deposit from cointracking)
+    await historyPage.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+    await historyPage.applyTableFilter('location', 'poloniex');
+
+    await expect(async () => {
+      const count = await historyPage.getEventRows();
+      expect(count).toBeGreaterThanOrEqual(1);
+    }).toPass({ timeout: TIMEOUT_MEDIUM });
+
+    // 5.00 XMR — exact, no rounding needed
+    await historyPage.verifyEventAmount('[data-cy=history-event-row]', 0, '5.00');
+    await historyPage.verifyEventTypeLabel('[data-cy=history-event-row]', 0, 'Exchange deposit');
+  });
+
+  test('import nexo csv', async () => {
+    await importPage.visit();
+    await importPage.selectSource('Nexo');
+    await importPage.importCsv('nexo', 'nexo.csv');
+
+    // Navigate to history and filter by nexo (all nexo events have location=nexo)
+    await historyPage.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+    await historyPage.applyTableFilter('location', 'nexo');
+
+    await expect(async () => {
+      const count = await historyPage.getEventRows();
+      const swaps = await historyPage.getSwapRows();
+      expect(count + swaps).toBeGreaterThanOrEqual(5);
+    }).toPass({ timeout: TIMEOUT_MEDIUM });
+
+    // 5.37250072 NEXO fixed term interest (2024-12-28) → rounded up to 5.38 with '<' prefix
+    const amountLocator = ctx.sharedPage.locator('[data-cy=event-amount]').filter({ hasText: '5.38' });
+    await expect(amountLocator.first()).toBeVisible({ timeout: TIMEOUT_MEDIUM });
+  });
+
+  test('filter history events by location', async () => {
+    await historyPage.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+
+    // Apply location filter for binance (has USDT withdrawal from generic events + USDC→ETH swap from generic trades)
+    await historyPage.applyTableFilter('location', 'binance');
+
+    await expect(async () => {
+      const rows = await historyPage.getEventRows();
+      const swaps = await historyPage.getSwapRows();
+      expect(rows + swaps).toBeGreaterThanOrEqual(2);
+    }).toPass({ timeout: TIMEOUT_MEDIUM });
+
+    // Verify the USDC→ETH swap exists: 1,875.64 USDC spend → rounded up to 1,875.64 (exact 2 decimals)
+    await historyPage.verifyEventAmount('[data-cy=history-event-swap]', 0, '1,875.64');
+  });
+});

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,7 +3,7 @@ import rotki from '@rotki/eslint-config';
 import { translationKeys } from '@rotki/ui-library';
 
 export default rotki({
-  ignores: ['app/backend-icons.generated.ts'],
+  ignores: ['app/backend-icons.generated.ts', 'app/tests/e2e/test-results/**'],
   vue: true,
   typescript: {
     tsconfigPath: 'tsconfig.json',


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for the CSV import page covering four import sources: rotki generic events, rotki generic trades, cointracking, and nexo
- Add `data-cy` attributes to import components (`FileUpload`, `GroupedImport`, `ImportSource`) and notification components for testability
- Add `ImportPage` page object and `applyTableFilter` helper to `HistoryEventsPage`
- Add `import` group to the CI E2E test matrix
- Reuse existing backend CSV test fixtures (`rotkehlchen/tests/data/`) instead of duplicating them
- Ignore `test-results/` directory in ESLint config

Related to #11252