### PR TITLE
Avoid traceback on missing uniswap routing assets

### DIFF
--- a/rotkehlchen/chain/ethereum/oracles/uniswap.py
+++ b/rotkehlchen/chain/ethereum/oracles/uniswap.py
@@ -186,7 +186,10 @@ class UniswapOracle(HistoricalPriceOracleInterface, CacheableMixIn):
         if len(self.routing_assets) == 0:
             self.resolve_routing_assets()  # May include external remote calls to add any missing assets  # noqa: E501
 
-        routing_assets = self.routing_assets[from_asset.chain_id]
+        if (routing_assets := self.routing_assets.get(from_asset.chain_id)) is None:
+            log.error(f'No {self.name} routing assets found for chain {from_asset.chain_id}')
+            return []
+
         output: list[str] = []
         # If any of the assets is in the glue assets let's see if we find any path
         # (avoids iterating the list of glue assets)


### PR DESCRIPTION
Should prevent https://discord.com/channels/657906918408585217/1080783409640648765/1474414468178903140
