### PR TITLE
Prevent customized default label when using edit events

### DIFF
--- a/rotkehlchen/api/rest_helpers/history_events.py
+++ b/rotkehlchen/api/rest_helpers/history_events.py
@@ -73,7 +73,11 @@ def edit_grouped_events_with_optional_fee(
         events_to_edit = events
 
     for event in events_to_edit:
-        events_db.edit_history_event(write_cursor=write_cursor, event=event)
+        events_db.edit_history_event(
+            write_cursor=write_cursor,
+            event=event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
+        )
 
 
 def edit_grouped_swap_events(
@@ -99,7 +103,11 @@ def edit_grouped_swap_events(
         if event.identifier is None:  # No existing identifier - this is a new event.
             new_events.append(event)
         else:  # Already has an identifier - edit existing event.
-            events_db.edit_history_event(write_cursor=write_cursor, event=event)
+            events_db.edit_history_event(
+                write_cursor=write_cursor,
+                event=event,
+                mapping_state=HistoryMappingState.CUSTOMIZED,
+            )
             edited_identifiers.append(event.identifier)
 
     if identifiers != edited_identifiers:  # There are identifiers with no corresponding events - these events need to be deleted.  # noqa: E501

--- a/rotkehlchen/api/services/history_events.py
+++ b/rotkehlchen/api/services/history_events.py
@@ -105,6 +105,7 @@ class HistoryEventsService:
                     events_db.edit_history_event(
                         event=event,
                         write_cursor=write_cursor,
+                        mapping_state=HistoryMappingState.CUSTOMIZED,
                     )
         except InputError as e:
             return {

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -442,13 +442,13 @@ class DBHistoryEvents:
             self,
             write_cursor: 'DBCursor',
             event: HistoryBaseEntry,
-            mapping_state: HistoryMappingState = HistoryMappingState.CUSTOMIZED,
+            mapping_state: HistoryMappingState | None,
             save_backup: bool = False,
     ) -> None:
         """
         Edit a history entry to the DB with information provided by the user.
         NOTE: It edits all the fields except the extra_data one.
-        Marks the event with the specified mapping state.
+        Marks the event with the specified mapping state if provided.
         Only tracks modification for balance cache invalidation if balance-affecting
         fields change (timestamp, asset, amount, type, subtype, location_label).
 
@@ -483,9 +483,9 @@ class DBHistoryEvents:
             else:  # all other data
                 write_cursor.execute(f'{updatestr} WHERE identifier=?', (*bindings, event.identifier))  # noqa: E501
 
-        # Mark as customized and store original position for duplicate prevention during redecode.
+        # Mark event state and store original position for duplicate prevention during redecode.
         # Only store original position on first customization (when INSERT succeeds).
-        if self.set_event_mapping_state(
+        if mapping_state is not None and self.set_event_mapping_state(
             write_cursor=write_cursor,
             event=event,
             mapping_state=mapping_state,

--- a/rotkehlchen/externalapis/monerium.py
+++ b/rotkehlchen/externalapis/monerium.py
@@ -230,7 +230,11 @@ class Monerium:
                     event.event_type = new_type
                     event.event_subtype = new_subtype  # type: ignore  # both type/subtype are set
 
-                dbevents.edit_history_event(write_cursor=write_cursor, event=event)
+                dbevents.edit_history_event(
+                    write_cursor=write_cursor,
+                    event=event,
+                    mapping_state=None,
+                )
 
     def update_events(self, events: list['EvmEvent']) -> None:
         """Query and update the event txs individually.

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -938,13 +938,21 @@ def test_event_modification_tracks_earliest_timestamp(database: 'DBHandler') -> 
     ):
         eth_event.identifier = 1
         eth_event.notes = 'Updated notes'
-        db.edit_history_event(write_cursor=write_cursor, event=eth_event)
+        db.edit_history_event(
+            write_cursor=write_cursor,
+            event=eth_event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
+        )
         mock_mark.assert_not_called()
 
     # edit asset and should update cache
     with database.user_write() as write_cursor:
         eth_event.asset = A_DAI
-        db.edit_history_event(write_cursor=write_cursor, event=eth_event)
+        db.edit_history_event(
+            write_cursor=write_cursor,
+            event=eth_event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
+        )
 
     with database.conn.read_ctx() as cursor:
         assert int(cursor.execute(

--- a/rotkehlchen/tests/external_apis/test_monerium.py
+++ b/rotkehlchen/tests/external_apis/test_monerium.py
@@ -12,6 +12,7 @@ from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.constants.assets import A_ETH_EURE
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.cache import DBCacheStatic
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.filtering import EvmEventFilterQuery, HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -86,6 +87,15 @@ def test_send_bank_transfer(database: DBHandler, monerium_credentials: Any) -> N
                 tx_hashes=[tx_hash],
             ),
         )
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM history_events_mappings '
+            'WHERE parent_identifier = ? AND name = ? AND value = ?',
+            (
+                event.identifier,
+                HISTORY_MAPPING_KEY_STATE,
+                HistoryMappingState.CUSTOMIZED.serialize_for_db(),
+            ),
+        ).fetchone()[0] == 0
     assert new_events == [event]
 
 

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -9,6 +9,7 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.constants import HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.history.events.structures.base import (
@@ -143,7 +144,11 @@ def test_edited_event_caches_original_position(database: 'DBHandler') -> None:
 
         # first edit stores original position with event identifier as value
         event.sequence_index = 5
-        events_db.edit_history_event(write_cursor=write_cursor, event=event)
+        events_db.edit_history_event(
+            write_cursor=write_cursor,
+            event=event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
+        )
         cache_entry = write_cursor.execute(
             'SELECT value FROM key_value_cache WHERE name = ?', (cache_key,),
         ).fetchone()
@@ -152,7 +157,11 @@ def test_edited_event_caches_original_position(database: 'DBHandler') -> None:
 
         # second edit does not create new cache entry for intermediate position
         event.sequence_index = 10
-        events_db.edit_history_event(write_cursor=write_cursor, event=event)
+        events_db.edit_history_event(
+            write_cursor=write_cursor,
+            event=event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
+        )
         assert write_cursor.execute(
             'SELECT 1 FROM key_value_cache WHERE name = ?',
             (DBCacheDynamic.CUSTOMIZED_EVENT_ORIGINAL_SEQ_IDX.get_db_key(
@@ -208,7 +217,11 @@ def test_non_onchain_edits_skip_cache(database: 'DBHandler') -> None:
         )) is not None
         event.identifier = event_id
         event.sequence_index = 5
-        events_db.edit_history_event(write_cursor=write_cursor, event=event)
+        events_db.edit_history_event(
+            write_cursor=write_cursor,
+            event=event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
+        )
 
         assert write_cursor.execute(
             'SELECT 1 FROM key_value_cache WHERE name = ?',


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
