### PR TITLE
Use slots for assets

### DIFF
--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -96,7 +96,7 @@ def _serialize_underlying_tokens(
 
 
 @total_ordering
-@dataclass(init=True, repr=False, eq=True, order=False, unsafe_hash=False, frozen=True)
+@dataclass(init=True, repr=False, eq=True, order=False, unsafe_hash=False, frozen=True, slots=True)
 class Asset:
     """Base class for all assets"""
     identifier: str
@@ -280,13 +280,13 @@ class Asset:
         return self.identifier
 
 
-@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class AssetWithNameAndType(Asset, abc.ABC):
     asset_type: AssetType = field(init=False)
     name: str = field(init=False)
 
     def to_dict(self) -> dict[str, Any]:
-        return super().to_dict() | {
+        return super(AssetWithNameAndType, self).to_dict() | {
             'name': self.name,
             'asset_type': str(self.asset_type),
         }
@@ -298,16 +298,18 @@ class AssetWithNameAndType(Asset, abc.ABC):
         return f'{self.identifier}({self.name})'
 
 
+@dataclass(init=False, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class AssetWithSymbol(AssetWithNameAndType, abc.ABC):
     symbol: str = field(init=False)
 
     def to_dict(self) -> dict[str, Any]:
-        return super().to_dict() | {'symbol': self.symbol}
+        return super(AssetWithSymbol, self).to_dict() | {'symbol': self.symbol}
 
     def __repr__(self) -> str:
         return f'<Asset identifier:{self.identifier} name:{self.name} symbol:{self.symbol}>'
 
 
+@dataclass(init=False, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class AssetWithOracles(AssetWithSymbol, abc.ABC):
     # None means no special mapping. '' means not supported
     cryptocompare: str | None = field(init=False)
@@ -342,17 +344,17 @@ class AssetWithOracles(AssetWithSymbol, abc.ABC):
         return self.coingecko is not None and self.coingecko != ''
 
     def to_dict(self) -> dict[str, Any]:
-        return super().to_dict() | {
+        return super(AssetWithOracles, self).to_dict() | {
             'cryptocompare': self.cryptocompare,
             'coingecko': self.coingecko,
         }
 
 
-@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class FiatAsset(AssetWithOracles):
 
     def __post_init__(self, direct_field_initialization: bool) -> None:
-        super().__post_init__(direct_field_initialization)
+        super(FiatAsset, self).__post_init__(direct_field_initialization)
         if direct_field_initialization is True:
             return
 
@@ -386,14 +388,14 @@ class FiatAsset(AssetWithOracles):
         return asset
 
 
-@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class CryptoAsset(AssetWithOracles):
     started: Timestamp | None = field(init=False)
     forked: Optional['CryptoAsset'] = field(init=False)
     swapped_for: Optional['CryptoAsset'] = field(init=False)
 
     def __post_init__(self, direct_field_initialization: bool) -> None:
-        super().__post_init__(direct_field_initialization)
+        super(CryptoAsset, self).__post_init__(direct_field_initialization)
         if direct_field_initialization is True:
             return
 
@@ -446,7 +448,7 @@ class CryptoAsset(AssetWithOracles):
         if self.swapped_for is not None:
             swapped_for = self.swapped_for.identifier
 
-        return super().to_dict() | {
+        return super(CryptoAsset, self).to_dict() | {
             'name': self.name,
             'symbol': self.symbol,
             'asset_type': str(self.asset_type),
@@ -459,8 +461,9 @@ class CryptoAsset(AssetWithOracles):
 
 
 class CustomAsset(AssetWithNameAndType):
-    notes: str | None = field(init=False)
-    custom_asset_type: str = field(init=False)
+    __slots__ = ('custom_asset_type', 'notes')
+    notes: str | None
+    custom_asset_type: str
 
     @classmethod
     def initialize(
@@ -545,7 +548,7 @@ SolanaTokenDBTuple = tuple[
 ]
 
 
-@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class EvmToken(CryptoAsset):
     evm_address: ChecksumEvmAddress = field(init=False)
     chain_id: ChainID = field(init=False)
@@ -555,7 +558,7 @@ class EvmToken(CryptoAsset):
     underlying_tokens: list[UnderlyingToken] | None = field(init=False)
 
     def __post_init__(self, direct_field_initialization: bool) -> None:
-        super().__post_init__(direct_field_initialization)
+        super(EvmToken, self).__post_init__(direct_field_initialization)
         if direct_field_initialization is True:
             return
 
@@ -648,7 +651,7 @@ class EvmToken(CryptoAsset):
             if self.underlying_tokens is not None
             else None
         )
-        result = super().to_dict() | {
+        result = super(EvmToken, self).to_dict() | {
             'address': self.evm_address,
             'evm_chain': self.chain_id.to_name(),
             'token_kind': self.token_kind.serialize(),
@@ -673,6 +676,7 @@ class EvmToken(CryptoAsset):
 
 
 class Nft(EvmToken):
+    __slots__ = ()
 
     def __post_init__(self, direct_field_initialization: bool) -> None:
         if direct_field_initialization is True:
@@ -735,7 +739,7 @@ class Nft(EvmToken):
         return asset
 
 
-@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True, slots=True)  # noqa: E501
 class SolanaToken(CryptoAsset):
     mint_address: SolanaAddress = field(init=False)
     token_kind: SOLANA_TOKEN_KINDS_TYPE = field(init=False)
@@ -743,7 +747,7 @@ class SolanaToken(CryptoAsset):
     protocol: str | None = field(init=False)
 
     def __post_init__(self, direct_field_initialization: bool) -> None:
-        super().__post_init__(direct_field_initialization)
+        super(SolanaToken, self).__post_init__(direct_field_initialization)
         if direct_field_initialization is True:
             return
 
@@ -820,7 +824,7 @@ class SolanaToken(CryptoAsset):
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return super().to_dict() | {
+        return super(SolanaToken, self).to_dict() | {
             'address': self.mint_address,
             'token_kind': self.token_kind.serialize(),
             'decimals': self.decimals,

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -50,7 +50,7 @@ def test_asset_nft():
     a = Asset('_nft_foo')
     assert a.identifier == '_nft_foo'
     should_not_exist = {'name', 'symbol', 'started', 'forked', 'swapped_for', 'cryptocompare', 'coingecko'}  # noqa: E501
-    assert len(should_not_exist & a.__dict__.keys()) == 0
+    assert all(hasattr(a, attr) is False for attr in should_not_exist)
 
 
 def test_repr():


### PR DESCRIPTION
more about slots https://stackoverflow.com/a/28059785
used this script https://gist.github.com/yabirgb/57a08495cf8a95c7fb04781cbd8b18f4

### Measurements in develop

```
Parameters: memory_n=50000, create_n=200000, access_n=500000, runs=5
```

| Asset class | Bytes/instance | KiB/instance |
|---|---:|---:|
| Asset | 88.96 | 0.0869 |
| CryptoAsset | 160.93 | 0.1572 |
| EvmToken | 322.91 | 0.3153 |
| SolanaToken | 298.92 | 0.2919 |


| Asset class | Bytes/instance | Create mean (s) | Create stdev (s) | Access mean (s) | Access stdev (s) | 
|---|---:|---:|---:|---:|---:|
| Asset | 88.96 | 0.142378 | 0.062685 | 0.017544 | 0.000094 |
| CryptoAsset | 160.93 | 0.349777 | 0.015528 | 0.027612 | 0.000031 | 
| EvmToken | 322.91 | 0.588429 | 0.018593 | 0.027796 | 0.000247 | 
| SolanaToken | 298.92 | 0.535212 | 0.017921 | 0.027941 | 0.000496 |

### Measurements in this branch

| Asset class | Bytes/instance | KiB/instance |
|---|---:|---:|
| Asset | 48.90 | 0.0477 |
| CryptoAsset | 112.90 | 0.1103 |
| EvmToken | 266.90 | 0.2606 |
| SolanaToken | 250.90 | 0.2450 |

| Asset class | Bytes/instance | Create mean (s) | Create stdev (s) | Access mean (s) | Access stdev (s) |
|---|---:|---:|---:|---:|---:|
| Asset | 48.90 | 0.081590 | 0.004800 | 0.016474 | 0.000140 |
| CryptoAsset | 112.90 | 0.328284 | 0.012245 | 0.025556 | 0.000358 |
| EvmToken | 266.90 | 0.659761 | 0.033551 | 0.025683 | 0.000303 |
| SolanaToken | 250.90 | 0.584349 | 0.026658 | 0.025781 | 0.000253 |

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
